### PR TITLE
Updates to Travis to resolve job timeouts.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,6 +45,10 @@ matrix:
         directories:
           - $TRAVIS_BUILD_DIR/../hypre-2.10.0b/src/hypre/lib
           - $TRAVIS_BUILD_DIR/../hypre-2.10.0b/src/hypre/include
+          - $TRAVIS_BUILD_DIR/../metis-4.0
+      before_cache:
+        - cd $TRAVIS_BUILD_DIR/../metis-4.0;
+          mv libmetis.a ..; rm -rf *; mv ../libmetis.a .
     #
     - os: linux
       compiler: gcc
@@ -70,6 +74,10 @@ matrix:
         directories:
           - $TRAVIS_BUILD_DIR/../hypre-2.10.0b/src/hypre/lib
           - $TRAVIS_BUILD_DIR/../hypre-2.10.0b/src/hypre/include
+          - $TRAVIS_BUILD_DIR/../metis-4.0
+      before_cache:
+        - cd $TRAVIS_BUILD_DIR/../metis-4.0;
+          mv libmetis.a ..; rm -rf *; mv ../libmetis.a .
     #
     # Mac OS X
     #
@@ -102,6 +110,10 @@ matrix:
         directories:
           - $TRAVIS_BUILD_DIR/../hypre-2.10.0b/src/hypre/lib
           - $TRAVIS_BUILD_DIR/../hypre-2.10.0b/src/hypre/include
+          - $TRAVIS_BUILD_DIR/../metis-4.0
+      before_cache:
+        - cd $TRAVIS_BUILD_DIR/../metis-4.0;
+          mv libmetis.a ..; rm -rf *; mv ../libmetis.a .
     #
     - os: osx
       # osx_image: xcode7.3
@@ -116,6 +128,10 @@ matrix:
         directories:
           - $TRAVIS_BUILD_DIR/../hypre-2.10.0b/src/hypre/lib
           - $TRAVIS_BUILD_DIR/../hypre-2.10.0b/src/hypre/include
+          - $TRAVIS_BUILD_DIR/../metis-4.0
+      before_cache:
+        - cd $TRAVIS_BUILD_DIR/../metis-4.0;
+          mv libmetis.a ..; rm -rf *; mv ../libmetis.a .
 
 
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -116,7 +116,6 @@ install:
 
 script:
    # Compiler
-   # set NPROCS=2 for linux
    - if [ $MPI == "YES" ]; then
         export MYCXX=mpic++;
         if [ "$TRAVIS_OS_NAME" == "linux" ]; then
@@ -129,27 +128,24 @@ script:
      else
         export MYCXX="$CXX";
      fi
+
    # Print the compiler version
    - $MYCXX -v
 
-   # Colors and time format
-   - purple=$'\E[0;35m';
-     none=$'\E[0m';
-     TIMEFORMAT="${purple}"$'real=%3Rs  user=%3Us  sys=%3Ss  %%cpu=%P'"${none}"
-
-   # Build and check/test MFEM, its examples and miniapps
-   - cd $TRAVIS_BUILD_DIR &&
-     CPPFLAGS="" &&
-     SKIP_TEST_DIRS="" &&
+   # Set some variables
+   - cd $TRAVIS_BUILD_DIR;
+     CPPFLAGS="";
+     SKIP_TEST_DIRS="";
      if [ "$CODECOV" == "YES" ]; then
         CPPFLAGS="--coverage -g";
-     fi &&
-     echo "${purple}Number of MPI tasks = ${NPROCS}${none}" &&
-     make config MFEM_USE_MPI=$MPI MFEM_DEBUG=$DEBUG MFEM_CXX="$MYCXX"
-        MFEM_MPI_NP=$NPROCS CPPFLAGS="$CPPFLAGS" &&
-     make info &&
-     time make -j3 all &&
-     time make $MFEM_TEST_TARGET SKIP_TEST_DIRS="$SKIP_TEST_DIRS"
+     fi
+
+   # Build and check/test MFEM, its examples and miniapps
+   - make config MFEM_USE_MPI=$MPI MFEM_DEBUG=$DEBUG MFEM_CXX="$MYCXX"
+        MFEM_MPI_NP=$NPROCS CPPFLAGS="$CPPFLAGS"
+   - make info
+   - make -j3 all
+   - make $MFEM_TEST_TARGET SKIP_TEST_DIRS="$SKIP_TEST_DIRS"
 
 after_success:
    - if [ "$CODECOV" == "YES" ]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -178,8 +178,9 @@ install:
 
    # hypre
    - if [ $MPI == "YES" ]; then
-        if [ ! -d hypre-2.10.0b ]; then
+        if [ ! -e hypre-2.10.0b/src/lib/libHYPRE.a ]; then
            wget https://computation.llnl.gov/project/linear_solvers/download/hypre-2.10.0b.tar.gz --no-check-certificate;
+           rm -rf hypre-2.10.0b;
            tar xvzf hypre-2.10.0b.tar.gz;
            cd hypre-2.10.0b/src;
            ./configure --disable-fortran --without-fei CC=mpicc CXX=mpic++;
@@ -194,12 +195,11 @@ install:
 
    # METIS
    - if [ $MPI == "YES" ]; then
-        if [ ! -d metis-4.0 ]; then
+        if [ ! -e metis-4.0/libmetis.a ]; then
            wget http://glaros.dtc.umn.edu/gkhome/fetch/sw/metis/OLD/metis-4.0.3.tar.gz;
            tar xvzf metis-4.0.3.tar.gz;
