### PR TITLE
Add GridFunction::ProjectDiscCoefficient with averaging for VectorCoefficients [vec-project-avg]

### DIFF
--- a/fem/gridfunc.cpp
+++ b/fem/gridfunc.cpp
@@ -1257,19 +1257,31 @@ void GridFunction::AccumulateAndCountZones(VectorCoefficient &vcoeff,
       // Accumulate values in all dofs, count the zones.
       for (int j = 0; j < vdofs.Size(); j++)
       {
+	int ldof;
+	int isign;
+	if (vdofs[j] < 0 ) {
+	  ldof = -1-vdofs[j];
+	  isign = -1;
+	}
+	else {
+	  ldof = vdofs[j];
+	  isign = 1;
+	}
+
          if (type == HARMONIC)
          {
             MFEM_VERIFY(vals[j] != 0.0,
                         "Coefficient has zeros, harmonic avg is undefined!");
-            (*this)(vdofs[j]) += 1.0 / vals[j];
+	   (*this)(ldof) += isign / vals[j];
          }
          else if (type == ARITHMETIC)
          {
-            (*this)(vdofs[j]) += vals[j];
+	   (*this)(ldof) += isign*vals[j];
+
          }
          else { MFEM_ABORT("Not implemented"); }
 
-         zones_per_vdof[vdofs[j]]++;
+         zones_per_vdof[ldof]++;
       }
    }
 }

--- a/fem/gridfunc.cpp
+++ b/fem/gridfunc.cpp
@@ -1257,26 +1257,28 @@ void GridFunction::AccumulateAndCountZones(VectorCoefficient &vcoeff,
       // Accumulate values in all dofs, count the zones.
       for (int j = 0; j < vdofs.Size(); j++)
       {
-	int ldof;
-	int isign;
-	if (vdofs[j] < 0 ) {
-	  ldof = -1-vdofs[j];
-	  isign = -1;
-	}
-	else {
-	  ldof = vdofs[j];
-	  isign = 1;
-	}
+         int ldof;
+         int isign;
+         if (vdofs[j] < 0 )
+         {
+            ldof = -1-vdofs[j];
+            isign = -1;
+         }
+         else
+         {
+            ldof = vdofs[j];
+            isign = 1;
+         }
 
          if (type == HARMONIC)
          {
             MFEM_VERIFY(vals[j] != 0.0,
                         "Coefficient has zeros, harmonic avg is undefined!");
-	   (*this)(ldof) += isign / vals[j];
+            (*this)(ldof) += isign / vals[j];
          }
          else if (type == ARITHMETIC)
          {
-	   (*this)(ldof) += isign*vals[j];
+            (*this)(ldof) += isign*vals[j];
 
          }
          else { MFEM_ABORT("Not implemented"); }

--- a/fem/gridfunc.hpp
+++ b/fem/gridfunc.hpp
@@ -218,11 +218,20 @@ public:
    /** @brief Projects a discontinuous coefficient so that the values in shared
        vdofs are computed by taking an average of the possible values. */
    virtual void ProjectDiscCoefficient(Coefficient &coeff, AvgType type);
+   /** @brief Projects a discontinuous _vector_ coefficient so that the values
+       in shared vdofs are computed by taking an average of the possible values.
+   */
+   virtual void ProjectDiscCoefficient(VectorCoefficient &coeff, AvgType type);
 
 protected:
    /** @brief Accumulates (depending on @a type) the values of @a coeff at all
        shared vdofs and counts in how many zones each vdof appears. */
    void AccumulateAndCountZones(Coefficient &coeff, AvgType type,
+                                Array<int> &zones_per_vdof);
+
+   /** @brief Accumulates (depending on @a type) the values of @a vcoeff at all
+       shared vdofs and counts in how many zones each vdof appears. */
+   void AccumulateAndCountZones(VectorCoefficient &vcoeff, AvgType type,
                                 Array<int> &zones_per_vdof);
 
    // Complete the computation of averages; called e.g. after

--- a/fem/pgridfunc.hpp
+++ b/fem/pgridfunc.hpp
@@ -195,6 +195,8 @@ public:
 
    virtual void ProjectDiscCoefficient(Coefficient &coeff, AvgType type);
 
+   virtual void ProjectDiscCoefficient(VectorCoefficient &vcoeff, AvgType type);
+
    virtual double ComputeL1Error(Coefficient *exsol[],
                                  const IntegrationRule *irs[] = NULL) const
    {


### PR DESCRIPTION
In classes `GridFunction` and `ParGridFunction`, add a new projection method, `ProjectDiscCoefficient`, that works with `VectorCoefficient`s performing averaging over elements.
