### PR TITLE
[DISCUSS] Modifies the interface of PArray and PVector for the backends [engine-dev-pr]

### DIFF
--- a/backends/base/engine.hpp
+++ b/backends/base/engine.hpp
@@ -146,20 +146,6 @@ public:
    // Note: There may be other ways to construct layouts in the future, e.g.
    //       block-vector layouts, or multi-vector layouts.
 
-   /// TODO
-   virtual DArray MakeArray(PLayout &layout, std::size_t item_size) const = 0;
-
-   /// Allocate and return a new vector using the given @a layout.
-   /** The returned object is a smart pointer that will automatically deallocate
-       the vector.
-
-       TODO: Produce an error if memory allocation fails?
-
-       Only layouts returned by this Engine are guaranteed to be supported.
-       Using a type that is not supported will produce an error. */
-   virtual DVector MakeVector(PLayout &layout,
-                              int type_id = ScalarId<double>::value) const = 0;
-
    /// TODO: doxygen
    virtual DFiniteElementSpace MakeFESpace(FiniteElementSpace &fes) const = 0;
 


### PR DESCRIPTION
- Remove the diamond problem (And the need for users to know about `virtual inheritance`)
- Recover type information
- Remove `void**` pointers
- Favors composition over inheritance
- Remove the unused `MakeArray` and `MakeVector` in the Engine factory

This is more to open the discussion about the Engine interface, this is the most important change I see for the moment.

Among the following changes I see:
- We could always use a `PArray` and `PVector` under `mfem::Array` and `mfem::Vector`, that would mean that we would have a default implementation that uses a `default` cpu `PArray` and `PVector`. That would avoid all the unsafe `NULL` pointers that make `mfem::Array` and `mfem::Vector` sloppy, unsafe, create special cases (we have to check for `NULL` all the time), is difficult to debug, and makes poor API. That would also avoid `mfem::Array` and `mfem::Vector` containing both cpu and gpu data which is really bug prone. It might be useful to carry some kind of [RTTI](https://en.wikipedia.org/wiki/Run-time_type_information) related to the dynamic type of the underlying `PArray` and `PVector`. This would always allow us to at least chain `Pull()` then `Push()` to make backends compatible with each other.

- I'm also very sceptical about the real need for `Layout`, so far this only add a layer of complexity which seems to never be used, and the only thing that a `Layout` represents is an `Integer`... So it would be good to know at least what is the expected behaviour of `Layout(mfem::Array<int>& offsets)` because it is really obscure for the moment.
update: After a team discussion with @v-dobrev , I think it is still open if this is really needed, since we couldn't have a clear explanation of what they are used for. It would be very nice to have some abstract execution trace to give a clearer idea of the parallelization ideas behind `Layout`. To me it sounded like it imposes backends to support a parallelism model that is very uncertain to ever be used (and might prevent us from using a different one). Besides, we cannot implement for the moment this parallel model since none of us understands what is supposed to happen with `Layout` that are not just an `Integer`. I think it should be a priority to, at least, clarify for the team what a `Layout` is wanting to achieve.

- I think that the new structure for `mfem::Array` and `mfem::Vector` is overly complicated, I believe it now requires about 10 hours for a new user to understand how an `mfem::Vector` works. Most of the classes are never used anywhere, they just make things complicated. Here also having composition between `mfem::Array` and `mfem::Vector` would simplify a lot the class structure. Coupled with the first change, it could be easy for a user to understand the new class structure. We should not forget that the point of inheritance **is to be reused, and not to reuse code**. So is it that important to have `Array` functions to also take `Vector`? It would not be difficult to extract the `Array` if needed. To me `Array` and `Vector` are two different concepts, an `Array` is a linear collection, a `Vector` is a math object (which conceptually shouldn't be resized for instance), so a `Vector` is not an `Array`.