### PR TITLE
Define operator= for Table [table_op_equal]

### DIFF
--- a/general/table.cpp
+++ b/general/table.cpp
@@ -40,6 +40,16 @@ Table::Table(const Table &table)
    }
 }
 
+Table& Table::operator=(const Table &rhs)
+{
+   Clear();
+
+   Table copy(rhs);
+   Swap(copy);
+
+   return *this;
+}
+
 Table::Table (int dim, int connections_per_row)
 {
    int i, j, sum = dim * connections_per_row;

--- a/general/table.hpp
+++ b/general/table.hpp
@@ -58,6 +58,9 @@ public:
    /// Copy constructor
    Table(const Table &);
 
+   /// Assignment operator: deep copy
+   Table& operator=(const Table &rhs);
+
    /// Create a table with an upper limit for the number of connections.
    explicit Table (int dim, int connections_per_row = 3);
 


### PR DESCRIPTION
This should deep copy instead of the implicit shallow copy.

Similar to #352, #361.