### PR TITLE
Preserve the global attribute lists after parallel derefinement [issue-463-fix]

### DIFF
--- a/mesh/mesh.cpp
+++ b/mesh/mesh.cpp
@@ -6077,6 +6077,10 @@ void Mesh::DerefineMesh(const Array<int> &derefinements)
    Mesh* mesh2 = new Mesh(*ncmesh);
    ncmesh->OnMeshUpdated(mesh2);
 
+   // In parallel, preserve the global attribute lists.
+   attributes.Copy(mesh2->attributes);
+   bdr_attributes.Copy(mesh2->bdr_attributes);
+
    Swap(*mesh2, false);
    delete mesh2;
 


### PR DESCRIPTION
This resolves #463.