-           cd metis-4.0.3;
-           make -j3 -C Lib CC="$CC" OPTFLAGS="-O2";
-           cd ..;
+           make -j3 -C metis-4.0.3/Lib CC="$CC" OPTFLAGS="-O2";
+           rm -rf metis-4.0;
            mv metis-4.0.3 metis-4.0;
         else
            echo "Reusing cached metis-4.0/";

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,8 +43,8 @@ matrix:
            NPROCS=2
       cache:
         directories:
-          - $HOME/../hypre-2.10.0b/src/hypre/lib
-          - $HOME/../hypre-2.10.0b/src/hypre/include
+          - $TRAVIS_BUILD_DIR/../hypre-2.10.0b/src/hypre/lib
+          - $TRAVIS_BUILD_DIR/../hypre-2.10.0b/src/hypre/include
     #
     - os: linux
       compiler: gcc
@@ -68,8 +68,8 @@ matrix:
            NPROCS=2
       cache:
         directories:
-          - $HOME/../hypre-2.10.0b/src/hypre/lib
-          - $HOME/../hypre-2.10.0b/src/hypre/include
+          - $TRAVIS_BUILD_DIR/../hypre-2.10.0b/src/hypre/lib
+          - $TRAVIS_BUILD_DIR/../hypre-2.10.0b/src/hypre/include
     #
     # Mac OS X
     #
@@ -100,8 +100,8 @@ matrix:
            TMPDIR=/tmp
       cache:
         directories:
-          - $HOME/../hypre-2.10.0b/src/hypre/lib
-          - $HOME/../hypre-2.10.0b/src/hypre/include
+          - $TRAVIS_BUILD_DIR/../hypre-2.10.0b/src/hypre/lib
+          - $TRAVIS_BUILD_DIR/../hypre-2.10.0b/src/hypre/include
     #
     - os: osx
       # osx_image: xcode7.3
@@ -114,8 +114,8 @@ matrix:
            TMPDIR=/tmp
       cache:
         directories:
-          - $HOME/../hypre-2.10.0b/src/hypre/lib
-          - $HOME/../hypre-2.10.0b/src/hypre/include
+          - $TRAVIS_BUILD_DIR/../hypre-2.10.0b/src/hypre/lib
+          - $TRAVIS_BUILD_DIR/../hypre-2.10.0b/src/hypre/include
 
 
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,67 +2,123 @@ sudo: false
 
 language: cpp
 
-compiler:
-   - gcc
-   - clang
-
-os:
-   - linux
-   - osx
-
-env:
-   global:
-      - TMPDIR=/tmp
-# Travis VM environment provides 2 processor cores.
-# Note: NPROCS=2 for linux, see below.
-      - NPROCS=4
-   matrix:
-      - DEBUG=YES
-        MPI=YES
-        CODECOV=NO
-        MFEM_TEST_TARGET=check
-      - DEBUG=NO
-        MPI=YES
-        CODECOV=YES
-        MFEM_TEST_TARGET=test
-      - DEBUG=YES
-        MPI=NO
-        CODECOV=NO
-        MFEM_TEST_TARGET=check
-      - DEBUG=NO
-        MPI=NO
-        CODECOV=NO
-        MFEM_TEST_TARGET=test
-
-addons:
-   apt:
-      sources:
-         - ubuntu-toolchain-r-test
-      packages:
-         - g++-4.9
-# MPICH
-         - mpich
-         - libmpich-dev
-# OpenMPI
-#         - openmpi-bin
-#         - libopenmpi-dev
-
-# Test with GCC on Linux an Clang on Mac
 matrix:
-   exclude:
-      - compiler: clang
-        os: linux
-      - compiler: gcc
-        os: osx
+  include:
+    #
+    # Linux
+    #
+    - os: linux
+      compiler: gcc
+      env: DEBUG=YES
+           MPI=NO
+           CODECOV=NO
+           MFEM_TEST_TARGET=check
+    #
+    - os: linux
+      compiler: gcc
+      env: DEBUG=NO
+           MPI=NO
+           CODECOV=NO
+           MFEM_TEST_TARGET=test
+    #
+    - os: linux
+      compiler: gcc
+      addons:
+        apt:
+          # sources:
+            # - ubuntu-toolchain-r-test
+          packages:
+            # GCC 4.9
+            # - g++-4.9
+            # MPICH
+            - mpich
+            - libmpich-dev
+            # OpenMPI
+            # - openmpi-bin
+            # - libopenmpi-dev
+      env: DEBUG=YES
+           MPI=YES
+           CODECOV=NO
+           MFEM_TEST_TARGET=check
+           NPROC=2
+    #
+    - os: linux
+      compiler: gcc
+      addons:
+        apt:
+          # sources:
+            # - ubuntu-toolchain-r-test
+          packages:
+            # GCC 4.9
+            # - g++-4.9
+            # MPICH
+            - mpich
+            - libmpich-dev
+            # OpenMPI
+            # - openmpi-bin
+            # - libopenmpi-dev
+      env: DEBUG=NO
+           MPI=YES
+           CODECOV=YES
+           MFEM_TEST_TARGET=test
+           NPROC=2
+    #
+    # Mac OS X
+    #
+    - os: osx
+      # osx_image: xcode7.3
+      compiler: clang
+      env: DEBUG=YES
+           MPI=NO
+           CODECOV=NO
+           MFEM_TEST_TARGET=check
+    #
+    - os: osx
+      # osx_image: xcode7.3
+      compiler: clang
+      env: DEBUG=NO
+           MPI=NO
+           CODECOV=NO
+           MFEM_TEST_TARGET=test
+    #
+    - os: osx
+      # osx_image: xcode7.3
+      compiler: clang
+      env: DEBUG=YES
+           MPI=YES
+           CODECOV=NO
+           MFEM_TEST_TARGET=check
+           NPROC=4
+           TMPDIR=/tmp
+    #
+    - os: osx
+      # osx_image: xcode7.3
+      compiler: clang
+      env: DEBUG=NO
+           MPI=YES
+           CODECOV=YES
+           MFEM_TEST_TARGET=test
+           NPROC=4
+           TMPDIR=/tmp
+
 
 before_install:
