### PR TITLE
Extract bdr dofs

### DIFF
--- a/examples/ex9.cpp
+++ b/examples/ex9.cpp
@@ -148,7 +148,7 @@ private:
 
       int dim = fes->GetMesh()->Dimension();
       int num_cells = fes->GetNE();
-      int NDOFs        = fes->GetVSize();
+      int NDOFs = fes->GetVSize();
       int NDOFs_shared = 0; //fes->num_face_nbr_dofs;
       DOFs_coord.SetSize(dim, NDOFs + NDOFs_shared);
 
@@ -206,8 +206,8 @@ private:
 
       int dim = mesh->Dimension();
       int num_cells = mesh->GetNE();
-      int NDOFs     = fes->GetVSize();
-      double dist=0;
+      int NDOFs = fes->GetVSize();
+      double dist = 0;
       const double tol = 1e-10;
       // hk at ref element with some tolerance
       //double dist_level = 1.0 / fes->GetOrder(0) + tol;
@@ -750,9 +750,9 @@ int main(int argc, char *argv[])
    args.AddOption(&ode_solver_type, "-s", "--ode-solver",
                   "ODE solver: 1 - Forward Euler,\n\t"
                   "            2 - RK2 SSP, 3 - RK3 SSP, 4 - RK4, 6 - RK6.");
-   //args.AddOption(&mono, "-mt", "--mono",
-   //               "Type of monotonicity treatment: 0 - no monotonicity treatment,\n\t"
-   //               "                                1 - matrix-free Rusanov scheme.");
+   args.AddOption((int*)(&mono), "-mt", "--mono",
+                  "Type of monotonicity treatment: 0 - no monotonicity treatment,\n\t"
+                  "                                1 - matrix-free Rusanov scheme.");
    args.AddOption(&t_final, "-tf", "--t-final",
                   "Final time; start time is 0.");
    args.AddOption(&dt, "-dt", "--time-step",
@@ -867,7 +867,7 @@ int main(int argc, char *argv[])
    DenseMatrix bdrDiff;
    preprocessLowOrderScheme(&fes, velocity, mono, elDiff, bdrDiff, lumpedM);
    
-   int method = 1; // from sparsity
+   int method = 0; // from sparsity
 //   int method = 1; // local bounds
    SolutionBounds bnds(&fes, k, method);
 

--- a/examples/ex9.cpp
+++ b/examples/ex9.cpp
@@ -656,8 +656,8 @@ void FE_Evolution::Mult(const Vector &x, Vector &y) const
                uSum += x(k*nd+dofs[j]);
             
             // boundary update
-            for (j = 0; j < nd; j++)
-               z(k*nd+j) += bdrDiff(k,i)*(uSum - numDofs*x(k*nd+j));
+            for (j = 0; j < numDofs; j++)
+               z(k*nd+dofs[j]) += bdrDiff(k,i)*(uSum - numDofs*x(k*nd+dofs[j]));
          }
          ///////////////////////////
          // Element contributions //

--- a/examples/ex9.cpp
+++ b/examples/ex9.cpp
@@ -334,14 +334,14 @@ void preprocessLowOrderScheme(FiniteElementSpace* fes, VectorFunctionCoefficient
 int main(int argc, char *argv[])
 {
    // 1. Parse command-line options.
-   problem = 1;
+   problem = 0;
    const char *mesh_file = "../data/periodic-hexagon.mesh";
-   int ref_levels = 4;
-   int order = 0;
-   int ode_solver_type = 1;
+   int ref_levels = 2;
+   int order = 3;
+   int ode_solver_type = 4;
    int mono_type = 1;
-   double t_final = 1.0;
-   double dt = 0.001;
+   double t_final = 10.0;
+   double dt = 0.01;
    bool visualization = true;
    bool visit = false;
    bool binary = false;
@@ -586,6 +586,7 @@ int main(int argc, char *argv[])
    delete ode_solver;
    delete dc;
    return 0;
+   
 }
 
 
@@ -605,7 +606,6 @@ FE_Evolution::FE_Evolution(FiniteElementSpace* _fes, SparseMatrix &_M, SparseMat
    M_solver.SetMaxIter(100);
    M_solver.SetPrintLevel(0);
 }
-
 
 void FE_Evolution::Mult(const Vector &x, Vector &y) const
 {
@@ -675,6 +675,7 @@ void FE_Evolution::Mult(const Vector &x, Vector &y) const
       }
    }
 }
