### PR TITLE
Add prefix_path string as a member of DataCollection class

### DIFF
--- a/fem/datacollection.hpp
+++ b/fem/datacollection.hpp
@@ -63,8 +63,12 @@ protected:
    /// Error state
    int error;
 
+   /// A path where the directory with results is saved
+   std::string prefix_path;
+
    /// Create an empty collection with the given name.
-   DataCollection(const char *collection_name);
+   DataCollection(const char *collection_name,
+                  const char *prefix = NULL);
    /// Delete data owned by the DataCollection keeping field information
    void DeleteData();
    /// Delete data owned by the DataCollection including field information
@@ -75,7 +79,8 @@ protected:
 
 public:
    /// Initialize the collection with its name and Mesh.
-   DataCollection(const char *collection_name, Mesh *_mesh);
+   DataCollection(const char *collection_name, Mesh *_mesh,
+                  const char *prefix = NULL);
 
    /// Add a grid function to the collection
    virtual void RegisterField(const char *field_name, GridFunction *gf);
@@ -165,9 +170,11 @@ protected:
 public:
    /** Create an empty collection with the given name, that will be filled in
        later with the Load() function. Currently this only works in serial! */
-   VisItDataCollection(const char *collection_name);
+   VisItDataCollection(const char *collection_name,
+                       const char *prefix = NULL);
    /// Initialize the collection with its mesh, fill-in the extra VisIt data
-   VisItDataCollection(const char *collection_name, Mesh *_mesh);
+   VisItDataCollection(const char *collection_name, Mesh *_mesh,
+                       const char *prefix = NULL);
 
    /// Set/change the mesh associated with the collection
    virtual void SetMesh(Mesh *new_mesh);

--- a/linalg/sparsemat.cpp
+++ b/linalg/sparsemat.cpp
@@ -2769,6 +2769,30 @@ SparseMatrix *MultAbstractSparseMatrix (const AbstractSparseMatrix &A,
    return C;
 }
 
+DenseMatrix *Mult (const SparseMatrix &A, DenseMatrix &B)
+{
+  DenseMatrix *C = new DenseMatrix(A.Height(), B.Width());
+  Vector columnB, columnC;
+  for (int j = 0; j < B.Width(); ++j)
+  {
+    B.GetColumnReference(j, columnB);
+    C->GetColumnReference(j, columnC);
+    A.Mult(columnB, columnC);
+  }
+  return C;
+}
+
+DenseMatrix *RAP (const SparseMatrix &A, DenseMatrix &P)
+{
+  DenseMatrix R (P);
+  R.Transpose(); // R = P^T
+  DenseMatrix *AP   = Mult (A, P);
+  DenseMatrix *_RAP = new DenseMatrix(R.Height(), AP->Width());
+  Mult (R, *AP, *_RAP);
+  delete AP;
+  return _RAP;
+}
+
 SparseMatrix *RAP (const SparseMatrix &A, const SparseMatrix &R,
                    SparseMatrix *ORAP)
 {

--- a/linalg/sparsemat.hpp
+++ b/linalg/sparsemat.hpp
@@ -396,6 +396,11 @@ SparseMatrix *Mult(const SparseMatrix &A, const SparseMatrix &B,
 SparseMatrix *MultAbstractSparseMatrix (const AbstractSparseMatrix &A,
                                         const AbstractSparseMatrix &B);
 
+/// Matrix product A.B
+DenseMatrix *Mult(const SparseMatrix &A, DenseMatrix &B);
+
+/// RAP matrix product (with R=P^T)
+DenseMatrix *RAP(const SparseMatrix &A, DenseMatrix &P);
 
 /** RAP matrix product (with P=R^T). ORAP is like OAB above.
     All matrices must be finalized. */


### PR DESCRIPTION
The prefix_path is initialized upon contruction of a DataCollection object by
a provided C-string, or by an empty string if the C-string is not provided.
The prefix_path allows to save output data files in a custom directory.