### PR TITLE
Adding a desired LOD field to the visit output [visit-lod-dev]

### DIFF
--- a/fem/datacollection.cpp
+++ b/fem/datacollection.cpp
@@ -10,6 +10,7 @@
 // Software Foundation) version 2.1 dated February 1999.
 
 #include "fem.hpp"
+#include "../mesh/nurbs.hpp"
 #include "../general/text.hpp"
 #include "picojson.h"
 
@@ -349,6 +350,8 @@ VisItDataCollection::VisItDataCollection(const std::string& collection_name,
       topo_dim = 0;
    }
    visit_max_levels_of_detail = 32;
+   visit_levels_of_detail = 1;
+   if (mesh->NURBSext) { visit_levels_of_detail = mesh->NURBSext->GetOrder(); }
 }
 
 #ifdef MFEM_USE_MPI
@@ -365,6 +368,8 @@ VisItDataCollection::VisItDataCollection(MPI_Comm comm,
    spatial_dim = 0;
    topo_dim = 0;
    visit_max_levels_of_detail = 32;
+   visit_levels_of_detail = 1;
+   if (mesh->NURBSext) { visit_levels_of_detail = mesh->NURBSext->GetOrder(); }
 }
 #endif
 
@@ -392,6 +397,21 @@ void VisItDataCollection::RegisterField(const std::string& name,
 {
    DataCollection::RegisterField(name, gf);
    field_info_map[name] = VisItFieldInfo("nodes", gf->VectorDim());
+
+   int LOD = 1;
+   if (gf->FESpace()->GetNURBSext())
+   {
+      LOD = gf->FESpace()->GetNURBSext()->GetOrder();
+   }
+   else
+   {
+      for (int e=0; e<gf->FESpace()->GetNE() ; e++)
+      {
+         LOD = std::max(LOD,gf->FESpace()->GetFE(e)->GetOrder());
+      }
+   }
+
+   visit_levels_of_detail = std::max(visit_levels_of_detail, LOD);
 }
 
 void VisItDataCollection::SetMaxLevelsOfDetail(int max_levels_of_detail)
@@ -595,6 +615,7 @@ std::string VisItDataCollection::GetVisItRootString()
    {
       ftags["assoc"] = picojson::value((it->second).association);
       ftags["comps"] = picojson::value(to_string((it->second).num_components));
+      ftags["lod"] = picojson::value(to_string(visit_levels_of_detail));
       field["path"] = picojson::value(path_str + it->first + file_ext_format);
       field["tags"] = picojson::value(ftags);
       fields[it->first] = picojson::value(field);

--- a/fem/datacollection.hpp
+++ b/fem/datacollection.hpp
@@ -398,6 +398,7 @@ protected:
    // Additional data needed in the VisIt root file, which describes the mesh
    // and all the fields in the collection
    int spatial_dim, topo_dim;
+   int visit_levels_of_detail;
    int visit_max_levels_of_detail;
    std::map<std::string, VisItFieldInfo> field_info_map;
    typedef std::map<std::string, VisItFieldInfo>::iterator FieldInfoMapIterator;

--- a/fem/datacollection.hpp
+++ b/fem/datacollection.hpp
@@ -408,6 +408,8 @@ protected:
    /// Read in a VisIt root file in JSON format
    void ParseVisItRootString(const std::string& json);
 
+   void UpdateMeshInfo();
+
    // Helper functions for Load()
    void LoadVisItRootFile(const std::string& root_name);
    void LoadMesh();
@@ -437,6 +439,9 @@ public:
 
    /// Add a grid function to the collection and update the root file
    virtual void RegisterField(const std::string& field_name, GridFunction *gf);
+
+   /// Set VisIt parameter: default levels of detail for the MultiresControl
+   void SetLevelsOfDetail(int levels_of_detail);
 
    /// Set VisIt parameter: maximum levels of detail for the MultiresControl
    void SetMaxLevelsOfDetail(int max_levels_of_detail);


### PR DESCRIPTION
This PR adds a desired field to the visit meta data. This allows visit to represent the data at a higher LOD (level-fo-detail). This is a need feature for plotting higher order solutions such as NURBS.

For this to work a small patch needs to be applied to visit.