### PR TITLE
Distinguish between GCC optimization options for x86 and PowerPC [march-native-dev]

### DIFF
--- a/miniapps/performance/makefile
+++ b/miniapps/performance/makefile
@@ -23,10 +23,17 @@ TEST_MK = $(MFEM_DIR)/config/test.mk
 MFEM_LIB_FILE = mfem_is_not_built
 -include $(CONFIG_MK)
 
+# Distinguish x86 from PowerPC systems
+MFEM_MACHINE ?= $(shell uname -m)
+
 # Compiler specific optimizations.
 # For best performance, GCC 5 (or newer) is recommended.
 ifneq (,$(findstring $(MFEM_CXX),g++ mpicxx))
-   MFEM_CXXFLAGS += -march=native
+   ifeq ($(MFEM_MACHINE),x86_64)
+      MFEM_CXXFLAGS += -march=native
+   else ifneq (,$(findstring ppc64,$(MFEM_MACHINE)))
+      MFEM_CXXFLAGS += -mcpu=native -mtune=native
+   endif
    # MFEM_CXXFLAGS += -std=c++03
    MFEM_CXXFLAGS += -std=c++11
    MFEM_CXXFLAGS += -pedantic -Wall


### PR DESCRIPTION
Switch between `-march=native`  (x86) and `-mcpu=native -mtune=native` (PowerPC) based on `uname -m`.

Resolves issue #216.