### PR TITLE
Simplified Travis CI testing [travis-dev]

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,90 @@
+language: cpp
+
+compiler:
+   - gcc
+   - clang
+
+os:
+   - linux
+   - osx
+
+env:
+   - DEBUG=YES MPI=YES
+   - DEBUG=NO MPI=YES
+   - DEBUG=YES MPI=NO
+   - DEBUG=NO MPI=NO
+
+# Test with GCC on Linux an Clang on Mac
+matrix:
+   exclude:
+      - compiler: clang
+        os: linux
+      - compiler: gcc
+        os: osx
+
+before_install:
+   # g++-4.8.1
+   - if [ $TRAVIS_OS_NAME == "linux" -a "$CXX" == "g++" ]; then sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test; fi
+   - if [ $TRAVIS_OS_NAME == "linux" ]; then sudo apt-get update; fi || true
+
+install:
+   # g++-4.8.1
+   - if [ $TRAVIS_OS_NAME == "linux" -a "$CXX" == "g++" ]; then sudo apt-get install -qq g++-4.8; fi
+   - if [ $TRAVIS_OS_NAME == "linux" -a "$CXX" == "g++" ]; then export CXX="g++-4.8"; fi
+
+   # Back out of the mfem directory to install the libraries
+   - cd ..
+
+   # OpenMPI
+   - if [ $TRAVIS_OS_NAME == "linux" ]; then
+        sudo apt-get install openmpi-bin openmpi-common openssh-client openssh-server libopenmpi1.3 libopenmpi-dbg libopenmpi-dev;
+     else
+        travis_wait brew install open-mpi;
+     fi
+
+   # hypre
+   - if [ $MPI == "YES" ]; then
+        if [ ! -d hypre-2.10.0b ]; then
+            wget https://computation.llnl.gov/project/linear_solvers/download/hypre-2.10.0b.tar.gz --no-check-certificate;
+            tar xvzf hypre-2.10.0b.tar.gz;
+            cd hypre-2.10.0b/src;
+            ./configure --disable-fortran CC=mpicc CXX=mpic++;
+            make -j 4;
+            cd ../..;
+        else
+            echo "Reusing cached hypre-2.10.0b/";
+        fi;
+     else
+        echo "Serial build, not using hypre";
+     fi
+
+   # METIS
+   - if [ ! -d metis-4.0 ]; then
+        wget http://glaros.dtc.umn.edu/gkhome/fetch/sw/metis/OLD/metis-4.0.3.tar.gz;
+        tar xvzf metis-4.0.3.tar.gz;
+        cd metis-4.0.3;
+        make -j 4;
+        cd ..;
+        mv metis-4.0.3 metis-4.0;
+     else
+        echo "Reusing cached metis-4.0/";
+     fi
+
+# # Delete an expired cache here: https://travis-ci.org/mfem/mfem/caches
+# cache:
+#   directories:
+#     - $TRAVIS_BUILD_DIR/../hypre-2.10.0b
+#     - $TRAVIS_BUILD_DIR/../metis-4.0
+
+script:
+   # Compiler
+   - if [ $MPI == "YES" ]; then export MYCXX=mpic++; else export MYCXX=$CXX; fi
+
+   # Build the code and do a quick check (debug mode) or a full tests run (non-debug mode)
+   - if [ $DEBUG == "NO" ]; then export MFEM_TEST_TARGET="test"; else export MFEM_TARGET="check"; fi
+
+   # Build and check/test MFEM, its examples and miniapps
+   - cd $TRAVIS_BUILD_DIR
+   - make config MFEM_USE_MPI=$MPI MFEM_DEBUG=$DEBUG MFEM_CXX=$MYCXX
+   - make all -j 4
+   - make $MFEM_TEST_TARGET

--- a/.travis.yml
+++ b/.travis.yml
@@ -81,7 +81,7 @@ script:
    - if [ $MPI == "YES" ]; then export MYCXX=mpic++; else export MYCXX=$CXX; fi
 
    # Build the code and do a quick check (debug mode) or a full tests run (non-debug mode)
-   - if [ $DEBUG == "NO" ]; then export MFEM_TEST_TARGET="test"; else export MFEM_TARGET="check"; fi
+   - if [ $DEBUG == "NO" ]; then export MFEM_TEST_TARGET="test"; else export MFEM_TEST_TARGET="check"; fi
 
    # Build and check/test MFEM, its examples and miniapps
    - cd $TRAVIS_BUILD_DIR


### PR DESCRIPTION
This PR brings up a simplified Travis CI testing based heavily on [Aaron's work in the old-travis-dev
branch](https://github.com/mfem/mfem/blob/old-travis-dev/.travis.yml) (previously known as develop and travis-dev).

I am not a Travis expert, but wanted to get us started with something... suggestions for improvements are definitely welcomed :)

Some of the changes are:
- I removed the unit testing and (for simplicity) the codecov coverage.
- Debug builds run only `make check`. Non-debug builds run `make test`.
- Testing gcc on Linux and clang on Mac with all `DEBUG=YES/NO` and `MPI=YES/NO` combinations (a total of 8 builds).

Jobs now take between 2 and 10 minutes, e.g. in my last test the total run time for all 8 jobs was 47 minutes, but due to overlapping the test completed in 13 minutes.

I tried caching some of the build, but had some issues and decided against it at the end.

