### PR TITLE
Allowing to work with 1D meshes in ParMesh::PrintAsOne().

### DIFF
--- a/mesh/pmesh.cpp
+++ b/mesh/pmesh.cpp
@@ -3688,7 +3688,11 @@ void ParMesh::PrintAsOne(std::ostream &out)
          {
             // processor number + 1 as bdr. attr. and bdr. geometry type
             out << p+1 << ' ' << ints[i];
-            k = Geometries.GetVertices(ints[i++])->GetNPoints();
+            if (Dim==1) 
+            {
+               k = 2;
+            }
+            else { k = Geometries.GetVertices(ints[i++])->GetNPoints(); }
             // vertices
             for (j = 0; j < k; j++)
             {

--- a/mesh/pmesh.cpp
+++ b/mesh/pmesh.cpp
@@ -3690,7 +3690,8 @@ void ParMesh::PrintAsOne(std::ostream &out)
             out << p+1 << ' ' << ints[i];
             if (Dim==1) 
             {
-               k = 2;
+               k = 1;
+               i++;
             }
             else { k = Geometries.GetVertices(ints[i++])->GetNPoints(); }
             // vertices


### PR DESCRIPTION
In ParMesh::PrintAsOne(std::ostream &out), number of vertices is based on IntRule of given geometry.
This did not work for SEGMENT, because Geometries.GetVertices(SEGMENT) == NULL. A simple workaround returning 2 vertices solves the problem.