### PR TITLE
Clean up memory in Cubit/NetCDF mesh reader

### DIFF
--- a/mesh/mesh_readers.cpp
+++ b/mesh/mesh_readers.cpp
@@ -1802,7 +1802,7 @@ void Mesh::ReadCubit(const char *filename, int &curved, int &read_gf)
    delete [] coordz;
    for (int i = 0; i < (int) num_el_blk; i++)
    {
-      delete elem_blk[i];
+      delete [] elem_blk[i];
    }
    delete [] elem_blk;
    delete [] start_of_block;

--- a/mesh/mesh_readers.cpp
+++ b/mesh/mesh_readers.cpp
@@ -1815,11 +1815,14 @@ void Mesh::ReadCubit(const char *filename, int &curved, int &read_gf)
    for (int i = 0; i < (int) num_side_sets; i++)
    {
       delete [] ss_node_id[i];
+      delete [] elem_ss[i];
+      delete [] side_ss[i];
    }
    delete [] ss_node_id;
+   delete [] elem_ss;
+   delete [] side_ss;
    delete [] ebprop;
    delete [] ssprop;
-
 }
 #endif // #ifdef MFEM_USE_NETCDF
 

--- a/mesh/mesh_readers.cpp
+++ b/mesh/mesh_readers.cpp
@@ -1793,6 +1793,12 @@ void Mesh::ReadCubit(const char *filename, int &curved, int &read_gf)
       }
    }
 
+   // close NetCDF file and reclaim memory
+   if ((retval = nc_close(ncid)))
+   {
+      MFEM_ABORT("Fatal NetCDF error: " << nc_strerror(retval));
+   }
+
    // clean up all netcdf stuff
    delete [] num_el_in_blk;
    delete [] num_nod_per_el;


### PR DESCRIPTION
Running an application that read a Cubit mesh through valgrind I noticed that this did not cleanly delete all its memory. This PR fixes these memory issues.

To recreate the issues on master, run the following under valgrind:
```
#include "mfem.hpp"

int main(int argc, char * argv[])
{
   mfem::Mesh mesh("/home/barker29/design-optimization/data/bridge.gen");
   return 0;
}
```