### PR TITLE
Remove old workaround for xlC compiler [fix-xlc-hpc]

### DIFF
--- a/linalg/tmatrix.hpp
+++ b/linalg/tmatrix.hpp
@@ -474,7 +474,7 @@ template <typename scalar_t, typename layout_t, typename data_t>
 inline scalar_t TDet(const layout_t &a, const data_t &A)
 {
    MFEM_STATIC_ASSERT(layout_t::rank == 2, "invalid rank");
-#ifndef __bg__
+#if !defined(__xlC__) || (__xlC__ >= 0x0d00)
    return internal::MatrixOps<layout_t::dim_1,layout_t::dim_2>::
           template Det<scalar_t>(a, A);
 #else

--- a/linalg/tmatrix.hpp
+++ b/linalg/tmatrix.hpp
@@ -474,7 +474,7 @@ template <typename scalar_t, typename layout_t, typename data_t>
 inline scalar_t TDet(const layout_t &a, const data_t &A)
 {
    MFEM_STATIC_ASSERT(layout_t::rank == 2, "invalid rank");
-#ifndef __xlC__
+#ifndef __bg__
    return internal::MatrixOps<layout_t::dim_1,layout_t::dim_2>::
           template Det<scalar_t>(a, A);
 #else
@@ -490,7 +490,7 @@ template <AssignOp::Type Op, typename A_layout_t, typename A_data_t,
 inline void TDet(const A_layout_t &a, const A_data_t &A, D_data_t &D)
 {
    MFEM_STATIC_ASSERT(A_layout_t::rank == 3, "invalid rank");
-#ifndef __xlC__
+#ifndef __bg__
    internal::MatrixOps<A_layout_t::dim_2,A_layout_t::dim_3>::
    template Det<Op>(a, A, D);
 #else

--- a/linalg/tmatrix.hpp
+++ b/linalg/tmatrix.hpp
@@ -490,7 +490,7 @@ template <AssignOp::Type Op, typename A_layout_t, typename A_data_t,
 inline void TDet(const A_layout_t &a, const A_data_t &A, D_data_t &D)
 {
    MFEM_STATIC_ASSERT(A_layout_t::rank == 3, "invalid rank");
-#ifndef __bg__
+#if !defined(__xlC__) || (__xlC__ >= 0x0d00)
    internal::MatrixOps<A_layout_t::dim_2,A_layout_t::dim_3>::
    template Det<Op>(a, A, D);
 #else


### PR DESCRIPTION
The current version of xlC does not require this syntax, and in fact throws an error.

```
In file included from ../../mfem-performance.hpp:18:0,
                 from ex1.cpp:32:
../../linalg/tmatrix.hpp: In function ‘scalar_t mfem::TDet(const layout_t&, const data_t&)’:
../../linalg/tmatrix.hpp:478:20: error: expected primary-expression before ‘>’ token
        Det<scalar_t>(a, A); 
```