### PR TITLE
Component-wise essential dofs for vector fields. [laghos-dev]

### DIFF
--- a/fem/fespace.cpp
+++ b/fem/fespace.cpp
@@ -256,9 +256,10 @@ static void mark_dofs(const Array<int> &dofs, Array<int> &mark_array)
 }
 
 void FiniteElementSpace::GetEssentialVDofs(const Array<int> &bdr_attr_is_ess,
-                                           Array<int> &ess_vdofs) const
+                                           Array<int> &ess_vdofs,
+                                           int component) const
 {
-   Array<int> vdofs;
+   Array<int> vdofs, dofs;
 
    ess_vdofs.SetSize(GetVSize());
    ess_vdofs = 0;
@@ -267,8 +268,19 @@ void FiniteElementSpace::GetEssentialVDofs(const Array<int> &bdr_attr_is_ess,
    {
       if (bdr_attr_is_ess[GetBdrAttribute(i)-1])
       {
-         GetBdrElementVDofs(i, vdofs);
-         mark_dofs(vdofs, ess_vdofs);
+         if (component < 0)
+         {
+            // Mark all components.
+            GetBdrElementVDofs(i, vdofs);
+            mark_dofs(vdofs, ess_vdofs);
+         }
+         else
+         {
+            GetBdrElementDofs(i, dofs);
+            for (int d = 0; d < dofs.Size(); d++)
+            { dofs[d] = DofToVDof(dofs[d], component); }
+            mark_dofs(dofs, ess_vdofs);
+         }
       }
    }
 
@@ -281,22 +293,43 @@ void FiniteElementSpace::GetEssentialVDofs(const Array<int> &bdr_attr_is_ess,
 
       for (int i = 0; i < bdr_verts.Size(); i++)
       {
-         GetVertexVDofs(bdr_verts[i], vdofs);
-         mark_dofs(vdofs, ess_vdofs);
+         if (component < 0)
+         {
+            GetVertexVDofs(bdr_verts[i], vdofs);
+            mark_dofs(vdofs, ess_vdofs);
+         }
+         else
+         {
+            GetVertexDofs(bdr_verts[i], dofs);
+            for (int d = 0; d < dofs.Size(); d++)
+            { dofs[d] = DofToVDof(dofs[d], component); }
+            mark_dofs(dofs, ess_vdofs);
+         }
       }
       for (int i = 0; i < bdr_edges.Size(); i++)
       {
-         GetEdgeVDofs(bdr_edges[i], vdofs);
-         mark_dofs(vdofs, ess_vdofs);
+         if (component < 0)
+         {
+            GetEdgeVDofs(bdr_edges[i], vdofs);
+            mark_dofs(vdofs, ess_vdofs);
+         }
+         else
+         {
+            GetEdgeDofs(bdr_edges[i], dofs);
+            for (int d = 0; d < dofs.Size(); d++)
+            { dofs[d] = DofToVDof(dofs[d], component); }
+            mark_dofs(dofs, ess_vdofs);
+         }
       }
    }
 }
 
 void FiniteElementSpace::GetEssentialTrueDofs(const Array<int> &bdr_attr_is_ess,
-                                              Array<int> &ess_tdof_list)
+                                              Array<int> &ess_tdof_list,
+                                              int component)
 {
    Array<int> ess_vdofs, ess_tdofs;
-   GetEssentialVDofs(bdr_attr_is_ess, ess_vdofs);
+   GetEssentialVDofs(bdr_attr_is_ess, ess_vdofs, component);
    const SparseMatrix *R = GetConformingRestriction();
    if (!R)
    {

--- a/fem/fespace.hpp
+++ b/fem/fespace.hpp
@@ -307,12 +307,14 @@ public:
    /** Mark degrees of freedom associated with boundary elements with
        the specified boundary attributes (marked in 'bdr_attr_is_ess'). */
    virtual void GetEssentialVDofs(const Array<int> &bdr_attr_is_ess,
-                                  Array<int> &ess_vdofs) const;
+                                  Array<int> &ess_vdofs,
+                                  int component = -1) const;
 
    /** Get a list of essential true dofs, ess_tdof_list, corresponding to the
        boundary attributes marked in the array bdr_attr_is_ess. */
    virtual void GetEssentialTrueDofs(const Array<int> &bdr_attr_is_ess,
-                                     Array<int> &ess_tdof_list);
+                                     Array<int> &ess_tdof_list,
+                                     int component = -1);
 
    /// Convert a Boolean marker array to a list containing all marked indices.
    static void MarkerToList(const Array<int> &marker, Array<int> &list);

