### PR TITLE
[fem] GetLocalInterpolation(coarse to fine) to GetTransferMatrix [gTmtx]

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -32,7 +32,7 @@ Discretization improvements
   mesh. The new methods, GetTransferOperator and GetTrueTransferOperator in the
   FiniteElementSpace classes, work in both serial and parallel and support
   matrix-based as well as matrix-free transfer operator representations. They
-  use a version of GetLocalInterpolation in the FiniteElement class that allows
+  use a version of GetTransferMatrix in the FiniteElement class that allows
   the coarse FiniteElement to be different from the fine FiniteElement.
 
 - Added class ComplexOperator, that implements the action of a complex operator

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -32,8 +32,9 @@ Discretization improvements
   mesh. The new methods, GetTransferOperator and GetTrueTransferOperator in the
   FiniteElementSpace classes, work in both serial and parallel and support
   matrix-based as well as matrix-free transfer operator representations. They
-  use a version of GetTransferMatrix in the FiniteElement class that allows
-  the coarse FiniteElement to be different from the fine FiniteElement.
+  use a new method, GetTransferMatrix, in the FiniteElement class similar to
+  GetLocalInterpolation, that allows the coarse FiniteElement to be different
+  from the fine FiniteElement.
 
 - Added class ComplexOperator, that implements the action of a complex operator
   through the equivalent 2x2 real formulation. Both symmetric and antisymmetric

--- a/fem/fe.cpp
+++ b/fem/fe.cpp
@@ -114,9 +114,9 @@ void FiniteElement::GetLocalInterpolation (ElementTransformation &Trans,
    mfem_error ("GetLocalInterpolation (...) is not overloaded !");
 }
 
-void FiniteElement::GetLocalInterpolation(const FiniteElement &fe,
-                                          ElementTransformation &Trans,
-                                          DenseMatrix &I) const
+void FiniteElement::GetTransferMatrix(const FiniteElement &fe,
+                                      ElementTransformation &Trans,
+                                      DenseMatrix &I) const
 {
    MFEM_ABORT("method is not overloaded !");
 }

--- a/fem/fe.hpp
+++ b/fem/fe.hpp
@@ -344,9 +344,9 @@ public:
        FiniteElement as when h-refinement is combined with p-refinement or
        p-derefinement. It is assumed that both finite elements use the same
        MapType. */
