### PR TITLE
Change vars in ex8 to 'unsigned int' to avoid optimization warnings [bugfix/fix_baseline_compiler_warning]

### DIFF
--- a/examples/ex8.cpp
+++ b/examples/ex8.cpp
@@ -86,9 +86,9 @@ int main(int argc, char *argv[])
    //    - The test space, test_space, is an enriched space where the enrichment
    //      degree may depend on the spatial dimension of the domain, the type of
    //      the mesh and the trial space order.
-   int trial_order = order;
-   int trace_order = order - 1;
-   int test_order  = order; // reduced order, full order is (order + dim - 1)
+   unsigned int trial_order = order;
+   unsigned int trace_order = order - 1;
+   unsigned int test_order  = order; // reduced order, full order is (order + dim - 1)
    if (dim == 2 && (order%2 == 0 || (mesh->MeshGenerator() & 2 && order > 1)))
    {
       test_order++;

--- a/examples/ex8.cpp
+++ b/examples/ex8.cpp
@@ -88,7 +88,8 @@ int main(int argc, char *argv[])
    //      the mesh and the trial space order.
    unsigned int trial_order = order;
    unsigned int trace_order = order - 1;
-   unsigned int test_order  = order; // reduced order, full order is (order + dim - 1)
+   unsigned int test_order  = order; /* reduced order, full order is
+                                        (order + dim - 1) */
    if (dim == 2 && (order%2 == 0 || (mesh->MeshGenerator() & 2 && order > 1)))
    {
       test_order++;

--- a/examples/ex8p.cpp
+++ b/examples/ex8p.cpp
@@ -116,7 +116,8 @@ int main(int argc, char *argv[])
    //      the mesh and the trial space order.
    unsigned int trial_order = order;
    unsigned int trace_order = order - 1;
-   unsigned int test_order  = order; // reduced order, full order is (order + dim - 1)
+   unsigned int test_order  = order; /* reduced order, full order is
+                                        (order + dim - 1) */
    if (dim == 2 && (order%2 == 0 || (pmesh->MeshGenerator() & 2 && order > 1)))
    {
       test_order++;

--- a/examples/ex8p.cpp
+++ b/examples/ex8p.cpp
@@ -114,9 +114,9 @@ int main(int argc, char *argv[])
    //    - The test space, test_space, is an enriched space where the enrichment
    //      degree may depend on the spatial dimension of the domain, the type of
    //      the mesh and the trial space order.
-   int trial_order = order;
-   int trace_order = order - 1;
-   int test_order  = order; // reduced order, full order is (order + dim - 1)
+   unsigned int trial_order = order;
+   unsigned int trace_order = order - 1;
+   unsigned int test_order  = order; // reduced order, full order is (order + dim - 1)
    if (dim == 2 && (order%2 == 0 || (pmesh->MeshGenerator() & 2 && order > 1)))
    {
       test_order++;


### PR DESCRIPTION
Change some vars in ex8 from int to unsigned int to avoid compiler warning regarding possible overflow.