### PR TITLE
When no physical domain are present, use 1 as material ID to prevent …

### DIFF
--- a/mesh/mesh.cpp
+++ b/mesh/mesh.cpp
@@ -2514,6 +2514,7 @@ Element *Mesh::ReadElementWithoutAttr(std::istream &input)
 
    input >> geom;
    el = NewElement(geom);
+   if (!el) MFEM_ABORT("Unsupported element type " << geom);
    nv = el->GetNVertices();
    v  = el->GetVertices();
    for (int i = 0; i < nv; i++)

--- a/mesh/mesh.cpp
+++ b/mesh/mesh.cpp
@@ -2514,7 +2514,7 @@ Element *Mesh::ReadElementWithoutAttr(std::istream &input)
 
    input >> geom;
    el = NewElement(geom);
-   if (!el) MFEM_ABORT("Unsupported element type " << geom);
+   MFEM_VERIFY(el, "Unsupported element type: " << geom);
    nv = el->GetNVertices();
    v  = el->GetVertices();
    for (int i = 0; i < nv; i++)

--- a/mesh/mesh_readers.cpp
+++ b/mesh/mesh_readers.cpp
@@ -1028,7 +1028,7 @@ void Mesh::ReadGmshMesh(std::istream &input)
                   serial_number = data[dd++];
                   // physical domain - the most important value (to distinguish
                   // materials with different properties)
-                  phys_domain = (n_tags > 0) ? data[dd++] : 0;
+                  phys_domain = (n_tags > 0) ? data[dd++] : 1;
                   // elementary domain - to distinguish different geometrical
                   // domains (typically, it's used rarely)
                   elem_domain = (n_tags > 1) ? data[dd++] : 0;
@@ -1111,7 +1111,7 @@ void Mesh::ReadGmshMesh(std::istream &input)
                for (int i = 0; i < n_tags; ++i) { input >> data[i]; }
                // physical domain - the most important value (to distinguish
                // materials with different properties)
-               phys_domain = (n_tags > 0) ? data[0] : 0;
+               phys_domain = (n_tags > 0) ? data[0] : 1;
                // elementary domain - to distinguish different geometrical
                // domains (typically, it's used rarely)
                elem_domain = (n_tags > 1) ? data[1] : 0;


### PR DESCRIPTION
…useless errors

Report the error instead of segfaulting when the element is not supported