### PR TITLE
Fix segfault when adding hypre matrices [fix_parmatrix_add]

### DIFF
--- a/linalg/hypre_parcsr.cpp
+++ b/linalg/hypre_parcsr.cpp
@@ -1234,12 +1234,15 @@ hypre_ParCSRMatrixAdd(hypre_ParCSRMatrix *A,
    {
       cmap_differ = 1; /* A and B have different cmap_size */
    }
-   for (im = 0; im < A_cmap_size; im++)
+   else
    {
-      if (A_cmap[im] != B_cmap[im])
+      for (im = 0; im < A_cmap_size; im++)
       {
-         cmap_differ = 1; /* A and B have different cmap arrays */
-         break;
+         if (A_cmap[im] != B_cmap[im])
+         {
+            cmap_differ = 1; /* A and B have different cmap arrays */
+            break;
+         }
       }
    }
 


### PR DESCRIPTION
If ```B_cmap``` is smaller than ```A_cmap```, there is a segfault when comparing them.

Since different sizes imply different cmaps, the walk through both cmaps is only performed when the sizes are the same.