### PR TITLE
Make HiopNlpOptimizer more general

### DIFF
--- a/examples/hiop/ex9.cpp
+++ b/examples/hiop/ex9.cpp
@@ -432,7 +432,7 @@ void FE_Evolution::Mult(const Vector &x, Vector &y) const
 
    OptimizationSolver* optsolver = NULL;
    if (optimizer_type == 1) { optsolver = new SLBQPOptimizer(); }
-   else                     { optsolver = new HiopNlpOptimizer(); }
+   else                     { optsolver = new HiopNlpOptimizer_Simple(); }
 
    optsolver->SetMaxIter(max_iter);
    optsolver->SetAbsTol(atol);

--- a/examples/hiop/ex9.cpp
+++ b/examples/hiop/ex9.cpp
@@ -428,7 +428,8 @@ void FE_Evolution::Mult(const Vector &x, Vector &y) const
    // Perform optimization.
    Vector y_out(dofs);
    const int max_iter = 50;
-   const double rtol = 1.e-12, atol = 1e-15;
+   const double rtol = 1.e-12;
+   double atol = 1.e-7;
 
    OptimizationSolver* optsolver = NULL;
    HiopNlpOptimizer *tmp_opt_ptr = NULL;
@@ -443,7 +444,11 @@ void FE_Evolution::Mult(const Vector &x, Vector &y) const
       optsolver = tmp_opt_ptr;
    }
    else if (optimizer_type == 2) { optsolver = new HiopNlpOptimizer_Simple(); }
-   else                          { optsolver = new SLBQPOptimizer(); }
+   else
+   {
+      optsolver = new SLBQPOptimizer();
+      atol = 1.e-15;
+   }
 
    optsolver->SetMaxIter(max_iter);
    optsolver->SetAbsTol(atol);

--- a/examples/hiop/ex9p.cpp
+++ b/examples/hiop/ex9p.cpp
@@ -540,7 +540,7 @@ void FE_Evolution::Mult(const Vector &x, Vector &y) const
    }
    else
    {
-      optsolver = new HiopNlpOptimizer(MPI_COMM_WORLD);
+      optsolver = new HiopNlpOptimizer_Simple(MPI_COMM_WORLD);
    }
    optsolver->SetMaxIter(max_iter);
    optsolver->SetAbsTol(atol);

--- a/examples/hiop/ex9p.cpp
+++ b/examples/hiop/ex9p.cpp
@@ -531,7 +531,8 @@ void FE_Evolution::Mult(const Vector &x, Vector &y) const
    // Perform optimization on the ldofs.
    Vector y_out(ldofs);
    const int max_iter = 50;
-   const double rtol = 1.e-12, atol = 1e-15;
+   const double rtol = 1.e-12;
+   double atol = 1.e-7;
 
    OptimizationSolver* optsolver = NULL;
    HiopNlpOptimizer *tmp_opt_ptr = NULL;
@@ -552,6 +553,7 @@ void FE_Evolution::Mult(const Vector &x, Vector &y) const
    else
    {
       optsolver = new SLBQPOptimizer(MPI_COMM_WORLD);
+      atol = 1.e-15;
    }
    optsolver->SetMaxIter(max_iter);
    optsolver->SetAbsTol(atol);

