### PR TITLE
Fix a bug in ParMesh::PrintAsOne [print-as-one-fix]

### DIFF
--- a/mesh/pmesh.cpp
+++ b/mesh/pmesh.cpp
@@ -4107,6 +4107,7 @@ void ParMesh::PrintAsOne(std::ostream &out)
                ints.Append(shared_quads[i].v, 4);
                ne++;
             }
+            break;
 
          default:
             MFEM_ABORT("invalid dimension: " << Dim);


### PR DESCRIPTION
Resolves #645.