--- a/fem/fespace.hpp
+++ b/fem/fespace.hpp
@@ -305,13 +305,17 @@ public:
    const FiniteElement *GetTraceElement(int i, int geom_type) const;
 
    /** Mark degrees of freedom associated with boundary elements with
-       the specified boundary attributes (marked in 'bdr_attr_is_ess'). */
+       the specified boundary attributes (marked in 'bdr_attr_is_ess').
+       For spaces with 'vdim' > 1, the 'component' parameter can be used
+       to restricts the marked vDOFs to the specified component. */
    virtual void GetEssentialVDofs(const Array<int> &bdr_attr_is_ess,
                                   Array<int> &ess_vdofs,
                                   int component = -1) const;
 
    /** Get a list of essential true dofs, ess_tdof_list, corresponding to the
-       boundary attributes marked in the array bdr_attr_is_ess. */
+       boundary attributes marked in the array bdr_attr_is_ess.
+       For spaces with 'vdim' > 1, the 'component' parameter can be used
+       to restricts the marked tDOFs to the specified component. */
    virtual void GetEssentialTrueDofs(const Array<int> &bdr_attr_is_ess,
                                      Array<int> &ess_tdof_list,
                                      int component = -1);

--- a/fem/pfespace.cpp
+++ b/fem/pfespace.cpp
@@ -506,9 +506,10 @@ void ParFiniteElementSpace::Synchronize(Array<int> &ldof_marker) const
 }
 
 void ParFiniteElementSpace::GetEssentialVDofs(const Array<int> &bdr_attr_is_ess,
-                                              Array<int> &ess_dofs) const
+                                              Array<int> &ess_dofs,
+                                              int component) const
 {
-   FiniteElementSpace::GetEssentialVDofs(bdr_attr_is_ess, ess_dofs);
+   FiniteElementSpace::GetEssentialVDofs(bdr_attr_is_ess, ess_dofs, component);
 
    if (Conforming())
    {
@@ -518,12 +519,14 @@ void ParFiniteElementSpace::GetEssentialVDofs(const Array<int> &bdr_attr_is_ess,
    }
 }
 
-void ParFiniteElementSpace::GetEssentialTrueDofs(
-   const Array<int> &bdr_attr_is_ess, Array<int> &ess_tdof_list)
+void ParFiniteElementSpace::GetEssentialTrueDofs(const Array<int>
+                                                 &bdr_attr_is_ess,
+                                                 Array<int> &ess_tdof_list,
+                                                 int component)
 {
    Array<int> ess_dofs, true_ess_dofs;
 
-   GetEssentialVDofs(bdr_attr_is_ess, ess_dofs);
+   GetEssentialVDofs(bdr_attr_is_ess, ess_dofs, component);
    GetRestrictionMatrix()->BooleanMult(ess_dofs, true_ess_dofs);
    MarkerToList(true_ess_dofs, ess_tdof_list);
 }

--- a/fem/pfespace.hpp
+++ b/fem/pfespace.hpp
@@ -218,12 +218,14 @@ public:
 
    /// Determine the boundary degrees of freedom
    virtual void GetEssentialVDofs(const Array<int> &bdr_attr_is_ess,
-                                  Array<int> &ess_dofs) const;
+                                  Array<int> &ess_dofs,
+                                  int component = -1) const;
 
    /** Get a list of essential true dofs, ess_tdof_list, corresponding to the
        boundary attributes marked in the array bdr_attr_is_ess. */
    virtual void GetEssentialTrueDofs(const Array<int> &bdr_attr_is_ess,
-                                     Array<int> &ess_tdof_list);
+                                     Array<int> &ess_tdof_list,
+                                     int component = -1);
 
    /** If the given ldof is owned by the current processor, return its local
        tdof number, otherwise return -1 */


### PR DESCRIPTION
Added an optional parameter to specify a component when getting the essential dofs for vector fields in serial and parallel.

Required for the [Laghos miniapp](http://ceed.exascaleproject.org/miniapps/#laghos-new).