### PR TITLE
Converted sidre usage from 'asctoolkit' to 'axom' namespace. [axom-dev]

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -183,7 +183,7 @@ if (MFEM_USE_MPFR)
   include_directories(${MPFR_INCLUDE_DIRS})
 endif()
 
-# ATK/Sidre
+# Axom/Sidre
 if (MFEM_USE_SIDRE)
   if (NOT MFEM_USE_MPI)
     find_package(ATK REQUIRED Sidre SLIC common)

--- a/INSTALL
+++ b/INSTALL
@@ -287,11 +287,11 @@ MFEM_USE_MPFR = YES/NO
    see below.
 
 MFEM_USE_SIDRE = YES/NO
-   Sidre is a component of LLNL's ASC toolkit, http://goo.gl/cZyJdn, that
+   Sidre is a component of LLNL's axom project, http://goo.gl/cZyJdn, that
    provides an HDF5-based file format for visualization or restart capability
    following the Conduit (https://github.com/LLNL/conduit) mesh blueprint
    specification. When enabled, this option requires installation of HDF5 (see
-   also MFEM_USE_NETCDF), Conduit and LLNL's ASC toolkit.
+   also MFEM_USE_NETCDF), Conduit and LLNL's axom project.
 
 MFEM_USE_GZSTREAM = YES/NO
    Enables use of on-the-fly gzip compressed streams. With this feature enabled
@@ -390,8 +390,8 @@ The specific libraries and their options are:
   URL: https://www.mcs.anl.gov/petsc
   Options: PETSC_OPT, PETSC_LIB.
 
-- ATK/Sidre (optional), used when MFEM_USE_SIDRE = YES.
-  URL: http://goo.gl/cZyJdn (ASC toolkit, to be released)
+- Sidre (optional), part of LLNL's axom project, used when MFEM_USE_SIDRE = YES.
+  URL: http://goo.gl/cZyJdn (axom, to be released)
        https://github.com/LLNL/conduit (Conduit)
        https://support.hdfgroup.org/HDF5 (HDF5)
   Options: SIDRE_OPT, SIDRE_LIB.

--- a/fem/sidredatacollection.cpp
+++ b/fem/sidredatacollection.cpp
@@ -24,7 +24,7 @@
 #include <iomanip>      // for setw, setfill
 #include <cstdio>       // for snprintf()
 
