### PR TITLE
Small changes to HYPRE wrapper [hypre-rap-add-dev]

### DIFF
--- a/linalg/hypre.cpp
+++ b/linalg/hypre.cpp
@@ -1262,6 +1262,9 @@ void HypreParMatrix::Threshold(double threshold)
       ierr += hypre_CSRMatrixDestroy(csr_A);
    }
 
+   /* FIXME: GenerateDiagAndOffd() uses an int array of size equal to the number
+      of columns in csr_A_wo_z which is the global number of columns in A. This
+      does not scale well. */
    ierr += GenerateDiagAndOffd(csr_A_wo_z,parcsr_A_ptr,
                                col_start,col_end);
 

--- a/linalg/hypre.cpp
+++ b/linalg/hypre.cpp
@@ -1497,17 +1497,23 @@ HypreParMatrix * RAP(HypreParMatrix * Rt, HypreParMatrix *A, HypreParMatrix *P)
 
    hypre_ParCSRMatrixSetNumNonzeros(rap);
    // hypre_MatvecCommPkgCreate(rap);
-   if (!P_owns_its_col_starts)
+
+   /* Warning: hypre_BoomerAMGBuildCoarseOperator steals the col_starts
+      from Rt and P (even if they do not own them)! */
+   hypre_ParCSRMatrixSetRowStartsOwner(rap,0);
+   hypre_ParCSRMatrixSetColStartsOwner(rap,0);
+
+   if (P_owns_its_col_starts)
    {
       /* Warning: hypre_BoomerAMGBuildCoarseOperator steals the col_starts
          from P (even if it does not own them)! */
-      hypre_ParCSRMatrixSetColStartsOwner(rap,0);
+      hypre_ParCSRMatrixSetColStartsOwner(*P,1);
    }
-   if (!Rt_owns_its_col_starts)
+   if (Rt_owns_its_col_starts)
    {
       /* Warning: hypre_BoomerAMGBuildCoarseOperator steals the col_starts
          from P (even if it does not own them)! */
-      hypre_ParCSRMatrixSetRowStartsOwner(rap,0);
+      hypre_ParCSRMatrixSetRowStartsOwner(*Rt,1);
    }
    return new HypreParMatrix(rap);
 }

--- a/linalg/hypre.cpp
+++ b/linalg/hypre.cpp
@@ -1505,16 +1505,13 @@ HypreParMatrix * RAP(HypreParMatrix * Rt, HypreParMatrix *A, HypreParMatrix *P)
 
    if (P_owns_its_col_starts)
    {
-      /* Warning: hypre_BoomerAMGBuildCoarseOperator steals the col_starts
-         from P (even if it does not own them)! */
-      hypre_ParCSRMatrixSetColStartsOwner(*P,1);
+      hypre_ParCSRMatrixSetColStartsOwner(*P, 1);
    }
    if (Rt_owns_its_col_starts)
    {
-      /* Warning: hypre_BoomerAMGBuildCoarseOperator steals the col_starts
-         from P (even if it does not own them)! */
-      hypre_ParCSRMatrixSetRowStartsOwner(*Rt,1);
+      hypre_ParCSRMatrixSetRowStartsOwner(*Rt, 1);
    }
+
    return new HypreParMatrix(rap);
 }
 

--- a/linalg/hypre.cpp
+++ b/linalg/hypre.cpp
@@ -1509,7 +1509,7 @@ HypreParMatrix * RAP(HypreParMatrix * Rt, HypreParMatrix *A, HypreParMatrix *P)
    }
    if (Rt_owns_its_col_starts)
    {
-      hypre_ParCSRMatrixSetRowStartsOwner(*Rt, 1);
+      hypre_ParCSRMatrixSetColStartsOwner(*Rt, 1);
    }
 
    return new HypreParMatrix(rap);