-    # No addon for brew yet, have to install OSX packages this way.
+   # No addon for brew yet, have to install OSX packages this way.
    - if [ $TRAVIS_OS_NAME == "osx" ]; then
         rvm get stable;
         if [ $MPI == "YES" ]; then
            travis_wait brew install open-mpi;
-        fi
-      fi
+        fi;
+     fi
+
+   # Update environment to find g++ 4.9 installation first.
+   # - if [ $TRAVIS_OS_NAME == "linux" ]; then
+   #      mkdir -p latest-gcc-symlinks;
+   #      ln -s /usr/bin/g++-4.9 latest-gcc-symlinks/g++;
+   #      ln -s /usr/bin/gcc-4.9 latest-gcc-symlinks/gcc;
+   #      ln -s /usr/bin/gcov-4.9 latest-gcc-symlinks/gcov;
+   #      export PATH=$PWD/latest-gcc-symlinks:$PATH;
+   #   fi
 
    # Install tool to upload code coverage reports to coveralls.io
    - if [ "$CODECOV" == "YES" ]; then
@@ -70,15 +126,6 @@ before_install:
         pip install --user cpp-coveralls;
         pip install --user pyyaml;
         PATH=$HOME/local/bin:$PATH;
-     fi
-
-   # Update environment to find g++ 4.9 installation first.
-   - if [ $TRAVIS_OS_NAME == "linux" ]; then
-         mkdir -p latest-gcc-symlinks;
-         ln -s /usr/bin/g++-4.9 latest-gcc-symlinks/g++;
-         ln -s /usr/bin/gcc-4.9 latest-gcc-symlinks/gcc;
-         ln -s /usr/bin/gcov-4.9 latest-gcc-symlinks/gcov;
-         export PATH=$PWD/latest-gcc-symlinks:$PATH;
      fi
 
 install:
@@ -134,9 +181,6 @@ script:
    # Compiler
    - if [ $MPI == "YES" ]; then
         export MYCXX=mpic++;
-        if [ "$TRAVIS_OS_NAME" == "linux" ]; then
-           NPROCS=2;
-        fi;
      else
         export MYCXX="$CXX";
      fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ env:
    global:
       - TMPDIR=/tmp
 # Travis VM environment provides 2 processor cores.
-      - NPROCS=2
+      - NPROCS=4
    matrix:
       - DEBUG=YES
         MPI=YES
@@ -39,8 +39,10 @@ addons:
          - ubuntu-toolchain-r-test
       packages:
          - g++-4.9
-         - openmpi-bin
-         - libopenmpi-dev;
+         - mpich
+         - libmpich-dev
+#         - openmpi-bin
+#         - libopenmpi-dev;
 
 # Test with GCC on Linux an Clang on Mac
 matrix:
@@ -110,11 +112,22 @@ install:
      fi
 
 script:
+   # System info
+   - if [ "$TRAVIS_OS_NAME" == "linux" ]; then
+        cat /proc/{version,cpuinfo,meminfo};
+     elif [ "$TRAVIS_OS_NAME" == "osx" ]; then
+        /usr/sbin/sysctl kern.version hw;
+     fi;
+
    # Compiler
    - if [ $MPI == "YES" ]; then
         export MYCXX=mpic++;
-        export OMPI_CXX="$CXX";
-        $MYCXX --showme:version;
+        if [ "$TRAVIS_OS_NAME" == "linux" ]; then
+           export MPICH_CXX="$CXX";
+        else
+           export OMPI_CXX="$CXX";
+           $MYCXX --showme:version;
+        fi;
      else
         export MYCXX="$CXX";
      fi
@@ -127,7 +140,7 @@ script:
      SKIP_TEST_DIRS="" &&
      if [ "$CODECOV" == "YES" ]; then
         CPPFLAGS="--coverage -g";
-        SKIP_TEST_DIRS="miniapps/performance";
+#        SKIP_TEST_DIRS="miniapps/performance";
      fi &&
      make config MFEM_USE_MPI=$MPI MFEM_DEBUG=$DEBUG MFEM_CXX="$MYCXX"
         MFEM_MPI_NP=$NPROCS CPPFLAGS="$CPPFLAGS" &&

--- a/.travis.yml
+++ b/.travis.yml
@@ -111,6 +111,7 @@ matrix:
           - $TRAVIS_BUILD_DIR/../hypre-2.10.0b/src/hypre/lib
           - $TRAVIS_BUILD_DIR/../hypre-2.10.0b/src/hypre/include
           - $TRAVIS_BUILD_DIR/../metis-4.0
+          - $HOME/bottles
       before_cache:
         - cd $TRAVIS_BUILD_DIR/../metis-4.0;
           mv libmetis.a ..; rm -rf *; mv ../libmetis.a .
@@ -129,6 +130,7 @@ matrix:
           - $TRAVIS_BUILD_DIR/../hypre-2.10.0b/src/hypre/lib
           - $TRAVIS_BUILD_DIR/../hypre-2.10.0b/src/hypre/include
           - $TRAVIS_BUILD_DIR/../metis-4.0
+          - $HOME/bottles
       before_cache:
         - cd $TRAVIS_BUILD_DIR/../metis-4.0;
           mv libmetis.a ..; rm -rf *; mv ../libmetis.a .
@@ -136,8 +138,25 @@ matrix:
 
 before_install:
    # No addon for brew yet, have to install OSX packages this way.
