### PR TITLE
Fix namespace conflict with hypre [namespace-conflict-bugfix]

### DIFF
--- a/examples/petsc/ex5p.cpp
+++ b/examples/petsc/ex5p.cpp
@@ -210,7 +210,7 @@ int main(int argc, char *argv[])
    PetscParMatrix *pM = NULL, *pB = NULL, *pBT = NULL;
    HypreParMatrix *M = NULL, *B = NULL, *BT = NULL;
    Operator::Type tid =
-      !use_petsc ? Operator::MFEM_HYPRE_PARCSR :
+      !use_petsc ? Operator::Hypre_ParCSR :
       (use_nonoverlapping ? Operator::PETSC_MATIS : Operator::PETSC_MATAIJ);
    OperatorHandle Mh(tid), Bh(tid);
 

--- a/examples/petsc/ex5p.cpp
+++ b/examples/petsc/ex5p.cpp
@@ -210,7 +210,7 @@ int main(int argc, char *argv[])
    PetscParMatrix *pM = NULL, *pB = NULL, *pBT = NULL;
    HypreParMatrix *M = NULL, *B = NULL, *BT = NULL;
    Operator::Type tid =
-      !use_petsc ? Operator::HYPRE_PARCSR :
+      !use_petsc ? Operator::MFEM_HYPRE_PARCSR :
       (use_nonoverlapping ? Operator::PETSC_MATIS : Operator::PETSC_MATAIJ);
    OperatorHandle Mh(tid), Bh(tid);
 

--- a/examples/petsc/ex6p.cpp
+++ b/examples/petsc/ex6p.cpp
@@ -224,7 +224,7 @@ int main(int argc, char *argv[])
 
       a.Assemble();
       b.Assemble();
-      a.SetOperatorType(Operator::HYPRE_PARCSR);
+      a.SetOperatorType(Operator::MFEM_HYPRE_PARCSR);
       HypreParMatrix A;
       Vector B, X;
       MPI_Barrier(MPI_COMM_WORLD);

--- a/examples/petsc/ex6p.cpp
+++ b/examples/petsc/ex6p.cpp
@@ -224,7 +224,7 @@ int main(int argc, char *argv[])
 
       a.Assemble();
       b.Assemble();
-      a.SetOperatorType(Operator::MFEM_HYPRE_PARCSR);
+      a.SetOperatorType(Operator::Hypre_ParCSR);
       HypreParMatrix A;
       Vector B, X;
       MPI_Barrier(MPI_COMM_WORLD);

