### PR TITLE
Fix the out-of-source build for the miniapps sample runs

### DIFF
--- a/miniapps/electromagnetics/makefile
+++ b/miniapps/electromagnetics/makefile
@@ -51,6 +51,22 @@ $(COMMON_O) $(addsuffix _solver.o,$(MINIAPPS)): \
 %.o: $(SRC)%.cpp $(SRC)%.hpp $(CONFIG_MK)
 	$(MFEM_CXX) $(MFEM_FLAGS) -c $(<) -o $(@)
 
+# Rules to copy the *.mesh files - needed for running the sample runs when
+# building out-of-source:
+ifneq ($(SRC),)
+JOULE_MESH_FILES = cylinder-hex.mesh cylinder-tet.mesh
+ifeq ($(MFEM_USE_NETCDF),YES)
+   JOULE_MESH_FILES += cylinder-hex-q2.gen cylinder-tet-p2.gen
+endif
+TESLA_MESH_FILES = square-angled-pipe.mesh
+VOLTA_MESH_FILES = llnl.mesh
+$(JOULE_MESH_FILES) $(TESLA_MESH_FILES) $(VOLTA_MESH_FILES): %: $(SRC)%
+	ln -sf $(<) .
+joule: | $(JOULE_MESH_FILES)
+tesla: | $(TESLA_MESH_FILES)
+volta: | $(VOLTA_MESH_FILES)
+endif
+
 MFEM_TESTS = MINIAPPS
 include $(MFEM_TEST_MK)
 
@@ -67,7 +83,7 @@ maxwell-test-par: maxwell
 	-abcs '-1' -dp '-0.3 0.0 0.0 0.3 0.0 0.0 0.1 1 .5 .5')
 joule-test-par: joule
 	@$(call mfem-test,$<, $(RUN_MPI), Electromagnetic miniapp,\
-	-p rod -tf 3 -m $(SRC)cylinder-hex.mesh)
+	-m cylinder-hex.mesh -p rod -tf 3)
 
 # Testing: "test" target and mfem-test* variables are defined in config/test.mk
 

--- a/miniapps/meshing/makefile
+++ b/miniapps/meshing/makefile
@@ -42,6 +42,15 @@ endif
 
 all: $(MINIAPPS)
 
+# Rules to copy the *.mesh files - needed for running the sample runs when
+# building out-of-source:
+ifneq ($(SRC),)
+MESH_FILES = blade.mesh icf.mesh
+$(MESH_FILES): %: $(SRC)%
+	ln -sf $(<) .
+mesh-optimizer pmesh-optimizer: | $(MESH_FILES)
+endif
+
 MFEM_TESTS = MINIAPPS
 include $(MFEM_TEST_MK)
 
@@ -52,10 +61,9 @@ RUN_MPI = $(MFEM_MPIEXEC) $(MFEM_MPIEXEC_NP) $(MFEM_MPI_NP)
 %-test-seq: %
 	@$(call mfem-test-file,$<,, Meshing miniapp,$(<).mesh)
 mesh-optimizer-test-seq: mesh-optimizer
-	@$(call mfem-test,$<,, Meshing miniapp,-m $(SRC)icf.mesh)
+	@$(call mfem-test,$<,, Meshing miniapp)
 pmesh-optimizer-test-par: pmesh-optimizer
-	@$(call mfem-test,$<, $(RUN_MPI), Parallel meshing miniapp,\
-	-m $(SRC)icf.mesh)
+	@$(call mfem-test,$<, $(RUN_MPI), Parallel meshing miniapp)
 
 # Testing: Specific execution options
 mesh-explorer-test-seq:


### PR DESCRIPTION
In the makefile build system, ensure that the sample runs in the miniapps directory can be run when using an out-of-source build.
