### PR TITLE
Correct definitions of DVLocal_t and QVLocal_t [occa-dev]

### DIFF
--- a/fem/kernels/defines/tensor.okl
+++ b/fem/kernels/defines/tensor.okl
@@ -57,14 +57,14 @@ typedef double* QLocal2D_t @dim(NUM_QUAD_1D, NUM_QUAD_1D, numElements);
 typedef double* QLocal3D_t @dim(NUM_QUAD_1D, NUM_QUAD_1D, NUM_QUAD_1D, numElements);
 
 typedef double* DVLocal_t   @dim(NUM_VDIM, NUM_DOFS, numElements);
-typedef double* DVLocal1D_t @dim(1, NUM_DOFS_1D, numElements);
-typedef double* DVLocal2D_t @dim(2, NUM_DOFS_1D, NUM_DOFS_1D, numElements);
-typedef double* DVLocal3D_t @dim(3, NUM_DOFS_1D, NUM_DOFS_1D, NUM_DOFS_1D, numElements);
+typedef double* DVLocal1D_t @dim(NUM_VDIM, NUM_DOFS_1D, numElements);
+typedef double* DVLocal2D_t @dim(NUM_VDIM, NUM_DOFS_1D, NUM_DOFS_1D, numElements);
+typedef double* DVLocal3D_t @dim(NUM_VDIM, NUM_DOFS_1D, NUM_DOFS_1D, NUM_DOFS_1D, numElements);
 
 typedef double* QVLocal_t   @dim(NUM_VDIM, NUM_QUAD, numElements);
-typedef double* QVLocal1D_t @dim(1, NUM_QUAD_1D, numElements);
-typedef double* QVLocal2D_t @dim(2, NUM_QUAD_1D, NUM_QUAD_1D, numElements);
-typedef double* QVLocal3D_t @dim(3, NUM_QUAD_1D, NUM_QUAD_1D, NUM_QUAD_1D, numElements);
+typedef double* QVLocal1D_t @dim(NUM_VDIM, NUM_QUAD_1D, numElements);
+typedef double* QVLocal2D_t @dim(NUM_VDIM, NUM_QUAD_1D, NUM_QUAD_1D, numElements);
+typedef double* QVLocal3D_t @dim(NUM_VDIM, NUM_QUAD_1D, NUM_QUAD_1D, NUM_QUAD_1D, numElements);
 
 typedef int* DLocalMap_t   @dim(NUM_DOFS, numElements);
 typedef int* DLocalMap1D_t @dim(NUM_DOFS_1D, numElements);


### PR DESCRIPTION
We've been mixing up the problem dimension and NUM_VDIM in the GridFunction ToQuad calculations.