### PR TITLE
SidreDataCollection changes, rename "asctoolkit" to "axom".  [exo-dev]

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -187,7 +187,7 @@ Improved file output
 - Added experimental support for an HDF5-based output file format following the
   Conduit (https://github.com/LLNL/conduit) mesh blueprint specification for
   visualization and/or restart capability. This functionality is aimed primarily
-  at user of LLNL's ASC Toolkit (Sidre component) that run problems at extreme
+  at user of LLNL's axom project (Sidre component) that run problems at extreme
   scales. Users desiring a small scale binary format may want to look at the
   gzstream functionality instead.
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,7 +57,7 @@ if (CMAKE_VERSION VERSION_LESS 3.2 OR MFEM_USE_SIDRE OR MFEM_USE_PETSC)
    # This seems to be needed by:
    #  * find_package(BLAS REQUIRED) and
    #  * find_package(HDF5 REQUIRED) needed, in turn, by:
-   #    - find_package(ATK REQUIRED)
+   #    - find_package(AXOM REQUIRED)
    #  * find_package(PETSc REQUIRED)
    enable_language(C)
 endif()
@@ -200,11 +200,11 @@ endif()
 # Axom/Sidre
 if (MFEM_USE_SIDRE)
   if (NOT MFEM_USE_MPI)
-    find_package(ATK REQUIRED Sidre SLIC common)
+    find_package(Axom REQUIRED Sidre SLIC axom_utils)
   else()
-    find_package(ATK REQUIRED Sidre SPIO SLIC common)
+    find_package(Axom REQUIRED Sidre SPIO SLIC axom_utils)
   endif()
-  include_directories(${ATK_INCLUDE_DIRS})
+  include_directories(${AXOM_INCLUDE_DIRS})
 endif()
 
 # MFEM_TIMER_TYPE
@@ -225,7 +225,7 @@ endif()
 
 # List all possible libraries in order of dependencies.
 set(MFEM_TPLS HYPRE OPENMP SUNDIALS MESQUITE SuiteSparse SuperLUDist
-    ParMETIS METIS LAPACK BLAS GECKO GNUTLS NETCDF PETSC MPFR ATK POSIXCLOCKS
+    ParMETIS METIS LAPACK BLAS GECKO GNUTLS NETCDF PETSC MPFR AXOM POSIXCLOCKS
     MFEMBacktrace ZLIB)
 # Add all *_FOUND libraries in the variable TPL_LIBRARIES.
 set(TPL_LIBRARIES "")

--- a/config/cmake/modules/FindAxom.cmake
+++ b/config/cmake/modules/FindAxom.cmake
@@ -10,15 +10,15 @@
 # Software Foundation) version 2.1 dated February 1999.
 
 # Defines the following variables:
-#   - ATK_FOUND
-#   - ATK_LIBRARIES
-#   - ATK_INCLUDE_DIRS
+#   - AXOM_FOUND
+#   - AXOM_LIBRARIES
+#   - AXOM_INCLUDE_DIRS
 
 include(MfemCmakeUtilities)
 # Note: components are enabled based on the find_package() parameters.
-mfem_find_package(ATK ATK ATK_DIR "include" "" "lib" ""
-  "Paths to headers required by ATK." "Libraries required by ATK."
+mfem_find_package(Axom AXOM AXOM_DIR "include" "" "lib" ""
+  "Paths to headers required by Axom." "Libraries required by Axom."
   ADD_COMPONENT Sidre "include" sidre/sidre.hpp "lib" sidre
   ADD_COMPONENT SPIO "include" spio/IOManager.hpp "lib" spio
   ADD_COMPONENT SLIC "include" slic/slic.hpp "lib" slic
-  ADD_COMPONENT common "include" common/ATKMacros.hpp "lib" common)
+  ADD_COMPONENT axom_utils "include" axom_utils/Utilities.hpp "lib" axom_utils)

--- a/config/defaults.cmake
+++ b/config/defaults.cmake
@@ -35,7 +35,7 @@ option(MFEM_USE_GNUTLS "Enable GNUTLS usage" OFF)
 option(MFEM_USE_NETCDF "Enable NETCDF usage" OFF)
 option(MFEM_USE_PETSC "Enable PETSc support." OFF)
 option(MFEM_USE_MPFR "Enable MPFR usage." OFF)
-option(MFEM_USE_SIDRE "Enable ATK/Sidre usage" OFF)
+option(MFEM_USE_SIDRE "Enable Axom/Sidre usage" OFF)
 
 # Allow a user to disable testing, examples, and/or miniapps at CONFIGURE TIME
 # if they don't want/need them (e.g. if MFEM is "just a dependency" and all they
@@ -111,10 +111,10 @@ set(CONDUIT_DIR "${MFEM_DIR}/../conduit" CACHE PATH
 set(Conduit_REQUIRED_PACKAGES "HDF5" CACHE STRING
     "Additional packages required by Conduit.")
 
-set(ATK_DIR "${MFEM_DIR}/../asctoolkit" CACHE PATH "Path to the ATK library.")
+set(AXOM_DIR "${MFEM_DIR}/../axom" CACHE PATH "Path to the Axom library.")
 # May need to add "Boost" as requirement.
-set(ATK_REQUIRED_PACKAGES "Conduit/relay" CACHE STRING
-    "Additional packages required by ATK.")
+set(Axom_REQUIRED_PACKAGES "Conduit/relay" CACHE STRING
+    "Additional packages required by Axom.")
 
 set(BLAS_INCLUDE_DIRS "" CACHE STRING "Path to BLAS headers.")
 set(BLAS_LIBRARIES "" CACHE STRING "The BLAS library.")

--- a/config/defaults.mk
+++ b/config/defaults.mk
@@ -182,19 +182,20 @@ MPFR_LIB = -lmpfr
 
 # Sidre and required libraries configuration
 # Be sure to check the HDF5_DIR (set above) is correct
-SIDRE_DIR = @MFEM_DIR@/../asctoolkit
+SIDRE_DIR = @MFEM_DIR@/../axom
 CONDUIT_DIR = @MFEM_DIR@/../conduit
 SIDRE_OPT = -I$(SIDRE_DIR)/include -I$(CONDUIT_DIR)/include/conduit\
  -I$(HDF5_DIR)/include
-SIDRE_LIB = -L$(SIDRE_DIR)/lib \
-            -L$(CONDUIT_DIR)/lib \
-            -Wl,-rpath -Wl,$(CONDUIT_DIR)/lib \
-            -L$(HDF5_DIR)/lib\
-            -Wl,-rpath -Wl,$(HDF5_DIR)/lib \
-            -lsidre -lslic -lcommon -lconduit -lconduit_relay -lhdf5 -lz -ldl
+SIDRE_LIB = \
+   -L$(SIDRE_DIR)/lib \
+   -L$(CONDUIT_DIR)/lib \
+   -Wl,-rpath -Wl,$(CONDUIT_DIR)/lib \
+   -L$(HDF5_DIR)/lib \
+   -Wl,-rpath -Wl,$(HDF5_DIR)/lib \
+   -lsidre -lslic -laxom_utils -lconduit -lconduit_relay -lhdf5 -lz -ldl
 
 ifeq ($(MFEM_USE_MPI),YES)
-   SIDRE_LIB += -lspio -lcommon
+   SIDRE_LIB += -lspio
 endif
 
 # If YES, enable some informational messages

--- a/fem/sidredatacollection.cpp
+++ b/fem/sidredatacollection.cpp
@@ -125,13 +125,19 @@ SidreDataCollection::alloc_view(axom::sidre::Group *grp,
                                 const std::string &view_name)
 {
    MFEM_ASSERT(grp, "Group pointer is NULL");
-   sidre::View *v = grp->getView(view_name);
-   if (!v)
+   sidre::View *v = NULL;
+   
+   if (! grp->hasView(view_name) )
    {
       v = grp->createView(view_name);
       MFEM_ASSERT(v, "error allocating View " << view_name
                   << " in group " << grp->getPathName());
    }
+   else
+   {
+      v = grp->getView(view_name);
+   }
+   
    return v;
 }
 
@@ -142,8 +148,9 @@ SidreDataCollection::alloc_view(axom::sidre::Group *grp,
                                 const axom::sidre::DataType &dtype)
 {
    MFEM_ASSERT(grp, "Group pointer is NULL");
-   sidre::View *v = grp->getView(view_name);
-   if (!v)
+   sidre::View *v = NULL;
+   
+   if (! grp->hasView(view_name))
    {
       v = grp->createView(view_name, dtype);
       MFEM_ASSERT(v, "error allocating View " << view_name
@@ -151,6 +158,7 @@ SidreDataCollection::alloc_view(axom::sidre::Group *grp,
    }
    else
    {
+      v = grp->getView(view_name);
       MFEM_ASSERT(v->getSchema().dtype().equals(dtype), "");
    }
    return v;
@@ -162,12 +170,17 @@ SidreDataCollection::alloc_group(axom::sidre::Group *grp,
                                  const std::string &group_name)
 {
    MFEM_ASSERT(grp, "Group pointer is NULL");
-   sidre::Group *g = grp->getGroup(group_name);
-   if (!g)
+   sidre::Group *g = NULL;
+   
+   if (! grp->hasGroup(group_name) )
    {
       g = grp->createGroup(group_name);
       MFEM_ASSERT(g, "error allocating Group " << group_name
                   << " in group " << grp->getPathName());
+   }
+   else
+   {
+      g = grp->getGroup(group_name);
    }
    return g;
 }
@@ -197,14 +210,16 @@ SidreDataCollection::AllocNamedBuffer(const std::string& buffer_name,
 {
    sz = std::max(sz, sidre::SidreLength(0));
    sidre::Group *f = named_buffers_grp();
-   sidre::View  *v = f->getView(buffer_name);
-   if ( v == NULL )
+   sidre::View  *v = NULL;
+   
+   if(! f->hasView(buffer_name) )
    {
       // create a buffer view
       v = f->createViewAndAllocate(buffer_name, type, sz);
    }
    else
    {
+      v = f->getView(buffer_name);
       MFEM_ASSERT(v->getTypeID() == type, "type does not match existing type");
 
       // Here v is the view holding the buffer in the named_buffers group, so

--- a/fem/sidredatacollection.cpp
+++ b/fem/sidredatacollection.cpp
@@ -537,8 +537,9 @@ void SidreDataCollection::createMeshBlueprintAdjacencies(bool hasBP)
          group_grp->createViewString("association", "vertex");
          group_grp->createViewString("topology", "mesh");
 
-         sidre::View* gneighbors_view = group_grp->createViewAndAllocate(
-                                           "neighbors", sidre::INT_ID, num_gneighbors - 1);
+         sidre::View* gneighbors_view =
+            group_grp->createViewAndAllocate(
+               "neighbors", sidre::INT_ID, num_gneighbors - 1);
          int* gneighbors_data = gneighbors_view->getData<int*>();
 
          // skip local domain when adding Blueprint neighbors
@@ -1018,14 +1019,15 @@ void SidreDataCollection::RegisterField(const std::string &field_name,
       //    the data collection.
       if (HasField(field_name))
       {
-         MFEM_DEBUG_DO(
-            // Warn about overwriting field.
-            // Skip warning when re-registering the nodal grid function
-            if (field_name != m_meshNodesGFName)
-      {
-         MFEM_WARNING("field with the name '" << field_name<< "' is already "
-                      "registered, overwriting the old field");
-         });
+#ifdef MFEM_DEBUG
+         // Warn about overwriting field.
+         // Skip warning when re-registering the nodal grid function
+         if (field_name != m_meshNodesGFName)
+         {
+            MFEM_WARNING("field with the name '" << field_name<< "' is already "
+                         "registered, overwriting the old field");
+         }
+#endif
          DeregisterField(field_name);
       }
    }

--- a/fem/sidredatacollection.cpp
+++ b/fem/sidredatacollection.cpp
@@ -40,9 +40,9 @@ SidreDataCollection::SidreDataCollection(const std::string& collection_name,
 {
    m_datastore_ptr = new sidre::DataStore();
 
-   sidre::DataGroup * global_grp =
+   sidre::Group * global_grp =
       m_datastore_ptr->getRoot()->createGroup(collection_name + "_global");
-   sidre::DataGroup * domain_grp =
+   sidre::Group * domain_grp =
       m_datastore_ptr->getRoot()->createGroup(collection_name);
 
    bp_grp = domain_grp->createGroup("blueprint");
@@ -70,8 +70,8 @@ SidreDataCollection::SidreDataCollection(const std::string& collection_name,
 // in the future.  When this is available, all the blueprint index code can be
 // removed from the data collection class.
 SidreDataCollection::SidreDataCollection(const std::string& collection_name,
-                                         axom::sidre::DataGroup* global_grp,
-                                         axom::sidre::DataGroup* domain_grp,
+                                         axom::sidre::Group* global_grp,
+                                         axom::sidre::Group* domain_grp,
                                          bool own_mesh_data)
    : mfem::DataCollection(collection_name),
      m_owns_datastore(false),
@@ -111,7 +111,7 @@ void SidreDataCollection::SetComm(MPI_Comm comm)
 #endif
 
 // protected method
-sidre::DataGroup *SidreDataCollection::named_buffers_grp() const
+sidre::Group *SidreDataCollection::named_buffers_grp() const
 {
    MFEM_ASSERT(named_bufs_grp != NULL,
                "No group 'named_buffers' in data collection.  Verify that"
@@ -120,33 +120,33 @@ sidre::DataGroup *SidreDataCollection::named_buffers_grp() const
 }
 
 // protected method
-axom::sidre::DataView *
-SidreDataCollection::alloc_view(axom::sidre::DataGroup *grp,
+axom::sidre::View *
+SidreDataCollection::alloc_view(axom::sidre::Group *grp,
                                 const std::string &view_name)
 {
-   MFEM_ASSERT(grp, "DataGroup pointer is NULL");
-   sidre::DataView *v = grp->getView(view_name);
+   MFEM_ASSERT(grp, "Group pointer is NULL");
+   sidre::View *v = grp->getView(view_name);
    if (!v)
    {
       v = grp->createView(view_name);
-      MFEM_ASSERT(v, "error allocating DataView " << view_name
+      MFEM_ASSERT(v, "error allocating View " << view_name
                   << " in group " << grp->getPathName());
    }
    return v;
 }
 
 // protected method
-axom::sidre::DataView *
-SidreDataCollection::alloc_view(axom::sidre::DataGroup *grp,
+axom::sidre::View *
+SidreDataCollection::alloc_view(axom::sidre::Group *grp,
                                 const std::string &view_name,
                                 const axom::sidre::DataType &dtype)
 {
-   MFEM_ASSERT(grp, "DataGroup pointer is NULL");
-   sidre::DataView *v = grp->getView(view_name);
+   MFEM_ASSERT(grp, "Group pointer is NULL");
+   sidre::View *v = grp->getView(view_name);
    if (!v)
    {
       v = grp->createView(view_name, dtype);
-      MFEM_ASSERT(v, "error allocating DataView " << view_name
+      MFEM_ASSERT(v, "error allocating View " << view_name
                   << " in group " << grp->getPathName());
    }
    else
@@ -157,16 +157,16 @@ SidreDataCollection::alloc_view(axom::sidre::DataGroup *grp,
 }
 
 // protected method
-axom::sidre::DataGroup *
-SidreDataCollection::alloc_group(axom::sidre::DataGroup *grp,
+axom::sidre::Group *
+SidreDataCollection::alloc_group(axom::sidre::Group *grp,
                                  const std::string &group_name)
 {
-   MFEM_ASSERT(grp, "DataGroup pointer is NULL");
-   sidre::DataGroup *g = grp->getGroup(group_name);
+   MFEM_ASSERT(grp, "Group pointer is NULL");
+   sidre::Group *g = grp->getGroup(group_name);
    if (!g)
    {
       g = grp->createGroup(group_name);
-      MFEM_ASSERT(g, "error allocating DataGroup " << group_name
+      MFEM_ASSERT(g, "error allocating Group " << group_name
                   << " in group " << grp->getPathName());
    }
    return g;
@@ -190,14 +190,14 @@ SidreDataCollection::get_file_path(const std::string &filename) const
    return fNameSstr.str();
 }
 
-axom::sidre::DataView *
+axom::sidre::View *
 SidreDataCollection::AllocNamedBuffer(const std::string& buffer_name,
                                       axom::sidre::SidreLength sz,
                                       axom::sidre::TypeID type)
 {
    sz = std::max(sz, sidre::SidreLength(0));
-   sidre::DataGroup *f = named_buffers_grp();
-   sidre::DataView  *v = f->getView(buffer_name);
+   sidre::Group *f = named_buffers_grp();
+   sidre::View  *v = f->getView(buffer_name);
    if ( v == NULL )
    {
       // create a buffer view
@@ -213,7 +213,7 @@ SidreDataCollection::AllocNamedBuffer(const std::string& buffer_name,
       // check if we need to resize.
       if (!v->isApplied() || v->getNumElements() < sz)
       {
-         // resize, even if the buffer has more than 1 DataView.
+         // resize, even if the buffer has more than 1 View.
          // v->reallocate(sz); // this will not work for more than 1 view.
          sidre::DataType dtype(v->getSchema().dtype());
          dtype.set_number_of_elements(sz);
@@ -290,7 +290,7 @@ void SidreDataCollection::createMeshBlueprintCoordset(bool hasBP)
       dtype.set_stride(stride*NUM_COORDS);
 
       // Set up views for x, y, z values
-      sidre::DataView *vx, *vy = NULL, *vz = NULL;
+      sidre::View *vx, *vy = NULL, *vz = NULL;
       vx = bp_grp->createView("coordsets/coords/values/x", dtype);
 
       if (dim >= 2)
@@ -307,7 +307,7 @@ void SidreDataCollection::createMeshBlueprintCoordset(bool hasBP)
       if (m_owns_mesh_data)
       {
          // Allocate buffer for coord values.
-         sidre::DataBuffer* coordbuf =
+         sidre::Buffer* coordbuf =
             AllocNamedBuffer("vertex_coords", coordset_len)->getBuffer();
 
          vx->attachBuffer(coordbuf);
@@ -397,7 +397,7 @@ createMeshBlueprintTopologies(bool hasBP, const std::string& mesh_name)
 
    if ( !hasBP )
    {
-      sidre::DataGroup* topology_grp = bp_grp->createGroup(mesh_topo_str);
+      sidre::Group* topology_grp = bp_grp->createGroup(mesh_topo_str);
 
       // Add mesh topology
       topology_grp->createViewString("type", "unstructured");
@@ -415,7 +415,7 @@ createMeshBlueprintTopologies(bool hasBP, const std::string& mesh_name)
       }
 
       // Add material attribute field to blueprint
-      sidre::DataGroup* attr_grp = bp_grp->createGroup(mesh_attr_str);
+      sidre::Group* attr_grp = bp_grp->createGroup(mesh_attr_str);
       attr_grp->createViewString("association", "element");
       attr_grp->createViewAndAllocate("values", sidre::INT_ID, num_elements);
       attr_grp->createViewString("topology", mesh_name);
@@ -437,9 +437,9 @@ createMeshBlueprintTopologies(bool hasBP, const std::string& mesh_name)
          ->copyView( bp_grp->getView("topologies/mesh/boundary_topology") );
       }
 
-      sidre::DataGroup *bp_index_topo_grp =
+      sidre::Group *bp_index_topo_grp =
          bp_index_grp->createGroup(mesh_topo_str);
-      sidre::DataGroup *topology_grp = bp_grp->getGroup(mesh_topo_str);
+      sidre::Group *topology_grp = bp_grp->getGroup(mesh_topo_str);
 
       bp_index_topo_grp->createViewString(
          "path", bp_grp_path + "/" + mesh_topo_str);
@@ -454,9 +454,9 @@ createMeshBlueprintTopologies(bool hasBP, const std::string& mesh_name)
       }
 
       // Create blueprint index for material attributes.
-      sidre::DataGroup *bp_index_attr_grp =
+      sidre::Group *bp_index_attr_grp =
          bp_index_grp->createGroup(mesh_attr_str);
-      sidre::DataGroup *attr_grp = bp_grp->getGroup(mesh_attr_str);
+      sidre::Group *attr_grp = bp_grp->getGroup(mesh_attr_str);
 
       bp_index_attr_grp->createViewString(
          "path", bp_grp_path + "/" + mesh_attr_str );
@@ -469,9 +469,9 @@ createMeshBlueprintTopologies(bool hasBP, const std::string& mesh_name)
    }
 
    // Finally, change ownership or copy the element arrays into Sidre
-   sidre::DataView* conn_view =
+   sidre::View* conn_view =
       bp_grp->getGroup(mesh_topo_str)->getView("elements/connectivity");
-   sidre::DataView* attr_view =
+   sidre::View* attr_view =
       bp_grp->getGroup(mesh_attr_str)->getView("values");
    // The SidreDataCollection always owns these arrays:
    Array<int> conn_array(conn_view->getData<int*>(), num_indices);
@@ -533,7 +533,7 @@ void SidreDataCollection::SetMesh(Mesh *new_mesh)
       if (hasBP)
       {
          // Get the bp mesh nodes name.
-         sidre::DataView *v_bp_nodes_name =
+         sidre::View *v_bp_nodes_name =
             bp_grp->getView("topologies/mesh/grid_function");
          std::string bp_nodes_name(v_bp_nodes_name->getString());
 
@@ -584,8 +584,8 @@ void SidreDataCollection::SetMesh(Mesh *new_mesh)
 }
 
 void SidreDataCollection::
-SetGroupPointers(axom::sidre::DataGroup *global_grp,
-                 axom::sidre::DataGroup *domain_grp)
+SetGroupPointers(axom::sidre::Group *global_grp,
+                 axom::sidre::Group *domain_grp)
 {
    MFEM_VERIFY(domain_grp->hasGroup("blueprint"),
                "Domain group does not contain a blueprint group.");
@@ -688,7 +688,7 @@ void SidreDataCollection::Save(const std::string& filename,
 
    std::string file_path = get_file_path(filename);
 
-   sidre::DataGroup * blueprint_indicies_grp = bp_index_grp->getParent();
+   sidre::Group * blueprint_indicies_grp = bp_index_grp->getParent();
 #ifdef MFEM_USE_MPI
    if (m_comm != MPI_COMM_NULL)
    {
@@ -727,7 +727,7 @@ addScalarBasedGridFunction(const std::string &field_name, GridFunction *gf,
                            const std::string &buffer_name,
                            axom::sidre::SidreLength offset)
 {
-   sidre::DataGroup* grp = bp_grp->getGroup("fields/" + field_name);
+   sidre::Group* grp = bp_grp->getGroup("fields/" + field_name);
    MFEM_ASSERT(grp != NULL, "field " << field_name << " does not exist");
 
    const int numDofs = gf->FESpace()->GetVSize();
@@ -746,13 +746,13 @@ addScalarBasedGridFunction(const std::string &field_name, GridFunction *gf,
     *              -- array of size numDofs
     */
 
-   // Make sure we have the DataView "values".
-   sidre::DataView *vv = alloc_view(grp, "values");
+   // Make sure we have the View "values".
+   sidre::View *vv = alloc_view(grp, "values");
 
-   // Describe and apply the "values" DataView.
+   // Describe and apply the "values" View.
    // If the data store has buffer for field_name (e.g. AllocNamedBuffer was
    // called, or it was loaded from file), use that buffer.
-   sidre::DataView *bv = named_buffers_grp()->getView(buffer_name);
+   sidre::View *bv = named_buffers_grp()->getView(buffer_name);
    if (bv)
    {
       MFEM_ASSERT(bv->hasBuffer() && bv->isDescribed(), "");
@@ -777,11 +777,11 @@ addScalarBasedGridFunction(const std::string &field_name, GridFunction *gf,
    }
    MFEM_ASSERT((numDofs > 0 && vv->isApplied()) ||
                (numDofs == 0 && vv->isEmpty() && vv->isDescribed()),
-               "invlid DataView state");
+               "invlid View state");
    MFEM_ASSERT(numDofs == 0 || vv->getData() == gf->GetData(),
-               "DataView data is different from GridFunction data");
+               "View data is different from GridFunction data");
    MFEM_ASSERT(vv->getNumElements() == numDofs,
-               "DataView size is different from GridFunction size");
+               "View size is different from GridFunction size");
 }
 
 // private method
@@ -790,7 +790,7 @@ addVectorBasedGridFunction(const std::string& field_name, GridFunction *gf,
                            const std::string &buffer_name,
                            axom::sidre::SidreLength offset)
 {
-   sidre::DataGroup* grp = bp_grp->getGroup("fields/" + field_name);
+   sidre::Group* grp = bp_grp->getGroup("fields/" + field_name);
    MFEM_ASSERT(grp != NULL, "field " << field_name << " does not exist");
 
    const int FLD_SZ = 20;
@@ -817,18 +817,18 @@ addVectorBasedGridFunction(const std::string& field_name, GridFunction *gf,
     *              -- each coordinate is an array of size ndof
     */
 
-   // Get/create the DataGroup "values".
-   sidre::DataGroup *vg = alloc_group(grp, "values");
+   // Get/create the Group "values".
+   sidre::Group *vg = alloc_group(grp, "values");
 
-   // Create the DataViews "x0", "x1", etc inside the "values" DataGroup, vg.
-   // If we have a named buffer for field_name, attach it to the DataViews;
-   // otherwise set the DataViews to use gf->GetData() as external data.
+   // Create the Views "x0", "x1", etc inside the "values" Group, vg.
+   // If we have a named buffer for field_name, attach it to the Views;
+   // otherwise set the Views to use gf->GetData() as external data.
    sidre::DataType dtype = sidre::DataType::c_double(ndof);
    const int entry_stride = (ordering == Ordering::byNODES ? 1 : vdim);
    const int vdim_stride  = (ordering == Ordering::byNODES ? ndof : 1);
    dtype.set_stride(dtype.stride()*entry_stride);
 
-   sidre::DataView *bv = named_buffers_grp()->getView(buffer_name);
+   sidre::View *bv = named_buffers_grp()->getView(buffer_name);
    if (bv)
    {
       MFEM_ASSERT(bv->hasBuffer() && bv->isDescribed(), "");
@@ -840,7 +840,7 @@ addVectorBasedGridFunction(const std::string& field_name, GridFunction *gf,
       for (int d = 0;  d < vdim; d++)
       {
          std::snprintf(fidxName, FLD_SZ, "x%d", d);
-         sidre::DataView *xv = alloc_view(vg, fidxName, dtype);
+         sidre::View *xv = alloc_view(vg, fidxName, dtype);
          xv->attachBuffer(bv->getBuffer());
          dtype.set_offset(dtype.offset() + dtype.element_bytes()*vdim_stride);
       }
@@ -852,7 +852,7 @@ addVectorBasedGridFunction(const std::string& field_name, GridFunction *gf,
       for (int d = 0;  d < vdim; d++)
       {
          std::snprintf(fidxName, FLD_SZ, "x%d", d);
-         sidre::DataView *xv = alloc_view(vg, fidxName, dtype);
+         sidre::View *xv = alloc_view(vg, fidxName, dtype);
          xv->setExternalDataPtr(gf->GetData());
          dtype.set_offset(dtype.offset() + dtype.element_bytes()*vdim_stride);
       }
@@ -862,14 +862,14 @@ addVectorBasedGridFunction(const std::string& field_name, GridFunction *gf,
    for (int d = 0;  d < vdim; d++)
    {
       std::snprintf(fidxName, FLD_SZ, "x%d", d);
-      sidre::DataView *xv = vg->getView(fidxName);
+      sidre::View *xv = vg->getView(fidxName);
       MFEM_ASSERT((ndof > 0 && xv->isApplied()) ||
                   (ndof == 0 && xv->isEmpty() && xv->isDescribed()),
-                  "invlid DataView state");
+                  "invlid View state");
       MFEM_ASSERT(ndof == 0 || xv->getData() == gf->GetData() + d*vdim_stride,
-                  "DataView data is different from GridFunction data");
+                  "View data is different from GridFunction data");
       MFEM_ASSERT(xv->getNumElements() == ndof,
-                  "DataView size is different from GridFunction size");
+                  "View size is different from GridFunction size");
    }
 #endif
 }
@@ -879,8 +879,8 @@ addVectorBasedGridFunction(const std::string& field_name, GridFunction *gf,
 void SidreDataCollection::
 RegisterFieldInBPIndex(const std::string& field_name, GridFunction *gf)
 {
-   sidre::DataGroup *bp_field_grp = bp_grp->getGroup("fields/" + field_name);
-   sidre::DataGroup *bp_index_field_grp =
+   sidre::Group *bp_field_grp = bp_grp->getGroup("fields/" + field_name);
+   sidre::Group *bp_index_field_grp =
       bp_index_grp->createGroup("fields/" + field_name);
 
    bp_index_field_grp->createViewString( "path", bp_field_grp->getPathName() );
@@ -900,7 +900,7 @@ RegisterFieldInBPIndex(const std::string& field_name, GridFunction *gf)
 void SidreDataCollection::
 DeregisterFieldInBPIndex(const std::string& field_name)
 {
-   sidre::DataGroup * fields_grp = bp_index_grp->getGroup("fields");
+   sidre::Group * fields_grp = bp_index_grp->getGroup("fields");
    MFEM_VERIFY(fields_grp->hasGroup(field_name),
                "No field exists in blueprint index with name " << name);
 
@@ -922,7 +922,7 @@ void SidreDataCollection::RegisterField(const std::string &field_name,
    }
 
    // Register field_name in the blueprint group.
-   sidre::DataGroup* f = bp_grp->getGroup("fields");
+   sidre::Group* f = bp_grp->getGroup("fields");
 
    if (f->hasGroup( field_name ))
    {
@@ -940,11 +940,11 @@ void SidreDataCollection::RegisterField(const std::string &field_name,
       }
    }
 
-   sidre::DataGroup* grp = f->createGroup( field_name );
+   sidre::Group* grp = f->createGroup( field_name );
 
    // Set the "basis" string using the gf's finite element space, overwrite if
    // necessary.
-   sidre::DataView *v = alloc_view(grp, "basis");
+   sidre::View *v = alloc_view(grp, "basis");
    v->setString(gf->FESpace()->FEColl()->Name());
 
    // Set the topology of the GridFunction.
@@ -961,12 +961,12 @@ void SidreDataCollection::RegisterField(const std::string &field_name,
    bool const isScalarValued = (gf->FESpace()->GetVDim() == 1);
    if (isScalarValued)
    {
-      // Set the DataView "<bp_grp>/fields/<field_name>/values"
+      // Set the View "<bp_grp>/fields/<field_name>/values"
       addScalarBasedGridFunction(field_name, gf, buffer_name, offset);
    }
    else // vector valued
    {
-      // Set the DataGroup "<bp_grp>/fields/<field_name>/values"
+      // Set the Group "<bp_grp>/fields/<field_name>/values"
       addVectorBasedGridFunction(field_name, gf, buffer_name, offset);
    }
 
@@ -985,7 +985,7 @@ void SidreDataCollection::DeregisterField(const std::string& field_name)
    // Deregister field_name from field_map.
    DataCollection::DeregisterField(field_name);
 
-   sidre::DataGroup * fields_grp = bp_grp->getGroup("fields");
+   sidre::Group * fields_grp = bp_grp->getGroup("fields");
    MFEM_VERIFY(fields_grp->hasGroup(field_name),
                "No field exists in blueprint with name " << field_name);
 

--- a/fem/sidredatacollection.cpp
+++ b/fem/sidredatacollection.cpp
@@ -1013,8 +1013,13 @@ void SidreDataCollection::RegisterField(const std::string &field_name,
       if (HasField(field_name))
       {
          MFEM_DEBUG_DO(
-            MFEM_WARNING("field with the name '" << field_name<< "' is already "
-                         "registered, overwriting the old field"));
+            // Warn about overwriting field.
+            // Skip warning when re-registering the nodal grid function
+            if(field_name != m_meshNodesGFName)
+            {
+               MFEM_WARNING("field with the name '" << field_name<< "' is already "
+                         "registered, overwriting the old field");
+            });
          DeregisterField(field_name);
       }
    }

--- a/fem/sidredatacollection.cpp
+++ b/fem/sidredatacollection.cpp
@@ -504,6 +504,7 @@ createMeshBlueprintTopologies(bool hasBP, const std::string& mesh_name)
 }
 
 // private method
+#ifdef MFEM_USE_MPI
 void SidreDataCollection::createMeshBlueprintAdjacencies(bool hasBP)
 {
    ParMesh *pmesh = dynamic_cast<ParMesh*>(mesh);
@@ -560,6 +561,7 @@ void SidreDataCollection::createMeshBlueprintAdjacencies(bool hasBP)
       }
    }
 }
+#endif
 
 // private method
 void SidreDataCollection::verifyMeshBlueprint()

--- a/fem/sidredatacollection.cpp
+++ b/fem/sidredatacollection.cpp
@@ -514,6 +514,7 @@ void SidreDataCollection::createMeshBlueprintAdjacencies(bool hasBP)
 
    // TODO(JRC): Separate this out into group hierarchy setup and data allocation
    // stages like all of the other "createMeshBlueprint*" functions.
+   MFEM_VERIFY(hasBP == false, "The case hasBP == true is not supported yet!");
 
    if (pmesh->GetNGroups() > 1)
    {

--- a/fem/sidredatacollection.hpp
+++ b/fem/sidredatacollection.hpp
@@ -467,6 +467,12 @@ private:
     */
    void createMeshBlueprintTopologies(bool hasBP, const std::string& mesh_name);
 
+   /// Sets up the mesh blueprint 'adjacencies' group.
+   /**
+    * \param hasBP Indicates whether the blueprint has already been set up.
+    */
+   void createMeshBlueprintAdjacencies(bool hasBP);
+
    /// Verifies that the contents of the mesh blueprint data is valid.
    void verifyMeshBlueprint();
 };

--- a/fem/sidredatacollection.hpp
+++ b/fem/sidredatacollection.hpp
@@ -328,7 +328,11 @@ public:
     */
    axom::sidre::View *
    GetNamedBuffer(const std::string& buffer_name) const
-   { return named_buffers_grp()->getView(buffer_name); }
+   { 
+      return named_buffers_grp()->hasView(buffer_name)
+            ? named_buffers_grp()->getView(buffer_name)
+            : NULL;
+   }
 
    /// Return newly allocated or existing named buffer for @a buffer_name.
    /** The buffer is stored in the named_buffers group. If the currently

--- a/fem/sidredatacollection.hpp
+++ b/fem/sidredatacollection.hpp
@@ -467,11 +467,14 @@ private:
     */
    void createMeshBlueprintTopologies(bool hasBP, const std::string& mesh_name);
 
+#ifdef MFEM_USE_MPI
    /// Sets up the mesh blueprint 'adjacencies' group.
    /**
     * \param hasBP Indicates whether the blueprint has already been set up.
+    * \note Only valid when using parallel meshes
     */
    void createMeshBlueprintAdjacencies(bool hasBP);
+#endif 
 
    /// Verifies that the contents of the mesh blueprint data is valid.
    void verifyMeshBlueprint();

--- a/fem/sidredatacollection.hpp
+++ b/fem/sidredatacollection.hpp
@@ -328,10 +328,10 @@ public:
     */
    axom::sidre::View *
    GetNamedBuffer(const std::string& buffer_name) const
-   { 
+   {
       return named_buffers_grp()->hasView(buffer_name)
-            ? named_buffers_grp()->getView(buffer_name)
-            : NULL;
+             ? named_buffers_grp()->getView(buffer_name)
+             : NULL;
    }
 
    /// Return newly allocated or existing named buffer for @a buffer_name.
@@ -478,7 +478,7 @@ private:
     * \note Only valid when using parallel meshes
     */
    void createMeshBlueprintAdjacencies(bool hasBP);
-#endif 
+#endif
 
    /// Verifies that the contents of the mesh blueprint data is valid.
    void verifyMeshBlueprint();

--- a/fem/sidredatacollection.hpp
+++ b/fem/sidredatacollection.hpp
@@ -188,12 +188,12 @@ public:
 
        With this constructor, the SidreDataCollection does not own the Sidre
        DataStore.
-       @note No mesh or fields are read from the given DataGroups. The mesh has
+       @note No mesh or fields are read from the given Groups. The mesh has
        to be set with SetMesh() and fields registered with RegisterField().
     */
    SidreDataCollection(const std::string& collection_name,
-                       axom::sidre::DataGroup * global_grp,
-                       axom::sidre::DataGroup * domain_grp,
+                       axom::sidre::Group * global_grp,
+                       axom::sidre::Group * domain_grp,
                        bool owns_mesh_data = false);
 
 #ifdef MFEM_USE_MPI
@@ -263,11 +263,11 @@ public:
        reset to valid groups in the datastore.
        @sa Load(const std::string &path, const std::string &protocol).
     */
-   void SetGroupPointers(axom::sidre::DataGroup * global_grp,
-                         axom::sidre::DataGroup * domain_grp);
+   void SetGroupPointers(axom::sidre::Group * global_grp,
+                         axom::sidre::Group * domain_grp);
 
-   axom::sidre::DataGroup * GetBPGroup() { return bp_grp; }
-   axom::sidre::DataGroup * GetBPIndexGroup() { return bp_index_grp; }
+   axom::sidre::Group * GetBPGroup() { return bp_grp; }
+   axom::sidre::Group * GetBPIndexGroup() { return bp_index_grp; }
 
    /// Prepare the DataStore for writing
    virtual void PrepareToSave();
@@ -320,13 +320,13 @@ public:
    /** @name Methods for named buffer access and manipulation. */
    ///@{
 
-   /** @brief Get a pointer to the sidre::DataView holding the named buffer for
+   /** @brief Get a pointer to the sidre::View holding the named buffer for
        @a buffer_name. */
    /** If such named buffer is not allocated, the method returns NULL.
-       @note To access the underlying pointer, use DataView::getData().
-       @note To query the size of the buffer, use DataView::getNumElements().
+       @note To access the underlying pointer, use View::getData().
+       @note To query the size of the buffer, use View::getNumElements().
     */
-   axom::sidre::DataView *
+   axom::sidre::View *
    GetNamedBuffer(const std::string& buffer_name) const
    { return named_buffers_grp()->getView(buffer_name); }
 
@@ -334,9 +334,9 @@ public:
    /** The buffer is stored in the named_buffers group. If the currently
        allocated buffer size is smaller than @a sz, then the buffer is
        reallocated with size @a sz, destroying its contents.
-       @note To access the underlying pointer, use DataView::getData().
+       @note To access the underlying pointer, use View::getData().
     */
-   axom::sidre::DataView *
+   axom::sidre::View *
    AllocNamedBuffer(const std::string& buffer_name,
                     axom::sidre::SidreLength sz,
                     axom::sidre::TypeID type =
@@ -374,19 +374,19 @@ private:
 #endif
 
 protected:
-   axom::sidre::DataGroup *named_buffers_grp() const;
+   axom::sidre::Group *named_buffers_grp() const;
 
-   axom::sidre::DataView *
-   alloc_view(axom::sidre::DataGroup *grp,
+   axom::sidre::View *
+   alloc_view(axom::sidre::Group *grp,
               const std::string &view_name);
 
-   axom::sidre::DataView *
-   alloc_view(axom::sidre::DataGroup *grp,
+   axom::sidre::View *
+   alloc_view(axom::sidre::Group *grp,
               const std::string &view_name,
               const axom::sidre::DataType &dtype);
 
-   axom::sidre::DataGroup *
-   alloc_group(axom::sidre::DataGroup *grp,
+   axom::sidre::Group *
+   alloc_group(axom::sidre::Group *grp,
                const std::string &group_name);
 
    // return the filename based on prefix_path, collection name and cycle.
@@ -395,11 +395,11 @@ protected:
 private:
    // If the data collection does not own the datastore, it will need pointers
    // to the blueprint and blueprint index group to use.
-   axom::sidre::DataGroup * bp_grp;
-   axom::sidre::DataGroup * bp_index_grp;
+   axom::sidre::Group * bp_grp;
+   axom::sidre::Group * bp_index_grp;
 
    // This is stored for convenience.
-   axom::sidre::DataGroup * named_bufs_grp;
+   axom::sidre::Group * named_bufs_grp;
 
    // Private helper functions
 


### PR DESCRIPTION
This PR relates to a name change of Sidre's underlying codebase from ``asctoolkit`` to ``axom`` and a refactoring of the class names within Sidre (e.g. from ``asctoolkit::sidre::DataGroup`` to ``axom::sidre::Group``).

It also adds the ability to encode parallel meshes within the ``SidreDataCollection`` class through a new ``sidre::Group`` called ``adjacencies``.

Finally, it modifies how ``SidreDataCollection`` uses the ``Sidre`` API to avoid/reduce the verbosity of warnings when mfem is run in debug mode.