-namespace sidre = asctoolkit::sidre;
+namespace sidre = axom::sidre;
 
 namespace mfem
 {
@@ -70,8 +70,8 @@ SidreDataCollection::SidreDataCollection(const std::string& collection_name,
 // in the future.  When this is available, all the blueprint index code can be
 // removed from the data collection class.
 SidreDataCollection::SidreDataCollection(const std::string& collection_name,
-                                         asctoolkit::sidre::DataGroup* global_grp,
-                                         asctoolkit::sidre::DataGroup* domain_grp,
+                                         axom::sidre::DataGroup* global_grp,
+                                         axom::sidre::DataGroup* domain_grp,
                                          bool own_mesh_data)
    : mfem::DataCollection(collection_name),
      m_owns_datastore(false),
@@ -120,8 +120,8 @@ sidre::DataGroup *SidreDataCollection::named_buffers_grp() const
 }
 
 // protected method
-asctoolkit::sidre::DataView *
-SidreDataCollection::alloc_view(asctoolkit::sidre::DataGroup *grp,
+axom::sidre::DataView *
+SidreDataCollection::alloc_view(axom::sidre::DataGroup *grp,
                                 const std::string &view_name)
 {
    MFEM_ASSERT(grp, "DataGroup pointer is NULL");
@@ -136,10 +136,10 @@ SidreDataCollection::alloc_view(asctoolkit::sidre::DataGroup *grp,
 }
 
 // protected method
-asctoolkit::sidre::DataView *
-SidreDataCollection::alloc_view(asctoolkit::sidre::DataGroup *grp,
+axom::sidre::DataView *
+SidreDataCollection::alloc_view(axom::sidre::DataGroup *grp,
                                 const std::string &view_name,
-                                const asctoolkit::sidre::DataType &dtype)
+                                const axom::sidre::DataType &dtype)
 {
    MFEM_ASSERT(grp, "DataGroup pointer is NULL");
    sidre::DataView *v = grp->getView(view_name);
@@ -157,8 +157,8 @@ SidreDataCollection::alloc_view(asctoolkit::sidre::DataGroup *grp,
 }
 
 // protected method
-asctoolkit::sidre::DataGroup *
-SidreDataCollection::alloc_group(asctoolkit::sidre::DataGroup *grp,
+axom::sidre::DataGroup *
+SidreDataCollection::alloc_group(axom::sidre::DataGroup *grp,
                                  const std::string &group_name)
 {
    MFEM_ASSERT(grp, "DataGroup pointer is NULL");
@@ -190,10 +190,10 @@ SidreDataCollection::get_file_path(const std::string &filename) const
    return fNameSstr.str();
 }
 
-asctoolkit::sidre::DataView *
+axom::sidre::DataView *
 SidreDataCollection::AllocNamedBuffer(const std::string& buffer_name,
-                                      asctoolkit::sidre::SidreLength sz,
-                                      asctoolkit::sidre::TypeID type)
+                                      axom::sidre::SidreLength sz,
+                                      axom::sidre::TypeID type)
 {
    sz = std::max(sz, sidre::SidreLength(0));
    sidre::DataGroup *f = named_buffers_grp();
@@ -584,8 +584,8 @@ void SidreDataCollection::SetMesh(Mesh *new_mesh)
 }
 
 void SidreDataCollection::
-SetGroupPointers(asctoolkit::sidre::DataGroup *global_grp,
-                 asctoolkit::sidre::DataGroup *domain_grp)
+SetGroupPointers(axom::sidre::DataGroup *global_grp,
+                 axom::sidre::DataGroup *domain_grp)
 {
    MFEM_VERIFY(domain_grp->hasGroup("blueprint"),
                "Domain group does not contain a blueprint group.");
@@ -606,7 +606,7 @@ void SidreDataCollection::Load(const std::string& path,
 #ifdef MFEM_USE_MPI
    if (m_comm != MPI_COMM_NULL)
    {
-      asctoolkit::spio::IOManager reader(m_comm);
+      axom::spio::IOManager reader(m_comm);
       reader.read(bp_grp->getDataStore()->getRoot(), path);
    }
    else
@@ -635,7 +635,7 @@ void SidreDataCollection::LoadExternalData(const std::string& path)
 #ifdef MFEM_USE_MPI
    if (m_comm != MPI_COMM_NULL)
    {
-      asctoolkit::spio::IOManager reader(m_comm);
+      axom::spio::IOManager reader(m_comm);
       reader.loadExternalData(bp_grp->getDataStore()->getRoot(), path);
    }
    else
@@ -692,7 +692,7 @@ void SidreDataCollection::Save(const std::string& filename,
 #ifdef MFEM_USE_MPI
    if (m_comm != MPI_COMM_NULL)
    {
-      asctoolkit::spio::IOManager writer(m_comm);
+      axom::spio::IOManager writer(m_comm);
       sidre::DataStore *datastore = bp_grp->getDataStore();
       writer.write(datastore->getRoot(), num_procs, file_path, protocol);
       if (myid == 0)
@@ -725,7 +725,7 @@ void SidreDataCollection::Save(const std::string& filename,
 void SidreDataCollection::
 addScalarBasedGridFunction(const std::string &field_name, GridFunction *gf,
                            const std::string &buffer_name,
-                           asctoolkit::sidre::SidreLength offset)
+                           axom::sidre::SidreLength offset)
 {
    sidre::DataGroup* grp = bp_grp->getGroup("fields/" + field_name);
    MFEM_ASSERT(grp != NULL, "field " << field_name << " does not exist");
@@ -788,7 +788,7 @@ addScalarBasedGridFunction(const std::string &field_name, GridFunction *gf,
 void SidreDataCollection::
 addVectorBasedGridFunction(const std::string& field_name, GridFunction *gf,
                            const std::string &buffer_name,
-                           asctoolkit::sidre::SidreLength offset)
+                           axom::sidre::SidreLength offset)
 {
    sidre::DataGroup* grp = bp_grp->getGroup("fields/" + field_name);
    MFEM_ASSERT(grp != NULL, "field " << field_name << " does not exist");
@@ -913,7 +913,7 @@ DeregisterFieldInBPIndex(const std::string& field_name)
 void SidreDataCollection::RegisterField(const std::string &field_name,
                                         GridFunction *gf,
                                         const std::string &buffer_name,
-                                        asctoolkit::sidre::SidreLength offset)
+                                        axom::sidre::SidreLength offset)
 {
    if ( field_name.empty() || buffer_name.empty() ||
         gf == NULL || gf->FESpace() == NULL )

--- a/fem/sidredatacollection.hpp
+++ b/fem/sidredatacollection.hpp
@@ -26,10 +26,10 @@ namespace mfem
     blueprint specification. */
 /** SidreDataCollection provides an HDF5-based file format for visualization or
     restart capability.  This functionality is aimed primarily at customers of
-    LLNL's ASC Toolkit that run problems at extreme scales.
+    LLNL's axom project that run problems at extreme scales.
 
     For more information, see:
-    - LLNL ASC toolkit Sidre component (to be open-sourced), http://goo.gl/cZyJdn
+    - Sidre component of LLNL's axom project (to be open-sourced), http://goo.gl/cZyJdn
     - LLNL conduit/blueprint library, https://github.com/LLNL/conduit
     - HDF5 library, https://support.hdfgroup.org/HDF5
 
@@ -192,8 +192,8 @@ public:
        to be set with SetMesh() and fields registered with RegisterField().
     */
    SidreDataCollection(const std::string& collection_name,
-                       asctoolkit::sidre::DataGroup * global_grp,
-                       asctoolkit::sidre::DataGroup * domain_grp,
+                       axom::sidre::DataGroup * global_grp,
+                       axom::sidre::DataGroup * domain_grp,
                        bool owns_mesh_data = false);
 
 #ifdef MFEM_USE_MPI
@@ -231,7 +231,7 @@ public:
     */
    void RegisterField(const std::string &field_name, GridFunction *gf,
                       const std::string &buffer_name,
-                      asctoolkit::sidre::SidreLength offset);
+                      axom::sidre::SidreLength offset);
 
    /// Set the name of the mesh nodes field.
    /** This name will be used by SetMesh() to register the mesh nodes, if not
@@ -263,11 +263,11 @@ public:
        reset to valid groups in the datastore.
        @sa Load(const std::string &path, const std::string &protocol).
     */
-   void SetGroupPointers(asctoolkit::sidre::DataGroup * global_grp,
-                         asctoolkit::sidre::DataGroup * domain_grp);
+   void SetGroupPointers(axom::sidre::DataGroup * global_grp,
+                         axom::sidre::DataGroup * domain_grp);
 
-   asctoolkit::sidre::DataGroup * GetBPGroup() { return bp_grp; }
-   asctoolkit::sidre::DataGroup * GetBPIndexGroup() { return bp_index_grp; }
+   axom::sidre::DataGroup * GetBPGroup() { return bp_grp; }
+   axom::sidre::DataGroup * GetBPIndexGroup() { return bp_index_grp; }
 
    /// Prepare the DataStore for writing
    virtual void PrepareToSave();
@@ -326,7 +326,7 @@ public:
        @note To access the underlying pointer, use DataView::getData().
        @note To query the size of the buffer, use DataView::getNumElements().
     */
-   asctoolkit::sidre::DataView *
+   axom::sidre::DataView *
    GetNamedBuffer(const std::string& buffer_name) const
    { return named_buffers_grp()->getView(buffer_name); }
 
@@ -336,11 +336,11 @@ public:
        reallocated with size @a sz, destroying its contents.
        @note To access the underlying pointer, use DataView::getData().
     */
-   asctoolkit::sidre::DataView *
+   axom::sidre::DataView *
    AllocNamedBuffer(const std::string& buffer_name,
-                    asctoolkit::sidre::SidreLength sz,
-                    asctoolkit::sidre::TypeID type =
-                       asctoolkit::sidre::DOUBLE_ID);
+                    axom::sidre::SidreLength sz,
+                    axom::sidre::TypeID type =
+                       axom::sidre::DOUBLE_ID);
 
    /// Deallocate the named buffer @a buffer_name.
    void FreeNamedBuffer(const std::string& buffer_name)
@@ -367,26 +367,26 @@ private:
 
    // If the data collection owns the datastore, it will store a pointer to it.
    // Otherwise, this pointer is NULL.
-   asctoolkit::sidre::DataStore * m_datastore_ptr;
+   axom::sidre::DataStore * m_datastore_ptr;
 
 #ifdef MFEM_USE_MPI
    MPI_Comm m_comm;
 #endif
 
 protected:
-   asctoolkit::sidre::DataGroup *named_buffers_grp() const;
+   axom::sidre::DataGroup *named_buffers_grp() const;
 
-   asctoolkit::sidre::DataView *
-   alloc_view(asctoolkit::sidre::DataGroup *grp,
+   axom::sidre::DataView *
+   alloc_view(axom::sidre::DataGroup *grp,
               const std::string &view_name);
 
-   asctoolkit::sidre::DataView *
-   alloc_view(asctoolkit::sidre::DataGroup *grp,
+   axom::sidre::DataView *
+   alloc_view(axom::sidre::DataGroup *grp,
               const std::string &view_name,
-              const asctoolkit::sidre::DataType &dtype);
+              const axom::sidre::DataType &dtype);
 
-   asctoolkit::sidre::DataGroup *
-   alloc_group(asctoolkit::sidre::DataGroup *grp,
+   axom::sidre::DataGroup *
+   alloc_group(axom::sidre::DataGroup *grp,
                const std::string &group_name);
 
    // return the filename based on prefix_path, collection name and cycle.
@@ -395,11 +395,11 @@ protected:
 private:
    // If the data collection does not own the datastore, it will need pointers
    // to the blueprint and blueprint index group to use.
-   asctoolkit::sidre::DataGroup * bp_grp;
-   asctoolkit::sidre::DataGroup * bp_index_grp;
+   axom::sidre::DataGroup * bp_grp;
+   axom::sidre::DataGroup * bp_index_grp;
 
    // This is stored for convenience.
-   asctoolkit::sidre::DataGroup * named_bufs_grp;
+   axom::sidre::DataGroup * named_bufs_grp;
 
    // Private helper functions
 
@@ -423,7 +423,7 @@ private:
    void addScalarBasedGridFunction(const std::string& field_name,
                                    GridFunction* gf,
                                    const std::string &buffer_name,
-                                   asctoolkit::sidre::SidreLength offset);
+                                   axom::sidre::SidreLength offset);
 
    /**
     * \brief A private helper function to set up the views associated with the
@@ -437,7 +437,7 @@ private:
    void addVectorBasedGridFunction(const std::string& field_name,
                                    GridFunction* gf,
                                    const std::string &buffer_name,
-                                   asctoolkit::sidre::SidreLength offset);
+                                   axom::sidre::SidreLength offset);
 
    /// Sets up the four main mesh blueprint groups.
    /**


### PR DESCRIPTION
Changes required due to renaming of the LLNL's CS Toolkit to 'axom'.

Note: This PR depends on a corresponding PR in the axom project.