### PR TITLE
Expose DiagonalPolicy to the user interface

### DIFF
--- a/fem/bilinearform.cpp
+++ b/fem/bilinearform.cpp
@@ -541,8 +541,7 @@ void BilinearForm::ConformingAssemble()
 void BilinearForm::FormLinearSystem(const Array<int> &ess_tdof_list,
                                     Vector &x, Vector &b,
                                     SparseMatrix &A, Vector &X, Vector &B,
-                                    int copy_interior,
-                                    DiagonalPolicy diag_policy)
+                                    int copy_interior)
 {
    const SparseMatrix *P = fes->GetConformingProlongation();
 
@@ -606,8 +605,7 @@ void BilinearForm::FormLinearSystem(const Array<int> &ess_tdof_list,
 }
 
 void BilinearForm::FormSystemMatrix(const Array<int> &ess_tdof_list,
-                                    SparseMatrix &A,
-                                    DiagonalPolicy diag_policy)
+                                    SparseMatrix &A)
 {
    // Finish the matrix assembly and perform BC elimination, storing the
    // eliminated part of the matrix.
@@ -907,6 +905,11 @@ void BilinearForm::Update(FiniteElementSpace *nfes)
    }
 
    height = width = fes->GetVSize();
+}
+
+void BilinearForm::SetDiagonalPolicy(DiagonalPolicy policy)
+{
+  diag_policy = policy;
 }
 
 BilinearForm::~BilinearForm()

--- a/fem/bilinearform.cpp
+++ b/fem/bilinearform.cpp
@@ -73,6 +73,7 @@ BilinearForm::BilinearForm (FiniteElementSpace * f)
    static_cond = NULL;
    hybridization = NULL;
    precompute_sparsity = 0;
+   diag_policy = DIAG_KEEP;
 }
 
 BilinearForm::BilinearForm (FiniteElementSpace * f, BilinearForm * bf, int ps)
@@ -89,6 +90,7 @@ BilinearForm::BilinearForm (FiniteElementSpace * f, BilinearForm * bf, int ps)
    static_cond = NULL;
    hybridization = NULL;
    precompute_sparsity = ps;
+   diag_policy = DIAG_KEEP;
 
    bfi = bf->GetDBFI();
    dbfi.SetSize (bfi->Size());
@@ -545,7 +547,7 @@ void BilinearForm::FormLinearSystem(const Array<int> &ess_tdof_list,
 {
    const SparseMatrix *P = fes->GetConformingProlongation();
 
-   FormSystemMatrix(ess_tdof_list, A, diag_policy);
+   FormSystemMatrix(ess_tdof_list, A);
 
    // Transform the system and perform the elimination in B, based on the
    // essential BC values from x. Restrict the BC part of x in X, and set the

--- a/fem/bilinearform.cpp
+++ b/fem/bilinearform.cpp
@@ -911,7 +911,7 @@ void BilinearForm::Update(FiniteElementSpace *nfes)
 
 void BilinearForm::SetDiagonalPolicy(DiagonalPolicy policy)
 {
-  diag_policy = policy;
+   diag_policy = policy;
 }
 
 BilinearForm::~BilinearForm()

--- a/fem/bilinearform.hpp
+++ b/fem/bilinearform.hpp
@@ -66,6 +66,13 @@ protected:
    StaticCondensation *static_cond;
    Hybridization *hybridization;
 
+   /**
+    * This member allows one to specify what should be done
+    * to the diagonal matrix entries and corresponding RHS
+    * values upon elimination of the constrained DoFs.
+    */
+   DiagonalPolicy diag_policy;
+
    int precompute_sparsity;
    // Allocate appropriate SparseMatrix and assign it to mat
    void AllocMat();
@@ -79,6 +86,7 @@ protected:
       mat = mat_e = NULL; extern_bfs = 0; element_matrices = NULL;
       static_cond = NULL; hybridization = NULL;
       precompute_sparsity = 0;
+      diag_policy = DIAG_KEEP;
    }
 
 public:
@@ -260,10 +268,6 @@ public:
        are set to zero (@a copy_interior == 0) or copied from @a x
        (@a copy_interior != 0).
 
-       The parameter @a diag_policy allows one to specify what should be done
-       to the diagonal matrix entries and corresponding RHS values upon
-       elimination of the constrained DoFs.
-
        This method can be called multiple times (with the same @a ess_tdof_list
        array) to initialize different right-hand sides and boundary condition
        values.
@@ -276,12 +280,10 @@ public:
              @a x. */
    void FormLinearSystem(const Array<int> &ess_tdof_list, Vector &x, Vector &b,
                          SparseMatrix &A, Vector &X, Vector &B,
-                         int copy_interior = 0,
-                         DiagonalPolicy diag_policy = DIAG_KEEP);
+                         int copy_interior = 0);
 
    /// Form the linear system matrix A, see FormLinearSystem() for details.
-   void FormSystemMatrix(const Array<int> &ess_tdof_list, SparseMatrix &A,
-                         DiagonalPolicy diag_policy = DIAG_KEEP);
+   void FormSystemMatrix(const Array<int> &ess_tdof_list, SparseMatrix &A);
 
    /// Recover the solution of a linear system formed with FormLinearSystem().
    /** Call this method after solving a linear system constructed using the
@@ -365,6 +367,9 @@ public:
    FiniteElementSpace *FESpace() { return fes; }
    /// Read-only access to the associated FiniteElementSpace.
    const FiniteElementSpace *FESpace() const { return fes; }
+
+   /// Sets diagonal policy used upon construction of the linear system
+   void SetDiagonalPolicy(DiagonalPolicy policy);
 
    /// Destroys bilinear form.
    virtual ~BilinearForm();

--- a/fem/bilinearform.hpp
+++ b/fem/bilinearform.hpp
@@ -260,6 +260,10 @@ public:
        are set to zero (@a copy_interior == 0) or copied from @a x
        (@a copy_interior != 0).
 
+       The parameter @a diag_policy allows one to specify what should be done
+       to the diagonal matrix entries and corresponding RHS values upon
+       elimination of the constrained DoFs.
+
        This method can be called multiple times (with the same @a ess_tdof_list
        array) to initialize different right-hand sides and boundary condition
        values.
@@ -272,10 +276,12 @@ public:
              @a x. */
    void FormLinearSystem(const Array<int> &ess_tdof_list, Vector &x, Vector &b,
                          SparseMatrix &A, Vector &X, Vector &B,
-                         int copy_interior = 0);
+                         int copy_interior = 0,
+                         DiagonalPolicy diag_policy = DIAG_KEEP);
 
    /// Form the linear system matrix A, see FormLinearSystem() for details.
-   void FormSystemMatrix(const Array<int> &ess_tdof_list, SparseMatrix &A);
+   void FormSystemMatrix(const Array<int> &ess_tdof_list, SparseMatrix &A,
+                         DiagonalPolicy diag_policy = DIAG_KEEP);
 
    /// Recover the solution of a linear system formed with FormLinearSystem().
    /** Call this method after solving a linear system constructed using the


### PR DESCRIPTION
This PR merely enables a user to choose DiagonalPolicy introduced in #340 when assembling the system matrix. The default parameter value of DIAG_KEEP ensures backward compatibility.