### PR TITLE
Fix for Tetrahedral Mesh Refinement [conforming-tet-refinement-fix]

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -11,6 +11,13 @@
 Version 3.4.1 (development)
 ===========================
 
+- The tetrahedral mesh refinement algorithm in serial and in parallel now
+  follows precisely the paper:
+     D. Arnold, A. Mukherjee, and L. Pouly, "Locally Adapted Tetrahedral Meshes
+     Using Bisection", SIAM J. Sci. Comput., 22(2), 431–448.
+  This guarantees that the shape regularity of the elements will be preserved
+  under refinement.
+
 
 Version 3.4, released on May 29, 2018
 =====================================

--- a/examples/ex13p.cpp
+++ b/examples/ex13p.cpp
@@ -110,6 +110,7 @@ int main(int argc, char *argv[])
    {
       pmesh->UniformRefinement();
    }
+   pmesh->ReorientTetMesh();
 
    // 6. Define a parallel finite element space on the parallel mesh. Here we
    //    use the Nedelec finite elements of the specified order.

--- a/general/sort_pairs.hpp
+++ b/general/sort_pairs.hpp
@@ -58,6 +58,11 @@ public:
    A one;
    B two;
    C three;
+
+   Triple() { }
+
+   Triple(const A &one, const B &two, const C &three)
+      : one(one), two(two), three(three) { }
 };
 
 /// @brief Lexicographic comparison operator for class Triple.

--- a/mesh/element.hpp
+++ b/mesh/element.hpp
@@ -81,7 +81,6 @@ public:
    virtual void MarkEdge(const DSTable &v_to_v, const int *length) {}
 
    /// Return 1 if the element needs refinement in order to get conforming mesh.
-   virtual int NeedRefinement(DSTable &v_to_v, int *middle) const { return 0; }
    virtual int NeedRefinement(HashTable<Hashed2> &v_to_v) const { return 0; }
 
    /// Set current coarse-fine transformation number.

--- a/mesh/element.hpp
+++ b/mesh/element.hpp
@@ -17,6 +17,7 @@
 #include "../general/table.hpp"
 #include "../linalg/densemat.hpp"
 #include "../fem/geom.hpp"
+#include "../general/hash.hpp"
 
 namespace mfem
 {
@@ -81,6 +82,7 @@ public:
 
    /// Return 1 if the element needs refinement in order to get conforming mesh.
    virtual int NeedRefinement(DSTable &v_to_v, int *middle) const { return 0; }
+   virtual int NeedRefinement(HashTable<Hashed2> &v_to_v) const { return 0; }
 
    /// Set current coarse-fine transformation number.
    virtual void ResetTransform(int tr) {}

--- a/mesh/mesh.cpp
+++ b/mesh/mesh.cpp
@@ -6556,127 +6556,9 @@ void Mesh::Bisection(int i, const DSTable &v_to_v,
       }
       NumOfElements++;
    }
