### PR TITLE
Adding methods which compute element-wise Lp errors [elementwise-error-dev]

### DIFF
--- a/fem/gridfunc.cpp
+++ b/fem/gridfunc.cpp
@@ -2237,10 +2237,10 @@ double GridFunction::ComputeLpError(const double p, Coefficient &exsol,
    return error;
 }
 
-void GridFunction::ComputeElementLpError(const double p, Coefficient &exsol,
-                                         GridFunction &error,
-                                         Coefficient *weight,
-                                         const IntegrationRule *irs[]) const
+void GridFunction::ComputeElementLpErrors(const double p, Coefficient &exsol,
+                                          GridFunction &error,
+                                          Coefficient *weight,
+                                          const IntegrationRule *irs[]) const
 {
    error = 0.0;
    const FiniteElement *fe;
@@ -2391,12 +2391,12 @@ double GridFunction::ComputeLpError(const double p, VectorCoefficient &exsol,
    return error;
 }
 
-void GridFunction::ComputeElementLpError(const double p,
-                                         VectorCoefficient &exsol,
-                                         GridFunction &error,
-                                         Coefficient *weight,
-                                         VectorCoefficient *v_weight,
-                                         const IntegrationRule *irs[]) const
+void GridFunction::ComputeElementLpErrors(const double p,
+                                          VectorCoefficient &exsol,
+                                          GridFunction &error,
+                                          Coefficient *weight,
+                                          VectorCoefficient *v_weight,
+                                          const IntegrationRule *irs[]) const
 {
    error = 0.0;
    const FiniteElement *fe;

--- a/fem/gridfunc.cpp
+++ b/fem/gridfunc.cpp
@@ -2237,6 +2237,69 @@ double GridFunction::ComputeLpError(const double p, Coefficient &exsol,
    return error;
 }
 
+void GridFunction::ComputeLpError(const double p, Coefficient &exsol,
+				  GridFunction &error,
+				  Coefficient *weight,
+				  const IntegrationRule *irs[]) const
+{
+   error = 0.0;
+   const FiniteElement *fe;
+   ElementTransformation *T;
+   Vector vals;
+
+   for (int i = 0; i < fes->GetNE(); i++)
+   {
+      fe = fes->GetFE(i);
+      const IntegrationRule *ir;
+      if (irs)
+      {
+         ir = irs[fe->GetGeomType()];
+      }
+      else
+      {
+         int intorder = 2*fe->GetOrder() + 1; // <----------
+         ir = &(IntRules.Get(fe->GetGeomType(), intorder));
+      }
+      GetValues(i, *ir, vals);
+      T = fes->GetElementTransformation(i);
+      for (int j = 0; j < ir->GetNPoints(); j++)
+      {
+         const IntegrationPoint &ip = ir->IntPoint(j);
+         T->SetIntPoint(&ip);
+         double err = fabs(vals(j) - exsol.Eval(*T, ip));
+         if (p < infinity())
+         {
+            err = pow(err, p);
+            if (weight)
+            {
+               err *= weight->Eval(*T, ip);
+            }
+            error[i] += ip.weight * T->Weight() * err;
+         }
+         else
+         {
+            if (weight)
+            {
+               err *= weight->Eval(*T, ip);
+            }
+            error[i] = std::max(error[i], err);
+         }
+      }
+      if (p < infinity())
+      {
+	 // negative quadrature weights may cause the error to be negative
+	 if (error[i] < 0.)
+	 {
+	    error[i] = -pow(-error[i], 1./p);
+	 }
+	 else
+	 {
+ 	    error[i] = pow(error[i], 1./p);
+	 }
+      }
+   }
+}
+
 double GridFunction::ComputeLpError(const double p, VectorCoefficient &exsol,
                                     Coefficient *weight,
                                     VectorCoefficient *v_weight,
@@ -2326,6 +2389,95 @@ double GridFunction::ComputeLpError(const double p, VectorCoefficient &exsol,
    }
 
    return error;
+}
+
+void GridFunction::ComputeLpError(const double p, VectorCoefficient &exsol,
+				  GridFunction &error,
+				  Coefficient *weight,
+				  VectorCoefficient *v_weight,
+				  const IntegrationRule *irs[]) const
+{
+   error = 0.0;
+   const FiniteElement *fe;
+   ElementTransformation *T;
+   DenseMatrix vals, exact_vals;
+   Vector loc_errs;
+
+   for (int i = 0; i < fes->GetNE(); i++)
+   {
+      fe = fes->GetFE(i);
+      const IntegrationRule *ir;
+      if (irs)
+      {
+         ir = irs[fe->GetGeomType()];
+      }
+      else
+      {
+         int intorder = 2*fe->GetOrder() + 1; // <----------
+         ir = &(IntRules.Get(fe->GetGeomType(), intorder));
+      }
+      T = fes->GetElementTransformation(i);
+      GetVectorValues(*T, *ir, vals);
+      exsol.Eval(exact_vals, *T, *ir);
+      vals -= exact_vals;
+      loc_errs.SetSize(vals.Width());
+      if (!v_weight)
+      {
+         // compute the lengths of the errors at the integration points
+         // thus the vector norm is rotationally invariant
+         vals.Norm2(loc_errs);
+      }
+      else
+      {
+         v_weight->Eval(exact_vals, *T, *ir);
+         // column-wise dot product of the vector error (in vals) and the
+         // vector weight (in exact_vals)
+         for (int j = 0; j < vals.Width(); j++)
+         {
+            double err = 0.0;
+            for (int d = 0; d < vals.Height(); d++)
+            {
+               err += vals(d,j)*exact_vals(d,j);
+            }
+            loc_errs(j) = fabs(err);
+         }
+      }
+      for (int j = 0; j < ir->GetNPoints(); j++)
+      {
+         const IntegrationPoint &ip = ir->IntPoint(j);
+         T->SetIntPoint(&ip);
+         double err = loc_errs(j);
+         if (p < infinity())
+         {
+            err = pow(err, p);
+            if (weight)
+            {
+               err *= weight->Eval(*T, ip);
+            }
+            error[i] += ip.weight * T->Weight() * err;
+         }
+         else
+         {
+            if (weight)
+            {
+               err *= weight->Eval(*T, ip);
+            }
+            error[i] = std::max(error[i], err);
+         }
+      }
+      if (p < infinity())
+      {
+         // negative quadrature weights may cause the error to be negative
+	 if (error[i] < 0.)
+         {
+            error[i] = -pow(-error[i], 1./p);
+	 }
+	 else
+	 {
+            error[i] = pow(error[i], 1./p);
+	 }
+      }
+   }
 }
 
 GridFunction & GridFunction::operator=(double value)

--- a/fem/gridfunc.cpp
+++ b/fem/gridfunc.cpp
@@ -2238,9 +2238,9 @@ double GridFunction::ComputeLpError(const double p, Coefficient &exsol,
 }
 
 void GridFunction::ComputeLpError(const double p, Coefficient &exsol,
-				  GridFunction &error,
-				  Coefficient *weight,
-				  const IntegrationRule *irs[]) const
+                                  GridFunction &error,
+                                  Coefficient *weight,
+                                  const IntegrationRule *irs[]) const
 {
    error = 0.0;
    const FiniteElement *fe;
@@ -2287,15 +2287,15 @@ void GridFunction::ComputeLpError(const double p, Coefficient &exsol,
       }
       if (p < infinity())
       {
-	 // negative quadrature weights may cause the error to be negative
-	 if (error[i] < 0.)
-	 {
-	    error[i] = -pow(-error[i], 1./p);
-	 }
-	 else
-	 {
- 	    error[i] = pow(error[i], 1./p);
-	 }
+         // negative quadrature weights may cause the error to be negative
+         if (error[i] < 0.)
+         {
+            error[i] = -pow(-error[i], 1./p);
+         }
+         else
+         {
+            error[i] = pow(error[i], 1./p);
+         }
       }
    }
 }
