### PR TITLE
Fixed assignment of an IntegrationRule in the constructor of NonlinearFormIntegrator

### DIFF
--- a/fem/nonlininteg.hpp
+++ b/fem/nonlininteg.hpp
@@ -29,7 +29,7 @@ protected:
    const IntegrationRule *IntRule;
 
    NonlinearFormIntegrator(const IntegrationRule *ir = NULL)
-      : IntRule(NULL) { }
+      : IntRule(ir) { }
 
 public:
    /** @brief Prescribe a fixed IntegrationRule to use (when @a ir != NULL) or


### PR DESCRIPTION
This was a very small bug, but it may be critical for certain applications, since it may caused that the desired IntegrationRule was not assigned.