### PR TITLE
Fix a couple of bugs introduced in the tbasis-dev PR, #283 [tbasis-fix]

### DIFF
--- a/fem/fe.hpp
+++ b/fem/fe.hpp
@@ -70,6 +70,19 @@ public:
       }
       return Quadrature1D::Invalid;
    }
+   /// Return the nodal BasisType corresponding to the Quadrature1D type.
+   static int GetNodalBasis(int qpt_type)
+   {
+      switch (qpt_type)
+      {
+         case Quadrature1D::GaussLegendre:   return GaussLegendre;
+         case Quadrature1D::GaussLobatto:    return GaussLobatto;
+         case Quadrature1D::OpenUniform:     return OpenUniform;
+         case Quadrature1D::ClosedUniform:   return ClosedUniform;
+         case Quadrature1D::OpenHalfUniform: return OpenHalfUniform;
+      }
+      return Invalid;
+   }
    /// Check and convert a BasisType constant to a string identifier.
    static const char *Name(int b_type)
    {
@@ -1597,7 +1610,14 @@ protected:
    Poly_1D::Basis &basis1d;
 
 public:
-   TensorBasisElement(const int dims, const int p, const int btype);
+   enum DofMapType
+   {
+      L2_DOF_MAP = 0,
+      H1_DOF_MAP = 1
+   };
+
+   TensorBasisElement(const int dims, const int p, const int btype,
+                      const DofMapType dmtype);
 
    int GetBasisType() const { return b_type; }
 
@@ -1637,14 +1657,16 @@ class NodalTensorFiniteElement : public NodalFiniteElement,
    public TensorBasisElement
 {
 public:
-   NodalTensorFiniteElement(const int dims, const int p, const int btype);
+   NodalTensorFiniteElement(const int dims, const int p, const int btype,
+                            const DofMapType dmtype);
 };
 
 class PositiveTensorFiniteElement : public PositiveFiniteElement,
    public TensorBasisElement
 {
 public:
-   PositiveTensorFiniteElement(const int dims, const int p);
+   PositiveTensorFiniteElement(const int dims, const int p,
+                               const DofMapType dmtype);
 };
 
 class H1_SegmentElement : public NodalTensorFiniteElement

--- a/fem/geom.cpp
+++ b/fem/geom.cpp
@@ -806,7 +806,7 @@ RefinedGeometry * GeometryRefiner::Refine(int Geom, int Times, int ETimes)
 
    Times = std::max(Times, 1);
    ETimes = std::max(ETimes, 1);
-   const double *cp = poly1d.GetPoints(Times, type);
+   const double *cp = poly1d.GetPoints(Times, BasisType::GetNodalBasis(type));
 
    RefinedGeometry *RG = FindInRGeom(Geom, Times, ETimes, type);
    if (RG) { return RG; }


### PR DESCRIPTION
Fix a bug: in class `TensorBasisElement` and its derived classes, `NodalTensorFiniteElement` and `PositiveTensorFiniteElement`, add a parameter to their constructors of a new type, `DofMapType`, to indicate the type of basis being constructed: L2 or H1.

Add a new static method `BasisType::GetNodalBasis()` that converts a `Quadrature1D` type to the corresponding nodal `BasisType`.

Fix a bug: in `GeometryRefiner::Refine()`, convert the `Quadrature1D` type to `BasisType` before calling `poly1d.GetPoints()`.