@@ -2392,10 +2392,10 @@ double GridFunction::ComputeLpError(const double p, VectorCoefficient &exsol,
 }
 
 void GridFunction::ComputeLpError(const double p, VectorCoefficient &exsol,
-				  GridFunction &error,
-				  Coefficient *weight,
-				  VectorCoefficient *v_weight,
-				  const IntegrationRule *irs[]) const
+                                  GridFunction &error,
+                                  Coefficient *weight,
+                                  VectorCoefficient *v_weight,
+                                  const IntegrationRule *irs[]) const
 {
    error = 0.0;
    const FiniteElement *fe;
@@ -2468,14 +2468,14 @@ void GridFunction::ComputeLpError(const double p, VectorCoefficient &exsol,
       if (p < infinity())
       {
          // negative quadrature weights may cause the error to be negative
-	 if (error[i] < 0.)
+         if (error[i] < 0.)
          {
             error[i] = -pow(-error[i], 1./p);
-	 }
-	 else
-	 {
+         }
+         else
+         {
             error[i] = pow(error[i], 1./p);
-	 }
+         }
       }
    }
 }

--- a/fem/gridfunc.cpp
+++ b/fem/gridfunc.cpp
@@ -2237,10 +2237,10 @@ double GridFunction::ComputeLpError(const double p, Coefficient &exsol,
    return error;
 }
 
