### PR TITLE
Fixed DenseMatrix::SetSize call argument [FixVectorRestrictedCoefficient]

### DIFF
--- a/fem/coefficient.cpp
+++ b/fem/coefficient.cpp
@@ -209,7 +209,7 @@ void VectorRestrictedCoefficient::Eval(
    }
    else
    {
-      M.SetSize(vdim);
+      M.SetSize(vdim, ir.GetNPoints());
       M = 0.0;
    }
 }


### PR DESCRIPTION
Corrected the size argument so that DenseMatrix reserves the necessary
memory space.

Resolves #539.