### PR TITLE
Operator::Type for any class derived from Operator [oper-type-any] -> [refine-operator-dev]

### DIFF
--- a/fem/pbilinearform.cpp
+++ b/fem/pbilinearform.cpp
@@ -171,6 +171,10 @@ void ParBilinearForm::ParallelAssemble(OperatorHandle &A, SparseMatrix *A_local)
 
    // TODO - assemble the Dof_TrueDof_Matrix directly in the required format?
    Ph.ConvertFrom(pfes->Dof_TrueDof_Matrix());
+   // TODO: When Ph.Type() == Operator::ANY_TYPE we want to use the Operator
+   // returned by pfes->GetProlongationMatrix(), however that Operator is a
+   // const Operator, so we cannot store it in OperatorHandle. We need a const
+   // version of class OperatorHandle, e.g. ConstOperatorHandle.
 
    A.MakePtAP(dA, Ph);
 }

--- a/linalg/handle.cpp
+++ b/linalg/handle.cpp
@@ -215,7 +215,9 @@ void OperatorHandle::ConvertFrom(OperatorHandle &A)
       }
       case Operator::Hypre_ParCSR:
       {
+#ifdef MFEM_USE_MPI
          oper = A.Is<HypreParMatrix>();
+#endif
          break;
       }
       case Operator::PETSC_MATAIJ:
@@ -230,7 +232,13 @@ void OperatorHandle::ConvertFrom(OperatorHandle &A)
                break;
             default: break;
          }
-         if (!oper) { oper = A.Is<PetscParMatrix>(); }
+#ifdef MFEM_USE_PETSC
+         if (!oper)
+         {
+            PetscParMatrix *pA = A.Is<PetscParMatrix>();
+            if (pA->GetType() == Type()) { oper = pA; }
+         }
+#endif
          break;
       }
       default: break;

