### PR TITLE
Added const qualifier to the solutions in the essential bc elimination methods

### DIFF
--- a/fem/bilinearform.cpp
+++ b/fem/bilinearform.cpp
@@ -825,7 +825,8 @@ void BilinearForm::EliminateVDofs(const Array<int> &vdofs,
 }
 
 void BilinearForm::EliminateEssentialBCFromDofs(
-   const Array<int> &ess_dofs, const Vector &sol, Vector &rhs, DiagonalPolicy dpolicy)
+   const Array<int> &ess_dofs, const Vector &sol, Vector &rhs,
+   DiagonalPolicy dpolicy)
 {
    MFEM_ASSERT(ess_dofs.Size() == height, "incorrect dof Array size");
    MFEM_ASSERT(sol.Size() == height, "incorrect sol Vector size");

--- a/fem/bilinearform.cpp
+++ b/fem/bilinearform.cpp
@@ -734,7 +734,7 @@ void BilinearForm::ComputeElementMatrices()
 }
 
 void BilinearForm::EliminateEssentialBC(const Array<int> &bdr_attr_is_ess,
-                                        Vector &sol, Vector &rhs, DiagonalPolicy dpolicy)
+                                        const Vector &sol, Vector &rhs, DiagonalPolicy dpolicy)
 {
    Array<int> ess_dofs, conf_ess_dofs;
    fes->GetEssentialVDofs(bdr_attr_is_ess, ess_dofs);
@@ -785,7 +785,7 @@ void BilinearForm::EliminateEssentialBCDiag (const Array<int> &bdr_attr_is_ess,
 }
 
 void BilinearForm::EliminateVDofs(const Array<int> &vdofs,
-                                  Vector &sol, Vector &rhs,
+                                  const Vector &sol, Vector &rhs,
                                   DiagonalPolicy dpolicy)
 {
    for (int i = 0; i < vdofs.Size(); i++)
@@ -825,7 +825,7 @@ void BilinearForm::EliminateVDofs(const Array<int> &vdofs,
 }
 
 void BilinearForm::EliminateEssentialBCFromDofs(
-   const Array<int> &ess_dofs, Vector &sol, Vector &rhs, DiagonalPolicy dpolicy)
+   const Array<int> &ess_dofs, const Vector &sol, Vector &rhs, DiagonalPolicy dpolicy)
 {
    MFEM_ASSERT(ess_dofs.Size() == height, "incorrect dof Array size");
    MFEM_ASSERT(sol.Size() == height, "incorrect sol Vector size");
@@ -1118,7 +1118,7 @@ void MixedBilinearForm::ConformingAssemble()
 }
 
 void MixedBilinearForm::EliminateTrialDofs (
-   Array<int> &bdr_attr_is_ess, Vector &sol, Vector &rhs )
+   Array<int> &bdr_attr_is_ess, const Vector &sol, Vector &rhs )
 {
    int i, j, k;
    Array<int> tr_vdofs, cols_marker (trial_fes -> GetVSize());
@@ -1141,7 +1141,7 @@ void MixedBilinearForm::EliminateTrialDofs (
 }
 
 void MixedBilinearForm::EliminateEssentialBCFromTrialDofs (
-   Array<int> &marked_vdofs, Vector &sol, Vector &rhs)
+   Array<int> &marked_vdofs, const Vector &sol, Vector &rhs)
 {
    mat -> EliminateCols (marked_vdofs, &sol, &rhs);
 }

--- a/fem/bilinearform.hpp
+++ b/fem/bilinearform.hpp
@@ -311,7 +311,7 @@ public:
        essential DOFs is set to 1.0. This behavior is controlled by the argument
        @a dpolicy. */
    void EliminateEssentialBC(const Array<int> &bdr_attr_is_ess,
-                             Vector &sol, Vector &rhs,
+                             const Vector &sol, Vector &rhs,
                              DiagonalPolicy dpolicy = DIAG_ONE);
 
    /// Eliminate essential boundary DOFs from the system matrix.
@@ -322,7 +322,7 @@ public:
                                  double value);
 
    /// Eliminate the given @a vdofs. NOTE: here, @a vdofs is a list of DOFs.
