### PR TITLE
Fixes for *ArrayCoefficient classes

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -11,6 +11,11 @@
 Development version 3.3.1, not released
 =======================================
 
+- API change: the methods VectorArrayCoefficient::GetCoeff(int) and
+  MatrixArrayCoefficient::GetCoeff(int,int) now return a pointer to Coefficient
+  (instead of reference). Note that NULL pointer is a valid entry for these two
+  classes - it is treated as the zero function.
+
 - Added SUNDIALS version of example 16/16p.
 
 - Added optional support for the STRUMPACK parallel sparse direct solver and

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -11,32 +11,12 @@
 Development version 3.3.1, not released
 =======================================
 
-- API change: the methods VectorArrayCoefficient::GetCoeff(int) and
-  MatrixArrayCoefficient::GetCoeff(int,int) now return a pointer to Coefficient
-  (instead of reference). Note that NULL pointer is a valid entry for these two
-  classes - it is treated as the zero function.
-
-- Added SUNDIALS version of example 16/16p.
-
+New and improved solvers and preconditioners
+--------------------------------------------
 - Added optional support for the STRUMPACK parallel sparse direct solver and
   preconditioner. STRUMPACK uses Hierarchically Semi-Separable (HSS) compression
   in a fully algebraic manner, with interface similar to SuperLU_DIST. See
   http://portal.nersc.gov/project/sparse/strumpack for more details.
-
-- Added a new macro, MFEM_VERSION, defined as a single integer of the form
-  (major*100 + minor)*100 + patch. The new convention is that an even number
-  (i.e. even patch number) denotes a "release" version, while an odd number
-  denotes a "development" version. See config/config.hpp.in.
-
-- Memory optimizations in the NCMesh class, which now uses 50% less memory.
-  The average cost of an NC element in a uniformly refined mesh (including the
-  refinement hierarchy, but excluding the temporary face_list and edge_list)
-  is now only about 290 bytes. This also makes the class faster.
-
-- Added a new meshing miniapp, Shaper, that can be used to resolve complicated
-  material interfaces by mesh refinement, e.g. as a tool for initial mesh
-  generation from prescribed "material()" function.  Both conforming and
-  non-conforming (isotropic and anisotropic) refinements are supported.
 
 - Added a block lower triangular preconditioner based (only) on the actions of
   each block, see class BlockLowerTriangularPreconditioner.
@@ -44,6 +24,39 @@ Development version 3.3.1, not released
 - Added an optional operator in LOBPCG to projects vectors onto a desired
   subspace (e.g. divergence-free). Other small changes in LOBPCG include the
   ability to set the starting vectors and support for relative tolerance.
+
+Performance improvements
+------------------------
+- Memory optimizations in the NCMesh class, which now uses 50% less memory.
+  The average cost of an NC element in a uniformly refined mesh (including the
+  refinement hierarchy, but excluding the temporary face_list and edge_list)
+  is now only about 290 bytes. This also makes the class faster.
+
+New and updated examples and miniapps
+-------------------------------------
+- Added a new meshing miniapp, Shaper, that can be used to resolve complicated
+  material interfaces by mesh refinement, e.g. as a tool for initial mesh
+  generation from prescribed "material()" function.  Both conforming and
+  non-conforming (isotropic and anisotropic) refinements are supported.
+
+- Added SUNDIALS version of Example 16/16p.
+
+Miscellaneous
+-------------
+- Added a new macro, MFEM_VERSION, defined as a single integer of the form
+  (major*100 + minor)*100 + patch. The new convention is that an even number
+  (i.e. even patch number) denotes a "release" version, while an odd number
+  denotes a "development" version. See config/config.hpp.in.
+
+- Added Linux, Mac and Windows CI testing on GitHub with Travis CI and Appveyor.
+
+- Various small fixes and styling updates.
+
+API changes
+-----------
+- The methods GetCoeff of VectorArrayCoefficient and MatrixArrayCoefficient now
+  return a pointer to Coefficient (instead of reference). Note that NULL pointer
+  is a valid entry for these two classes - it is treated as the zero function.
 
 
 Version 3.3, released on Jan 28, 2017