-   else if (t == Element::TETRAHEDRON)
-   {
-      int j, type, new_type, old_redges[2], new_redges[2][2], flag;
-      Tetrahedron *tet = (Tetrahedron *) el;
-
-      MFEM_VERIFY(tet->GetRefinementFlag() != 0,
-                  "TETRAHEDRON element is not marked for refinement.");
-
-      vert = tet->GetVertices();
-
-      // 1. Get the index for the new vertex in v_new.
-      bisect = v_to_v(vert[0], vert[1]);
-      if (bisect == -1)
-      {
-         tet->ParseRefinementFlag(old_redges, type, flag);
-         mfem::err << "Error in Bisection(...) of tetrahedron!" << endl
-                   << "   redge[0] = " << old_redges[0]
-                   << "   redge[1] = " << old_redges[1]
-                   << "   type = " << type
-                   << "   flag = " << flag << endl;
-         mfem_error();
-      }
-
-      if (middle[bisect] == -1)
-      {
-         v_new = NumOfVertices++;
-         for (j = 0; j < 3; j++)
-         {
-            V(j) = 0.5 * (vertices[vert[0]](j) + vertices[vert[1]](j));
-         }
-         vertices.Append(V);
-
-         middle[bisect] = v_new;
-      }
-      else
-      {
-         v_new = middle[bisect];
-      }
-
-      // 2. Set the node indices for the new elements in v[2][4] so that
-      //    the edge marked for refinement is between the first two nodes.
-      tet->ParseRefinementFlag(old_redges, type, flag);
-
-      v[0][3] = v_new;
-      v[1][3] = v_new;
-      new_redges[0][0] = 2;
-      new_redges[0][1] = 1;
-      new_redges[1][0] = 2;
-      new_redges[1][1] = 1;
-      int tr1 = -1, tr2 = -1;
-      switch (old_redges[0])
-      {
-         case 2:
-            v[0][0] = vert[0]; v[0][1] = vert[2]; v[0][2] = vert[3];
-            if (type == Tetrahedron::TYPE_PF) { new_redges[0][1] = 4; }
-            tr1 = 0;
-            break;
-         case 3:
-            v[0][0] = vert[3]; v[0][1] = vert[0]; v[0][2] = vert[2];
-            tr1 = 2;
-            break;
-         case 5:
-            v[0][0] = vert[2]; v[0][1] = vert[3]; v[0][2] = vert[0];
-            tr1 = 4;
-      }
-      switch (old_redges[1])
-      {
-         case 1:
-            v[1][0] = vert[2]; v[1][1] = vert[1]; v[1][2] = vert[3];
-            if (type == Tetrahedron::TYPE_PF) { new_redges[1][0] = 3; }
-            tr2 = 1;
-            break;
-         case 4:
-            v[1][0] = vert[1]; v[1][1] = vert[3]; v[1][2] = vert[2];
-            tr2 = 3;
-            break;
-         case 5:
-            v[1][0] = vert[3]; v[1][1] = vert[2]; v[1][2] = vert[1];
-            tr2 = 5;
-      }
-
-      int attr = tet->GetAttribute();
-      tet->SetVertices(v[0]);
-
-#ifdef MFEM_USE_MEMALLOC
-      Tetrahedron *tet2 = TetMemory.Alloc();
-      tet2->SetVertices(v[1]);
-      tet2->SetAttribute(attr);
-#else
-      Tetrahedron *tet2 = new Tetrahedron(v[1], attr);
-#endif
-      tet2->ResetTransform(tet->GetTransform());
-      elements.Append(tet2);
-
-      // record the sequence of refinements
-      tet->PushTransform(tr1);
-      tet2->PushTransform(tr2);
-
-      int coarse = FindCoarseElement(i);
-      CoarseFineTr.embeddings[i].parent = coarse;
-      CoarseFineTr.embeddings.Append(Embedding(coarse));
-
-      // 3. Set the bisection flag
-      switch (type)
-      {
-         case Tetrahedron::TYPE_PU:
-            new_type = Tetrahedron::TYPE_PF; break;
-         case Tetrahedron::TYPE_PF:
-            new_type = Tetrahedron::TYPE_A;  break;
-         default:
-            new_type = Tetrahedron::TYPE_PU;
-      }
-
-      tet->CreateRefinementFlag(new_redges[0], new_type, flag+1);
-      tet2->CreateRefinementFlag(new_redges[1], new_type, flag+1);
-
-      NumOfElements++;
-   }
    else
    {
-      MFEM_ABORT("Bisection for now works only for triangles & tetrahedra.");
+      MFEM_ABORT("Bisection for now works only for triangles.");
    }
 }
 
@@ -6831,7 +6713,8 @@ void Mesh::BdrBisection(int i, const HashTable<Hashed2> &v_to_v)
    }
    else
    {
-      MFEM_ABORT("Bisection of boundary elements with HashTable works only for triangles!");
+      MFEM_ABORT("Bisection of boundary elements with HashTable works only for"
+                 " triangles!");
    }
 }
 

--- a/mesh/mesh.hpp
+++ b/mesh/mesh.hpp
@@ -248,13 +248,13 @@ protected:
                         int *edge1, int *edge2, int *middle)
    { Bisection(i, v_to_v, edge1, edge2, middle); }
 
-   /// Bisection. Element with index @a i is bisected.
+   /// Bisect a triangle: element with index @a i is bisected.
    void Bisection(int i, const DSTable &, int *, int *, int *);
 
-   /// Bisection. Element with index @a i is bisected.
+   /// Bisect a tetrahedron: element with index @a i is bisected.
    void Bisection(int i, HashTable<Hashed2> &);
 
-   /// Boundary bisection. Boundary element with index @a i is bisected.
+   /// Bisect a boundary triangle: boundary element with index @a i is bisected.
    void BdrBisection(int i, const HashTable<Hashed2> &);
 
    /** Uniform Refinement. Element with index i is refined uniformly. */

--- a/mesh/mesh.hpp
+++ b/mesh/mesh.hpp
@@ -251,8 +251,14 @@ protected:
    /** Bisection. Element with index i is bisected. */
    void Bisection(int i, const DSTable &, int *, int *, int *);
 
