### PR TITLE
Adds ability to define arbitrary attribute fields in SidreDataCollection [tracer-dev]

### DIFF
--- a/fem/datacollection.cpp
+++ b/fem/datacollection.cpp
@@ -431,7 +431,7 @@ void VisItDataCollection::Load(int cycle_)
          MPI_Comm_size(m_comm, &comm_size);
          if (comm_size != num_procs)
          {
-            MFEM_WARNING("Processor number missmatch: VisIt root file: "
+            MFEM_WARNING("Processor number mismatch: VisIt root file: "
                          << num_procs << ", MPI_comm: " << comm_size);
             error = READ_ERROR;
          }

--- a/fem/datacollection.cpp
+++ b/fem/datacollection.cpp
@@ -133,67 +133,6 @@ void DataCollection::SetMesh(Mesh *new_mesh)
 #endif
 }
 
-void DataCollection::RegisterField(const std::string& name, GridFunction *gf)
-{
-   GridFunction *&ref = field_map[name];
-   if (own_data)
-   {
-      delete ref; // if newly allocated -> ref is null -> OK
-   }
-   ref = gf;
-}
-
-void DataCollection::DeregisterField(const std::string& name)
-{
-   FieldMapIterator it = field_map.find(name);
-   if (it != field_map.end())
-   {
-      if (own_data)
-      {
-         delete it->second;
-      }
-      field_map.erase(it);
-   }
-}
-
-void DataCollection::RegisterQField(const std::string& q_field_name,
-                                    QuadratureFunction *qf)
-{
-   QuadratureFunction *&ref = q_field_map[q_field_name];
-   if (own_data)
-   {
-      delete ref; // if newly allocated -> ref is null -> OK
-   }
-   ref = qf;
-}
-
-void DataCollection::DeregisterQField(const std::string& name)
-{
-   QFieldMapIterator it = q_field_map.find(name);
-   if (it != q_field_map.end())
-   {
-      if (own_data)
-      {
-         delete it->second;
-      }
-      q_field_map.erase(it);
-   }
-}
-
-GridFunction *DataCollection::GetField(const std::string& field_name)
-{
-   FieldMapConstIterator it = field_map.find(field_name);
-
-   return (it != field_map.end()) ? it->second : NULL;
-}
-
-QuadratureFunction *DataCollection::GetQField(const std::string& q_field_name)
-{
-   QFieldMapConstIterator it = q_field_map.find(q_field_name);
-
-   return (it != q_field_map.end()) ? it->second : NULL;
-}
-
 void DataCollection::SetFormat(int fmt)
 {
    switch (fmt)
@@ -358,17 +297,8 @@ void DataCollection::DeleteData()
    if (own_data) { delete mesh; }
    mesh = NULL;
 
-   for (FieldMapIterator it = field_map.begin(); it != field_map.end(); ++it)
-   {
-      if (own_data) { delete it->second; }
-      it->second = NULL;
-   }
-   for (QFieldMapIterator it = q_field_map.begin();
-        it != q_field_map.end(); ++it)
-   {
-      if (own_data) { delete it->second; }
-      it->second = NULL;
-   }
+   field_map.DeleteData(own_data);
+   q_field_map.DeleteData(own_data);
    own_data = false;
 }
 
