### PR TITLE
Unused variables when MFEM_THREAD_SAFE is on [unused-p1-fix]

### DIFF
--- a/fem/fe.cpp
+++ b/fem/fe.cpp
@@ -6950,9 +6950,9 @@ H1_QuadrilateralElement::H1_QuadrilateralElement(const int p, const int btype)
 {
    const double *cp = poly1d.ClosedPoints(p, b_type);
 
+#ifndef MFEM_THREAD_SAFE
    const int p1 = p + 1;
 
-#ifndef MFEM_THREAD_SAFE
    shape_x.SetSize(p1);
    shape_y.SetSize(p1);
    dshape_x.SetSize(p1);
@@ -7064,9 +7064,9 @@ H1_HexahedronElement::H1_HexahedronElement(const int p, const int btype)
 {
    const double *cp = poly1d.ClosedPoints(p, b_type);
 
+#ifndef MFEM_THREAD_SAFE
    const int p1 = p + 1;
 
-#ifndef MFEM_THREAD_SAFE
    shape_x.SetSize(p1);
    shape_y.SetSize(p1);
    shape_z.SetSize(p1);
@@ -7282,9 +7282,9 @@ void H1Pos_SegmentElement::ProjectDelta(int vertex, Vector &dofs) const
 H1Pos_QuadrilateralElement::H1Pos_QuadrilateralElement(const int p)
    : PositiveTensorFiniteElement(2, p)
 {
+#ifndef MFEM_THREAD_SAFE
    const int p1 = p + 1;
 
-#ifndef MFEM_THREAD_SAFE
    shape_x.SetSize(p1);
    shape_y.SetSize(p1);
    dshape_x.SetSize(p1);
@@ -7350,9 +7350,9 @@ void H1Pos_QuadrilateralElement::ProjectDelta(int vertex, Vector &dofs) const
 H1Pos_HexahedronElement::H1Pos_HexahedronElement(const int p)
    : PositiveTensorFiniteElement(3, p)
 {
+#ifndef MFEM_THREAD_SAFE
    const int p1 = p + 1;
 
-#ifndef MFEM_THREAD_SAFE
    shape_x.SetSize(p1);
    shape_y.SetSize(p1);
    shape_z.SetSize(p1);


### PR DESCRIPTION
Some of the tensor product finite element types declare variables for the size of internal vectors even when those internal vectors are not present.  This is related to the MFEM_THREAD_SAFE variable which determines wether or not these internal vectors are declared as member data.