### PR TITLE
Adding methods to obtain more mesh information [mesh-info-dev]

### DIFF
--- a/mesh/mesh.cpp
+++ b/mesh/mesh.cpp
@@ -148,13 +148,13 @@ void Mesh::GetBoundingBox(Vector &min, Vector &max, int ref)
    }
 }
 
-void Mesh::PrintCharacteristics(Vector *Vh, Vector *Vk, std::ostream &out)
+void Mesh::GetCharacteristics(double &h_min, double &h_max,
+                              double &kappa_min, double &kappa_max,
+                              Vector *Vh, Vector *Vk)
 {
    int i, dim, sdim;
    DenseMatrix J;
-   double h_min, h_max, kappa_min, kappa_max, h, kappa;
-
-   out << "Mesh Characteristics:";
+   double h, kappa;
 
    dim = Dimension();
    sdim = SpaceDimension();
@@ -179,7 +179,18 @@ void Mesh::PrintCharacteristics(Vector *Vh, Vector *Vk, std::ostream &out)
       if (kappa < kappa_min) { kappa_min = kappa; }
       if (kappa > kappa_max) { kappa_max = kappa; }
    }
+}
 
+void Mesh::PrintCharacteristics(Vector *Vh, Vector *Vk, std::ostream &out)
+{
+   int i, dim, sdim;
+   double h_min, h_max, kappa_min, kappa_max, h, kappa;
+
+   out << "Mesh Characteristics:";
+
+   this->GetCharacteristics(h_min, h_max, kappa_min, kappa_max, Vh, Vk);
+
+   dim = Dimension();
    if (dim == 1)
    {
       out << '\n'

--- a/mesh/mesh.cpp
+++ b/mesh/mesh.cpp
@@ -87,13 +87,13 @@ double Mesh::GetElementVolume(int i)
 // Similar to VisualizationSceneSolution3d::FindNewBox in GLVis
 void Mesh::GetBoundingBox(Vector &min, Vector &max, int ref)
 {
-   min.SetSize(Dim);
-   max.SetSize(Dim);
+   min.SetSize(spaceDim);
+   max.SetSize(spaceDim);
 
-   for (int d = 0; d < Dim; d++)
+   for (int d = 0; d < spaceDim; d++)
    {
-      min[d] = numeric_limits<double>::infinity();
-      max[d] = -numeric_limits<double>::infinity();
+      min(d) = numeric_limits<double>::infinity();
+      max(d) = -numeric_limits<double>::infinity();
    }
 
    if (Nodes == NULL)
@@ -102,16 +102,17 @@ void Mesh::GetBoundingBox(Vector &min, Vector &max, int ref)
       for (int i = 0; i < NumOfVertices; i++)
       {
          coord = GetVertex(i);
-         for (int d = 0; d < Dim; d++)
+         for (int d = 0; d < spaceDim; d++)
          {
-            if (coord[d] < min[d]) { min[d] = coord[d]; }
-            if (coord[d] > max[d]) { max[d] = coord[d]; }
+            if (coord[d] < min(d)) { min(d) = coord[d]; }
+            if (coord[d] > max(d)) { max(d) = coord[d]; }
          }
       }
    }
    else
    {
-      int ne = (Dim == 3) ? GetNBE() : GetNE();
+      const bool use_boundary = false; // make this a parameter?
+      int ne = use_boundary ? GetNBE() : GetNE();
       int fn, fo;
       DenseMatrix pointmat;
       RefinedGeometry *RefG;
@@ -121,7 +122,7 @@ void Mesh::GetBoundingBox(Vector &min, Vector &max, int ref)
 
       for (int i = 0; i < ne; i++)
       {
-         if (Dim == 3)
+         if (use_boundary)
          {
             GetBdrElementFace(i, &fn, &fo);
             RefG = GlobGeometryRefiner.Refine(GetFaceBaseGeometry(fn), ref);
@@ -138,10 +139,10 @@ void Mesh::GetBoundingBox(Vector &min, Vector &max, int ref)
          }
          for (int j = 0; j < pointmat.Width(); j++)
          {
-            for (int d = 0; d < Dim; d++)
+            for (int d = 0; d < pointmat.Height(); d++)
             {
-               if (pointmat(d,j) < min[d]) { min[d] = pointmat(d,j); }
-               if (pointmat(d,j) > max[d]) { max[d] = pointmat(d,j); }
+               if (pointmat(d,j) < min(d)) { min(d) = pointmat(d,j); }
+               if (pointmat(d,j) > max(d)) { max(d) = pointmat(d,j); }
             }
          }
       }
@@ -183,15 +184,13 @@ void Mesh::GetCharacteristics(double &h_min, double &h_max,
 
 void Mesh::PrintCharacteristics(Vector *Vh, Vector *Vk, std::ostream &out)
 {
-   int i, dim, sdim;
-   double h_min, h_max, kappa_min, kappa_max, h, kappa;
+   double h_min, h_max, kappa_min, kappa_max;
 
    out << "Mesh Characteristics:";
 
    this->GetCharacteristics(h_min, h_max, kappa_min, kappa_max, Vh, Vk);
 
-   dim = Dimension();
-   if (dim == 1)
+   if (Dim == 1)
    {
       out << '\n'
           << "Number of vertices : " << GetNV() << '\n'
@@ -200,7 +199,7 @@ void Mesh::PrintCharacteristics(Vector *Vh, Vector *Vk, std::ostream &out)
           << "h_min              : " << h_min << '\n'
           << "h_max              : " << h_max << '\n';
    }
-   else if (dim == 2)
+   else if (Dim == 2)
    {
       out << '\n'
           << "Number of vertices : " << GetNV() << '\n'

--- a/mesh/mesh.hpp
+++ b/mesh/mesh.hpp
@@ -1043,6 +1043,10 @@ public:
    /// high-order meshes, the geometry is refined first "ref" times.
    void GetBoundingBox(Vector &min, Vector &max, int ref = 2);
 
+   void GetCharacteristics(double &h_min, double &h_max,
+                           double &kappa_min, double &kappa_max,
+                           Vector *Vh = NULL, Vector *Vk = NULL);
+
    void PrintCharacteristics(Vector *Vh = NULL, Vector *Vk = NULL,
                              std::ostream &out = std::cout);
 

--- a/mesh/pmesh.cpp
+++ b/mesh/pmesh.cpp
@@ -4318,6 +4318,35 @@ void ParMesh::PrintAsOneXG(std::ostream &out)
    }
 }
 
+void ParMesh::GetBoundingBox(Vector &gp_min, Vector &gp_max, int ref)
+{
+   int sdim;
+   Vector p_min, p_max;
+
+   this->Mesh::GetBoundingBox(p_min, p_max, ref);
+
+   sdim = SpaceDimension();
+
+   gp_min.SetSize(sdim);
+   gp_max.SetSize(sdim);
+
+   MPI_Allreduce(p_min.GetData(), gp_min, sdim, MPI_DOUBLE, MPI_MIN, MyComm);
+   MPI_Allreduce(p_max.GetData(), gp_max, sdim, MPI_DOUBLE, MPI_MAX, MyComm);
+}
+
+void ParMesh::GetCharacteristics(double &gh_min, double &gh_max,
+                                 double &gk_min, double &gk_max)
+{
+   double h_min, h_max, kappa_min, kappa_max;
+
+   this->Mesh::GetCharacteristics(h_min, h_max, kappa_min, kappa_max);
+
+   MPI_Allreduce(&h_min, &gh_min, 1, MPI_DOUBLE, MPI_MIN, MyComm);
+   MPI_Allreduce(&h_max, &gh_max, 1, MPI_DOUBLE, MPI_MAX, MyComm);
+   MPI_Allreduce(&kappa_min, &gk_min, 1, MPI_DOUBLE, MPI_MIN, MyComm);
+   MPI_Allreduce(&kappa_max, &gk_max, 1, MPI_DOUBLE, MPI_MAX, MyComm);
+}
+
 void ParMesh::PrintInfo(std::ostream &out)
 {
    int i;

--- a/mesh/pmesh.hpp
+++ b/mesh/pmesh.hpp
@@ -200,6 +200,13 @@ public:
    /// Old mesh format (Netgen/Truegrid) version of 'PrintAsOne'
    void PrintAsOneXG(std::ostream &out = std::cout);
 
+   /// Returns the minimum and maximum corners of the mesh bounding box. For
+   /// high-order meshes, the geometry is refined first "ref" times.
+   void GetBoundingBox(Vector &p_min, Vector &p_max, int ref = 2);
+
+   void GetCharacteristics(double &h_min, double &h_max,
+                           double &kappa_min, double &kappa_max);
+
    /// Print various parallel mesh stats
    virtual void PrintInfo(std::ostream &out = std::cout);
 


### PR DESCRIPTION
These changes were part of the arpack-dev branch on MyStash but they stand on their own as potentially useful enhancements.

Adding a serial method to obtain the information printed by
PrintCharacteristics.  This includes minimum and maximum edge lengths
as well as kappa which seems to be related to the aspect ratio of the
elements.

Adding a parallel method to compute the same mesh characteristics
mentioned above.

Adding a parallel method to compute the bounding box of a distributed
mesh.