### PR TITLE
Adjusting const correctness of Coefficient::Eval methods [coef-eval-const-dev]

### DIFF
--- a/examples/ex10.cpp
+++ b/examples/ex10.cpp
@@ -135,12 +135,12 @@ class ElasticEnergyCoefficient : public Coefficient
 private:
    HyperelasticModel  &model;
    const GridFunction &x;
-   DenseMatrix         J;
+   mutable DenseMatrix J;
 
 public:
    ElasticEnergyCoefficient(HyperelasticModel &m, const GridFunction &x_)
       : model(m), x(x_) { }
-   virtual double Eval(ElementTransformation &T);
+   virtual double Eval(const ElementTransformation &T) const;
    virtual ~ElasticEnergyCoefficient() { }
 };
 
@@ -575,9 +575,8 @@ HyperelasticOperator::~HyperelasticOperator()
 }
 
 
-double ElasticEnergyCoefficient::Eval(ElementTransformation &T)
+double ElasticEnergyCoefficient::Eval(const ElementTransformation &T) const
 {
-   model.SetTransformation(T);
    x.GetVectorGradient(T, J);
    // return model.EvalW(J);  // in reference configuration
    return model.EvalW(J)/J.Det(); // in deformed configuration

--- a/examples/ex10p.cpp
+++ b/examples/ex10p.cpp
@@ -140,12 +140,12 @@ class ElasticEnergyCoefficient : public Coefficient
 private:
    HyperelasticModel     &model;
    const ParGridFunction &x;
-   DenseMatrix            J;
+   mutable DenseMatrix    J;
 
 public:
    ElasticEnergyCoefficient(HyperelasticModel &m, const ParGridFunction &x_)
       : model(m), x(x_) { }
-   virtual double Eval(ElementTransformation &T);
+   virtual double Eval(const ElementTransformation &T) const;
    virtual ~ElasticEnergyCoefficient() { }
 };
 
@@ -648,9 +648,8 @@ HyperelasticOperator::~HyperelasticOperator()
 }
 
 
-double ElasticEnergyCoefficient::Eval(ElementTransformation &T)
+double ElasticEnergyCoefficient::Eval(const ElementTransformation &T) const
 {
-   model.SetTransformation(T);
    x.GetVectorGradient(T, J);
    // return model.EvalW(J);  // in reference configuration
    return model.EvalW(J)/J.Det(); // in deformed configuration

--- a/examples/ex17.cpp
+++ b/examples/ex17.cpp
@@ -59,7 +59,7 @@ protected:
    GridFunction *u; // displacement
    int si, sj; // component of the stress to evaluate, 0 <= si,sj < dim
 
-   DenseMatrix grad; // auxiliary matrix, used in Eval
+   mutable DenseMatrix grad; // auxiliary matrix, used in Eval
 
 public:
    StressCoefficient(Coefficient &lambda_, Coefficient &mu_)
@@ -68,7 +68,7 @@ public:
    void SetDisplacement(GridFunction &u_) { u = &u_; }
    void SetComponent(int i, int j) { si = i; sj = j; }
 
-   virtual double Eval(ElementTransformation &T);
+   virtual double Eval(const ElementTransformation &T) const;
 };
 
 // Simple GLVis visualization manager.
@@ -336,7 +336,7 @@ void InitDisplacement(const Vector &x, Vector &u)
 }
 
 
-double StressCoefficient::Eval(ElementTransformation &T)
+double StressCoefficient::Eval(const ElementTransformation &T) const
 {
    MFEM_ASSERT(u != NULL, "displacement field is not set");
 

--- a/examples/ex17p.cpp
+++ b/examples/ex17p.cpp
@@ -59,7 +59,7 @@ protected:
    GridFunction *u; // displacement
    int si, sj; // component of the stress to evaluate, 0 <= si,sj < dim
 
-   DenseMatrix grad; // auxiliary matrix, used in Eval
+   mutable DenseMatrix grad; // auxiliary matrix, used in Eval
 
 public:
    StressCoefficient(Coefficient &lambda_, Coefficient &mu_)
@@ -68,7 +68,7 @@ public:
    void SetDisplacement(GridFunction &u_) { u = &u_; }
    void SetComponent(int i, int j) { si = i; sj = j; }
 
-   virtual double Eval(ElementTransformation &T);
+   virtual double Eval(const ElementTransformation &T) const;
 };
 
 // Simple GLVis visualization manager.
@@ -374,7 +374,7 @@ void InitDisplacement(const Vector &x, Vector &u)
 }
 
 