--- a/linalg/hypre_parcsr.cpp
+++ b/linalg/hypre_parcsr.cpp
@@ -1228,7 +1228,7 @@ hypre_ParCSRMatrixAdd(hypre_ParCSRMatrix *A,
    HYPRE_Int           im;
    HYPRE_Int           cmap_differ;
 
-   /* Make sure A_cmap and B_cmap are the same. */
+   /* Check if A_cmap and B_cmap are the same. */
    cmap_differ = 0;
    if (A_cmap_size != B_cmap_size)
    {
@@ -1318,6 +1318,9 @@ hypre_ParCSRMatrixAdd(hypre_ParCSRMatrix *A,
                                    0, 0, 0);
 
       /* split C into diag and off-diag portions */
+      /* FIXME: GenerateDiagAndOffd() uses an int array of size equal to the
+         number of columns in csr_C_temp which is the global number of columns
+         in A and B. This does not scale well. */
       ierr += GenerateDiagAndOffd(csr_C_temp, C,
                                   hypre_ParCSRMatrixFirstColDiag(A),
                                   hypre_ParCSRMatrixLastColDiag(A));

--- a/linalg/hypre_parcsr.cpp
+++ b/linalg/hypre_parcsr.cpp
@@ -1226,56 +1226,106 @@ hypre_ParCSRMatrixAdd(hypre_ParCSRMatrix *A,
    hypre_CSRMatrix    *C_offd;
    HYPRE_Int          *C_cmap;
    HYPRE_Int           im;
+   HYPRE_Int           cmap_differ;
 
    /* Make sure A_cmap and B_cmap are the same. */
+   cmap_differ = 0;
    if (A_cmap_size != B_cmap_size)
    {
-      return NULL; /* error: A and B have different cmap_size */
+      cmap_differ = 1; /* error: A and B have different cmap_size */
    }
    for (im = 0; im < A_cmap_size; im++)
    {
       if (A_cmap[im] != B_cmap[im])
       {
-         return NULL; /* error: A and B have different cmap arrays */
+         cmap_differ = 1; /* error: A and B have different cmap arrays */
+         break;
       }
    }
 
-   /* Add diagonals, off-diagonals, copy cmap. */
-   C_diag = hypre_CSRMatrixAdd(A_diag, B_diag);
-   if (!C_diag)
+   if ( cmap_differ == 0 )
    {
-      return NULL; /* error: A_diag and B_diag have different dimensions */
-   }
-   C_offd = hypre_CSRMatrixAdd(A_offd, B_offd);
-   if (!C_offd)
-   {
-      hypre_CSRMatrixDestroy(C_diag);
-      return NULL; /* error: A_offd and B_offd have different dimensions */
-   }
-   /* copy A_cmap -> C_cmap */
-   C_cmap = hypre_TAlloc(HYPRE_Int, A_cmap_size);
-   for (im = 0; im < A_cmap_size; im++)
-   {
-      C_cmap[im] = A_cmap[im];
-   }
+      /* A and B have the same column mapping for their off-diagonal
+         blocks so we can sum the diagonal and off-diagonal blocks
+      separately and reduce temporary memory usage. */
 
-   C = hypre_ParCSRMatrixCreate(comm,
-                                hypre_ParCSRMatrixGlobalNumRows(A),
-                                hypre_ParCSRMatrixGlobalNumCols(A),
-                                hypre_ParCSRMatrixRowStarts(A),
-                                hypre_ParCSRMatrixColStarts(A),
-                                hypre_CSRMatrixNumCols(C_offd),
-                                hypre_CSRMatrixNumNonzeros(C_diag),
-                                hypre_CSRMatrixNumNonzeros(C_offd));
+      /* Add diagonals, off-diagonals, copy cmap. */
+      C_diag = hypre_CSRMatrixAdd(A_diag, B_diag);
+      if (!C_diag)
+      {
+         return NULL; /* error: A_diag and B_diag have different dimensions */
+      }
+      C_offd = hypre_CSRMatrixAdd(A_offd, B_offd);
+      if (!C_offd)
+      {
+         hypre_CSRMatrixDestroy(C_diag);
+         return NULL; /* error: A_offd and B_offd have different dimensions */
+      }
+      /* copy A_cmap -> C_cmap */
+      C_cmap = hypre_TAlloc(HYPRE_Int, A_cmap_size);
+      for (im = 0; im < A_cmap_size; im++)
+      {
+         C_cmap[im] = A_cmap[im];
+      }
 
-   /* In C, destroy diag/offd (allocated by Create) and replace them with
+      C = hypre_ParCSRMatrixCreate(comm,
+                                   hypre_ParCSRMatrixGlobalNumRows(A),
+                                   hypre_ParCSRMatrixGlobalNumCols(A),
+                                   hypre_ParCSRMatrixRowStarts(A),
+                                   hypre_ParCSRMatrixColStarts(A),
+                                   hypre_CSRMatrixNumCols(C_offd),
+                                   hypre_CSRMatrixNumNonzeros(C_diag),
+                                   hypre_CSRMatrixNumNonzeros(C_offd));
+
+      /* In C, destroy diag/offd (allocated by Create) and replace them with
       C_diag/C_offd. */
-   hypre_CSRMatrixDestroy(hypre_ParCSRMatrixDiag(C));
-   hypre_CSRMatrixDestroy(hypre_ParCSRMatrixOffd(C));
-   hypre_ParCSRMatrixDiag(C) = C_diag;
-   hypre_ParCSRMatrixOffd(C) = C_offd;
+      hypre_CSRMatrixDestroy(hypre_ParCSRMatrixDiag(C));
+      hypre_CSRMatrixDestroy(hypre_ParCSRMatrixOffd(C));
+      hypre_ParCSRMatrixDiag(C) = C_diag;
+      hypre_ParCSRMatrixOffd(C) = C_offd;
 
-   hypre_ParCSRMatrixColMapOffd(C) = C_cmap;
+      hypre_ParCSRMatrixColMapOffd(C) = C_cmap;
+   }
+   else
+   {
+      /* A and B have different column mappings for their off-diagonal
+      blocks so we need to use the column maps to create full-width
+      CSR matricies. */
+
+      int  ierr = 0;
+      hypre_CSRMatrix * csr_A;
+      hypre_CSRMatrix * csr_B;
+      hypre_CSRMatrix * csr_C_temp;
+
+      /* merge diag and off-diag portions of A */
+      csr_A = hypre_MergeDiagAndOffd(A);
+
+      /* merge diag and off-diag portions of B */
+      csr_B = hypre_MergeDiagAndOffd(B);
+
+      /* add A and B */
+      csr_C_temp = hypre_CSRMatrixAdd(csr_A,csr_B);
+
+      /* delete CSR versions of A and B */
+      ierr += hypre_CSRMatrixDestroy(csr_A);
+      ierr += hypre_CSRMatrixDestroy(csr_B);
+
+      /* create a new empty ParCSR matrix to contain the sum */
+      C = hypre_ParCSRMatrixCreate(hypre_ParCSRMatrixComm(A),
+                                   hypre_ParCSRMatrixGlobalNumRows(A),
+                                   hypre_ParCSRMatrixGlobalNumCols(A),
+                                   hypre_ParCSRMatrixRowStarts(A),
+                                   hypre_ParCSRMatrixColStarts(A),
+                                   0, 0, 0);
+
+      /* split C into diag and off-diag portions */
+      ierr += GenerateDiagAndOffd(csr_C_temp, C,
+                                  hypre_ParCSRMatrixFirstColDiag(A),
+                                  hypre_ParCSRMatrixLastColDiag(A));
+
+      /* delete CSR version of C */
+      ierr += hypre_CSRMatrixDestroy(csr_C_temp);
+   }
 
    /* hypre_ParCSRMatrixSetNumNonzeros(A); */
 

--- a/linalg/hypre_parcsr.cpp
+++ b/linalg/hypre_parcsr.cpp
@@ -1232,22 +1232,22 @@ hypre_ParCSRMatrixAdd(hypre_ParCSRMatrix *A,
    cmap_differ = 0;
    if (A_cmap_size != B_cmap_size)
    {
-      cmap_differ = 1; /* error: A and B have different cmap_size */
+      cmap_differ = 1; /* A and B have different cmap_size */
    }
    for (im = 0; im < A_cmap_size; im++)
    {
       if (A_cmap[im] != B_cmap[im])
       {
-         cmap_differ = 1; /* error: A and B have different cmap arrays */
+         cmap_differ = 1; /* A and B have different cmap arrays */
          break;
       }
    }
 
    if ( cmap_differ == 0 )
    {
-      /* A and B have the same column mapping for their off-diagonal
-         blocks so we can sum the diagonal and off-diagonal blocks
-      separately and reduce temporary memory usage. */
+      /* A and B have the same column mapping for their off-diagonal blocks so
+         we can sum the diagonal and off-diagonal blocks separately and reduce
+         temporary memory usage. */
 
       /* Add diagonals, off-diagonals, copy cmap. */
       C_diag = hypre_CSRMatrixAdd(A_diag, B_diag);
@@ -1288,9 +1288,8 @@ hypre_ParCSRMatrixAdd(hypre_ParCSRMatrix *A,
    }
    else
    {
-      /* A and B have different column mappings for their off-diagonal
-      blocks so we need to use the column maps to create full-width
-      CSR matricies. */
+      /* A and B have different column mappings for their off-diagonal blocks so
+      we need to use the column maps to create full-width CSR matricies. */
 
       int  ierr = 0;
       hypre_CSRMatrix * csr_A;

--- a/linalg/hypre_parcsr.hpp
+++ b/linalg/hypre_parcsr.hpp
@@ -91,8 +91,9 @@ hypre_CSRMatrixSum(hypre_CSRMatrix *A,
                    hypre_CSRMatrix *B);
 
 /** Return a new matrix containing the sum of A and B, assuming that both
-    matrices use the same row and column partitions and the same col_map_offd
-    arrays. */
+    matrices use the same row and column partitions. The col_map_offd do not
+    need to be the same, but a more efficient algorithm is used if that's the
+    case. */
 hypre_ParCSRMatrix *
 hypre_ParCSRMatrixAdd(hypre_ParCSRMatrix *A,
                       hypre_ParCSRMatrix *B);


### PR DESCRIPTION
The two and three argument versions of the RAP function handled Row/ColStartsOwner issues differently.  The first change alters the three argument version to follow the same pattern used in the two argument version.  The problem was that if the R or P matrix does not own its row/col starts array then the resulting RAP matrix should not own these either but the hypre_BoomerAMGBuildCoarseOperator used by the RAP function does not do things this way.  Consequently, the RAP function needs to adjust the ownership of these arrays after the coarse operator is built.  The logic used to make these adjustments was different in the two versions of RAP but now they should be the same.

The second change extends the hypre_ParCSRMatrixAdd function defined in hypre_parcsr.cpp.  Originally this function required that the two matrices being added contained identical off-diagonal column mappings.  This is clearly a special case which allows the matrices to be added efficiently with little additional memory overhead.  The proposed extension introduces a less memory efficient alternative when the column mappings differ.  This extension has been tested (and used) in another branch(s) (bloch-wave-dev and bravais-dev) which is not yet ready to be merged into MFEM.