### PR TITLE
Mesh copy constructor bug fix [mesh-copy-ctor-bugfix]

### DIFF
--- a/mesh/mesh.cpp
+++ b/mesh/mesh.cpp
@@ -2286,6 +2286,10 @@ Mesh::Mesh(const Mesh &mesh, bool copy_nodes)
 
    meshgen = mesh.meshgen;
 
+   // Create the new Mesh instance without a record of its refinement history
+   sequence = 0;
+   last_operation = Mesh::NONE;
+
    // Duplicate the elements
    elements.SetSize(NumOfElements);
    for (int i = 0; i < NumOfElements; i++)


### PR DESCRIPTION
The member data Mesh::sequence and Mesh::last_operation were not being set in the copy constructor.  These are used as flags to keep track of the mesh state during refinement and derefinement.  Following Jakub's suggestion we chose to set these to the default values for newly created meshes.