+   # - if [ $TRAVIS_OS_NAME == "osx" ] && [ $MPI == "YES" ]; then
+   #      brew install open-mpi;
+   #   fi
+
+   # Use cached bottle for open-mpi:
    - if [ $TRAVIS_OS_NAME == "osx" ] && [ $MPI == "YES" ]; then
-        brew install open-mpi;
+        if [ ! -e $HOME/bottles/open-mpi.tgz ]; then
+           mkdir -p $HOME/bottles;
+           cd $HOME/bottles;
+           brew install --build-from-source --build-bottle
+              open-mpi --without-fortran;
+           brew bottle --root-url=$HOME open-mpi;
+           mv open-mpi-*.tar.gz open-mpi.tgz;
+        else
+           brew install --only-dependencies open-mpi --without-fortran;
+           cd $(brew --cellar) && tar zxf $HOME/bottles/open-mpi.tgz;
+           brew link open-mpi;
+        fi;
+        cd $TRAVIS_BUILD_DIR;
      fi
 
    # Update environment to find g++ 4.9 installation first.

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ env:
    global:
       - TMPDIR=/tmp
 # Travis VM environment provides 2 processor cores.
+# Note: NPROCS=2 for linux, see below.
       - NPROCS=4
    matrix:
       - DEBUG=YES
@@ -39,8 +40,10 @@ addons:
          - ubuntu-toolchain-r-test
       packages:
          - g++-4.9
+# MPICH
          - mpich
          - libmpich-dev
+# OpenMPI
 #         - openmpi-bin
 #         - libopenmpi-dev
 
@@ -112,18 +115,13 @@ install:
      fi
 
 script:
-   # System info
-   - if [ "$TRAVIS_OS_NAME" == "linux" ]; then
-        cat /proc/{version,cpuinfo,meminfo};
-     elif [ "$TRAVIS_OS_NAME" == "osx" ]; then
-        /usr/sbin/sysctl kern.version hw;
-     fi
-
    # Compiler
+   # set NPROCS=2 for linux
    - if [ $MPI == "YES" ]; then
         export MYCXX=mpic++;
         if [ "$TRAVIS_OS_NAME" == "linux" ]; then
            export MPICH_CXX="$CXX";
+           NPROCS=2;
         else
            export OMPI_CXX="$CXX";
            $MYCXX --showme:version;
@@ -134,6 +132,11 @@ script:
    # Print the compiler version
    - $MYCXX -v
 
+   # Colors and time format
+   - purple=$'\E[0;35m';
+     none=$'\E[0m';
+     TIMEFORMAT="${purple}"$'real=%3Rs  user=%3Us  sys=%3Ss  %%cpu=%P'"${none}"
+
    # Build and check/test MFEM, its examples and miniapps
    - cd $TRAVIS_BUILD_DIR &&
      CPPFLAGS="" &&
@@ -141,11 +144,12 @@ script:
      if [ "$CODECOV" == "YES" ]; then
         CPPFLAGS="--coverage -g";
      fi &&
+     echo "${purple}Number of MPI tasks = ${NPROCS}${none}" &&
      make config MFEM_USE_MPI=$MPI MFEM_DEBUG=$DEBUG MFEM_CXX="$MYCXX"
         MFEM_MPI_NP=$NPROCS CPPFLAGS="$CPPFLAGS" &&
      make info &&
-     make -j3 all &&
-     make $MFEM_TEST_TARGET SKIP_TEST_DIRS="$SKIP_TEST_DIRS"
+     time make -j3 all &&
+     time make $MFEM_TEST_TARGET SKIP_TEST_DIRS="$SKIP_TEST_DIRS"
 
 after_success:
    - if [ "$CODECOV" == "YES" ]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -104,11 +104,8 @@ matrix:
 
 before_install:
    # No addon for brew yet, have to install OSX packages this way.
-   - if [ $TRAVIS_OS_NAME == "osx" ]; then
-        rvm get stable;
-        if [ $MPI == "YES" ]; then
-           travis_wait brew install open-mpi;
-        fi;
+   - if [ $TRAVIS_OS_NAME == "osx" ] && [ $MPI == "YES" ]; then
+        brew install open-mpi --without-fortran;
      fi
 
    # Update environment to find g++ 4.9 installation first.

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,6 +41,10 @@ matrix:
            CODECOV=NO
            MFEM_TEST_TARGET=check
            NPROCS=2
+      cache:
+        directories:
+          - $HOME/../hypre-2.10.0b/src/hypre/lib
+          - $HOME/../hypre-2.10.0b/src/hypre/include
     #
     - os: linux
       compiler: gcc
@@ -62,6 +66,10 @@ matrix:
            CODECOV=YES
            MFEM_TEST_TARGET=test
            NPROCS=2
+      cache:
+        directories:
+          - $HOME/../hypre-2.10.0b/src/hypre/lib
+          - $HOME/../hypre-2.10.0b/src/hypre/include
     #
     # Mac OS X
     #
@@ -90,6 +98,10 @@ matrix:
            MFEM_TEST_TARGET=check
            NPROCS=4
            TMPDIR=/tmp
+      cache:
+        directories:
+          - $HOME/../hypre-2.10.0b/src/hypre/lib
+          - $HOME/../hypre-2.10.0b/src/hypre/include
     #
     - os: osx
       # osx_image: xcode7.3
@@ -100,6 +112,10 @@ matrix:
            MFEM_TEST_TARGET=test
            NPROCS=4
            TMPDIR=/tmp
+      cache:
+        directories:
+          - $HOME/../hypre-2.10.0b/src/hypre/lib
+          - $HOME/../hypre-2.10.0b/src/hypre/include
 
 
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -92,9 +92,9 @@ install:
            export OMPI_CXX="$CXX";
            mpic++ --showme:version;
         fi;
