### PR TITLE
ParMesh groups communicaton for NC meshes [cut-mesh-groups-dev-3]

### DIFF
--- a/data/inline-quad.mesh
+++ b/data/inline-quad.mesh
@@ -1,7 +1,7 @@
 MFEM INLINE mesh v1.0
 
 type = quad
-nx = 4
-ny = 4
-sx = 1.0
+nx = 2
+ny = 1
+sx = 2.0
 sy = 1.0

--- a/data/inline-quad.mesh
+++ b/data/inline-quad.mesh
@@ -1,7 +1,7 @@
 MFEM INLINE mesh v1.0
 
 type = quad
-nx = 2
-ny = 1
-sx = 2.0
+nx = 4
+ny = 4
+sx = 1.0
 sy = 1.0

--- a/examples/ex0p.cpp
+++ b/examples/ex0p.cpp
@@ -1,0 +1,134 @@
+
+
+#include "mfem.hpp"
+#include <fstream>
+#include <iostream>
+
+using namespace std;
+using namespace mfem;
+
+int main(int argc, char *argv[])
+{
+   // 1. Initialize MPI.
+   int num_procs, myid;
+   MPI_Init(&argc, &argv);
+   MPI_Comm_size(MPI_COMM_WORLD, &num_procs);
+   MPI_Comm_rank(MPI_COMM_WORLD, &myid);
+
+   // 2. Parse command-line options.
+   const char *mesh_file = "../data/star.mesh";
+   int order = 1;
+   int ref_levels = 0;
+   bool visualization = 1;
+
+   OptionsParser args(argc, argv);
+   args.AddOption(&mesh_file, "-m", "--mesh",
+                  "Mesh file to use.");
+   args.AddOption(&order, "-o", "--order",
+                  "Finite element order (polynomial degree) or -1 for"
+                  " isoparametric space.");
+   args.AddOption(&ref_levels, "-r", "--ref-levels",
+                  "Number of serial refinement levels.");
+   args.AddOption(&visualization, "-vis", "--visualization", "-no-vis",
+                  "--no-visualization",
+                  "Enable or disable GLVis visualization.");
+   args.Parse();
+   if (!args.Good())
+   {
+      if (myid == 0)
+      {
+         args.PrintUsage(cout);
+      }
+      MPI_Finalize();
+      return 1;
+   }
+   if (myid == 0)
+   {
+      args.PrintOptions(cout);
+   }
+
+   // 3. Read the (serial) mesh from the given mesh file on all processors.
+   Mesh *mesh = new Mesh(mesh_file, 1, 1);
+   int dim = mesh->Dimension();
+
+   mesh->EnsureNCMesh();
+
+   // 4. Refine the serial mesh on all processors to increase the resolution.
+   {
+      for (int l = 0; l < ref_levels; l++)
+      {
+         mesh->UniformRefinement();
+      }
+   }
+
+   // 5. Define a parallel mesh by a partitioning of the serial mesh.
+   ParMesh *pmesh = new ParMesh(MPI_COMM_WORLD, *mesh);
+   delete mesh;
+   {
+      int par_ref_levels = 2;
+      for (int l = 0; l < par_ref_levels; l++)
+      {
+         pmesh->UniformRefinement();
+      }
+   }
+
+   // 6. Define a parallel finite element space on the parallel mesh. Here we
+   //    use continuous Lagrange finite elements of the specified order. If
+   //    order < 1, we instead use an isoparametric/isogeometric space.
+   FiniteElementCollection *fec;
+   if (order > 0)
+   {
+      fec = new H1_FECollection(order, dim);
+   }
+   else if (pmesh->GetNodes())
+   {
+      fec = pmesh->GetNodes()->OwnFEC();
+      if (myid == 0)
+      {
+         cout << "Using isoparametric FEs: " << fec->Name() << endl;
+      }
+   }
+   else
+   {
+      fec = new H1_FECollection(order = 1, dim);
+   }
+   ParFiniteElementSpace *fespace = new ParFiniteElementSpace(pmesh, fec);
+   HYPRE_Int size = fespace->GlobalTrueVSize();
+   if (myid == 0)
+   {
+      cout << "Number of finite element unknowns: " << size << endl;
+   }
+
+   // 9. Define the solution vector x as a parallel finite element grid function
+   //    corresponding to fespace. Initialize x with initial guess of zero,
+   //    which satisfies the boundary conditions.
+   ParGridFunction x(fespace);
+   x = myid + 1;
+
+   // TEST ParallelAverage
+   HypreParVector *tv;
+   tv = x.ParallelAverage();
+   //tv = x.ParallelProject();
+   x.Distribute(tv);
+   delete tv;
+
+   // 15. Send the solution by socket to a GLVis server.
+   if (visualization)
+   {
+      char vishost[] = "localhost";
+      int  visport   = 19916;
+      socketstream sol_sock(vishost, visport);
+      sol_sock << "parallel " << num_procs << " " << myid << "\n";
+      sol_sock.precision(8);
+      sol_sock << "solution\n" << *pmesh << x << flush;
+   }
+
+   // 16. Free the used memory.
+   delete fespace;
+   if (order > 0) { delete fec; }
+   delete pmesh;
+
+   MPI_Finalize();
+
+   return 0;
+}

--- a/examples/ex0p.cpp
+++ b/examples/ex0p.cpp
@@ -7,6 +7,10 @@
 using namespace std;
 using namespace mfem;
 
+namespace mfem {
+int nc = 0;
+}
+
 int main(int argc, char *argv[])
 {
    // 1. Initialize MPI.
@@ -29,6 +33,8 @@ int main(int argc, char *argv[])
                   " isoparametric space.");
    args.AddOption(&ref_levels, "-r", "--ref-levels",
                   "Number of serial refinement levels.");
+   args.AddOption(&nc, "-nc", "--nc",
+                  "Confirming (0), or NC (1).");
    args.AddOption(&visualization, "-vis", "--visualization", "-no-vis",
                   "--no-visualization",
                   "Enable or disable GLVis visualization.");
@@ -51,7 +57,10 @@ int main(int argc, char *argv[])
    Mesh *mesh = new Mesh(mesh_file, 1, 1);
    int dim = mesh->Dimension();
 
