### PR TITLE
Fix ordering of cut mesh groups and orientation of shared edges/faces [cut-mesh-groups-fix]

### DIFF
--- a/mesh/ncmesh.cpp
+++ b/mesh/ncmesh.cpp
@@ -1848,7 +1848,7 @@ void NCMesh::BuildFaceList()
          MFEM_ASSERT(face >= 0, "face not found!");
 
          // tell ParNCMesh about the face
-         ElementSharesFace(elem, face);
+         ElementSharesFace(elem, j, face);
 
          // have we already processed this face? skip if yes
          if (processed_faces[face]) { continue; }
@@ -1963,7 +1963,7 @@ void NCMesh::BuildEdgeList()
          MFEM_ASSERT(nd.HasEdge(), "edge not found!");
 
          // tell ParNCMesh about the edge
-         ElementSharesEdge(elem, enode);
+         ElementSharesEdge(elem, j, enode);
 
          // (2D only, store boundary faces)
          if (Dim <= 2)
@@ -2051,7 +2051,7 @@ void NCMesh::BuildVertexList()
          int index = nd.vert_index;
          if (index >= 0)
          {
-            ElementSharesVertex(elem, node);
+            ElementSharesVertex(elem, j, node);
 
             if (processed_vertices[index]) { continue; }
             processed_vertices[index] = 1;

--- a/mesh/ncmesh.cpp
+++ b/mesh/ncmesh.cpp
@@ -2989,7 +2989,8 @@ void NCMesh::ClearTransforms()
 
 //// Utility ///////////////////////////////////////////////////////////////////
 
-void NCMesh::GetEdgeVertices(const MeshId &edge_id, int vert_index[2]) const
+void NCMesh::GetEdgeVertices(const MeshId &edge_id, int vert_index[2],
+                             bool oriented) const
 {
    const Element &el = elements[edge_id.element];
    const GeomInfo& gi = GI[(int) el.geom];
@@ -3001,7 +3002,7 @@ void NCMesh::GetEdgeVertices(const MeshId &edge_id, int vert_index[2]) const
    vert_index[0] = nodes[n0].vert_index;
    vert_index[1] = nodes[n1].vert_index;
 
-   if (vert_index[0] > vert_index[1])
+   if (oriented && vert_index[0] > vert_index[1])
    {
       std::swap(vert_index[0], vert_index[1]);
    }

--- a/mesh/ncmesh.hpp
+++ b/mesh/ncmesh.hpp
@@ -248,12 +248,13 @@ public:
    // utility
 
    /// Return Mesh vertex indices of an edge identified by 'edge_id'.
-   void GetEdgeVertices(const MeshId &edge_id, int vert_index[2]) const;
+   void GetEdgeVertices(const MeshId &edge_id, int vert_index[2],
+                        bool oriented = true) const;
 
-   /** Return "NC" orientation of an edge. As opposed standard Mesh edge
+   /** Return "NC" orientation of an edge. As opposed to standard Mesh edge
        orientation based on vertex IDs, "NC" edge orientation follows the local
        edge orientation within the element 'edge_id.element' and is thus
-       processor independent. */
+       processor independent. FIXME this seems only partially true */
    int GetEdgeNCOrientation(const MeshId &edge_id) const;
 
    /// Return Mesh vertex and edge indices of a face identified by 'face_id'.

--- a/mesh/ncmesh.hpp
+++ b/mesh/ncmesh.hpp
@@ -547,9 +547,9 @@ protected: // implementation
    virtual void BuildEdgeList();
    virtual void BuildVertexList();
 
-   virtual void ElementSharesFace(int elem, int face) {} // ParNCMesh
-   virtual void ElementSharesEdge(int elem, int enode) {} // ParNCMesh
-   virtual void ElementSharesVertex(int elem, int vnode) {} // ParNCMesh
+   virtual void ElementSharesFace(int elem, int local, int face) {} // ParNCMesh
+   virtual void ElementSharesEdge(int elem, int local, int enode) {} // ParNCMesh
+   virtual void ElementSharesVertex(int elem, int local, int vnode) {} // ParNCMesh
 
 
    // neighbors / element_vertex table

--- a/mesh/pmesh.cpp
+++ b/mesh/pmesh.cpp
@@ -21,6 +21,7 @@
 #include "../general/globals.hpp"
 
 #include <iostream>
+#include <fstream>
 
 using namespace std;
 
@@ -5059,6 +5060,102 @@ int ParMesh::FindPoints(DenseMatrix& point_mat, Array<int>& elem_id,
       MFEM_WARNING((npts-pts_found) << " points were not found");
    }
    return pts_found;
+}
+
+static void PrintVertex(const Vertex &v, int space_dim, ostream &out)
+{
+   out << v(0);
+   for (int d = 1; d < space_dim; d++)
+   {
+      out << ' ' << v(d);
+   }
+}
+
+void ParMesh::PrintSharedEntities(const char *fname_prefix) const
+{
+   stringstream out_name;
+   out_name << fname_prefix << '_' << setw(5) << setfill('0') << MyRank
+            << ".shared_entities";
+   ofstream out(out_name.str().c_str());
+   out.precision(16);
+
+   gtopo.Save(out);
+
+   out << "\ntotal_shared_vertices " << svert_lvert.Size() << '\n';
+   if (Dim >= 2)
+   {
+      out << "total_shared_edges " << shared_edges.Size() << '\n';
+   }
+   if (Dim >= 3)
+   {
+      out << "total_shared_faces " << sface_lface.Size() << '\n';
+   }
+   for (int gr = 1; gr < GetNGroups(); gr++)
+   {
+      {
+         const int  nv = group_svert.RowSize(gr-1);
+         const int *sv = group_svert.GetRow(gr-1);
+         out << "\n# group " << gr << "\n\nshared_vertices " << nv << '\n';
+         for (int i = 0; i < nv; i++)
+         {
+            const int lvi = svert_lvert[sv[i]];
+            // out << lvi << '\n';
+            PrintVertex(vertices[lvi], spaceDim, out);
+            out << '\n';
+         }
+      }
+      if (Dim >= 2)
+      {
+         const int  ne = group_sedge.RowSize(gr-1);
+         const int *se = group_sedge.GetRow(gr-1);
+         out << "\nshared_edges " << ne << '\n';
+         for (int i = 0; i < ne; i++)
+         {
+            const int *v = shared_edges[se[i]]->GetVertices();
+            // out << v[0] << ' ' << v[1] << '\n';
+            PrintVertex(vertices[v[0]], spaceDim, out);
+            out << " | ";
+            PrintVertex(vertices[v[1]], spaceDim, out);
+            out << '\n';
+         }
+      }
+      if (Dim >= 3)
+      {
+         const int  nt = group_stria.RowSize(gr-1);
+         const int *st = group_stria.GetRow(gr-1);
+         const int  nq = group_squad.RowSize(gr-1);
+         const int *sq = group_squad.GetRow(gr-1);
+         out << "\nshared_faces " << nt+nq << '\n';
+         for (int i = 0; i < nt; i++)
+         {
+            const int *v = shared_trias[st[i]].v;
+#if 0
+            out << Geometry::TRIANGLE;
+            for (int j = 0; j < 3; j++) { out << ' ' << v[j]; }
+            out << '\n';
+#endif
+            for (int j = 0; j < 3; j++)
+            {
+               PrintVertex(vertices[v[j]], spaceDim, out);
+               (j < 2) ? out << " | " : out << '\n';
+            }
+         }
+         for (int i = 0; i < nq; i++)
+         {
+            const int *v = shared_quads[sq[i]].v;
+#if 0
+            out << Geometry::SQUARE;
+            for (int j = 0; j < 4; j++) { out << ' ' << v[j]; }
+            out << '\n';
+#endif
+            for (int j = 0; j < 4; j++)
+            {
+               PrintVertex(vertices[v[j]], spaceDim, out);
+               (j < 3) ? out << " | " : out << '\n';
+            }
+         }
+      }
+   }
 }
 
 ParMesh::~ParMesh()

--- a/mesh/pmesh.hpp
+++ b/mesh/pmesh.hpp
@@ -323,6 +323,9 @@ public:
                           Array<IntegrationPoint>& ips, bool warn = true,
                           InverseElementTransformation *inv_trans = NULL);
 
