### PR TITLE
GradientVectorFEIntegrator

### DIFF
--- a/fem/bilininteg.cpp
+++ b/fem/bilininteg.cpp
@@ -1565,6 +1565,84 @@ void VectorFEMassIntegrator::AssembleElementMatrix2(
       }
    }
 }
+  
+void GradientVectorFEIntegrator::AssembleElementMatrix2(const FiniteElement &trial_el,
+                                    const FiniteElement &test_el,
+                                    ElementTransformation &Trans,
+     			            DenseMatrix &elmat){
+   // test  H1
+   // trial ND
+   int dim = test_el.GetDim();
+   int trial_dof = trial_el.GetDof();
+   int test_dof = test_el.GetDof();
+   int spaceDim = Trans.GetSpaceDim();   
+   double w;
+   
+   elmat.SetSize(test_dof, trial_dof);
+   Jinv.  SetSize(dim);
+   dshape.SetSize(test_dof, dim);
+   gshape.SetSize(test_dof, dim);
+#ifdef MFEM_THREAD_SAFE
+   Vector D(VQ ? VQ->GetVDim() : 0);
+   DenseMatrix trial_vshape(trial_dof, spaceDim);
+   DenseMatrix K(MQ ? MQ->GetVDim() : 0, MQ ? MQ->GetVDim() : 0);
+#else
+   trial_vshape.SetSize(trial_dof, spaceDim);
+   D.SetSize(VQ ? VQ->GetVDim() : 0);
+   K.SetSize(MQ ? MQ->GetVDim() : 0, MQ ? MQ->GetVDim() : 0);
+#endif
+   DenseMatrix tmp(trial_vshape.Height(), K.Width());
+   DenseMatrix tmp2(test_dof, trial_dof);
+
+   const IntegrationRule *ir = IntRule;
+   if (ir == NULL)
+   {
+      int order = Trans.OrderGrad(&test_el) + trial_el.GetOrder() + Trans.OrderW();
+      if (test_el.Space() == FunctionSpace::rQk)
+      {
+         ir = &RefinedIntRules.Get(test_el.GetGeomType(), order);
+      }
+      else
+      {
+         ir = &IntRules.Get(test_el.GetGeomType(), order);
+      }
+   }
+   for (int i = 0; i < ir -> GetNPoints(); i++)
+   {
+      const IntegrationPoint &ip = ir->IntPoint(i);
+
+      test_el.CalcDShape (ip, dshape);
+      Trans.SetIntPoint (&ip);     
+      CalcInverse (Trans.Jacobian(), Jinv);
+      Mult (dshape, Jinv, gshape);
+      Trans.SetIntPoint (&ip);
+
+      trial_el.CalcVShape(Trans, trial_vshape);
+      w = ip.weight * Trans.Weight();
+      if (MQ)
+      {
+         MQ->Eval(K, Trans, ip);
+         K *= w;
+         Mult(gshape, K, tmp);
+         AddMultABt(tmp,trial_vshape,elmat);
+      }
+      else if (VQ)
+      {
+         VQ->Eval(D, Trans, ip);
+         D *= w;
+         MultADBt(gshape, D, trial_vshape, tmp2);	 
+         elmat += tmp2;
+      }
+      else
+      {
+         if (Q){
+            w *= Q -> Eval (Trans, ip);
+         }
+         gshape *= w;
+         AddMultABt(gshape, trial_vshape, elmat);
+      }
+   }
+}
 
 void VectorDivergenceIntegrator::AssembleElementMatrix2(
    const FiniteElement &trial_fe,

--- a/fem/bilininteg.hpp
+++ b/fem/bilininteg.hpp
@@ -496,7 +496,34 @@ public:
                                        ElementTransformation &Trans,
                                        DenseMatrix &elmat);
 };
+/*  (grad u v), where u is H1 and v is Nedelec */
+class GradientVectorFEIntegrator : public BilinearFormIntegrator
+{
+private:
+   Coefficient *Q;
+   VectorCoefficient *VQ;
+   MatrixCoefficient *MQ;
 
+   DenseMatrix Jinv;
+   DenseMatrix dshape;
+   DenseMatrix gshape;
+   DenseMatrix elmat;
+#ifndef MFEM_THREAD_SAFE
+   Vector shape;
+   Vector D;
+   DenseMatrix K;
+   DenseMatrix test_vshape;
+   DenseMatrix trial_vshape;
+#endif
+public:
+   GradientVectorFEIntegrator() { Q = NULL; VQ = NULL; MQ = NULL;}
+   GradientVectorFEIntegrator(Coefficient *_q) { Q = _q;  VQ = NULL; MQ = NULL;}
+   GradientVectorFEIntegrator(Coefficient &q) { Q = &q; VQ = NULL; MQ = NULL;}
+   virtual void AssembleElementMatrix2(const FiniteElement &trial_el,
+                                       const FiniteElement &test_el,
+                                      ElementTransformation &Trans,
+				       DenseMatrix &elmat);
+};     
 /** Integrator for (Q div u, p) where u=(v1,...,vn) and all
     vi are in the same scalar FE space; p is also in
     a (different) scalar FE space.  */


### PR DESCRIPTION
An integrator to be used to use divJ constraint to a frequency domain
Maxwell problem.

In the frequency domain Maxwell equation, div J = 0 constraint is used
to stabilize solutions when frequency is low.
(curl W, curl E) - (a W, E) - (a grad u, W) = (W, f)
(E, grad v) = 0

, where u is a Lagrange multiplier (equivalent to true charge). 
This term is also effective when pure vacuum is contacting highly 
conductive material like a plasma.

This pull request adds an integrate to assemble (grad u, W).

Below, I am attaching a test performed using a simple coaxial cable 
model ( This complex problem is assembled using PyMFEM and solved 
with MUMPS). It shows that this terms allow for solver to
converge to a correct solution at frequencies low enough that it
does not converge without this constraint.

When reviewing this pull request, please note that,,,
1) Please check if the counting of integration order in this patch is right.
2) Test is only performed for a constant coefficient. I don' to know 
if the section to handle vector and matrix coefficients is right.
3) Above formalism assumes that f is already divergence free. If not
an additional term, which requires another new linear integrator, needed
to be added.

![pull_request](https://cloud.githubusercontent.com/assets/1929159/19539238/4ae2490e-9693-11e6-80fa-cb060799c55e.png)
