### PR TITLE
Fix const correctness for SparseMatrix methods EliminateCols() and GetSubMatrix()

### DIFF
--- a/linalg/sparsemat.cpp
+++ b/linalg/sparsemat.cpp
@@ -1992,7 +1992,7 @@ void SparseMatrix::SetSubMatrixTranspose(const Array<int> &rows,
 }
 
 void SparseMatrix::GetSubMatrix(const Array<int> &rows, const Array<int> &cols,
-                                DenseMatrix &subm)
+                                DenseMatrix &subm) const
 {
    int i, j, gi, gj, s, t;
    double a;

--- a/linalg/sparsemat.cpp
+++ b/linalg/sparsemat.cpp
@@ -1128,7 +1128,7 @@ void SparseMatrix::EliminateCol(int col)
          }
 }
 
-void SparseMatrix::EliminateCols(Array<int> &cols, Vector *x, Vector *b)
+void SparseMatrix::EliminateCols(const Array<int> &cols, Vector *x, Vector *b)
 {
    if (Rows == NULL)
    {

--- a/linalg/sparsemat.hpp
+++ b/linalg/sparsemat.hpp
@@ -225,7 +225,7 @@ public:
    void EliminateRow(int row, int setOneDiagonal = 0);
    void EliminateCol(int col);
    /// Eliminate all columns 'i' for which cols[i] != 0
-   void EliminateCols(Array<int> &cols, Vector *x = NULL, Vector *b = NULL);
+   void EliminateCols(const Array<int> &cols, Vector *x = NULL, Vector *b = NULL);
 
    /** Eliminates the column 'rc' to the 'rhs', deletes the row 'rc' and
        replaces the element (rc,rc) with 1.0; assumes that element (i,rc)
@@ -289,7 +289,7 @@ public:
    void GetBlocks(Array2D<SparseMatrix *> &blocks) const;
 
    void GetSubMatrix(const Array<int> &rows, const Array<int> &cols,
-                     DenseMatrix &subm);
+                     DenseMatrix &subm) const;
 
    inline void SetColPtr(const int row) const;
    inline void ClearColPtr() const;


### PR DESCRIPTION
It is natural to have const specifier for the input Array which stores indices in EliminateCols() and to make the method GetSubMatrix() a const one.