### PR TITLE
Fix initialization of a curved mesh from the NCMesh [curved-mesh-init-fix]

### DIFF
--- a/mesh/mesh.cpp
+++ b/mesh/mesh.cpp
@@ -6159,8 +6159,7 @@ void Mesh::InitFromNCMesh(const NCMesh &ncmesh)
 
    DeleteTables();
 
-   bool linear = (Nodes == NULL);
-   ncmesh.GetMeshComponents(vertices, elements, boundary, linear);
+   ncmesh.GetMeshComponents(vertices, elements, boundary);
 
    NumOfVertices = vertices.Size();
    NumOfElements = elements.Size();

--- a/mesh/ncmesh.cpp
+++ b/mesh/ncmesh.cpp
@@ -1523,12 +1523,12 @@ const double* NCMesh::CalcVertexPos(int node) const
 
 void NCMesh::GetMeshComponents(Array<mfem::Vertex>& mvertices,
                                Array<mfem::Element*>& melements,
-                               Array<mfem::Element*>& mboundary,
-                               bool want_vertices) const
+                               Array<mfem::Element*>& mboundary) const
 {
-   if (want_vertices)
+   mvertices.SetSize(vertex_nodeId.Size());
+   if (top_vertex_pos.Size())
    {
-      mvertices.SetSize(vertex_nodeId.Size());
+      // calculate vertex positions from stored top-level vertex coordinates
       tmp_vertex = new TmpVertex[nodes.NumIds()];
       for (int i = 0; i < mvertices.Size(); i++)
       {
@@ -1536,6 +1536,9 @@ void NCMesh::GetMeshComponents(Array<mfem::Vertex>& mvertices,
       }
       delete [] tmp_vertex;
    }
+   // NOTE: if the mesh is curved (top_vertex_pos is empty), mvertices are left
+   // uninitialized here; they will be initialized later by the Mesh from Nodes
+   // - here we just make sure mvertices has the correct size.
 
    melements.SetSize(leaf_elements.Size() - GetNumGhosts());
    melements.SetSize(0);

--- a/mesh/ncmesh.hpp
+++ b/mesh/ncmesh.hpp
@@ -266,8 +266,7 @@ protected: // interface for Mesh to be able to construct itself from NCMesh
    /// Return the basic Mesh arrays for the current finest level.
    void GetMeshComponents(Array<mfem::Vertex>& mvertices,
                           Array<mfem::Element*>& melements,
-                          Array<mfem::Element*>& mboundary,
-                          bool want_vertices) const;
+                          Array<mfem::Element*>& mboundary) const;
 
    /** Get edge and face numbering from 'mesh' (i.e., set all Edge::index and
        Face::index) after a new mesh was created from us. */


### PR DESCRIPTION
MFEM will crash in Example 1 trying to do UniformRefinement on an AMR mesh with Nodes (like the attached one). This is a bug in ncmesh-mem-opt-dev and this PR should fix it.

[amr.mesh.gz](https://github.com/mfem/mfem/files/1356932/amr.mesh.gz)
