### PR TITLE
Add -lblas to LAPACK_LIB in defaults.mk

### DIFF
--- a/config/defaults.mk
+++ b/config/defaults.mk
@@ -89,7 +89,7 @@ endif
 
 # LAPACK library configuration
 LAPACK_OPT =
-LAPACK_LIB = -llapack
+LAPACK_LIB = -llapack -lblas
 ifeq ($(SYSNAME),Darwin)
    LAPACK_LIB = -framework Accelerate
 endif


### PR DESCRIPTION
When the MFEM library is built with MFEM_USE_LAPACK=YES option, the projects relied on the MFEM, such as examples or GLVis, need the -lblas option to get linked correctly. Although it may be system specific, I needed that on my Linux Mint and Debian machines.