-        mpic++ -v
+        mpic++ -v;
      else
-        $CXX -v
+        $CXX -v;
      fi
 
    # Back out of the mfem directory to install the libraries
@@ -106,7 +106,7 @@ install:
            wget https://computation.llnl.gov/project/linear_solvers/download/hypre-2.10.0b.tar.gz --no-check-certificate;
            tar xvzf hypre-2.10.0b.tar.gz;
            cd hypre-2.10.0b/src;
-           ./configure --disable-fortran --without-fei CC=mpicc CXX=mpic++
+           ./configure --disable-fortran --without-fei CC=mpicc CXX=mpic++;
            make -j3;
            cd ../..;
         else

--- a/.travis.yml
+++ b/.travis.yml
@@ -67,7 +67,6 @@ before_install:
    # Install tool to upload code coverage reports to coveralls.io
    - if [ "$CODECOV" == "YES" ]; then
         export PYTHONUSERBASE=$HOME/local;
-        echo "Using PYTHONUSERBASE=$PYTHONUSERBASE";
         pip install --user cpp-coveralls;
         pip install --user pyyaml;
         PATH=$HOME/local/bin:$PATH;
@@ -83,18 +82,33 @@ before_install:
      fi
 
 install:
+   # Set MPI compilers, print compiler version
+   - if [ $MPI == "YES" ]; then
+        if [ "$TRAVIS_OS_NAME" == "linux" ]; then
+           export MPICH_CC="$CC";
+           export MPICH_CXX="$CXX";
+        else
+           export OMPI_CC="$CC";
+           export OMPI_CXX="$CXX";
+           mpic++ --showme:version;
+        fi;
+        mpic++ -v
+     else
+        $CXX -v
+     fi
+
    # Back out of the mfem directory to install the libraries
    - cd ..
 
    # hypre
    - if [ $MPI == "YES" ]; then
         if [ ! -d hypre-2.10.0b ]; then
-            wget https://computation.llnl.gov/project/linear_solvers/download/hypre-2.10.0b.tar.gz --no-check-certificate;
-            tar xvzf hypre-2.10.0b.tar.gz;
-            cd hypre-2.10.0b/src;
-            ./configure --disable-fortran --without-fei CC=mpicc CXX=mpic++;
-            make -j3;
-            cd ../..;
+           wget https://computation.llnl.gov/project/linear_solvers/download/hypre-2.10.0b.tar.gz --no-check-certificate;
+           tar xvzf hypre-2.10.0b.tar.gz;
+           cd hypre-2.10.0b/src;
+           ./configure --disable-fortran --without-fei CC=mpicc CXX=mpic++
+           make -j3;
+           cd ../..;
         else
             echo "Reusing cached hypre-2.10.0b/";
         fi;
@@ -103,15 +117,17 @@ install:
      fi
 
    # METIS
-   - if [ ! -d metis-4.0 ]; then
-        wget http://glaros.dtc.umn.edu/gkhome/fetch/sw/metis/OLD/metis-4.0.3.tar.gz;
-        tar xvzf metis-4.0.3.tar.gz;
-        cd metis-4.0.3;
-        make -j3;
-        cd ..;
-        mv metis-4.0.3 metis-4.0;
-     else
-        echo "Reusing cached metis-4.0/";
+   - if [ $MPI == "YES" ]; then
+        if [ ! -d metis-4.0 ]; then
+           wget http://glaros.dtc.umn.edu/gkhome/fetch/sw/metis/OLD/metis-4.0.3.tar.gz;
+           tar xvzf metis-4.0.3.tar.gz;
+           cd metis-4.0.3;
+           make -j3 -C Lib CC="$CC" OPTFLAGS="-O2";
+           cd ..;
+           mv metis-4.0.3 metis-4.0;
+        else
+           echo "Reusing cached metis-4.0/";
+        fi;
      fi
 
 script:
@@ -119,11 +135,7 @@ script:
    - if [ $MPI == "YES" ]; then
         export MYCXX=mpic++;
         if [ "$TRAVIS_OS_NAME" == "linux" ]; then
-           export MPICH_CXX="$CXX";
            NPROCS=2;
-        else
-           export OMPI_CXX="$CXX";
-           $MYCXX --showme:version;
         fi;
      else
         export MYCXX="$CXX";
@@ -140,14 +152,20 @@ script:
         CPPFLAGS="--coverage -g";
      fi
 
-   # Build and check/test MFEM, its examples and miniapps
+   # Configure the library
    - make config MFEM_USE_MPI=$MPI MFEM_DEBUG=$DEBUG MFEM_CXX="$MYCXX"
         MFEM_MPI_NP=$NPROCS CPPFLAGS="$CPPFLAGS"
+   # Show the configuration
    - make info
+   # Build the library
+   - make -j3
+   # Build the examples and the miniapps
    - make -j3 all
+   # Run tests
    - make $MFEM_TEST_TARGET SKIP_TEST_DIRS="$SKIP_TEST_DIRS"
 
 after_success:
    - if [ "$CODECOV" == "YES" ]; then
-        coveralls --include fem --include general --include linalg --include mesh --exclude /usr --gcov-options '\-lp' --root $TRAVIS_BUILD_DIR;
-     fi;
+        coveralls --include fem --include general --include linalg --include
+           mesh --exclude /usr --gcov-options '\-lp' --root $TRAVIS_BUILD_DIR;
+     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ matrix:
            MPI=YES
            CODECOV=NO
            MFEM_TEST_TARGET=check
-           NPROC=2
+           NPROCS=2
     #
     - os: linux
       compiler: gcc
