### PR TITLE
Fix row_starts memory bug in HypreParMatrix::LeftDiagMult() [bugfix/leftdiagmult]

### DIFF
--- a/linalg/hypre.cpp
+++ b/linalg/hypre.cpp
@@ -1056,10 +1056,17 @@ HypreParMatrix* HypreParMatrix::LeftDiagMult(const SparseMatrix &D,
    if (assumed_partition)
    {
       part_size = 2;
-      global_num_rows = row_starts[2];
-      // Here, we use row_starts[2], so row_starts must come from the methods
-      // GetDofOffsets/GetTrueDofOffsets of ParFiniteElementSpace (HYPRE's
-      // partitions have only 2 entries).
+      if (row_starts == NULL)
+      {
+         global_num_rows = hypre_ParCSRMatrixGlobalNumRows(A);
+      }
+      else
+      {
+         global_num_rows = row_starts[2];
+         // Here, we use row_starts[2], so row_starts must come from the
+         // methods GetDofOffsets/GetTrueDofOffsets of ParFiniteElementSpace
+         // (HYPRE's partitions have only 2 entries).
+      }
    }
    else
    {

--- a/linalg/hypre.cpp
+++ b/linalg/hypre.cpp
@@ -1026,7 +1026,8 @@ HypreParMatrix* HypreParMatrix::LeftDiagMult(const SparseMatrix &D,
                                              HYPRE_Int* row_starts) const
 {
    const bool assumed_partition = HYPRE_AssumedPartitionCheck();
-   if (row_starts == NULL)
+   const bool row_starts_given = (row_starts != NULL);
+   if (!row_starts_given)
    {
       row_starts = hypre_ParCSRMatrixRowStarts(A);
       MFEM_VERIFY(D.Height() == hypre_CSRMatrixNumRows(A->diag),
@@ -1056,16 +1057,16 @@ HypreParMatrix* HypreParMatrix::LeftDiagMult(const SparseMatrix &D,
    if (assumed_partition)
    {
       part_size = 2;
-      if (row_starts == NULL)
-      {
-         global_num_rows = hypre_ParCSRMatrixGlobalNumRows(A);
-      }
-      else
+      if (row_starts_given)
       {
          global_num_rows = row_starts[2];
          // Here, we use row_starts[2], so row_starts must come from the
          // methods GetDofOffsets/GetTrueDofOffsets of ParFiniteElementSpace
          // (HYPRE's partitions have only 2 entries).
+      }
+      else
+      {
+         global_num_rows = hypre_ParCSRMatrixGlobalNumRows(A);
       }
    }
    else

--- a/linalg/hypre.hpp
+++ b/linalg/hypre.hpp
@@ -430,13 +430,14 @@ public:
       return *this;
    }
 
-   /** Multiply A on the left by a block-diagonal parallel matrix D. Return
-       a new parallel matrix, D*A. If D has a different number of rows than A,
-       D's row starts array needs to be given (as returned by the methods
-       GetDofOffsets/GetTrueDofOffsets of ParFiniteElementSpace). The new matrix
-       D*A uses copies of the row-, column-starts arrays, so "this" matrix and
-       "row_starts" can be deleted.
-       NOTE: this operation is local and does not require communication. */
+   /** @brief Multiply the HypreParMatrix on the left by a block-diagonal
+       parallel matrix @a D and return the result as a new HypreParMatrix. */
+   /** If @a D has a different number of rows than @a A (this matrix), @a D's
+       row starts array needs to be given (as returned by the methods
+       GetDofOffsets/GetTrueDofOffsets of ParFiniteElementSpace). The new
+       matrix @a D*A uses copies of the row- and column-starts arrays, so "this"
+       matrix and @a row_starts can be deleted.
+       @note This operation is local and does not require communication. */
    HypreParMatrix* LeftDiagMult(const SparseMatrix &D,
                                 HYPRE_Int* row_starts = NULL) const;
 


### PR DESCRIPTION
Previously, this routine would segfault for a square matrix,
row_starts = NULL, and HYPRE assumed partition turned on.

See also #229 , #236 