### PR TITLE
Fix an issue in ProjectBdrCoefficient [project-bdr-coeff-fix]

### DIFF
--- a/fem/gridfunc.cpp
+++ b/fem/gridfunc.cpp
@@ -1289,7 +1289,7 @@ void GridFunction::AccumulateAndCountZones(VectorCoefficient &vcoeff,
 }
 
 void GridFunction::AccumulateAndCountBdrValues(
-      Coefficient *coeff[], Array<int> &attr, Array<int> &values_counter)
+   Coefficient *coeff[], Array<int> &attr, Array<int> &values_counter)
 {
    int i, j, fdof, d, ind, vdim;
    double val;
@@ -1341,11 +1341,10 @@ void GridFunction::AccumulateAndCountBdrValues(
    // to set the values of all dofs on which the dofs set above depend.
    // Dependency is defined from the matrix A = cP.cR: dof i depends on dof j
    // iff A_ij != 0. It is sufficient to resolve just the first level of
-   // dependency since A is a projection matrix: A^n = A due to cR.cP = I.
-   // Cases like this arise in 3D when boundary edges are constrained by (depend
-   // on) internal faces/elements.
-   // We use the virtual method GetBoundaryClosure from NCMesh to resolve the
-   // dependencies.
+   // dependency, since A is a projection matrix: A^n = A due to cR.cP = I.
+   // Cases like these arise in 3D when boundary edges are constrained by
+   // (depend on) internal faces/elements. We use the virtual method
+   // GetBoundaryClosure from NCMesh to resolve the dependencies.
 
    if (fes->Nonconforming() && fes->GetMesh()->Dimension() == 3)
    {

--- a/fem/gridfunc.cpp
+++ b/fem/gridfunc.cpp
@@ -1303,35 +1303,34 @@ void GridFunction::AccumulateAndCountBdrValues(
    vdim = fes->GetVDim();
    for (i = 0; i < fes->GetNBE(); i++)
    {
-      if (attr[fes->GetBdrAttribute(i) - 1])
+      if (attr[fes->GetBdrAttribute(i) - 1] == 0) { continue; }
+
+      fe = fes->GetBE(i);
+      fdof = fe->GetDof();
+      transf = fes->GetBdrElementTransformation(i);
+      const IntegrationRule &ir = fe->GetNodes();
+      fes->GetBdrElementVDofs(i, vdofs);
+
+      for (j = 0; j < fdof; j++)
       {
-         fe = fes->GetBE(i);
-         fdof = fe->GetDof();
-         transf = fes->GetBdrElementTransformation(i);
-         const IntegrationRule &ir = fe->GetNodes();
-         fes->GetBdrElementVDofs(i, vdofs);
-
-         for (j = 0; j < fdof; j++)
+         const IntegrationPoint &ip = ir.IntPoint(j);
+         transf->SetIntPoint(&ip);
+         for (d = 0; d < vdim; d++)
          {
-            const IntegrationPoint &ip = ir.IntPoint(j);
-            transf->SetIntPoint(&ip);
-            for (d = 0; d < vdim; d++)
-            {
-               if (!coeff[d]) { continue; }
+            if (!coeff[d]) { continue; }
 
-               val = coeff[d]->Eval(*transf, ip);
-               if ( (ind = vdofs[fdof*d+j]) < 0 )
-               {
-                  val = -val, ind = -1-ind;
-               }
-               if (values_counter.Size() == 0 || ++values_counter[ind] == 1)
-               {
-                  (*this)(ind) = val;
-               }
-               else
-               {
-                  (*this)(ind) += val;
-               }
+            val = coeff[d]->Eval(*transf, ip);
+            if ( (ind = vdofs[fdof*d+j]) < 0 )
+            {
+               val = -val, ind = -1-ind;
+            }
+            if (++values_counter[ind] == 1)
+            {
+               (*this)(ind) = val;
+            }
+            else
+            {
+               (*this)(ind) += val;
             }
          }
       }
@@ -1372,7 +1371,7 @@ void GridFunction::AccumulateAndCountBdrValues(
             for (int k = 0; k < vals.Size(); k++)
             {
                ind = vdofs[d*vals.Size()+k];
-               if (values_counter.Size() == 0 || ++values_counter[ind] == 1)
+               if (++values_counter[ind] == 1)
                {
                   (*this)(ind) = vals(k);
                }
@@ -1380,7 +1379,6 @@ void GridFunction::AccumulateAndCountBdrValues(
                {
                   (*this)(ind) += vals(k);
                }
-               values_counter[ind]++;
             }
          }
       }

--- a/fem/gridfunc.hpp
+++ b/fem/gridfunc.hpp
@@ -254,6 +254,15 @@ public:
       Array<int> values_counter;
       AccumulateAndCountBdrValues(coeff, attr, values_counter);
       ComputeMeans(ARITHMETIC, values_counter);
+#ifdef MFEM_DEBUG
+      Array<int> ess_vdofs_marker;
+      fes->GetEssentialVDofs(attr, ess_vdofs_marker);
+      for (int i = 0; i < values_counter.Size(); i++)
+      {
+         MFEM_ASSERT(bool(values_counter[i]) == bool(ess_vdofs_marker[i]),
+                     "internal error");
+      }
+#endif
    }
 
    /** Project the normal component of the given VectorCoefficient on

--- a/fem/gridfunc.hpp
+++ b/fem/gridfunc.hpp
@@ -238,32 +238,30 @@ protected:
    void AccumulateAndCountBdrValues(Coefficient *coeff[], Array<int> &attr,
                                     Array<int> &values_counter);
 
+   void AccumulateAndCountBdrTangentValues(VectorCoefficient &vcoeff,
+                                           Array<int> &bdr_attr,
+                                           Array<int> &values_counter);
+
    // Complete the computation of averages; called e.g. after
    // AccumulateAndCountZones().
    void ComputeMeans(AvgType type, Array<int> &zones_per_vdof);
 
 public:
+   /** @brief Project a Coefficient on the GridFunction, modifying only DOFs on
+       the boundary associated with the boundary attributed marked in the
+       @a attr array. */
    void ProjectBdrCoefficient(Coefficient &coeff, Array<int> &attr)
    {
       Coefficient *coeff_p = &coeff;
       ProjectBdrCoefficient(&coeff_p, attr);
    }
 
-   virtual void ProjectBdrCoefficient(Coefficient *coeff[], Array<int> &attr)
-   {
-      Array<int> values_counter;
-      AccumulateAndCountBdrValues(coeff, attr, values_counter);
-      ComputeMeans(ARITHMETIC, values_counter);
-#ifdef MFEM_DEBUG
-      Array<int> ess_vdofs_marker;
-      fes->GetEssentialVDofs(attr, ess_vdofs_marker);
-      for (int i = 0; i < values_counter.Size(); i++)
-      {
-         MFEM_ASSERT(bool(values_counter[i]) == bool(ess_vdofs_marker[i]),
-                     "internal error");
-      }
-#endif
-   }
+   /** @brief Project a set of Coefficient%s on the components of the
+       GridFunction, modifying only DOFs on the boundary associated with the
+       boundary attributed marked in the @a attr array. */
+   /** If a Coefficient pointer in the array @a coeff is NULL, that component
+       will not be touched. */
+   virtual void ProjectBdrCoefficient(Coefficient *coeff[], Array<int> &attr);
 
    /** Project the normal component of the given VectorCoefficient on
        the boundary. Only boundary attributes that are marked in
@@ -271,11 +269,11 @@ public:
    void ProjectBdrCoefficientNormal(VectorCoefficient &vcoeff,
                                     Array<int> &bdr_attr);
 
-   /** Project the tangential components of the given VectorCoefficient on
-       the boundary. Only boundary attributes that are marked in
-       'bdr_attr' are projected. Assumes ND-type VectorFE GridFunction. */
-   void ProjectBdrCoefficientTangent(VectorCoefficient &vcoeff,
-                                     Array<int> &bdr_attr);
+   /** @brief Project the tangential components of the given VectorCoefficient
+       on the boundary. Only boundary attributes that are marked in @a bdr_attr
+       are projected. Assumes ND-type VectorFE GridFunction. */
+   virtual void ProjectBdrCoefficientTangent(VectorCoefficient &vcoeff,
+                                             Array<int> &bdr_attr);
 
    virtual double ComputeL2Error(Coefficient &exsol,
                                  const IntegrationRule *irs[] = NULL) const

--- a/fem/gridfunc.hpp
+++ b/fem/gridfunc.hpp
@@ -235,6 +235,9 @@ protected:
    void AccumulateAndCountZones(VectorCoefficient &vcoeff, AvgType type,
                                 Array<int> &zones_per_vdof);
 
+   void AccumulateAndCountBdrValues(Coefficient *coeff[], Array<int> &attr,
+                                    Array<int> &values_counter);
+
    // Complete the computation of averages; called e.g. after
    // AccumulateAndCountZones().
    void ComputeMeans(AvgType type, Array<int> &zones_per_vdof);
@@ -246,7 +249,12 @@ public:
       ProjectBdrCoefficient(&coeff_p, attr);
    }
 
-   void ProjectBdrCoefficient(Coefficient *coeff[], Array<int> &attr);
+   virtual void ProjectBdrCoefficient(Coefficient *coeff[], Array<int> &attr)
+   {
+      Array<int> values_counter;
+      AccumulateAndCountBdrValues(coeff, attr, values_counter);
+      ComputeMeans(ARITHMETIC, values_counter);
+   }
 
    /** Project the normal component of the given VectorCoefficient on
        the boundary. Only boundary attributes that are marked in

--- a/fem/pgridfunc.cpp
+++ b/fem/pgridfunc.cpp
@@ -425,6 +425,7 @@ void ParGridFunction::ProjectBdrCoefficient(
    {
       // FIXME: same as the conforming case after 'cut-mesh-groups-dev-*' is
       //        merged?
+      ComputeMeans(ARITHMETIC, values_counter);
    }
 #ifdef MFEM_DEBUG
    Array<int> ess_vdofs_marker;
@@ -468,6 +469,7 @@ void ParGridFunction::ProjectBdrCoefficientTangent(VectorCoefficient &vcoeff,
    {
       // FIXME: same as the conforming case after 'cut-mesh-groups-dev-*' is
       //        merged?
+      ComputeMeans(ARITHMETIC, values_counter);
    }
 #ifdef MFEM_DEBUG
    Array<int> ess_vdofs_marker;

--- a/fem/pgridfunc.cpp
+++ b/fem/pgridfunc.cpp
@@ -438,6 +438,49 @@ void ParGridFunction::ProjectBdrCoefficient(
 #endif
 }
 
+void ParGridFunction::ProjectBdrCoefficientTangent(VectorCoefficient &vcoeff,
+                                                   Array<int> &bdr_attr)
+{
+   Array<int> values_counter;
+   AccumulateAndCountBdrTangentValues(vcoeff, bdr_attr, values_counter);
+   if (pfes->Conforming())
+   {
+      Vector values(Size());
+      for (int i = 0; i < values.Size(); i++)
+      {
+         values(i) = values_counter[i] ? (*this)(i) : 0.0;
+      }
+      // Count the values globally.
+      GroupCommunicator &gcomm = pfes->GroupComm();
+      gcomm.Reduce<int>(values_counter, GroupCommunicator::Sum);
+      // Accumulate the values globally.
+      gcomm.Reduce<double>(values, GroupCommunicator::Sum);
+      // Only the values in the master are guaranteed to be correct!
+      for (int i = 0; i < values.Size(); i++)
+      {
+         if (values_counter[i])
+         {
+            (*this)(i) = values(i)/values_counter[i];
+         }
+      }
+   }
+   else
+   {
+      // FIXME: same as the conforming case after 'cut-mesh-groups-dev-*' is
+      //        merged?
+   }
+#ifdef MFEM_DEBUG
+   Array<int> ess_vdofs_marker;
+   pfes->GetEssentialVDofs(bdr_attr, ess_vdofs_marker);
+   for (int i = 0; i < values_counter.Size(); i++)
+   {
+      MFEM_ASSERT(pfes->GetLocalTDofNumber(i) == -1 ||
+                  bool(values_counter[i]) == bool(ess_vdofs_marker[i]),
+                  "internal error");
+   }
+#endif
+}
+
 void ParGridFunction::Save(std::ostream &out) const
 {
    for (int i = 0; i < size; i++)

--- a/fem/pgridfunc.hpp
+++ b/fem/pgridfunc.hpp
@@ -197,6 +197,9 @@ public:
 
    virtual void ProjectDiscCoefficient(VectorCoefficient &vcoeff, AvgType type);
 
+   using GridFunction::ProjectBdrCoefficient;
+   virtual void ProjectBdrCoefficient(Coefficient *coeff[], Array<int> &attr);
+
    virtual double ComputeL1Error(Coefficient *exsol[],
                                  const IntegrationRule *irs[] = NULL) const
    {

--- a/fem/pgridfunc.hpp
+++ b/fem/pgridfunc.hpp
@@ -198,6 +198,8 @@ public:
    virtual void ProjectDiscCoefficient(VectorCoefficient &vcoeff, AvgType type);
 
    using GridFunction::ProjectBdrCoefficient;
+
+   // Only the values in the master are guaranteed to be correct!
    virtual void ProjectBdrCoefficient(Coefficient *coeff[], Array<int> &attr);
 
    virtual double ComputeL1Error(Coefficient *exsol[],

--- a/fem/pgridfunc.hpp
+++ b/fem/pgridfunc.hpp
@@ -202,6 +202,10 @@ public:
    // Only the values in the master are guaranteed to be correct!
    virtual void ProjectBdrCoefficient(Coefficient *coeff[], Array<int> &attr);
 
+   // Only the values in the master are guaranteed to be correct!
+   virtual void ProjectBdrCoefficientTangent(VectorCoefficient &vcoeff,
+                                             Array<int> &bdr_attr);
+
    virtual double ComputeL1Error(Coefficient *exsol[],
                                  const IntegrationRule *irs[] = NULL) const
    {


### PR DESCRIPTION
Fix for an issue in the method `ProjectBdrCoefficient` in class `GridFunction` when used in parallel. The issue manifests when the master processor for a boundary DOF does not own any of the boundary elements adjacent to that DOF. The result is that such DOFs remain uninitialized.

TODO:

- [x] Fix the same issue in `ProjectBdrCoefficientTangent`.