### PR TITLE
CalcHessian for H1_TriangleElement and H1_TetrahedronElement [h1_hessian-dev]

### DIFF
--- a/fem/fe.cpp
+++ b/fem/fe.cpp
@@ -7835,17 +7835,20 @@ void H1_TetrahedronElement::CalcHessian(const IntegrationPoint &ip,
             int l = p - i - j - k;
             ddu(o,0) = ((ddshape_x(i) * shape_l(l)) - 2. * (dshape_x(i) * dshape_l(l)) +
                         (shape_x(i) * ddshape_l(l))) * shape_y(j) * shape_z(k);
-            ddu(o,1) = ((dshape_y(j) * ((dshape_x(i) * shape_l(l)) - (shape_x(i) * dshape_l(
-                                                                         l)))) + (shape_y(j) * ((ddshape_l(l) * shape_x(i)) - (dshape_x(i) * dshape_l(
-                                                                                     l)))))* shape_z(k);
-            ddu(o,2) = ((dshape_z(k) * ((dshape_x(i) * shape_l(l)) - (shape_x(i) * dshape_l(
-                                                                         l)))) + (shape_z(k) * ((ddshape_l(l) * shape_x(i)) - (dshape_x(i) * dshape_l(
-                                                                                     l)))))* shape_y(j);
+            ddu(o,1) = ((dshape_y(j) * ((dshape_x(i) * shape_l(l)) -
+                                        (shape_x(i) * dshape_l(l)))) +
+                        (shape_y(j) * ((ddshape_l(l) * shape_x(i)) -
+                                       (dshape_x(i) * dshape_l(l)))))* shape_z(k);
+            ddu(o,2) = ((dshape_z(k) * ((dshape_x(i) * shape_l(l)) -
+                                        (shape_x(i) * dshape_l(l)))) +
+                        (shape_z(k) * ((ddshape_l(l) * shape_x(i)) -
+                                       (dshape_x(i) * dshape_l(l)))))* shape_y(j);
             ddu(o,3) = ((ddshape_y(j) * shape_l(l)) - 2. * (dshape_y(j) * dshape_l(l)) +
                         (shape_y(j) * ddshape_l(l))) * shape_x(i) * shape_z(k);
-            ddu(o,4) = ((dshape_z(k) * ((dshape_y(j) * shape_l(l)) - (shape_y(j)*dshape_l(
-                                                                         l))) ) + (shape_z(k)* ((ddshape_l(l)*shape_y(j)) - (dshape_y(j) * dshape_l(
-                                                                                      l)) ) ) )* shape_x(i);
+            ddu(o,4) = ((dshape_z(k) * ((dshape_y(j) * shape_l(l)) -
+                                        (shape_y(j)*dshape_l(l))) ) +
+                        (shape_z(k)* ((ddshape_l(l)*shape_y(j)) -
+                                      (dshape_y(j) * dshape_l(l)) ) ) )* shape_x(i);
             ddu(o,5) = ((ddshape_z(k) * shape_l(l)) - 2. * (dshape_z(k) * dshape_l(l)) +
                         (shape_z(k) * ddshape_l(l))) * shape_y(j) * shape_x(i);
             o++;

--- a/fem/fe.cpp
+++ b/fem/fe.cpp
@@ -6598,6 +6598,35 @@ void Poly_1D::CalcChebyshev(const int p, const double x, double *u, double *d)
    }
 }
 
