### PR TITLE
Add support to specify the names used blueprint results

### DIFF
--- a/fem/conduitdatacollection.cpp
+++ b/fem/conduitdatacollection.cpp
@@ -164,6 +164,7 @@ ConduitDataCollection::SetProtocol(const std::string &protocol)
 //---------------------------------------------------------------------------//
 mfem::Mesh *
 ConduitDataCollection::BlueprintMeshToMesh(const Node &n_mesh,
+                                           const std::string &main_toplogy_name,
                                            bool zero_copy)
 {
    // n_conv holds converted data (when necessary for mfem api)
@@ -172,11 +173,31 @@ ConduitDataCollection::BlueprintMeshToMesh(const Node &n_mesh,
    // can't return a mesh that zero copies the conduit data
    Node n_conv;
 
-   MFEM_ASSERT(n_mesh.has_path("coordsets/coords"),
-               "Expected topology named \"coords\" "
-               "(node is missing path \"coordsets/coords\")");
+   //
+   // we need to find the topology and its coordset.
+   //
 
-   const Node &n_coordset = n_mesh["coordsets/coords"];
+   std::string topo_name = main_toplogy_name;
+   // if topo name is not set, look for first topology
+   if (topo_name == "")
+   {
+      topo_name = n_mesh["topologies"].schema().child_name(0);
+   }
+
+   MFEM_ASSERT(n_mesh.has_path("topologies/" + topo_name),
+               "Expected topology named \"" + topo_name + "\" "
+               "(node is missing path \"topologies/" + topo_name + "\")");
+
+   // find the coord set
+   std::string coords_name =
+      n_mesh["topologies"][topo_name]["coordset"].as_string();
+
+
+   MFEM_ASSERT(n_mesh.has_path("coordsets/" + coords_name),
+               "Expected topology named \"" + coords_name + "\" "
+               "(node is missing path \"coordsets/" + coords_name + "\")");
+
+   const Node &n_coordset = n_mesh["coordsets"][coords_name];
    const Node &n_coordset_vals = n_coordset["values"];
 
    // get the number of dims of the coordset
@@ -238,17 +259,15 @@ ConduitDataCollection::BlueprintMeshToMesh(const Node &n_mesh,
          n_tmp["y"].set(DataType::c_double(num_verts));
       }
 
-      Node &n_conv_coords_vals = n_conv["coordsets/coords/values"];
+      Node &n_conv_coords_vals = n_conv["coordsets"][coords_name]["values"];
       blueprint::mcarray::to_interleaved(n_tmp,
                                          n_conv_coords_vals);
       verts_ptr = n_conv_coords_vals[0].value();
    }
 
-   MFEM_ASSERT(n_mesh.has_path("topologies/main"),
-               "Expected topology named \"main\" "
-               "(node is missing path \"topologies/main\")");
 
-   const Node &n_mesh_topo    = n_mesh["topologies/main"];
+
+   const Node &n_mesh_topo    = n_mesh["topologies"][topo_name];
    std::string mesh_ele_shape = n_mesh_topo["elements/shape"].as_string();
 
    mfem::Geometry::Type mesh_geo = ShapeNameToGeomType(mesh_ele_shape);
@@ -265,7 +284,8 @@ ConduitDataCollection::BlueprintMeshToMesh(const Node &n_mesh,
    }
    else
    {
-      Node &n_mesh_conn_conv= n_conv["topologies/main/elements/connectivity"];
+      Node &n_mesh_conn_conv=
+         n_conv["topologies"][topo_name]["elements/connectivity"];
       n_mesh_conn.to_int_array(n_mesh_conn_conv);
       elem_indices = n_mesh_conn_conv.value();
    }
@@ -281,9 +301,10 @@ ConduitDataCollection::BlueprintMeshToMesh(const Node &n_mesh,
    // table lookup, even if we don't have boundary info.
    mfem::Geometry::Type bndry_geo = mfem::Geometry::POINT;
 
-   if ( n_mesh.has_path("topologies/boundary") )
+   if ( n_mesh_topo.has_child("boundary_topology") )
    {
-      const Node &n_bndry_topo    = n_mesh["topologies/boundary"];
+      std::string bndry_topo_name = n_mesh_topo["boundary_topology"].as_string();
+      const Node &n_bndry_topo    = n_mesh["topologies"][bndry_topo_name];
       std::string bndry_ele_shape = n_bndry_topo["elements/shape"].as_string();
 
       bndry_geo = ShapeNameToGeomType(bndry_ele_shape);
@@ -299,7 +320,8 @@ ConduitDataCollection::BlueprintMeshToMesh(const Node &n_mesh,
       }
       else
       {
-         Node &(n_bndry_conn_conv) = n_conv["topologies/boundary/elements/connectivity"];
+         Node &(n_bndry_conn_conv) =
+            n_conv["topologies"][bndry_topo_name]["elements/connectivity"];
          n_bndry_conn.to_int_array(n_bndry_conn_conv);
          bndry_indices = (n_bndry_conn_conv).value();
 
@@ -609,14 +631,17 @@ ConduitDataCollection::BlueprintFieldToGridFunction(Mesh *mesh,
 //---------------------------------------------------------------------------//
 void
 ConduitDataCollection::MeshToBlueprintMesh(Mesh *mesh,
-                                           Node &n_mesh)
+                                           Node &n_mesh,
+                                           const std::string &coordset_name,
+                                           const std::string &main_topology_name,
+                                           const std::string &boundary_topology_name)
 {
    int dim = mesh->SpaceDimension();
 
    MFEM_ASSERT(dim >= 1 && dim <= 3, "invalid mesh dimension");
 
    ////////////////////////////////////////////
-   // Setup main coordset "coords"
+   // Setup main coordset
    ////////////////////////////////////////////
 
    // Assumes  mfem::Vertex has the layout of a double array.
@@ -628,38 +653,40 @@ ConduitDataCollection::MeshToBlueprintMesh(Mesh *mesh,
    MFEM_ASSERT( ( stride == 3 * sizeof(double) ),
                 "Unexpected stride for Vertex");
 
-   n_mesh["coordsets/coords/type"] =  "explicit";
+   Node &n_mesh_coords = n_mesh["coordsets"][coordset_name];
+   n_mesh_coords["type"] =  "explicit";
+
 
    double *coords_ptr = mesh->GetVertex(0);
 
-   n_mesh["coordsets/coords/values/x"].set_external(coords_ptr,
-                                                    num_vertices,
-                                                    0,
-                                                    stride);
+   n_mesh_coords["values/x"].set_external(coords_ptr,
+                                          num_vertices,
+                                          0,
+                                          stride);
 
    if (dim >= 2)
    {
-      n_mesh["coordsets/coords/values/y"].set_external(coords_ptr,
-                                                       num_vertices,
-                                                       sizeof(double),
-                                                       stride);
+      n_mesh_coords["values/y"].set_external(coords_ptr,
+                                             num_vertices,
+                                             sizeof(double),
+                                             stride);
    }
    if (dim >= 3)
    {
-      n_mesh["coordsets/coords/values/z"].set_external(coords_ptr,
-                                                       num_vertices,
-                                                       sizeof(double) * 2,
-                                                       stride);
+      n_mesh_coords["values/z"].set_external(coords_ptr,
+                                             num_vertices,
+                                             sizeof(double) * 2,
+                                             stride);
    }
 
    ////////////////////////////////////////////
-   // Setup main topo "main"
+   // Setup main topo
    ////////////////////////////////////////////
 
-   Node &n_topo = n_mesh["topologies/main"];
+   Node &n_topo = n_mesh["topologies"][main_topology_name];
 
    n_topo["type"]  = "unstructured";
-   n_topo["coordset"] = "coords";
+   n_topo["coordset"] = coordset_name;
 
    Element::Type ele_type = static_cast<Element::Type>(mesh->GetElement(
                                                           0)->GetType());
@@ -702,7 +729,8 @@ ConduitDataCollection::MeshToBlueprintMesh(Mesh *mesh,
    if (gf_mesh_nodes != NULL)
    {
       GridFunctionToBlueprintField(gf_mesh_nodes,
-                                   n_mesh["fields/mesh_nodes"]);
+                                   n_mesh["fields/mesh_nodes"],
+                                   main_topology_name);
    }
 
    ////////////////////////////////////////////
@@ -712,7 +740,7 @@ ConduitDataCollection::MeshToBlueprintMesh(Mesh *mesh,
    Node &n_mesh_att = n_mesh["fields/element_attribute"];
 
    n_mesh_att["association"] = "element";
-   n_mesh_att["topology"] = "main";
+   n_mesh_att["topology"] = main_topology_name;
    n_mesh_att["values"].set(DataType::c_int(num_ele));
 
    int_array att_vals = n_mesh_att["values"].value();
@@ -728,10 +756,12 @@ ConduitDataCollection::MeshToBlueprintMesh(Mesh *mesh,
    // guard vs if we have boundary elements
    if (mesh->GetNBE() > 0)
    {
-      Node &n_bndry_topo = n_mesh["topologies/boundary"];
+      n_topo["boundary_topology"] = boundary_topology_name;
+
+      Node &n_bndry_topo = n_mesh["topologies"][boundary_topology_name];
 
       n_bndry_topo["type"]     = "unstructured";
-      n_bndry_topo["coordset"] = "coords";
+      n_bndry_topo["coordset"] = coordset_name;
 
       Element::Type bndry_ele_type = static_cast<Element::Type>(mesh->GetBdrElement(
                                                                    0)->GetType());
@@ -767,7 +797,7 @@ ConduitDataCollection::MeshToBlueprintMesh(Mesh *mesh,
       Node &n_bndry_mesh_att = n_mesh["fields/boundary_attribute"];
 
       n_bndry_mesh_att["association"] = "element";
-      n_bndry_mesh_att["topology"] = "boundary";
+      n_bndry_mesh_att["topology"] = boundary_topology_name;
       n_bndry_mesh_att["values"].set(DataType::c_int(num_bndry_ele));
 
       int_array bndry_att_vals = n_bndry_mesh_att["values"].value();
@@ -781,10 +811,11 @@ ConduitDataCollection::MeshToBlueprintMesh(Mesh *mesh,
 //---------------------------------------------------------------------------//
 void
 ConduitDataCollection::GridFunctionToBlueprintField(mfem::GridFunction *gf,
-                                                    Node &n_field)
+                                                    Node &n_field,
+                                                    const std::string &main_topology_name)
 {
    n_field["basis"] = gf->FESpace()->FEColl()->Name();
-   n_field["topology"] = "main";
+   n_field["topology"] = main_topology_name;
 
    int vdim  = gf->FESpace()->GetVDim();
    int ndofs = gf->FESpace()->GetNDofs();

--- a/fem/conduitdatacollection.hpp
+++ b/fem/conduitdatacollection.hpp
@@ -148,17 +148,25 @@ public:
 
        Zero-copies as much data as possible.
 
-       Describes the mesh's coordinates with a coordinate set entry named
-       `coords`. Describes the mesh with a topology entry named 'main'.  If the
-       mesh has nodes, these are described in a field entry named
-       `mesh_nodes`. If the mesh has an attribute field, this is described in a
-       field entry named `mesh_attribute`.
+       @a coordset_name, @a main_topology_name, and @a boundary_topology_name
+       control the names used for the mesh blueprint entires.
+
+       With the default set of names, this method describes the mesh's
+       coordinates with a coordinate set entry named `coords`. Describes the
+       mesh with a topology entry named 'main'.  If the mesh has nodes, these
+       are described in a field entry named `mesh_nodes`. If the mesh has an
+       attribute field, this is described in a field entry named
+       `mesh_attribute`.
 
        If the mesh has boundary info, this is described in a topology entry
        named `boundary`. If the boundary has an attribute field, this is
        described in a field entry named `boundary_attribute`.
    */
-   static void MeshToBlueprintMesh(Mesh *m, conduit::Node &out);
+   static void MeshToBlueprintMesh(Mesh *m,
+                                   conduit::Node &out,
+                                   const std::string &coordset_name = "coords",
+                                   const std::string &main_topology_name = "main",
+                                   const std::string &boundary_topology_name = "boundary");
 
    /// Describes a MFEM grid function using the mesh blueprint
    /** Sets up passed conduit::Node out to describe the given grid function
@@ -166,18 +174,26 @@ public:
 
        Zero-copies as much data as possible.
 
-       The resulting field is associated with the topology `main`.
+       @a main_toplogy_name is used to set the associated topology name.
+       With the default setting, the resulting field is associated with the
+       topology `main`.
    */
-   static void GridFunctionToBlueprintField(GridFunction *gf, conduit::Node &out);
+   static void GridFunctionToBlueprintField(GridFunction *gf,
+                                            conduit::Node &out,
+                                            const std::string &main_topology_name = "main");
 
    /// Constructs and MFEM mesh from a Conduit Blueprint Description
-   /** If zero_copy == true, tries to construct a mesh that points to the data
+   /** @a main_toplogy_name is used to select which topology to use, when
+       empty ("") the first topology entry will be used.
+
+       If zero_copy == true, tries to construct a mesh that points to the data
        described by the conduit node. This is only possible if the data in the
        node matches the data types needed for the MFEM API (ints for
        connectivity, doubles for field values, etc). If these constraints are
        not met, a mesh that owns the data is created and returned.
    */
    static Mesh *BlueprintMeshToMesh(const conduit::Node &n_mesh,
+                                    const std::string &main_toplogy_name = "",
                                     bool zero_copy = false);
 
    /// Constructs and MFEM Grid Function from a Conduit Blueprint Description

--- a/fem/conduitdatacollection.hpp
+++ b/fem/conduitdatacollection.hpp
@@ -149,7 +149,7 @@ public:
        Zero-copies as much data as possible.
 
        @a coordset_name, @a main_topology_name, and @a boundary_topology_name
-       control the names used for the mesh blueprint entires.
+       control the names used for the mesh blueprint entries.
 
        With the default set of names, this method describes the mesh's
        coordinates with a coordinate set entry named `coords`. Describes the
@@ -183,7 +183,7 @@ public:
                                             const std::string &main_topology_name = "main");
 
    /// Constructs and MFEM mesh from a Conduit Blueprint Description
-   /** @a main_toplogy_name is used to select which topology to use, when
+   /** @a main_topology_name is used to select which topology to use, when
        empty ("") the first topology entry will be used.
 
        If zero_copy == true, tries to construct a mesh that points to the data


### PR DESCRIPTION
This extends the mfem to/from blueprint functions to accept the names of the topology, coordinate set and boundary topology.

Prior to this, support relied on a fixed set of names. That works for round trip in MFEM, but not
for more general cases. 

The defaults provided correspond to the hold behavior. 

Note: This is still a WIP  -- I want to review a bit more. I'll post a note here when I think its ready. 
