### PR TITLE
Fixed BlockVector Update method [najlkin:pr5]

### DIFF
--- a/linalg/blockvector.cpp
+++ b/linalg/blockvector.cpp
@@ -90,7 +90,11 @@ void BlockVector::Update(const Array<int> &bOffsets, bool force)
             for (int i = 0; true; i++)
             {
                if (blockOffsets[i] != bOffsets[i]) { break; }
-               if (i == numBlocks) { return; }
+               if (i == numBlocks)
+               {
+                  blockOffsets = bOffsets.GetData();
+                  return;
+               }
             }
          }
       }

--- a/linalg/blockvector.cpp
+++ b/linalg/blockvector.cpp
@@ -85,12 +85,16 @@ void BlockVector::Update(const Array<int> &bOffsets)
       // check if 'bOffsets' agree with the 'blocks'
       if (bOffsets.Size() == numBlocks+1)
       {
-         for (int i = 0; true; i++)
+         if (numBlocks == 0) { return; }
+         if (Size() == bOffsets.Last())
          {
-            if (i >= numBlocks) { return; }
-            if (blocks[i].Size() != bOffsets[i+1] - bOffsets[i]) { break; }
-            MFEM_ASSERT(blocks[i].GetData() == data + bOffsets[i],
-                        "invalid blocks[" << i << ']');
+            for (int i = numBlocks - 1; true; i--)
+            {
+               if (i < 0) { return; }
+               if (blocks[i].Size() != bOffsets[i+1] - bOffsets[i]) { break; }
+               MFEM_ASSERT(blocks[i].GetData() == data + bOffsets[i],
+                           "invalid blocks[" << i << ']');
+            }
          }
       }
    }

--- a/linalg/blockvector.cpp
+++ b/linalg/blockvector.cpp
@@ -81,18 +81,22 @@ void BlockVector::Update(const Array<int> &bOffsets)
 {
    if (OwnsData())
    {
-      // check if 'bOffsets' are the same as 'blockOffsets'
+      // check if 'bOffsets' agree with the 'blocks'
       if (bOffsets.Size() == numBlocks+1)
       {
-         if (bOffsets.GetData() == blockOffsets || numBlocks == 0) { return; }
+         if (numBlocks == 0) { return; }
          for (int i = 0; true; i++)
          {
-            if (blockOffsets[i] != bOffsets[i]) { break; }
-            if (i == numBlocks)
-            {
-               blockOffsets = bOffsets.GetData();
-               return;
-            }
+            if (blocks[i].GetData() - data != bOffsets[i]) { break; }
+            if (i == numBlocks - 1)
+               if (blocks[numBlocks - 1].Size() ==
+                   bOffsets[numBlocks] - bOffsets[numBlocks - 1])
+               {
+                  blockOffsets = bOffsets.GetData();
+                  return;
+               }
+               else
+               { break; }
          }
       }
    }

--- a/linalg/blockvector.cpp
+++ b/linalg/blockvector.cpp
@@ -79,24 +79,18 @@ void BlockVector::Update(double *data, const Array<int> & bOffsets)
 
 void BlockVector::Update(const Array<int> &bOffsets)
 {
+   blockOffsets = bOffsets.GetData();
    if (OwnsData())
    {
       // check if 'bOffsets' agree with the 'blocks'
       if (bOffsets.Size() == numBlocks+1)
       {
-         if (numBlocks == 0) { return; }
          for (int i = 0; true; i++)
          {
-            if (blocks[i].GetData() - data != bOffsets[i]) { break; }
-            if (i == numBlocks - 1)
-               if (blocks[numBlocks - 1].Size() ==
-                   bOffsets[numBlocks] - bOffsets[numBlocks - 1])
-               {
-                  blockOffsets = bOffsets.GetData();
-                  return;
-               }
-               else
-               { break; }
+            if (i >= numBlocks) { return; }
+            if (blocks[i].Size() != bOffsets[i+1] - bOffsets[i]) { break; }
+            MFEM_ASSERT(blocks[i].GetData() == data + bOffsets[i],
+                        "invalid blocks[" << i << ']');
          }
       }
    }
@@ -105,7 +99,6 @@ void BlockVector::Update(const Array<int> &bOffsets)
       Destroy();
    }
    SetSize(bOffsets.Last());
-   blockOffsets = bOffsets.GetData();
    if (numBlocks != bOffsets.Size()-1)
    {
       delete [] blocks;

--- a/linalg/blockvector.cpp
+++ b/linalg/blockvector.cpp
@@ -77,24 +77,21 @@ void BlockVector::Update(double *data, const Array<int> & bOffsets)
    SetBlocks();
 }
 
-void BlockVector::Update(const Array<int> &bOffsets, bool force)
+void BlockVector::Update(const Array<int> &bOffsets)
 {
    if (OwnsData())
    {
-      if (!force)
+      // check if 'bOffsets' are the same as 'blockOffsets'
+      if (bOffsets.Size() == numBlocks+1)
       {
-         // check if 'bOffsets' are the same as 'blockOffsets'
-         if (bOffsets.Size() == numBlocks+1)
+         if (bOffsets.GetData() == blockOffsets || numBlocks == 0) { return; }
+         for (int i = 0; true; i++)
          {
-            if (bOffsets.GetData() == blockOffsets || numBlocks == 0) { return; }
-            for (int i = 0; true; i++)
+            if (blockOffsets[i] != bOffsets[i]) { break; }
+            if (i == numBlocks)
             {
-               if (blockOffsets[i] != bOffsets[i]) { break; }
-               if (i == numBlocks)
-               {
-                  blockOffsets = bOffsets.GetData();
-                  return;
-               }
+               blockOffsets = bOffsets.GetData();
+               return;
             }
          }
       }

--- a/linalg/blockvector.hpp
+++ b/linalg/blockvector.hpp
@@ -20,10 +20,11 @@ namespace mfem
 {
 
 //! @class BlockVector
-/*
+/**
  * \brief A class to handle Vectors in a block fashion
  *
- * All data is contained in Vector::data, while blockVector is just a viewer for this data
+ * All data is contained in Vector::data, while blockVector is just a viewer for
+ * this data.
  *
  */
 class BlockVector: public Vector
@@ -35,9 +36,12 @@ protected:
    //! Offset for each block start. (length numBlocks+1)
    /**
     * blockOffsets[i+1] - blockOffsets[i] is the size of block i.
+    *
+    * This array is not owned.
     */
    const int *blockOffsets;
    //! array of Vector objects used to extract blocks without allocating memory.
+   /** This array is owned. */
    Vector *blocks;
 
    void SetBlocks();

--- a/linalg/blockvector.hpp
+++ b/linalg/blockvector.hpp
@@ -99,9 +99,8 @@ public:
    /// Update a BlockVector with new @a bOffsets and make sure it owns its data.
    /** The block-vector will be re-allocated if either:
        - the offsets @a bOffsets are different from the current offsets, or
-       - currently, the block-vector does not own its data, or
-       - @a force is set to true. */
-   void Update(const Array<int> &bOffsets, bool force = false);
+       - currently, the block-vector does not own its data. */
+   void Update(const Array<int> &bOffsets);
 };
 
 }


### PR DESCRIPTION
Fixed BlockVector Update method, where the change of the offsets array was ignored in the case the offsets were identical, but just the location in memory differed.

The check if the offsets are identical cannot guarantee the offsets will be identical in the future. There may be a good reason why the user calls this method like rewriting or deallocating the original array. The pointer must be changed even if the forced reallocation is not performed (but it may be reconsidered if it is really needed).