### PR TITLE
Allow derived classes of the ParMesh class.

### DIFF
--- a/general/communication.hpp
+++ b/general/communication.hpp
@@ -43,6 +43,7 @@ private:
    void ProcToLProc();
 
 public:
+   GroupTopology() : MyComm(0) {;}
    GroupTopology(MPI_Comm comm) { MyComm = comm; }
 
    /// Copy constructor

--- a/mesh/pmesh.hpp
+++ b/mesh/pmesh.hpp
@@ -27,7 +27,7 @@ namespace mfem
 /// Class for parallel meshes
 class ParMesh : public Mesh
 {
-private:
+protected:
    MPI_Comm MyComm;
    int NRanks, MyRank;
 
@@ -73,6 +73,7 @@ private:
    void DeleteFaceNbrData();
 
 public:
+   ParMesh() {;}
    /** Copy constructor. Performs a deep copy of (almost) all data, so that the
        source mesh can be modified (e.g. deleted, refined) without affecting the
        new mesh. The source mesh has to be in a NORMAL, i.e. not TWO_LEVEL_*,


### PR DESCRIPTION
I would like to derive from ParMesh to create a ParMesh object from an existing mesh.