### PR TITLE
Adjust a few sample runs ... [sample-runs-fix]

### DIFF
--- a/examples/ex12p.cpp
+++ b/examples/ex12p.cpp
@@ -2,14 +2,15 @@
 //
 // Compile with: make ex12p
 //
-// Sample runs:  mpirun -np 4 ex12p -m ../data/beam-tri.mesh
-//               mpirun -np 4 ex12p -m ../data/beam-quad.mesh
-//               mpirun -np 4 ex12p -m ../data/beam-tet.mesh -n 10 -o 2 -elast
-//               mpirun -np 4 ex12p -m ../data/beam-hex.mesh -s 3876
-//               mpirun -np 4 ex12p -m ../data/beam-tri.mesh -o 2 -sys
-//               mpirun -np 4 ex12p -m ../data/beam-quad.mesh -n 6 -o 3 -elast
-//               mpirun -np 4 ex12p -m ../data/beam-quad-nurbs.mesh
-//               mpirun -np 4 ex12p -m ../data/beam-hex-nurbs.mesh
+// Sample runs:
+//    mpirun -np 4 ex12p -m ../data/beam-tri.mesh
+//    mpirun -np 4 ex12p -m ../data/beam-quad.mesh
+//    mpirun -np 4 ex12p -m ../data/beam-tet.mesh -n 10 -o 2 -elast
+//    mpirun -np 4 ex12p -m ../data/beam-hex.mesh -s 3876
+//    mpirun -np 4 ex12p -m ../data/beam-tri.mesh -o 2 -sys
+//    mpirun -np 4 ex12p -m ../data/beam-quad.mesh -s 4526 -n 6 -o 3 -elast
+//    mpirun -np 4 ex12p -m ../data/beam-quad-nurbs.mesh
+//    mpirun -np 4 ex12p -m ../data/beam-hex-nurbs.mesh
 //
 // Description:  This example code solves the linear elasticity eigenvalue
 //               problem for a multi-material cantilever beam.

--- a/examples/ex18p.cpp
+++ b/examples/ex18p.cpp
@@ -6,9 +6,9 @@
 //
 //       mpirun -np 4 ex18p -p 1 -rs 2 -rp 1 -o 1 -s 3
 //       mpirun -np 4 ex18p -p 1 -rs 1 -rp 1 -o 3 -s 4
-//       mpirun -np 4 ex18p -p 1 -rs 0 -rp 1 -o 5 -s 6
+//       mpirun -np 4 ex18p -p 1 -rs 1 -rp 1 -o 5 -s 6
 //       mpirun -np 4 ex18p -p 2 -rs 1 -rp 1 -o 1 -s 3
-//       mpirun -np 4 ex18p -p 2 -rs 0 -rp 1 -o 3 -s 3
+//       mpirun -np 4 ex18p -p 2 -rs 1 -rp 1 -o 3 -s 3
 //
 // Description:  This example code solves the compressible Euler system of
 //               equations, a model nonlinear hyperbolic PDE, with a


### PR DESCRIPTION
... to get rid of LOBPCG errors (ex12p) and warnings about empty partitions (ex18p).

For the 6th sample run in ex12p, I had to try around 10 different seed values until I found one that works, i.e. does NOT produce the message
```ascii
Error in LOBPCG:
GEVP solver failure
```
on both, my desktop and my laptop.