### PR TITLE
Fix the NNZ of the returned matrix of ParMult [hypreparmatrix_nnz]

### DIFF
--- a/linalg/hypre.cpp
+++ b/linalg/hypre.cpp
@@ -1376,6 +1376,7 @@ HypreParMatrix * ParMult(HypreParMatrix *A, HypreParMatrix *B)
 {
    hypre_ParCSRMatrix * ab;
    ab = hypre_ParMatmul(*A,*B);
+   hypre_ParCSRMatrixSetNumNonzeros(ab);
 
    hypre_MatvecCommPkgCreate(ab);
 


### PR DESCRIPTION
adding the function call 'hypre_ParCSRMatrixSetNumNonzeros' to ParMult so that the returned matrix has the correct number of non-zeros (NNZ).