### PR TITLE
Bugfix: Error in Lagrange1DFiniteElement::CalcShape() [lagrange1DFE-bugfix]

### DIFF
--- a/fem/fe.cpp
+++ b/fem/fe.cpp
@@ -3714,6 +3714,8 @@ void Lagrange1DFiniteElement::CalcShape(const IntegrationPoint &ip,
 #endif
 
    k = (int) floor ( m * x + 0.5 );
+   k = k > m ? m : k < 0? 0 : k; // clamp k to [0,m]
+
    wk = 1.0;
    for (i = 0; i <= m; i++)
       if (i != k)
@@ -3760,6 +3762,8 @@ void Lagrange1DFiniteElement::CalcDShape(const IntegrationPoint &ip,
 #endif
 
    k = (int) floor ( m * x + 0.5 );
+   k = k > m ? m : k < 0? 0 : k; // clamp k to [0,m]
+
    wk = 1.0;
    for (i = 0; i <= m; i++)
       if (i != k)

--- a/fem/fe.cpp
+++ b/fem/fe.cpp
@@ -3714,7 +3714,7 @@ void Lagrange1DFiniteElement::CalcShape(const IntegrationPoint &ip,
 #endif
 
    k = (int) floor ( m * x + 0.5 );
-   k = k > m ? m : k < 0? 0 : k; // clamp k to [0,m]
+   k = k > m ? m : k < 0 ? 0 : k; // clamp k to [0,m]
 
    wk = 1.0;
    for (i = 0; i <= m; i++)
@@ -3762,7 +3762,7 @@ void Lagrange1DFiniteElement::CalcDShape(const IntegrationPoint &ip,
 #endif
 
    k = (int) floor ( m * x + 0.5 );
-   k = k > m ? m : k < 0? 0 : k; // clamp k to [0,m]
+   k = k > m ? m : k < 0 ? 0 : k; // clamp k to [0,m]
 
    wk = 1.0;
    for (i = 0; i <= m; i++)


### PR DESCRIPTION
Resolves #310: 

Problem is when isoparametric coordinates are outside unit interval.
This also effects ``LagrangeHexFiniteElement::CalcShape()`` which uses this function internally.

Here is a simple reproducer for the bug:

```cpp
const int order =1;
IntegrationPoint ip;
Vector weights(order+1);

Lagrange1DFiniteElement fe(order);
ip.x = 1.5;
fe.CalcShape(ip, weights);   // segfaults -- invalid memory access
```