### PR TITLE
Select the dimension in which the (boundary) coefficients are projected

### DIFF
--- a/fem/gridfunc.cpp
+++ b/fem/gridfunc.cpp
@@ -1492,6 +1492,8 @@ void GridFunction::ProjectCoefficient(Coefficient *coeff[])
          transf->SetIntPoint(&ip);
          for (d = 0; d < vdim; d++)
          {
+            if (!coeff[d]) { continue; }
+
             val = coeff[d]->Eval(*transf, ip);
             if ( (ind = vdofs[fdof*d+j]) < 0 )
             {
@@ -1586,6 +1588,8 @@ void GridFunction::ProjectBdrCoefficient(
             transf->SetIntPoint(&ip);
             for (d = 0; d < vdim; d++)
             {
+               if (!coeff[d]) { continue; }
+
                val = coeff[d]->Eval(*transf, ip);
                if ( (ind = vdofs[fdof*d+j]) < 0 )
                {
@@ -1627,6 +1631,8 @@ void GridFunction::ProjectBdrCoefficient(
          vals.SetSize(fe->GetDof());
          for (d = 0; d < vdim; d++)
          {
+            if (!coeff[d]) { continue; }
+
             fe->Project(*coeff[d], *transf, vals);
             for (int k = 0; k < vals.Size(); k++)
             {

--- a/linalg/densemat.cpp
+++ b/linalg/densemat.cpp
@@ -3776,6 +3776,30 @@ void AddMultVWt(const Vector &v, const Vector &w, DenseMatrix &VWt)
    }
 }
 
+void AddMultVVt(const Vector &v, DenseMatrix &VVt)
+{
+   int n = v.Size();
+
+#ifdef MFEM_DEBUG
+   if (VVt.Height() != n || VVt.Width() != n)
+   {
+      mfem_error("AddMultVVt(...)");
+   }
+#endif
+
+   for (int i = 0; i < n; i++)
+   {
+      double vi = v(i);
+      for (int j = 0; j < i; j++)
+      {
+         double vivj = vi * v(j);
+         VVt(i, j) += vivj;
+         VVt(j, i) += vivj;
+      }
+      VVt(i, i) += vi * v(i);
+   }
+}
+
 void AddMult_a_VWt(const double a, const Vector &v, const Vector &w,
                    DenseMatrix &VWt)
 {

--- a/linalg/densemat.hpp
+++ b/linalg/densemat.hpp
@@ -421,6 +421,9 @@ void MultVWt(const Vector &v, const Vector &w, DenseMatrix &VWt);
 /// VWt += v w^t
 void AddMultVWt(const Vector &v, const Vector &w, DenseMatrix &VWt);
 
+/// VVt += v v^t
+void AddMultVVt(const Vector &v, DenseMatrix &VWt);
+
 /// VWt += a * v w^t
 void AddMult_a_VWt(const double a, const Vector &v, const Vector &w,
                    DenseMatrix &VWt);


### PR DESCRIPTION
….When using a vector grid function, it was not possible to specify a subset of the components of the vectors in which you want to project the coefficients and only a full array for all dimensions had to be passed. This is important if you have a problem with essential boundary conditions only along some axes and you do not want to overwrite the solution along the other axes for example.
The proposed fix does not add a special method for that, but only checks if the pointers to the coefficients are not NULL and do not project anything to that component in that case.  Moreover, it serves as a protection against dereferencing NULL pointers.