-double StressCoefficient::Eval(ElementTransformation &T)
+double StressCoefficient::Eval(const ElementTransformation &T) const
 {
    MFEM_ASSERT(u != NULL, "displacement field is not set");
 

--- a/fem/bilininteg.cpp
+++ b/fem/bilininteg.cpp
@@ -3063,7 +3063,7 @@ ScalarProductInterpolator::AssembleElementMatrix2(const FiniteElement &dom_fe,
          : VectorCoefficient(fe_.GetDof()), Q(q), fe(fe_) { }
 
       using VectorCoefficient::Eval;
-      virtual void Eval(Vector &V, ElementTransformation &T)
+      virtual void Eval(Vector &V, const ElementTransformation &T) const
       {
          V.SetSize(vdim);
          fe.CalcPhysShape(T, V);
@@ -3097,7 +3097,7 @@ ScalarVectorProductInterpolator::AssembleElementMatrix2(
       VShapeCoefficient(Coefficient &q, const FiniteElement &fe_, int sdim)
          : MatrixCoefficient(fe_.GetDof(), sdim), Q(q), fe(fe_) { }
 
-      virtual void Eval(DenseMatrix &M, ElementTransformation &T)
+      virtual void Eval(DenseMatrix &M, const ElementTransformation &T) const
       {
          M.SetSize(height, width);
          fe.CalcPhysVShape(T, M);
@@ -3127,13 +3127,13 @@ VectorScalarProductInterpolator::AssembleElementMatrix2(
    {
       VectorCoefficient &VQ;
       const FiniteElement &fe;
-      Vector vc, shape;
+      mutable Vector vc, shape;
 
       VecShapeCoefficient(VectorCoefficient &vq, const FiniteElement &fe_)
          : MatrixCoefficient(fe_.GetDof(), vq.GetVDim()), VQ(vq), fe(fe_),
            vc(width), shape(height) { }
 
-      virtual void Eval(DenseMatrix &M, ElementTransformation &T)
+      virtual void Eval(DenseMatrix &M, const ElementTransformation &T) const
       {
          M.SetSize(height, width);
          VQ.Eval(vc, T);
@@ -3164,8 +3164,8 @@ VectorCrossProductInterpolator::AssembleElementMatrix2(
    {
       VectorCoefficient &VQ;
       const FiniteElement &fe;
-      DenseMatrix vshape;
-      Vector vc;
+      mutable DenseMatrix vshape;
+      mutable Vector vc;
 
       VCrossVShapeCoefficient(VectorCoefficient &vq, const FiniteElement &fe_)
          : MatrixCoefficient(fe_.GetDof(), vq.GetVDim()), VQ(vq), fe(fe_),
@@ -3174,7 +3174,7 @@ VectorCrossProductInterpolator::AssembleElementMatrix2(
          MFEM_ASSERT(width == 3, "");
       }
 
-      virtual void Eval(DenseMatrix &M, ElementTransformation &T)
+      virtual void Eval(DenseMatrix &M, const ElementTransformation &T) const
       {
          M.SetSize(height, width);
          VQ.Eval(vc, T);
@@ -3217,15 +3217,15 @@ VectorInnerProductInterpolator::AssembleElementMatrix2(
    {
       VectorCoefficient &VQ;
       const FiniteElement &fe;
-      DenseMatrix vshape;
-      Vector vc;
+      mutable DenseMatrix vshape;
+      mutable Vector vc;
 
       VDotVShapeCoefficient(VectorCoefficient &vq, const FiniteElement &fe_)
          : VectorCoefficient(fe_.GetDof()), VQ(vq), fe(fe_),
            vshape(vdim, vq.GetVDim()), vc(vq.GetVDim()) { }
 
       using VectorCoefficient::Eval;
-      virtual void Eval(Vector &V, ElementTransformation &T)
+      virtual void Eval(Vector &V, const ElementTransformation &T) const
       {
          V.SetSize(vdim);
          VQ.Eval(vc, T);

--- a/fem/coefficient.cpp
+++ b/fem/coefficient.cpp
@@ -21,13 +21,13 @@ namespace mfem
 
 using namespace std;
 
-double PWConstCoefficient::Eval(ElementTransformation & T)
+double PWConstCoefficient::Eval(const ElementTransformation & T) const
 {
    int att = T.Attribute;
    return (constants(att-1));
 }
 
-double FunctionCoefficient::Eval(ElementTransformation & T)
+double FunctionCoefficient::Eval(const ElementTransformation & T) const
 {
    MFEM_ASSERT(T.IntPointSet(), "Integration point not set.");
 
@@ -46,13 +46,13 @@ double FunctionCoefficient::Eval(ElementTransformation & T)
    }
 }
 
-double GridFunctionCoefficient::Eval (ElementTransformation &T)
+double GridFunctionCoefficient::Eval (const ElementTransformation &T) const
 {
    MFEM_ASSERT(T.IntPointSet(), "Integration point not set.");
    return GridF -> GetValue (T.ElementNo, T.GetIntPoint(), Component);
 }
 
-double TransformedCoefficient::Eval(ElementTransformation &T)
+double TransformedCoefficient::Eval(const ElementTransformation &T) const
 {
    if (Q2)
    {
@@ -73,13 +73,13 @@ void DeltaCoefficient::SetDeltaCenter(const Vector& vcenter)
    sdim = vcenter.Size();
 }
 
-void DeltaCoefficient::GetDeltaCenter(Vector& vcenter)
+void DeltaCoefficient::GetDeltaCenter(Vector& vcenter) const
 {
    vcenter.SetSize(sdim);
    vcenter = center;
 }
 
-double DeltaCoefficient::EvalDelta(ElementTransformation &T)
+double DeltaCoefficient::EvalDelta(const ElementTransformation &T) const
 {
    double w = Scale();
    return weight ? weight->Eval(T, GetTime())*w : w;
@@ -87,7 +87,7 @@ double DeltaCoefficient::EvalDelta(ElementTransformation &T)
 
 
 void VectorCoefficient::Eval(DenseMatrix &M, ElementTransformation &T,
-                             const IntegrationRule &ir)
+                             const IntegrationRule &ir) const
 {
    Vector Mi;
    M.SetSize(vdim, ir.GetNPoints());
@@ -100,7 +100,8 @@ void VectorCoefficient::Eval(DenseMatrix &M, ElementTransformation &T,
    }
 }
 
-void VectorFunctionCoefficient::Eval(Vector &V, ElementTransformation &T)
+void VectorFunctionCoefficient::Eval(Vector &V,
+                                     const ElementTransformation &T) const
 {
    MFEM_ASSERT(T.IntPointSet(), "Integration point not set.");
 
@@ -141,7 +142,8 @@ VectorArrayCoefficient::~VectorArrayCoefficient()
    }
 }
 
-void VectorArrayCoefficient::Eval(Vector &V, ElementTransformation &T)
+void VectorArrayCoefficient::Eval(Vector &V,
+                                  const ElementTransformation &T) const
 {
    V.SetSize(vdim);
    for (int i = 0; i < vdim; i++)
@@ -156,14 +158,15 @@ VectorGridFunctionCoefficient::VectorGridFunctionCoefficient (
    GridFunc = gf;
 }
 
-void VectorGridFunctionCoefficient::Eval(Vector &V, ElementTransformation &T)
+void VectorGridFunctionCoefficient::Eval(Vector &V,
+                                         const ElementTransformation &T) const
 {
    MFEM_ASSERT(T.IntPointSet(), "Integration point not set.");
    GridFunc->GetVectorValue(T.ElementNo, T.GetIntPoint(), V);
 }
 
 void VectorGridFunctionCoefficient::Eval(
-   DenseMatrix &M, ElementTransformation &T, const IntegrationRule &ir)
+   DenseMatrix &M, ElementTransformation &T, const IntegrationRule &ir) const
 {
    GridFunc->GetVectorValues(T, ir, M);
 }
@@ -175,14 +178,14 @@ void VectorDeltaCoefficient::SetDirection(const Vector &_d)
 }
 
 void VectorDeltaCoefficient::EvalDelta(
-   Vector &V, ElementTransformation &T)
+   Vector &V, const ElementTransformation &T) const
 {
    V = dir;
-   d.SetTime(GetTime());
    V *= d.EvalDelta(T);
 }
 
-void VectorRestrictedCoefficient::Eval(Vector &V, ElementTransformation &T)
+void VectorRestrictedCoefficient::Eval(Vector &V,
+                                       const ElementTransformation &T) const
 {
    V.SetSize(vdim);
    if (active_attr[T.Attribute-1])
@@ -197,7 +200,7 @@ void VectorRestrictedCoefficient::Eval(Vector &V, ElementTransformation &T)
 }
 
 void VectorRestrictedCoefficient::Eval(
-   DenseMatrix &M, ElementTransformation &T, const IntegrationRule &ir)
+   DenseMatrix &M, ElementTransformation &T, const IntegrationRule &ir) const
 {
    if (active_attr[T.Attribute-1])
    {
@@ -211,7 +214,8 @@ void VectorRestrictedCoefficient::Eval(
    }
 }
 
-void MatrixFunctionCoefficient::Eval(DenseMatrix &K, ElementTransformation &T)
+void MatrixFunctionCoefficient::Eval(DenseMatrix &K,
+                                     const ElementTransformation &T) const
 {
    MFEM_ASSERT(T.IntPointSet(), "Integration point not set.");
 
@@ -258,7 +262,8 @@ MatrixArrayCoefficient::~MatrixArrayCoefficient ()
    }
 }
 
-void MatrixArrayCoefficient::Eval(DenseMatrix &K, ElementTransformation &T)
+void MatrixArrayCoefficient::Eval(DenseMatrix &K,
+                                  const ElementTransformation &T) const
 {
    for (int i = 0; i < height; i++)
    {
@@ -269,7 +274,8 @@ void MatrixArrayCoefficient::Eval(DenseMatrix &K, ElementTransformation &T)
    }
 }
 
-void MatrixRestrictedCoefficient::Eval(DenseMatrix &K, ElementTransformation &T)
+void MatrixRestrictedCoefficient::Eval(DenseMatrix &K,
+                                       const ElementTransformation &T) const
 {
    if (active_attr[T.Attribute-1])
    {

--- a/fem/eltrans.cpp
+++ b/fem/eltrans.cpp
@@ -23,7 +23,7 @@ ElementTransformation::ElementTransformation()
      ElementNo(-1)
 { }
 
-double ElementTransformation::EvalWeight()
+double ElementTransformation::EvalWeight() const
 {
    MFEM_ASSERT((EvalState & WEIGHT_MASK) == 0, "");
    Jacobian();
@@ -31,7 +31,7 @@ double ElementTransformation::EvalWeight()
    return (Wght = (dFdx.Width() == 0) ? 1.0 : dFdx.Weight());
 }
 
-const DenseMatrix &ElementTransformation::EvalAdjugateJ()
+const DenseMatrix &ElementTransformation::EvalAdjugateJ() const
 {
    MFEM_ASSERT((EvalState & ADJUGATE_MASK) == 0, "");
    Jacobian();
@@ -41,7 +41,7 @@ const DenseMatrix &ElementTransformation::EvalAdjugateJ()
    return adjJ;
 }
 
-const DenseMatrix &ElementTransformation::EvalInverseJ()
+const DenseMatrix &ElementTransformation::EvalInverseJ() const
 {
    // TODO: compute as invJ = / adjJ/Weight,    if J is square,
    //                         \ adjJ/Weight^2,  otherwise.
@@ -55,7 +55,7 @@ const DenseMatrix &ElementTransformation::EvalInverseJ()
 
 
 int InverseElementTransformation::FindClosestPhysPoint(
-   const Vector& pt, const IntegrationRule &ir)
+   const Vector& pt, const IntegrationRule &ir) const
 {
    MFEM_VERIFY(T != NULL, "invalid ElementTransformation");
    MFEM_VERIFY(pt.Size() == T->GetSpaceDim(), "invalid point");
@@ -113,7 +113,7 @@ int InverseElementTransformation::FindClosestRefPoint(
    return minIndex;
 }
 
-void InverseElementTransformation::NewtonPrint(int mode, double val)
+void InverseElementTransformation::NewtonPrint(int mode, double val) const
 {
    std::ostream &out = mfem::out;
 
@@ -144,7 +144,7 @@ void InverseElementTransformation::NewtonPrint(int mode, double val)
 
 void InverseElementTransformation::NewtonPrintPoint(const char *prefix,
                                                     const Vector &pt,
-                                                    const char *suffix)
+                                                    const char *suffix) const
 {
    std::ostream &out = mfem::out;
 
@@ -392,7 +392,7 @@ void IsoparametricTransformation::SetIdentityTransformation(int GeomType)
    space_dim = dim;
 }
 
-const DenseMatrix &IsoparametricTransformation::EvalJacobian()
+const DenseMatrix &IsoparametricTransformation::EvalJacobian() const
 {
    MFEM_ASSERT(space_dim == PointMat.Height(),
                "the IsoparametricTransformation has not been finalized;"
@@ -411,7 +411,7 @@ const DenseMatrix &IsoparametricTransformation::EvalJacobian()
    return dFdx;
 }
 
-int IsoparametricTransformation::OrderJ()
+int IsoparametricTransformation::OrderJ() const
 {
    switch (FElem->Space())
    {
@@ -425,7 +425,7 @@ int IsoparametricTransformation::OrderJ()
    return 0;
 }
 
-int IsoparametricTransformation::OrderW()
+int IsoparametricTransformation::OrderW() const
 {
    switch (FElem->Space())
    {
@@ -439,7 +439,7 @@ int IsoparametricTransformation::OrderW()
    return 0;
 }
 
-int IsoparametricTransformation::OrderGrad(const FiniteElement *fe)
+int IsoparametricTransformation::OrderGrad(const FiniteElement *fe) const
 {
    if (FElem->Space() == fe->Space())
    {
@@ -459,7 +459,7 @@ int IsoparametricTransformation::OrderGrad(const FiniteElement *fe)
 }
 
 void IsoparametricTransformation::Transform (const IntegrationPoint &ip,
-                                             Vector &trans)
+                                             Vector &trans) const
 {
    shape.SetSize(FElem->GetDof());
    trans.SetSize(PointMat.Height());
@@ -469,7 +469,7 @@ void IsoparametricTransformation::Transform (const IntegrationPoint &ip,
 }
 
 void IsoparametricTransformation::Transform (const IntegrationRule &ir,
-                                             DenseMatrix &tr)
+                                             DenseMatrix &tr) const
 {
    int dof, n, dim, i, j, k;
 
@@ -495,7 +495,7 @@ void IsoparametricTransformation::Transform (const IntegrationRule &ir,
 }
 
 void IsoparametricTransformation::Transform (const DenseMatrix &matrix,
-                                             DenseMatrix &result)
+                                             DenseMatrix &result) const
 {
    MFEM_ASSERT(matrix.Height() == GetDimension(), "invalid input");
    result.SetSize(PointMat.Height(), matrix.Width());

--- a/fem/eltrans.cpp
+++ b/fem/eltrans.cpp
@@ -82,7 +82,7 @@ int InverseElementTransformation::FindClosestPhysPoint(
 }
 
 int InverseElementTransformation::FindClosestRefPoint(
-   const Vector& pt, const IntegrationRule &ir)
+   const Vector& pt, const IntegrationRule &ir) const
 {
    MFEM_VERIFY(T != NULL, "invalid ElementTransformation");
    MFEM_VERIFY(pt.Size() == T->GetSpaceDim(), "invalid point");
@@ -100,8 +100,9 @@ int InverseElementTransformation::FindClosestRefPoint(
       const IntegrationPoint &ip = ir.IntPoint(i);
       T->Transform(ip, dp);
       dp -= pt;
-      T->SetIntPoint(&ip);
+      SetIntPoint(&ip);
       T->InverseJacobian().Mult(dp, dr);
+      ResetIntPoint();
       double dist = dr.Norml2();
       // double dist = dr.Normlinf();
       if (dist < minDist)
@@ -157,7 +158,7 @@ void InverseElementTransformation::NewtonPrintPoint(const char *prefix,
 }
 
 int InverseElementTransformation::NewtonSolve(const Vector &pt,
-                                              IntegrationPoint &ip)
+                                              IntegrationPoint &ip) const
 {
    MFEM_ASSERT(pt.Size() == T->GetSpaceDim(), "invalid point");
 
@@ -263,8 +264,9 @@ int InverseElementTransformation::NewtonSolve(const Vector &pt,
       if (it == max_iter) { break; }
 
       // Perform a Newton step:
-      T->SetIntPoint(&xip);
+      SetIntPoint(&xip);
       T->InverseJacobian().Mult(y, dx);
+      ResetIntPoint();
       x += dx;
       it++;
       if (solver_type != Newton)
@@ -321,7 +323,7 @@ int InverseElementTransformation::NewtonSolve(const Vector &pt,
 }
 
 int InverseElementTransformation::Transform(const Vector &pt,
-                                            IntegrationPoint &ip)
+                                            IntegrationPoint &ip) const
 {
    MFEM_VERIFY(T != NULL, "invalid ElementTransformation");
 

--- a/fem/fe.cpp
+++ b/fem/fe.cpp
@@ -45,7 +45,7 @@ void FiniteElement::CalcVShape (
 }
 
 void FiniteElement::CalcVShape (
-   ElementTransformation &Trans, DenseMatrix &shape) const
+   const ElementTransformation &Trans, DenseMatrix &shape) const
 {
    mfem_error ("FiniteElement::CalcVShape (trans, ...)\n"
                "   is not implemented for this class!");
@@ -59,7 +59,7 @@ void FiniteElement::CalcDivShape (
 }
 
 void FiniteElement::CalcPhysDivShape(
-   ElementTransformation &Trans, Vector &div_shape) const
+   const ElementTransformation &Trans, Vector &div_shape) const
 {
    MFEM_ASSERT(Trans.IntPointSet(), "Integration point not set.");
    CalcDivShape(Trans.GetIntPoint(), div_shape);
@@ -73,7 +73,7 @@ void FiniteElement::CalcCurlShape(const IntegrationPoint &ip,
                "   is not implemented for this class!");
 }
 
-void FiniteElement::CalcPhysCurlShape(ElementTransformation &Trans,
+void FiniteElement::CalcPhysCurlShape(const ElementTransformation &Trans,
                                       DenseMatrix &curl_shape) const
 {
    MFEM_ASSERT(Trans.IntPointSet(), "Integration point not set.");
@@ -178,7 +178,7 @@ void FiniteElement::ProjectDiv(
               "this element!");
 }
 
-void FiniteElement::CalcPhysShape(ElementTransformation &Trans,
+void FiniteElement::CalcPhysShape(const ElementTransformation &Trans,
                                   Vector &shape) const
 {
    MFEM_ASSERT(Trans.IntPointSet(), "Integration point not set.");
@@ -189,7 +189,7 @@ void FiniteElement::CalcPhysShape(ElementTransformation &Trans,
    }
 }
 
-void FiniteElement::CalcPhysDShape(ElementTransformation &Trans,
+void FiniteElement::CalcPhysDShape(const ElementTransformation &Trans,
                                    DenseMatrix &dshape) const
 {
    MFEM_ASSERT(Trans.IntPointSet(), "Integration point not set.");

--- a/fem/fe.cpp
+++ b/fem/fe.cpp
@@ -549,7 +549,7 @@ void VectorFiniteElement::SetDerivMembers()
 }
 
 void VectorFiniteElement::CalcVShape_RT (
-   ElementTransformation &Trans, DenseMatrix &shape) const
+   const ElementTransformation &Trans, DenseMatrix &shape) const
 {
    MFEM_ASSERT(Trans.IntPointSet(), "Integration point not set.");
    MFEM_ASSERT(MapType == H_DIV, "");
@@ -562,7 +562,7 @@ void VectorFiniteElement::CalcVShape_RT (
 }
 
 void VectorFiniteElement::CalcVShape_ND (
-   ElementTransformation &Trans, DenseMatrix &shape) const
+   const ElementTransformation &Trans, DenseMatrix &shape) const
 {
    MFEM_ASSERT(Trans.IntPointSet(), "Integration point not set.");
    MFEM_ASSERT(MapType == H_CURL, "");

--- a/fem/fe.hpp
+++ b/fem/fe.hpp
@@ -249,7 +249,7 @@ public:
    /** @brief Evaluate the values of all shape functions of a scalar finite
        element in physical space at the point described by @a Trans. */
    /** The size (#Dof) of the result Vector @a shape must be set in advance. */
-   void CalcPhysShape(ElementTransformation &Trans, Vector &shape) const;
+   void CalcPhysShape(const ElementTransformation &Trans, Vector &shape) const;
 
    /** @brief Evaluate the gradients of all shape functions of a scalar finite
        element in reference space at the given point @a ip. */
@@ -265,7 +265,8 @@ public:
        one shape function. The size (#Dof x SDim) of @a dshape must be set in
        advance, where SDim >= #Dim is the physical space dimension as described
        by @a Trans. */
-   void CalcPhysDShape(ElementTransformation &Trans, DenseMatrix &dshape) const;
+   void CalcPhysDShape(const ElementTransformation &Trans,
+                       DenseMatrix &dshape) const;
 
    const IntegrationRule & GetNodes() const { return Nodes; }
 
@@ -285,11 +286,12 @@ public:
        one vector shape function. The size (#Dof x SDim) of @a shape must be set
        in advance, where SDim >= #Dim is the physical space dimension as
        described by @a Trans. */
-   virtual void CalcVShape(ElementTransformation &Trans,
+   virtual void CalcVShape(const ElementTransformation &Trans,
                            DenseMatrix &shape) const;
 
    /// Equivalent to the CalcVShape() method with the same arguments.
-   void CalcPhysVShape(ElementTransformation &Trans, DenseMatrix &shape) const
+   void CalcPhysVShape(const ElementTransformation &Trans,
+                       DenseMatrix &shape) const
    { CalcVShape(Trans, shape); }
 
    /** @brief Evaluate the divergence of all shape functions of a *vector*
@@ -303,7 +305,8 @@ public:
        finite element in physical space at the point described by @a Trans. */
    /** The size (#Dof) of the result Vector @a divshape must be set in advance.
     */
-   void CalcPhysDivShape(ElementTransformation &Trans, Vector &divshape) const;
+   void CalcPhysDivShape(const ElementTransformation &Trans,
+                         Vector &divshape) const;
 
    /** @brief Evaluate the curl of all shape functions of a *vector* finite
        element in reference space at the given point @a ip. */
@@ -320,7 +323,7 @@ public:
        of the curl of one vector shape function. The size (#Dof x CDim) of
        @a curl_shape must be set in advance, where CDim = 3 for #Dim = 3 and
        CDim = 1 for #Dim = 2. */
-   void CalcPhysCurlShape(ElementTransformation &Trans,
+   void CalcPhysCurlShape(const ElementTransformation &Trans,
                           DenseMatrix &curl_shape) const;
 
    virtual void GetFaceDofs(int face, int **dofs, int *ndofs) const;

--- a/fem/fe.hpp
+++ b/fem/fe.hpp
@@ -569,10 +569,10 @@ protected:
 #endif
    void SetDerivMembers();
 
-   void CalcVShape_RT(ElementTransformation &Trans,
+   void CalcVShape_RT(const ElementTransformation &Trans,
                       DenseMatrix &shape) const;
 
-   void CalcVShape_ND(ElementTransformation &Trans,
+   void CalcVShape_ND(const ElementTransformation &Trans,
                       DenseMatrix &shape) const;
 
    void Project_RT(const double *nk, const Array<int> &d2n,
@@ -1063,7 +1063,7 @@ public:
    virtual void CalcVShape(const IntegrationPoint &ip,
                            DenseMatrix &shape) const;
 
-   virtual void CalcVShape(ElementTransformation &Trans,
+   virtual void CalcVShape(const ElementTransformation &Trans,
                            DenseMatrix &shape) const
    { CalcVShape_RT(Trans, shape); }
 
@@ -1090,7 +1090,7 @@ public:
    virtual void CalcVShape(const IntegrationPoint &ip,
                            DenseMatrix &shape) const;
 
-   virtual void CalcVShape(ElementTransformation &Trans,
+   virtual void CalcVShape(const ElementTransformation &Trans,
                            DenseMatrix &shape) const
    { CalcVShape_RT(Trans, shape); }
 
@@ -1117,7 +1117,7 @@ public:
    virtual void CalcVShape(const IntegrationPoint &ip,
                            DenseMatrix &shape) const;
 
-   virtual void CalcVShape(ElementTransformation &Trans,
+   virtual void CalcVShape(const ElementTransformation &Trans,
                            DenseMatrix &shape) const
    { CalcVShape_RT(Trans, shape); }
 
@@ -1144,7 +1144,7 @@ public:
    virtual void CalcVShape(const IntegrationPoint &ip,
                            DenseMatrix &shape) const;
 
-   virtual void CalcVShape(ElementTransformation &Trans,
+   virtual void CalcVShape(const ElementTransformation &Trans,
                            DenseMatrix &shape) const
    { CalcVShape_RT(Trans, shape); }
 
@@ -1170,7 +1170,7 @@ public:
    virtual void CalcVShape(const IntegrationPoint &ip,
                            DenseMatrix &shape) const;
 
-   virtual void CalcVShape(ElementTransformation &Trans,
+   virtual void CalcVShape(const ElementTransformation &Trans,
                            DenseMatrix &shape) const
    { CalcVShape_RT(Trans, shape); }
 
@@ -1191,7 +1191,7 @@ public:
    virtual void CalcVShape(const IntegrationPoint &ip,
                            DenseMatrix &shape) const;
 
-   virtual void CalcVShape(ElementTransformation &Trans,
+   virtual void CalcVShape(const ElementTransformation &Trans,
                            DenseMatrix &shape) const
    { CalcVShape_RT(Trans, shape); }
 
@@ -1396,7 +1396,7 @@ public:
    Nedelec1HexFiniteElement();
    virtual void CalcVShape(const IntegrationPoint &ip,
                            DenseMatrix &shape) const;
-   virtual void CalcVShape(ElementTransformation &Trans,
+   virtual void CalcVShape(const ElementTransformation &Trans,
                            DenseMatrix &shape) const
    { CalcVShape_ND(Trans, shape); }
    virtual void CalcCurlShape(const IntegrationPoint &ip,
@@ -1418,7 +1418,7 @@ public:
    Nedelec1TetFiniteElement();
    virtual void CalcVShape(const IntegrationPoint &ip,
                            DenseMatrix &shape) const;
-   virtual void CalcVShape(ElementTransformation &Trans,
+   virtual void CalcVShape(const ElementTransformation &Trans,
                            DenseMatrix &shape) const
    { CalcVShape_ND(Trans, shape); }
    virtual void CalcCurlShape(const IntegrationPoint &ip,
@@ -1442,7 +1442,7 @@ public:
    virtual void CalcVShape(const IntegrationPoint &ip,
                            DenseMatrix &shape) const;
 
-   virtual void CalcVShape(ElementTransformation &Trans,
+   virtual void CalcVShape(const ElementTransformation &Trans,
                            DenseMatrix &shape) const
    { CalcVShape_RT(Trans, shape); }
 
@@ -1470,7 +1470,7 @@ public:
    virtual void CalcVShape(const IntegrationPoint &ip,
                            DenseMatrix &shape) const;
 
-   virtual void CalcVShape(ElementTransformation &Trans,
+   virtual void CalcVShape(const ElementTransformation &Trans,
                            DenseMatrix &shape) const
    { CalcVShape_RT(Trans, shape); }
 
@@ -1498,7 +1498,7 @@ public:
    virtual void CalcVShape(const IntegrationPoint &ip,
                            DenseMatrix &shape) const;
 
-   virtual void CalcVShape(ElementTransformation &Trans,
+   virtual void CalcVShape(const ElementTransformation &Trans,
                            DenseMatrix &shape) const
    { CalcVShape_RT(Trans, shape); }
 
@@ -2117,7 +2117,7 @@ public:
                            const int ob_type = BasisType::GaussLegendre);
    virtual void CalcVShape(const IntegrationPoint &ip,
                            DenseMatrix &shape) const;
-   virtual void CalcVShape(ElementTransformation &Trans,
+   virtual void CalcVShape(const ElementTransformation &Trans,
                            DenseMatrix &shape) const
    { CalcVShape_RT(Trans, shape); }
    virtual void CalcDivShape(const IntegrationPoint &ip,
@@ -2170,7 +2170,7 @@ public:
 
    virtual void CalcVShape(const IntegrationPoint &ip,
                            DenseMatrix &shape) const;
-   virtual void CalcVShape(ElementTransformation &Trans,
+   virtual void CalcVShape(const ElementTransformation &Trans,
                            DenseMatrix &shape) const
    { CalcVShape_RT(Trans, shape); }
    virtual void CalcDivShape(const IntegrationPoint &ip,
@@ -2216,7 +2216,7 @@ public:
    RT_TriangleElement(const int p);
    virtual void CalcVShape(const IntegrationPoint &ip,
                            DenseMatrix &shape) const;
-   virtual void CalcVShape(ElementTransformation &Trans,
+   virtual void CalcVShape(const ElementTransformation &Trans,
                            DenseMatrix &shape) const
    { CalcVShape_RT(Trans, shape); }
    virtual void CalcDivShape(const IntegrationPoint &ip,
@@ -2268,7 +2268,7 @@ public:
    RT_TetrahedronElement(const int p);
    virtual void CalcVShape(const IntegrationPoint &ip,
                            DenseMatrix &shape) const;
-   virtual void CalcVShape(ElementTransformation &Trans,
+   virtual void CalcVShape(const ElementTransformation &Trans,
                            DenseMatrix &shape) const
    { CalcVShape_RT(Trans, shape); }
    virtual void CalcDivShape(const IntegrationPoint &ip,
@@ -2316,7 +2316,7 @@ public:
    virtual void CalcVShape(const IntegrationPoint &ip,
                            DenseMatrix &shape) const;
 
-   virtual void CalcVShape(ElementTransformation &Trans,
+   virtual void CalcVShape(const ElementTransformation &Trans,
                            DenseMatrix &shape) const
    { CalcVShape_ND(Trans, shape); }
 
@@ -2376,7 +2376,7 @@ public:
                            const int ob_type = BasisType::GaussLegendre);
    virtual void CalcVShape(const IntegrationPoint &ip,
                            DenseMatrix &shape) const;
-   virtual void CalcVShape(ElementTransformation &Trans,
+   virtual void CalcVShape(const ElementTransformation &Trans,
                            DenseMatrix &shape) const
    { CalcVShape_ND(Trans, shape); }
    virtual void CalcCurlShape(const IntegrationPoint &ip,
@@ -2422,7 +2422,7 @@ public:
    ND_TetrahedronElement(const int p);
    virtual void CalcVShape(const IntegrationPoint &ip,
                            DenseMatrix &shape) const;
-   virtual void CalcVShape(ElementTransformation &Trans,
+   virtual void CalcVShape(const ElementTransformation &Trans,
                            DenseMatrix &shape) const
    { CalcVShape_ND(Trans, shape); }
    virtual void CalcCurlShape(const IntegrationPoint &ip,
@@ -2473,7 +2473,7 @@ public:
    ND_TriangleElement(const int p);
    virtual void CalcVShape(const IntegrationPoint &ip,
                            DenseMatrix &shape) const;
-   virtual void CalcVShape(ElementTransformation &Trans,
+   virtual void CalcVShape(const ElementTransformation &Trans,
                            DenseMatrix &shape) const
    { CalcVShape_ND(Trans, shape); }
    virtual void CalcCurlShape(const IntegrationPoint &ip,
@@ -2516,7 +2516,7 @@ public:
    { obasis1d.Eval(ip.x, shape); }
    virtual void CalcVShape(const IntegrationPoint &ip,
                            DenseMatrix &shape) const;
-   virtual void CalcVShape(ElementTransformation &Trans,
+   virtual void CalcVShape(const ElementTransformation &Trans,
                            DenseMatrix &shape) const
    { CalcVShape_ND(Trans, shape); }
    // virtual void CalcCurlShape(const IntegrationPoint &ip,

--- a/fem/gridfunc.cpp
+++ b/fem/gridfunc.cpp
@@ -886,7 +886,7 @@ void GridFunction::GetDerivative(int comp, int der_comp, GridFunction &der)
 
 
 void GridFunction::GetVectorGradientHat(
-   ElementTransformation &T, DenseMatrix &gh) const
+   const ElementTransformation &T, DenseMatrix &gh) const
 {
    MFEM_ASSERT(T.IntPointSet(), "Integration point not set.");
    int elNo = T.ElementNo;
@@ -905,7 +905,7 @@ void GridFunction::GetVectorGradientHat(
    MultAtB(loc_data_mat, dshape, gh);
 }
 
-double GridFunction::GetDivergence(ElementTransformation &tr) const
+double GridFunction::GetDivergence(const ElementTransformation &tr) const
 {
    double div_v;
    int elNo = tr.ElementNo;
@@ -942,7 +942,7 @@ double GridFunction::GetDivergence(ElementTransformation &tr) const
    return div_v;
 }
 
-void GridFunction::GetCurl(ElementTransformation &tr, Vector &curl) const
+void GridFunction::GetCurl(const ElementTransformation &tr, Vector &curl) const
 {
    int elNo = tr.ElementNo;
    const FiniteElement *FElem = fes->GetFE(elNo);
@@ -996,7 +996,8 @@ void GridFunction::GetCurl(ElementTransformation &tr, Vector &curl) const
    }
 }
 
-void GridFunction::GetGradient(ElementTransformation &tr, Vector &grad) const
+void GridFunction::GetGradient(const ElementTransformation &tr,
+                               Vector &grad) const
 {
    int elNo = tr.ElementNo;
    const FiniteElement *fe = fes->GetFE(elNo);
@@ -1042,7 +1043,7 @@ void GridFunction::GetGradients(const int elem, const IntegrationRule &ir,
 }
 
 void GridFunction::GetVectorGradient(
-   ElementTransformation &tr, DenseMatrix &grad) const
+   const ElementTransformation &tr, DenseMatrix &grad) const
 {
    MFEM_ASSERT(fes->GetFE(tr.ElementNo)->GetMapType() == FiniteElement::VALUE,
                "invalid FE map type");
@@ -2765,7 +2766,7 @@ double ComputeElementLpDistance(double p, int i,
 }
 
 
-double ExtrudeCoefficient::Eval(ElementTransformation &T)
+double ExtrudeCoefficient::Eval(const ElementTransformation &T) const
 {
    MFEM_ASSERT(T.IntPointSet(), "Integration point not set.");
    ElementTransformation *T_in =

--- a/fem/gridfunc.hpp
+++ b/fem/gridfunc.hpp
@@ -42,7 +42,8 @@ protected:
 
    void SaveSTLTri(std::ostream &out, double p1[], double p2[], double p3[]);
 
-   void GetVectorGradientHat(ElementTransformation &T, DenseMatrix &gh) const;
+   void GetVectorGradientHat(const ElementTransformation &T,
+                             DenseMatrix &gh) const;
 
    // Project the delta coefficient without scaling and return the (local)
    // integral of the projection.
@@ -167,16 +168,17 @@ public:
 
    void GetDerivative(int comp, int der_comp, GridFunction &der);
 
-   double GetDivergence(ElementTransformation &tr) const;
+   double GetDivergence(const ElementTransformation &tr) const;
 
-   void GetCurl(ElementTransformation &tr, Vector &curl) const;
+   void GetCurl(const ElementTransformation &tr, Vector &curl) const;
 
-   void GetGradient(ElementTransformation &tr, Vector &grad) const;
+   void GetGradient(const ElementTransformation &tr, Vector &grad) const;
 
    void GetGradients(const int elem, const IntegrationRule &ir,
                      DenseMatrix &grad) const;
 
-   void GetVectorGradient(ElementTransformation &tr, DenseMatrix &grad) const;
+   void GetVectorGradient(const ElementTransformation &tr,
+                          DenseMatrix &grad) const;
 
    /** Compute \f$ (\int_{\Omega} (*this) \psi_i)/(\int_{\Omega} \psi_i) \f$,
        where \f$ \psi_i \f$ are the basis functions for the FE space of avgs.
@@ -555,7 +557,7 @@ private:
 public:
    ExtrudeCoefficient(Mesh *m, Coefficient &s, int _n)
       : n(_n), mesh_in(m), sol_in(s) { }
-   virtual double Eval(ElementTransformation &T);
+   virtual double Eval(const ElementTransformation &T) const;
    virtual ~ExtrudeCoefficient() { }
 };
 

--- a/mesh/mesh.cpp
+++ b/mesh/mesh.cpp
@@ -8667,7 +8667,8 @@ NodeExtrudeCoefficient::NodeExtrudeCoefficient(const int dim, const int _n,
 {
 }
 
-void NodeExtrudeCoefficient::Eval(Vector &V, ElementTransformation &T)
+void NodeExtrudeCoefficient::Eval(Vector &V,
+                                  const ElementTransformation &T) const
 {
    V.SetSize(vdim);
 

--- a/mesh/mesh.hpp
+++ b/mesh/mesh.hpp
@@ -1152,12 +1152,12 @@ class NodeExtrudeCoefficient : public VectorCoefficient
 private:
    int n, layer;
    double p[2], s;
-   Vector tip;
+   mutable Vector tip;
 public:
    NodeExtrudeCoefficient(const int dim, const int _n, const double _s);
    void SetLayer(const int l) { layer = l; }
    using VectorCoefficient::Eval;
-   virtual void Eval(Vector &V, ElementTransformation &T);
+   virtual void Eval(Vector &V, const ElementTransformation &T) const;
    virtual ~NodeExtrudeCoefficient() { }
 };
 

--- a/miniapps/electromagnetics/joule_solver.cpp
+++ b/miniapps/electromagnetics/joule_solver.cpp
@@ -901,7 +901,7 @@ void MagneticDiffusionEOperator::Debug(const char *base, double)
    }
 }
 
-double JouleHeatingCoefficient::Eval(ElementTransformation &T)
+double JouleHeatingCoefficient::Eval(const ElementTransformation &T) const
 {
    Vector E;
    double thisSigma;
@@ -928,7 +928,7 @@ MeshDependentCoefficient::MeshDependentCoefficient(
    scaleFactor = cloneMe.scaleFactor;
 }
 
-double MeshDependentCoefficient::Eval(ElementTransformation &T)
+double MeshDependentCoefficient::Eval(const ElementTransformation &T) const
 {
    // given the attribute, extract the coefficient value from the map
    std::map<int, double>::iterator it;
@@ -954,7 +954,7 @@ ScaledGFCoefficient::ScaledGFCoefficient(GridFunction *gf,
                                          MeshDependentCoefficient &input_mdc)
    : GridFunctionCoefficient(gf), mdc(input_mdc) {}
 
-double ScaledGFCoefficient::Eval(ElementTransformation &T)
+double ScaledGFCoefficient::Eval(const ElementTransformation &T) const
 {
    return mdc.Eval(T) * GridFunctionCoefficient::Eval(T);
 }

--- a/miniapps/electromagnetics/joule_solver.hpp
+++ b/miniapps/electromagnetics/joule_solver.hpp
@@ -52,7 +52,7 @@ public:
    MeshDependentCoefficient(const std::map<int, double> &inputMap,
                             double scale = 1.0);
    MeshDependentCoefficient(const MeshDependentCoefficient &cloneMe);
-   virtual double Eval(ElementTransformation &T);
+   virtual double Eval(const ElementTransformation &T) const;
    void SetScaleFactor(const double &scale) { scaleFactor = scale; }
    virtual ~MeshDependentCoefficient()
    {
@@ -69,7 +69,7 @@ private:
    MeshDependentCoefficient mdc;
 public:
    ScaledGFCoefficient(GridFunction *gf, MeshDependentCoefficient &input_mdc);
-   virtual double Eval(ElementTransformation &T);
+   virtual double Eval(const ElementTransformation &T) const;
    void SetMDC(const MeshDependentCoefficient &input_mdc) { mdc = input_mdc; }
    virtual ~ScaledGFCoefficient() {}
 };
@@ -234,7 +234,7 @@ public:
    JouleHeatingCoefficient(const MeshDependentCoefficient &sigma_,
                            ParGridFunction &E_gf_)
       : E_gf(E_gf_), sigma(sigma_) {}
-   virtual double Eval(ElementTransformation &T);
+   virtual double Eval(const ElementTransformation &T) const;
    virtual ~JouleHeatingCoefficient() {}
 };
 

--- a/miniapps/tools/display-basis.cpp
+++ b/miniapps/tools/display-basis.cpp
@@ -78,12 +78,12 @@ public:
    Deformation(int dim, DefType dType, const DeformationData & data)
       : VectorCoefficient(dim), dim_(dim), dType_(dType), data_(data) {}
 
-   void Eval(Vector &v, ElementTransformation &T);
+   void Eval(Vector &v, const ElementTransformation &T) const;
 
 private:
-   void Def1D(const Vector & u, Vector & v);
-   void Def2D(const Vector & u, Vector & v);
-   void Def3D(const Vector & u, Vector & v);
+   void Def1D(const Vector & u, Vector & v) const;
+   void Def2D(const Vector & u, Vector & v) const;
+   void Def3D(const Vector & u, Vector & v) const;
 
    int     dim_;
    DefType dType_;
@@ -624,7 +624,7 @@ mapTypeStr(int mType)
 }
 
 void
-Deformation::Eval(Vector &v, ElementTransformation &T)
+Deformation::Eval(Vector &v, const ElementTransformation &T) const
 {
    Vector u(dim_);
 
@@ -647,7 +647,7 @@ Deformation::Eval(Vector &v, ElementTransformation &T)
 }
 
 void
-Deformation::Def1D(const Vector & u, Vector & v)
+Deformation::Def1D(const Vector & u, Vector & v) const
 {
    v = u;
    if ( dType_ == UNIFORM )
@@ -657,7 +657,7 @@ Deformation::Def1D(const Vector & u, Vector & v)
 }
 
 void
-Deformation::Def2D(const Vector & u, Vector & v)
+Deformation::Def2D(const Vector & u, Vector & v) const
 {
    switch (dType_)
    {
@@ -680,7 +680,7 @@ Deformation::Def2D(const Vector & u, Vector & v)
 }
 
 void
-Deformation::Def3D(const Vector & u, Vector & v)
+Deformation::Def3D(const Vector & u, Vector & v) const
 {
    switch (dType_)
    {


### PR DESCRIPTION
There are two main ideas implemented here.  The first is that evaluating a Coefficient should not alter that coefficient object.  The second is that evaluating a Coefficient should not alter the transformation object being passed to the eval method.

The second point leads to an issue with the ElementTransformation class.  Specifically, which of its methods should be const?  The approach implemented here is that methods which "Set" data members of ElementTransformation are NOT const.  Methods which "Get" information from ElementTransformation ARE const.  For example setting an integration point will change the object but getting the Jacobian or Transforming a point should not change the object.