-   void EliminateVDofs(const Array<int> &vdofs, Vector &sol, Vector &rhs,
+   void EliminateVDofs(const Array<int> &vdofs, const Vector &sol, Vector &rhs,
                        DiagonalPolicy dpolicy = DIAG_ONE);
 
    /// Eliminate the given @a vdofs, storing the eliminated part internally.
@@ -333,10 +333,10 @@ public:
                        DiagonalPolicy dpolicy = DIAG_ONE);
 
    /** @brief Similar to
-       EliminateVDofs(const Array<int> &, Vector &, Vector &, DiagonalPolicy)
+       EliminateVDofs(const Array<int> &, const Vector &, Vector &, DiagonalPolicy)
        but here @a ess_dofs is a marker (boolean) array on all vector-dofs
        (@a ess_dofs[i] < 0 is true). */
-   void EliminateEssentialBCFromDofs(const Array<int> &ess_dofs, Vector &sol,
+   void EliminateEssentialBCFromDofs(const Array<int> &ess_dofs, const Vector &sol,
                                      Vector &rhs, DiagonalPolicy dpolicy = DIAG_ONE);
 
    /** @brief Similar to EliminateVDofs(const Array<int> &, DiagonalPolicy) but
@@ -460,10 +460,10 @@ public:
    void ConformingAssemble();
 
    void EliminateTrialDofs(Array<int> &bdr_attr_is_ess,
-                           Vector &sol, Vector &rhs);
+                           const Vector &sol, Vector &rhs);
 
    void EliminateEssentialBCFromTrialDofs(Array<int> &marked_vdofs,
-                                          Vector &sol, Vector &rhs);
+                                          const Vector &sol, Vector &rhs);
 
    virtual void EliminateTestDofs(Array<int> &bdr_attr_is_ess);
 

--- a/linalg/sparsemat.cpp
+++ b/linalg/sparsemat.cpp
@@ -1170,7 +1170,7 @@ void SparseMatrix::EliminateCol(int col, DiagonalPolicy dpolicy)
    }
 }
 
-void SparseMatrix::EliminateCols(const Array<int> &cols, Vector *x, Vector *b)
+void SparseMatrix::EliminateCols(const Array<int> &cols, const Vector *x, Vector *b)
 {
    if (Rows == NULL)
    {

--- a/linalg/sparsemat.cpp
+++ b/linalg/sparsemat.cpp
@@ -1170,7 +1170,8 @@ void SparseMatrix::EliminateCol(int col, DiagonalPolicy dpolicy)
    }
 }
 
-void SparseMatrix::EliminateCols(const Array<int> &cols, const Vector *x, Vector *b)
+void SparseMatrix::EliminateCols(const Array<int> &cols, const Vector *x,
+                                 Vector *b)
 {
    if (Rows == NULL)
    {

--- a/linalg/sparsemat.hpp
+++ b/linalg/sparsemat.hpp
@@ -240,7 +240,7 @@ public:
        zero. In addition, if the pointers @a x and @a b are not NULL, the
        eliminated matrix entries are multiplied by the corresponding solution
        value in @a *x and subtracted from the r.h.s. vector, @a *b. */
-   void EliminateCols(const Array<int> &cols, Vector *x = NULL, Vector *b = NULL);
+   void EliminateCols(const Array<int> &cols, const Vector *x = NULL, Vector *b = NULL);
 
    /// Eliminate row @a rc and column @a rc and modify the @a rhs using @a sol.
    /** Eliminates the column @a rc to the @a rhs, deletes the row @a rc and

--- a/linalg/sparsemat.hpp
+++ b/linalg/sparsemat.hpp
@@ -240,7 +240,8 @@ public:
        zero. In addition, if the pointers @a x and @a b are not NULL, the
        eliminated matrix entries are multiplied by the corresponding solution
        value in @a *x and subtracted from the r.h.s. vector, @a *b. */
-   void EliminateCols(const Array<int> &cols, const Vector *x = NULL, Vector *b = NULL);
+   void EliminateCols(const Array<int> &cols, const Vector *x = NULL,
+                      Vector *b = NULL);
 
    /// Eliminate row @a rc and column @a rc and modify the @a rhs using @a sol.
    /** Eliminates the column @a rc to the @a rhs, deletes the row @a rc and


### PR DESCRIPTION
Added missing const qualifier to the solution vectors in BC elimination methods, which do not need the write access. Moreover, it was confusing for the users and potentially problematic if someone uses const qualifiers heavily in the code and had to copy the solution vector or use C-style casting to remove the qualifier of the vector.