### PR TITLE
Adding LinearForm::operator=() methods [bugfix-linearform-equal-dev]

### DIFF
--- a/fem/gridfunc.cpp
+++ b/fem/gridfunc.cpp
@@ -2579,11 +2579,6 @@ GridFunction & GridFunction::operator=(const Vector &v)
    return *this;
 }
 
-GridFunction & GridFunction::operator=(const GridFunction &v)
-{
-   return this->operator=((const Vector &)v);
-}
-
 void GridFunction::Save(std::ostream &out) const
 {
    fes->Save(out);

--- a/fem/gridfunc.hpp
+++ b/fem/gridfunc.hpp
@@ -396,11 +396,6 @@ public:
        @a fes. */
    GridFunction &operator=(const Vector &v);
 
-   /// Copy the data from @a v.
-   /** The GridFunctions @a v and @a *this must have FiniteElementSpaces with
-       the same size. */
-   GridFunction &operator=(const GridFunction &v);
-
    /// Transform by the Space UpdateMatrix (e.g., on Mesh change).
    virtual void Update();
 

--- a/fem/linearform.cpp
+++ b/fem/linearform.cpp
@@ -193,11 +193,6 @@ LinearForm & LinearForm::operator=(const Vector &v)
    return *this;
 }
 
-LinearForm & LinearForm::operator=(const LinearForm &v)
-{
-   return this->operator=((const Vector &)v);
-}
-
 LinearForm::~LinearForm()
 {
    int k;

--- a/fem/linearform.cpp
+++ b/fem/linearform.cpp
@@ -180,6 +180,24 @@ void LinearForm::AssembleDelta()
    }
 }
 
+LinearForm & LinearForm::operator=(double value)
+{
+   Vector::operator=(value);
+   return *this;
+}
+
+LinearForm & LinearForm::operator=(const Vector &v)
+{
+   MFEM_ASSERT(fes && v.Size() == fes->GetVSize(), "");
+   Vector::operator=(v);
+   return *this;
+}
+
+LinearForm & LinearForm::operator=(const LinearForm &v)
+{
+   return this->operator=((const Vector &)v);
+}
+
 LinearForm::~LinearForm()
 {
    int k;

--- a/fem/linearform.hpp
+++ b/fem/linearform.hpp
@@ -101,6 +101,19 @@ public:
        and GridFunction. */
    double operator()(const GridFunction &gf) const { return (*this)*gf; }
 
+   /// Redefine '=' for LinearForm = constant.
+   LinearForm &operator=(double value);
+
+   /// Copy the data from @a v.
+   /** The size of @a v must be equal to the size of the FiniteElementSpace
+       @a fes. */
+   LinearForm &operator=(const Vector &v);
+
+   /// Copy the data from @a v.
+   /** The LinearForms @a v and @a *this must have FiniteElementSpaces with
+       the same size. */
+   LinearForm &operator=(const LinearForm &v);
+
    /// Destroys linear form.
    ~LinearForm();
 };

--- a/fem/linearform.hpp
+++ b/fem/linearform.hpp
@@ -109,11 +109,6 @@ public:
        @a fes. */
    LinearForm &operator=(const Vector &v);
 
-   /// Copy the data from @a v.
-   /** The LinearForms @a v and @a *this must have FiniteElementSpaces with
-       the same size. */
-   LinearForm &operator=(const LinearForm &v);
-
    /// Destroys linear form.
    ~LinearForm();
 };

--- a/fem/pgridfunc.hpp
+++ b/fem/pgridfunc.hpp
@@ -82,6 +82,10 @@ public:
    ParGridFunction &operator=(const Vector &v)
    { GridFunction::operator=(v); return *this; }
 
+   /// Copy the data from a ParGridFunction to the ParGridFunction data.
+   ParGridFunction &operator=(const ParGridFunction &v)
+   { GridFunction::operator=(v); return *this; }
+
    ParFiniteElementSpace *ParFESpace() const { return pfes; }
 
    virtual void Update();

--- a/fem/pgridfunc.hpp
+++ b/fem/pgridfunc.hpp
@@ -82,10 +82,6 @@ public:
    ParGridFunction &operator=(const Vector &v)
    { GridFunction::operator=(v); return *this; }
 
-   /// Copy the data from a ParGridFunction to the ParGridFunction data.
-   ParGridFunction &operator=(const ParGridFunction &v)
-   { GridFunction::operator=(v); return *this; }
-
    ParFiniteElementSpace *ParFESpace() const { return pfes; }
 
    virtual void Update();

--- a/fem/plinearform.hpp
+++ b/fem/plinearform.hpp
@@ -62,10 +62,6 @@ public:
    /// Copy the data from a Vector to the ParLinearForm data.
    ParLinearForm &operator=(const Vector &v)
    { LinearForm::operator=(v); return *this; }
-
-   /// Copy the data from a ParLinearForm to the ParLinearForm data.
-   ParLinearForm &operator=(const ParLinearForm &v)
-   { LinearForm::operator=(v); return *this; }
 };
 
 }

--- a/fem/plinearform.hpp
+++ b/fem/plinearform.hpp
@@ -54,6 +54,18 @@ public:
    {
       return InnerProduct(pfes->GetComm(), *this, gf);
    }
+
+   /// Assign constant values to the ParLinearForm data.
+   ParLinearForm &operator=(double value)
+   { LinearForm::operator=(value); return *this; }
+
+   /// Copy the data from a Vector to the ParLinearForm data.
+   ParLinearForm &operator=(const Vector &v)
+   { LinearForm::operator=(v); return *this; }
+
+   /// Copy the data from a ParLinearForm to the ParLinearForm data.
+   ParLinearForm &operator=(const ParLinearForm &v)
+   { LinearForm::operator=(v); return *this; }
 };
 
 }


### PR DESCRIPTION
This PR addresses issue #627 by adding explicit `operator=` overloading methods.