### PR TITLE
Fixed a possible bug in VectorMassIntegrator::AssembleElementMatrix

### DIFF
--- a/fem/bilininteg.cpp
+++ b/fem/bilininteg.cpp
@@ -615,14 +615,13 @@ void VectorMassIntegrator::AssembleElementMatrix
 ( const FiniteElement &el, ElementTransformation &Trans,
   DenseMatrix &elmat )
 {
-   int nd   = el.GetDof();
-   int dim  = el.GetDim();
-   int vdim;
+   int nd = el.GetDof();
 
    double norm;
 
-   // Get vdim from the ElementTransformation Trans ?
-   vdim = (VQ) ? (VQ -> GetVDim()) : ((MQ) ? (MQ -> GetVDim()) : (dim));
+   int vdim = Trans.GetSpaceDim();
+   if (VQ) MFEM_ASSERT(VQ->GetVDim() == vdim, "Dimensions mismatch");
+   if (MQ) MFEM_ASSERT(MQ->GetVDim() == vdim, "Dimensions mismatch");
 
    elmat.SetSize(nd*vdim);
    shape.SetSize(nd);

--- a/fem/bilininteg.cpp
+++ b/fem/bilininteg.cpp
@@ -616,12 +616,12 @@ void VectorMassIntegrator::AssembleElementMatrix
   DenseMatrix &elmat )
 {
    int nd = el.GetDof();
+   int spaceDim = Trans.GetSpaceDim();
 
    double norm;
 
-   int vdim = Trans.GetSpaceDim();
-   if (VQ) MFEM_ASSERT(VQ->GetVDim() == vdim, "Dimensions mismatch");
-   if (MQ) MFEM_ASSERT(MQ->GetVDim() == vdim, "Dimensions mismatch");
+   // Get vdim from VQ, MQ, or the space dimension
+   int vdim = (VQ) ? (VQ -> GetVDim()) : ((MQ) ? (MQ -> GetVDim()) : spaceDim);
 
    elmat.SetSize(nd*vdim);
    shape.SetSize(nd);


### PR DESCRIPTION
Hi all,

I think I found a bug. Here is the description: VectorMassIntegrator::AssembleElementMatrix got an information about the dimension of the vector problem based on the dimension of the vector or matrix coefficient. If the integrator is supposed to use a scalar coefficient the dimension was equal to the dimension of the finite element, which is okay if it's a domain integration, but is wrong when it's integration on a boundary.

For example, this code fails because of the issue mentioned above:
```cxx
Mesh mesh(10, 10, 10, Element::HEXAHEDRON, 1);
H1_FECollection fec(1, mesh.Dimension());
FiniteElementSpace fespace(&mesh, &fec, mesh.Dimension());
BilinearForm bdrmass(&fespace);
bdrmass.AddBoundaryIntegrator(new VectorMassIntegrator()); // scalar coefficient 1
bdrmass.Assemble(); // it fails here
```

Best regards,
Mikhail