+   /// Debugging method
+   void PrintSharedEntities(const char *fname_prefix) const;
+
    virtual ~ParMesh();
 
    friend class ParNCMesh;

--- a/mesh/pncmesh.cpp
+++ b/mesh/pncmesh.cpp
@@ -936,9 +936,11 @@ void ParNCMesh::GetConformingSharedStructures(ParMesh &pmesh)
    pmesh.shared_quads.SetSize(pmesh.sface_lface.Size());
    for (int i = 0; i < pmesh.shared_quads.Size(); i++)
    {
+      int el_loc = entity_elem_local[2][pmesh.sface_lface[i]];
+      MeshId face_id(-1, leaf_elements[(el_loc >> 4)], (el_loc & 0xf));
+
       int e[4], eo[4];
-      GetFaceVerticesEdges(face_list.LookUp(pmesh.sface_lface[i]),
-                           pmesh.shared_quads[i].v, e, eo);
+      GetFaceVerticesEdges(face_id, pmesh.shared_quads[i].v, e, eo);
    }
 
    // free the arrays, they're not needed anymore (until next mesh update)

--- a/mesh/pncmesh.cpp
+++ b/mesh/pncmesh.cpp
@@ -852,13 +852,7 @@ void ParNCMesh::MakeSharedTable(int ngroups, int ent, Array<int> &shared_local,
       int *row = group_shared.GetRow(i);
 
       Array<int> ref_row(row, size);
-      //mfem::out << "Rank " << MyRank << ": ent_glob_order: ";
-      //entity_glob_order[ent].Print(mfem::out, 100);
-      //mfem::out << "Rank " << MyRank << ": before: ";
-      //ref_row.Print(mfem::out, 100);
       ref_row.Sort(CompareShared(entity_glob_order[ent], shared_local));
-      //mfem::out << "Rank " << MyRank << ":  after: ";
-      //ref_row.Print(mfem::out, 100);
    }
 }
 
