### PR TITLE
Define SparseMatrix operator equal [sparsemat_op_equal]

### DIFF
--- a/linalg/sparsemat.cpp
+++ b/linalg/sparsemat.cpp
@@ -184,6 +184,13 @@ SparseMatrix::SparseMatrix(const SparseMatrix &mat, bool copy_graph)
    isSorted = mat.isSorted;
 }
 
+SparseMatrix& SparseMatrix::operator=(SparseMatrix other)
+{
+    Swap(other);
+
+    return *this;
+}
+
 void SparseMatrix::MakeRef(const SparseMatrix &master)
 {
    MFEM_ASSERT(master.Finalized(), "'master' must be finalized");

--- a/linalg/sparsemat.cpp
+++ b/linalg/sparsemat.cpp
@@ -184,9 +184,12 @@ SparseMatrix::SparseMatrix(const SparseMatrix &mat, bool copy_graph)
    isSorted = mat.isSorted;
 }
 
-SparseMatrix& SparseMatrix::operator=(SparseMatrix other)
+SparseMatrix& SparseMatrix::operator=(const SparseMatrix &rhs)
 {
-   Swap(other);
+   Clear();
+
+   SparseMatrix copy(rhs);
+   Swap(copy);
 
    return *this;
 }

--- a/linalg/sparsemat.cpp
+++ b/linalg/sparsemat.cpp
@@ -186,9 +186,9 @@ SparseMatrix::SparseMatrix(const SparseMatrix &mat, bool copy_graph)
 
 SparseMatrix& SparseMatrix::operator=(SparseMatrix other)
 {
-    Swap(other);
+   Swap(other);
 
-    return *this;
+   return *this;
 }
 
 void SparseMatrix::MakeRef(const SparseMatrix &master)

--- a/linalg/sparsemat.hpp
+++ b/linalg/sparsemat.hpp
@@ -112,7 +112,7 @@ public:
        ownership. */
    SparseMatrix(const SparseMatrix &mat, bool copy_graph = true);
 
-   /// Deep copy 
+   /// Deep copy
    SparseMatrix& operator=(SparseMatrix mat);
 
    /** @brief Clear the contents of the SparseMatrix and make it a reference to

--- a/linalg/sparsemat.hpp
+++ b/linalg/sparsemat.hpp
@@ -112,6 +112,9 @@ public:
        ownership. */
    SparseMatrix(const SparseMatrix &mat, bool copy_graph = true);
 
+   /// Deep copy 
+   SparseMatrix& operator=(SparseMatrix mat);
+
    /** @brief Clear the contents of the SparseMatrix and make it a reference to
        @a master */
    /** After this call, the matrix will point to the same data as @a master but

--- a/linalg/sparsemat.hpp
+++ b/linalg/sparsemat.hpp
@@ -112,8 +112,8 @@ public:
        ownership. */
    SparseMatrix(const SparseMatrix &mat, bool copy_graph = true);
 
-   /// Deep copy
-   SparseMatrix& operator=(SparseMatrix mat);
+   /// Assignment operator: deep copy
+   SparseMatrix& operator=(const SparseMatrix &rhs);
 
    /** @brief Clear the contents of the SparseMatrix and make it a reference to
        @a master */


### PR DESCRIPTION
This should deep copy instead of the implicit shallow copy.