--- a/linalg/handle.cpp
+++ b/linalg/handle.cpp
@@ -33,6 +33,7 @@ Operator::Type OperatorHandle::CheckType(Operator::Type tid)
 {
    switch (tid)
    {
+      case Operator::ANY_TYPE: break;
       case Operator::MFEM_SPARSEMAT: break;
       case Operator::Hypre_ParCSR:
 #ifdef MFEM_USE_MPI
@@ -64,6 +65,12 @@ void OperatorHandle::MakeSquareBlockDiag(MPI_Comm comm, HYPRE_Int glob_size,
 
    switch (type_id)
    {
+      case Operator::ANY_TYPE: // --> MFEM_SPARSEMAT
+      case Operator::MFEM_SPARSEMAT:
+         // As a parallel Operator, the SparseMatrix simply represents the local
+         // Operator, without the need of any communication.
+         pSet(diag, false);
+         return;
       case Operator::Hypre_ParCSR:
          oper = new HypreParMatrix(comm, glob_size, row_starts, diag);
          break;
@@ -88,6 +95,12 @@ MakeRectangularBlockDiag(MPI_Comm comm, HYPRE_Int glob_num_rows,
 
    switch (type_id)
    {
+      case Operator::ANY_TYPE: // --> MFEM_SPARSEMAT
+      case Operator::MFEM_SPARSEMAT:
+         // As a parallel Operator, the SparseMatrix simply represents the local
+         // Operator, without the need of any communication.
+         pSet(diag, false);
+         return;
       case Operator::Hypre_ParCSR:
          oper = new HypreParMatrix(comm, glob_num_rows, glob_num_cols,
                                    row_starts, col_starts, diag);
@@ -108,10 +121,16 @@ MakeRectangularBlockDiag(MPI_Comm comm, HYPRE_Int glob_num_rows,
 
 void OperatorHandle::MakePtAP(OperatorHandle &A, OperatorHandle &P)
 {
-   MFEM_VERIFY(A.Type() == P.Type(), "type mismatch in A and P");
+   if (A.Type() != Operator::ANY_TYPE)
+   {
+      MFEM_VERIFY(A.Type() == P.Type(), "type mismatch in A and P");
+   }
    Clear();
    switch (A.Type())
    {
+      case Operator::ANY_TYPE:
+         pSet(new RAPOperator(*P.Ptr(), *A.Ptr(), *P.Ptr()));
+         break;
       case Operator::MFEM_SPARSEMAT:
       {
          SparseMatrix *R  = mfem::Transpose(*P.As<SparseMatrix>());
@@ -141,11 +160,17 @@ void OperatorHandle::MakePtAP(OperatorHandle &A, OperatorHandle &P)
 void OperatorHandle::MakeRAP(OperatorHandle &Rt, OperatorHandle &A,
                              OperatorHandle &P)
 {
-   MFEM_VERIFY(A.Type() == Rt.Type(), "type mismatch in A and Rt");
-   MFEM_VERIFY(A.Type() == P.Type(), "type mismatch in A and P");
+   if (A.Type() != Operator::ANY_TYPE)
+   {
+      MFEM_VERIFY(A.Type() == Rt.Type(), "type mismatch in A and Rt");
+      MFEM_VERIFY(A.Type() == P.Type(), "type mismatch in A and P");
+   }
    Clear();
    switch (A.Type())
    {
+      case Operator::ANY_TYPE:
+         pSet(new RAPOperator(*Rt.Ptr(), *A.Ptr(), *P.Ptr()));
+         break;
       case Operator::MFEM_SPARSEMAT:
       {
          pSet(mfem::RAP(*Rt.As<SparseMatrix>(), *A.As<SparseMatrix>(),
@@ -174,7 +199,7 @@ void OperatorHandle::MakeRAP(OperatorHandle &Rt, OperatorHandle &A,
 void OperatorHandle::ConvertFrom(OperatorHandle &A)
 {
    if (own_oper) { delete oper; }
-   if (Type() == A.Type())
+   if (Type() == A.Type() || Type() == Operator::ANY_TYPE)
    {
       oper = A.Ptr();
       own_oper = false;
@@ -183,8 +208,19 @@ void OperatorHandle::ConvertFrom(OperatorHandle &A)
    oper = NULL;
    switch (Type()) // target type id
    {
+      case Operator::MFEM_SPARSEMAT:
+      {
+         oper = A.Is<SparseMatrix>();
+         break;
+      }
+      case Operator::Hypre_ParCSR:
+      {
+         oper = A.Is<HypreParMatrix>();
+         break;
+      }
       case Operator::PETSC_MATAIJ:
       case Operator::PETSC_MATIS:
+      {
          switch (A.Type()) // source type id
          {
             case Operator::Hypre_ParCSR:
@@ -194,7 +230,9 @@ void OperatorHandle::ConvertFrom(OperatorHandle &A)
                break;
             default: break;
          }
+         if (!oper) { oper = A.Is<PetscParMatrix>(); }
          break;
+      }
       default: break;
    }
    MFEM_VERIFY(oper != NULL, "conversion from type id = " << A.Type()
@@ -208,6 +246,15 @@ void OperatorHandle::EliminateRowsCols(OperatorHandle &A,
    Clear();
    switch (A.Type())
    {
+      case Operator::ANY_TYPE:
+      {
+         bool own_A = A.OwnsOperator();
+         A.SetOperatorOwner(false);
+         A.Reset(new ConstrainedOperator(A.Ptr(), ess_dof_list, own_A));
+         // Keep this object empty - this will be OK if this object is only
+         // used as the A_e parameter in a call to A.EliminateBC().
+         break;
+      }
       case Operator::MFEM_SPARSEMAT:
       {
          const Matrix::DiagonalPolicy preserve_diag = Matrix::DIAG_KEEP;
@@ -250,6 +297,13 @@ void OperatorHandle::EliminateBC(const OperatorHandle &A_e,
 {
    switch (Type())
    {
+      case Operator::ANY_TYPE:
+      {
+         ConstrainedOperator *A = Is<ConstrainedOperator>();
+         MFEM_VERIFY(A != NULL, "EliminateRowsCols() is not called");
+         A->EliminateRHS(X, B);
+         break;
+      }
       case Operator::MFEM_SPARSEMAT:
       {
          A_e.As<SparseMatrix>()->AddMult(X, B, -1.);

--- a/linalg/handle.hpp
+++ b/linalg/handle.hpp
@@ -57,7 +57,7 @@ public:
 
    /** @brief Create a OperatorHandle with a specified type id, @a tid, without
        allocating the actual matrix. */
-   OperatorHandle(Operator::Type tid)
+   explicit OperatorHandle(Operator::Type tid)
       : oper(NULL), type_id(CheckType(tid)), own_oper(false) { }
 
    /// Create an OperatorHandle for the given OpType pointer, @a A.
@@ -161,8 +161,9 @@ public:
    void MakeRAP(OperatorHandle &Rt, OperatorHandle &A, OperatorHandle &P);
 
    /// Convert the given OperatorHandle @a A to the currently set type id.
-   /** The operator ownership flag is set to false if the target type id is the
-       same as the input; otherwise it is set to true. */
+   /** The operator ownership flag is set to false if the object held by @a A
+       will be held by this object as well, e.g. when the source and destanation
+       types are the same; otherwise it is set to true. */
    void ConvertFrom(OperatorHandle &A);
 
    /// Convert the given OpType pointer, @a A, to the currently set type id.

--- a/linalg/operator.hpp
+++ b/linalg/operator.hpp
@@ -120,17 +120,26 @@ public:
    virtual ~Operator() { }
 
    /// Enumeration defining IDs for some classes derived from Operator.
+   /** This enumeration is primarily used with class OperatorHandle. */
    enum Type
    {
-      MFEM_SPARSEMAT,
-      Hypre_ParCSR,
-      PETSC_MATAIJ,
-      PETSC_MATIS,
-      PETSC_MATSHELL,
-      PETSC_MATNEST,
-      PETSC_MATHYPRE,
-      PETSC_MATGENERIC
+      ANY_TYPE,         ///< ID for the base class Operator, i.e. any type.
+      MFEM_SPARSEMAT,   ///< ID for class SparseMatrix
+      Hypre_ParCSR,     ///< ID for class HypreParMatrix.
+      PETSC_MATAIJ,     ///< ID for class PetscParMatrix, MATAIJ format.
+      PETSC_MATIS,      ///< ID for class PetscParMatrix, MATIS format.
+      PETSC_MATSHELL,   ///< ID for class PetscParMatrix, MATSHELL format.
+      PETSC_MATNEST,    ///< ID for class PetscParMatrix, MATNEST format.
+      PETSC_MATHYPRE,   ///< ID for class PetscParMatrix, MATHYPRE format.
+      PETSC_MATGENERIC  ///< ID for class PetscParMatrix, unspecified format.
    };
+
+   /// Return the type ID of the Operator class.
+   /** This method is intentionally non-virtual, so that it returns the ID of
+       the specific pointer or reference type used when calling this method. If
+       not overriden by derived classes, they will automatically use the type ID
+       of the base Operator class, ANY_TYPE. */
+   Type GetType() const { return ANY_TYPE; }
 };
 
 


### PR DESCRIPTION
In this PR: (to be merged in branch `refine-operator-dev` and then in master, see PR #400)
- Add new `Operator::Type` - `ANY_TYPE` which represents the base class `Operator` or any derived class. The operations that `OperatorHandle` supports (e.g. `MakeSquareBlockDiag()`, `MakePtAP()`, etc) are implemented so that they are valid for any derived `Operator` class. For example, `MakePtAP()` creates an object of class `RAPOperator`, and elimination of boundary conditions is done using class `ConstrainedOperator`.
- This will allow the "FormSystemMatrix" + "FormLinearSystem" interface to support matrix-free local matrix representations.
- In `(Par)FiniteElementSpace`, store the update operators in an `OperatorHandle` object. Specifying the type of the update operator is now done by setting the type of the `OperatorHandle`. The type `ANY_TYPE` is used to indicate an automatic choice by the FE space - e.g. action-only operator (when supported).
