### PR TITLE
[Evaluate for merging] A more reliable way to send data to GLVis in parallel [par-sockets-dev]

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -11,6 +11,13 @@
 Development version 3.3.1, not released
 =======================================
 
+- In all parallel examples, when sending data to GLVis, switch to using the new
+  methods, open_parallel and send_parallel, from class socketstream.
+
+- In class socketstream, added new methods, open_parallel and send_parallel,
+  that handle connections to GLVis from parallel MPI code in a more reliable and
+  synchronized manner.
+
 - Added a new macro, MFEM_VERSION, defined as a single integer of the form
   (major*100 + minor)*100 + patch. The new convention is that an even number
   (i.e. even patch number) denotes a "release" version, while an odd number

--- a/examples/ex11p.cpp
+++ b/examples/ex11p.cpp
@@ -267,7 +267,8 @@ int main(int argc, char *argv[])
    {
       char vishost[] = "localhost";
       int  visport   = 19916;
-      socketstream mode_sock(vishost, visport);
+      socketstream mode_sock;
+      mode_sock.open_parallel(MPI_COMM_WORLD, vishost, visport);
       mode_sock.precision(8);
 
       for (int i=0; i<nev; i++)
@@ -281,9 +282,8 @@ int main(int argc, char *argv[])
          // convert eigenvector from HypreParVector to ParGridFunction
          x = lobpcg->GetEigenvector(i);
 
-         mode_sock << "parallel " << num_procs << " " << myid << "\n"
-                   << "solution\n" << *pmesh << x << flush
-                   << "window_title 'Eigenmode " << i+1 << '/' << nev
+         mode_sock.send_parallel(*pmesh, x);
+         mode_sock << "window_title 'Eigenmode " << i+1 << '/' << nev
                    << ", Lambda = " << eigenvalues[i] << "'" << endl;
 
          char c;
@@ -299,7 +299,7 @@ int main(int argc, char *argv[])
             break;
          }
       }
-      mode_sock.close();
+      mode_sock.close(); // not needed, just for clarity
    }
 
    // 12. Free the used memory.

--- a/examples/ex1p.cpp
+++ b/examples/ex1p.cpp
@@ -224,10 +224,10 @@ int main(int argc, char *argv[])
    {
       char vishost[] = "localhost";
       int  visport   = 19916;
-      socketstream sol_sock(vishost, visport);
-      sol_sock << "parallel " << num_procs << " " << myid << "\n";
+      socketstream sol_sock;
+      sol_sock.open_parallel(MPI_COMM_WORLD, vishost, visport);
       sol_sock.precision(8);
-      sol_sock << "solution\n" << *pmesh << x << flush;
+      sol_sock.send_parallel(*pmesh, x);
    }
 
    // 16. Free the used memory.

--- a/examples/ex2p.cpp
+++ b/examples/ex2p.cpp
@@ -300,10 +300,10 @@ int main(int argc, char *argv[])
    {
       char vishost[] = "localhost";
       int  visport   = 19916;
-      socketstream sol_sock(vishost, visport);
-      sol_sock << "parallel " << num_procs << " " << myid << "\n";
+      socketstream sol_sock;
+      sol_sock.open_parallel(MPI_COMM_WORLD, vishost, visport);
       sol_sock.precision(8);
-      sol_sock << "solution\n" << *pmesh << x << flush;
+      sol_sock.send_parallel(*pmesh, x);
    }
 
    // 18. Free the used memory.

--- a/examples/ex3p.cpp
+++ b/examples/ex3p.cpp
@@ -236,10 +236,10 @@ int main(int argc, char *argv[])
    {
       char vishost[] = "localhost";
       int  visport   = 19916;
-      socketstream sol_sock(vishost, visport);
-      sol_sock << "parallel " << num_procs << " " << myid << "\n";
+      socketstream sol_sock;
+      sol_sock.open_parallel(MPI_COMM_WORLD, vishost, visport);
       sol_sock.precision(8);
-      sol_sock << "solution\n" << *pmesh << x << flush;
+      sol_sock.send_parallel(*pmesh, x);
    }
 
    // 17. Free the used memory.

--- a/examples/ex4p.cpp
+++ b/examples/ex4p.cpp
@@ -263,10 +263,10 @@ int main(int argc, char *argv[])
    {
       char vishost[] = "localhost";
       int  visport   = 19916;
-      socketstream sol_sock(vishost, visport);
-      sol_sock << "parallel " << num_procs << " " << myid << "\n";
+      socketstream sol_sock;
+      sol_sock.open_parallel(MPI_COMM_WORLD, vishost, visport);
       sol_sock.precision(8);
-      sol_sock << "solution\n" << *pmesh << x << flush;
+      sol_sock.send_parallel(*pmesh, x);
    }
 
    // 17. Free the used memory.


### PR DESCRIPTION
In class socketstream, add new methods, in parallel, which should be a much more reliable way to connect and send data to GLVis in parallel. These methods basically serialize the communications by processor rank: first rank 0 connects or sends its data; then after rank 0 is done and if there were no errors, rank 1 takes turn, and so on. This approach should be very reliable because it follows the logic/sequence used in GLVis.

Updated examples 1p, 2p, 3p, 4p, 10p, and 11p to use the new methods; if all testing goes smooth, we should update the rest of the parallel examples too.