-   mesh->EnsureNCMesh();
+   if (nc)
+   {
+      mesh->EnsureNCMesh();
+   }
 
    // 4. Refine the serial mesh on all processors to increase the resolution.
    {
@@ -65,7 +74,7 @@ int main(int argc, char *argv[])
    ParMesh *pmesh = new ParMesh(MPI_COMM_WORLD, *mesh);
    delete mesh;
    {
-      int par_ref_levels = 2;
+      int par_ref_levels = 0;
       for (int l = 0; l < par_ref_levels; l++)
       {
          pmesh->UniformRefinement();

--- a/examples/ex0p.cpp
+++ b/examples/ex0p.cpp
@@ -34,7 +34,7 @@ int main(int argc, char *argv[])
    args.AddOption(&ref_levels, "-r", "--ref-levels",
                   "Number of serial refinement levels.");
    args.AddOption(&nc, "-nc", "--nc",
-                  "Confirming (0), or NC (1).");
+                  "Conforming (0), or NC (1).");
    args.AddOption(&visualization, "-vis", "--visualization", "-no-vis",
                   "--no-visualization",
                   "Enable or disable GLVis visualization.");

--- a/examples/makefile
+++ b/examples/makefile
@@ -23,7 +23,7 @@ MFEM_LIB_FILE = mfem_is_not_built
 
 SEQ_EXAMPLES = ex1 ex2 ex3 ex4 ex5 ex6 ex7 ex8 ex9 ex10 ex14 ex15 ex16 ex17\
   ex18 ex19
-PAR_EXAMPLES = ex1p ex2p ex3p ex4p ex5p ex6p ex7p ex8p ex9p ex10p ex11p ex12p\
+PAR_EXAMPLES = ex0p ex1p ex2p ex3p ex4p ex5p ex6p ex7p ex8p ex9p ex10p ex11p ex12p\
  ex13p ex14p ex15p ex16p ex17p ex18p ex19p
 
 ifeq ($(MFEM_USE_MPI),NO)

--- a/fem/pfespace.cpp
+++ b/fem/pfespace.cpp
@@ -142,8 +142,6 @@ void ParFiniteElementSpace::Construct()
    }
    else // Nonconforming()
    {
-      /*gcomm = new GroupCommunicator(GetGroupTopo());
-      GetGroupComm(*gcomm, 1);*/
       ConstructTrueDofs();
 
       // calculate number of ghost DOFs

--- a/fem/pfespace.cpp
+++ b/fem/pfespace.cpp
@@ -574,12 +574,6 @@ void ParFiniteElementSpace::DivideByGroupSize(double *vec)
 
 GroupCommunicator *ParFiniteElementSpace::ScalarGroupComm()
 {
-   if (Nonconforming())
-   {
-      // MFEM_WARNING("Not implemented for NC mesh.");
-      return NULL;
-   }
-
    GroupCommunicator *gc = new GroupCommunicator(GetGroupTopo());
    if (NURBSext)
    {

--- a/fem/pfespace.cpp
+++ b/fem/pfespace.cpp
@@ -140,8 +140,9 @@ void ParFiniteElementSpace::Construct()
    }
    else // Nonconforming()
    {
-      gcomm = new GroupCommunicator(GetGroupTopo());
-      GetGroupComm(*gcomm, 1);
+      /*gcomm = new GroupCommunicator(GetGroupTopo());
+      GetGroupComm(*gcomm, 1);*/
+      ConstructTrueDofs();
 
       // calculate number of ghost DOFs
       ngvdofs = pncmesh->GetNGhostVertices()
@@ -560,6 +561,11 @@ HypreParMatrix *ParFiniteElementSpace::GetPartialConformingInterpolation()
 void ParFiniteElementSpace::DivideByGroupSize(double *vec)
 {
    GroupTopology &gt = GetGroupTopo();
+
+   for (int i = 0; i < gt.NGroups(); i++)
+   {
+      std::cout << "Group " << i << ": size " << gt.GetGroupSize(i) << std::endl;
+   }
 
    for (int i = 0; i < ldof_group.Size(); i++)
    {

--- a/fem/pfespace.cpp
+++ b/fem/pfespace.cpp
@@ -140,6 +140,9 @@ void ParFiniteElementSpace::Construct()
    }
    else // Nonconforming()
    {
+      gcomm = new GroupCommunicator(GetGroupTopo());
+      GetGroupComm(*gcomm, 1);
+
       // calculate number of ghost DOFs
       ngvdofs = pncmesh->GetNGhostVertices()
                 * fec->DofForGeometry(Geometry::POINT);

--- a/fem/pfespace.cpp
+++ b/fem/pfespace.cpp
@@ -558,32 +558,11 @@ HypreParMatrix *ParFiniteElementSpace::GetPartialConformingInterpolation()
    return P_pc;
 }
 
-extern int nc;
-
 void ParFiniteElementSpace::DivideByGroupSize(double *vec)
 {
    GroupTopology &gt = GetGroupTopo();
-
-   char fname[200];
-   sprintf(fname, "%d_ldof_group_%d.txt", nc, MyRank);
-   std::ofstream f(fname);
-
-   gt.Save(f);
-   f << std::endl;
-
-   pmesh->DebugPrint(f);
-
-   /*for (int i = 0; i < gt.NGroups(); i++)
-   {
-      f << "Rank " << MyRank << ", group " << i
-        << ": size " << gt.GetGroupSize(i) << std::endl;
-   }*/
-
    for (int i = 0; i < ldof_group.Size(); i++)
    {
-      f << "Rank " << MyRank << ", ldof " << i
-        << ": ldof_group " << ldof_group[i] << std::endl;
-
       if (gt.IAmMaster(ldof_group[i])) // we are the master
       {
          vec[ldof_ltdof[i]] /= gt.GetGroupSize(ldof_group[i]);

--- a/fem/pfespace.cpp
+++ b/fem/pfespace.cpp
@@ -559,11 +559,6 @@ HypreParMatrix *ParFiniteElementSpace::GetPartialConformingInterpolation()
 
 void ParFiniteElementSpace::DivideByGroupSize(double *vec)
 {
-   if (Nonconforming())
-   {
-      MFEM_ABORT("Not implemented for NC mesh.");
-   }
-
    GroupTopology &gt = GetGroupTopo();
 
    for (int i = 0; i < ldof_group.Size(); i++)

--- a/fem/pfespace.cpp
+++ b/fem/pfespace.cpp
@@ -22,6 +22,8 @@
 #include <limits>
 #include <list>
 
+#include <fstream>
+
 namespace mfem
 {
 
@@ -558,17 +560,32 @@ HypreParMatrix *ParFiniteElementSpace::GetPartialConformingInterpolation()
    return P_pc;
 }
 
+extern int nc;
+
 void ParFiniteElementSpace::DivideByGroupSize(double *vec)
 {
    GroupTopology &gt = GetGroupTopo();
 
-   for (int i = 0; i < gt.NGroups(); i++)
+   char fname[200];
+   sprintf(fname, "%d_ldof_group_%d.txt", nc, MyRank);
+   std::ofstream f(fname);
+
+   gt.Save(f);
+   f << std::endl;
+
+   pmesh->DebugPrint(f);
+
+   /*for (int i = 0; i < gt.NGroups(); i++)
    {
-      std::cout << "Group " << i << ": size " << gt.GetGroupSize(i) << std::endl;
-   }
+      f << "Rank " << MyRank << ", group " << i
+        << ": size " << gt.GetGroupSize(i) << std::endl;
+   }*/
 
    for (int i = 0; i < ldof_group.Size(); i++)
    {
+      f << "Rank " << MyRank << ", ldof " << i
+        << ": ldof_group " << ldof_group[i] << std::endl;
+
       if (gt.IAmMaster(ldof_group[i])) // we are the master
       {
          vec[ldof_ltdof[i]] /= gt.GetGroupSize(ldof_group[i]);

--- a/mesh/mesh.cpp
+++ b/mesh/mesh.cpp
@@ -6199,7 +6199,7 @@ STable3D* Mesh::InitFromNCMesh(const NCMesh &ncmesh)
    STable3D *faces_tbl = NULL;
    if (Dim > 2)
    {
-     faces_tbl = GetElementToFaceTable(1);
+      faces_tbl = GetElementToFaceTable(1);
    }
    GenerateFaces();
 #ifdef MFEM_DEBUG

--- a/mesh/mesh.cpp
+++ b/mesh/mesh.cpp
@@ -6158,7 +6158,7 @@ bool Mesh::DerefineByError(const Vector &elem_error, double threshold,
 }
 
 
-void Mesh::InitFromNCMesh(const NCMesh &ncmesh)
+STable3D* Mesh::InitFromNCMesh(const NCMesh &ncmesh)
 {
    Dim = ncmesh.Dimension();
    spaceDim = ncmesh.SpaceDimension();
@@ -6195,14 +6195,18 @@ void Mesh::InitFromNCMesh(const NCMesh &ncmesh)
       el_to_edge = new Table;
       NumOfEdges = GetElementToEdgeTable(*el_to_edge, be_to_edge);
    }
+
+   STable3D *faces_tbl = NULL;
    if (Dim > 2)
    {
-      GetElementToFaceTable();
+     faces_tbl = GetElementToFaceTable(1);
    }
    GenerateFaces();
 #ifdef MFEM_DEBUG
    CheckBdrElementOrientation(false);
 #endif
+
+   return faces_tbl;
 
    // NOTE: ncmesh->OnMeshUpdated() and GenerateNCFaceInfo() should be called
    // outside after this method.

--- a/mesh/mesh.cpp
+++ b/mesh/mesh.cpp
@@ -772,13 +772,13 @@ FaceElementTransformations *Mesh::GetBdrFaceTransformations(int BdrElemNo)
    return tr;
 }
 
-void Mesh::GetFaceElements(int Face, int *Elem1, int *Elem2)
+void Mesh::GetFaceElements(int Face, int *Elem1, int *Elem2) const
 {
    *Elem1 = faces_info[Face].Elem1No;
    *Elem2 = faces_info[Face].Elem2No;
 }
 
-void Mesh::GetFaceInfos(int Face, int *Inf1, int *Inf2)
+void Mesh::GetFaceInfos(int Face, int *Inf1, int *Inf2) const
 {
    *Inf1 = faces_info[Face].Elem1Inf;
    *Inf2 = faces_info[Face].Elem2Inf;

--- a/mesh/mesh.cpp
+++ b/mesh/mesh.cpp
@@ -6158,7 +6158,7 @@ bool Mesh::DerefineByError(const Vector &elem_error, double threshold,
 }
 
 
-STable3D* Mesh::InitFromNCMesh(const NCMesh &ncmesh)
+void Mesh::InitFromNCMesh(const NCMesh &ncmesh)
 {
    Dim = ncmesh.Dimension();
    spaceDim = ncmesh.SpaceDimension();
@@ -6195,18 +6195,14 @@ STable3D* Mesh::InitFromNCMesh(const NCMesh &ncmesh)
       el_to_edge = new Table;
       NumOfEdges = GetElementToEdgeTable(*el_to_edge, be_to_edge);
    }
-
-   STable3D *faces_tbl = NULL;
    if (Dim > 2)
    {
-      faces_tbl = GetElementToFaceTable(1);
+      GetElementToFaceTable();
    }
    GenerateFaces();
 #ifdef MFEM_DEBUG
    CheckBdrElementOrientation(false);
 #endif
-
-   return faces_tbl;
 
    // NOTE: ncmesh->OnMeshUpdated() and GenerateNCFaceInfo() should be called
    // outside after this method.

--- a/mesh/mesh.hpp
+++ b/mesh/mesh.hpp
@@ -405,7 +405,7 @@ protected:
    void Make1D(int n, double sx = 1.0);
 
    /// Initialize vertices/elements/boundary/tables from a nonconforming mesh.
-   STable3D* InitFromNCMesh(const NCMesh &ncmesh);
+   void InitFromNCMesh(const NCMesh &ncmesh);
 
    /// Create from a nonconforming mesh.
    explicit Mesh(const NCMesh &ncmesh);

--- a/mesh/mesh.hpp
+++ b/mesh/mesh.hpp
@@ -405,7 +405,7 @@ protected:
    void Make1D(int n, double sx = 1.0);
 
    /// Initialize vertices/elements/boundary/tables from a nonconforming mesh.
-   void InitFromNCMesh(const NCMesh &ncmesh);
+   STable3D* InitFromNCMesh(const NCMesh &ncmesh);
 
    /// Create from a nonconforming mesh.
    explicit Mesh(const NCMesh &ncmesh);

--- a/mesh/mesh.hpp
+++ b/mesh/mesh.hpp
@@ -412,7 +412,7 @@ protected:
 
    /// Swaps internal data with another mesh. By default, non-geometry members
    /// like 'ncmesh' and 'NURBSExt' are only swapped when 'non_geometry' is set.
-   void Swap(Mesh& other, bool non_geometry = false);
+   void Swap(Mesh& other, bool non_geometry);
 
    // used in GetElementData() and GetBdrElementData()
    void GetElementData(const Array<Element*> &elem_array, int geom,

--- a/mesh/mesh.hpp
+++ b/mesh/mesh.hpp
@@ -850,8 +850,8 @@ public:
    {
       return (faces_info[FaceNo].Elem2No >= 0);
    }
-   void GetFaceElements (int Face, int *Elem1, int *Elem2);
-   void GetFaceInfos (int Face, int *Inf1, int *Inf2);
+   void GetFaceElements (int Face, int *Elem1, int *Elem2) const;
+   void GetFaceInfos (int Face, int *Inf1, int *Inf2) const;
 
    int GetFaceGeometryType(int Face) const;
    int GetFaceElementType(int Face) const;

--- a/mesh/pmesh.cpp
+++ b/mesh/pmesh.cpp
@@ -87,7 +87,6 @@ ParMesh::ParMesh(MPI_Comm comm, Mesh &mesh, int *partitioning_,
                  int part_method)
    : gtopo(comm)
 {
-   int i, j;
    int *partitioning;
    Array<bool> activeBdrElem;
 
@@ -95,48 +94,10 @@ ParMesh::ParMesh(MPI_Comm comm, Mesh &mesh, int *partitioning_,
    MPI_Comm_size(MyComm, &NRanks);
    MPI_Comm_rank(MyComm, &MyRank);
 
-   if (mesh.Nonconforming())
-   {
-      pncmesh = new ParNCMesh(comm, *mesh.ncmesh);
-
-      // save the element partitioning before Prune()
-      int* partition = new int[mesh.GetNE()];
-      for (int i = 0; i < mesh.GetNE(); i++)
-      {
-         partition[i] = pncmesh->InitialPartition(i);
-      }
-
-      pncmesh->Prune();
-
-      Mesh::InitFromNCMesh(*pncmesh);
-      pncmesh->OnMeshUpdated(this);
-
-      ncmesh = pncmesh;
-      meshgen = mesh.MeshGenerator();
-
-      mesh.attributes.Copy(attributes);
-      mesh.bdr_attributes.Copy(bdr_attributes);
-
-      GenerateNCFaceInfo();
-
-      if (mesh.GetNodes())
-      {
-         Nodes = new ParGridFunction(this, mesh.GetNodes(), partition);
-         own_nodes = 1;
-      }
-      delete [] partition;
-
-      have_face_nbr_data = false;
-      return;
-   }
-
-   Dim = mesh.Dim;
-   spaceDim = mesh.spaceDim;
-
-   BaseGeom = mesh.BaseGeom;
-   BaseBdrGeom = mesh.BaseBdrGeom;
-
    ncmesh = pncmesh = NULL;
+   if (mesh.Nonconforming()) {
+      ncmesh = pncmesh = new ParNCMesh(comm, *mesh.ncmesh);
+   }
 
    if (partitioning_)
    {
@@ -144,183 +105,88 @@ ParMesh::ParMesh(MPI_Comm comm, Mesh &mesh, int *partitioning_,
    }
    else
    {
-      partitioning = mesh.GeneratePartitioning(NRanks, part_method);
-   }
-
-   // re-enumerate the partitions to better map to actual processor
-   // interconnect topology !?
-
-   Array<int> vert;
-   Array<int> vert_global_local(mesh.GetNV());
-   int vert_counter, element_counter, bdrelem_counter;
-
-   // build vert_global_local
-   vert_global_local = -1;
-
-   element_counter = 0;
-   vert_counter = 0;
-   for (i = 0; i < mesh.GetNE(); i++)
-      if (partitioning[i] == MyRank)
-      {
-         mesh.GetElementVertices(i, vert);
-         element_counter++;
-         for (j = 0; j < vert.Size(); j++)
-            if (vert_global_local[vert[j]] < 0)
-            {
-               vert_global_local[vert[j]] = vert_counter++;
-            }
-      }
-
-   NumOfVertices = vert_counter;
-   NumOfElements = element_counter;
-   vertices.SetSize(NumOfVertices);
-
-   // Re-enumerate the local vertices to preserve the global ordering.
-   for (i = vert_counter = 0; i < vert_global_local.Size(); i++)
-      if (vert_global_local[i] >= 0)
-      {
-         vert_global_local[i] = vert_counter++;
-      }
-
-   // determine vertices
-   for (i = 0; i < vert_global_local.Size(); i++)
-      if (vert_global_local[i] >= 0)
-      {
-         vertices[vert_global_local[i]].SetCoords(mesh.SpaceDimension(),
-                                                  mesh.GetVertex(i));
-      }
-
-   // Determine elements, enumerating the local elements to preserve the global
-   // order. This is used, e.g. by the ParGridFunction ctor that takes a global
-   // GridFunction as input parameter.
-   element_counter = 0;
-   elements.SetSize(NumOfElements);
-   for (i = 0; i < mesh.GetNE(); i++)
-      if (partitioning[i] == MyRank)
-      {
-         elements[element_counter] = mesh.GetElement(i)->Duplicate(this);
-         int *v = elements[element_counter]->GetVertices();
-         int nv = elements[element_counter]->GetNVertices();
-         for (j = 0; j < nv; j++)
+      if (mesh.Nonconforming()) {
+         // save the element partitioning before Prune()
+         partitioning = new int[mesh.GetNE()];
+         for (int i = 0; i < mesh.GetNE(); i++)
          {
-            v[j] = vert_global_local[v[j]];
+            partitioning[i] = pncmesh->InitialPartition(i);
          }
-         element_counter++;
       }
-
+      else {
+         partitioning = mesh.GeneratePartitioning(NRanks, part_method);
+      }
+   }
+   
    Table *edge_element = NULL;
-   if (mesh.NURBSext)
-   {
-      activeBdrElem.SetSize(mesh.GetNBE());
-      activeBdrElem = false;
+   STable3D *faces_tbl = NULL;
+   Array<int> vert_global_local(mesh.GetNV());
+   
+   if (mesh.Nonconforming()) {
+
+      pncmesh->Prune();
+      Mesh::InitFromNCMesh(*pncmesh);
+      pncmesh->OnMeshUpdated(this);
+
+      // in the nc case we already have local numbering for the
+      // element vertices, which has come from InitFromNCMesh.  So
+      // derive vert_global_local from it.
+      
+      vert_global_local = -1;
+      int le = 0;
+      for (int i = 0; i < mesh.GetNE(); i++) {
+         if (partitioning[i] == MyRank)
+         {
+            Array<int> vert_global;
+            mesh.GetElementVertices(i,vert_global);
+            Array<int> vert_local;
+            elements[le++]->GetVertices(vert_local);
+            for (int j = 0; j < vert_local.Size(); j++) {
+               vert_global_local[vert_global[j]] = vert_local[j];
+            }
+         }
+      }
+
+      GenerateNCFaceInfo();
    }
-   // build boundary elements
-   if (Dim == 3)
-   {
-      NumOfBdrElements = 0;
-      for (i = 0; i < mesh.GetNBE(); i++)
+   else {
+
+      // These are the equivalent steps that InitFromNCMesh performs
+
+      Dim = mesh.Dim;
+      spaceDim = mesh.spaceDim;
+
+      BaseGeom = mesh.BaseGeom;
+      BaseBdrGeom = mesh.BaseBdrGeom;
+
+      // fills out Mesh::vertices from partition of global mesh and
+      // generates vert_global_local.
+      NumOfVertices = BuildLocalVertices(mesh, partitioning,
+                                         vert_global_local);
+
+      // fills out Mesh::elements
+      NumOfElements = BuildLocalElements(mesh, partitioning,
+                                         vert_global_local);
+
+      // fills out Mesh::boundary
+      NumOfBdrElements = BuildLocalBoundary(mesh, partitioning,
+                                            vert_global_local,
+                                            activeBdrElem, edge_element);
+
+      NumOfEdges = NumOfFaces = 0;
+      
+      if (Dim > 1)
       {
-         int face, o, el1, el2;
-         mesh.GetBdrElementFace(i, &face, &o);
-         mesh.GetFaceElements(face, &el1, &el2);
-         if (partitioning[(o % 2 == 0 || el2 < 0) ? el1 : el2] == MyRank)
-         {
-            NumOfBdrElements++;
-            if (mesh.NURBSext)
-            {
-               activeBdrElem[i] = true;
-            }
-         }
+         el_to_edge = new Table;
+         NumOfEdges = Mesh::GetElementToEdgeTable(*el_to_edge, be_to_edge);
       }
 
-      bdrelem_counter = 0;
-      boundary.SetSize(NumOfBdrElements);
-      for (i = 0; i < mesh.GetNBE(); i++)
+      if (Dim == 3)
       {
-         int face, o, el1, el2;
-         mesh.GetBdrElementFace(i, &face, &o);
-         mesh.GetFaceElements(face, &el1, &el2);
-         if (partitioning[(o % 2 == 0 || el2 < 0) ? el1 : el2] == MyRank)
-         {
-            boundary[bdrelem_counter] = mesh.GetBdrElement(i)->Duplicate(this);
-            int *v = boundary[bdrelem_counter]->GetVertices();
-            int nv = boundary[bdrelem_counter]->GetNVertices();
-            for (j = 0; j < nv; j++)
-            {
-               v[j] = vert_global_local[v[j]];
-            }
-            bdrelem_counter++;
-         }
+         faces_tbl = GetElementToFaceTable(1);
       }
-   }
-   else if (Dim == 2)
-   {
-      edge_element = new Table;
-      Transpose(mesh.ElementToEdgeTable(), *edge_element, mesh.GetNEdges());
-
-      NumOfBdrElements = 0;
-      for (i = 0; i < mesh.GetNBE(); i++)
-      {
-         int edge = mesh.GetBdrElementEdgeIndex(i);
-         int el1 = edge_element->GetRow(edge)[0];
-         if (partitioning[el1] == MyRank)
-         {
-            NumOfBdrElements++;
-            if (mesh.NURBSext)
-            {
-               activeBdrElem[i] = true;
-            }
-         }
-      }
-
-      bdrelem_counter = 0;
-      boundary.SetSize(NumOfBdrElements);
-      for (i = 0; i < mesh.GetNBE(); i++)
-      {
-         int edge = mesh.GetBdrElementEdgeIndex(i);
-         int el1 = edge_element->GetRow(edge)[0];
-         if (partitioning[el1] == MyRank)
-         {
-            boundary[bdrelem_counter] = mesh.GetBdrElement(i)->Duplicate(this);
-            int *v = boundary[bdrelem_counter]->GetVertices();
-            int nv = boundary[bdrelem_counter]->GetNVertices();
-            for (j = 0; j < nv; j++)
-            {
-               v[j] = vert_global_local[v[j]];
-            }
-            bdrelem_counter++;
-         }
-      }
-   }
-   else if (Dim == 1)
-   {
-      NumOfBdrElements = 0;
-      for (i = 0; i < mesh.GetNBE(); i++)
-      {
-         int vert = mesh.boundary[i]->GetVertices()[0];
-         int el1, el2;
-         mesh.GetFaceElements(vert, &el1, &el2);
-         if (partitioning[el1] == MyRank)
-         {
-            NumOfBdrElements++;
-         }
-      }
-
-      bdrelem_counter = 0;
-      boundary.SetSize(NumOfBdrElements);
-      for (i = 0; i < mesh.GetNBE(); i++)
-      {
-         int vert = mesh.boundary[i]->GetVertices()[0];
-         int el1, el2;
-         mesh.GetFaceElements(vert, &el1, &el2);
-         if (partitioning[el1] == MyRank)
-         {
-            boundary[bdrelem_counter] = mesh.GetBdrElement(i)->Duplicate(this);
-            int *v = boundary[bdrelem_counter]->GetVertices();
-            v[0] = vert_global_local[v[0]];
-            bdrelem_counter++;
-         }
-      }
+   
+      GenerateFaces();
    }
 
    meshgen = mesh.MeshGenerator();
@@ -328,318 +194,55 @@ ParMesh::ParMesh(MPI_Comm comm, Mesh &mesh, int *partitioning_,
    mesh.attributes.Copy(attributes);
    mesh.bdr_attributes.Copy(bdr_attributes);
 
-   // this is called by the default Mesh constructor
-   // InitTables();
-
-   if (Dim > 1)
-   {
-      el_to_edge = new Table;
-      NumOfEdges = Mesh::GetElementToEdgeTable(*el_to_edge, be_to_edge);
-   }
-   else
-   {
-      NumOfEdges = 0;
-   }
-
-   STable3D *faces_tbl = NULL;
-   if (Dim == 3)
-   {
-      faces_tbl = GetElementToFaceTable(1);
-   }
-   else
-   {
-      NumOfFaces = 0;
-   }
-   GenerateFaces();
-
+   // Build groups.  At this point there is no difference between the
+   // conforming and nc cases.
+   
    ListOfIntegerSets  groups;
-   IntegerSet         group;
-
-   // the first group is the local one
-   group.Recreate(1, &MyRank);
-   groups.Insert(group);
+   {
+      // the first group is the local one
+      IntegerSet         group;
+      group.Recreate(1, &MyRank);
+      groups.Insert(group);
+   }
 
 #ifdef MFEM_DEBUG
    if (Dim < 3 && mesh.GetNFaces() != 0)
    {
-      mfem::err << "ParMesh::ParMesh (proc " << MyRank << ") : "
-                "(Dim < 3 && mesh.GetNFaces() != 0) is true!" << endl;
+      cerr << "ParMesh::ParMesh (proc " << MyRank << ") : "
+         "(Dim < 3 && mesh.GetNFaces() != 0) is true!" << endl;
       mfem_error();
    }
 #endif
-   // determine shared faces
-   int sface_counter = 0;
+
    Array<int> face_group(mesh.GetNFaces());
-   for (i = 0; i < face_group.Size(); i++)
-   {
-      int el[2];
-      face_group[i] = -1;
-      mesh.GetFaceElements(i, &el[0], &el[1]);
-      if (el[1] >= 0)
-      {
-         el[0] = partitioning[el[0]];
-         el[1] = partitioning[el[1]];
-         if ((el[0] == MyRank && el[1] != MyRank) ||
-             (el[0] != MyRank && el[1] == MyRank))
-         {
-            group.Recreate(2, el);
-            face_group[i] = groups.Insert(group) - 1;
-            sface_counter++;
-         }
-      }
-   }
-
-   // determine shared edges
-   int sedge_counter = 0;
-   if (!edge_element)
-   {
-      edge_element = new Table;
-      if (Dim == 1)
-      {
-         edge_element->SetDims(0,0);
-      }
-      else
-      {
-         Transpose(mesh.ElementToEdgeTable(), *edge_element, mesh.GetNEdges());
-      }
-   }
-   for (i = 0; i < edge_element->Size(); i++)
-   {
-      int me = 0, others = 0;
-      for (j = edge_element->GetI()[i]; j < edge_element->GetI()[i+1]; j++)
-      {
-         edge_element->GetJ()[j] = partitioning[edge_element->GetJ()[j]];
-         if (edge_element->GetJ()[j] == MyRank)
-         {
-            me = 1;
-         }
-         else
-         {
-            others = 1;
-         }
-      }
-
-      if (me && others)
-      {
-         sedge_counter++;
-         group.Recreate(edge_element->RowSize(i), edge_element->GetRow(i));
-         edge_element->GetRow(i)[0] = groups.Insert(group) - 1;
-      }
-      else
-      {
-         edge_element->GetRow(i)[0] = -1;
-      }
-   }
-
-   // determine shared vertices
-   int svert_counter = 0;
    Table *vert_element = mesh.GetVertexToElementTable(); // we must delete this
 
-   for (i = 0; i < vert_element->Size(); i++)
-   {
-      int me = 0, others = 0;
-      for (j = vert_element->GetI()[i]; j < vert_element->GetI()[i+1]; j++)
-      {
-         vert_element->GetJ()[j] = partitioning[vert_element->GetJ()[j]];
-         if (vert_element->GetJ()[j] == MyRank)
-         {
-            me = 1;
-         }
-         else
-         {
-            others = 1;
-         }
-      }
-
-      if (me && others)
-      {
-         svert_counter++;
-         group.Recreate(vert_element->RowSize(i), vert_element->GetRow(i));
-         vert_element->GetI()[i] = groups.Insert(group) - 1;
-      }
-      else
-      {
-         vert_element->GetI()[i] = -1;
-      }
-   }
-
-   // build group_sface
-   group_sface.MakeI(groups.Size()-1);
-
-   for (i = 0; i < face_group.Size(); i++)
-   {
-      if (face_group[i] >= 0)
-      {
-         group_sface.AddAColumnInRow(face_group[i]);
-      }
-   }
-
-   group_sface.MakeJ();
-
-   sface_counter = 0;
-   for (i = 0; i < face_group.Size(); i++)
-   {
-      if (face_group[i] >= 0)
-      {
-         group_sface.AddConnection(face_group[i], sface_counter++);
-      }
-   }
-
-   group_sface.ShiftUpI();
-
-   // build group_sedge
-   group_sedge.MakeI(groups.Size()-1);
-
-   for (i = 0; i < edge_element->Size(); i++)
-   {
-      if (edge_element->GetRow(i)[0] >= 0)
-      {
-         group_sedge.AddAColumnInRow(edge_element->GetRow(i)[0]);
-      }
-   }
-
-   group_sedge.MakeJ();
-
-   sedge_counter = 0;
-   for (i = 0; i < edge_element->Size(); i++)
-   {
-      if (edge_element->GetRow(i)[0] >= 0)
-      {
-         group_sedge.AddConnection(edge_element->GetRow(i)[0], sedge_counter++);
-      }
-   }
-
-   group_sedge.ShiftUpI();
-
-   // build group_svert
-   group_svert.MakeI(groups.Size()-1);
-
-   for (i = 0; i < vert_element->Size(); i++)
-   {
-      if (vert_element->GetI()[i] >= 0)
-      {
-         group_svert.AddAColumnInRow(vert_element->GetI()[i]);
-      }
-   }
-
-   group_svert.MakeJ();
-
-   svert_counter = 0;
-   for (i = 0; i < vert_element->Size(); i++)
-   {
-      if (vert_element->GetI()[i] >= 0)
-      {
-         group_svert.AddConnection(vert_element->GetI()[i], svert_counter++);
-      }
-   }
-
-   group_svert.ShiftUpI();
-
-   // build shared_faces and sface_lface
-   shared_faces.SetSize(sface_counter);
-   sface_lface. SetSize(sface_counter);
-
-   if (Dim == 3)
-   {
-      sface_counter = 0;
-      for (i = 0; i < face_group.Size(); i++)
-      {
-         if (face_group[i] >= 0)
-         {
-            shared_faces[sface_counter] = mesh.GetFace(i)->Duplicate(this);
-            int *v = shared_faces[sface_counter]->GetVertices();
-            int nv = shared_faces[sface_counter]->GetNVertices();
-            for (j = 0; j < nv; j++)
-            {
-               v[j] = vert_global_local[v[j]];
-            }
-            switch (shared_faces[sface_counter]->GetType())
-            {
-               case Element::TRIANGLE:
-                  sface_lface[sface_counter] = (*faces_tbl)(v[0], v[1], v[2]);
-                  // mark the shared face for refinement by reorienting
-                  // it according to the refinement flag in the tetrahedron
-                  // to which this shared face belongs to.
-                  {
-                     int lface = sface_lface[sface_counter];
-                     Tetrahedron *tet =
-                        (Tetrahedron *)(elements[faces_info[lface].Elem1No]);
-                     tet->GetMarkedFace(faces_info[lface].Elem1Inf/64, v);
-                     // flip the shared face in the processor that owns the
-                     // second element (in 'mesh')
-                     {
-                        int gl_el1, gl_el2;
-                        mesh.GetFaceElements(i, &gl_el1, &gl_el2);
-                        if (MyRank == partitioning[gl_el2])
-                        {
-                           std::swap(v[0], v[1]);
-                        }
-                     }
-                  }
-                  break;
-               case Element::QUADRILATERAL:
-                  sface_lface[sface_counter] =
-                     (*faces_tbl)(v[0], v[1], v[2], v[3]);
-                  break;
-            }
-            sface_counter++;
-         }
-      }
-
-      delete faces_tbl;
-   }
-
-   // build shared_edges and sedge_ledge
-   shared_edges.SetSize(sedge_counter);
-   sedge_ledge. SetSize(sedge_counter);
-
-   {
-      DSTable v_to_v(NumOfVertices);
-      GetVertexToVertexTable(v_to_v);
-
-      sedge_counter = 0;
-      for (i = 0; i < edge_element->Size(); i++)
-      {
-         if (edge_element->GetRow(i)[0] >= 0)
-         {
-            mesh.GetEdgeVertices(i, vert);
-
-            shared_edges[sedge_counter] =
-               new Segment(vert_global_local[vert[0]],
-                           vert_global_local[vert[1]], 1);
-
-            if ((sedge_ledge[sedge_counter] =
-                    v_to_v(vert_global_local[vert[0]],
-                           vert_global_local[vert[1]])) < 0)
-            {
-               mfem::err << "\n\n\n" << MyRank << ": ParMesh::ParMesh: "
-                         << "ERROR in v_to_v\n\n" << endl;
-               mfem_error();
-            }
-
-            sedge_counter++;
-         }
-      }
-   }
-
-   delete edge_element;
-
-   // build svert_lvert
-   svert_lvert.SetSize(svert_counter);
-
-   svert_counter = 0;
-   for (i = 0; i < vert_element->Size(); i++)
-   {
-      if (vert_element->GetI()[i] >= 0)
-      {
-         svert_lvert[svert_counter++] = vert_global_local[i];
-      }
-   }
-
-   delete vert_element;
+   int nsfaces = FindSharedFaces(mesh, partitioning, face_group, groups);
+   int nsedges = FindSharedEdges(mesh, partitioning, edge_element, groups);
+   int nsvert = FindSharedVertices(mesh, partitioning, vert_element, groups);
 
    // build the group communication topology
    gtopo.Create(groups, 822);
+
+   // fill out group_sface, group_sedge, group_svert
+   int ngroups = groups.Size()-1;
+   BuildFaceGroup(ngroups, face_group, group_sface);
+   BuildEdgeGroup(ngroups, *edge_element, group_sedge);
+   BuildVertexGroup(ngroups, *vert_element, group_svert);
+   
+   // build shared_faces and sface_lface mapping
+   BuildSharedFaceElems(nsfaces, mesh, partitioning, faces_tbl,
+                        face_group, vert_global_local);
+
+   // build shared_edges and sedge_ledge mapping
+   BuildSharedEdgeElems(nsedges, mesh, vert_global_local,
+                        edge_element);
+   delete edge_element;
+
+   // build svert_lvert mapping
+   BuildSharedVertMapping(nsvert, vert_element, vert_global_local);
+   delete vert_element;
+
 
    if (mesh.NURBSext)
    {
@@ -683,7 +286,7 @@ ParMesh::ParMesh(MPI_Comm comm, Mesh &mesh, int *partitioning_,
          }
    }
 
-   if (partitioning_ == NULL)
+   if (partitioning)
    {
       delete [] partitioning;
    }
@@ -1046,6 +649,553 @@ ParMesh::ParMesh(ParMesh *orig_mesh, int ref_factor, int ref_type)
       }
       delete faces_tbl;
    }
+}
+
+
+int ParMesh::FindSharedFaces(const Mesh &mesh, const int *partitioning,
+                             Array<int>& face_group,
+                             ListOfIntegerSets& groups)
+{
+   IntegerSet group;
+   
+   int sface_counter = 0;
+   for (int i = 0; i < face_group.Size(); i++)
+   {
+      int el[2];
+      face_group[i] = -1;
+      mesh.GetFaceElements(i, &el[0], &el[1]);
+      if (el[1] >= 0)
+      {
+         el[0] = partitioning[el[0]];
+         el[1] = partitioning[el[1]];
+         if ((el[0] == MyRank && el[1] != MyRank) ||
+             (el[0] != MyRank && el[1] == MyRank))
+         {
+            group.Recreate(2, el);
+            face_group[i] = groups.Insert(group) - 1;
+            sface_counter++;
+         }
+      }
+   }
+   return sface_counter;
+}
+
+
+int ParMesh::FindSharedEdges(const Mesh &mesh, const int *partitioning,
+                             Table*& edge_element,
+                             ListOfIntegerSets& groups)
+{
+   IntegerSet group;
+   
+   int sedge_counter = 0;
+   if (!edge_element)
+   {
+      edge_element = new Table;
+      if (Dim == 1)
+      {
+         edge_element->SetDims(0,0);
+      }
+      else
+      {
+         Transpose(mesh.ElementToEdgeTable(), *edge_element, mesh.GetNEdges());
+      }
+   }
+
+   for (int i = 0; i < edge_element->Size(); i++)
+   {
+      int me = 0, others = 0;
+      for (int j = edge_element->GetI()[i]; j < edge_element->GetI()[i+1]; j++)
+      {
+         int k = edge_element->GetJ()[j];
+         int rank = partitioning[k];
+         edge_element->GetJ()[j] = rank;
+         if (rank == MyRank)
+         {
+            me = 1;
+         }
+         else
+         {
+            others = 1;
+         }
+      }
+
+      if (me && others)
+      {
+         sedge_counter++;
+         group.Recreate(edge_element->RowSize(i), edge_element->GetRow(i));
+         edge_element->GetRow(i)[0] = groups.Insert(group) - 1;
+      }
+      else
+      {
+         edge_element->GetRow(i)[0] = -1;
+      }
+   }
+
+   return sedge_counter;
+}
+
+int ParMesh::FindSharedVertices(const Mesh &mesh, const int *partitioning,
+                                Table* vert_element,
+                                ListOfIntegerSets& groups)
+{
+   IntegerSet group;
+
+   int svert_counter = 0;
+   for (int i = 0; i < vert_element->Size(); i++)
+   {
+      int me = 0, others = 0;
+      for (int j = vert_element->GetI()[i]; j < vert_element->GetI()[i+1]; j++)
+      {
+         vert_element->GetJ()[j] = partitioning[vert_element->GetJ()[j]];
+         if (vert_element->GetJ()[j] == MyRank)
+         {
+            me = 1;
+         }
+         else
+         {
+            others = 1;
+         }
+      }
+
+      if (me && others)
+      {
+         svert_counter++;
+         group.Recreate(vert_element->RowSize(i), vert_element->GetRow(i));
+         vert_element->GetI()[i] = groups.Insert(group) - 1;
+      }
+      else
+      {
+         vert_element->GetI()[i] = -1;
+      }
+   }
+
+   return svert_counter;
+}
+
+void ParMesh::BuildFaceGroup(int ngroups, const Array<int>& face_group,
+                             Table& group_sface)
+{
+   group_sface.MakeI(ngroups);
+
+   for (int i = 0; i < face_group.Size(); i++)
+   {
+      if (face_group[i] >= 0)
+      {
+         group_sface.AddAColumnInRow(face_group[i]);
+      }
+   }
+
+   group_sface.MakeJ();
+
+   int sface_counter = 0;
+   for (int i = 0; i < face_group.Size(); i++)
+   {
+      if (face_group[i] >= 0)
+      {
+         group_sface.AddConnection(face_group[i], sface_counter++);
+      }
+   }
+
+   group_sface.ShiftUpI();
+}
+
+
+void ParMesh::BuildEdgeGroup(int ngroups, const Table& edge_element,
+                             Table& group_sface)
+{
+   group_sedge.MakeI(ngroups);
+
+   for (int i = 0; i < edge_element.Size(); i++)
+   {
+      if (edge_element.GetRow(i)[0] >= 0)
+      {
+         group_sedge.AddAColumnInRow(edge_element.GetRow(i)[0]);
+      }
+   }
+
+   group_sedge.MakeJ();
+
+   int sedge_counter = 0;
+   for (int i = 0; i < edge_element.Size(); i++)
+   {
+      if (edge_element.GetRow(i)[0] >= 0)
+      {
+         group_sedge.AddConnection(edge_element.GetRow(i)[0], sedge_counter++);
+      }
+   }
+
+   group_sedge.ShiftUpI();
+}
+
+void ParMesh::BuildVertexGroup(int ngroups, const Table& vert_element,
+                               Table& group_svert)
+{
+   group_svert.MakeI(ngroups);
+
+   for (int i = 0; i < vert_element.Size(); i++)
+   {
+      if (vert_element.GetI()[i] >= 0)
+      {
+         group_svert.AddAColumnInRow(vert_element.GetI()[i]);
+      }
+   }
+
+   group_svert.MakeJ();
+
+   int svert_counter = 0;
+   for (int i = 0; i < vert_element.Size(); i++)
+   {
+      if (vert_element.GetI()[i] >= 0)
+      {
+         group_svert.AddConnection(vert_element.GetI()[i], svert_counter++);
+      }
+   }
+
+   group_svert.ShiftUpI();
+}
+
+void ParMesh::BuildSharedFaceElems(int nfaces, const Mesh& mesh,
+                                   int* partitioning,
+                                   STable3D* faces_tbl,
+                                   Array<int>& face_group,
+                                   Array<int>& vert_global_local)
+{
+   shared_faces.SetSize(nfaces);
+   sface_lface. SetSize(nfaces);
+
+   if (Dim == 3)
+   {
+      int sface_counter = 0;
+      for (int i = 0; i < face_group.Size(); i++)
+      {
+         if (face_group[i] >= 0)
+         {
+            shared_faces[sface_counter] = mesh.GetFace(i)->Duplicate(this);
+            int *v = shared_faces[sface_counter]->GetVertices();
+            int nv = shared_faces[sface_counter]->GetNVertices();
+            for (int j = 0; j < nv; j++)
+            {
+               v[j] = vert_global_local[v[j]];
+            }
+            switch (shared_faces[sface_counter]->GetType())
+            {
+            case Element::TRIANGLE:
+               sface_lface[sface_counter] = (*faces_tbl)(v[0], v[1], v[2]);
+               // mark the shared face for refinement by reorienting
+               // it according to the refinement flag in the tetrahedron
+               // to which this shared face belongs to.
+               {
+                  int lface = sface_lface[sface_counter];
+                  Tetrahedron *tet =
+                     (Tetrahedron *)(elements[faces_info[lface].Elem1No]);
+                  tet->GetMarkedFace(faces_info[lface].Elem1Inf/64, v);
+                  // flip the shared face in the processor that owns the
+                  // second element (in 'mesh')
+                  {
+                     int gl_el1, gl_el2;
+                     mesh.GetFaceElements(i, &gl_el1, &gl_el2);
+                     if (MyRank == partitioning[gl_el2])
+                     {
+                        std::swap(v[0], v[1]);
+                     }
+                  }
+               }
+               break;
+            case Element::QUADRILATERAL:
+               sface_lface[sface_counter] =
+                  (*faces_tbl)(v[0], v[1], v[2], v[3]);
+               break;
+            }
+            sface_counter++;
+         }
+      }
+
+      delete faces_tbl;
+   }
+}
+
+void ParMesh::BuildSharedEdgeElems(int nedges, Mesh& mesh,
+                                   Array<int>& vert_global_local,
+                                   Table* edge_element)
+{
+   // The passed in mesh is still the global mesh.  "this" mesh is the
+   // local partitioned mesh.
+
+   shared_edges.SetSize(nedges);
+   sedge_ledge. SetSize(nedges);
+
+   {
+      DSTable v_to_v(NumOfVertices);
+      GetVertexToVertexTable(v_to_v);
+
+      int sedge_counter = 0;
+      for (int i = 0; i < edge_element->Size(); i++)
+      {
+         if (edge_element->GetRow(i)[0] >= 0)
+         {
+            Array<int> vert;
+            mesh.GetEdgeVertices(i, vert);
+
+            shared_edges[sedge_counter] =
+               new Segment(vert_global_local[vert[0]],
+                           vert_global_local[vert[1]], 1);
+
+            sedge_ledge[sedge_counter] = v_to_v(vert_global_local[vert[0]],
+                                                vert_global_local[vert[1]]);
+
+            
+
+            if (sedge_ledge[sedge_counter] < 0) {
+               cerr << "\n\n\n" << MyRank << ": ParMesh::ParMesh: "
+                    << "ERROR in v_to_v\n\n" << endl;
+               mfem_error();
+            }
+
+            sedge_counter++;
+         }
+      }
+   }
+}
+
+void ParMesh::BuildSharedVertMapping(int nvert, Table* vert_element,
+                                     Array<int>& vert_global_local)
+{
+   // build svert_lvert
+   svert_lvert.SetSize(nvert);
+
+   int svert_counter = 0;
+   for (int i = 0; i < vert_element->Size(); i++)
+   {
+      if (vert_element->GetI()[i] >= 0)
+      {
+         svert_lvert[svert_counter++] = vert_global_local[i];
+      }
+   }
+}
+
+// Fills out vert_global_local
+
+int ParMesh::BuildVertGlobalLocal(Mesh& mesh, int* partitioning,
+                                  Array<int>& vert_global_local)
+{
+   vert_global_local = -1;
+
+   int vert_counter = 0;
+   for (int i = 0; i < mesh.GetNE(); i++) {
+      if (partitioning[i] == MyRank)
+      {
+         Array<int> vert;
+         mesh.GetElementVertices(i, vert);
+         for (int j = 0; j < vert.Size(); j++)
+            if (vert_global_local[vert[j]] < 0)
+            {
+               vert_global_local[vert[j]] = vert_counter++;
+            }
+      }
+   }
+   
+   // re-enumerate the local vertices to preserve the global ordering
+   vert_counter = 0;
+   for (int i = 0; i < vert_global_local.Size(); i++) {
+      if (vert_global_local[i] >= 0)
+      {
+         vert_global_local[i] = vert_counter++;
+      }
+   }
+
+   return vert_counter;
+}
+
+int ParMesh::BuildLocalVertices(const mfem::Mesh &mesh,
+                                const int* partitioning,
+                                Array<int> &vert_global_local)
+{
+   vert_global_local = -1;
+
+   int vert_counter = 0;
+   for (int i = 0; i < mesh.GetNE(); i++) {
+      if (partitioning[i] == MyRank)
+      {
+         Array<int> vert;
+         mesh.GetElementVertices(i, vert);
+         for (int j = 0; j < vert.Size(); j++)
+            if (vert_global_local[vert[j]] < 0)
+            {
+               vert_global_local[vert[j]] = vert_counter++;
+            }
+      }
+   }
+   
+   // re-enumerate the local vertices to preserve the global ordering
+   vert_counter = 0;
+   for (int i = 0; i < vert_global_local.Size(); i++) {
+      if (vert_global_local[i] >= 0)
+      {
+         vert_global_local[i] = vert_counter++;
+      }
+   }
+
+   vertices.SetSize(vert_counter);
+   
+   for (int i = 0; i < vert_global_local.Size(); i++) {
+      if (vert_global_local[i] >= 0)
+      {
+         vertices[vert_global_local[i]].SetCoords(mesh.SpaceDimension(),
+                                                  mesh.GetVertex(i));
+      }
+   }
+
+   return vert_counter;
+}
+
+int ParMesh::BuildLocalElements(const Mesh& mesh, const int* partitioning,
+                                const Array<int>& vert_global_local)
+{
+   int nelems = 0;
+   for (int i = 0; i < mesh.GetNE(); i++) {
+      if (partitioning[i] == MyRank) nelems++;
+   }
+
+   elements.SetSize(nelems);
+
+   int element_counter = 0;
+   for (int i = 0; i < mesh.GetNE(); i++) {
+      if (partitioning[i] == MyRank)
+      {
+         elements[element_counter] = mesh.GetElement(i)->Duplicate(this);
+         int *v = elements[element_counter]->GetVertices();
+         int nv = elements[element_counter]->GetNVertices();
+         for (int j = 0; j < nv; j++)
+         {
+            v[j] = vert_global_local[v[j]];
+         }
+         element_counter++;
+      }
+   }
+
+   return element_counter;
+}
+
+int ParMesh::BuildLocalBoundary(const Mesh& mesh, const int* partitioning,
+                                const Array<int>& vert_global_local,
+                                Array<bool>& activeBdrElem,
+                                Table*& edge_element)
+  
+{
+   int nbdry = 0;
+   
+   if (mesh.NURBSext)
+   {
+      activeBdrElem.SetSize(mesh.GetNBE());
+      activeBdrElem = false;
+   }
+   // build boundary elements
+   if (Dim == 3)
+   {
+      for (int i = 0; i < mesh.GetNBE(); i++)
+      {
+         int face, o, el1, el2;
+         mesh.GetBdrElementFace(i, &face, &o);
+         mesh.GetFaceElements(face, &el1, &el2);
+         if (partitioning[(o % 2 == 0 || el2 < 0) ? el1 : el2] == MyRank)
+         {
+            nbdry++;
+            if (mesh.NURBSext)
+            {
+               activeBdrElem[i] = true;
+            }
+         }
+      }
+
+      int bdrelem_counter = 0;
+      boundary.SetSize(nbdry);
+      for (int i = 0; i < mesh.GetNBE(); i++)
+      {
+         int face, o, el1, el2;
+         mesh.GetBdrElementFace(i, &face, &o);
+         mesh.GetFaceElements(face, &el1, &el2);
+         if (partitioning[(o % 2 == 0 || el2 < 0) ? el1 : el2] == MyRank)
+         {
+            boundary[bdrelem_counter] = mesh.GetBdrElement(i)->Duplicate(this);
+            int *v = boundary[bdrelem_counter]->GetVertices();
+            int nv = boundary[bdrelem_counter]->GetNVertices();
+            for (int j = 0; j < nv; j++)
+            {
+               v[j] = vert_global_local[v[j]];
+            }
+            bdrelem_counter++;
+         }
+      }
+   }
+   else if (Dim == 2)
+   {
+      edge_element = new Table;
+      Transpose(mesh.ElementToEdgeTable(), *edge_element, mesh.GetNEdges());
+
+      for (int i = 0; i < mesh.GetNBE(); i++)
+      {
+         int edge = mesh.GetBdrElementEdgeIndex(i);
+         int el1 = edge_element->GetRow(edge)[0];
+         if (partitioning[el1] == MyRank)
+         {
+            nbdry++;
+            if (mesh.NURBSext)
+            {
+               activeBdrElem[i] = true;
+            }
+         }
+      }
+
+      int bdrelem_counter = 0;
+      boundary.SetSize(nbdry);
+      for (int i = 0; i < mesh.GetNBE(); i++)
+      {
+         int edge = mesh.GetBdrElementEdgeIndex(i);
+         int el1 = edge_element->GetRow(edge)[0];
+         if (partitioning[el1] == MyRank)
+         {
+            boundary[bdrelem_counter] = mesh.GetBdrElement(i)->Duplicate(this);
+            int *v = boundary[bdrelem_counter]->GetVertices();
+            int nv = boundary[bdrelem_counter]->GetNVertices();
+            for (int j = 0; j < nv; j++)
+            {
+               v[j] = vert_global_local[v[j]];
+            }
+            bdrelem_counter++;
+         }
+      }
+   }
+   else if (Dim == 1)
+   {
+      for (int i = 0; i < mesh.GetNBE(); i++)
+      {
+         int vert = mesh.boundary[i]->GetVertices()[0];
+         int el1, el2;
+         mesh.GetFaceElements(vert, &el1, &el2);
+         if (partitioning[el1] == MyRank)
+         {
+            nbdry++;
+         }
+      }
+
+      int bdrelem_counter = 0;
+      boundary.SetSize(nbdry);
+      for (int i = 0; i < mesh.GetNBE(); i++)
+      {
+         int vert = mesh.boundary[i]->GetVertices()[0];
+         int el1, el2;
+         mesh.GetFaceElements(vert, &el1, &el2);
+         if (partitioning[el1] == MyRank)
+         {
+            boundary[bdrelem_counter] = mesh.GetBdrElement(i)->Duplicate(this);
+            int *v = boundary[bdrelem_counter]->GetVertices();
+            v[0] = vert_global_local[v[0]];
+            bdrelem_counter++;
+         }
+      }
+   }
+
+   return nbdry;
 }
 
 void ParMesh::GroupEdge(int group, int i, int &edge, int &o)

--- a/mesh/pmesh.cpp
+++ b/mesh/pmesh.cpp
@@ -125,7 +125,7 @@ ParMesh::ParMesh(MPI_Comm comm, Mesh &mesh, int *partitioning_,
    if (mesh.Nonconforming()) {
 
       pncmesh->Prune();
-      Mesh::InitFromNCMesh(*pncmesh);
+      faces_tbl = Mesh::InitFromNCMesh(*pncmesh);
       pncmesh->OnMeshUpdated(this);
 
       // in the nc case we already have local numbering for the

--- a/mesh/pmesh.cpp
+++ b/mesh/pmesh.cpp
@@ -95,7 +95,8 @@ ParMesh::ParMesh(MPI_Comm comm, Mesh &mesh, int *partitioning_,
    MPI_Comm_rank(MyComm, &MyRank);
 
    ncmesh = pncmesh = NULL;
-   if (mesh.Nonconforming()) {
+   if (mesh.Nonconforming())
+   {
       ncmesh = pncmesh = new ParNCMesh(comm, *mesh.ncmesh);
    }
 
@@ -105,7 +106,8 @@ ParMesh::ParMesh(MPI_Comm comm, Mesh &mesh, int *partitioning_,
    }
    else
    {
-      if (mesh.Nonconforming()) {
+      if (mesh.Nonconforming())
+      {
          // save the element partitioning before Prune()
          partitioning = new int[mesh.GetNE()];
          for (int i = 0; i < mesh.GetNE(); i++)
@@ -113,16 +115,18 @@ ParMesh::ParMesh(MPI_Comm comm, Mesh &mesh, int *partitioning_,
             partitioning[i] = pncmesh->InitialPartition(i);
          }
       }
-      else {
+      else
+      {
          partitioning = mesh.GeneratePartitioning(NRanks, part_method);
       }
    }
-   
+
    Table *edge_element = NULL;
    STable3D *faces_tbl = NULL;
    Array<int> vert_global_local(mesh.GetNV());
-   
-   if (mesh.Nonconforming()) {
+
+   if (mesh.Nonconforming())
+   {
 
       pncmesh->Prune();
       faces_tbl = Mesh::InitFromNCMesh(*pncmesh);
@@ -131,17 +135,19 @@ ParMesh::ParMesh(MPI_Comm comm, Mesh &mesh, int *partitioning_,
       // in the nc case we already have local numbering for the
       // element vertices, which has come from InitFromNCMesh.  So
       // derive vert_global_local from it.
-      
+
       vert_global_local = -1;
       int le = 0;
-      for (int i = 0; i < mesh.GetNE(); i++) {
+      for (int i = 0; i < mesh.GetNE(); i++)
+      {
          if (partitioning[i] == MyRank)
          {
             Array<int> vert_global;
             mesh.GetElementVertices(i,vert_global);
             Array<int> vert_local;
             elements[le++]->GetVertices(vert_local);
-            for (int j = 0; j < vert_local.Size(); j++) {
+            for (int j = 0; j < vert_local.Size(); j++)
+            {
                vert_global_local[vert_global[j]] = vert_local[j];
             }
          }
@@ -149,7 +155,8 @@ ParMesh::ParMesh(MPI_Comm comm, Mesh &mesh, int *partitioning_,
 
       GenerateNCFaceInfo();
    }
-   else {
+   else
+   {
 
       // These are the equivalent steps that InitFromNCMesh performs
 
@@ -174,7 +181,7 @@ ParMesh::ParMesh(MPI_Comm comm, Mesh &mesh, int *partitioning_,
                                             activeBdrElem, edge_element);
 
       NumOfEdges = NumOfFaces = 0;
-      
+
       if (Dim > 1)
       {
          el_to_edge = new Table;
@@ -185,7 +192,7 @@ ParMesh::ParMesh(MPI_Comm comm, Mesh &mesh, int *partitioning_,
       {
          faces_tbl = GetElementToFaceTable(1);
       }
-   
+
       GenerateFaces();
    }
 
@@ -196,7 +203,7 @@ ParMesh::ParMesh(MPI_Comm comm, Mesh &mesh, int *partitioning_,
 
    // Build groups.  At this point there is no difference between the
    // conforming and nc cases.
-   
+
    ListOfIntegerSets  groups;
    {
       // the first group is the local one
@@ -209,7 +216,7 @@ ParMesh::ParMesh(MPI_Comm comm, Mesh &mesh, int *partitioning_,
    if (Dim < 3 && mesh.GetNFaces() != 0)
    {
       cerr << "ParMesh::ParMesh (proc " << MyRank << ") : "
-         "(Dim < 3 && mesh.GetNFaces() != 0) is true!" << endl;
+           "(Dim < 3 && mesh.GetNFaces() != 0) is true!" << endl;
       mfem_error();
    }
 #endif
@@ -229,7 +236,7 @@ ParMesh::ParMesh(MPI_Comm comm, Mesh &mesh, int *partitioning_,
    BuildFaceGroup(ngroups, face_group, group_sface);
    BuildEdgeGroup(ngroups, *edge_element, group_sedge);
    BuildVertexGroup(ngroups, *vert_element, group_svert);
-   
+
    // build shared_faces and sface_lface mapping
    BuildSharedFaceElems(nsfaces, mesh, partitioning, faces_tbl,
                         face_group, vert_global_local);
@@ -657,7 +664,7 @@ int ParMesh::FindSharedFaces(const Mesh &mesh, const int *partitioning,
                              ListOfIntegerSets& groups)
 {
    IntegerSet group;
-   
+
    int sface_counter = 0;
    for (int i = 0; i < face_group.Size(); i++)
    {
@@ -686,7 +693,7 @@ int ParMesh::FindSharedEdges(const Mesh &mesh, const int *partitioning,
                              ListOfIntegerSets& groups)
 {
    IntegerSet group;
-   
+
    int sedge_counter = 0;
    if (!edge_element)
    {
@@ -879,32 +886,32 @@ void ParMesh::BuildSharedFaceElems(int nfaces, const Mesh& mesh,
             }
             switch (shared_faces[sface_counter]->GetType())
             {
-            case Element::TRIANGLE:
-               sface_lface[sface_counter] = (*faces_tbl)(v[0], v[1], v[2]);
-               // mark the shared face for refinement by reorienting
-               // it according to the refinement flag in the tetrahedron
-               // to which this shared face belongs to.
-               {
-                  int lface = sface_lface[sface_counter];
-                  Tetrahedron *tet =
-                     (Tetrahedron *)(elements[faces_info[lface].Elem1No]);
-                  tet->GetMarkedFace(faces_info[lface].Elem1Inf/64, v);
-                  // flip the shared face in the processor that owns the
-                  // second element (in 'mesh')
+               case Element::TRIANGLE:
+                  sface_lface[sface_counter] = (*faces_tbl)(v[0], v[1], v[2]);
+                  // mark the shared face for refinement by reorienting
+                  // it according to the refinement flag in the tetrahedron
+                  // to which this shared face belongs to.
                   {
-                     int gl_el1, gl_el2;
-                     mesh.GetFaceElements(i, &gl_el1, &gl_el2);
-                     if (MyRank == partitioning[gl_el2])
+                     int lface = sface_lface[sface_counter];
+                     Tetrahedron *tet =
+                        (Tetrahedron *)(elements[faces_info[lface].Elem1No]);
+                     tet->GetMarkedFace(faces_info[lface].Elem1Inf/64, v);
+                     // flip the shared face in the processor that owns the
+                     // second element (in 'mesh')
                      {
-                        std::swap(v[0], v[1]);
+                        int gl_el1, gl_el2;
+                        mesh.GetFaceElements(i, &gl_el1, &gl_el2);
+                        if (MyRank == partitioning[gl_el2])
+                        {
+                           std::swap(v[0], v[1]);
+                        }
                      }
                   }
-               }
-               break;
-            case Element::QUADRILATERAL:
-               sface_lface[sface_counter] =
-                  (*faces_tbl)(v[0], v[1], v[2], v[3]);
-               break;
+                  break;
+               case Element::QUADRILATERAL:
+                  sface_lface[sface_counter] =
+                     (*faces_tbl)(v[0], v[1], v[2], v[3]);
+                  break;
             }
             sface_counter++;
          }
@@ -943,9 +950,10 @@ void ParMesh::BuildSharedEdgeElems(int nedges, Mesh& mesh,
             sedge_ledge[sedge_counter] = v_to_v(vert_global_local[vert[0]],
                                                 vert_global_local[vert[1]]);
 
-            
 
-            if (sedge_ledge[sedge_counter] < 0) {
+
+            if (sedge_ledge[sedge_counter] < 0)
+            {
                cerr << "\n\n\n" << MyRank << ": ParMesh::ParMesh: "
                     << "ERROR in v_to_v\n\n" << endl;
                mfem_error();
@@ -981,7 +989,8 @@ int ParMesh::BuildVertGlobalLocal(Mesh& mesh, int* partitioning,
    vert_global_local = -1;
 
    int vert_counter = 0;
-   for (int i = 0; i < mesh.GetNE(); i++) {
+   for (int i = 0; i < mesh.GetNE(); i++)
+   {
       if (partitioning[i] == MyRank)
       {
          Array<int> vert;
@@ -993,10 +1002,11 @@ int ParMesh::BuildVertGlobalLocal(Mesh& mesh, int* partitioning,
             }
       }
    }
-   
+
    // re-enumerate the local vertices to preserve the global ordering
    vert_counter = 0;
-   for (int i = 0; i < vert_global_local.Size(); i++) {
+   for (int i = 0; i < vert_global_local.Size(); i++)
+   {
       if (vert_global_local[i] >= 0)
       {
          vert_global_local[i] = vert_counter++;
@@ -1013,7 +1023,8 @@ int ParMesh::BuildLocalVertices(const mfem::Mesh &mesh,
    vert_global_local = -1;
 
    int vert_counter = 0;
-   for (int i = 0; i < mesh.GetNE(); i++) {
+   for (int i = 0; i < mesh.GetNE(); i++)
+   {
       if (partitioning[i] == MyRank)
       {
          Array<int> vert;
@@ -1025,10 +1036,11 @@ int ParMesh::BuildLocalVertices(const mfem::Mesh &mesh,
             }
       }
    }
-   
+
    // re-enumerate the local vertices to preserve the global ordering
    vert_counter = 0;
-   for (int i = 0; i < vert_global_local.Size(); i++) {
+   for (int i = 0; i < vert_global_local.Size(); i++)
+   {
       if (vert_global_local[i] >= 0)
       {
          vert_global_local[i] = vert_counter++;
@@ -1036,8 +1048,9 @@ int ParMesh::BuildLocalVertices(const mfem::Mesh &mesh,
    }
 
    vertices.SetSize(vert_counter);
-   
-   for (int i = 0; i < vert_global_local.Size(); i++) {
+
+   for (int i = 0; i < vert_global_local.Size(); i++)
+   {
       if (vert_global_local[i] >= 0)
       {
          vertices[vert_global_local[i]].SetCoords(mesh.SpaceDimension(),
@@ -1052,14 +1065,16 @@ int ParMesh::BuildLocalElements(const Mesh& mesh, const int* partitioning,
                                 const Array<int>& vert_global_local)
 {
    int nelems = 0;
-   for (int i = 0; i < mesh.GetNE(); i++) {
-      if (partitioning[i] == MyRank) nelems++;
+   for (int i = 0; i < mesh.GetNE(); i++)
+   {
+      if (partitioning[i] == MyRank) { nelems++; }
    }
 
    elements.SetSize(nelems);
 
    int element_counter = 0;
-   for (int i = 0; i < mesh.GetNE(); i++) {
+   for (int i = 0; i < mesh.GetNE(); i++)
+   {
       if (partitioning[i] == MyRank)
       {
          elements[element_counter] = mesh.GetElement(i)->Duplicate(this);
@@ -1080,10 +1095,10 @@ int ParMesh::BuildLocalBoundary(const Mesh& mesh, const int* partitioning,
                                 const Array<int>& vert_global_local,
                                 Array<bool>& activeBdrElem,
                                 Table*& edge_element)
-  
+
 {
    int nbdry = 0;
-   
+
    if (mesh.NURBSext)
    {
       activeBdrElem.SetSize(mesh.GetNBE());

--- a/mesh/pmesh.cpp
+++ b/mesh/pmesh.cpp
@@ -274,8 +274,8 @@ ParMesh::ParMesh(MPI_Comm comm, Mesh &mesh, int *partitioning_,
 
       Array<int> gvdofs, lvdofs;
       Vector lnodes;
-      element_counter = 0;
-      for (i = 0; i < mesh.GetNE(); i++)
+      int element_counter = 0;
+      for (int i = 0; i < mesh.GetNE(); i++)
          if (partitioning[i] == MyRank)
          {
             Nodes->FESpace()->GetElementVDofs(element_counter, lvdofs);

--- a/mesh/pmesh.hpp
+++ b/mesh/pmesh.hpp
@@ -120,19 +120,22 @@ protected:
 
    void BuildSharedFaceElems(int nfaces, const Mesh& mesh,
                              int* partitioning,
-                             STable3D* faces_tbl,
-                             Array<int>& face_group,
-                             Array<int>& vert_global_local);
+                             const STable3D *faces_tbl,
+                             const Array<int> &face_group,
+                             const Array<int> &vert_global_local);
 
    void BuildSharedEdgeElems(int nedges, Mesh& mesh,
-                             Array<int>& vert_global_local,
-                             Table* edge_element);
+                             const Array<int> &vert_global_local,
+                             const Table *edge_element);
 
-   void BuildSharedVertMapping(int nvert, Table* vert_element,
-                               Array<int>& vert_global_local);
+   void BuildSharedVertMapping(int nvert, const Table* vert_element,
+                               const Array<int>& vert_global_local);
 
+#if 0
+   /// fills out vert_global_local
    int BuildVertGlobalLocal(Mesh& mesh, int* partitioning,
                             Array<int>& vert_global_local);
+#endif
 
    /// fills out partitioned Mesh::vertices
    int BuildLocalVertices(const Mesh& global_mesh, const int* partitioning,
@@ -277,6 +280,20 @@ public:
 
    /// Save the mesh in a parallel mesh format.
    void ParPrint(std::ostream &out) const;
+
+   void DebugPrint(std::ostream &out) const
+   {
+      out << "group_svert:\n";
+      group_svert.Print(out);
+
+      out << "group_sedge:\n";
+      group_sedge.Print(out);
+
+      out << "group_sface:\n";
+      group_sedge.Print(out);
+
+      out << std::endl;
+   }
 
    virtual int FindPoints(DenseMatrix& point_mat, Array<int>& elem_ids,
                           Array<IntegrationPoint>& ips, bool warn = true,

--- a/mesh/pmesh.hpp
+++ b/mesh/pmesh.hpp
@@ -31,9 +31,6 @@ class ParPumiMesh;
 /// Class for parallel meshes
 class ParMesh : public Mesh
 {
-#ifdef MFEM_USE_PUMI
-   friend class ParPumiMesh;
-#endif
 protected:
    ParMesh() : MyComm(0), NRanks(0), MyRank(-1),
       have_face_nbr_data(false), pncmesh(NULL) {}
@@ -300,6 +297,11 @@ public:
                           InverseElementTransformation *inv_trans = NULL);
 
    virtual ~ParMesh();
+
+   friend class ParNCMesh;
+#ifdef MFEM_USE_PUMI
+   friend class ParPumiMesh;
+#endif
 };
 
 }

--- a/mesh/pmesh.hpp
+++ b/mesh/pmesh.hpp
@@ -108,22 +108,22 @@ protected:
    int FindSharedVertices(const Mesh &mesh, const int *partition,
                           Table* vertex_element,
                           ListOfIntegerSets& groups);
-   
+
    void BuildFaceGroup(int ngroups, const Array<int>& face_group,
                        Table& group_sface);
 
    void BuildEdgeGroup(int ngroups, const Table& edge_element,
-                       Table& group_sedge); 
+                       Table& group_sedge);
 
    void BuildVertexGroup(int ngroups, const Table& vert_element,
-                         Table& group_svert); 
+                         Table& group_svert);
 
    void BuildSharedFaceElems(int nfaces, const Mesh& mesh,
                              int* partitioning,
                              STable3D* faces_tbl,
                              Array<int>& face_group,
                              Array<int>& vert_global_local);
-   
+
    void BuildSharedEdgeElems(int nedges, Mesh& mesh,
                              Array<int>& vert_global_local,
                              Table* edge_element);
@@ -142,13 +142,13 @@ protected:
    int BuildLocalElements(const Mesh& global_mesh, const int* partitioning,
                           const Array<int>& vert_global_local);
 
-    /// fills out partitioned Mesh::boundary
+   /// fills out partitioned Mesh::boundary
    int BuildLocalBoundary(const Mesh& global_mesh, const int* partitioning,
                           const Array<int>& vert_global_local,
                           Array<bool>& activeBdrElem,
                           Table*& edge_element);
 
-   
+
 public:
    /** Copy constructor. Performs a deep copy of (almost) all data, so that the
        source mesh can be modified (e.g. deleted, refined) without affecting the

--- a/mesh/pmesh.hpp
+++ b/mesh/pmesh.hpp
@@ -98,6 +98,57 @@ protected:
 
    bool WantSkipSharedMaster(const NCMesh::Master &master) const;
 
+   int FindSharedFaces(const Mesh &mesh, const int* partition,
+                       Array<int>& face_group,
+                       ListOfIntegerSets& groups);
+
+   int FindSharedEdges(const Mesh &mesh, const int* partition,
+                       Table*& edge_element, ListOfIntegerSets& groups);
+
+   int FindSharedVertices(const Mesh &mesh, const int *partition,
+                          Table* vertex_element,
+                          ListOfIntegerSets& groups);
+   
+   void BuildFaceGroup(int ngroups, const Array<int>& face_group,
+                       Table& group_sface);
+
+   void BuildEdgeGroup(int ngroups, const Table& edge_element,
+                       Table& group_sedge); 
+
+   void BuildVertexGroup(int ngroups, const Table& vert_element,
+                         Table& group_svert); 
+
+   void BuildSharedFaceElems(int nfaces, const Mesh& mesh,
+                             int* partitioning,
+                             STable3D* faces_tbl,
+                             Array<int>& face_group,
+                             Array<int>& vert_global_local);
+   
+   void BuildSharedEdgeElems(int nedges, Mesh& mesh,
+                             Array<int>& vert_global_local,
+                             Table* edge_element);
+
+   void BuildSharedVertMapping(int nvert, Table* vert_element,
+                               Array<int>& vert_global_local);
+
+   int BuildVertGlobalLocal(Mesh& mesh, int* partitioning,
+                            Array<int>& vert_global_local);
+
+   /// fills out partitioned Mesh::vertices
+   int BuildLocalVertices(const Mesh& global_mesh, const int* partitioning,
+                          Array<int>& vert_global_local);
+
+   /// fills out partitioned Mesh::elements
+   int BuildLocalElements(const Mesh& global_mesh, const int* partitioning,
+                          const Array<int>& vert_global_local);
+
+    /// fills out partitioned Mesh::boundary
+   int BuildLocalBoundary(const Mesh& global_mesh, const int* partitioning,
+                          const Array<int>& vert_global_local,
+                          Array<bool>& activeBdrElem,
+                          Table*& edge_element);
+
+   
 public:
    /** Copy constructor. Performs a deep copy of (almost) all data, so that the
        source mesh can be modified (e.g. deleted, refined) without affecting the

--- a/mesh/pmesh.hpp
+++ b/mesh/pmesh.hpp
@@ -128,12 +128,6 @@ protected:
    void BuildSharedVertMapping(int nvert, const Table* vert_element,
                                const Array<int>& vert_global_local);
 
-#if 0
-   /// fills out vert_global_local
-   int BuildVertGlobalLocal(Mesh& mesh, int* partitioning,
-                            Array<int>& vert_global_local);
-#endif
-
    /// fills out partitioned Mesh::vertices
    int BuildLocalVertices(const Mesh& global_mesh, const int* partitioning,
                           Array<int>& vert_global_local);

--- a/mesh/pncmesh.cpp
+++ b/mesh/pncmesh.cpp
@@ -823,7 +823,23 @@ void ParNCMesh::GetConformingSharedStructures(ParMesh &pmesh)
    MakeSharedTable(ng, entity_conf_group[1], pmesh.sedge_ledge, pmesh.group_sedge);
    MakeSharedTable(ng, entity_conf_group[2], pmesh.sface_lface, pmesh.group_sface);
 
-   // TODO: create shared_edges, shared_faces
+   // create shared_edges
+   pmesh.shared_edges.SetSize(pmesh.sedge_ledge.Size());
+   for (int i = 0; i < pmesh.shared_edges.Size(); i++)
+   {
+      int v[2];
+      GetEdgeVertices(edge_list.LookUp(pmesh.sedge_ledge[i]), v);
+      pmesh.shared_edges[i] = new Segment(v, 1);
+   }
+
+   // create shared_faces
+   pmesh.shared_faces.SetSize(pmesh.sface_lface.Size());
+   for (int i = 0; i < pmesh.shared_faces.Size(); i++)
+   {
+      int v[4], e[4], eo[4];
+      GetFaceVerticesEdges(face_list.LookUp(pmesh.sface_lface[i]), v, e, eo);
+      pmesh.shared_faces = new Quadrilateral(v, 1);
+   }
 
    // free conf_group arrays, they're not needed now (until next mesh update)
    for (int ent = 0; ent < Dim; ent++)

--- a/mesh/pncmesh.cpp
+++ b/mesh/pncmesh.cpp
@@ -750,6 +750,22 @@ void ParNCMesh::NeighborProcessors(Array<int> &neighbors)
 
 //// ParMesh compatibility /////////////////////////////////////////////////////
 
+static void SharedToLocalMap(const Array<ParNCMesh::GroupId> &conf_group,
+                             Array<int> &shared_local)
+{
+   int num_shared = 0;
+   for (int i = 0; i < conf_group.Size(); i++)
+   {
+      if (conf_group[i]) { num_shared++; }
+   }
+   shared_local.SetSize(num_shared);
+
+   for (int i = 0, j = 0; i < conf_group.Size(); i++)
+   {
+      if (conf_group[i]) { shared_local[j++] = i; }
+   }
+}
+
 void ParNCMesh::GetConformingSharedStructures(ParMesh &pmesh)
 {
    // make sure we have entity_conf_group[x]
@@ -770,6 +786,11 @@ void ParNCMesh::GetConformingSharedStructures(ParMesh &pmesh)
       }
       pmesh.gtopo.Create(int_groups, 822);
    }
+
+   // create shared to local index mappings
+   SharedToLocalMap(entity_conf_group[0], pmesh.svert_lvert);
+   SharedToLocalMap(entity_conf_group[1], pmesh.sedge_ledge);
+   SharedToLocalMap(entity_conf_group[2], pmesh.sface_lface);
 
 
    // TODO

--- a/mesh/pncmesh.cpp
+++ b/mesh/pncmesh.cpp
@@ -838,7 +838,7 @@ void ParNCMesh::GetConformingSharedStructures(ParMesh &pmesh)
    {
       int v[4], e[4], eo[4];
       GetFaceVerticesEdges(face_list.LookUp(pmesh.sface_lface[i]), v, e, eo);
-      pmesh.shared_faces = new Quadrilateral(v, 1);
+      pmesh.shared_faces[i] = new Quadrilateral(v, 1);
    }
 
    // free conf_group arrays, they're not needed now (until next mesh update)

--- a/mesh/pncmesh.hpp
+++ b/mesh/pncmesh.hpp
@@ -226,7 +226,7 @@ protected: // interface for ParMesh
 
    /** For compatibility with conforming code in ParMesh and ParFESpace.
        Initializes shared structures in ParMesh: gtopo, shared_*, group_s*, s*_l*.
-       The ParMesh then acts as a parallel mesh cut along NC interfaces. */
+       The ParMesh then acts as a parallel mesh cut along the NC interfaces. */
    void GetConformingSharedStructures(class ParMesh &pmesh);
 
    /** Populate face neighbor members of ParMesh from the ghost layer, without

--- a/mesh/pncmesh.hpp
+++ b/mesh/pncmesh.hpp
@@ -176,13 +176,6 @@ public:
    }
 
 
-   // interface for ParMesh
-
-   /** Populate face neighbor members of ParMesh from the ghost layer, without
-       communication. */
-   void GetFaceNeighbors(class ParMesh &pmesh);
-
-
    // utility
 
    int GetMyRank() const { return MyRank; }
@@ -227,7 +220,22 @@ public:
    void GetDebugMesh(Mesh &debug_mesh) const;
 
 
-protected:
+protected: // interface for ParMesh
+
+   friend class ParMesh;
+
+   /** For compatibility with conforming code in ParMesh and ParFESpace.
+       Initializes shared structures in ParMesh: gtopo, shared_*, group_s*, s*_l*.
+       The ParMesh then acts as a parallel mesh cut along NC interfaces. */
+   void GetConformingSharedStructures(class ParMesh &pmesh);
+
+   /** Populate face neighbor members of ParMesh from the ghost layer, without
+       communication. */
+   void GetFaceNeighbors(class ParMesh &pmesh);
+
+
+protected: // implementation
+
    MPI_Comm MyComm;
    int NRanks, MyRank;
 
@@ -242,8 +250,10 @@ protected:
 
    // owner rank for each vertex, edge and face (encoded as singleton groups)
    Array<GroupId> entity_owner[3];
-   // P matrix comm pattern groups for each vertex, edge and face (0/1/2)
+   // P matrix comm pattern groups for each vertex/edge/face (0/1/2)
    Array<GroupId> entity_pmat_group[3];
+   // ParMesh-compatible (conforming) groups for each vertex/edge/face (0/1/2)
+   Array<GroupId> entity_conf_group[3];
 
    // lists of vertices/edges/faces shared by us and at least one more processor
    NCList shared_vertices, shared_edges, shared_faces;
@@ -504,7 +514,6 @@ protected:
 
    static bool compare_ranks_indices(const Element* a, const Element* b);
 
-   friend class ParMesh;
    friend class NeighborRowMessage;
 };
 


### PR DESCRIPTION
This is a branch that builds on Bob's `cut-mesh-groups-dev-2`, keeps the refactoring of the huge ParMesh constructor but adds the ability to build the ParMesh communication groups directly from ParNCMesh at any time (on construction, after refinement and rebalancing).

The groups built from ParNCMesh are very basic and only connect DOFs on conforming vertices/edges/faces -- there is no connectivity between master/slave DOFs. The `gtopo` is a subset of the ParNCMesh groups.

I added a new example ex0p (not to be merged) that tests `ParGridFunction::ParallelAverage`, and it seems to work both in 2D and 3D.

I also tested hybridization in ex4p, it seems this run works OK: 
`mpirun -np 4 ex4p -m ../data/amr-hex.mesh -o 2 -hb`

There may be other things to test that I don't know about.