@@ -597,13 +527,14 @@ void VisItDataCollection::LoadFields()
       // TODO: 1) load parallel GridFunction on one processor
       if (serial)
       {
-         field_map[it->first] = new GridFunction(mesh, file);
+         field_map.Register(it->first, new GridFunction(mesh, file), own_data);
       }
       else
       {
 #ifdef MFEM_USE_MPI
-         field_map[it->first] =
-            new ParGridFunction(dynamic_cast<ParMesh*>(mesh), file);
+         field_map.Register(
+            it->first,
+            new ParGridFunction(dynamic_cast<ParMesh*>(mesh), file), own_data);
 #else
          error = READ_ERROR;
          MFEM_WARNING("Reading parallel format in serial is not supported");

--- a/fem/datacollection.hpp
+++ b/fem/datacollection.hpp
@@ -132,13 +132,13 @@ private:
    /// A collection of named QuadratureFunctions
    typedef NamedFieldsMap<QuadratureFunction> QFieldMap;
 public:
-   typedef typename GFieldMap::MapType FieldMapType;
-   typedef typename GFieldMap::iterator FieldMapIterator;
-   typedef typename GFieldMap::const_iterator FieldMapConstIterator;
+   typedef GFieldMap::MapType FieldMapType;
+   typedef GFieldMap::iterator FieldMapIterator;
+   typedef GFieldMap::const_iterator FieldMapConstIterator;
 
-   typedef typename QFieldMap::MapType QFieldMapType;
-   typedef typename QFieldMap::iterator QFieldMapIterator;
-   typedef typename QFieldMap::const_iterator QFieldMapConstIterator;
+   typedef QFieldMap::MapType QFieldMapType;
+   typedef QFieldMap::iterator QFieldMapIterator;
+   typedef QFieldMap::const_iterator QFieldMapConstIterator;
 
    /// Format constants to be used with SetFormat().
    /** Derived classes can define their own format enumerations and override the

--- a/fem/datacollection.hpp
+++ b/fem/datacollection.hpp
@@ -23,14 +23,122 @@
 namespace mfem
 {
 
+/// Lightweight adaptor over an std::map from strings to pointer to T
+template<typename T>
+class NamedFieldsMap
+{
+public:
+   typedef std::map<std::string, T*> MapType;
+   typedef typename MapType::iterator iterator;
+   typedef typename MapType::const_iterator const_iterator;
+
+   /// Register field @a field with name @a fname
+   /** Replace existing field associated with @a fname (and optionally
+       delete associated pointer if @a own_data is true) */
+   void Register(const std::string& fname, T* field, bool own_data)
+   {
+      T*& ref = field_map[fname];
+      if (own_data)
+      {
+         delete ref; // if newly allocated -> ref is null -> OK
+      }
+      ref = field;
+   }
+
+   /// Unregister association between field @a field and name @a fname
+   /** Optionally delete associated pointer if @a own_data is true */
+   void Deregister(const std::string& fname, bool own_data)
+   {
+      iterator it = field_map.find(fname);
+      if ( it != field_map.end() )
+      {
+         if (own_data)
+         {
+            delete it->second;
+         }
+         field_map.erase(it);
+      }
+   }
+
+   /// Clear all associations between names and fields
+   /** Delete associated pointers when @a own_data is true */
+   void DeleteData(bool own_data)
+   {
+      for (iterator it = field_map.begin(); it != field_map.end(); ++it)
+      {
+         if (own_data)
+         {
+            delete it->second;
+         }
+         it->second = NULL;
+      }
+   }
+
+   /// Predicate to check if a field is associated with name @a fname
+   bool Has(const std::string& fname) const
+   {
+      return field_map.find(fname) != field_map.end();
+   }
+
+   /// Get a pointer to the field associated with name @a fname
+   /** @return Pointer to field associated with @a fname or NULL */
+   T* Get(const std::string& fname) const
+   {
+      const_iterator it = field_map.find(fname);
+      return it != field_map.end() ? it->second : NULL;
+   }
+
+   /// Returns a const reference to the underlying map
+   const MapType& GetMap() const { return field_map; }
+
+   /// Returns the number of registered fields
+   int NumFields() const { return field_map.size(); }
+
+   /// Returns a begin iterator to the registered fields
+   iterator begin() { return field_map.begin(); }
+   /// Returns a begin const iterator to the registered fields
+   const_iterator begin() const { return field_map.begin(); }
+
+   /// Returns an end iterator to the registered fields
+   iterator end() { return field_map.end(); }
+   /// Returns an end const iterator to the registered fields
+   const_iterator end() const { return field_map.end(); }
+
+   /// Returns an iterator to the field @a fname
+   iterator find(const std::string& fname)
+   { return field_map.find(fname); }
+
+   /// Returns a const iterator to the field @a fname
+   const_iterator find(const std::string& fname) const
+   { return field_map.find(fname); }
+
+   /// Clears the map of registered fields without reclaiming memory
+   void clear() { field_map.clear(); }
+
+protected:
+   MapType field_map;
+};
+
+
 /** A class for collecting finite element data that is part of the same
     simulation. Currently, this class groups together grid functions (fields),
     quadrature functions (q-fields), and the mesh that they are defined on. */
 class DataCollection
 {
+private:
+   /// A collection of named GridFunctions
+   typedef NamedFieldsMap<GridFunction> GFieldMap;
+
+   /// A collection of named QuadratureFunctions
+   typedef NamedFieldsMap<QuadratureFunction> QFieldMap;
 public:
-   typedef std::map<std::string, GridFunction*> FieldMapType;
-   typedef std::map<std::string, QuadratureFunction*> QFieldMapType;
+   typedef typename GFieldMap::MapType FieldMapType;
+   typedef typename GFieldMap::iterator FieldMapIterator;
+   typedef typename GFieldMap::const_iterator FieldMapConstIterator;
+
+   typedef typename QFieldMap::MapType QFieldMapType;
+   typedef typename QFieldMap::iterator QFieldMapIterator;
+   typedef typename QFieldMap::const_iterator QFieldMapConstIterator;
 
    /// Format constants to be used with SetFormat().
    /** Derived classes can define their own format enumerations and override the
@@ -53,16 +161,11 @@ protected:
        If not empty, it has '/' at the end. */
    std::string prefix_path;
 
-   /// The fields and their names (used when saving)
-   typedef FieldMapType::iterator FieldMapIterator;
-   typedef FieldMapType::const_iterator FieldMapConstIterator;
-   /** An std::map containing the registered fields' names as keys (std::string)
-       and their GridFunction pointers as values. */
-   FieldMapType field_map;
+   /** A FieldMap mapping registered field names to GridFunction pointers. */
+   GFieldMap field_map;
 
-   typedef QFieldMapType::iterator QFieldMapIterator;
-   typedef QFieldMapType::const_iterator QFieldMapConstIterator;
-   QFieldMapType q_field_map;
+   /** A FieldMap mapping registered names to QuadratureFunction pointers. */
+   QFieldMap q_field_map;
 
    /// The (common) mesh for the collected fields
    Mesh *mesh;
@@ -135,25 +238,31 @@ public:
                            Mesh *mesh_ = NULL);
 
    /// Add a grid function to the collection