+
 
 // Velocity coefficient
 void velocity_function(const Vector &x, Vector &v)

--- a/examples/ex9.cpp
+++ b/examples/ex9.cpp
@@ -363,7 +363,8 @@ int main(int argc, char *argv[])
                   "ODE solver: 1 - Forward Euler,\n\t"
                   "            2 - RK2 SSP, 3 - RK3 SSP, 4 - RK4, 6 - RK6.");
    args.AddOption(&mono_type, "-mt", "--mono_type",
-                  "Type of monotonicity treatment.");
+                  "Type of monotonicity treatment: 0 - no monotonicity treatment,\n\t"
+                  "                                1 - matrix-free Rusanov scheme.");
    args.AddOption(&t_final, "-tf", "--t-final",
                   "Final time; start time is 0.");
    args.AddOption(&dt, "-dt", "--time-step",
@@ -437,6 +438,8 @@ int main(int argc, char *argv[])
       if (order==0)
          mfem_warning("No need to use monotonicity treatment for polynomial order 0.");
    }
+   else if (mono_type!=0)
+      mfem_error("Unsupported option for monotonicity treatment.");
 
    cout << "Number of unknowns: " << fes.GetVSize() << endl;
 

--- a/fem/fe.hpp
+++ b/fem/fe.hpp
@@ -429,6 +429,12 @@ public:
    {
       return BasisType::CheckNodal(b_type);
    }
+
+   /** Routine that extracts the indices of all p-th order Bernstein basis functions
+       that are non-zero on each of the (dim-1)-dimensional boundaries of a finite
+       element. The columns of dofs hold the indices of basis functions corresponding
+       to one respective boundary defined according to the class Geometry. */
+   virtual void ExtractBdrDofs(DenseMatrix &dofs) const;
 };
 
 class ScalarFiniteElement : public FiniteElement
@@ -474,6 +480,9 @@ public:
    void ScalarLocalInterpolation(ElementTransformation &Trans,
                                  DenseMatrix &I,
                                  const ScalarFiniteElement &fine_fe) const;
+
+   /// Overrides the ExtractBdrDofs function to print an error.
+   virtual void ExtractBdrDofs(DenseMatrix &dofs) const;
 };
 
 class NodalFiniteElement : public ScalarFiniteElement
@@ -516,6 +525,9 @@ public:
    virtual void ProjectDiv(const FiniteElement &fe,
                            ElementTransformation &Trans,
                            DenseMatrix &div) const;
+
+   /// Overrides the ExtractBdrDofs function to print an error.
+   virtual void ExtractBdrDofs(DenseMatrix &dofs) const;
 };
 
 
@@ -545,6 +557,9 @@ public:
 
    virtual void Project(const FiniteElement &fe, ElementTransformation &Trans,
                         DenseMatrix &I) const;
+
+   /// Overrides the ExtractBdrDofs function to print an error.
+   virtual void ExtractBdrDofs(DenseMatrix &dofs) const;
 };
 
 class VectorFiniteElement : public FiniteElement
@@ -644,6 +659,9 @@ public:
       FiniteElement(D, G, Do, O, F), Jinv(D)
    { RangeType = VECTOR; MapType = M; SetDerivMembers(); }
 #endif
+
+   /// Overrides the ExtractBdrDofs function to print an error.
+   virtual void ExtractBdrDofs(DenseMatrix &dofs) const;
 };
 
 class PointFiniteElement : public NodalFiniteElement
@@ -786,6 +804,7 @@ public:
    virtual void CalcShape(const IntegrationPoint &ip, Vector &shape) const;
    virtual void CalcDShape(const IntegrationPoint &ip,
                            DenseMatrix &dshape) const;
+   void ExtractBdrDofs(DenseMatrix &dofs) const;
 };
 
 /// Class for quadratic FE on triangle
@@ -865,6 +884,7 @@ public:
                         Vector &dofs) const;
    virtual void ProjectDelta(int vertex, Vector &dofs) const
    { dofs = 0.; dofs(vertex) = 1.; }
+   void ExtractBdrDofs(DenseMatrix &dofs) const;
 };
 
 /// Bi-quadratic element on quad with nodes at the 9 Gaussian points
@@ -1710,6 +1730,9 @@ class PositiveTensorFiniteElement : public PositiveFiniteElement,
 public:
    PositiveTensorFiniteElement(const int dims, const int p,
                                const DofMapType dmtype);