+void Poly_1D::CalcChebyshev(const int p, const double x, double *u, double *d, double *dd)
+{
+   // recursive definition, z in [-1,1]
+   // T_0(z) = 1,  T_1(z) = z
+   // T_{n+1}(z) = 2*z*T_n(z) - T_{n-1}(z)
+   // T'_n(z) = n*U_{n-1}(z)
+   // U_0(z) = 1  U_1(z) = 2*z
+   // U_{n+1}(z) = 2*z*U_n(z) - U_{n-1}(z)
+   // U_n(z) = z*U_{n-1}(z) + T_n(z) = z*T'_n(z)/n + T_n(z)
+   // T'_{n+1}(z) = (n + 1)*(z*T'_n(z)/n + T_n(z))
+   // T''_{n}(z) = n/(z^2 - 1)*(n*T_n(z) - z*U_{n-1}(z))
+   // T''_{n+1}(z) = 2*(z*n*T'_{n+1}(z) - ((n+1)^2/n)* T'_n(z) ) / (z^2 - 1)
+   double z;
+   u[0] = 1.;
+   d[0] = 0.;
+   dd[0]= 0.;
+   if (p == 0) { return; }
+   u[1] = z = 2.*x - 1.;
+   d[1] = 2.;
+   dd[1] = 0;
+   double denom = (z*z) -1.;
+   for (int n = 1; n < p; n++)
+   {
+      u[n+1] = 2*z*u[n] - u[n-1];
+      d[n+1] = (n + 1)*(z*d[n]/n + 2*u[n]);
+      dd[n+1] = (denom == 0 ? 4.*((n+1)*(n+1)*((n+1)*(n+1) - 1)/3. ) : 2.*(z*n*d[n+1] - ( (n+1.)*(n+1.)/n ) * d[n] ) / (z*z - 1.) );
+   }
+}
+
 const double *Poly_1D::GetPoints(const int p, const int btype)
 {
    BasisType::Check(btype);
@@ -7463,8 +7492,12 @@ H1_TriangleElement::H1_TriangleElement(const int p, const int btype)
    dshape_x.SetSize(p + 1);
    dshape_y.SetSize(p + 1);
    dshape_l.SetSize(p + 1);
+   ddshape_x.SetSize(p + 1);
+   ddshape_y.SetSize(p + 1);
+   ddshape_l.SetSize(p + 1);
    u.SetSize(Dof);
    du.SetSize(Dof, Dim);
+   ddu.SetSize(Dof, (Dim * (Dim + 1)) / 2 );
 #else
    Vector shape_x(p + 1), shape_y(p + 1), shape_l(p + 1);
 #endif
@@ -7568,6 +7601,35 @@ void H1_TriangleElement::CalcDShape(const IntegrationPoint &ip,
    Ti.Mult(du, dshape);
 }
 
+void H1_TriangleElement::CalcHessian(const IntegrationPoint &ip,
+                                     DenseMatrix &ddshape) const
+{
+    const int p = Order;
+#ifdef MFEM_THREAD_SAFE
+   Vector   shape_x(p + 1),   shape_y(p + 1),   shape_l(p + 1);
+   Vector  dshape_x(p + 1),  dshape_y(p + 1),  dshape_l(p + 1);
+   Vector ddshape_x(p + 1), ddshape_y(p + 1), ddshape_l(p + 1);
+   DenseMatrix ddu(Dof, Dim);
+#endif
+   
+   poly1d.CalcBasis(p, ip.x, shape_x, dshape_x, ddshape_x);
+   poly1d.CalcBasis(p, ip.y, shape_y, dshape_y, ddshape_y);
+   poly1d.CalcBasis(p, 1. - ip.x - ip.y, shape_l, dshape_l, ddshape_l);
+   
+   for (int o = 0, j = 0; j <= p; j++)
+      for (int i = 0; i + j <= p; i++)
+      {
+         int k = p - i - j;
+         // u_xx, u_xy, u_yy
+         ddu(o,0) = ((ddshape_x(i) * shape_l(k)) - 2. * (dshape_x(i) * dshape_l(k)) + (shape_x(i) * ddshape_l(k))) * shape_y(j);
+         ddu(o,1) = (((shape_x(i) * ddshape_l(k)) - dshape_x(i) * dshape_l(k)) * shape_y(j)) + (((dshape_x(i) * shape_l(k)) - (shape_x(i) * dshape_l(k))) * dshape_y(j));
+         ddu(o,2) = ((ddshape_y(j) * shape_l(k)) - 2. * (dshape_y(j) * dshape_l(k)) + (shape_y(j) * ddshape_l(k))) * shape_x(i);
+         o++;
+      }
+      
+   Ti.Mult(ddu, ddshape);
+}
+
 
 H1_TetrahedronElement::H1_TetrahedronElement(const int p, const int btype)
    : NodalFiniteElement(3, Geometry::TETRAHEDRON, ((p + 1)*(p + 2)*(p + 3))/6,
@@ -7584,8 +7646,13 @@ H1_TetrahedronElement::H1_TetrahedronElement(const int p, const int btype)
    dshape_y.SetSize(p + 1);
    dshape_z.SetSize(p + 1);
    dshape_l.SetSize(p + 1);
+   ddshape_x.SetSize(p + 1);
+   ddshape_y.SetSize(p + 1);
+   ddshape_z.SetSize(p + 1);
+   ddshape_l.SetSize(p + 1);
    u.SetSize(Dof);
    du.SetSize(Dof, Dim);
+   ddu.SetSize(Dof, (Dim * (Dim + 1)) / 2);
 #else
    Vector shape_x(p + 1), shape_y(p + 1), shape_z(p + 1), shape_l(p + 1);
 #endif
@@ -7738,6 +7805,39 @@ void H1_TetrahedronElement::CalcDShape(const IntegrationPoint &ip,
    Ti.Mult(du, dshape);
 }
 
+void H1_TetrahedronElement::CalcHessian(const IntegrationPoint &ip,
+                                       DenseMatrix &ddshape) const
+{
+   const int p = Order;
+
+#ifdef MFEM_THREAD_SAFE
+   Vector   shape_x(p + 1),   shape_y(p + 1),   shape_z(p + 1),   shape_l(p + 1);
+   Vector  dshape_x(p + 1),  dshape_y(p + 1),  dshape_z(p + 1),  dshape_l(p + 1);
+   Vector ddshape_x(p + 1), ddshape_y(p + 1), ddshape_z(p + 1), ddshape_l(p + 1);
+   DenseMatrix ddu(Dof, ((Dim + 1) * Dim) / 2);
+#endif
+
+   poly1d.CalcBasis(p, ip.x, shape_x, dshape_x, ddshape_x);
+   poly1d.CalcBasis(p, ip.y, shape_y, dshape_y, ddshape_y);
+   poly1d.CalcBasis(p, ip.z, shape_z, dshape_z, ddshape_z);
+   poly1d.CalcBasis(p, 1. - ip.x - ip.y - ip.z, shape_l, dshape_l, ddshape_l);
+
+   for (int o = 0, k = 0; k <= p; k++)
+      for (int j = 0; j + k <= p; j++)
+         for (int i = 0; i + j + k <= p; i++)
+         {
+             // u_xx, u_xy, u_xz, u_yy, u_yz, u_zz
+            int l = p - i - j - k;
+            ddu(o,0) = ((ddshape_x(i) * shape_l(l)) - 2. * (dshape_x(i) * dshape_l(l)) + (shape_x(i) * ddshape_l(l))) * shape_y(j) * shape_z(k);
+            ddu(o,1) = ((dshape_y(j) * ((dshape_x(i) * shape_l(l)) - (shape_x(i) * dshape_l(l)))) + (shape_y(j) * ((ddshape_l(l) * shape_x(i)) - (dshape_x(i) * dshape_l(l)))))* shape_z(k);
+            ddu(o,2) = ((dshape_z(k) * ((dshape_x(i) * shape_l(l)) - (shape_x(i) * dshape_l(l)))) + (shape_z(k) * ((ddshape_l(l) * shape_x(i)) - (dshape_x(i) * dshape_l(l)))))* shape_y(j);
+            ddu(o,3) = ((ddshape_y(j) * shape_l(l)) - 2. * (dshape_y(j) * dshape_l(l)) + (shape_y(j) * ddshape_l(l))) * shape_x(i) * shape_z(k);
+            ddu(o,4) = ((dshape_z(k) * ((dshape_y(j) * shape_l(l)) - (shape_y(j)*dshape_l(l))) ) + (shape_z(k)* ((ddshape_l(l)*shape_y(j)) - (dshape_y(j) * dshape_l(l)) ) ) )* shape_x(i);
+            ddu(o,5) = ((ddshape_z(k) * shape_l(l)) - 2. * (dshape_z(k) * dshape_l(l)) + (shape_z(k) * ddshape_l(l))) * shape_y(j) * shape_x(i);
+            o++;
+         }
+   Ti.Mult(ddu, ddshape);
+}
 
 H1Pos_TriangleElement::H1Pos_TriangleElement(const int p)
    : PositiveFiniteElement(2, Geometry::TRIANGLE, ((p + 1)*(p + 2))/2, p,

--- a/fem/fe.cpp
+++ b/fem/fe.cpp
@@ -6609,8 +6609,7 @@ void Poly_1D::CalcChebyshev(const int p, const double x, double *u, double *d,
    // U_{n+1}(z) = 2*z*U_n(z) - U_{n-1}(z)
    // U_n(z) = z*U_{n-1}(z) + T_n(z) = z*T'_n(z)/n + T_n(z)
    // T'_{n+1}(z) = (n + 1)*(z*T'_n(z)/n + T_n(z))
-   // T''_{n}(z) = n/(z^2 - 1)*(n*T_n(z) - z*U_{n-1}(z))
-   // T''_{n+1}(z) = 2*(z*n*T'_{n+1}(z) - ((n+1)^2/n)* T'_n(z) ) / (z^2 - 1)
+   // T''_{n+1}(z) = (n + 1)*(2*(n + 1)*T'_n(z) + z*T''_n(z)) / n
    double z;
    u[0] = 1.;
    d[0] = 0.;
@@ -6619,13 +6618,11 @@ void Poly_1D::CalcChebyshev(const int p, const double x, double *u, double *d,
    u[1] = z = 2.*x - 1.;
    d[1] = 2.;
    dd[1] = 0;
-   double denom = (z*z) -1.;
    for (int n = 1; n < p; n++)
    {
       u[n+1] = 2*z*u[n] - u[n-1];
       d[n+1] = (n + 1)*(z*d[n]/n + 2*u[n]);
-      dd[n+1] = (denom == 0 ? 4.*((n+1)*(n+1)*((n+1)*(n+1) - 1)/3. ) : 2.*
-                 (z*n*d[n+1] - ( (n+1.)*(n+1.)/n ) * d[n] ) / (z*z - 1.) );
+      dd[n+1] = (n + 1)*(2.*(n + 1)*d[n] + z*dd[n])/n;
    }
 }
 

--- a/fem/fe.hpp
+++ b/fem/fe.hpp
@@ -1564,7 +1564,8 @@ private:
 
    static void CalcChebyshev(const int p, const double x, double *u);
    static void CalcChebyshev(const int p, const double x, double *u, double *d);
-   static void CalcChebyshev(const int p, const double x, double *u, double *d, double *dd);
+   static void CalcChebyshev(const int p, const double x, double *u, double *d,
+                             double *dd);
 
    QuadratureFunctions1D quad_func;
 
@@ -1618,9 +1619,10 @@ public:
    // { CalcBernstein(p, x, u, d); }
    // { CalcLegendre(p, x, u, d); }
    { CalcChebyshev(p, x, u, d); }
-   
+
    // Evaluate the values, derivatives and second derivatives of a hierarchical 1D basis at point x
-   static void CalcBasis(const int p, const double x, double *u, double *d, double *dd)
+   static void CalcBasis(const int p, const double x, double *u, double *d,
+                         double *dd)
    // { CalcMono(p, x, u, d); }
    // { CalcBernstein(p, x, u, d); }
    // { CalcLegendre(p, x, u, d); }
@@ -1839,7 +1841,7 @@ public:
    virtual void CalcDShape(const IntegrationPoint &ip,
                            DenseMatrix &dshape) const;
    virtual void CalcHessian(const IntegrationPoint &ip,
-                           DenseMatrix &ddshape) const;
+                            DenseMatrix &ddshape) const;
 };
 
 
@@ -1861,7 +1863,7 @@ public:
    virtual void CalcDShape(const IntegrationPoint &ip,
                            DenseMatrix &dshape) const;
    virtual void CalcHessian(const IntegrationPoint &ip,
-                           DenseMatrix &ddshape) const;
+                            DenseMatrix &ddshape) const;
 };
 
 