+   /** Bisection. Element or boundary element with index i is bisected. */
+   void Bisection(int i, HashTable<Hashed2> &);
+
    /** Bisection. Boundary element with index i is bisected. */
    void Bisection(int i, const DSTable &, int *);
+
+   /** Bisection. Boundary element with index i is bisected (using HashTable). */
+   void BdrBisection(int i, const HashTable<Hashed2> &);
 
    /** Uniform Refinement. Element with index i is refined uniformly. */
    void UniformRefinement(int i, const DSTable &, int *, int *, int *);

--- a/mesh/mesh.hpp
+++ b/mesh/mesh.hpp
@@ -248,16 +248,13 @@ protected:
                         int *edge1, int *edge2, int *middle)
    { Bisection(i, v_to_v, edge1, edge2, middle); }
 
-   /** Bisection. Element with index i is bisected. */
+   /// Bisection. Element with index @a i is bisected.
    void Bisection(int i, const DSTable &, int *, int *, int *);
 
-   /** Bisection. Element or boundary element with index i is bisected. */
+   /// Bisection. Element with index @a i is bisected.
    void Bisection(int i, HashTable<Hashed2> &);
 
-   /** Bisection. Boundary element with index i is bisected. */
-   void Bisection(int i, const DSTable &, int *);
-
-   /** Bisection. Boundary element with index i is bisected (using HashTable). */
+   /// Boundary bisection. Boundary element with index @a i is bisected.
    void BdrBisection(int i, const HashTable<Hashed2> &);
 
    /** Uniform Refinement. Element with index i is refined uniformly. */

--- a/mesh/pmesh.cpp
+++ b/mesh/pmesh.cpp
@@ -2260,6 +2260,7 @@ void ParMesh::LocalRefinement(const Array<int> &marked_el, int type)
                // it is enough to communicate through the faces
                if (faces_in_group == 0) { continue; }
 
