### PR TITLE
Fix a typo [typo-fix]

### DIFF
--- a/linalg/superlu.cpp
+++ b/linalg/superlu.cpp
@@ -410,9 +410,10 @@ void SuperLUSolver::SetupGrid()
    {
       if ( myid_ == 0 )
       {
-      mfem:err << "Warning: User specified nprow and npcol are such that "
-                  << "(nprow * npcol) > numProcs or (nprow * npcol) < 1.  "
-                  << "Using default values for nprow and npcol instead." << endl;
+         mfem::err << "Warning: User specified nprow and npcol are such that "
+                   << "(nprow * npcol) > numProcs or (nprow * npcol) < 1.  "
+                   << "Using default values for nprow and npcol instead."
+                   << endl;
       }
 
       nprow_ = (int)superlu_internal::sqrti((unsigned int)numProcs_);


### PR DESCRIPTION
An interesting typo: `mfem:err` --> `mfem::err` and it is not a bug. :-)