-   virtual void RegisterField(const std::string& field_name, GridFunction *gf);
+   virtual void RegisterField(const std::string& field_name, GridFunction *gf)
+   { field_map.Register(field_name, gf, own_data); }
 
    /// Remove a grid function from the collection
-   virtual void DeregisterField(const std::string& field_name);
+   virtual void DeregisterField(const std::string& field_name)
+   { field_map.Deregister(field_name, own_data); }
 
    /// Add a QuadratureFunction to the collection.
    virtual void RegisterQField(const std::string& q_field_name,
-                               QuadratureFunction *qf);
+                               QuadratureFunction *qf)
+   { q_field_map.Register(q_field_name, qf, own_data); }
+
 
    /// Remove a QuadratureFunction from the collection
-   virtual void DeregisterQField(const std::string& field_name);
+   virtual void DeregisterQField(const std::string& field_name)
+   { q_field_map.Deregister(field_name, own_data); }
 
    /// Check if a grid function is part of the collection
    bool HasField(const std::string& name) const
-   { return field_map.find(name) != field_map.end(); }
+   { return field_map.Has(name); }
 
    /// Get a pointer to a grid function in the collection.
    /** Returns NULL if @a field_name is not in the collection. */
-   GridFunction *GetField(const std::string& field_name);
+   GridFunction *GetField(const std::string& field_name)
+   { return field_map.Get(field_name); }
 
 #ifdef MFEM_USE_MPI
    /// Return the associated MPI communicator or MPI_COMM_NULL.
@@ -169,21 +278,24 @@ public:
 
    /// Check if a QuadratureFunction with the given name is in the collection.
    bool HasQField(const std::string& q_field_name) const
-   { return q_field_map.find(q_field_name) != q_field_map.end(); }
+   { return q_field_map.Has(q_field_name); }
 
    /// Get a pointer to a QuadratureFunction in the collection.
    /** Returns NULL if @a field_name is not in the collection. */
-   QuadratureFunction *GetQField(const std::string& q_field_name);
+   QuadratureFunction *GetQField(const std::string& q_field_name)
+   { return q_field_map.Get(q_field_name); }
 
    /// Get a const reference to the internal field map.
    /** The keys in the map are the field names and the values are pointers to
        GridFunction%s. */
-   const FieldMapType &GetFieldMap() const { return field_map; }
+   const FieldMapType &GetFieldMap() const
+   { return field_map.GetMap(); }
 
    /// Get a const reference to the internal q-field map.
    /** The keys in the map are the q-field names and the values are pointers to
        QuadratureFunction%s. */