-void GridFunction::ComputeLpError(const double p, Coefficient &exsol,
-                                  GridFunction &error,
-                                  Coefficient *weight,
-                                  const IntegrationRule *irs[]) const
+void GridFunction::ComputeElementLpError(const double p, Coefficient &exsol,
+                                         GridFunction &error,
+                                         Coefficient *weight,
+                                         const IntegrationRule *irs[]) const
 {
    error = 0.0;
    const FiniteElement *fe;
@@ -2391,11 +2391,12 @@ double GridFunction::ComputeLpError(const double p, VectorCoefficient &exsol,
    return error;
 }
 
-void GridFunction::ComputeLpError(const double p, VectorCoefficient &exsol,
-                                  GridFunction &error,
-                                  Coefficient *weight,
-                                  VectorCoefficient *v_weight,
-                                  const IntegrationRule *irs[]) const
+void GridFunction::ComputeElementLpError(const double p,
+                                         VectorCoefficient &exsol,
+                                         GridFunction &error,
+                                         Coefficient *weight,
+                                         VectorCoefficient *v_weight,
+                                         const IntegrationRule *irs[]) const
 {
    error = 0.0;
    const FiniteElement *fe;

--- a/fem/gridfunc.hpp
+++ b/fem/gridfunc.hpp
@@ -309,25 +309,27 @@ public:
    /** Compute the Lp error in each element of the mesh and store the
        results in a GridFunction, error.  The result should be an L2
        GridFunction of order zero using map type VALUE. */
-   virtual void ComputeLpError(const double p, Coefficient &exsol,
-                               GridFunction &error,
-                               Coefficient *weight = NULL,
-                               const IntegrationRule *irs[] = NULL) const;
+   virtual void ComputeElementLpError(const double p, Coefficient &exsol,
+                                      GridFunction &error,
+                                      Coefficient *weight = NULL,
+                                      const IntegrationRule *irs[] = NULL
+                                     ) const;
 
-   virtual void ComputeL1Error(Coefficient &exsol,
-                               GridFunction &error,
-                               const IntegrationRule *irs[] = NULL) const
-   { ComputeLpError(1.0, exsol, error, NULL, irs); }
+   virtual void ComputeElementL1Error(Coefficient &exsol,
+                                      GridFunction &error,
+                                      const IntegrationRule *irs[] = NULL) const
+   { ComputeElementLpError(1.0, exsol, error, NULL, irs); }
 
-   virtual void ComputeL2Error(Coefficient &exsol,
-                               GridFunction &error,
-                               const IntegrationRule *irs[] = NULL) const
-   { ComputeLpError(2.0, exsol, error, NULL, irs); }
+   virtual void ComputeElementL2Error(Coefficient &exsol,
+                                      GridFunction &error,
+                                      const IntegrationRule *irs[] = NULL) const
+   { ComputeElementLpError(2.0, exsol, error, NULL, irs); }
 
-   virtual void ComputeMaxError(Coefficient &exsol,
-                                GridFunction &error,
-                                const IntegrationRule *irs[] = NULL) const
-   { ComputeLpError(infinity(), exsol, error, NULL, irs); }
+   virtual void ComputeElementMaxError(Coefficient &exsol,
+                                       GridFunction &error,
+                                       const IntegrationRule *irs[] = NULL
+                                      ) const
+   { ComputeElementLpError(infinity(), exsol, error, NULL, irs); }
 
    /** When given a vector weight, compute the pointwise (scalar) error as the
        dot product of the vector error with the vector weight. Otherwise, the
@@ -340,26 +342,28 @@ public:
    /** Compute the Lp error in each element of the mesh and store the
        results in a GridFunction, error.  The result should be an L2
        GridFunction of order zero using map type VALUE. */
-   virtual void ComputeLpError(const double p, VectorCoefficient &exsol,
-                               GridFunction &error,
-                               Coefficient *weight = NULL,
-                               VectorCoefficient *v_weight = NULL,
-                               const IntegrationRule *irs[] = NULL) const;
+   virtual void ComputeElementLpError(const double p, VectorCoefficient &exsol,
+                                      GridFunction &error,
+                                      Coefficient *weight = NULL,
+                                      VectorCoefficient *v_weight = NULL,
+                                      const IntegrationRule *irs[] = NULL
+                                     ) const;
 
-   virtual void ComputeL1Error(VectorCoefficient &exsol,
-                               GridFunction &error,
-                               const IntegrationRule *irs[] = NULL) const
-   { ComputeLpError(1.0, exsol, error, NULL, NULL, irs); }
+   virtual void ComputeElementL1Error(VectorCoefficient &exsol,
+                                      GridFunction &error,
+                                      const IntegrationRule *irs[] = NULL) const
+   { ComputeElementLpError(1.0, exsol, error, NULL, NULL, irs); }
 
-   virtual void ComputeL2Error(VectorCoefficient &exsol,
-                               GridFunction &error,
-                               const IntegrationRule *irs[] = NULL) const
-   { ComputeLpError(2.0, exsol, error, NULL, NULL, irs); }
+   virtual void ComputeElementL2Error(VectorCoefficient &exsol,
+                                      GridFunction &error,
+                                      const IntegrationRule *irs[] = NULL) const
+   { ComputeElementLpError(2.0, exsol, error, NULL, NULL, irs); }
 
-   virtual void ComputeMaxError(VectorCoefficient &exsol,
-                                GridFunction &error,
-                                const IntegrationRule *irs[] = NULL) const
-   { ComputeLpError(infinity(), exsol, error, NULL, NULL, irs); }
+   virtual void ComputeElementMaxError(VectorCoefficient &exsol,
+                                       GridFunction &error,
+                                       const IntegrationRule *irs[] = NULL
+                                      ) const
+   { ComputeElementLpError(infinity(), exsol, error, NULL, NULL, irs); }
 
    virtual void ComputeFlux(BilinearFormIntegrator &blfi,
                             GridFunction &flux,

--- a/fem/gridfunc.hpp
+++ b/fem/gridfunc.hpp
@@ -306,6 +306,29 @@ public:
                                  Coefficient *weight = NULL,
                                  const IntegrationRule *irs[] = NULL) const;
 
+   /** Compute the Lp error in each element of the mesh and store the
+       results in a GridFunction, error.  The result should be an L2
+       GridFunction of order zero using map type VALUE. */
+   virtual void ComputeLpError(const double p, Coefficient &exsol,
+			       GridFunction &error,
+			       Coefficient *weight = NULL,
+			       const IntegrationRule *irs[] = NULL) const;
+
+   virtual void ComputeL1Error(Coefficient &exsol,
+			       GridFunction &error,
+			       const IntegrationRule *irs[] = NULL) const
+   { ComputeLpError(1.0, exsol, error, NULL, irs); }
+
+   virtual void ComputeL2Error(Coefficient &exsol,
+			       GridFunction &error,
+			       const IntegrationRule *irs[] = NULL) const
+   { ComputeLpError(2.0, exsol, error, NULL, irs); }
+
+   virtual void ComputeMaxError(Coefficient &exsol,
+				GridFunction &error,
+				const IntegrationRule *irs[] = NULL) const
+   { ComputeLpError(infinity(), exsol, error, NULL, irs); }
+
    /** When given a vector weight, compute the pointwise (scalar) error as the
        dot product of the vector error with the vector weight. Otherwise, the
        scalar error is the l_2 norm of the vector error. */
@@ -313,6 +336,30 @@ public:
                                  Coefficient *weight = NULL,
                                  VectorCoefficient *v_weight = NULL,
                                  const IntegrationRule *irs[] = NULL) const;
+
+   /** Compute the Lp error in each element of the mesh and store the
+       results in a GridFunction, error.  The result should be an L2
+       GridFunction of order zero using map type VALUE. */
+   virtual void ComputeLpError(const double p, VectorCoefficient &exsol,
+			       GridFunction &error,
+			       Coefficient *weight = NULL,
+			       VectorCoefficient *v_weight = NULL,
+			       const IntegrationRule *irs[] = NULL) const;
+
+   virtual void ComputeL1Error(VectorCoefficient &exsol,
+			       GridFunction &error,
+			       const IntegrationRule *irs[] = NULL) const
+   { ComputeLpError(1.0, exsol, error, NULL, NULL, irs); }
+
+   virtual void ComputeL2Error(VectorCoefficient &exsol,
+			       GridFunction &error,
+			       const IntegrationRule *irs[] = NULL) const
+   { ComputeLpError(2.0, exsol, error, NULL, NULL, irs); }
+
+   virtual void ComputeMaxError(VectorCoefficient &exsol,
+				GridFunction &error,
+				const IntegrationRule *irs[] = NULL) const
+   { ComputeLpError(infinity(), exsol, error, NULL, NULL, irs); }
 
    virtual void ComputeFlux(BilinearFormIntegrator &blfi,
                             GridFunction &flux,

--- a/fem/gridfunc.hpp
+++ b/fem/gridfunc.hpp
@@ -306,9 +306,9 @@ public:
                                  Coefficient *weight = NULL,
                                  const IntegrationRule *irs[] = NULL) const;
 
-   /** Compute the Lp error in each element of the mesh and store the
-       results in a GridFunction, error.  The result should be an L2
-       GridFunction of order zero using map type VALUE. */
+   /** Compute the Lp error in each element of the mesh and store the results in
+       the GridFunction @a error. The result should be an L2 GridFunction of
+       order zero using map type VALUE. */
    virtual void ComputeElementLpErrors(const double p, Coefficient &exsol,
                                        GridFunction &error,
                                        Coefficient *weight = NULL,
@@ -341,9 +341,9 @@ public:
                                  VectorCoefficient *v_weight = NULL,
                                  const IntegrationRule *irs[] = NULL) const;
 
-   /** Compute the Lp error in each element of the mesh and store the
-       results in a GridFunction, error.  The result should be an L2
-       GridFunction of order zero using map type VALUE. */
+   /** Compute the Lp error in each element of the mesh and store the results in
+       the GridFunction @ error. The result should be an L2 GridFunction of
+       order zero using map type VALUE. */
    virtual void ComputeElementLpErrors(const double p, VectorCoefficient &exsol,
                                        GridFunction &error,
                                        Coefficient *weight = NULL,

--- a/fem/gridfunc.hpp
+++ b/fem/gridfunc.hpp
@@ -309,27 +309,29 @@ public:
    /** Compute the Lp error in each element of the mesh and store the
        results in a GridFunction, error.  The result should be an L2
        GridFunction of order zero using map type VALUE. */
-   virtual void ComputeElementLpError(const double p, Coefficient &exsol,
-                                      GridFunction &error,
-                                      Coefficient *weight = NULL,
-                                      const IntegrationRule *irs[] = NULL
-                                     ) const;
+   virtual void ComputeElementLpErrors(const double p, Coefficient &exsol,
+                                       GridFunction &error,
+                                       Coefficient *weight = NULL,
+                                       const IntegrationRule *irs[] = NULL
+                                      ) const;
 
-   virtual void ComputeElementL1Error(Coefficient &exsol,
-                                      GridFunction &error,
-                                      const IntegrationRule *irs[] = NULL) const
-   { ComputeElementLpError(1.0, exsol, error, NULL, irs); }
-
-   virtual void ComputeElementL2Error(Coefficient &exsol,
-                                      GridFunction &error,
-                                      const IntegrationRule *irs[] = NULL) const
-   { ComputeElementLpError(2.0, exsol, error, NULL, irs); }
-
-   virtual void ComputeElementMaxError(Coefficient &exsol,
+   virtual void ComputeElementL1Errors(Coefficient &exsol,
                                        GridFunction &error,
                                        const IntegrationRule *irs[] = NULL
                                       ) const
-   { ComputeElementLpError(infinity(), exsol, error, NULL, irs); }
+   { ComputeElementLpErrors(1.0, exsol, error, NULL, irs); }
+
+   virtual void ComputeElementL2Errors(Coefficient &exsol,
+                                       GridFunction &error,
+                                       const IntegrationRule *irs[] = NULL
+                                      ) const
+   { ComputeElementLpErrors(2.0, exsol, error, NULL, irs); }
+
+   virtual void ComputeElementMaxErrors(Coefficient &exsol,
+                                        GridFunction &error,
+                                        const IntegrationRule *irs[] = NULL
+                                       ) const
+   { ComputeElementLpErrors(infinity(), exsol, error, NULL, irs); }
 
    /** When given a vector weight, compute the pointwise (scalar) error as the
        dot product of the vector error with the vector weight. Otherwise, the
@@ -342,28 +344,30 @@ public:
    /** Compute the Lp error in each element of the mesh and store the
        results in a GridFunction, error.  The result should be an L2
        GridFunction of order zero using map type VALUE. */
-   virtual void ComputeElementLpError(const double p, VectorCoefficient &exsol,
-                                      GridFunction &error,
-                                      Coefficient *weight = NULL,
-                                      VectorCoefficient *v_weight = NULL,
-                                      const IntegrationRule *irs[] = NULL
-                                     ) const;
+   virtual void ComputeElementLpErrors(const double p, VectorCoefficient &exsol,
+                                       GridFunction &error,
+                                       Coefficient *weight = NULL,
+                                       VectorCoefficient *v_weight = NULL,
+                                       const IntegrationRule *irs[] = NULL
+                                      ) const;
 
-   virtual void ComputeElementL1Error(VectorCoefficient &exsol,
-                                      GridFunction &error,
-                                      const IntegrationRule *irs[] = NULL) const
-   { ComputeElementLpError(1.0, exsol, error, NULL, NULL, irs); }
-
-   virtual void ComputeElementL2Error(VectorCoefficient &exsol,
-                                      GridFunction &error,
-                                      const IntegrationRule *irs[] = NULL) const
-   { ComputeElementLpError(2.0, exsol, error, NULL, NULL, irs); }
-
-   virtual void ComputeElementMaxError(VectorCoefficient &exsol,
+   virtual void ComputeElementL1Errors(VectorCoefficient &exsol,
                                        GridFunction &error,
                                        const IntegrationRule *irs[] = NULL
                                       ) const
-   { ComputeElementLpError(infinity(), exsol, error, NULL, NULL, irs); }
+   { ComputeElementLpErrors(1.0, exsol, error, NULL, NULL, irs); }
+
+   virtual void ComputeElementL2Errors(VectorCoefficient &exsol,
+                                       GridFunction &error,
+                                       const IntegrationRule *irs[] = NULL
+                                      ) const
+   { ComputeElementLpErrors(2.0, exsol, error, NULL, NULL, irs); }
+
+   virtual void ComputeElementMaxErrors(VectorCoefficient &exsol,
+                                        GridFunction &error,
+                                        const IntegrationRule *irs[] = NULL
+                                       ) const
+   { ComputeElementLpErrors(infinity(), exsol, error, NULL, NULL, irs); }
 
    virtual void ComputeFlux(BilinearFormIntegrator &blfi,
                             GridFunction &flux,

--- a/fem/gridfunc.hpp
+++ b/fem/gridfunc.hpp
@@ -310,23 +310,23 @@ public:
        results in a GridFunction, error.  The result should be an L2
        GridFunction of order zero using map type VALUE. */
    virtual void ComputeLpError(const double p, Coefficient &exsol,
-			       GridFunction &error,
-			       Coefficient *weight = NULL,
-			       const IntegrationRule *irs[] = NULL) const;
+                               GridFunction &error,
+                               Coefficient *weight = NULL,
+                               const IntegrationRule *irs[] = NULL) const;
 
    virtual void ComputeL1Error(Coefficient &exsol,
-			       GridFunction &error,
-			       const IntegrationRule *irs[] = NULL) const
+                               GridFunction &error,
+                               const IntegrationRule *irs[] = NULL) const
    { ComputeLpError(1.0, exsol, error, NULL, irs); }
 
    virtual void ComputeL2Error(Coefficient &exsol,
-			       GridFunction &error,
-			       const IntegrationRule *irs[] = NULL) const
+                               GridFunction &error,
+                               const IntegrationRule *irs[] = NULL) const
    { ComputeLpError(2.0, exsol, error, NULL, irs); }
 
    virtual void ComputeMaxError(Coefficient &exsol,
-				GridFunction &error,
-				const IntegrationRule *irs[] = NULL) const
+                                GridFunction &error,
+                                const IntegrationRule *irs[] = NULL) const
    { ComputeLpError(infinity(), exsol, error, NULL, irs); }
 
    /** When given a vector weight, compute the pointwise (scalar) error as the
@@ -341,24 +341,24 @@ public:
        results in a GridFunction, error.  The result should be an L2
        GridFunction of order zero using map type VALUE. */
    virtual void ComputeLpError(const double p, VectorCoefficient &exsol,
-			       GridFunction &error,
-			       Coefficient *weight = NULL,
-			       VectorCoefficient *v_weight = NULL,
-			       const IntegrationRule *irs[] = NULL) const;
+                               GridFunction &error,
+                               Coefficient *weight = NULL,
+                               VectorCoefficient *v_weight = NULL,
+                               const IntegrationRule *irs[] = NULL) const;
 
    virtual void ComputeL1Error(VectorCoefficient &exsol,
-			       GridFunction &error,
-			       const IntegrationRule *irs[] = NULL) const
+                               GridFunction &error,
+                               const IntegrationRule *irs[] = NULL) const
    { ComputeLpError(1.0, exsol, error, NULL, NULL, irs); }
 
    virtual void ComputeL2Error(VectorCoefficient &exsol,
-			       GridFunction &error,
-			       const IntegrationRule *irs[] = NULL) const
+                               GridFunction &error,
+                               const IntegrationRule *irs[] = NULL) const
    { ComputeLpError(2.0, exsol, error, NULL, NULL, irs); }
 
    virtual void ComputeMaxError(VectorCoefficient &exsol,
-				GridFunction &error,
-				const IntegrationRule *irs[] = NULL) const
+                                GridFunction &error,
+                                const IntegrationRule *irs[] = NULL) const
    { ComputeLpError(infinity(), exsol, error, NULL, NULL, irs); }
 
    virtual void ComputeFlux(BilinearFormIntegrator &blfi,


### PR DESCRIPTION
These methods can be useful for plotting the spatial distribution of error when an exact solution is known.  They could also be handy for evaluating local error estimators.