@@ -2698,6 +2692,9 @@ long ParNCMesh::MemoryUsage(bool with_base) const
           GroupsMemoryUsage() +
           arrays_memory_usage(entity_owner) +
           arrays_memory_usage(entity_pmat_group) +
+          arrays_memory_usage(entity_conf_group) +
+          leaf_glob_order.MemoryUsage() +
+          arrays_memory_usage(entity_glob_order) +
           shared_vertices.MemoryUsage() +
           shared_edges.MemoryUsage() +
           shared_faces.MemoryUsage() +
@@ -2723,6 +2720,9 @@ int ParNCMesh::PrintMemoryDetail(bool with_base) const
    mfem::out << GroupsMemoryUsage() << " groups\n"
              << arrays_memory_usage(entity_owner) << " entity_owner\n"
              << arrays_memory_usage(entity_pmat_group) << " entity_pmat_group\n"
+             << arrays_memory_usage(entity_conf_group) << " entity_conf_group\n"
+             << leaf_glob_order.MemoryUsage() << " leaf_glob_order\n"
+             << arrays_memory_usage(entity_glob_order) << " entity_glob_order\n"
              << shared_vertices.MemoryUsage() << " shared_vertices\n"
              << shared_edges.MemoryUsage() << " shared_edges\n"
              << shared_faces.MemoryUsage() << " shared_faces\n"

--- a/mesh/pncmesh.hpp
+++ b/mesh/pncmesh.hpp
@@ -264,7 +264,7 @@ protected: // implementation
    // ParMesh-compatible (conforming) groups for each vertex/edge/face (0/1/2)
    Array<GroupId> entity_conf_group[3];
    // ParMesh compatibility helper arrays to order groups, also temporary
-   Array<int> leaf_glob_order, entity_glob_order[3];
+   Array<int> leaf_glob_order, entity_elem_local[3];
 
    // lists of vertices/edges/faces shared by us and at least one more processor
    NCList shared_vertices, shared_edges, shared_faces;

--- a/mesh/pncmesh.hpp
+++ b/mesh/pncmesh.hpp
@@ -260,8 +260,11 @@ protected: // implementation
    Array<GroupId> entity_owner[3];
    // P matrix comm pattern groups for each vertex/edge/face (0/1/2)
    Array<GroupId> entity_pmat_group[3];
+
    // ParMesh-compatible (conforming) groups for each vertex/edge/face (0/1/2)
    Array<GroupId> entity_conf_group[3];
+   // ParMesh compatibility helper arrays to order groups, also temporary
+   Array<int> leaf_glob_order, entity_glob_order[3];
 
    // lists of vertices/edges/faces shared by us and at least one more processor
    NCList shared_vertices, shared_edges, shared_faces;
@@ -307,9 +310,9 @@ protected: // implementation
    virtual void BuildEdgeList();
    virtual void BuildVertexList();
 
-   virtual void ElementSharesFace(int elem, int face);
-   virtual void ElementSharesEdge(int elem, int enode);
-   virtual void ElementSharesVertex(int elem, int vnode);
+   virtual void ElementSharesFace(int elem, int local, int face);
+   virtual void ElementSharesEdge(int elem, int local, int enode);
+   virtual void ElementSharesVertex(int elem, int local, int vnode);
 
    GroupId GetGroupId(const CommGroup &group);
    GroupId GetSingletonGroup(int rank);
@@ -331,6 +334,9 @@ protected: // implementation
    void CalcFaceOrientations();
 
    void UpdateLayers();
+
+   void MakeSharedTable(int ngroups, int ent, Array<int> &shared_local,
+                        Table &group_shared);
 
    /** Uniquely encodes a set of leaf elements in the refinement hierarchy of
        an NCMesh. Can be dumped to a stream, sent to another processor, loaded,
@@ -524,6 +530,7 @@ protected: // implementation
 
    friend class NeighborRowMessage;
 };
+
 
 
 // comparison operator so that MeshId can be used as key in std::map


### PR DESCRIPTION
ParMesh groups (`group_svert`, `group_sedge`, ...) need to have consistent ordering across processors in order for the GroupCommunicator to work correctly. Shared edges and faces also need to be oriented consistently. 

This is a fix of the conforming (cut-mesh) groups generated by `ParNCMesh`. The rows of the group tables are sorted according to a global vertex/edge/face ordering derived from the global leaf element sequence. Shared element orientation is determined in a similar way.