-   virtual void GetLocalInterpolation(const FiniteElement &fe,
-                                      ElementTransformation &Trans,
-                                      DenseMatrix &I) const;
+   virtual void GetTransferMatrix(const FiniteElement &fe,
+                                  ElementTransformation &Trans,
+                                  DenseMatrix &I) const;
 
    /** Given a coefficient and a transformation, compute its projection
        (approximation) in the local finite dimensional space in terms
@@ -491,9 +491,9 @@ public:
                                       DenseMatrix &I) const
    { NodalLocalInterpolation(Trans, I, *this); }
 
-   virtual void GetLocalInterpolation(const FiniteElement &fe,
-                                      ElementTransformation &Trans,
-                                      DenseMatrix &I) const
+   virtual void GetTransferMatrix(const FiniteElement &fe,
+                                  ElementTransformation &Trans,
+                                  DenseMatrix &I) const
    { CheckScalarFE(fe).NodalLocalInterpolation(Trans, I, *this); }
 
    virtual void Project (Coefficient &coeff,
@@ -531,9 +531,9 @@ public:
                                       DenseMatrix &I) const
    { ScalarLocalInterpolation(Trans, I, *this); }
 
-   virtual void GetLocalInterpolation(const FiniteElement &fe,
-                                      ElementTransformation &Trans,
-                                      DenseMatrix &I) const
+   virtual void GetTransferMatrix(const FiniteElement &fe,
+                                  ElementTransformation &Trans,
+                                  DenseMatrix &I) const
    { CheckScalarFE(fe).ScalarLocalInterpolation(Trans, I, *this); }
 
    using FiniteElement::Project;
@@ -2106,9 +2106,9 @@ public:
    virtual void GetLocalInterpolation(ElementTransformation &Trans,
                                       DenseMatrix &I) const
    { LocalInterpolation_RT(*this, nk, dof2nk, Trans, I); }
-   virtual void GetLocalInterpolation(const FiniteElement &fe,
-                                      ElementTransformation &Trans,
-                                      DenseMatrix &I) const
+   virtual void GetTransferMatrix(const FiniteElement &fe,
+                                  ElementTransformation &Trans,
+                                  DenseMatrix &I) const
    { LocalInterpolation_RT(CheckVectorFE(fe), nk, dof2nk, Trans, I); }
    using FiniteElement::Project;
    virtual void Project(VectorCoefficient &vc,
@@ -2159,9 +2159,9 @@ public:
    virtual void GetLocalInterpolation(ElementTransformation &Trans,
                                       DenseMatrix &I) const
    { LocalInterpolation_RT(*this, nk, dof2nk, Trans, I); }
-   virtual void GetLocalInterpolation(const FiniteElement &fe,
-                                      ElementTransformation &Trans,
-                                      DenseMatrix &I) const
+   virtual void GetTransferMatrix(const FiniteElement &fe,
+                                  ElementTransformation &Trans,
+                                  DenseMatrix &I) const
    { LocalInterpolation_RT(CheckVectorFE(fe), nk, dof2nk, Trans, I); }
    using FiniteElement::Project;
    virtual void Project(VectorCoefficient &vc,
@@ -2205,9 +2205,9 @@ public:
    virtual void GetLocalInterpolation(ElementTransformation &Trans,
                                       DenseMatrix &I) const
    { LocalInterpolation_RT(*this, nk, dof2nk, Trans, I); }
-   virtual void GetLocalInterpolation(const FiniteElement &fe,
-                                      ElementTransformation &Trans,
-                                      DenseMatrix &I) const
+   virtual void GetTransferMatrix(const FiniteElement &fe,
+                                  ElementTransformation &Trans,
+                                  DenseMatrix &I) const
    { LocalInterpolation_RT(CheckVectorFE(fe), nk, dof2nk, Trans, I); }
    using FiniteElement::Project;
    virtual void Project(VectorCoefficient &vc,
@@ -2257,9 +2257,9 @@ public:
    virtual void GetLocalInterpolation(ElementTransformation &Trans,
                                       DenseMatrix &I) const
    { LocalInterpolation_RT(*this, nk, dof2nk, Trans, I); }
-   virtual void GetLocalInterpolation(const FiniteElement &fe,
-                                      ElementTransformation &Trans,
-                                      DenseMatrix &I) const
+   virtual void GetTransferMatrix(const FiniteElement &fe,
+                                  ElementTransformation &Trans,
+                                  DenseMatrix &I) const
    { LocalInterpolation_RT(CheckVectorFE(fe), nk, dof2nk, Trans, I); }
    using FiniteElement::Project;
    virtual void Project(VectorCoefficient &vc,
@@ -2308,9 +2308,9 @@ public:
                                       DenseMatrix &I) const
    { LocalInterpolation_ND(*this, tk, dof2tk, Trans, I); }
 
-   virtual void GetLocalInterpolation(const FiniteElement &fe,
-                                      ElementTransformation &Trans,
-                                      DenseMatrix &I) const
+   virtual void GetTransferMatrix(const FiniteElement &fe,
+                                  ElementTransformation &Trans,
+                                  DenseMatrix &I) const
    { LocalInterpolation_ND(CheckVectorFE(fe), tk, dof2tk, Trans, I); }
 
    using FiniteElement::Project;
@@ -2365,9 +2365,9 @@ public:
    virtual void GetLocalInterpolation(ElementTransformation &Trans,
                                       DenseMatrix &I) const
    { LocalInterpolation_ND(*this, tk, dof2tk, Trans, I); }
-   virtual void GetLocalInterpolation(const FiniteElement &fe,
-                                      ElementTransformation &Trans,
-                                      DenseMatrix &I) const
+   virtual void GetTransferMatrix(const FiniteElement &fe,
+                                  ElementTransformation &Trans,
+                                  DenseMatrix &I) const
    { LocalInterpolation_ND(CheckVectorFE(fe), tk, dof2tk, Trans, I); }
    using FiniteElement::Project;
    virtual void Project(VectorCoefficient &vc,
@@ -2411,9 +2411,9 @@ public:
    virtual void GetLocalInterpolation(ElementTransformation &Trans,
                                       DenseMatrix &I) const
    { LocalInterpolation_ND(*this, tk, dof2tk, Trans, I); }
-   virtual void GetLocalInterpolation(const FiniteElement &fe,
-                                      ElementTransformation &Trans,
-                                      DenseMatrix &I) const
+   virtual void GetTransferMatrix(const FiniteElement &fe,
+                                  ElementTransformation &Trans,
+                                  DenseMatrix &I) const
    { LocalInterpolation_ND(CheckVectorFE(fe), tk, dof2tk, Trans, I); }
    using FiniteElement::Project;
    virtual void Project(VectorCoefficient &vc,
@@ -2462,9 +2462,9 @@ public:
    virtual void GetLocalInterpolation(ElementTransformation &Trans,
                                       DenseMatrix &I) const
    { LocalInterpolation_ND(*this, tk, dof2tk, Trans, I); }
-   virtual void GetLocalInterpolation(const FiniteElement &fe,
-                                      ElementTransformation &Trans,
-                                      DenseMatrix &I) const
+   virtual void GetTransferMatrix(const FiniteElement &fe,
+                                  ElementTransformation &Trans,
+                                  DenseMatrix &I) const
    { LocalInterpolation_ND(CheckVectorFE(fe), tk, dof2tk, Trans, I); }
    using FiniteElement::Project;
    virtual void Project(VectorCoefficient &vc,
@@ -2505,9 +2505,9 @@ public:
    virtual void GetLocalInterpolation(ElementTransformation &Trans,
                                       DenseMatrix &I) const
    { LocalInterpolation_ND(*this, tk, dof2tk, Trans, I); }
-   virtual void GetLocalInterpolation(const FiniteElement &fe,
-                                      ElementTransformation &Trans,
-                                      DenseMatrix &I) const
+   virtual void GetTransferMatrix(const FiniteElement &fe,
+                                  ElementTransformation &Trans,
+                                  DenseMatrix &I) const
    { LocalInterpolation_ND(CheckVectorFE(fe), tk, dof2tk, Trans, I); }
    using FiniteElement::Project;
    virtual void Project(VectorCoefficient &vc,

--- a/fem/fespace.cpp
+++ b/fem/fespace.cpp
@@ -1085,7 +1085,7 @@ void FiniteElementSpace::GetLocalRefinementMatrices(
    {
       isotr.GetPointMat() = rtrans.point_matrices(i);
       isotr.FinalizeTransformation();
-      fine_fe->GetLocalInterpolation(*coarse_fe, isotr, localP(i));
+      fine_fe->GetTransferMatrix(*coarse_fe, isotr, localP(i));
    }
 }
 


### PR DESCRIPTION
Rename the new `FiniteElement::GetLocalInterpolation` to `FiniteElement::GetTransferMatrix` to avoid compiler warnings with `nvcc`.