### PR TITLE
Support any vector dimentsion in NodalFiniteElement::Project. [extend-nodal-projection]

### DIFF
--- a/fem/fe.cpp
+++ b/fem/fe.cpp
@@ -254,10 +254,7 @@ void NodalFiniteElement::Project (
 void NodalFiniteElement::Project (
    VectorCoefficient &vc, ElementTransformation &Trans, Vector &dofs) const
 {
-   MFEM_ASSERT(vc.GetVDim() <= 3, "");
-
-   double v[3];
-   Vector x (v, vc.GetVDim());
+   Vector x(vc.GetVDim());
 
    for (int i = 0; i < Dof; i++)
    {
@@ -270,7 +267,7 @@ void NodalFiniteElement::Project (
       }
       for (int j = 0; j < x.Size(); j++)
       {
-         dofs(Dof*j+i) = v[j];
+         dofs(Dof*j+i) = x(j);
       }
    }
 }


### PR DESCRIPTION
Extend the method `NodalFiniteElement::Project` for `VectorCoefficient` to work with arbitrary number of vector components.