+
+   /// Overrides the ExtractBdrDofs function to print an error.
+   virtual void ExtractBdrDofs(DenseMatrix &dofs) const;
 };
 
 class H1_SegmentElement : public NodalTensorFiniteElement
@@ -1778,6 +1801,7 @@ public:
    virtual void CalcDShape(const IntegrationPoint &ip,
                            DenseMatrix &dshape) const;
    virtual void ProjectDelta(int vertex, Vector &dofs) const;
+   void ExtractBdrDofs(DenseMatrix &dofs) const;
 };
 
 
@@ -1795,6 +1819,7 @@ public:
    virtual void CalcDShape(const IntegrationPoint &ip,
                            DenseMatrix &dshape) const;
    virtual void ProjectDelta(int vertex, Vector &dofs) const;
+   void ExtractBdrDofs(DenseMatrix &dofs) const;
 };
 
 
@@ -1812,6 +1837,7 @@ public:
    virtual void CalcDShape(const IntegrationPoint &ip,
                            DenseMatrix &dshape) const;
    virtual void ProjectDelta(int vertex, Vector &dofs) const;
+   void ExtractBdrDofs(DenseMatrix &dofs) const;
 };
 
 
@@ -1874,6 +1900,7 @@ public:
    virtual void CalcShape(const IntegrationPoint &ip, Vector &shape) const;
    virtual void CalcDShape(const IntegrationPoint &ip,
                            DenseMatrix &dshape) const;
+   void ExtractBdrDofs(DenseMatrix &dofs) const;
 };
 
 
@@ -1900,6 +1927,7 @@ public:
    virtual void CalcShape(const IntegrationPoint &ip, Vector &shape) const;
    virtual void CalcDShape(const IntegrationPoint &ip,
                            DenseMatrix &dshape) const;
+   void ExtractBdrDofs(DenseMatrix &dofs) const;
 };
 
 
@@ -1932,6 +1960,7 @@ public:
    virtual void CalcDShape(const IntegrationPoint &ip,
                            DenseMatrix &dshape) const;
    virtual void ProjectDelta(int vertex, Vector &dofs) const;
+   void ExtractBdrDofs(DenseMatrix &dofs) const;
 };
 
 
@@ -1969,6 +1998,7 @@ public:
    virtual void CalcDShape(const IntegrationPoint &ip,
                            DenseMatrix &dshape) const;
    virtual void ProjectDelta(int vertex, Vector &dofs) const;
+   void ExtractBdrDofs(DenseMatrix &dofs) const;
 };
 
 
@@ -2002,6 +2032,7 @@ public:
    virtual void CalcDShape(const IntegrationPoint &ip,
                            DenseMatrix &dshape) const;
    virtual void ProjectDelta(int vertex, Vector &dofs) const;
+   void ExtractBdrDofs(DenseMatrix &dofs) const;
 };
 
 
@@ -2041,6 +2072,7 @@ public:
    virtual void CalcDShape(const IntegrationPoint &ip,
                            DenseMatrix &dshape) const;
    virtual void ProjectDelta(int vertex, Vector &dofs) const;
+   void ExtractBdrDofs(DenseMatrix &dofs) const;
 };
 
 
@@ -2077,6 +2109,7 @@ public:
    virtual void CalcDShape(const IntegrationPoint &ip,
                            DenseMatrix &dshape) const;
    virtual void ProjectDelta(int vertex, Vector &dofs) const;
+   void ExtractBdrDofs(DenseMatrix &dofs) const;
 };
 
 
@@ -2556,6 +2589,9 @@ public:
    Vector              &Weights    ()         const { return weights; }
    /// Update the NURBSFiniteElement according to the currently set knot vectors
    virtual void         SetOrder   ()         const { }
+
+   /// Overrides the ExtractBdrDofs function to print an error.
+   virtual void ExtractBdrDofs(DenseMatrix &dofs) const;
 };
 
 class NURBS1DFiniteElement : public NURBSFiniteElement


### PR DESCRIPTION
For my matrix-free-FCT purposes I required the local indices of Bernstein (this is essential, it doesn't make much sense for other bases!!!) basis functions on boundaries. Orientation is not considered and the routines may be optimisable but I just call any of them once per simulation, and don't care about the order of DOFs, i.e. this is optimal for my purposes. 