--- a/linalg/hiop.cpp
+++ b/linalg/hiop.cpp
@@ -58,7 +58,9 @@ void HiopNlpOptimizer::Mult(Vector &x) const
 {
    if (use_initial_x_value) optProb_->setStartingPoint(x);
    hiop::hiopNlpDenseConstraints hiopInstance(*optProb_);
-   hiopInstance.options->SetNumericValue("tolerance", 1e-7);
+   //Set tolerance:
+   hiopInstance.options->SetNumericValue("tolerance", abs_tol);
+   // TODO add capability to pass in more arguments
    //0: no output; 3: not too much
    hiopInstance.options->SetIntegerValue("verbosity_level", 0);
 

--- a/linalg/hiop.cpp
+++ b/linalg/hiop.cpp
@@ -58,11 +58,12 @@ void HiopNlpOptimizer::Mult(Vector &x) const
 {
    if (use_initial_x_value) optProb_->setStartingPoint(x);
    hiop::hiopNlpDenseConstraints hiopInstance(*optProb_);
+
    //Set tolerance:
    hiopInstance.options->SetNumericValue("tolerance", abs_tol);
-   // TODO add capability to pass in more arguments
    //0: no output; 3: not too much
-   hiopInstance.options->SetIntegerValue("verbosity_level", 0);
+   hiopInstance.options->SetIntegerValue("verbosity_level", print_level);
+   // TODO add capability to pass in some of these arguments
 
    //use the IPM solver
    hiop::hiopAlgFilterIPM solver(&hiopInstance);

--- a/linalg/hiop.cpp
+++ b/linalg/hiop.cpp
@@ -23,7 +23,7 @@ using namespace hiop;
 namespace mfem
 {
 HiopNlpOptimizer::HiopNlpOptimizer() 
-  : OptimizationSolver(), optProb_(NULL) 
+  : OptimizationSolver(), optProb_(NULL), use_initial_x_value(false)
 { 
 
 #ifdef MFEM_USE_MPI
@@ -42,7 +42,8 @@ HiopNlpOptimizer::HiopNlpOptimizer()
 HiopNlpOptimizer::HiopNlpOptimizer(MPI_Comm _comm) 
   : OptimizationSolver(_comm),
     optProb_(NULL),
-    comm_(_comm) 
+    comm_(_comm),
+    use_initial_x_value(false)
 { 
 
 }
@@ -55,6 +56,7 @@ HiopNlpOptimizer::~HiopNlpOptimizer()
 
 void HiopNlpOptimizer::Mult(Vector &x) const
 {
+   if (use_initial_x_value) optProb_->setStartingPoint(x);
    hiop::hiopNlpDenseConstraints hiopInstance(*optProb_);
    hiopInstance.options->SetNumericValue("tolerance", 1e-7);
    //0: no output; 3: not too much
@@ -89,8 +91,6 @@ void HiopNlpOptimizer_Simple::Mult(const Vector &xt, Vector &x) const
 {
    //set xt in the problemSpec to compute the objective
    optProb_Simple_->setObjectiveTarget(xt);
-
-   x = 0.;
    HiopNlpOptimizer::Mult(x);
 }
 

--- a/linalg/hiop.cpp
+++ b/linalg/hiop.cpp
@@ -50,80 +50,84 @@ HiopNlpOptimizer::HiopNlpOptimizer(MPI_Comm _comm)
 
 HiopNlpOptimizer::~HiopNlpOptimizer()
 {
-  if(optProb_) delete optProb_;
+   if (optProb_) delete optProb_;
 }
 
 void HiopNlpOptimizer::Mult(Vector &x) const
 {
-  hiop::hiopNlpDenseConstraints hiopInstance(*optProb_);
-  hiopInstance.options->SetNumericValue("tolerance", 1e-7);
-  hiopInstance.options->SetIntegerValue("verbosity_level", 0); //0: no output; 3: not too much
+   hiop::hiopNlpDenseConstraints hiopInstance(*optProb_);
+   hiopInstance.options->SetNumericValue("tolerance", 1e-7);
+   //0: no output; 3: not too much
+   hiopInstance.options->SetIntegerValue("verbosity_level", 0);
 
-  //use the IPM solver
-  hiop::hiopAlgFilterIPM solver(&hiopInstance);
-  hiop::hiopSolveStatus status = solver.run();
-  double objective = solver.getObjective();
+   //use the IPM solver
+   hiop::hiopAlgFilterIPM solver(&hiopInstance);
+   hiop::hiopSolveStatus status = solver.run();
+   double objective = solver.getObjective();
 
-  MFEM_ASSERT(solver.getSolveStatus()==hiop::Solve_Success, "optimizer returned with a non-success status: " << solver.getSolveStatus());
+   MFEM_ASSERT(solver.getSolveStatus()==hiop::Solve_Success,
+               "optimizer returned with a non-success status: "
+                  << solver.getSolveStatus());
 
-  //copy the solution to x
-  solver.getSolution(x.GetData());
+   //copy the solution to x
+   solver.getSolution(x.GetData());
 }
 
 void HiopNlpOptimizer_Simple::Mult(Vector &x) const
 {
-  long long int n_local, m;
-  optProb_Simple_->get_prob_sizes(n_local, m);
+   long long int n_local, m;
+   optProb_Simple_->get_prob_sizes(n_local, m);
 
-  // Solve assuming xt = 0
-  Vector xt(n_local);
-  xt = 0.;
-  MFEM_WARNING("Assuming xt = 0 in HiopNlpOptimizer_Simple::Mult!");
-  Mult(xt, x);
+   // Solve assuming xt = 0
+   Vector xt(n_local);
+   xt = 0.;
+   MFEM_WARNING("Assuming xt = 0 in HiopNlpOptimizer_Simple::Mult!");
+   Mult(xt, x);
 }
 
 void HiopNlpOptimizer_Simple::Mult(const Vector &xt, Vector &x) const
 {
-  //set xt in the problemSpec to compute the objective
-  optProb_Simple_->setObjectiveTarget(xt);
+   //set xt in the problemSpec to compute the objective
+   optProb_Simple_->setObjectiveTarget(xt);
 
-  x = 0.;
-  HiopNlpOptimizer::Mult(x);
+   x = 0.;
+   HiopNlpOptimizer::Mult(x);
 }
 
 void HiopNlpOptimizer::SetBounds(const Vector &_lo, const Vector &_hi)
 {
-  if(NULL==optProb_) 
-    allocHiopProbSpec(_lo.Size());
+   if (NULL==optProb_)
+      allocHiopProbSpec(_lo.Size());
 
-  optProb_->setBounds(_lo, _hi);
+   optProb_->setBounds(_lo, _hi);
 }
 
 void HiopNlpOptimizer::SetLinearConstraint(const Vector &_w, double _a)
 {
-  if(NULL==optProb_) 
-    allocHiopProbSpec(_w.Size());
+   if (NULL==optProb_)
+      allocHiopProbSpec(_w.Size());
 
-  optProb_->setLinearConstraint(_w, _a);
+   optProb_->setLinearConstraint(_w, _a);
 }
 
-void HiopNlpOptimizer::SetObjectiveFunction(const DenseMatrix &_A, const Vector &_c)
+void HiopNlpOptimizer::SetObjectiveFunction(const DenseMatrix &_A,
+                                            const Vector &_c)
 {
-  if(NULL==optProb_)
-    allocHiopProbSpec(_c.Size());
-  optProb_->setObjectiveFunction(_A, _c);
+   if (NULL==optProb_)
+      allocHiopProbSpec(_c.Size());
+   optProb_->setObjectiveFunction(_A, _c);
 }
 void HiopNlpOptimizer::SetObjectiveFunction(const DenseMatrix &_A)
 {
-  if(NULL==optProb_)
-    allocHiopProbSpec(_A.Width());
-  optProb_->setObjectiveFunction(_A);
+   if (NULL==optProb_)
+      allocHiopProbSpec(_A.Width());
+   optProb_->setObjectiveFunction(_A);
 }
 void HiopNlpOptimizer::SetObjectiveFunction(const Vector &_c)
 {
-  if(NULL==optProb_)
-    allocHiopProbSpec(_c.Size());
-  optProb_->setObjectiveFunction(_c);
+   if (NULL==optProb_)
+      allocHiopProbSpec(_c.Size());
+   optProb_->setObjectiveFunction(_c);
 }
 
 void HiopNlpOptimizer::allocHiopProbSpec(const long long& numvars)

--- a/linalg/hiop.cpp
+++ b/linalg/hiop.cpp
@@ -78,6 +78,7 @@ void HiopNlpOptimizer_Simple::Mult(Vector &x) const
   // Solve assuming xt = 0
   Vector xt(n_local);
   xt = 0.;
+  MFEM_WARNING("Assuming xt = 0 in HiopNlpOptimizer_Simple::Mult!");
   Mult(xt, x);
 }
 
@@ -104,6 +105,25 @@ void HiopNlpOptimizer::SetLinearConstraint(const Vector &_w, double _a)
     allocHiopProbSpec(_w.Size());
 
   optProb_->setLinearConstraint(_w, _a);
+}
+
+void HiopNlpOptimizer::SetObjectiveFunction(const DenseMatrix &_A, const Vector &_c)
+{
+  if(NULL==optProb_)
+    allocHiopProbSpec(_c.Size());
+  optProb_->setObjectiveFunction(_A, _c);
+}
+void HiopNlpOptimizer::SetObjectiveFunction(const DenseMatrix &_A)
+{
+  if(NULL==optProb_)
+    allocHiopProbSpec(_A.Width());
+  optProb_->setObjectiveFunction(_A);
+}
+void HiopNlpOptimizer::SetObjectiveFunction(const Vector &_c)
+{
+  if(NULL==optProb_)
+    allocHiopProbSpec(_c.Size());
+  optProb_->setObjectiveFunction(_c);
 }
 
 void HiopNlpOptimizer::allocHiopProbSpec(const long long& numvars)

--- a/linalg/hiop.hpp
+++ b/linalg/hiop.hpp
@@ -42,220 +42,219 @@ public:
 #endif
   }
 
-  // TODO: Switch to 3 indents?
 #ifdef MFEM_USE_MPI
-  HiopProblemSpec(const MPI_Comm& _comm, const long long& _n_local)
-    : comm_(_comm), n_local_(_n_local), a_(0.), workVec_(_n_local)
-  { 
-     int ierr = MPI_Allreduce(&n_local_, &n_, 1, MPI_LONG_LONG_INT, MPI_SUM, comm_);
-     MFEM_ASSERT(ierr==MPI_SUCCESS, "MPI_Allreduce failed with error" << ierr);
-  }
+   HiopProblemSpec(const MPI_Comm& _comm, const long long& _n_local)
+      : comm_(_comm), n_local_(_n_local), a_(0.), workVec_(_n_local)
+   {
+      int ierr = MPI_Allreduce(&n_local_, &n_, 1, MPI_LONG_LONG_INT, MPI_SUM, comm_);
+      MFEM_ASSERT(ierr==MPI_SUCCESS, "MPI_Allreduce failed with error" << ierr);
+   }
 #endif
 
-  /** f = 1/2 x^T Q x + c^T x */
-  virtual void setObjectiveFunction(const DenseMatrix &_A, const Vector &_c)
-  {
-    setObjectiveFunction(_A);
-    setObjectiveFunction(_c);
-  }
-  virtual void setObjectiveFunction(const DenseMatrix &_A)
-  {
-    A_ = _A;
-    workVec2_.SetSize(n_local_);
-  }
-  virtual void setObjectiveFunction(const Vector &_c)  { c_ = _c; }
+   /** f = 1/2 x^T Q x + c^T x */
+   virtual void setObjectiveFunction(const DenseMatrix &_A, const Vector &_c)
+   {
+      setObjectiveFunction(_A);
+      setObjectiveFunction(_c);
+   }
+   virtual void setObjectiveFunction(const DenseMatrix &_A)
+   {
+      A_ = _A;
+      workVec2_.SetSize(n_local_);
+   }
+   virtual void setObjectiveFunction(const Vector &_c)  { c_ = _c; }
 
-  /** problem dimensions: n number of variables, m number of constraints */
-  virtual bool get_prob_sizes(long long int& n, long long int& m) {
-    n = n_;
-    m = 1;
-    return true;
-  };
+   /** problem dimensions: n number of variables, m number of constraints */
+   virtual bool get_prob_sizes(long long int& n, long long int& m) {
+      n = n_;
+      m = 1;
+      return true;
+   };
 
-  virtual bool get_vars_info(const long long& n, double *xlow, double* xupp, NonlinearityType* type) {
-    MFEM_ASSERT(n==n_, "global size input mismatch");
-    std::memcpy(xlow, lo_.GetData(), n_local_*sizeof(double));
-    std::memcpy(xupp, hi_.GetData(), n_local_*sizeof(double));
-    return true;
-  };
-  /** bounds on the constraints 
+   virtual bool get_vars_info(const long long& n, double *xlow, double* xupp, NonlinearityType* type) {
+      MFEM_ASSERT(n==n_, "global size input mismatch");
+      std::memcpy(xlow, lo_.GetData(), n_local_*sizeof(double));
+      std::memcpy(xupp, hi_.GetData(), n_local_*sizeof(double));
+      return true;
+   };
+   /** bounds on the constraints
    *  (clow<=-1e20 means no lower bound, cupp>=1e20 means no upper bound) */
-  virtual bool get_cons_info(const long long& m, double* clow, double* cupp, NonlinearityType* type) {
-    MFEM_ASSERT(m==1, "only one constraint should be present");
-    *clow = *cupp = a_;
-    return true;
-  };
+   virtual bool get_cons_info(const long long& m, double* clow, double* cupp, NonlinearityType* type) {
+      MFEM_ASSERT(m==1, "only one constraint should be present");
+      *clow = *cupp = a_;
+      return true;
+   };
 
-  /** Objective function evaluation. Each rank returns the global obj. value.
+   /** Objective function evaluation. Each rank returns the global obj. value.
    *  f = 1/2 x^T * A * x + c^T * x                                           */
-  virtual bool eval_f(const long long& n, const double* x, bool new_x, double& obj_value) {
-    MFEM_ASSERT(n==n_, "global size input mismatch");
-
-    workVec_ = x;
-    obj_value = 0.5 * A_.InnerProduct(workVec_, workVec_) + (c_ * workVec_);
-
-#ifdef MFEM_USE_MPI
-    double loc_obj = obj_value;
-    int ierr = MPI_Allreduce(&loc_obj, &obj_value, 1, MPI_DOUBLE, MPI_SUM, comm_);
-    MFEM_ASSERT(ierr==MPI_SUCCESS, "MPI_Allreduce failed with error" << ierr);
-#endif
-
-    return true;
-  };
-
-  /** Gradient of objective (local chunk), grad(f) = A*x + c */
-  virtual bool eval_grad_f(const long long& n, const double* x, bool new_x, double* gradf) {
-    MFEM_ASSERT(n==n_, "global size input mismatch");
-
-    workVec_  = x;
-    workVec2_ = workVec_;
-    A_.Mult(workVec_, workVec2_);
-    workVec2_ += c_;
-    std::memcpy(gradf, workVec2_.GetData(), n_local_*sizeof(double));
-
-    return true;
-  };
-
-  /** Evaluates a subset of the constraints cons(x) (where clow<=cons(x)<=cupp). The subset is of size
-   *  'num_cons' and is described by indexes in the 'idx_cons' array. The methods may be called 
-   *  multiple times, each time for a subset of the constraints, for example, for the 
-   *  subset containing the equalities and for the subset containing the inequalities. However, each 
-   *  constraint will be inquired EXACTLY once. This is done for performance considerations, to avoid 
-   *  temporary holders and memory copying.
-   *
-   *  Parameters:
-   *   - n, m: the global number of variables and constraints
-   *   - num_cons, idx_cons (array of size num_cons): the number and indexes of constraints to be evaluated
-   *   - x: the point where the constraints are to be evaluated
-   *   - new_x: whether x has been changed from the previous call to f, grad_f, or Jac
-   *   - cons: array of size num_cons containing the value of the  constraints indicated by idx_cons
-   *  
-   *  When MPI enabled, every rank populates 'cons' since the constraints are not distributed.
-   */
-  virtual bool eval_cons(const long long& n, const long long& m, 
-			 const long long& num_cons, const long long* idx_cons,  
-			 const double* x, bool new_x, 
-			 double* cons) {
-    MFEM_ASSERT(n==n_, "global size input mismatch");
-    MFEM_ASSERT(m==1, "only one constraint should be present");
-    MFEM_ASSERT(num_cons<=m, "num_cons should be at most m=" << m);
-    if(num_cons>0) {
-      MFEM_ASSERT(idx_cons[0]==0, "index of the constraint should be 0");
+   virtual bool eval_f(const long long& n, const double* x, bool new_x, double& obj_value) {
+      MFEM_ASSERT(n==n_, "global size input mismatch");
 
       workVec_ = x;
-      double wtx = w_ * workVec_;
+      obj_value = 0.5 * A_.InnerProduct(workVec_, workVec_) + (c_ * workVec_);
 
 #ifdef MFEM_USE_MPI
-      double loc_wtx = wtx;
-      int ierr = MPI_Allreduce(&loc_wtx, &wtx, 1, MPI_DOUBLE, MPI_SUM, comm_);
+      double loc_obj = obj_value;
+      int ierr = MPI_Allreduce(&loc_obj, &obj_value, 1, MPI_DOUBLE, MPI_SUM, comm_);
       MFEM_ASSERT(ierr==MPI_SUCCESS, "MPI_Allreduce failed with error" << ierr);
 #endif
-      //w' * x - a
-      cons[0] = wtx - a_;
-    }
-    return true;
-  };
 
-  /** provide a primal starting point. This point is subject to adjustments internally in hiOP.*/
-  virtual bool get_starting_point(const long long&n, double* x0) {
-    MFEM_ASSERT(n_local_ == w_.Size(), "Linear constraint vector not set ?!?");
-    memcpy(x0, w_.GetData(), n_local_*sizeof(double));
-    return true;
-    //let hiop decide: return false;
-  };
+      return true;
+   };
 
+   /** Gradient of objective (local chunk), grad(f) = A*x + c */
+   virtual bool eval_grad_f(const long long& n, const double* x, bool new_x, double* gradf) {
+      MFEM_ASSERT(n==n_, "global size input mismatch");
 
-  /** Evaluates the Jacobian of the subset of constraints indicated by idx_cons and of size num_cons.
-   *  Example: Assuming idx_cons[k]=i, which means that the gradient of the (i+1)th constraint is
-   *  to be evaluated, one needs to do Jac[k][0]=d/dx_0 con_i(x), Jac[k][1]=d/dx_1 con_i(x), ...
-   *  When MPI enabled, each rank computes only the local columns of the Jacobian, that is the partials
-   *  with respect to local variables.
-   *
-   *  Parameters: see eval_cons
-   */
-  virtual bool eval_Jac_cons(const long long& n, const long long& m, 
-			     const long long& num_cons, const long long* idx_cons,  
-			     const double* x, bool new_x,
-			     double** Jac) {
-    MFEM_ASSERT(n==n_, "global size input mismatch");
-    MFEM_ASSERT(m==1, "only one constraint should be present");
-    MFEM_ASSERT(num_cons<=m, "num_cons should be at most m=" << m);
-    if(num_cons>0) {
-      MFEM_ASSERT(idx_cons[0]==0, "index of the constraint should be 0");
+      workVec_  = x;
+      workVec2_ = workVec_;
+      A_.Mult(workVec_, workVec2_);
+      workVec2_ += c_;
+      std::memcpy(gradf, workVec2_.GetData(), n_local_*sizeof(double));
 
-      std::memcpy(Jac[0], w_.GetData(), n_local_*sizeof(double));
-    }
-    return true;
-  };
+      return true;
+   };
 
-  /**  column partitioning specification for distributed memory vectors 
-   *  Process P owns cols[P], cols[P]+1, ..., cols[P+1]-1, P={0,1,...,NumRanks}.
-   *  Example: for a vector x of 6 elements on 3 ranks, the col partitioning is cols=[0,2,4,6].
-   *  The caller manages memory associated with 'cols', array of size NumRanks+1 
-   */
-  virtual bool get_vecdistrib_info(long long global_n, long long* cols) {
+   /** Evaluates a subset of the constraints cons(x) (where clow<=cons(x)<=cupp). The subset is of size
+    *  'num_cons' and is described by indexes in the 'idx_cons' array. The methods may be called
+    *  multiple times, each time for a subset of the constraints, for example, for the
+    *  subset containing the equalities and for the subset containing the inequalities. However, each
+    *  constraint will be inquired EXACTLY once. This is done for performance considerations, to avoid
+    *  temporary holders and memory copying.
+    *
+    *  Parameters:
+    *   - n, m: the global number of variables and constraints
+    *   - num_cons, idx_cons (array of size num_cons): the number and indexes of constraints to be evaluated
+    *   - x: the point where the constraints are to be evaluated
+    *   - new_x: whether x has been changed from the previous call to f, grad_f, or Jac
+    *   - cons: array of size num_cons containing the value of the  constraints indicated by idx_cons
+    *
+    *  When MPI enabled, every rank populates 'cons' since the constraints are not distributed.
+    */
+   virtual bool eval_cons(const long long& n, const long long& m,
+			   const long long& num_cons, const long long* idx_cons,
+			   const double* x, bool new_x,
+			   double* cons) {
+      MFEM_ASSERT(n==n_, "global size input mismatch");
+      MFEM_ASSERT(m==1, "only one constraint should be present");
+      MFEM_ASSERT(num_cons<=m, "num_cons should be at most m=" << m);
+      if (num_cons>0) {
+         MFEM_ASSERT(idx_cons[0]==0, "index of the constraint should be 0");
+
+         workVec_ = x;
+         double wtx = w_ * workVec_;
+
 #ifdef MFEM_USE_MPI
-    int nranks;
-    int ierr = MPI_Comm_size(comm_, &nranks);
-    MFEM_ASSERT(ierr==MPI_SUCCESS, "MPI_Comm_size failed with error" << ierr);
-    
-    long long* sizes = new long long[nranks];
-    ierr = MPI_Allgather(&n_local_, 1, MPI_LONG_LONG_INT, sizes, 1, MPI_LONG_LONG_INT, comm_);
-    MFEM_ASSERT(MPI_SUCCESS==ierr,
+         double loc_wtx = wtx;
+         int ierr = MPI_Allreduce(&loc_wtx, &wtx, 1, MPI_DOUBLE, MPI_SUM, comm_);
+         MFEM_ASSERT(ierr==MPI_SUCCESS, "MPI_Allreduce failed with error" << ierr);
+#endif
+         //w' * x - a
+         cons[0] = wtx - a_;
+      }
+      return true;
+   };
+
+   /** provide a primal starting point. This point is subject to adjustments internally in hiOP.*/
+   virtual bool get_starting_point(const long long&n, double* x0) {
+      MFEM_ASSERT(n_local_ == w_.Size(), "Linear constraint vector not set ?!?");
+      memcpy(x0, w_.GetData(), n_local_*sizeof(double));
+      return true;
+      //let hiop decide: return false;
+   };
+
+
+   /** Evaluates the Jacobian of the subset of constraints indicated by idx_cons and of size num_cons.
+    *  Example: Assuming idx_cons[k]=i, which means that the gradient of the (i+1)th constraint is
+    *  to be evaluated, one needs to do Jac[k][0]=d/dx_0 con_i(x), Jac[k][1]=d/dx_1 con_i(x), ...
+    *  When MPI enabled, each rank computes only the local columns of the Jacobian, that is the partials
+    *  with respect to local variables.
+    *
+    *  Parameters: see eval_cons
+    */
+   virtual bool eval_Jac_cons(const long long& n, const long long& m,
+			   const long long& num_cons, const long long* idx_cons,
+			   const double* x, bool new_x,
+			   double** Jac) {
+      MFEM_ASSERT(n==n_, "global size input mismatch");
+      MFEM_ASSERT(m==1, "only one constraint should be present");
+      MFEM_ASSERT(num_cons<=m, "num_cons should be at most m=" << m);
+      if (num_cons>0) {
+         MFEM_ASSERT(idx_cons[0]==0, "index of the constraint should be 0");
+
+         std::memcpy(Jac[0], w_.GetData(), n_local_*sizeof(double));
+      }
+      return true;
+   };
+
+   /**  column partitioning specification for distributed memory vectors
+    *  Process P owns cols[P], cols[P]+1, ..., cols[P+1]-1, P={0,1,...,NumRanks}.
+    *  Example: for a vector x of 6 elements on 3 ranks, the col partitioning is cols=[0,2,4,6].
+    *  The caller manages memory associated with 'cols', array of size NumRanks+1
+    */
+   virtual bool get_vecdistrib_info(long long global_n, long long* cols) {
+#ifdef MFEM_USE_MPI
+      int nranks;
+      int ierr = MPI_Comm_size(comm_, &nranks);
+      MFEM_ASSERT(ierr==MPI_SUCCESS, "MPI_Comm_size failed with error" << ierr);
+
+      long long* sizes = new long long[nranks];
+      ierr = MPI_Allgather(&n_local_, 1, MPI_LONG_LONG_INT, sizes, 1, MPI_LONG_LONG_INT, comm_);
+      MFEM_ASSERT(MPI_SUCCESS==ierr,
 		"Error in MPI_Allgather of number of decision variables." << ierr);
-    
-    //compute global indeces
-    cols[0]=0;
-    for (int r=1; r<=nranks; r++) {
-      cols[r] = sizes[r-1] + cols[r-1];
-    }
 
-    delete[] sizes;
-    return true;
+      //compute global indeces
+      cols[0]=0;
+      for (int r=1; r<=nranks; r++) {
+         cols[r] = sizes[r-1] + cols[r-1];
+      }
+
+      delete[] sizes;
+      return true;
 #else
-    return false; //hiop runs in non-distributed mode 
+      return false; //hiop runs in non-distributed mode 
 #endif    
-  };
+   };
 
 #ifdef MFEM_USE_MPI
-  virtual bool get_MPI_comm(MPI_Comm& comm_out) 
-  { 
-    comm_out=comm_; 
-    return true;
-  }
+   virtual bool get_MPI_comm(MPI_Comm& comm_out) 
+   { 
+      comm_out=comm_; 
+      return true;
+   }
 #endif
 
   /** Seter/geter methods below; not inherited from the HiOp interface class */
-  virtual void setBounds(const Vector &_lo, const Vector &_hi) {
-    lo_ = _lo;
-    hi_ = _hi;
-  };
-  virtual void setLinearConstraint(const Vector &_w, const double& _a) {
-    w_ = _w;
-    a_ = _a;
-  };
+   virtual void setBounds(const Vector &_lo, const Vector &_hi) {
+      lo_ = _lo;
+      hi_ = _hi;
+   };
+   virtual void setLinearConstraint(const Vector &_w, const double& _a) {
+      w_ = _w;
+      a_ = _a;
+   };
 
 protected:
 #ifdef MFEM_USE_MPI
-  MPI_Comm comm_;
+   MPI_Comm comm_;
 #endif
 
-  //members that store problem info
-  long long n_; //number of variables (global)
-  long long n_local_; //number of variables (local to the MPI process)
+   //members that store problem info
+   long long n_; //number of variables (global)
+   long long n_local_; //number of variables (local to the MPI process)
 
-  //Objective function: f = 1/2 x^T A x + c^T x
-  DenseMatrix A_;
-  Vector c_;
+   //Objective function: f = 1/2 x^T A x + c^T x
+   DenseMatrix A_;
+   Vector c_;
 
-  Vector lo_,hi_; //lower and upper bounds
-  Vector w_;      //linear constraint coefficients 
-  double a_;      //linear constraint rhs
+   Vector lo_,hi_; //lower and upper bounds
+   Vector w_;      //linear constraint coefficients
+   double a_;      //linear constraint rhs
 
-  Vector workVec_; //used as work space of size n_local_
+   Vector workVec_; //used as work space of size n_local_
 
 private:
-  Vector workVec2_; //used as work space of size n_local_
+   Vector workVec2_; //used as work space of size n_local_
 
 }; //End of HiopProblemSpec class
 
@@ -269,99 +268,99 @@ public:
       : HiopProblemSpec(n_loc) {}
 
 #ifdef MFEM_USE_MPI
-  HiopProblemSpec_Simple(const MPI_Comm& _comm, const long long& _n_local)
-    : HiopProblemSpec(_comm, _n_local) {}
+   HiopProblemSpec_Simple(const MPI_Comm& _comm, const long long& _n_local)
+      : HiopProblemSpec(_comm, _n_local) {}
 #endif
 
-  /** Objective function evaluation. Each rank returns the global obj. value. */
-  virtual bool eval_f(const long long& n, const double* x, bool new_x, double& obj_value) {
-    MFEM_ASSERT(n==n_, "global size input mismatch");
+   /** Objective function evaluation. Each rank returns the global obj. value. */
+   virtual bool eval_f(const long long& n, const double* x, bool new_x, double& obj_value) {
+      MFEM_ASSERT(n==n_, "global size input mismatch");
 
-    workVec_ = x;
-    workVec_.Add(-1.0, xt_);
-    obj_value = 0.5 * (workVec_ * workVec_);
+      workVec_ = x;
+      workVec_.Add(-1.0, xt_);
+      obj_value = 0.5 * (workVec_ * workVec_);
 
 #ifdef MFEM_USE_MPI
-    double loc_obj = obj_value;
-    int ierr = MPI_Allreduce(&loc_obj, &obj_value, 1, MPI_DOUBLE, MPI_SUM, comm_);
-    MFEM_ASSERT(ierr==MPI_SUCCESS, "MPI_Allreduce failed with error" << ierr);
+      double loc_obj = obj_value;
+      int ierr = MPI_Allreduce(&loc_obj, &obj_value, 1, MPI_DOUBLE, MPI_SUM, comm_);
+      MFEM_ASSERT(ierr==MPI_SUCCESS, "MPI_Allreduce failed with error" << ierr);
 #endif
 
-    return true;
-  };
+      return true;
+   };
 
-  /** Gradient of objective (local chunk) */
-  virtual bool eval_grad_f(const long long& n, const double* x, bool new_x, double* gradf) {
-    MFEM_ASSERT(n==n_, "global size input mismatch");
+   /** Gradient of objective (local chunk) */
+   virtual bool eval_grad_f(const long long& n, const double* x, bool new_x, double* gradf) {
+      MFEM_ASSERT(n==n_, "global size input mismatch");
 
-    // compute gradf = x-xt
-    workVec_  = x;
-    workVec_ -= xt_;
-    std::memcpy(gradf, workVec_.GetData(), n_local_*sizeof(double));
+      // compute gradf = x-xt
+      workVec_  = x;
+      workVec_ -= xt_;
+      std::memcpy(gradf, workVec_.GetData(), n_local_*sizeof(double));
 
-    return true;
-  };
+      return true;
+   };
 
-  // Capitalization consistency
-  virtual void setObjectiveTarget(const Vector &_xt) {
-    xt_ = _xt;
-  };
-
-protected:
-  // A is always I and c is always xt_.  Neither are used in eval_f or eval_grad_f
-  virtual void setObjectiveFunction(const DenseMatrix &_A, const Vector &_c)
-  {
-    MFEM_WARNING("setObjectiveFunction does nothing for class "
-                  "HiopProblemSpec_Simple.  Use setObjectiveTarget to set xt_.");
-  }
-  virtual void setObjectiveFunction(const Vector &_c)
-  {
-    MFEM_WARNING("setObjectiveFunction does nothing for class "
-                  "HiopProblemSpec_Simple.  Use setObjectiveTarget to set xt_.");
-  }
-  virtual void setObjectiveFunction(const DenseMatrix &_A)
-  {
-    MFEM_WARNING("setObjectiveFunction does nothing for class "
-                  "HiopProblemSpec_Simple.  Use setObjectiveTarget to set xt_.");
-  }
+   // Capitalization consistency
+   virtual void setObjectiveTarget(const Vector &_xt) {
+      xt_ = _xt;
+   };
 
 protected:
-  Vector xt_;     //target vector in the L2 objective
+   // A is always I and c is always xt_.  Neither are used in eval_f or eval_grad_f
+   virtual void setObjectiveFunction(const DenseMatrix &_A, const Vector &_c)
+   {
+      MFEM_WARNING("setObjectiveFunction does nothing for class "
+                  "HiopProblemSpec_Simple.  Use setObjectiveTarget to set xt_.");
+   }
+   virtual void setObjectiveFunction(const Vector &_c)
+   {
+      MFEM_WARNING("setObjectiveFunction does nothing for class "
+                  "HiopProblemSpec_Simple.  Use setObjectiveTarget to set xt_.");
+   }
+   virtual void setObjectiveFunction(const DenseMatrix &_A)
+   {
+      MFEM_WARNING("setObjectiveFunction does nothing for class "
+                  "HiopProblemSpec_Simple.  Use setObjectiveTarget to set xt_.");
+   }
+
+protected:
+   Vector xt_;     //target vector in the L2 objective
 
 }; //End of HiopProblemSpec_Simple class
 
 class HiopNlpOptimizer : public OptimizationSolver
 {
 public:
-  HiopNlpOptimizer(); 
+   HiopNlpOptimizer(); 
 #ifdef MFEM_USE_MPI
-  HiopNlpOptimizer(MPI_Comm _comm);
+   HiopNlpOptimizer(MPI_Comm _comm);
 #endif
-  virtual ~HiopNlpOptimizer();
+   virtual ~HiopNlpOptimizer();
 
-  virtual void SetBounds(const Vector &_lo, const Vector &_hi);
-  virtual void SetLinearConstraint(const Vector &_w, double _a);
-  virtual void SetObjectiveFunction(const DenseMatrix &_A, const Vector &_c);
-  virtual void SetObjectiveFunction(const DenseMatrix &_A);
-  virtual void SetObjectiveFunction(const Vector &_c);
+   virtual void SetBounds(const Vector &_lo, const Vector &_hi);
+   virtual void SetLinearConstraint(const Vector &_w, double _a);
+   virtual void SetObjectiveFunction(const DenseMatrix &_A, const Vector &_c);
+   virtual void SetObjectiveFunction(const DenseMatrix &_A);
+   virtual void SetObjectiveFunction(const Vector &_c);
 
-  virtual void Mult(Vector &x) const;
+   virtual void Mult(Vector &x) const;
 
-  // For this problem type, xt is just used as a starting guess
-  //   (if applicable) to x
-  virtual void Mult(const Vector &xt, Vector &x) const{
-     x = xt;
-     Mult(x);
-  }
-
-protected:
-  virtual void allocHiopProbSpec(const long long& numvars);
+   // For this problem type, xt is just used as a starting guess
+   //   (if applicable) to x
+   virtual void Mult(const Vector &xt, Vector &x) const{
+      x = xt;
+      Mult(x);
+   }
 
 protected:
-  HiopProblemSpec* optProb_;
+   virtual void allocHiopProbSpec(const long long& numvars);
+
+protected:
+   HiopProblemSpec* optProb_;
 
 #ifdef MFEM_USE_MPI
-  MPI_Comm comm_;
+   MPI_Comm comm_;
 #endif
 
 }; //end of HiopNlpOptimizer class
@@ -370,42 +369,42 @@ protected:
 class HiopNlpOptimizer_Simple : public HiopNlpOptimizer
 {
 public:
-  HiopNlpOptimizer_Simple() : HiopNlpOptimizer(),
-                       optProb_Simple_(NULL) { }
+   HiopNlpOptimizer_Simple() : HiopNlpOptimizer(),
+                               optProb_Simple_(NULL) { }
 
 #ifdef MFEM_USE_MPI
-  HiopNlpOptimizer_Simple(MPI_Comm _comm) : HiopNlpOptimizer(_comm),
-                                     optProb_Simple_(NULL) { }
+   HiopNlpOptimizer_Simple(MPI_Comm _comm) : HiopNlpOptimizer(_comm),
+                                             optProb_Simple_(NULL) { }
 #endif
 
-  // Assumes xt = 0
-  virtual void Mult(Vector &x) const;
+   // Assumes xt = 0
+   virtual void Mult(Vector &x) const;
 
-  // For this problem type, we let the target values play the role of the
-  // initial vector xt, from which the operator generates the optimal vector x.
-  virtual void Mult(const Vector &xt, Vector &x) const;
+   // For this problem type, we let the target values play the role of the
+   // initial vector xt, from which the operator generates the optimal vector x.
+   virtual void Mult(const Vector &xt, Vector &x) const;
 
 protected:
-  virtual void allocHiopProbSpec(const long long& numvars);
-  // A is always I and c is always xt_.  Neither are used in eval_f or eval_grad_f
-  virtual void SetObjectiveFunction(const DenseMatrix &_A, const Vector &_c)
-  {
-    MFEM_WARNING("SetObjectiveFunction does nothing for class "
-                  "HiopNlpOptimizer_Simple.  Use Mult to set xt_.");
-  }
-  virtual void SetObjectiveFunction(const Vector &_c)
-  {
-    MFEM_WARNING("SetObjectiveFunction does nothing for class "
-                  "HiopNlpOptimizer_Simple.  Use Mult to set xt_.");
-  }
-  virtual void SetObjectiveFunction(const DenseMatrix &_A)
-  {
-    MFEM_WARNING("SetObjectiveFunction does nothing for class "
-                  "HiopNlpOptimizer_Simple.  Use Mult to set xt_.");
-  }
+   virtual void allocHiopProbSpec(const long long& numvars);
+   // A is always I and c is always xt_.  Neither are used in eval_f or eval_grad_f
+   virtual void SetObjectiveFunction(const DenseMatrix &_A, const Vector &_c)
+   {
+      MFEM_WARNING("SetObjectiveFunction does nothing for class "
+                   "HiopNlpOptimizer_Simple.  Use Mult to set xt_.");
+   }
+   virtual void SetObjectiveFunction(const Vector &_c)
+   {
+      MFEM_WARNING("SetObjectiveFunction does nothing for class "
+                   "HiopNlpOptimizer_Simple.  Use Mult to set xt_.");
+   }
+   virtual void SetObjectiveFunction(const DenseMatrix &_A)
+   {
+      MFEM_WARNING("SetObjectiveFunction does nothing for class "
+                   "HiopNlpOptimizer_Simple.  Use Mult to set xt_.");
+   }
 
 private:
-  HiopProblemSpec_Simple* optProb_Simple_;
+   HiopProblemSpec_Simple* optProb_Simple_;
 
 }; //end of HiopNlpOptimizer class
 

--- a/linalg/hiop.hpp
+++ b/linalg/hiop.hpp
@@ -53,7 +53,7 @@ public:
    }
 #endif
 