+               face_splittings[i].SetSize(0);
                for (int j = 0; j < faces_in_group; j++)
                {
                   GetFaceSplittings(shared_faces[group_faces[j]], v_to_v,

--- a/mesh/pmesh.hpp
+++ b/mesh/pmesh.hpp
@@ -64,7 +64,6 @@ protected:
    /// Return a number(0-1) identifying how the given edge has been split
    int GetEdgeSplittings(Element *edge, const DSTable &v_to_v, int *middle);
    /// Return a number(0-4) identifying how the given face has been split
-   int GetFaceSplittings(Element *face, const DSTable &v_to_v, int *middle);
    int GetFaceSplittings(Element *face, const HashTable<Hashed2> &v_to_v);
 
    void GetFaceNbrElementTransformation(
@@ -186,8 +185,9 @@ public:
    /// Utility function: sum integers from all processors (Allreduce).
    virtual long ReduceInt(int value) const;
 
-   /// Update the groups after tet refinement
+   /// Update the groups after triangle refinement
    void RefineGroups(const DSTable &v_to_v, int *middle);
+   /// Update the groups after tetrahedron refinement
    void RefineGroups(const HashTable<Hashed2> &v_to_v);
 
    /// Load balance the mesh. NC meshes only.

--- a/mesh/pmesh.hpp
+++ b/mesh/pmesh.hpp
@@ -63,8 +63,11 @@ protected:
 
    /// Return a number(0-1) identifying how the given edge has been split
    int GetEdgeSplittings(Element *edge, const DSTable &v_to_v, int *middle);
-   /// Return a number(0-4) identifying how the given face has been split
+   /// Return a code identifying how the given face has been split
    int GetFaceSplittings(Element *face, const HashTable<Hashed2> &v_to_v);
+
+   bool DecodeFaceSplittings(HashTable<Hashed2> &v_to_v, const int *v,
+                             int code);
 
    void GetFaceNbrElementTransformation(
       int i, IsoparametricTransformation *ElTr);

--- a/mesh/pmesh.hpp
+++ b/mesh/pmesh.hpp
@@ -65,6 +65,7 @@ protected:
    int GetEdgeSplittings(Element *edge, const DSTable &v_to_v, int *middle);
    /// Return a number(0-4) identifying how the given face has been split
    int GetFaceSplittings(Element *face, const DSTable &v_to_v, int *middle);
+   int GetFaceSplittings(Element *face, const HashTable<Hashed2> &v_to_v);
 
    void GetFaceNbrElementTransformation(
       int i, IsoparametricTransformation *ElTr);
@@ -238,6 +239,7 @@ public:
 
    /// Update the groups after tet refinement
    void RefineGroups(const DSTable &v_to_v, int *middle);
+   void RefineGroups(const HashTable<Hashed2> &v_to_v);
 
    /// Load balance the mesh. NC meshes only.
    void Rebalance();

--- a/mesh/pmesh.hpp
+++ b/mesh/pmesh.hpp
@@ -63,11 +63,12 @@ protected:
 
    /// Return a number(0-1) identifying how the given edge has been split
    int GetEdgeSplittings(Element *edge, const DSTable &v_to_v, int *middle);
-   /// Return a code identifying how the given face has been split
-   int GetFaceSplittings(Element *face, const HashTable<Hashed2> &v_to_v);
+   /// Append codes identifying how the given face has been split to @a codes
+   void GetFaceSplittings(Element *face, const HashTable<Hashed2> &v_to_v,
+                          Array<unsigned> &codes);
 
    bool DecodeFaceSplittings(HashTable<Hashed2> &v_to_v, const int *v,
-                             int code);
+                             const Array<unsigned> &codes, int &pos);
 
    void GetFaceNbrElementTransformation(
       int i, IsoparametricTransformation *ElTr);

--- a/mesh/tetrahedron.cpp
+++ b/mesh/tetrahedron.cpp
@@ -172,6 +172,23 @@ int Tetrahedron::NeedRefinement(DSTable &v_to_v, int *middle) const
    return 0;
 }
 
+int Tetrahedron::NeedRefinement(HashTable<Hashed2> &v_to_v) const
+{
+   if (v_to_v.FindId(indices[0], indices[1]) != -1)
+      { return 1; }
+   if (v_to_v.FindId(indices[1], indices[2]) != -1)
+      { return 1; }
+   if (v_to_v.FindId(indices[2], indices[0]) != -1)
+      { return 1; }
+   if (v_to_v.FindId(indices[0], indices[3]) != -1)
+      { return 1; }
+   if (v_to_v.FindId(indices[1], indices[3]) != -1)
+      { return 1; }
+   if (v_to_v.FindId(indices[2], indices[3]) != -1)
+      { return 1; }
+   return 0;
+}
+
 void Tetrahedron::SetVertices(const int *ind)
 {
    for (int i = 0; i < 4; i++)

--- a/mesh/tetrahedron.cpp
+++ b/mesh/tetrahedron.cpp
@@ -153,39 +153,14 @@ void Tetrahedron::GetMarkedFace(const int face, int *fv)
    }
 }
 
-int Tetrahedron::NeedRefinement(DSTable &v_to_v, int *middle) const
-{
-   int m;
-
-   if ((m = v_to_v(indices[0], indices[1])) != -1)
-      if (middle[m] != -1) { return 1; }
-   if ((m = v_to_v(indices[1], indices[2])) != -1)
-      if (middle[m] != -1) { return 1; }
-   if ((m = v_to_v(indices[2], indices[0])) != -1)
-      if (middle[m] != -1) { return 1; }
-   if ((m = v_to_v(indices[0], indices[3])) != -1)
-      if (middle[m] != -1) { return 1; }
-   if ((m = v_to_v(indices[1], indices[3])) != -1)
-      if (middle[m] != -1) { return 1; }
-   if ((m = v_to_v(indices[2], indices[3])) != -1)
-      if (middle[m] != -1) { return 1; }
-   return 0;
-}
-
 int Tetrahedron::NeedRefinement(HashTable<Hashed2> &v_to_v) const
 {
-   if (v_to_v.FindId(indices[0], indices[1]) != -1)
-      { return 1; }
-   if (v_to_v.FindId(indices[1], indices[2]) != -1)
-      { return 1; }
-   if (v_to_v.FindId(indices[2], indices[0]) != -1)
-      { return 1; }
-   if (v_to_v.FindId(indices[0], indices[3]) != -1)
-      { return 1; }
-   if (v_to_v.FindId(indices[1], indices[3]) != -1)
-      { return 1; }
-   if (v_to_v.FindId(indices[2], indices[3]) != -1)
-      { return 1; }
+   if (v_to_v.FindId(indices[0], indices[1]) != -1) { return 1; }
+   if (v_to_v.FindId(indices[1], indices[2]) != -1) { return 1; }
+   if (v_to_v.FindId(indices[2], indices[0]) != -1) { return 1; }
+   if (v_to_v.FindId(indices[0], indices[3]) != -1) { return 1; }
+   if (v_to_v.FindId(indices[1], indices[3]) != -1) { return 1; }
+   if (v_to_v.FindId(indices[2], indices[3]) != -1) { return 1; }
    return 0;
 }
 

