### PR TITLE
Bugfix for handling of SidreDataCollection boundary mesh blueprint index [sidre-dev]

### DIFF
--- a/fem/sidredatacollection.hpp
+++ b/fem/sidredatacollection.hpp
@@ -255,6 +255,9 @@ public:
    bool HasAttributeField(const std::string& field_name) const
    { return attr_map.Has(field_name); }
 
+   /** Checks if any rank in the mesh has boundary elements */
+   bool HasBoundaryMesh() const;
+
    /// Set the name of the mesh nodes field.
    /** This name will be used by SetMesh() to register the mesh nodes, if not
        already registered. Also, this method should be called if the mesh nodes


### PR DESCRIPTION
The blueprint index was only being generated for the boundary mesh when rank 0 had boundary elements. We need to generate the boundary mesh group and associated blueprint index if any of the domains have boundary elements.