### PR TITLE
Doxygen updates [doxygen-updates]

### DIFF
--- a/doc/CodeDocumentation.conf.in
+++ b/doc/CodeDocumentation.conf.in
@@ -140,7 +140,7 @@ INLINE_INHERITED_MEMB  = NO
 # shortest path that makes the file name unique will be used
 # The default value is: YES.
 
-FULL_PATH_NAMES        = NO
+FULL_PATH_NAMES        = YES
 
 # The STRIP_FROM_PATH tag can be used to strip a user-defined part of the path.
 # Stripping is only done if one of the specified strings matches the left-hand
@@ -152,7 +152,7 @@ FULL_PATH_NAMES        = NO
 # will be relative from the directory where doxygen is started.
 # This tag requires that the tag FULL_PATH_NAMES is set to YES.
 
-STRIP_FROM_PATH        =
+STRIP_FROM_PATH        = @MFEM_SOURCE_DIR@
 
 # The STRIP_FROM_INC_PATH tag can be used to strip a user-defined part of the
 # path mentioned in the documentation of a class, which tells the reader which
@@ -1440,7 +1440,7 @@ FORMULA_TRANSPARENT    = YES
 # The default value is: NO.
 # This tag requires that the tag GENERATE_HTML is set to YES.
 
-USE_MATHJAX            = NO
+USE_MATHJAX            = YES
 
 # When MathJax is enabled you can set the default output format to be used for
 # the MathJax output. See the MathJax site (see:
@@ -1463,14 +1463,14 @@ MATHJAX_FORMAT         = HTML-CSS
 # The default value is: http://cdn.mathjax.org/mathjax/latest.
 # This tag requires that the tag USE_MATHJAX is set to YES.
 
-MATHJAX_RELPATH        = http://www.mathjax.org/mathjax
+MATHJAX_RELPATH        = https://cdn.llnl.gov/mathjax/2.7.2
 
 # The MATHJAX_EXTENSIONS tag can be used to specify one or more MathJax
 # extension names that should be enabled during MathJax rendering. For example
 # MATHJAX_EXTENSIONS = TeX/AMSmath TeX/AMSsymbols
 # This tag requires that the tag USE_MATHJAX is set to YES.
 
-MATHJAX_EXTENSIONS     =
+MATHJAX_EXTENSIONS     = TeX/AMSmath TeX/AMSsymbols
 
 # The MATHJAX_CODEFILE tag can be used to specify a file with javascript pieces
 # of code that will be used on startup of the MathJax code. See the MathJax site

--- a/doc/makefile
+++ b/doc/makefile
@@ -10,17 +10,17 @@
 # Software Foundation) version 2.1 dated February 1999.
 
 MFEM_DIR ?= ..
-DOXYGEN_CONG = CodeDocumentation.conf
+DOXYGEN_CONF = CodeDocumentation.conf
 
 # doxygen uses: graphviz, latex
-html: $(DOXYGEN_CONG)
-	doxygen $(DOXYGEN_CONG)
+html: $(DOXYGEN_CONF)
+	doxygen $(DOXYGEN_CONF)
 	rm -f CodeDocumentation.html
 	ln -s CodeDocumentation/html/index.html CodeDocumentation.html
 
 clean:
-	rm -rf $(DOXYGEN_CONG) CodeDocumentation CodeDocumentation.html *~
+	rm -rf $(DOXYGEN_CONF) CodeDocumentation CodeDocumentation.html *~
 
-$(DOXYGEN_CONG): $(MFEM_DIR)/doc/$(DOXYGEN_CONG).in
+$(DOXYGEN_CONF): $(MFEM_DIR)/doc/$(DOXYGEN_CONF).in
 	sed -e 's%@MFEM_SOURCE_DIR@%$(MFEM_DIR)%g' $(<) \
-	  > $(DOXYGEN_CONG)
+	  > $(DOXYGEN_CONF)

--- a/fem/coefficient.hpp
+++ b/fem/coefficient.hpp
@@ -122,6 +122,8 @@ public:
    }
 
    /// (DEPRECATED) Define a time-independent coefficient from a C-function