-   const QFieldMapType &GetQFieldMap() const { return q_field_map; }
+   const QFieldMapType &GetQFieldMap() const
+   { return q_field_map.GetMap(); }
 
    /// Get a pointer to the mesh in the collection
    Mesh *GetMesh() { return mesh; }

--- a/fem/sidredatacollection.cpp
+++ b/fem/sidredatacollection.cpp
@@ -408,7 +408,7 @@ createMeshBlueprintTopologies(bool hasBP, const std::string& mesh_name)
                            mesh->GetBdrElement(0)->GetType() ) );
 
    const std::string mesh_topo_str = "topologies/" + mesh_name;
-   const std::string mesh_attr_str = "fields/"+mesh_name+"_material_attribute";
+   const std::string mesh_attr_str = mesh_name + "_material_attribute";
 
    if ( !hasBP )
    {
@@ -429,11 +429,8 @@ createMeshBlueprintTopologies(bool hasBP, const std::string& mesh_name)
          topology_grp->createViewString("grid_function",m_meshNodesGFName);
       }
 
-      // Add material attribute field to blueprint
-      sidre::Group* attr_grp = bp_grp->createGroup(mesh_attr_str);
-      attr_grp->createViewString("association", "element");
-      attr_grp->createViewAndAllocate("values", sidre::INT_ID, num_elements);
-      attr_grp->createViewString("topology", mesh_name);
+      // Add the mesh's attributes as an attribute field
+      RegisterAttributeField(mesh_attr_str, isBdry);
    }
 
    // If rank 0, set up blueprint index for topologies group and material
@@ -467,40 +464,25 @@ createMeshBlueprintTopologies(bool hasBP, const std::string& mesh_name)
       {
          bp_index_topo_grp->copyView(topology_grp->getView("grid_function"));
       }
-
-      // Create blueprint index for material attributes.
-      sidre::Group *bp_index_attr_grp =
-         bp_index_grp->createGroup(mesh_attr_str);
-      sidre::Group *attr_grp = bp_grp->getGroup(mesh_attr_str);
-
-      bp_index_attr_grp->createViewString(
-         "path", bp_grp_path + "/" + mesh_attr_str );
-      bp_index_attr_grp->copyView( attr_grp->getView("association") );
-      bp_index_attr_grp->copyView( attr_grp->getView("topology") );
-
-      int number_of_components = 1;
-      bp_index_attr_grp->createViewScalar("number_of_components",
-                                          number_of_components);
    }
 
    // Finally, change ownership or copy the element arrays into Sidre
    sidre::View* conn_view =
       bp_grp->getGroup(mesh_topo_str)->getView("elements/connectivity");
-   sidre::View* attr_view =
-      bp_grp->getGroup(mesh_attr_str)->getView("values");
+
    // The SidreDataCollection always owns these arrays:
    Array<int> conn_array(conn_view->getData<int*>(), num_indices);
-   Array<int> attr_array(attr_view->getData<int*>(), num_elements);
+   Array<int>* attr_array = attr_map.Get(mesh_attr_str);
    if (!isBdry)
    {
-      mesh->GetElementData(geom, conn_array, attr_array);
+      mesh->GetElementData(geom, conn_array, *attr_array);
    }
    else
    {
-      mesh->GetBdrElementData(geom, conn_array, attr_array);
+      mesh->GetBdrElementData(geom, conn_array, *attr_array);
    }
    MFEM_ASSERT(!conn_array.OwnsData(), "");
-   MFEM_ASSERT(!attr_array.OwnsData(), "");
+   MFEM_ASSERT(!attr_array->OwnsData(), "");
 }
 
 // private method