--- a/fem/fe.hpp
+++ b/fem/fe.hpp
@@ -1564,6 +1564,7 @@ private:
 
    static void CalcChebyshev(const int p, const double x, double *u);
    static void CalcChebyshev(const int p, const double x, double *u, double *d);
+   static void CalcChebyshev(const int p, const double x, double *u, double *d, double *dd);
 
    QuadratureFunctions1D quad_func;
 
@@ -1617,6 +1618,13 @@ public:
    // { CalcBernstein(p, x, u, d); }
    // { CalcLegendre(p, x, u, d); }
    { CalcChebyshev(p, x, u, d); }
+   
+   // Evaluate the values, derivatives and second derivatives of a hierarchical 1D basis at point x
+   static void CalcBasis(const int p, const double x, double *u, double *d, double *dd)
+   // { CalcMono(p, x, u, d); }
+   // { CalcBernstein(p, x, u, d); }
+   // { CalcLegendre(p, x, u, d); }
+   { CalcChebyshev(p, x, u, d, dd); }
 
    // Evaluate a representation of a Delta function at point x
    static double CalcDelta(const int p, const double x)
@@ -1820,7 +1828,8 @@ class H1_TriangleElement : public NodalFiniteElement
 private:
 #ifndef MFEM_THREAD_SAFE
    mutable Vector shape_x, shape_y, shape_l, dshape_x, dshape_y, dshape_l, u;
