### PR TITLE
ParNCMesh copy constructor, copying of NC ParMesh.

### DIFF
--- a/mesh/mesh.cpp
+++ b/mesh/mesh.cpp
@@ -2389,6 +2389,7 @@ Mesh::Mesh(const Mesh &mesh, bool copy_nodes)
       faces[i] = (face) ? face->Duplicate(this) : NULL;
    }
    mesh.faces_info.Copy(faces_info);
+   mesh.nc_faces_info.Copy(nc_faces_info);
 
    // Do NOT copy the element-to-element Table, el_to_el
    el_to_el = NULL;
@@ -2418,9 +2419,16 @@ Mesh::Mesh(const Mesh &mesh, bool copy_nodes)
    }
 
    // Deep copy the NCMesh.
-   // TODO: ParNCMesh; ParMesh has a separate 'pncmesh' pointer, and 'ncmesh'
-   //       is initialized from it. Need ParNCMesh copy constructor.
-   ncmesh = mesh.ncmesh ? new NCMesh(*mesh.ncmesh) : NULL;
+#ifdef MFEM_USE_MPI
+   if (dynamic_cast<const ParMesh*>(&mesh))
+   {
+      ncmesh = NULL; // skip; will be done in ParMesh copy ctor
+   }
+   else
+#endif
+   {
+      ncmesh = mesh.ncmesh ? new NCMesh(*mesh.ncmesh) : NULL;
+   }
 
    // Duplicate the Nodes, including the FiniteElementCollection and the
    // FiniteElementSpace

--- a/mesh/pmesh.cpp
+++ b/mesh/pmesh.cpp
@@ -62,9 +62,17 @@ ParMesh::ParMesh(const ParMesh &pmesh, bool copy_nodes)
    // If pmesh has a ParNURBSExtension, it was copied by the Mesh copy ctor, so
    // there is no need to do anything here.
 
-   MFEM_VERIFY(pmesh.pncmesh == NULL,
-               "copy of parallel non-conforming meshes is not implemented");
-   pncmesh = NULL;
+   // Copy ParNCMesh, if present
+   if (pmesh.pncmesh)
+   {
+      pncmesh = new ParNCMesh(*pmesh.pncmesh);
+      pncmesh->OnMeshUpdated(this);
+   }
+   else
+   {
+      pncmesh = NULL;
+   }
+   ncmesh = pncmesh;
 
    // Copy the Nodes as a ParGridFunction, including the FiniteElementCollection
    // and the FiniteElementSpace (as a ParFiniteElementSpace)

--- a/mesh/pncmesh.cpp
+++ b/mesh/pncmesh.cpp
@@ -47,7 +47,7 @@ ParNCMesh::ParNCMesh(MPI_Comm comm, const NCMesh &ncmesh)
 }
 
 ParNCMesh::ParNCMesh(const ParNCMesh &other)
-   // copy primary data only
+// copy primary data only
    : NCMesh(other)
    , MyComm(other.MyComm)
    , NRanks(other.NRanks)

--- a/mesh/pncmesh.cpp
+++ b/mesh/pncmesh.cpp
@@ -46,6 +46,16 @@ ParNCMesh::ParNCMesh(MPI_Comm comm, const NCMesh &ncmesh)
    // branches that only contain someone else's leaves (see Prune())
 }
 
+ParNCMesh::ParNCMesh(const ParNCMesh &other)
+   // copy primary data only
+   : NCMesh(other)
+   , MyComm(other.MyComm)
+   , NRanks(other.NRanks)
+   , MyRank(other.MyRank)
+{
+   Update(); // mark all secondary stuff for recalculation
+}
+
 ParNCMesh::~ParNCMesh()
 {
    ClearAuxPM();

--- a/mesh/pncmesh.hpp
+++ b/mesh/pncmesh.hpp
@@ -63,6 +63,8 @@ class ParNCMesh : public NCMesh
 public:
    ParNCMesh(MPI_Comm comm, const NCMesh& ncmesh);
 
+   ParNCMesh(const ParNCMesh &other);
+
    virtual ~ParNCMesh();
 
    /** An override of NCMesh::Refine, which is called eventually, after making


### PR DESCRIPTION
Implemented missing ParNCMesh copy constructor and made sure ParMesh can be copied in the nonconforming case. Should resolve issue #585.
