### PR TITLE
const ref B in A += B for sparse mat

### DIFF
--- a/linalg/sparsemat.cpp
+++ b/linalg/sparsemat.cpp
@@ -2109,7 +2109,7 @@ void SparseMatrix::ScaleColumns(const Vector & sr)
    }
 }
 
-SparseMatrix &SparseMatrix::operator+=(SparseMatrix &B)
+SparseMatrix &SparseMatrix::operator+=(const SparseMatrix &B)
 {
    MFEM_ASSERT(height == B.height && width == B.width,
                "Mismatch of this matrix size and rhs.  This height = "

--- a/linalg/sparsemat.hpp
+++ b/linalg/sparsemat.hpp
@@ -314,7 +314,7 @@ public:
 
    /** Add the sparse matrix 'B' to '*this'. This operation will cause an error
        if '*this' is finalized and 'B' has larger sparsity pattern. */
-   SparseMatrix &operator+=(SparseMatrix &B);
+   SparseMatrix &operator+=(const SparseMatrix &B);
 
    /** Add the sparse matrix 'B' scaled by the scalar 'a' into '*this'.
        Only entries in the sparsity pattern of '*this' are added. */


### PR DESCRIPTION
In SparseMatrix::operator+=(B) the B matrix is passed as a const reference
instead of just reference.