### PR TITLE
Fix petsc build [fix_petsc_build]

### DIFF
--- a/config/defaults.mk
+++ b/config/defaults.mk
@@ -174,9 +174,6 @@ ifeq ($(MFEM_USE_PETSC),YES)
    PETSC_OPT := $(shell sed -n "s/Cflags: *//p" $(PETSC_PC))
    PETSC_LIBS_PRIVATE := $(shell sed -n "s/Libs\.private: *//p" $(PETSC_PC))
    PETSC_LIB := -Wl,-rpath -Wl,$(abspath $(PETSC_DIR))/lib -L$(abspath $(PETSC_DIR))/lib -lpetsc $(PETSC_LIBS_PRIVATE)
-   ifneq ($(SYS_TYPE),)
-   	PETSC_LIB += -Wl,--auto_rpath
-   endif
 endif
 
 # MPFR library configuration

--- a/config/defaults.mk
+++ b/config/defaults.mk
@@ -172,8 +172,8 @@ ifeq ($(MFEM_USE_PETSC),YES)
    PETSC_PC  := $(PETSC_DIR)/lib/pkgconfig/PETSc.pc
    $(if $(wildcard $(PETSC_PC)),,$(error PETSc config not found - $(PETSC_PC)))
    PETSC_OPT := $(shell sed -n "s/Cflags: *//p" $(PETSC_PC))
-   PETSC_LIB := $(shell sed -n "s/Libs.*: *//p" $(PETSC_PC))
-   PETSC_LIB := -Wl,-rpath -Wl,$(abspath $(PETSC_DIR))/lib $(PETSC_LIB)
+   PETSC_LIBS_PRIVATE := $(shell sed -n "s/Libs\.private: *//p" $(PETSC_PC))
+   PETSC_LIB := -Wl,-rpath -Wl,$(abspath $(PETSC_DIR))/lib -L$(abspath $(PETSC_DIR))/lib -lpetsc $(PETSC_LIBS_PRIVATE)
 endif
 
 # MPFR library configuration

--- a/config/defaults.mk
+++ b/config/defaults.mk
@@ -174,6 +174,9 @@ ifeq ($(MFEM_USE_PETSC),YES)
    PETSC_OPT := $(shell sed -n "s/Cflags: *//p" $(PETSC_PC))
    PETSC_LIBS_PRIVATE := $(shell sed -n "s/Libs\.private: *//p" $(PETSC_PC))
    PETSC_LIB := -Wl,-rpath -Wl,$(abspath $(PETSC_DIR))/lib -L$(abspath $(PETSC_DIR))/lib -lpetsc $(PETSC_LIBS_PRIVATE)
+   ifneq ($(SYS_TYPE),)
+   	PETSC_LIB += -Wl,--auto_rpath
+   endif
 endif
 
 # MPFR library configuration


### PR DESCRIPTION
Update logic in default.mk to work with packageconf file in newer petsc versions.

Update logic to use LLNL LC ld auto-rpathing, if available.  Makes it unnecessary to manually add rpaths for shared libraries.