### PR TITLE
Adding square root inverse routine to dense matrix [square_root_inverse_dev]

### DIFF
--- a/linalg/densemat.cpp
+++ b/linalg/densemat.cpp
@@ -727,7 +727,7 @@ void DenseMatrix::SquareRootInverse()
 #ifdef MFEM_DEBUG
    if (Height() <= 0 || Height() != Width())
    {
-      mfem_error("DenseMatrix::Invert()");
+      mfem_error("DenseMatrix::SquareRootInverse() matrix not square.");
    }
 #endif
 

--- a/linalg/densemat.cpp
+++ b/linalg/densemat.cpp
@@ -721,6 +721,51 @@ void DenseMatrix::Invert()
 #endif
 }
 
+void DenseMatrix::SquareRootInverse()
+{
+   // Square root inverse using Denman--Beavers
+#ifdef MFEM_DEBUG
+   if (Height() <= 0 || Height() != Width())
+   {
+      mfem_error("DenseMatrix::Invert()");
+   }
+#endif
+
+   DenseMatrix tmp1(Height());
+   DenseMatrix tmp2(Height());
+   DenseMatrix tmp3(Height());
+
+   tmp1 = (*this);
+   (*this) = 0.0;
+   for (int v = 0; v < Height() ; v++) { (*this)(v,v) = 1.0; }
+
+   for (int j = 0; j < 10; j++)
+   {
+      for (int i = 0; i < 10; i++)
+      {
+         tmp2 = tmp1;
+         tmp3 = (*this);
+
+         tmp2.Invert();
+         tmp3.Invert();
+
+         tmp1 += tmp3;
+         (*this)  += tmp2;
+
+         tmp1 *= 0.5;
+         (*this)  *= 0.5;
+      }
+      mfem::Mult((*this), tmp1, tmp2);
+      for (int v = 0; v < Height() ; v++) { tmp2(v,v) -= 1.0; }
+      if (tmp2.FNorm() < 1e-10) { break; }
+   }
+
+   if (tmp2.FNorm() > 1e-10) { mfem_error("DenseMatrix::SquareRootInverse not converged"); }
+
+}
+
+
+
 void DenseMatrix::Norm2(double *v) const
 {
    for (int j = 0; j < Width(); j++)

--- a/linalg/densemat.cpp
+++ b/linalg/densemat.cpp
@@ -750,21 +750,21 @@ void DenseMatrix::SquareRootInverse()
          tmp3.Invert();
 
          tmp1 += tmp3;
-         (*this)  += tmp2;
+         (*this) += tmp2;
 
          tmp1 *= 0.5;
-         (*this)  *= 0.5;
+         (*this) *= 0.5;
       }
       mfem::Mult((*this), tmp1, tmp2);
       for (int v = 0; v < Height() ; v++) { tmp2(v,v) -= 1.0; }
       if (tmp2.FNorm() < 1e-10) { break; }
    }
 
-   if (tmp2.FNorm() > 1e-10) { mfem_error("DenseMatrix::SquareRootInverse not converged"); }
-
+   if (tmp2.FNorm() > 1e-10)
+   {
+      mfem_error("DenseMatrix::SquareRootInverse not converged");
+   }
 }
-
-
 
 void DenseMatrix::Norm2(double *v) const
 {

--- a/linalg/densemat.hpp
+++ b/linalg/densemat.hpp
@@ -159,6 +159,9 @@ public:
    /// Replaces the current matrix with its inverse
    void Invert();
 
+   /// Replaces the current matrix with its square root inverse
+   void SquareRootInverse();
+
    /// Calculates the determinant of the matrix
    /// (optimized for 2x2, 3x3, and 4x4 matrices)
    double Det() const;


### PR DESCRIPTION
This PR adds a square root inverse routine to the dense matrix class. This is computed using the iterative Denman-Beavers routine. This is routine is useful for computing stabilisation parameters for generic coupled convection-diffusion systems.