### PR TITLE
A small fix in the ConduitDataCollection [conduit-dc-fix]

### DIFF
--- a/fem/conduitdatacollection.cpp
+++ b/fem/conduitdatacollection.cpp
@@ -1089,7 +1089,7 @@ ConduitDataCollection::LoadMeshAndFields(int domain_id,
          )
       {
          GridFunction *gf = BlueprintFieldToGridFunction(mesh, n_field);
-         field_map[field_name] = gf;
+         field_map.Register(field_name, gf, true);
       }
    }
 }


### PR DESCRIPTION
Fix the conduit data collection: the member `field_map` is not an `std::map` anymore, so it does not support the array subscript operator.