@@ -1073,6 +1055,128 @@ void SidreDataCollection::RegisterField(const std::string &field_name,
 
    // Register field_name + gf in field_map.
    DataCollection::RegisterField(field_name, gf);
+}
+
+void SidreDataCollection::RegisterAttributeField(const std::string& attr_name,
+                                                 bool is_bdry)
+{
+   MFEM_ASSERT(
+      mesh != NULL,
+      "Need to set mesh before registering attributes in SidreDataCollection.");
+
+   // Register attr_name in the blueprint group.
+   sidre::Group* f = bp_grp->getGroup("fields");
+   if (f->hasGroup( attr_name ))
+   {
+      bool isAttr = attr_map.Has(attr_name);
+      bool isFld = field_map.Has(attr_name);
+
+      if (isAttr)
+      {
+         MFEM_WARNING("field with the name '" << attr_name<< "' is already "
+                      " registered as an attribute, overwriting old values.");
+         DeregisterAttributeField(attr_name);
+      }
+      else if (isFld)
+      {
+         MFEM_WARNING("field with the name '" << attr_name<< "' is already "
+                      " registered as a field, skipping register attribute.");
+         return;
+      }
+   }
+
+   // Generate sidre views and groups for this mesh attribute and allocate space
+   addIntegerAttributeField(attr_name, is_bdry);
+
+   if (myid == 0)
+   {
+      RegisterAttributeFieldInBPIndex(attr_name);
+   }
+
+   // Register new attribute array with attr_map
+   sidre::View* a =
+      bp_grp->getGroup("fields")->getGroup(attr_name)->getView("values");
+   Array<int>* attr = new Array<int>(a->getData<int*>(), a->getNumElements());
+
+   attr_map.Register(attr_name, attr, own_data);
+}
+
+void SidreDataCollection::RegisterAttributeFieldInBPIndex(
+   const std::string& attr_name)
+{
+   const std::string bp_grp_path = bp_grp->getPathName();
+
+   MFEM_ASSERT(bp_grp->getGroup("fields") != NULL,
+               "Mesh blueprint does not have 'fields' group");
+   MFEM_ASSERT(bp_index_grp->getGroup("fields") != NULL,
+               "Mesh blueprint index does not have 'fields' group");
+
+   // get the BP attr group
+   sidre::Group* attr_grp =
+      bp_grp->getGroup("fields")->getGroup(attr_name);
+
+   // create blueprint index for this attribute
+   sidre::Group *bp_index_attr_grp =
+      bp_index_grp->getGroup("fields")->createGroup(attr_name);
+
+   bp_index_attr_grp->createViewString("path", attr_grp->getPathName() );
+   bp_index_attr_grp->copyView( attr_grp->getView("association") );
+   bp_index_attr_grp->copyView( attr_grp->getView("topology") );
+   bp_index_attr_grp->createViewScalar("number_of_components", 1);
+}
+
+void SidreDataCollection::DeregisterAttributeField(const std::string& attr_name)
+{
+   attr_map.Deregister(name, own_data);
+
+   sidre::Group * attr_grp = bp_grp->getGroup("fields");
+   MFEM_VERIFY(attr_grp->hasGroup(attr_name),
+               "No field exists in blueprint with name " << attr_name);
+
+   // Delete attr_name from the blueprint group.
+
+   // Note: This will destroy all orphaned views or buffer classes under this
+   // group also.  If sidre owns this field data, the memory will be deleted
+   // unless it's referenced somewhere else in sidre.
+   attr_grp->destroyGroup(attr_name);
+
+   // Delete field_name from the blueprint_index group.
+   if (myid == 0)
+   {
+      DeregisterAttributeFieldInBPIndex(attr_name);
+   }
+
+   // Delete field_name from the named_buffers group, if allocated.
+   FreeNamedBuffer(attr_name);
+}
+
+void SidreDataCollection::DeregisterAttributeFieldInBPIndex(
+   const std::string& attr_name)
+{
+   sidre::Group * fields_grp = bp_index_grp->getGroup("fields");
+   MFEM_VERIFY(fields_grp->hasGroup(attr_name),
+               "No attribute exists in blueprint index with name " << attr_name);
+
+   // Note: This will destroy all orphaned views or buffer classes under this
+   // group also.  If sidre owns this field data, the memory will be deleted
+   // unless it's referenced somewhere else in sidre.
+   fields_grp->destroyGroup(attr_name);
+}
+
+
+void SidreDataCollection::
+addIntegerAttributeField(const std::string& attr_name, bool is_bdry)
+{
+   sidre::Group* fld_grp = bp_grp->getGroup("fields");
+   MFEM_ASSERT(fld_grp != NULL, "'fields' group does not exist");
+
+   const int num_elem = is_bdry? mesh->GetNBE() : mesh->GetNE();
+   std::string topo_name = is_bdry ? "boundary" : "mesh";
+
+   sidre::Group* attr_grp = fld_grp->createGroup(attr_name);
+   attr_grp->createViewString("association", "element");
+   attr_grp->createViewAndAllocate("values", sidre::INT_ID, num_elem);
+   attr_grp->createViewString("topology", topo_name);
 }
 
 void SidreDataCollection::DeregisterField(const std::string& field_name)