-   mutable DenseMatrix du;
+   mutable Vector ddshape_x, ddshape_y, ddshape_l;
+   mutable DenseMatrix du, ddu;
 #endif
    DenseMatrixInverse Ti;
 
@@ -1829,6 +1838,8 @@ public:
    virtual void CalcShape(const IntegrationPoint &ip, Vector &shape) const;
    virtual void CalcDShape(const IntegrationPoint &ip,
                            DenseMatrix &dshape) const;
+   virtual void CalcHessian(const IntegrationPoint &ip,
+                           DenseMatrix &ddshape) const;
 };
 
 
@@ -1838,7 +1849,8 @@ private:
 #ifndef MFEM_THREAD_SAFE
    mutable Vector shape_x, shape_y, shape_z, shape_l;
    mutable Vector dshape_x, dshape_y, dshape_z, dshape_l, u;
-   mutable DenseMatrix du;
+   mutable Vector ddshape_x, ddshape_y, ddshape_z, ddshape_l;
+   mutable DenseMatrix du, ddu;
 #endif
    DenseMatrixInverse Ti;
 
@@ -1848,6 +1860,8 @@ public:
    virtual void CalcShape(const IntegrationPoint &ip, Vector &shape) const;
    virtual void CalcDShape(const IntegrationPoint &ip,
                            DenseMatrix &dshape) const;
+   virtual void CalcHessian(const IntegrationPoint &ip,
+                           DenseMatrix &ddshape) const;
 };
 
 


### PR DESCRIPTION
I implemented CalcHessian for H1_TriangleElement and H1_TetrahedronElement. The 2nd derivatives in the Hessian are ordered "u_xx, u_xy, u_yy" and "u_xx, u_xy, u_xz, u_yy, u_yz, u_zz", respectively.

Poly_1D was expanded by a third CalcBasis function which takes an additional argument for the 2nd derivative. As only CalcChebyshev is not commented out, I just implemented the 2nd derivatives for the Chebyshev Polynomials, also with an additional argument for the 2nd derivative.