### PR TITLE
Shared slave faces fix

### DIFF
--- a/mesh/pncmesh.cpp
+++ b/mesh/pncmesh.cpp
@@ -433,7 +433,7 @@ struct MasterSlaveInfo
 
 void ParNCMesh::AddMasterSlaveConnections(int nitems, const NCList& list)
 {
-#if 1
+#if 0 // optimal version for P matrix construction but breaks ParMesh::Print and DG
    Array<int> masters(nitems);
    masters = -1;
 
@@ -462,7 +462,8 @@ void ParNCMesh::AddMasterSlaveConnections(int nitems, const NCList& list)
          index_rank.Append(Connection(master, rank));
       }
    }
-#else
+#else // suboptimal version fully linking master and slave entities in groups
+
    // create an auxiliary structure for each edge/face
    std::vector<MasterSlaveInfo> info(nitems);
 


### PR DESCRIPTION
This is a temporary fix of a problem in ParMesh::Print and in parallel nonconforming DG, caused by the changes introduced in pmatrix-dev. In the new P matrix construction algorithm, slave faces/edges are no longer considered shared, because their P rows are not needed by the MPI rank owning the master entity. This gives an optimal communication pattern, but breaks other things that rely on the list of shared slaves (pncmesh->shared_faces.slaves). This PR slows down P matrix construction by about 10% (tested on 8K CPUs on vulcan so far) but fixes mesh printing and NC DG. 

The permanent fix will require rethinking the way the processor groups are constructed in ParNCMesh. P matrix construction will probably require its own groups. It is already apparent from the current hackish solution in ParNCMesh::AugmentMasterGroups that the P matrix algorithm needs different treatment than the rest of the code working with shared entities. 
