### PR TITLE
Improve operator conversion and allow setting two operators for linear solver

### DIFF
--- a/examples/petsc/makefile
+++ b/examples/petsc/makefile
@@ -72,7 +72,8 @@ TESTNAME = Parallel PETSc example
 
 
 # Testing PETSc execution options.
-EX1_ARGS      := -m ../../data/amr-quad.mesh --usepetsc --petscopts rc_ex1p
+EX1_ARGS_W    := -m ../../data/amr-quad.mesh --usepetsc
+EX1_ARGS_P    := -m ../../data/amr-quad.mesh --usepetsc --petscopts rc_ex1p
 EX2_ARGS      := -m ../../data/beam-quad.mesh --usepetsc --petscopts rc_ex2p
 EX3_ARGS      := -m ../../data/klein-bottle.mesh -o 2 -f 0.1 --usepetsc --petscopts rc_ex3p_bddc --nonoverlapping
 EX4_ARGS      := -m ../../data/klein-bottle.mesh -o 2 --usepetsc --petscopts rc_ex4p_bddc --nonoverlapping
@@ -82,7 +83,8 @@ EX6_ARGS      := -m ../../data/amr-quad.mesh --usepetsc
 EX9_ARGS      := -m ../../data/periodic-hexagon.mesh --usepetsc --petscopts rc_ex9p_expl
 EX10_ARGS     := -m ../../data/beam-quad.mesh --usepetsc --petscopts rc_ex10p -tf 30 -s 3 -rs 2 -dt 3
 ex1p-test-par: ex1p
-	@$(call mfem-test,$<, $(RUN_MPI), $(TESTNAME),$(EX1_ARGS))
+	@$(call mfem-test,$<, $(RUN_MPI), $(TESTNAME),$(EX1_ARGS_W))
+	@$(call mfem-test,$<, $(RUN_MPI), $(TESTNAME),$(EX1_ARGS_P))
 ex2p-test-par: ex2p
 	@$(call mfem-test,$<, $(RUN_MPI), $(TESTNAME),$(EX2_ARGS))
 ex3p-test-par: ex3p

--- a/linalg/petsc.cpp
+++ b/linalg/petsc.cpp
@@ -641,10 +641,10 @@ void PetscParMatrix::ConvertOperator(MPI_Comm comm, const Operator &op, Mat* A,
       {
          if (tid == pA->GetType()) // use same object and return
          {
-           ierr = PetscObjectReference((PetscObject)(pA->A));
-           CCHKERRQ(pA->GetComm(),ierr);
-           *A = pA->A;
-           return;
+            ierr = PetscObjectReference((PetscObject)(pA->A));
+            CCHKERRQ(pA->GetComm(),ierr);
+            *A = pA->A;
+            return;
          }
          ierr = PetscObjectTypeCompare((PetscObject)(pA->A),MATIS,&ismatis);
          CCHKERRQ(pA->GetComm(),ierr);
@@ -678,19 +678,21 @@ void PetscParMatrix::ConvertOperator(MPI_Comm comm, const Operator &op, Mat* A,
          else
          {
             PetscMPIInt size;
-            ierr = MPI_Comm_size(comm,&size);CCHKERRQ(comm,ierr);
+            ierr = MPI_Comm_size(comm,&size); CCHKERRQ(comm,ierr);
 
             // call MatConvert and see if a converter is available
             if (istrans)
             {
                Mat B;
-               ierr = MatConvert(At,size > 1 ? MATMPIAIJ : MATSEQAIJ,MAT_INITIAL_MATRIX,&B);PCHKERRQ(pA->A,ierr);
+               ierr = MatConvert(At,size > 1 ? MATMPIAIJ : MATSEQAIJ,MAT_INITIAL_MATRIX,&B);
+               PCHKERRQ(pA->A,ierr);
                ierr = MatCreateTranspose(B,A); PCHKERRQ(pA->A,ierr);
-               ierr = MatDestroy(&B);PCHKERRQ(pA->A,ierr);
+               ierr = MatDestroy(&B); PCHKERRQ(pA->A,ierr);
             }
             else
             {
-               ierr = MatConvert(pA->A, size > 1 ? MATMPIAIJ : MATSEQAIJ,MAT_INITIAL_MATRIX,A);PCHKERRQ(pA->A,ierr);
+               ierr = MatConvert(pA->A, size > 1 ? MATMPIAIJ : MATSEQAIJ,MAT_INITIAL_MATRIX,A);
+               PCHKERRQ(pA->A,ierr);
             }
          }
       }
@@ -699,13 +701,13 @@ void PetscParMatrix::ConvertOperator(MPI_Comm comm, const Operator &op, Mat* A,
          if (istrans)
          {
             Mat B;
-            ierr = MatConvert(At,MATIS,MAT_INITIAL_MATRIX,&B);PCHKERRQ(pA->A,ierr);
+            ierr = MatConvert(At,MATIS,MAT_INITIAL_MATRIX,&B); PCHKERRQ(pA->A,ierr);
             ierr = MatCreateTranspose(B,A); PCHKERRQ(pA->A,ierr);
             ierr = MatDestroy(&B); PCHKERRQ(pA->A,ierr);
          }
          else
          {
-            ierr = MatConvert(pA->A,MATIS,MAT_INITIAL_MATRIX,A);PCHKERRQ(pA->A,ierr);
+            ierr = MatConvert(pA->A,MATIS,MAT_INITIAL_MATRIX,A); PCHKERRQ(pA->A,ierr);
          }
       }
       else if (tid == PETSC_MATSHELL)
@@ -745,7 +747,8 @@ void PetscParMatrix::ConvertOperator(MPI_Comm comm, const Operator &op, Mat* A,
       }
       else
       {
-         MFEM_ABORT("Conversion from HypreParCSR to operator type = " << tid << " is not implemented");
+         MFEM_ABORT("Conversion from HypreParCSR to operator type = " << tid <<
+                    " is not implemented");
       }
    }
    else if (pB)
@@ -1581,11 +1584,11 @@ void PetscLinearSolver::SetOperator(const Operator &op)
    KSP ksp = (KSP)obj;
    Mat P = NULL;
    PetscBool pmat;
-   ierr = KSPGetOperatorsSet(ksp,NULL,&pmat);PCHKERRQ(ksp,ierr);
+   ierr = KSPGetOperatorsSet(ksp,NULL,&pmat); PCHKERRQ(ksp,ierr);
    if (pmat)
    {
-      ierr = KSPGetOperators(ksp,NULL,&P);PCHKERRQ(ksp,ierr);
-      ierr = PetscObjectReference((PetscObject)P);PCHKERRQ(ksp,ierr);
+      ierr = KSPGetOperators(ksp,NULL,&P); PCHKERRQ(ksp,ierr);
+      ierr = PetscObjectReference((PetscObject)P); PCHKERRQ(ksp,ierr);
    }
 
    // update base classes: Operator, Solver, PetscLinearSolver
@@ -1602,7 +1605,8 @@ void PetscLinearSolver::SetOperator(const Operator &op)
       {
          // Create MATSHELL or MATNEST (if oA is a BlockOperator) object
          // If oA is a BlockOperator, Operator::Type is relevant to the subblocks
-         pA = new PetscParMatrix(PetscObjectComm(obj),oA, wrap ? PETSC_MATSHELL : PETSC_MATAIJ);
+         pA = new PetscParMatrix(PetscObjectComm(obj),oA,
+                                 wrap ? PETSC_MATSHELL : PETSC_MATAIJ);
          delete_pA = true;
       }
    }
