### PR TITLE
Shaper miniapp: anisotropic refinement option for quads/hexes. [shaper-aniso-dev]

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -21,13 +21,13 @@ Development version 3.3.1, not released
   refinement hierarchy, but excluding the temporary face_list and edge_list)
   is now only about 290 bytes. This also makes the class faster.
 
-- Added a new meshing miniapp, Shaper, that can be used to resolve
-  complicated material interfaces by mesh refinement, e.g. as a tool
-  for initial mesh generation from prescribed "material()" function.
-  Both conforming and non-conforming refinements are supported.
+- Added a new meshing miniapp, Shaper, that can be used to resolve complicated
+  material interfaces by mesh refinement, e.g. as a tool for initial mesh
+  generation from prescribed "material()" function.  Both conforming and
+  non-conforming (isotropic and anisotropic) refinements are supported.
 
-- Added a block lower triangular preconditioner based only on the
-  actions of each block see class BlockLowerTriangularPreconditioner.
+- Added a block lower triangular preconditioner based (only) on the actions of
+  each block, see class BlockLowerTriangularPreconditioner.
 
 
 Version 3.3, released on Jan 28, 2017

--- a/mesh/mesh.cpp
+++ b/mesh/mesh.cpp
@@ -7591,7 +7591,11 @@ void Mesh::PrintWithPartitioning(int *partitioning, std::ostream &out,
          l = partitioning[l];
          if (k != l)
          {
-            nbe += 2;
+            nbe++;
+            if (!Nonconforming() || !IsSlaveFace(faces_info[i]))
+            {
+               nbe++;
+            }
          }
       }
       else
@@ -7616,12 +7620,15 @@ void Mesh::PrintWithPartitioning(int *partitioning, std::ostream &out,
                out << ' ' << v[j];
             }
             out << '\n';
-            out << l+1 << ' ' << faces[i]->GetGeometryType();
-            for (j = nv-1; j >= 0; j--)
+            if (!Nonconforming() || !IsSlaveFace(faces_info[i]))
             {
-               out << ' ' << v[j];
+               out << l+1 << ' ' << faces[i]->GetGeometryType();
+               for (j = nv-1; j >= 0; j--)
+               {
+                  out << ' ' << v[j];
+               }
+               out << '\n';
             }
-            out << '\n';
          }
       }
       else

--- a/miniapps/meshing/shaper.cpp
+++ b/miniapps/meshing/shaper.cpp
@@ -149,35 +149,35 @@ int main(int argc, char *argv[])
             int type = 7;
             if (aniso)
             {
-                // Determine the XYZ bitmask for anisotropic refinement.
-                int dx = 0, dy = 0, dz = 0;
-                const int s = sd+1;
-                if (dim == 2)
-                {
-                    for (int j = 0; j <= sd; j++)
-                    for (int i = 0; i < sd; i++)
-                    {
+               // Determine the XYZ bitmask for anisotropic refinement.
+               int dx = 0, dy = 0, dz = 0;
+               const int s = sd+1;
+               if (dim == 2)
+               {
+                  for (int j = 0; j <= sd; j++)
+                     for (int i = 0; i < sd; i++)
+                     {
                         dx += abs(mat[j*s + i+1] - mat[j*s + i]);
                         dy += abs(mat[(i+1)*s + j] - mat[i*s + j]);
-                    }
-                }
-                else if (dim == 3)
-                {
-                    for (int k = 0; k <= sd; k++)
-                    for (int j = 0; j <= sd; j++)
-                    for (int i = 0; i < sd; i++)
-                    {
-                        dx += abs(mat[(k*s + j)*s + i+1] - mat[(k*s + j)*s + i]);
-                        dy += abs(mat[(k*s + i+1)*s + j] - mat[(k*s + i)*s + j]);
-                        dz += abs(mat[((i+1)*s + j)*s + k] - mat[(i*s + j)*s + k]);
-                    }
-                }
-                type = 0;
-                const int tol = mat.Size() / 10;
-                if (dx > tol) { type |= 1; }
-                if (dy > tol) { type |= 2; }
-                if (dz > tol) { type |= 4; }
-                if (!type) { type = 7; } // because of tol
+                     }
+               }
+               else if (dim == 3)
+               {
+                  for (int k = 0; k <= sd; k++)
+                     for (int j = 0; j <= sd; j++)
+                        for (int i = 0; i < sd; i++)
+                        {
+                           dx += abs(mat[(k*s + j)*s + i+1] - mat[(k*s + j)*s + i]);
+                           dy += abs(mat[(k*s + i+1)*s + j] - mat[(k*s + i)*s + j]);
+                           dz += abs(mat[((i+1)*s + j)*s + k] - mat[(i*s + j)*s + k]);
+                        }
+               }
+               type = 0;
+               const int tol = mat.Size() / 10;
+               if (dx > tol) { type |= 1; }
+               if (dy > tol) { type |= 2; }
+               if (dz > tol) { type |= 4; }
+               if (!type) { type = 7; } // because of tol
             }
 
             refs.Append(Refinement(i, type));


### PR DESCRIPTION
Added the "--aniso" option in miniapps/shaper. If set, additional processing is done for each element to be refined, to determine which of the possible x/y/z splits are needed. 

I modified the run "shaper -m ../../data/beam-quad.mesh" which seems to be a suitable 2D case that benefits from the anisotropic refinements.

There is a new 3D run on "fichera-amr.mesh", this is interesting because of the already existing anisotropy which actually needs to be removed by the miniapp at some places, and introduced at others. The original code (--iso) doesn't work well on this mesh.

The dx/dy/dz calculation relies on the ordering of the points returned by GlobGeometryRefiner -- not sure if this is OK.

There is a tolerance (NPoints/10) in the anisotropic decisions, this is to avoid too conservative (isotropic) refinements. I'm am not 100% certain about this code, maybe there is another way to design the x/y/z refinement thresholds.
