### PR TITLE
Size check in BlockMatrix::Mult()

### DIFF
--- a/linalg/blockmatrix.cpp
+++ b/linalg/blockmatrix.cpp
@@ -10,7 +10,6 @@
 // Software Foundation) version 2.1 dated February 1999.
 
 #include "../general/array.hpp"
-#include "../general/globals.hpp"
 #include "matrix.hpp"
 #include "sparsemat.hpp"
 #include "blockvector.hpp"
@@ -214,7 +213,7 @@ void BlockMatrix::EliminateRowCol(Array<int> & ess_bc_dofs, Vector & sol,
    for (int iiblock = 0; iiblock < nRowBlocks; ++iiblock)
       if (row_offsets[iiblock] != col_offsets[iiblock])
       {
-         mfem::out << "BlockMatrix::EliminateRowCol: row_offests["
+         std::cout << "BlockMatrix::EliminateRowCol: row_offests["
                    << iiblock << "] != col_offsets["<<iiblock<<"]\n";
          mfem_error();
       }
@@ -312,8 +311,8 @@ void BlockMatrix::EliminateZeroRows()
 
             if (norm < 1e-12)
             {
-               mfem::out<<"i = " << i << "\n";
-               mfem::out<<"norm = " << norm << "\n";
+               std::cout<<"i = " << i << "\n";
+               std::cout<<"norm = " << norm << "\n";
                mfem_error("BlockMatrix::EliminateZeroRows() #2");
             }
          }
@@ -328,6 +327,10 @@ void BlockMatrix::Mult(const Vector & x, Vector & y) const
       mfem_error("Error: x and y can't point to the same datas \n");
    }
 
+   MFEM_ASSERT(width == x.Size(), "Input vector size (" << x.Size()
+               << ") must match matrix width (" << width << ")");
+   MFEM_ASSERT(height == y.Size(), "Output vector size (" << y.Size()
+               << ") must match matrix height (" << height << ")");
    y = 0.;
    AddMult(x, y, 1.0);
 }
@@ -458,9 +461,9 @@ SparseMatrix * BlockMatrix::CreateMonolithic() const
 #ifdef MFEM_DEBUG
                if (glob_start_index > nnz)
                {
-                  mfem::out<<"glob_start_index = " << glob_start_index << "\n";
-                  mfem::out<<"Block:" << iblock << " " << jblock << "\n";
-                  mfem::out<<std::endl;
+                  std::cout<<"glob_start_index = " << glob_start_index << "\n";
+                  std::cout<<"Block:" << iblock << " " << jblock << "\n";
+                  std::cout<<std::endl;
                }
 #endif
                loc_end_index = *(i_it_aij);

--- a/linalg/blockmatrix.cpp
+++ b/linalg/blockmatrix.cpp
@@ -10,6 +10,7 @@
 // Software Foundation) version 2.1 dated February 1999.
 
 #include "../general/array.hpp"
+#include "../general/globals.hpp"
 #include "matrix.hpp"
 #include "sparsemat.hpp"
 #include "blockvector.hpp"

--- a/linalg/blockmatrix.cpp
+++ b/linalg/blockmatrix.cpp
@@ -213,7 +213,7 @@ void BlockMatrix::EliminateRowCol(Array<int> & ess_bc_dofs, Vector & sol,
    for (int iiblock = 0; iiblock < nRowBlocks; ++iiblock)
       if (row_offsets[iiblock] != col_offsets[iiblock])
       {
-         std::cout << "BlockMatrix::EliminateRowCol: row_offests["
+         mfem::out << "BlockMatrix::EliminateRowCol: row_offests["
                    << iiblock << "] != col_offsets["<<iiblock<<"]\n";
          mfem_error();
       }
@@ -311,8 +311,8 @@ void BlockMatrix::EliminateZeroRows()
 
             if (norm < 1e-12)
             {
-               std::cout<<"i = " << i << "\n";
-               std::cout<<"norm = " << norm << "\n";
+               mfem::out<<"i = " << i << "\n";
+               mfem::out<<"norm = " << norm << "\n";
                mfem_error("BlockMatrix::EliminateZeroRows() #2");
             }
          }
@@ -461,9 +461,9 @@ SparseMatrix * BlockMatrix::CreateMonolithic() const
 #ifdef MFEM_DEBUG
                if (glob_start_index > nnz)
                {
-                  std::cout<<"glob_start_index = " << glob_start_index << "\n";
-                  std::cout<<"Block:" << iblock << " " << jblock << "\n";
-                  std::cout<<std::endl;
+                  mfem::out<<"glob_start_index = " << glob_start_index << "\n";
+                  mfem::out<<"Block:" << iblock << " " << jblock << "\n";
+                  mfem::out<<std::endl;
                }
 #endif
                loc_end_index = *(i_it_aij);


### PR DESCRIPTION
The suggested changes are simply checks for size mismatch in BlockMatrix::Mult(). They are reasonable to have due to the existence of their counterparts in SparseMatrix::Mult().

Resolves #335.