### PR TITLE
Fix the order of CMake include directories [cmake-include-fix]

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -49,7 +49,7 @@ if (MFEM_USE_MPI)
 endif()
 
 # Include the source directory where mfem.hpp and mfem-performance.hpp are.
-include_directories(${PROJECT_BINARY_DIR})
+include_directories(BEFORE ${PROJECT_BINARY_DIR})
 
 # Add one executable per cpp file
 add_mfem_examples(ALL_EXE_SRCS)

--- a/examples/petsc/CMakeLists.txt
+++ b/examples/petsc/CMakeLists.txt
@@ -35,7 +35,7 @@ if (MFEM_USE_MPI)
 endif()
 
 # Include the source directory where mfem.hpp and mfem-performance.hpp are.
-include_directories(${PROJECT_BINARY_DIR})
+include_directories(BEFORE ${PROJECT_BINARY_DIR})
 
 # Add targets to copy rc_* files from the source directory
 foreach(RC_FILE ${PETSC_RC_FILES})

--- a/examples/sundials/CMakeLists.txt
+++ b/examples/sundials/CMakeLists.txt
@@ -25,7 +25,7 @@ if (MFEM_USE_MPI)
 endif()
 
 # Include the source directory where mfem.hpp and mfem-performance.hpp are.
-include_directories(${PROJECT_BINARY_DIR})
+include_directories(BEFORE ${PROJECT_BINARY_DIR})
 
 # Add "test_sundials" target, see below.
 add_custom_target(test_sundials

--- a/miniapps/CMakeLists.txt
+++ b/miniapps/CMakeLists.txt
@@ -10,7 +10,7 @@
 # Software Foundation) version 2.1 dated February 1999.
 
 # Include the source directory where mfem.hpp and mfem-performance.hpp are.
-include_directories(${PROJECT_BINARY_DIR})
+include_directories(BEFORE ${PROJECT_BINARY_DIR})
 
 set(MINIAPP_COMMON_HEADERS)
 add_subdirectory(common)


### PR DESCRIPTION
When building the examples and miniapps with CMake, include the the path to the main mfem headers, `${PROJECT_BINARY_DIR}`, BEFORE any other directories.

This should resolve #274.