--- a/mesh/tetrahedron.hpp
+++ b/mesh/tetrahedron.hpp
@@ -65,6 +65,7 @@ public:
 
    /// Return 1 if the element needs refinement in order to get conforming mesh.
    virtual int NeedRefinement(DSTable &v_to_v, int *middle) const;
+   virtual int NeedRefinement(HashTable<Hashed2> &v_to_v) const;
 
    /// Set the vertices according to the given input.
    virtual void SetVertices(const int *ind);

--- a/mesh/tetrahedron.hpp
+++ b/mesh/tetrahedron.hpp
@@ -64,7 +64,6 @@ public:
    void SetRefinementFlag(int rf) { refinement_flag = rf; }
 
    /// Return 1 if the element needs refinement in order to get conforming mesh.
-   virtual int NeedRefinement(DSTable &v_to_v, int *middle) const;
    virtual int NeedRefinement(HashTable<Hashed2> &v_to_v) const;
 
    /// Set the vertices according to the given input.

--- a/mesh/triangle.cpp
+++ b/mesh/triangle.cpp
@@ -44,6 +44,16 @@ int Triangle::NeedRefinement(DSTable &v_to_v, int *middle) const
    return 0;
 }
 
+int Triangle::NeedRefinement(HashTable<Hashed2> &v_to_v) const
+{
+   int m;
+
+   if (v_to_v.FindId(indices[0], indices[1]) != -1) { return 1; }
+   if (v_to_v.FindId(indices[1], indices[2]) != -1) { return 1; }
+   if (v_to_v.FindId(indices[2], indices[0]) != -1) { return 1; }
+   return 0;
+}
+
 void Triangle::SetVertices(const int *ind)
 {
    for (int i = 0; i < 3; i++)

--- a/mesh/triangle.cpp
+++ b/mesh/triangle.cpp
@@ -34,20 +34,8 @@ Triangle::Triangle(int ind1, int ind2, int ind3, int attr)
    transform = 0;
 }
 
-int Triangle::NeedRefinement(DSTable &v_to_v, int *middle) const
-{
-   int m;
-
-   if ((m = v_to_v(indices[0], indices[1])) != -1 && middle[m] != -1) { return 1; }
-   if ((m = v_to_v(indices[1], indices[2])) != -1 && middle[m] != -1) { return 1; }
-   if ((m = v_to_v(indices[2], indices[0])) != -1 && middle[m] != -1) { return 1; }
-   return 0;
-}
-
 int Triangle::NeedRefinement(HashTable<Hashed2> &v_to_v) const
 {
-   int m;
-
    if (v_to_v.FindId(indices[0], indices[1]) != -1) { return 1; }
    if (v_to_v.FindId(indices[1], indices[2]) != -1) { return 1; }
    if (v_to_v.FindId(indices[2], indices[0]) != -1) { return 1; }

--- a/mesh/triangle.hpp
+++ b/mesh/triangle.hpp
@@ -43,6 +43,7 @@ public:
 
    /// Return 1 if the element needs refinement in order to get conforming mesh.
    virtual int NeedRefinement(DSTable &v_to_v, int *middle) const;
+   virtual int NeedRefinement(HashTable<Hashed2> &v_to_v) const;
 
    /// Set the vertices according to the given input.
    virtual void SetVertices(const int *ind);

--- a/mesh/triangle.hpp
+++ b/mesh/triangle.hpp
@@ -42,7 +42,6 @@ public:
    virtual int GetType() const { return Element::TRIANGLE; }
 
    /// Return 1 if the element needs refinement in order to get conforming mesh.
-   virtual int NeedRefinement(DSTable &v_to_v, int *middle) const;
    virtual int NeedRefinement(HashTable<Hashed2> &v_to_v) const;
 
    /// Set the vertices according to the given input.


### PR DESCRIPTION
Fixed the local refinement for tetrahedral meshes such that no degeneration occurs. I followed @v-dobrev 's suggestion in #512  and used the `HashTable<Hashed2>` object instead of a `DSTable`.

I redid the numerical experiments that led me to this issue and now their results are as expected. 

For now the way `NumOfVertices` is updated is somewhat dirty. Maybe we can add another member variable to `Mesh` that contains the number of vertices of the unrefined mesh and update `NumOfVertices` as before.

Resolves #512.