--- a/fem/coefficient.cpp
+++ b/fem/coefficient.cpp
@@ -126,7 +126,7 @@ void VectorArrayCoefficient::Eval(Vector &V, ElementTransformation &T,
    V.SetSize(vdim);
    for (int i = 0; i < vdim; i++)
    {
-      V(i) = Coeff[i]->Eval(T, ip, GetTime());
+      V(i) = this->Eval(i, T, ip);
    }
 }
 
@@ -210,6 +210,11 @@ MatrixArrayCoefficient::MatrixArrayCoefficient (int dim)
    : MatrixCoefficient (dim)
 {
    Coeff.SetSize (vdim*vdim);
+   for (int i=0; i< vdim*vdim; i++)
+   {
+      Coeff[i] = NULL;
+   }
+
 }
 
 MatrixArrayCoefficient::~MatrixArrayCoefficient ()
@@ -228,7 +233,7 @@ void MatrixArrayCoefficient::Eval (DenseMatrix &K, ElementTransformation &T,
    for (i = 0; i < vdim; i++)
       for (j = 0; j < vdim; j++)
       {
-         K(i,j) = Coeff[i*vdim+j] -> Eval(T, ip, GetTime());
+         K(i,j) = this->Eval(i, j, T, ip);
       }
 }
 

--- a/fem/coefficient.hpp
+++ b/fem/coefficient.hpp
@@ -308,16 +308,16 @@ public:
    explicit VectorArrayCoefficient(int dim);
 
    /// Returns i'th coefficient.
-   Coefficient &GetCoeff(int i) { return *Coeff[i]; }
+   Coefficient* GetCoeff(int i) { return Coeff[i]; }
 
    Coefficient **GetCoeffs() { return Coeff; }
 
    /// Sets coefficient in the vector.
-   void Set(int i, Coefficient *c) { Coeff[i] = c; }
+   void Set(int i, Coefficient *c) { delete Coeff[i]; Coeff[i] = c; }
 
    /// Evaluates i'th component of the vector.
-   double Eval(int i, ElementTransformation &T, IntegrationPoint &ip)
-   { return Coeff[i]->Eval(T, ip, GetTime()); }
+   double Eval(int i, ElementTransformation &T, const IntegrationPoint &ip)
+   { return Coeff[i] ? Coeff[i]->Eval(T, ip, GetTime()) : 0.0; }
 
    using VectorCoefficient::Eval;
    virtual void Eval(Vector &V, ElementTransformation &T,
@@ -454,12 +454,12 @@ public:
 
    explicit MatrixArrayCoefficient (int dim);
 
-   Coefficient &GetCoeff (int i, int j) { return *Coeff[i*vdim+j]; }
+   Coefficient* GetCoeff (int i, int j) { return Coeff[i*vdim+j]; }
 
-   void Set(int i, int j, Coefficient * c) { Coeff[i*vdim+j] = c; }
+   void Set(int i, int j, Coefficient * c) { delete Coeff[i*vdim+j]; Coeff[i*vdim+j] = c; }
 
-   double Eval(int i, int j, ElementTransformation &T, IntegrationPoint &ip)
-   { return Coeff[i*vdim+j] -> Eval(T, ip, GetTime()); }
+   double Eval(int i, int j, ElementTransformation &T, const IntegrationPoint &ip)
+   { return Coeff[i*vdim+j] ? Coeff[i*vdim+j] -> Eval(T, ip, GetTime()) : 0.0; }
 
    virtual void Eval(DenseMatrix &K, ElementTransformation &T,
                      const IntegrationPoint &ip);


### PR DESCRIPTION
## Overview
- These classes take ownership of the Coefficients used for the i-th direction or (i,j) entry.
- When a new one is set, the old one should be deleted
- Added capability of handling NULL coefficients, instead of forcing the user to create a zero coefficient.
- Changed signature of GetCoeff, which now returns a pointer (that can be NULL) instead of a reference

Resolves #243.

## TODO
- [x] Update `CHANGELOG`