### PR TITLE
Install test.mk

### DIFF
--- a/examples/makefile
+++ b/examples/makefile
@@ -16,6 +16,7 @@ TEST_MK = $(MFEM_DIR)/config/test.mk
 # Use the MFEM install directory
 # MFEM_DIR = ../mfem
 # CONFIG_MK = $(MFEM_DIR)/config.mk
+# TEST_MK = $(MFEM_DIR)/test.mk
 
 MFEM_LIB_FILE = mfem_is_not_built
 -include $(CONFIG_MK)

--- a/makefile
+++ b/makefile
@@ -341,6 +341,8 @@ install: libmfem.a
 	$(MAKE) -C config config-mk CONFIG_MK=config-install.mk
 	$(INSTALL) -m 640 config/config-install.mk $(PREFIX)/config.mk
 	rm -f config/config-install.mk
+# install test.mk at root of install tree
+	$(INSTALL) -m 640 config/test.mk $(PREFIX)/test.mk
 
 $(CONFIG_MK):
 	$(info )


### PR DESCRIPTION
When the MFEM is installed with `make install PREFIX=<dir>` the test.mk file was not installed,
which made it impossible to compile examples.