### PR TITLE
Add support for compressed saves in Mesh Explorer [test_gzstream]

### DIFF
--- a/miniapps/meshing/mesh-explorer.cpp
+++ b/miniapps/meshing/mesh-explorer.cpp
@@ -221,8 +221,11 @@ int main (int argc, char *argv[])
            "x) Print sub-element stats\n"
            "f) Find physical point in reference space\n"
            "p) Generate a partitioning\n"
-           "S) Save\n"
+           "S) Save in MFEM format\n"
            "V) Save in VTK format (only linear and quadratic meshes)\n"
+#ifdef MFEM_USE_GZSTREAM
+           "Z) Save in MFEM format with compression\n"
+#endif
            "--> " << flush;
       char mk;
       cin >> mk;
@@ -769,8 +772,6 @@ int main (int argc, char *argv[])
       {
          const char mesh_file[] = "mesh-explorer.mesh";
          ofstream omesh(mesh_file);
-         // Save gzip-ed mesh, requires MFEM_USE_GZSTREAM = YES
-         // ofgzstream omesh(mesh_file, "zwb9");
          omesh.precision(14);
          mesh->Print(omesh);
          cout << "New mesh file: " << mesh_file << endl;
@@ -784,6 +785,18 @@ int main (int argc, char *argv[])
          mesh->PrintVTK(omesh);
          cout << "New VTK mesh file: " << mesh_file << endl;
       }
+
+#ifdef MFEM_USE_GZSTREAM
+      if (mk == 'Z')
+      {
+         const char mesh_file[] = "mesh-explorer.mesh.gz";
+         ofgzstream omesh(mesh_file, "zwb9");
+         omesh.precision(14);
+         mesh->Print(omesh);
+         cout << "New mesh file: " << mesh_file << endl;
+      }
+#endif
+
    }
 
    delete attr_fec;


### PR DESCRIPTION
Conditionally add a `Z` save option to save MFEM ascii but compressed when `MFEM_USE_GZSTREAM` is defined.

This also helps to debug that this feature is getting built correctly.