--- a/fem/hybridization.cpp
+++ b/fem/hybridization.cpp
@@ -34,7 +34,7 @@ Hybridization::Hybridization(FiniteElementSpace *fespace,
 {
 #ifdef MFEM_USE_MPI
    pC = P_pc = NULL;
-   pH.SetType(Operator::MFEM_HYPRE_PARCSR);
+   pH.SetType(Operator::Hypre_ParCSR);
 #endif
 }
 

--- a/fem/hybridization.cpp
+++ b/fem/hybridization.cpp
@@ -34,7 +34,7 @@ Hybridization::Hybridization(FiniteElementSpace *fespace,
 {
 #ifdef MFEM_USE_MPI
    pC = P_pc = NULL;
-   pH.SetType(Operator::HYPRE_PARCSR);
+   pH.SetType(Operator::MFEM_HYPRE_PARCSR);
 #endif
 }
 

--- a/fem/pbilinearform.cpp
+++ b/fem/pbilinearform.cpp
@@ -177,7 +177,7 @@ void ParBilinearForm::ParallelAssemble(OperatorHandle &A, SparseMatrix *A_local)
 
 HypreParMatrix *ParBilinearForm::ParallelAssemble(SparseMatrix *m)
 {
-   OperatorHandle Mh(Operator::MFEM_HYPRE_PARCSR);
+   OperatorHandle Mh(Operator::Hypre_ParCSR);
    ParallelAssemble(Mh, m);
    Mh.SetOperatorOwner(false);
    return Mh.As<HypreParMatrix>();

--- a/fem/pbilinearform.cpp
+++ b/fem/pbilinearform.cpp
@@ -177,7 +177,7 @@ void ParBilinearForm::ParallelAssemble(OperatorHandle &A, SparseMatrix *A_local)
 
 HypreParMatrix *ParBilinearForm::ParallelAssemble(SparseMatrix *m)
 {
-   OperatorHandle Mh(Operator::HYPRE_PARCSR);
+   OperatorHandle Mh(Operator::MFEM_HYPRE_PARCSR);
    ParallelAssemble(Mh, m);
    Mh.SetOperatorOwner(false);
    return Mh.As<HypreParMatrix>();

--- a/fem/pbilinearform.hpp
+++ b/fem/pbilinearform.hpp
@@ -43,12 +43,12 @@ protected:
 public:
    ParBilinearForm(ParFiniteElementSpace *pf)
       : BilinearForm(pf), pfes(pf),
-        p_mat(Operator::HYPRE_PARCSR), p_mat_e(Operator::HYPRE_PARCSR)
+        p_mat(Operator::MFEM_HYPRE_PARCSR), p_mat_e(Operator::MFEM_HYPRE_PARCSR)
    { keep_nbr_block = false; }
 
    ParBilinearForm(ParFiniteElementSpace *pf, ParBilinearForm *bf)
       : BilinearForm(pf, bf), pfes(pf),
-        p_mat(Operator::HYPRE_PARCSR), p_mat_e(Operator::HYPRE_PARCSR)
+        p_mat(Operator::MFEM_HYPRE_PARCSR), p_mat_e(Operator::MFEM_HYPRE_PARCSR)
    { keep_nbr_block = false; }
 
    /** When set to true and the ParBilinearForm has interior face integrators,

--- a/fem/pbilinearform.hpp
+++ b/fem/pbilinearform.hpp
@@ -43,12 +43,12 @@ protected:
 public:
    ParBilinearForm(ParFiniteElementSpace *pf)
       : BilinearForm(pf), pfes(pf),
-        p_mat(Operator::MFEM_HYPRE_PARCSR), p_mat_e(Operator::MFEM_HYPRE_PARCSR)
+        p_mat(Operator::Hypre_ParCSR), p_mat_e(Operator::Hypre_ParCSR)
    { keep_nbr_block = false; }
 
    ParBilinearForm(ParFiniteElementSpace *pf, ParBilinearForm *bf)
       : BilinearForm(pf, bf), pfes(pf),
-        p_mat(Operator::MFEM_HYPRE_PARCSR), p_mat_e(Operator::MFEM_HYPRE_PARCSR)
+        p_mat(Operator::Hypre_ParCSR), p_mat_e(Operator::Hypre_ParCSR)
    { keep_nbr_block = false; }
 
    /** When set to true and the ParBilinearForm has interior face integrators,

--- a/fem/pnonlinearform.hpp
+++ b/fem/pnonlinearform.hpp
@@ -31,7 +31,7 @@ protected:
 
 public:
    ParNonlinearForm(ParFiniteElementSpace *pf)
-      : NonlinearForm(pf), X(pf), Y(pf), pGrad(Operator::MFEM_HYPRE_PARCSR)
+      : NonlinearForm(pf), X(pf), Y(pf), pGrad(Operator::Hypre_ParCSR)
    { height = width = pf->TrueVSize(); }
 
    ParFiniteElementSpace *ParFESpace() const

--- a/fem/pnonlinearform.hpp
+++ b/fem/pnonlinearform.hpp
@@ -31,7 +31,7 @@ protected:
 
 public:
    ParNonlinearForm(ParFiniteElementSpace *pf)
-      : NonlinearForm(pf), X(pf), Y(pf), pGrad(Operator::HYPRE_PARCSR)
+      : NonlinearForm(pf), X(pf), Y(pf), pGrad(Operator::MFEM_HYPRE_PARCSR)
    { height = width = pf->TrueVSize(); }
 
    ParFiniteElementSpace *ParFESpace() const

--- a/fem/staticcond.cpp
+++ b/fem/staticcond.cpp
@@ -35,8 +35,8 @@ StaticCondensation::StaticCondensation(FiniteElementSpace *fespace)
                                           ordering);
       tr_fes = tr_pfes;
    }
-   pS.SetType(Operator::HYPRE_PARCSR);
-   pS_e.SetType(Operator::HYPRE_PARCSR);
+   pS.SetType(Operator::MFEM_HYPRE_PARCSR);
+   pS_e.SetType(Operator::MFEM_HYPRE_PARCSR);
 #endif
    S = S_e = NULL;
    symm = false;

--- a/fem/staticcond.cpp
+++ b/fem/staticcond.cpp
@@ -35,8 +35,8 @@ StaticCondensation::StaticCondensation(FiniteElementSpace *fespace)
                                           ordering);
       tr_fes = tr_pfes;
    }
-   pS.SetType(Operator::MFEM_HYPRE_PARCSR);
-   pS_e.SetType(Operator::MFEM_HYPRE_PARCSR);
+   pS.SetType(Operator::Hypre_ParCSR);
+   pS_e.SetType(Operator::Hypre_ParCSR);
 #endif
    S = S_e = NULL;
    symm = false;

--- a/linalg/handle.cpp
+++ b/linalg/handle.cpp
@@ -26,7 +26,7 @@ Operator::Type OperatorHandle::CheckType(Operator::Type tid)
    switch (tid)
    {
       case Operator::MFEM_SPARSEMAT: break;
-      case Operator::HYPRE_PARCSR:
+      case Operator::MFEM_HYPRE_PARCSR:
 #ifdef MFEM_USE_MPI
          break;
 #else
@@ -56,7 +56,7 @@ void OperatorHandle::MakeSquareBlockDiag(MPI_Comm comm, HYPRE_Int glob_size,
 
    switch (type_id)
    {
-      case Operator::HYPRE_PARCSR:
+      case Operator::MFEM_HYPRE_PARCSR:
          oper = new HypreParMatrix(comm, glob_size, row_starts, diag);
          break;
 #ifdef MFEM_USE_PETSC
@@ -80,7 +80,7 @@ MakeRectangularBlockDiag(MPI_Comm comm, HYPRE_Int glob_num_rows,
 
    switch (type_id)
    {
-      case Operator::HYPRE_PARCSR:
+      case Operator::MFEM_HYPRE_PARCSR:
          oper = new HypreParMatrix(comm, glob_num_rows, glob_num_cols,
                                    row_starts, col_starts, diag);
          break;
@@ -114,7 +114,7 @@ void OperatorHandle::MakePtAP(OperatorHandle &A, OperatorHandle &P)
          break;
       }
 #ifdef MFEM_USE_MPI
-      case Operator::HYPRE_PARCSR:
+      case Operator::MFEM_HYPRE_PARCSR:
          pSet(mfem::RAP(A.As<HypreParMatrix>(), P.As<HypreParMatrix>()));
          break;
 #ifdef MFEM_USE_PETSC
@@ -145,7 +145,7 @@ void OperatorHandle::MakeRAP(OperatorHandle &Rt, OperatorHandle &A,
          break;
       }
 #ifdef MFEM_USE_MPI
-      case Operator::HYPRE_PARCSR:
+      case Operator::MFEM_HYPRE_PARCSR:
          pSet(mfem::RAP(Rt.As<HypreParMatrix>(), A.As<HypreParMatrix>(),
                         P.As<HypreParMatrix>()));
          break;
@@ -179,7 +179,7 @@ void OperatorHandle::ConvertFrom(OperatorHandle &A)
       case Operator::PETSC_MATIS:
          switch (A.Type()) // source type id
          {
-            case Operator::HYPRE_PARCSR:
+            case Operator::MFEM_HYPRE_PARCSR:
 #ifdef MFEM_USE_PETSC
                oper = new PetscParMatrix(A.As<HypreParMatrix>(), Type());
 #endif
@@ -213,12 +213,12 @@ void OperatorHandle::EliminateRowsCols(OperatorHandle &A,
          pSet(Ae);
          break;
       }
-      case Operator::HYPRE_PARCSR:
+      case Operator::MFEM_HYPRE_PARCSR:
       {
 #ifdef MFEM_USE_MPI
          pSet(A.As<HypreParMatrix>()->EliminateRowsCols(ess_dof_list));
 #else
-         MFEM_ABORT("type id = Operator::HYPRE_PARCSR requires MFEM_USE_MPI");
+         MFEM_ABORT("type id = MFEM_HYPRE_PARCSR requires MFEM_USE_MPI");
 #endif
          break;
       }
@@ -248,13 +248,13 @@ void OperatorHandle::EliminateBC(const OperatorHandle &A_e,
          As<SparseMatrix>()->PartMult(ess_dof_list, X, B);
          break;
       }
-      case Operator::HYPRE_PARCSR:
+      case Operator::MFEM_HYPRE_PARCSR:
       {
 #ifdef MFEM_USE_MPI
          mfem::EliminateBC(*As<HypreParMatrix>(), *A_e.As<HypreParMatrix>(),
                            ess_dof_list, X, B);
 #else
-         MFEM_ABORT("type id = Operator::HYPRE_PARCSR requires MFEM_USE_MPI");
+         MFEM_ABORT("type id = MFEM_HYPRE_PARCSR requires MFEM_USE_MPI");
 #endif
          break;
       }

--- a/linalg/handle.cpp
+++ b/linalg/handle.cpp
@@ -26,7 +26,7 @@ Operator::Type OperatorHandle::CheckType(Operator::Type tid)
    switch (tid)
    {
       case Operator::MFEM_SPARSEMAT: break;
-      case Operator::MFEM_HYPRE_PARCSR:
+      case Operator::Hypre_ParCSR:
 #ifdef MFEM_USE_MPI
          break;
 #else
@@ -56,7 +56,7 @@ void OperatorHandle::MakeSquareBlockDiag(MPI_Comm comm, HYPRE_Int glob_size,
 
    switch (type_id)
    {
-      case Operator::MFEM_HYPRE_PARCSR:
+      case Operator::Hypre_ParCSR:
          oper = new HypreParMatrix(comm, glob_size, row_starts, diag);
          break;
 #ifdef MFEM_USE_PETSC
@@ -80,7 +80,7 @@ MakeRectangularBlockDiag(MPI_Comm comm, HYPRE_Int glob_num_rows,
 
    switch (type_id)
    {
-      case Operator::MFEM_HYPRE_PARCSR:
+      case Operator::Hypre_ParCSR:
          oper = new HypreParMatrix(comm, glob_num_rows, glob_num_cols,
                                    row_starts, col_starts, diag);
          break;
@@ -114,7 +114,7 @@ void OperatorHandle::MakePtAP(OperatorHandle &A, OperatorHandle &P)
          break;
       }
 #ifdef MFEM_USE_MPI
-      case Operator::MFEM_HYPRE_PARCSR:
+      case Operator::Hypre_ParCSR:
          pSet(mfem::RAP(A.As<HypreParMatrix>(), P.As<HypreParMatrix>()));
          break;
 #ifdef MFEM_USE_PETSC
@@ -145,7 +145,7 @@ void OperatorHandle::MakeRAP(OperatorHandle &Rt, OperatorHandle &A,
          break;
       }
 #ifdef MFEM_USE_MPI
-      case Operator::MFEM_HYPRE_PARCSR:
+      case Operator::Hypre_ParCSR:
          pSet(mfem::RAP(Rt.As<HypreParMatrix>(), A.As<HypreParMatrix>(),
                         P.As<HypreParMatrix>()));
          break;
@@ -179,7 +179,7 @@ void OperatorHandle::ConvertFrom(OperatorHandle &A)
       case Operator::PETSC_MATIS:
          switch (A.Type()) // source type id
          {
-            case Operator::MFEM_HYPRE_PARCSR:
+            case Operator::Hypre_ParCSR:
 #ifdef MFEM_USE_PETSC
                oper = new PetscParMatrix(A.As<HypreParMatrix>(), Type());
 #endif
@@ -213,12 +213,12 @@ void OperatorHandle::EliminateRowsCols(OperatorHandle &A,
          pSet(Ae);
          break;
       }
-      case Operator::MFEM_HYPRE_PARCSR:
+      case Operator::Hypre_ParCSR:
       {
 #ifdef MFEM_USE_MPI
          pSet(A.As<HypreParMatrix>()->EliminateRowsCols(ess_dof_list));
 #else
-         MFEM_ABORT("type id = MFEM_HYPRE_PARCSR requires MFEM_USE_MPI");
+         MFEM_ABORT("type id = Hypre_ParCSR requires MFEM_USE_MPI");
 #endif
          break;
       }
@@ -248,13 +248,13 @@ void OperatorHandle::EliminateBC(const OperatorHandle &A_e,
          As<SparseMatrix>()->PartMult(ess_dof_list, X, B);
          break;
       }
-      case Operator::MFEM_HYPRE_PARCSR:
+      case Operator::Hypre_ParCSR:
       {
 #ifdef MFEM_USE_MPI
          mfem::EliminateBC(*As<HypreParMatrix>(), *A_e.As<HypreParMatrix>(),
                            ess_dof_list, X, B);
 #else
-         MFEM_ABORT("type id = MFEM_HYPRE_PARCSR requires MFEM_USE_MPI");
+         MFEM_ABORT("type id = Hypre_ParCSR requires MFEM_USE_MPI");
 #endif
          break;
       }

--- a/linalg/handle.hpp
+++ b/linalg/handle.hpp
@@ -25,7 +25,7 @@ namespace mfem
 /** This class provides a common interface for global, matrix-type operators to
     be used in bilinear forms, gradients of nonlinear forms, static condensation,
     hybridization, etc. The following backends are currently supported:
-      - HYPRE parallel sparse matrix (MFEM_HYPRE_PARCSR)
+      - HYPRE parallel sparse matrix (Hypre_ParCSR)
       - PETSC globally assembled parallel sparse matrix (PETSC_MATAIJ)
       - PETSC parallel matrix assembled on each processor (PETSC_MATIS)
     See also Operator::Type.

--- a/linalg/handle.hpp
+++ b/linalg/handle.hpp
@@ -25,7 +25,7 @@ namespace mfem
 /** This class provides a common interface for global, matrix-type operators to
     be used in bilinear forms, gradients of nonlinear forms, static condensation,
     hybridization, etc. The following backends are currently supported:
-      - HYPRE parallel sparse matrix (HYPRE_PARCSR)
+      - HYPRE parallel sparse matrix (MFEM_HYPRE_PARCSR)
       - PETSC globally assembled parallel sparse matrix (PETSC_MATAIJ)
       - PETSC parallel matrix assembled on each processor (PETSC_MATIS)
     See also Operator::Type.

--- a/linalg/hypre.hpp
+++ b/linalg/hypre.hpp
@@ -467,7 +467,7 @@ public:
    /// Calls hypre's destroy function
    virtual ~HypreParMatrix() { Destroy(); }
 
-   Type GetType() const { return HYPRE_PARCSR; }
+   Type GetType() const { return MFEM_HYPRE_PARCSR; }
 };
 
 /** @brief Return a new matrix `C = alpha*A + beta*B`, assuming that both `A`

--- a/linalg/hypre.hpp
+++ b/linalg/hypre.hpp
@@ -467,7 +467,7 @@ public:
    /// Calls hypre's destroy function
    virtual ~HypreParMatrix() { Destroy(); }
 
-   Type GetType() const { return MFEM_HYPRE_PARCSR; }
+   Type GetType() const { return Hypre_ParCSR; }
 };
 
 /** @brief Return a new matrix `C = alpha*A + beta*B`, assuming that both `A`

--- a/linalg/hypre_parcsr.hpp
+++ b/linalg/hypre_parcsr.hpp
@@ -9,8 +9,8 @@
 // terms of the GNU Lesser General Public License (as published by the Free
 // Software Foundation) version 2.1 dated February 1999.
 
-#ifndef MFEM_HYPRE_PARCSR_FILE
-#define MFEM_HYPRE_PARCSR_FILE
+#ifndef MFEM_HYPRE_PARCSR_HPP
+#define MFEM_HYPRE_PARCSR_HPP
 
 #include "../config/config.hpp"
 

--- a/linalg/hypre_parcsr.hpp
+++ b/linalg/hypre_parcsr.hpp
@@ -9,8 +9,8 @@
 // terms of the GNU Lesser General Public License (as published by the Free
 // Software Foundation) version 2.1 dated February 1999.
 
-#ifndef MFEM_HYPRE_PARCSR
-#define MFEM_HYPRE_PARCSR
+#ifndef MFEM_HYPRE_PARCSR_FILE
+#define MFEM_HYPRE_PARCSR_FILE
 
 #include "../config/config.hpp"
 

--- a/linalg/operator.hpp
+++ b/linalg/operator.hpp
@@ -123,7 +123,7 @@ public:
    enum Type
    {
       MFEM_SPARSEMAT,
-      MFEM_HYPRE_PARCSR,
+      Hypre_ParCSR,
       PETSC_MATAIJ,
       PETSC_MATIS,
       PETSC_MATSHELL,

--- a/linalg/operator.hpp
+++ b/linalg/operator.hpp
@@ -123,7 +123,7 @@ public:
    enum Type
    {
       MFEM_SPARSEMAT,
-      HYPRE_PARCSR,
+      MFEM_HYPRE_PARCSR,
       PETSC_MATAIJ,
       PETSC_MATIS,
       PETSC_MATSHELL,


### PR DESCRIPTION
Rename `Operator::HYPRE_PARCSR` to `Operator::MFEM_HYPRE_PARCSR` to resolve #225.