--- a/fem/sidredatacollection.cpp
+++ b/fem/sidredatacollection.cpp
@@ -1073,13 +1073,13 @@ void SidreDataCollection::RegisterAttributeField(const std::string& attr_name,
 
       if (isAttr)
       {
-         MFEM_WARNING("field with the name '" << attr_name<< "' is already "
+         MFEM_WARNING("field with the name '" << attr_name << "' is already "
                       " registered as an attribute, overwriting old values.");
          DeregisterAttributeField(attr_name);
       }
       else if (isFld)
       {
-         MFEM_WARNING("field with the name '" << attr_name<< "' is already "
+         MFEM_WARNING("field with the name '" << attr_name << "' is already "
                       " registered as a field, skipping register attribute.");
          return;
       }
@@ -1162,7 +1162,6 @@ void SidreDataCollection::DeregisterAttributeFieldInBPIndex(
    // unless it's referenced somewhere else in sidre.
    fields_grp->destroyGroup(attr_name);
 }
-
 
 void SidreDataCollection::
 addIntegerAttributeField(const std::string& attr_name, bool is_bdry)

--- a/fem/sidredatacollection.hpp
+++ b/fem/sidredatacollection.hpp
@@ -159,6 +159,10 @@ namespace mfem
 class SidreDataCollection : public DataCollection
 {
 public:
+   typedef NamedFieldsMap< Array<int> > AttributeFieldMap;
+   AttributeFieldMap attr_map;
+
+public:
 
    /// Constructor that allocates and initializes a Sidre DataStore.
    /**
@@ -232,6 +236,24 @@ public:
    void RegisterField(const std::string &field_name, GridFunction *gf,
                       const std::string &buffer_name,
                       axom::sidre::SidreLength offset);
+
+   /// Registers an attribute field in the Sidre DataStore
+   /** The registration process is similar to that of RegisterField()
+       The attribute field is associated with the elements of the mesh
+       when @a is_bdry is false, and with the boundary elements, when
+       @a is_bdry is true.
+       @sa RegisterField()  */
+   void RegisterAttributeField(const std::string& name, bool is_bdry);
+   void DeregisterAttributeField(const std::string& name);
+
+   /** Returns a pointer to the attribute field associated with
+       @a field_name, or NULL when there is no associated field */
+   Array<int>* GetAttributeField(const std::string& field_name) const
+   { return attr_map.Get(field_name); }
+
+   /** Checks if there is an attribute field associated with @a field_name */
+   bool HasAttributeField(const std::string& field_name) const
+   { return attr_map.Has(field_name); }
 
    /// Set the name of the mesh nodes field.
    /** This name will be used by SetMesh() to register the mesh nodes, if not
@@ -407,6 +429,9 @@ private:
                                GridFunction *gf);
    void DeregisterFieldInBPIndex(const std::string & field_name);
 
+   void RegisterAttributeFieldInBPIndex(const std::string& attr_name);
+   void DeregisterAttributeFieldInBPIndex(const std::string& attr_name);
+
    /** @brief Return a string with the conduit blueprint name for the given
        Element::Type. */
    std::string getElementName( Element::Type elementEnum );
@@ -438,6 +463,10 @@ private:
                                    GridFunction* gf,
                                    const std::string &buffer_name,
                                    axom::sidre::SidreLength offset);
+
+   /** @brief A private helper function to set up the Views associated with
+       attribute field named @a field_name */
+   void addIntegerAttributeField(const std::string& field_name, bool is_bdry);
 
    /// Sets up the four main mesh blueprint groups.
    /**

--- a/mesh/mesh.cpp
+++ b/mesh/mesh.cpp
@@ -7269,9 +7269,14 @@ void Mesh::PrintVTK(std::ostream &out)
       }
       out << "CELLS " << NumOfElements << ' ' << size << '\n';
       const char *fec_name = Nodes->FESpace()->FEColl()->Name();
-      if (!strcmp(fec_name, "Linear") ||
-          !strcmp(fec_name, "H1_2D_P1") ||
-          !strcmp(fec_name, "H1_3D_P1"))
+
+      if (!strcmp(fec_name, "H1_0D_P1"))
+      {
+         order = 0;
+      }
+      else if (!strcmp(fec_name, "Linear") ||
+               !strcmp(fec_name, "H1_2D_P1") ||
+               !strcmp(fec_name, "H1_3D_P1"))
       {
          order = 1;
       }
@@ -7291,6 +7296,12 @@ void Mesh::PrintVTK(std::ostream &out)
       {
          Nodes->FESpace()->GetElementDofs(i, dofs);
          out << dofs.Size();
+         if (order == 0)
+         {
+            MFEM_ASSERT(dofs.Size() == 1,
+                        "Point meshes should have a single dof per element");
+            out << " " << dofs[0];
+         }
          if (order == 1)
          {
             for (int j = 0; j < dofs.Size(); j++)
@@ -7325,6 +7336,13 @@ void Mesh::PrintVTK(std::ostream &out)
    for (int i = 0; i < NumOfElements; i++)
    {
       int vtk_cell_type = 5;
+      if (order == 0)
+      {
+         switch (elements[i]->GetGeometryType())
+         {
+            case Geometry::POINT:        vtk_cell_type = 1;   break;
+         }
+      }
       if (order == 1)
       {
          switch (elements[i]->GetGeometryType())

--- a/mesh/mesh.cpp
+++ b/mesh/mesh.cpp
@@ -7265,22 +7265,23 @@ void Mesh::PrintVTK(std::ostream &out)
       for (int i = 0; i < NumOfElements; i++)
       {
          Nodes->FESpace()->GetElementDofs(i, dofs);
+         MFEM_ASSERT(Dim != 0 || dofs.Size() == 1,
+                     "Point meshes should have a single dof per element");
          size += dofs.Size() + 1;
       }
       out << "CELLS " << NumOfElements << ' ' << size << '\n';
       const char *fec_name = Nodes->FESpace()->FEColl()->Name();
 
-      if (!strcmp(fec_name, "H1_0D_P1"))
-      {
-         order = 0;
-      }
-      else if (!strcmp(fec_name, "Linear") ||
-               !strcmp(fec_name, "H1_2D_P1") ||
-               !strcmp(fec_name, "H1_3D_P1"))
+      if (!strcmp(fec_name, "Linear") ||
+          !strcmp(fec_name, "H1_0D_P1") ||
+          !strcmp(fec_name, "H1_1D_P1") ||
+          !strcmp(fec_name, "H1_2D_P1") ||
+          !strcmp(fec_name, "H1_3D_P1"))
       {
          order = 1;
       }
       else if (!strcmp(fec_name, "Quadratic") ||
+               !strcmp(fec_name, "H1_1D_P2") ||
                !strcmp(fec_name, "H1_2D_P2") ||
                !strcmp(fec_name, "H1_3D_P2"))
       {
@@ -7296,12 +7297,6 @@ void Mesh::PrintVTK(std::ostream &out)
       {
          Nodes->FESpace()->GetElementDofs(i, dofs);
          out << dofs.Size();
-         if (order == 0)
-         {
-            MFEM_ASSERT(dofs.Size() == 1,
-                        "Point meshes should have a single dof per element");
-            out << " " << dofs[0];
-         }
          if (order == 1)
          {
             for (int j = 0; j < dofs.Size(); j++)
@@ -7314,6 +7309,7 @@ void Mesh::PrintVTK(std::ostream &out)
             const int *vtk_mfem;
             switch (elements[i]->GetGeometryType())
             {
+               case Geometry::SEGMENT:
                case Geometry::TRIANGLE:
                case Geometry::SQUARE:
                   vtk_mfem = vtk_quadratic_hex; break; // identity map
@@ -7336,13 +7332,6 @@ void Mesh::PrintVTK(std::ostream &out)
    for (int i = 0; i < NumOfElements; i++)
    {
       int vtk_cell_type = 5;
-      if (order == 0)
-      {
-         switch (elements[i]->GetGeometryType())
-         {
-            case Geometry::POINT:        vtk_cell_type = 1;   break;
-         }
-      }
       if (order == 1)
       {
          switch (elements[i]->GetGeometryType())


### PR DESCRIPTION
* Refactors the ``FieldMap`` in ``DataCollection`` into its own self-contained class
  as a map from ``std::string`` to ``T*``, where ``T`` is the template parameter.
* Implements the field map for ``GridFunction``s and ``QuadratureFunction``s in terms of this class
* Adds functions to ``SidreDataCollection`` to register named attribute fields (``Array<int>`` fields associated with the mesh or boundary mesh's elements)
* Attribute fields are registered with the mesh blueprint
* Minor fixes for dumping vtk point meshes.