@@ -61,7 +61,7 @@ matrix:
            MPI=YES
            CODECOV=YES
            MFEM_TEST_TARGET=test
-           NPROC=2
+           NPROCS=2
     #
     # Mac OS X
     #
@@ -88,7 +88,7 @@ matrix:
            MPI=YES
            CODECOV=NO
            MFEM_TEST_TARGET=check
-           NPROC=4
+           NPROCS=4
            TMPDIR=/tmp
     #
     - os: osx
@@ -98,7 +98,7 @@ matrix:
            MPI=YES
            CODECOV=YES
            MFEM_TEST_TARGET=test
-           NPROC=4
+           NPROCS=4
            TMPDIR=/tmp
 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -178,7 +178,7 @@ install:
 
    # hypre
    - if [ $MPI == "YES" ]; then
-        if [ ! -e hypre-2.10.0b/src/lib/libHYPRE.a ]; then
+        if [ ! -e hypre-2.10.0b/src/hypre/lib/libHYPRE.a ]; then
            wget https://computation.llnl.gov/project/linear_solvers/download/hypre-2.10.0b.tar.gz --no-check-certificate;
            rm -rf hypre-2.10.0b;
            tar xvzf hypre-2.10.0b.tar.gz;

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,16 +13,16 @@ os:
 env:
    global:
       - TMPDIR=/tmp
+# Travis VM environment provides 2 processor cores.
+      - NPROCS=2
    matrix:
       - DEBUG=YES
         MPI=YES
-        NPROCS=4
-        CODECOV=YES
-        MFEM_TEST_TARGET=test
+        CODECOV=NO
+        MFEM_TEST_TARGET=check
       - DEBUG=NO
         MPI=YES
-        NPROCS=4
-        CODECOV=NO
+        CODECOV=YES
         MFEM_TEST_TARGET=test
       - DEBUG=YES
         MPI=NO
@@ -31,7 +31,7 @@ env:
       - DEBUG=NO
         MPI=NO
         CODECOV=NO
-        MFEM_TEST_TARGET=check
+        MFEM_TEST_TARGET=test
 
 addons:
    apt:
@@ -53,9 +53,11 @@ matrix:
 before_install:
     # No addon for brew yet, have to install OSX packages this way.
    - if [ $TRAVIS_OS_NAME == "osx" ]; then
-        travis_wait brew install open-mpi;
         rvm get stable;
-     fi
+        if [ $MPI == "YES" ]; then
+           travis_wait brew install open-mpi;
+        fi
+      fi
 
    # Install tool to upload code coverage reports to coveralls.io
    - if [ "$CODECOV" == "YES" ]; then
@@ -79,13 +81,6 @@ install:
    # Back out of the mfem directory to install the libraries
    - cd ..
 
-   # OpenMPI
-#   - if [ $TRAVIS_OS_NAME == "linux" ]; then
-#        sudo apt-get install openmpi-bin libopenmpi-dev;
-#     else
-#        travis_wait brew install open-mpi;
-#     fi
-
    # hypre
    - if [ $MPI == "YES" ]; then
         if [ ! -d hypre-2.10.0b ]; then
@@ -93,7 +88,7 @@ install:
             tar xvzf hypre-2.10.0b.tar.gz;
             cd hypre-2.10.0b/src;
             ./configure --disable-fortran --without-fei CC=mpicc CXX=mpic++;
-            make -j 4;
+            make -j3;
             cd ../..;
         else
             echo "Reusing cached hypre-2.10.0b/";
@@ -107,18 +102,12 @@ install:
         wget http://glaros.dtc.umn.edu/gkhome/fetch/sw/metis/OLD/metis-4.0.3.tar.gz;
         tar xvzf metis-4.0.3.tar.gz;
         cd metis-4.0.3;
-        make -j 4;
+        make -j3;
         cd ..;
         mv metis-4.0.3 metis-4.0;
      else
         echo "Reusing cached metis-4.0/";
      fi
-
-# # Delete an expired cache here: https://travis-ci.org/mfem/mfem/caches
-# cache:
-#   directories:
-#     - $TRAVIS_BUILD_DIR/../hypre-2.10.0b
-#     - $TRAVIS_BUILD_DIR/../metis-4.0
 
 script:
    # Compiler
@@ -137,16 +126,15 @@ script:
      CPPFLAGS="" &&
      SKIP_TEST_DIRS="" &&
      if [ "$CODECOV" == "YES" ]; then
-        CPPFLAGS="--coverage";
+        CPPFLAGS="--coverage -g";
         SKIP_TEST_DIRS="miniapps/performance";
      fi &&
      make config MFEM_USE_MPI=$MPI MFEM_DEBUG=$DEBUG MFEM_CXX="$MYCXX"
         MFEM_MPI_NP=$NPROCS CPPFLAGS="$CPPFLAGS" &&
      make info &&
-     make all -j 4 &&
+     make -j3 all &&
      make $MFEM_TEST_TARGET SKIP_TEST_DIRS="$SKIP_TEST_DIRS"
 
-#      coveralls --include fem --include general --include linalg --include mesh --include miniapps --gcov-options '\-lp' --root $TRAVIS_BUILD_DIR --build-root $TRAVIS_BUILD_DIR;
 after_success:
    - if [ "$CODECOV" == "YES" ]; then
         coveralls --include fem --include general --include linalg --include mesh --exclude /usr --gcov-options '\-lp' --root $TRAVIS_BUILD_DIR;

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ addons:
          - mpich
          - libmpich-dev
 #         - openmpi-bin
-#         - libopenmpi-dev;
+#         - libopenmpi-dev
 
 # Test with GCC on Linux an Clang on Mac
 matrix:
@@ -117,7 +117,7 @@ script:
         cat /proc/{version,cpuinfo,meminfo};
      elif [ "$TRAVIS_OS_NAME" == "osx" ]; then
         /usr/sbin/sysctl kern.version hw;
-     fi;
+     fi
 
    # Compiler
    - if [ $MPI == "YES" ]; then
@@ -140,7 +140,6 @@ script:
      SKIP_TEST_DIRS="" &&
      if [ "$CODECOV" == "YES" ]; then
         CPPFLAGS="--coverage -g";
-#        SKIP_TEST_DIRS="miniapps/performance";
      fi &&
      make config MFEM_USE_MPI=$MPI MFEM_DEBUG=$DEBUG MFEM_CXX="$MYCXX"
         MFEM_MPI_NP=$NPROCS CPPFLAGS="$CPPFLAGS" &&

--- a/.travis.yml
+++ b/.travis.yml
@@ -105,7 +105,7 @@ matrix:
 before_install:
    # No addon for brew yet, have to install OSX packages this way.
    - if [ $TRAVIS_OS_NAME == "osx" ] && [ $MPI == "YES" ]; then
-        brew install open-mpi --without-fortran;
+        brew install open-mpi;
      fi
 
    # Update environment to find g++ 4.9 installation first.

--- a/.travis.yml
+++ b/.travis.yml
@@ -111,7 +111,7 @@ matrix:
           - $TRAVIS_BUILD_DIR/../hypre-2.10.0b/src/hypre/lib
           - $TRAVIS_BUILD_DIR/../hypre-2.10.0b/src/hypre/include
           - $TRAVIS_BUILD_DIR/../metis-4.0
-          - $HOME/bottles
+          - $HOME/local-cached
       before_cache:
         - cd $TRAVIS_BUILD_DIR/../metis-4.0;
           mv libmetis.a ..; rm -rf *; mv ../libmetis.a .
@@ -130,7 +130,7 @@ matrix:
           - $TRAVIS_BUILD_DIR/../hypre-2.10.0b/src/hypre/lib
           - $TRAVIS_BUILD_DIR/../hypre-2.10.0b/src/hypre/include
           - $TRAVIS_BUILD_DIR/../metis-4.0
-          - $HOME/bottles
+          - $HOME/local-cached
       before_cache:
         - cd $TRAVIS_BUILD_DIR/../metis-4.0;
           mv libmetis.a ..; rm -rf *; mv ../libmetis.a .
@@ -142,20 +142,17 @@ before_install:
    #      brew install open-mpi;
    #   fi
 
-   # Use cached bottle for open-mpi:
+   # On Mac OS X, build and cache OpenMPI 2.1.1:
    - if [ $TRAVIS_OS_NAME == "osx" ] && [ $MPI == "YES" ]; then
-        if [ ! -e $HOME/bottles/open-mpi.tgz ]; then
-           mkdir -p $HOME/bottles;
-           cd $HOME/bottles;
-           brew install --build-from-source --build-bottle
-              open-mpi --without-fortran;
-           brew bottle --root-url=$HOME open-mpi;
-           mv open-mpi-*.tar.gz open-mpi.tgz;
-        else
-           brew install --only-dependencies open-mpi --without-fortran;
-           cd $(brew --cellar) && tar zxf $HOME/bottles/open-mpi.tgz;
-           brew link open-mpi;
+        if [ ! -e $HOME/local-cached/bin/mpicc ]; then
+           mkdir -p $HOME/builds && cd $HOME/builds &&
+           wget https://www.open-mpi.org/software/ompi/v2.1/downloads/openmpi-2.1.1.tar.bz2 &&
+           tar jxf openmpi-2.1.1.tar.bz2 &&
+           mkdir openmpi-build && cd openmpi-build &&
+           ../openmpi-2.1.1/configure --prefix=$HOME/local-cached &&
+           make -j3 all && make install;
         fi;
+        PATH=$HOME/local-cached/bin:$PATH;
         cd $TRAVIS_BUILD_DIR;
      fi
 

--- a/config/test.mk
+++ b/config/test.mk
@@ -16,29 +16,59 @@
 # no color '\033[0m'
 COLOR_PRINT = if [ -t 1 ]; then \
    printf $(1)$(2)'\033[0m'$(3); else printf $(2)$(3); fi
-PRINT_OK = $(call COLOR_PRINT,'\033[0;32m',OK,"  ($$1)\n")
-PRINT_FAILED = $(call COLOR_PRINT,'\033[0;31m',FAILED,"  ($$1)\n")
+PRINT_OK = $(call COLOR_PRINT,'\033[0;32m',OK,"  ($$1 $$2)\n")
+PRINT_FAILED = $(call COLOR_PRINT,'\033[0;31m',FAILED,"  ($$1 $$2)\n")
+
+# Timing support
+define TIMECMD_detect
+timecmd=$$(which time 2> /dev/null);
+if [ -n "$$timecmd" ]; then
+   if $$timecmd --version > /dev/null 2>&1; then
+   echo "$$timecmd" GNU; else echo "$$timecmd" NOTGNU; fi;
+else timecmd=$$(command -v time);
+   if [ "$$timecmd" = time ]; then
+   echo "$$timecmd" BASH; else echo X NONE; fi;
+fi
+endef
+define TIMECMD.GNU
+export TIME='%es %MkB %x'; \
+set -- $$($(1) $(SHELL) -c "$(2)" 2>&1); while [ "$$#" -gt 3 ]; do shift; done
+endef
+define TIMECMD.NOTGNU
+set -- $$($(1) -l $(SHELL) -c "$(2)" 2>&1; echo $$?); \
+set -- "$$1"s "$$(($$7/1024))"kB "$${60}"
+endef
+define TIMECMD.BASH
+TIMEFORMAT=$$'%3Rs'; \
+set -- $$({ time $(2); } 2>&1; echo $$?); set -- "$$1" "" "$$2"
+endef
+define TIMECMD.NONE
+$(2); set -- "" "" "$$?"
+endef
+TIMECMD := $(shell $(TIMECMD_detect))
+TIMEFUN := TIMECMD.$(word 2,$(TIMECMD))
+TIMECMD := $(word 1,$(TIMECMD))
+# Sample use of the timing macro: (returns shell commands as text)
+# $(call $(TIMEFUN),$(TIMECMD),$(MY_SHELL_COMMANDS))
 
 ifneq (,$(filter test%,$(MAKECMDGOALS)))
    MAKEFLAGS += -k
 endif
 # Test runs of the examples/miniapps with parameters - check exit code
 mfem-test = \
