### PR TITLE
Don't change ownership in HypreParMatrix::Threshold() [bugfix/threshold-rowstarts]

### DIFF
--- a/linalg/hypre.cpp
+++ b/linalg/hypre.cpp
@@ -1224,7 +1224,6 @@ void HypreParMatrix::Threshold(double threshold)
    int  ierr = 0;
 
    MPI_Comm comm;
-   int num_procs;
    hypre_CSRMatrix * csr_A;
    hypre_CSRMatrix * csr_A_wo_z;
    hypre_ParCSRMatrix * parcsr_A_ptr;
@@ -1233,8 +1232,6 @@ void HypreParMatrix::Threshold(double threshold)
    HYPRE_Int col_start = -1;   HYPRE_Int col_end = -1;
 
    comm = hypre_ParCSRMatrixComm(A);
-
-   MPI_Comm_size(comm, &num_procs);
 
    ierr += hypre_ParCSRMatrixGetLocalRange(A,
                                            &row_start,&row_end,

--- a/linalg/hypre.cpp
+++ b/linalg/hypre.cpp
@@ -1243,9 +1243,13 @@ void HypreParMatrix::Threshold(double threshold)
    row_starts = hypre_ParCSRMatrixRowStarts(A);
    col_starts = hypre_ParCSRMatrixColStarts(A);
 
+   bool old_owns_row = hypre_ParCSRMatrixOwnsRowStarts(A);
+   bool old_owns_col = hypre_ParCSRMatrixOwnsColStarts(A);
    parcsr_A_ptr = hypre_ParCSRMatrixCreate(comm,row_starts[num_procs],
                                            col_starts[num_procs],row_starts,
                                            col_starts,0,0,0);
+   hypre_ParCSRMatrixOwnsRowStarts(parcsr_A_ptr) = old_owns_row;
+   hypre_ParCSRMatrixOwnsColStarts(parcsr_A_ptr) = old_owns_col;
 
    csr_A = hypre_MergeDiagAndOffd(A);
 

--- a/linalg/hypre.cpp
+++ b/linalg/hypre.cpp
@@ -1245,15 +1245,18 @@ void HypreParMatrix::Threshold(double threshold)
 
    bool old_owns_row = hypre_ParCSRMatrixOwnsRowStarts(A);
    bool old_owns_col = hypre_ParCSRMatrixOwnsColStarts(A);
-   parcsr_A_ptr = hypre_ParCSRMatrixCreate(comm,row_starts[num_procs],
-                                           col_starts[num_procs],row_starts,
-                                           col_starts,0,0,0);
+   HYPRE_Int global_num_rows = hypre_ParCSRMatrixGlobalNumRows(A);
+   HYPRE_Int global_num_cols = hypre_ParCSRMatrixGlobalNumCols(A);
+   parcsr_A_ptr = hypre_ParCSRMatrixCreate(comm, global_num_rows,
+                                           global_num_cols,
+                                           row_starts, col_starts,
+                                           0, 0, 0);
    hypre_ParCSRMatrixOwnsRowStarts(parcsr_A_ptr) = old_owns_row;
    hypre_ParCSRMatrixOwnsColStarts(parcsr_A_ptr) = old_owns_col;
 
    csr_A = hypre_MergeDiagAndOffd(A);
 
-   csr_A_wo_z =  hypre_CSRMatrixDeleteZeros(csr_A,threshold);
+   csr_A_wo_z = hypre_CSRMatrixDeleteZeros(csr_A,threshold);
 
    /* hypre_CSRMatrixDeleteZeros will return a NULL pointer rather than a usable
       CSR matrix if it finds no non-zeros */


### PR DESCRIPTION
Modify `HypreParMatrix::Threshold()` so it does not change ownership flags of underlying object.

Resolves #290 .