### PR TITLE
Bugfix: add memory-safe Vertex.SetCoords() method. [bugfix-setcoords-memory]

### DIFF
--- a/mesh/mesh.cpp
+++ b/mesh/mesh.cpp
@@ -2768,7 +2768,8 @@ Mesh::Mesh(Mesh *mesh_array[], int num_pieces)
          // copy the vertices
          for (j = 0; j < m->GetNV(); j++)
          {
-            vertices[lvert_vert[j]].SetCoords(m->GetVertex(j));
+            vertices[lvert_vert[j]].SetCoords(m->SpaceDimension(),
+                                              m->GetVertex(j));
          }
       }
    }
@@ -2818,7 +2819,7 @@ Mesh::Mesh(Mesh *mesh_array[], int num_pieces)
          // copy the vertices
          for (j = 0; j < m->GetNV(); j++)
          {
-            vertices[iv++].SetCoords(m->GetVertex(j));
+            vertices[iv++].SetCoords(m->SpaceDimension(), m->GetVertex(j));
          }
       }
    }

--- a/mesh/mesh.cpp
+++ b/mesh/mesh.cpp
@@ -2926,7 +2926,7 @@ Mesh::Mesh(Mesh *orig_mesh, int ref_factor, int ref_type)
       const int *c2h_map = rfec.GetDofMap(geom);
       for (int i = 0; i < phys_pts.Width(); i++)
       {
-         vertices[rdofs[i]].SetCoords(Dim, phys_pts.GetColumn(i));
+         vertices[rdofs[i]].SetCoords(spaceDim, phys_pts.GetColumn(i));
       }
       for (int j = 0; j < RG.RefGeoms.Size()/nvert; j++)
       {

--- a/mesh/mesh.cpp
+++ b/mesh/mesh.cpp
@@ -2925,7 +2925,7 @@ Mesh::Mesh(Mesh *orig_mesh, int ref_factor, int ref_type)
       const int *c2h_map = rfec.GetDofMap(geom);
       for (int i = 0; i < phys_pts.Width(); i++)
       {
-         vertices[rdofs[i]].SetCoords(phys_pts.GetColumn(i));
+         vertices[rdofs[i]].SetCoords(Dim, phys_pts.GetColumn(i));
       }
       for (int j = 0; j < RG.RefGeoms.Size()/nvert; j++)
       {

--- a/mesh/ncmesh.cpp
+++ b/mesh/ncmesh.cpp
@@ -1601,7 +1601,7 @@ void NCMesh::GetMeshComponents(Array<mfem::Vertex>& vertices,
    for (int i = 0; i < vertices.Size(); i++)
    {
       Node* node = nodes.Peek(vertex_nodeId[i]);
-      vertices[i].SetCoords(node->vertex->pos);
+      vertices[i].SetCoords(spaceDim, node->vertex->pos);
    }
 
    elements.SetSize(leaf_elements.Size() - GetNumGhosts());

--- a/mesh/pmesh.cpp
+++ b/mesh/pmesh.cpp
@@ -183,7 +183,8 @@ ParMesh::ParMesh(MPI_Comm comm, Mesh &mesh, int *partitioning_,
    for (i = 0; i < vert_global_local.Size(); i++)
       if (vert_global_local[i] >= 0)
       {
-         vertices[vert_global_local[i]].SetCoords(mesh.GetVertex(i));
+         vertices[vert_global_local[i]].SetCoords(mesh.SpaceDimension(),
+                                                  mesh.GetVertex(i));
       }
 
    // determine elements

--- a/mesh/pncmesh.cpp
+++ b/mesh/pncmesh.cpp
@@ -703,7 +703,8 @@ void ParNCMesh::GetFaceNeighbors(ParMesh &pmesh)
    std::map<Vertex*, int>::iterator it;
    for (it = vert_map.begin(); it != vert_map.end(); ++it)
    {
-      pmesh.face_nbr_vertices[it->second-1].SetCoords(it->first->pos);
+      pmesh.face_nbr_vertices[it->second-1].SetCoords(spaceDim,
+                                                      it->first->pos);
    }
 
    // make the 'send_face_nbr_elements' table

--- a/mesh/vertex.hpp
+++ b/mesh/vertex.hpp
@@ -46,7 +46,7 @@ public:
 
    /// Sets vertex location based on given point p
    void SetCoords(int dim, const double *p)
-   { for (int i = 0; i < dim; i++) coord[i] = p[i]; }
+   { for (int i = 0; i < dim; i++) { coord[i] = p[i]; } }
 
    ~Vertex() { }
 };

--- a/mesh/vertex.hpp
+++ b/mesh/vertex.hpp
@@ -40,8 +40,13 @@ public:
    /// Returns the i'th coordinate of the vertex.
    inline const double & operator() (int i) const { return coord[i]; }
 
+   /// Safe in any dimension when argument is mesh.GetVertex()
    void SetCoords(const double *p)
    { coord[0] = p[0]; coord[1] = p[1]; coord[2] = p[2]; }
+
+   /// Should be used if p[] is not guaranteed to have length 3
+   void SetCoords(int dim, const double *p)
+   { for (int i = 0; i < dim; i++) coord[i] = p[i]; }
 
    ~Vertex() { }
 };

--- a/mesh/vertex.hpp
+++ b/mesh/vertex.hpp
@@ -40,11 +40,11 @@ public:
    /// Returns the i'th coordinate of the vertex.
    inline const double & operator() (int i) const { return coord[i]; }
 
-   /// Safe in any dimension when argument is mesh.GetVertex()
+   /// @deprecated old version of SetCoords is not always memory safe
    void SetCoords(const double *p)
    { coord[0] = p[0]; coord[1] = p[1]; coord[2] = p[2]; }
 
-   /// Should be used if p[] is not guaranteed to have length 3
+   /// Sets vertex location based on given point p
    void SetCoords(int dim, const double *p)
    { for (int i = 0; i < dim; i++) coord[i] = p[i]; }
 


### PR DESCRIPTION
Fixes Issue #129 

This is a minimal way to fix the issue, but it may be cleaner to only have one method `vertex.SetCoords(int dim, double *p)` instead of two, and change all the existing references to SetCoords().