-   printf "   $(3) [$(2) $(1) ... ]: "; TIMEFORMAT=$$'%3Rs'; \
-   set -- $$({ time $(2) ./$(1) -no-vis $(4) &> $(1).stderr; } \
-             2>&1; echo $$?); \
-   if [ "$$2" -eq 0 ]; \
+   printf "   $(3) [$(2) $(1) ... ]: "; \
+   $(call $(TIMEFUN),$(TIMECMD),$(2) ./$(1) -no-vis $(4) > $(1).stderr 2>&1); \
+   if [ "$$3" = 0 ]; \
    then $(PRINT_OK); else $(PRINT_FAILED); cat $(1).stderr; fi; \
-   rm -f $(1).stderr; exit $$2
+   rm -f $(1).stderr; exit $$3
 
 # Test runs of the examples/miniapps - check exit code and if a file exists
 mfem-test-file = \
-   printf "   $(3) [$(2) $(1) ... ]: "; TIMEFORMAT=$$'%3Rs'; \
-   set -- $$({ time $(2) ./$(1) -no-vis &> $(1).stderr; } \
-             2>&1; echo $$?); \
-   if [ "$$2" -eq 0 ] && [ -e $(4) ]; \
+   printf "   $(3) [$(2) $(1) ... ]: "; \
+   $(call $(TIMEFUN),$(TIMECMD),$(2) ./$(1) -no-vis > $(1).stderr 2>&1); \
+   if [ "$$3" = 0 ] && [ -e $(4) ]; \
    then $(PRINT_OK); else $(PRINT_FAILED); cat $(1).stderr; fi; \
-   rm -f $(1).stderr; exit $$2
+   rm -f $(1).stderr; exit $$3
 
 .PHONY: test test-par-YES test-par-NO
 

--- a/config/test.mk
+++ b/config/test.mk
@@ -16,8 +16,8 @@
 # no color '\033[0m'
 COLOR_PRINT = if [ -t 1 ]; then \
    printf $(1)$(2)'\033[0m'$(3); else printf $(2)$(3); fi
-PRINT_OK = $(call COLOR_PRINT,'\033[0;32m',OK,"  ($${timer_code[0]})\n")
-PRINT_FAILED = $(call COLOR_PRINT,'\033[0;31m',FAILED,"  ($${timer_code[0]})\n")
+PRINT_OK = $(call COLOR_PRINT,'\033[0;32m',OK,"  ($$1)\n")
+PRINT_FAILED = $(call COLOR_PRINT,'\033[0;31m',FAILED,"  ($$1)\n")
 
 ifneq (,$(filter test%,$(MAKECMDGOALS)))
    MAKEFLAGS += -k
@@ -25,20 +25,20 @@ endif
 # Test runs of the examples/miniapps with parameters - check exit code
 mfem-test = \
    printf "   $(3) [$(2) $(1) ... ]: "; TIMEFORMAT=$$'%3Rs'; \
-   timer_code=($$({ time $(2) ./$(1) -no-vis $(4) &> $(1).stderr; } \
-                  2>&1; echo $$?)); \
-   if [ "$${timer_code[1]}" -eq 0 ]; \
+   set -- $$({ time $(2) ./$(1) -no-vis $(4) &> $(1).stderr; } \
+             2>&1; echo $$?); \
+   if [ "$$2" -eq 0 ]; \
    then $(PRINT_OK); else $(PRINT_FAILED); cat $(1).stderr; fi; \
-   rm -f $(1).stderr; exit $${timer_code[1]}
+   rm -f $(1).stderr; exit $$2
 
 # Test runs of the examples/miniapps - check exit code and if a file exists
 mfem-test-file = \
    printf "   $(3) [$(2) $(1) ... ]: "; TIMEFORMAT=$$'%3Rs'; \
-   timer_code=($$({ time $(2) ./$(1) -no-vis &> $(1).stderr; } \
-                  2>&1; echo $$?)); \
-   if [ "$${timer_code[1]}" -eq 0 ] && [ -e $(4) ]; \
+   set -- $$({ time $(2) ./$(1) -no-vis &> $(1).stderr; } \
+             2>&1; echo $$?); \
+   if [ "$$2" -eq 0 ] && [ -e $(4) ]; \
    then $(PRINT_OK); else $(PRINT_FAILED); cat $(1).stderr; fi; \
-   rm -f $(1).stderr; exit $${timer_code[1]}
+   rm -f $(1).stderr; exit $$2
 
 .PHONY: test test-par-YES test-par-NO
 


### PR DESCRIPTION
Lower MPI ranks used in parallel examples to two, to match number of processor cores available in Travis VM.
Update code coverage c++ flags to add '-g' (mandatory)
Update code coverage travis job to be optimized code with debug symbols.
Only build Mac OpenMPI if parallel MFEM being used.
Lower -j4 to -j3, as two processor cores available.