-   /** f = 1/2 x^T Q x + c^T x */
+   /** f = 1/2 x^T A x + c^T x */
    virtual void setObjectiveFunction(const DenseMatrix &_A, const Vector &_c)
    {
       setObjectiveFunction(_A);

--- a/linalg/hiop.hpp
+++ b/linalg/hiop.hpp
@@ -149,8 +149,8 @@ public:
          int ierr = MPI_Allreduce(&loc_wtx, &wtx, 1, MPI_DOUBLE, MPI_SUM, comm_);
          MFEM_ASSERT(ierr==MPI_SUCCESS, "MPI_Allreduce failed with error" << ierr);
 #endif
-         //w' * x - a
-         cons[0] = wtx - a_;
+         //Constraint is w_ * x = a_, a_ is provided in get_cons_info
+         cons[0] = wtx;
       }
       return true;
    };


### PR DESCRIPTION
@vladotomov , I don't have permission to push to mfem/hiop-dev, so I'll just make a pull request instead.

The commits below generalize the HiopNlpOptimizer class to work for a general objective function f(x) = 1/2 x^T A x + c^T x.  The previous HiopNlpOptimizer class, which only does f(x) = 1/2 || x - x_t ||_2, has now been renamed HiopNlpOptimizer_Simple and inherits from HiopNlpOptimizer.  The HiopProblemSpec class was generalized in the same manner, and the original HiopProblemSpec class has been renamed HiopProblemSpec_Simple, inheriting from HiopProblemSpec.  Examples hiop/ex9 and hiop/ex9p have been updated so that you can use the new HiopNlpOptimizer class to get the same answer (set A = I and c^T = -x_t).

I also tweaked the interface a bit to add more capabilities.  It can now use the value stored in the solution vector x as its initial guess, and it passes both the atol and print_level values in the OptimizationSolver base class to Hiop.