+   /** @deprecated Use the method where the C-function, @a f, uses a const
+       Vector argument instead of Vector. */
    FunctionCoefficient(double (*f)(Vector &))
    {
       Function = reinterpret_cast<double(*)(const Vector&)>(f);
@@ -129,6 +131,8 @@ public:
    }
 
    /// (DEPRECATED) Define a time-dependent coefficient from a C-function
+   /** @deprecated Use the method where the C-function, @a tdf, uses a const
+       Vector argument instead of Vector. */
    FunctionCoefficient(double (*tdf)(Vector &, double))
    {
       Function = NULL;

--- a/fem/fe_coll.hpp
+++ b/fem/fe_coll.hpp
@@ -232,7 +232,7 @@ public:
    virtual ~L2_FECollection();
 };
 
-// Declare an alternative name for L2_FECollection = DG_FECollection
+/// Declare an alternative name for L2_FECollection = DG_FECollection
 typedef L2_FECollection DG_FECollection;
 
 /// Arbitrary order H(div)-conforming Raviart-Thomas finite elements.

--- a/general/isockstream.hpp
+++ b/general/isockstream.hpp
@@ -21,8 +21,8 @@ namespace mfem
 /** Data type for input socket stream class. The class is used as server
     to receive data from a client on specified port number. The user gets
     data from the stream as from any other input stream.
-    This class is DEPRECATED. New code should use class socketserver (see
-    "socketstream.hpp"). */
+    @deprecated This class is DEPRECATED. New code should use class
+    @ref socketserver (see socketstream.hpp). */
 class isockstream
 {
 private:

--- a/general/osockstream.hpp
+++ b/general/osockstream.hpp
@@ -23,8 +23,8 @@ namespace mfem
     writes in the stream, as in any other output stream and when the data
     is ready to be send function send() has to be executed. Otherwise (if
     not executed) the destructor will send the data.
-    This class is DEPRECATED. New code should use class socketstream (see
-    "socketstream.hpp"). */
+    @deprecated This class is DEPRECATED. New code should use class
+    @ref socketstream (see socketstream.hpp). */
 class osockstream : public socketstream
 {
 public:

--- a/general/text.hpp
+++ b/general/text.hpp
@@ -16,6 +16,7 @@
 #include <sstream>
 #include <string>
 #include <limits>
+#include <iomanip>
 
 namespace mfem
 {

--- a/linalg/densemat.cpp
+++ b/linalg/densemat.cpp
@@ -29,6 +29,33 @@
 #define copysign _copysign
 #endif
 
+
+#ifdef MFEM_USE_LAPACK
+extern "C" void
+dgemm_(char *, char *, int *, int *, int *, double *, double *,
+       int *, double *, int *, double *, double *, int *);
+extern "C" void
+dgetrf_(int *, int *, double *, int *, int *, int *);
+extern "C" void
+dgetrs_(char *, int *, int *, double *, int *, int *, double *, int *, int *);
+extern "C" void
+dgetri_(int *N, double *A, int *LDA, int *IPIV, double *WORK,
+        int *LWORK, int *INFO);
+extern "C" void
+dsyevr_(char *JOBZ, char *RANGE, char *UPLO, int *N, double *A, int *LDA,
+        double *VL, double *VU, int *IL, int *IU, double *ABSTOL, int *M,
+        double *W, double *Z, int *LDZ, int *ISUPPZ, double *WORK, int *LWORK,
+        int *IWORK, int *LIWORK, int *INFO);
+extern "C" void
+dsyev_(char *JOBZ, char *UPLO, int *N, double *A, int *LDA, double *W,
+       double *WORK, int *LWORK, int *INFO);
+extern "C" void
+dgesvd_(char *JOBU, char *JOBVT, int *M, int *N, double *A, int *LDA,
+        double *S, double *U, int *LDU, double *VT, int *LDVT, double *WORK,
+        int *LWORK, int *INFO);
+#endif
+
+
 namespace mfem
 {
 
@@ -612,16 +639,6 @@ void DenseMatrix::Neg()
    }
 }
 
-#ifdef MFEM_USE_LAPACK
-extern "C" void
-dgetrf_(int *, int *, double *, int *, int *, int *);
-extern "C" void
-dgetrs_(char *, int *, int *, double *, int *, int *, double *, int *, int *);
-extern "C" void
-dgetri_(int *N, double *A, int *LDA, int *IPIV, double *WORK,
-        int *LWORK, int *INFO);
-#endif
-
 void DenseMatrix::Invert()
 {
 #ifdef MFEM_DEBUG
@@ -838,21 +855,6 @@ void DenseMatrix::FNorm(double &scale_factor, double &scaled_fnorm2) const
    scale_factor = max_norm;
    scaled_fnorm2 = fnorm2;
 }
-
-#ifdef MFEM_USE_LAPACK
-extern "C" void
-dsyevr_(char *JOBZ, char *RANGE, char *UPLO, int *N, double *A, int *LDA,
-        double *VL, double *VU, int *IL, int *IU, double *ABSTOL, int *M,
-        double *W, double *Z, int *LDZ, int *ISUPPZ, double *WORK, int *LWORK,
-        int *IWORK, int *LIWORK, int *INFO);
-extern "C" void
-dsyev_(char *JOBZ, char *UPLO, int *N, double *A, int *LDA, double *W,
-       double *WORK, int *LWORK, int *INFO);
-extern "C" void
-dgesvd_(char *JOBU, char *JOBVT, int *M, int *N, double *A, int *LDA,
-        double *S, double *U, int *LDU, double *VT, int *LDVT, double *WORK,
-        int *LWORK, int *INFO);
-#endif
 
 void dsyevr_Eigensystem(DenseMatrix &a, Vector &ev, DenseMatrix *evect)
 {
@@ -2968,12 +2970,6 @@ void Add(double alpha, const DenseMatrix &A,
    Add(alpha, A.GetData(), beta, B.GetData(), C);
 }
 
-
-#ifdef MFEM_USE_LAPACK
-extern "C" void
-dgemm_(char *, char *, int *, int *, int *, double *, double *,
-       int *, double *, int *, double *, double *, int *);
-#endif
 
 void Mult(const DenseMatrix &b, const DenseMatrix &c, DenseMatrix &a)
 {

--- a/mesh/mesh.cpp
+++ b/mesh/mesh.cpp
@@ -31,6 +31,19 @@
 #include "metis.h"
 #endif
 
+// METIS 4 prototypes
+#if defined(MFEM_USE_METIS) && !defined(MFEM_USE_METIS_5)
+typedef int idxtype;
+extern "C" {
+   void METIS_PartGraphRecursive(int*, idxtype*, idxtype*, idxtype*, idxtype*,
+                                 int*, int*, int*, int*, int*, idxtype*);
+   void METIS_PartGraphKway(int*, idxtype*, idxtype*, idxtype*, idxtype*,
+                            int*, int*, int*, int*, int*, idxtype*);
+   void METIS_PartGraphVKway(int*, idxtype*, idxtype*, idxtype*, idxtype*,
+                             int*, int*, int*, int*, int*, idxtype*);
+}
+#endif
+
 #ifdef MFEM_USE_GECKO
 #include "graph.h"
 #endif
@@ -4570,19 +4583,6 @@ void Mesh::ReorientTetMesh()
       delete old_v_to_v;
    }
 }
-
-#if defined(MFEM_USE_METIS) && !defined(MFEM_USE_METIS_5)
-// METIS 4 prototypes
-typedef int idxtype;
-extern "C" {
-   void METIS_PartGraphRecursive(int*, idxtype*, idxtype*, idxtype*, idxtype*,
-                                 int*, int*, int*, int*, int*, idxtype*);
-   void METIS_PartGraphKway(int*, idxtype*, idxtype*, idxtype*, idxtype*,
-                            int*, int*, int*, int*, int*, idxtype*);
-   void METIS_PartGraphVKway(int*, idxtype*, idxtype*, idxtype*, idxtype*,
-                             int*, int*, int*, int*, int*, idxtype*);
-}
-#endif
 
 int *Mesh::CartesianPartitioning(int nxyz[])
 {


### PR DESCRIPTION
In the doxygen documentation, switch from using images for LaTeX formulas to using MathJax (with cdn.llnl.gov).

Move external function declarations for METIS 4 and LAPACK outside the mfem namespace and in the beginning of their respective files (otherwise doxygen was showing them as part of the mfem namespace).

Improve some deprecation documentation.

Fix a typo in doc/makefile.