### PR TITLE
Support for using zlib from a non-system prefix [zlib-makefile-tweak]

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -336,6 +336,7 @@ MFEM_USE_GZSTREAM = YES/NO
    able to properly read an input file if it is gzip compressed. In that case,
    the solution is to uncompress the file with an external tool (such as gunzip)
    before attempting to use it with MFEM.
+   When enabled, this option uses the ZLIB_* library options, see below.
 
 MFEM_BUILD_TAG = (any value)
    An optional tag to characterize the build. Exported to config/config.mk.
@@ -449,6 +450,11 @@ The specific libraries and their options are:
   the libunwind-devel package.
   URL: http://www.nongnu.org/libunwind
   Options: LIBUNWIND_OPT, LIBUNWIND_LIB.
+
+- ZLIB (optional), used when MFEM_USE_GZSTREAM = YES, or when MFEM_USE_NETCDF =
+  YES (in the default settings for NETCDF_OPT and NETCDF_LIB).
+  URL: https://zlib.net
+  Options: ZLIB_OPT, ZLIB_LIB.
 
 
 Building with CMake

--- a/config/defaults.mk
+++ b/config/defaults.mk
@@ -105,6 +105,10 @@ MFEM_USE_PETSC       = NO
 MFEM_USE_MPFR        = NO
 MFEM_USE_SIDRE       = NO
 
+# Compile and link options for zlib.
+ZLIB_OPT =
+ZLIB_LIB = -lz
+
 LIBUNWIND_OPT = -g
 LIBUNWIND_LIB = $(if $(NOTMAC),-lunwind -ldl,)
 

--- a/config/defaults.mk
+++ b/config/defaults.mk
@@ -106,8 +106,10 @@ MFEM_USE_MPFR        = NO
 MFEM_USE_SIDRE       = NO
 
 # Compile and link options for zlib.
-ZLIB_OPT =
-ZLIB_LIB = -lz
+ZLIB_DIR =
+ZLIB_OPT = $(if $(ZLIB_DIR),-I$(ZLIB_DIR)/include)
+ZLIB_LIB = $(if $(ZLIB_DIR),$(ZLIB_RPATH) -L$(ZLIB_DIR)/lib ,)-lz
+ZLIB_RPATH = -Wl,-rpath,$(ZLIB_DIR)/lib
 
 LIBUNWIND_OPT = -g
 LIBUNWIND_LIB = $(if $(NOTMAC),-lunwind -ldl,)
@@ -217,12 +219,10 @@ GNUTLS_LIB = -lgnutls
 # NetCDF library configuration
 NETCDF_DIR = $(HOME)/local
 HDF5_DIR   = $(HOME)/local
-ZLIB_DIR   = $(HOME)/local
-NETCDF_OPT = -I$(NETCDF_DIR)/include -I$(HDF5_DIR)/include -I$(ZLIB_DIR)/include
+NETCDF_OPT = -I$(NETCDF_DIR)/include -I$(HDF5_DIR)/include $(ZLIB_OPT)
 NETCDF_LIB = -Wl,-rpath,$(NETCDF_DIR)/lib -L$(NETCDF_DIR)/lib\
  -Wl,-rpath,$(HDF5_DIR)/lib -L$(HDF5_DIR)/lib\
- -Wl,-rpath,$(ZLIB_DIR)/lib -L$(ZLIB_DIR)/lib\
- -lnetcdf -lhdf5_hl -lhdf5 -lz
+ -lnetcdf -lhdf5_hl -lhdf5 $(ZLIB_LIB)
 
 # PETSc library configuration (version greater or equal to 3.8 or the dev branch)
 PETSC_ARCH := arch-linux2-c-debug

--- a/makefile
+++ b/makefile
@@ -233,7 +233,8 @@ endif
 
 # gzstream configuration
 ifeq ($(MFEM_USE_GZSTREAM),YES)
-   ALL_LIBS += -lz
+   INCFLAGS += $(ZLIB_OPT)
+   ALL_LIBS += $(ZLIB_LIB)
 endif
 
 # List of all defines that may be enabled in config.hpp and config.mk:


### PR DESCRIPTION
Any compile and link options can be specified by setting the makefile variables `ZLIB_OPT` and `ZLIB_LIB`.