@@ -1631,12 +1635,12 @@ void PetscLinearSolver::SetOperator(const Operator &op)
    }
    if (P)
    {
-     ierr = KSPSetOperators(ksp,A,P);PCHKERRQ(ksp,ierr);
-     ierr = MatDestroy(&P);PCHKERRQ(ksp,ierr);
+      ierr = KSPSetOperators(ksp,A,P); PCHKERRQ(ksp,ierr);
+      ierr = MatDestroy(&P); PCHKERRQ(ksp,ierr);
    }
    else
    {
-     ierr = KSPSetOperators(ksp,A,A);PCHKERRQ(ksp,ierr);
+      ierr = KSPSetOperators(ksp,A,A); PCHKERRQ(ksp,ierr);
    }
 
    // Update PetscSolver
@@ -1674,7 +1678,8 @@ void PetscLinearSolver::SetOperator(const Operator &op, const Operator &pop)
       {
          // Create MATSHELL or MATNEST (if oA is a BlockOperator) object
          // If oA is a BlockOperator, Operator::Type is relevant to the subblocks
-         pA = new PetscParMatrix(PetscObjectComm(obj),oA, wrap ? PETSC_MATSHELL : PETSC_MATAIJ);
+         pA = new PetscParMatrix(PetscObjectComm(obj),oA,
+                                 wrap ? PETSC_MATSHELL : PETSC_MATAIJ);
          delete_pA = true;
       }
    }
@@ -1739,11 +1744,11 @@ void PetscLinearSolver::SetPreconditioner(Solver &precond)
    // Preserve Amat if already set
    Mat A = NULL;
    PetscBool amat;
-   ierr = KSPGetOperatorsSet(ksp,&amat,NULL);PCHKERRQ(ksp,ierr);
+   ierr = KSPGetOperatorsSet(ksp,&amat,NULL); PCHKERRQ(ksp,ierr);
    if (amat)
    {
-      ierr = KSPGetOperators(ksp,&A,NULL);PCHKERRQ(ksp,ierr);
-      ierr = PetscObjectReference((PetscObject)A);PCHKERRQ(ksp,ierr);
+      ierr = KSPGetOperators(ksp,&A,NULL); PCHKERRQ(ksp,ierr);
+      ierr = PetscObjectReference((PetscObject)A); PCHKERRQ(ksp,ierr);
    }
    PetscPreconditioner *ppc = dynamic_cast<PetscPreconditioner *>(&precond);
    if (ppc)
@@ -1768,11 +1773,11 @@ void PetscLinearSolver::SetPreconditioner(Solver &precond)
    {
       Mat P;
 
-      ierr = KSPGetOperators(ksp,NULL,&P);PCHKERRQ(ksp,ierr);
-      ierr = PetscObjectReference((PetscObject)P);PCHKERRQ(ksp,ierr);
-      ierr = KSPSetOperators(ksp,A,P);PCHKERRQ(ksp,ierr);
-      ierr = MatDestroy(&A);PCHKERRQ(ksp,ierr);
-      ierr = MatDestroy(&P);PCHKERRQ(ksp,ierr);
+      ierr = KSPGetOperators(ksp,NULL,&P); PCHKERRQ(ksp,ierr);
+      ierr = PetscObjectReference((PetscObject)P); PCHKERRQ(ksp,ierr);
+      ierr = KSPSetOperators(ksp,A,P); PCHKERRQ(ksp,ierr);
+      ierr = MatDestroy(&A); PCHKERRQ(ksp,ierr);
+      ierr = MatDestroy(&P); PCHKERRQ(ksp,ierr);
    }
 }
 


### PR DESCRIPTION
This branch allows prescribing two different operators for the linear solver, following PETSc philosophy.
One is the operator for the linear system, one is the operator used to build the preconditioner

I have also modified how ConvertOperator works internally
