### PR TITLE
MPI_Waitany check [waitany-check]

### DIFF
--- a/general/communication.cpp
+++ b/general/communication.cpp
@@ -238,6 +238,8 @@ void GroupTopology::Create(ListOfIntegerSets &groups, int mpitag)
                    mpitag, MyComm, &recv_requests[nbr-1]);
       }
    }
+
+   if (recv_requests.Size() > 0)
    {
       int idx;
       IntegerSet group;


### PR DESCRIPTION
Some older mpi versions segfault when MPI_Waitany is called with empty data.