### PR TITLE
TMOP metrics for skew and aspect ratio

### DIFF
--- a/fem/tmop.cpp
+++ b/fem/tmop.cpp
@@ -51,8 +51,8 @@ double TMOP_Metric_skew2D::EvalW(const DenseMatrix &Jpt) const
    Jpr.GetColumn(0, col1);
    Jpr.GetColumn(1, col2);
    double norm_prod = col1.Norml2() * col2.Norml2();
-   const double cos_Jpt = (col1 * col2) / norm_prod,
-                sin_Jpt = Jpr.Det() / norm_prod;
+   const double cos_Jpr = (col1 * col2) / norm_prod,
+                sin_Jpr = std::sqrt(1.0 - cos_Jpr * cos_Jpr);
 
    Jtr->GetColumn(0, col1);
    Jtr->GetColumn(1, col2);
@@ -60,7 +60,47 @@ double TMOP_Metric_skew2D::EvalW(const DenseMatrix &Jpt) const
    const double cos_Jtr = (col1 * col2) / norm_prod,
                 sin_Jtr = Jtr->Det() / norm_prod;
 
-   return 0.5 * (1.0 - cos_Jpt * cos_Jtr - sin_Jpt * sin_Jtr);
+   return 0.5 * (1.0 - cos_Jpr * cos_Jtr - sin_Jpr * sin_Jtr);
+}
+
+double TMOP_Metric_skew3D::EvalW(const DenseMatrix &Jpt) const
+{
+   MFEM_VERIFY(Jtr != NULL,
+               "Requires a target Jacobian, use SetTargetJacobian().");
+
+   DenseMatrix Jpr(3, 3);
+   Mult(Jpt, *Jtr, Jpr);
+
+   Vector col1, col2, col3;
+   Jpr.GetColumn(0, col1);
+   Jpr.GetColumn(1, col2);
+   Jpr.GetColumn(2, col3);
+   double norm_c1 = col1.Norml2(),
+          norm_c2 = col2.Norml2(),
+          norm_c3 = col3.Norml2();
+   double cos_Jpr_12 = (col1 * col2) / (norm_c1 * norm_c2),
+          cos_Jpr_13 = (col1 * col3) / (norm_c1 * norm_c3),
+          cos_Jpr_23 = (col2 * col3) / (norm_c2 * norm_c3);
+   double sin_Jpr_12 = std::sqrt(1.0 - cos_Jpr_12 * cos_Jpr_12),
+          sin_Jpr_13 = std::sqrt(1.0 - cos_Jpr_13 * cos_Jpr_13),
+          sin_Jpr_23 = std::sqrt(1.0 - cos_Jpr_23 * cos_Jpr_23);
+
+   Jtr->GetColumn(0, col1);
+   Jtr->GetColumn(1, col2);
+   Jtr->GetColumn(2, col3);
+   norm_c1 = col1.Norml2();
+   norm_c2 = col2.Norml2(),
+   norm_c3 = col3.Norml2();
+   double cos_Jtr_12 = (col1 * col2) / (norm_c1 * norm_c2),
+          cos_Jtr_13 = (col1 * col3) / (norm_c1 * norm_c3),
+          cos_Jtr_23 = (col2 * col3) / (norm_c2 * norm_c3);
+   double sin_Jtr_12 = std::sqrt(1.0 - cos_Jtr_12 * cos_Jtr_12),
+          sin_Jtr_13 = std::sqrt(1.0 - cos_Jtr_13 * cos_Jtr_13),
+          sin_Jtr_23 = std::sqrt(1.0 - cos_Jtr_23 * cos_Jtr_23);
+
+   return (3.0 - cos_Jpr_12 * cos_Jtr_12 - sin_Jpr_12 * sin_Jtr_12
+               - cos_Jpr_13 * cos_Jtr_13 - sin_Jpr_13 * sin_Jtr_13
+               - cos_Jpr_23 * cos_Jtr_23 - sin_Jpr_23 * sin_Jtr_23) / 6.0;
 }
 
 double TMOP_Metric_aspratio2D::EvalW(const DenseMatrix &Jpt) const
@@ -74,13 +114,48 @@ double TMOP_Metric_aspratio2D::EvalW(const DenseMatrix &Jpt) const
    Vector col1, col2;
    Jpr.GetColumn(0, col1);
    Jpr.GetColumn(1, col2);
-   const double ratio_Jpt = col2.Norml2() / col1.Norml2();
+   const double ratio_Jpr = col2.Norml2() / col1.Norml2();
 
    Jtr->GetColumn(0, col1);
    Jtr->GetColumn(1, col2);
    const double ratio_Jtr = col2.Norml2() / col1.Norml2();
 
-   return 0.5 * (ratio_Jpt / ratio_Jtr + ratio_Jtr / ratio_Jpt) - 1.0;
+   return 0.5 * (ratio_Jpr / ratio_Jtr + ratio_Jtr / ratio_Jpr) - 1.0;
+}
+
+double TMOP_Metric_aspratio3D::EvalW(const DenseMatrix &Jpt) const
+{
+   MFEM_VERIFY(Jtr != NULL,
+               "Requires a target Jacobian, use SetTargetJacobian().");
+
+   DenseMatrix Jpr(3, 3);
+   Mult(Jpt, *Jtr, Jpr);
+
+   Vector col1, col2, col3;
+   Jpr.GetColumn(0, col1);
+   Jpr.GetColumn(1, col2);
+   Jpr.GetColumn(2, col3);
+   double norm_c1 = col1.Norml2(),
+          norm_c2 = col2.Norml2(),
+          norm_c3 = col3.Norml2();
+   double ratio_Jpr_1 = norm_c1 / std::sqrt(norm_c2 * norm_c3),
+          ratio_Jpr_2 = norm_c2 / std::sqrt(norm_c1 * norm_c3),
+          ratio_Jpr_3 = norm_c3 / std::sqrt(norm_c1 * norm_c2);
+
+   Jtr->GetColumn(0, col1);
+   Jtr->GetColumn(1, col2);
+   Jtr->GetColumn(2, col3);
+   norm_c1 = col1.Norml2();
+   norm_c2 = col2.Norml2();
+   norm_c3 = col3.Norml2();
+   double ratio_Jtr_1 = norm_c1 / std::sqrt(norm_c2 * norm_c3),
+          ratio_Jtr_2 = norm_c2 / std::sqrt(norm_c1 * norm_c3),
+          ratio_Jtr_3 = norm_c3 / std::sqrt(norm_c1 * norm_c2);
+
+   return ( 0.5 * (ratio_Jpr_1 / ratio_Jtr_1 + ratio_Jtr_1 / ratio_Jpr_1) +
+            0.5 * (ratio_Jpr_2 / ratio_Jtr_2 + ratio_Jtr_2 / ratio_Jpr_2) +
+            0.5 * (ratio_Jpr_3 / ratio_Jtr_3 + ratio_Jtr_3 / ratio_Jpr_3) - 3.0
+          ) / 3.0;
 }
 
 double TMOP_Metric_002::EvalW(const DenseMatrix &Jpt) const

--- a/fem/tmop.cpp
+++ b/fem/tmop.cpp
@@ -39,6 +39,50 @@ void TMOP_Metric_001::AssembleH(const DenseMatrix &Jpt,
    ie.Assemble_ddI1(weight, A.GetData());
 }
 
+double TMOP_Metric_skew2D::EvalW(const DenseMatrix &Jpt) const
+{
+   MFEM_VERIFY(Jtr != NULL,
+               "Requires a target Jacobian, use SetTargetJacobian().");
+
+   DenseMatrix Jpr(2, 2);
+   Mult(Jpt, *Jtr, Jpr);
+
+   Vector col1, col2;
+   Jpr.GetColumn(0, col1);
+   Jpr.GetColumn(1, col2);
+   double norm_prod = col1.Norml2() * col2.Norml2();
+   const double cos_Jpt = (col1 * col2) / norm_prod,
+                sin_Jpt = Jpr.Det() / norm_prod;
+
+   Jtr->GetColumn(0, col1);
+   Jtr->GetColumn(1, col2);
+   norm_prod = col1.Norml2() * col2.Norml2();
+   const double cos_Jtr = (col1 * col2) / norm_prod,
+                sin_Jtr = Jtr->Det() / norm_prod;
+
+   return 0.5 * (1.0 - cos_Jpt * cos_Jtr - sin_Jpt * sin_Jtr);
+}
+
+double TMOP_Metric_aspratio2D::EvalW(const DenseMatrix &Jpt) const
+{
+   MFEM_VERIFY(Jtr != NULL,
+               "Requires a target Jacobian, use SetTargetJacobian().");
+
+   DenseMatrix Jpr(2, 2);
+   Mult(Jpt, *Jtr, Jpr);
+
+   Vector col1, col2;
+   Jpr.GetColumn(0, col1);
+   Jpr.GetColumn(1, col2);
+   const double ratio_Jpt = col2.Norml2() / col1.Norml2();
+
+   Jtr->GetColumn(0, col1);
+   Jtr->GetColumn(1, col2);
+   const double ratio_Jtr = col2.Norml2() / col1.Norml2();
+
+   return 0.5 * (ratio_Jpt / ratio_Jtr + ratio_Jtr / ratio_Jpt) - 1.0;
+}
+
 double TMOP_Metric_002::EvalW(const DenseMatrix &Jpt) const
 {
    ie.SetJacobian(Jpt.GetData());

--- a/fem/tmop.hpp
+++ b/fem/tmop.hpp
@@ -88,6 +88,36 @@ public:
                           const double weight, DenseMatrix &A) const;
 };
 
+/// Skew metric, 2D.
+class TMOP_Metric_skew2D : public TMOP_QualityMetric
+{
+public:
+   // W = 0.5 (1 - cos(skew_Jpr - skew_Jtr)).
+   virtual double EvalW(const DenseMatrix &Jpt) const;
+
+   virtual void EvalP(const DenseMatrix &Jpt, DenseMatrix &P) const
+   { MFEM_ABORT("Not implemented"); }
+
+   virtual void AssembleH(const DenseMatrix &Jpt, const DenseMatrix &DS,
+                          const double weight, DenseMatrix &A) const
+   { MFEM_ABORT("Not implemented"); }
+};
+
+/// Aspect ratio metric, 2D.
+class TMOP_Metric_aspratio2D : public TMOP_QualityMetric
+{
+public:
+   // W = 0.5 (ar_Jpr/ar_Jtr + ar_Jtr/ar_Jpr) - 1.
+   virtual double EvalW(const DenseMatrix &Jpt) const;
+
+   virtual void EvalP(const DenseMatrix &Jpt, DenseMatrix &P) const
+   { MFEM_ABORT("Not implemented"); }
+
+   virtual void AssembleH(const DenseMatrix &Jpt, const DenseMatrix &DS,
+                          const double weight, DenseMatrix &A) const
+   { MFEM_ABORT("Not implemented"); }
+};
+
 /// Shape, ideal barrier metric, 2D
 class TMOP_Metric_002 : public TMOP_QualityMetric
 {

--- a/fem/tmop.hpp
+++ b/fem/tmop.hpp
@@ -103,11 +103,41 @@ public:
    { MFEM_ABORT("Not implemented"); }
 };
 
+/// Skew metric, 3D.
+class TMOP_Metric_skew3D : public TMOP_QualityMetric
+{
+public:
+   // W = 1/6 (3 - sum_i cos(skew_Jpr_i - skew_Jtr_i)), i = 1..3.
+   virtual double EvalW(const DenseMatrix &Jpt) const;
+
+   virtual void EvalP(const DenseMatrix &Jpt, DenseMatrix &P) const
+   { MFEM_ABORT("Not implemented"); }
+
+   virtual void AssembleH(const DenseMatrix &Jpt, const DenseMatrix &DS,
+                          const double weight, DenseMatrix &A) const
+   { MFEM_ABORT("Not implemented"); }
+};
+
 /// Aspect ratio metric, 2D.
 class TMOP_Metric_aspratio2D : public TMOP_QualityMetric
 {
 public:
    // W = 0.5 (ar_Jpr/ar_Jtr + ar_Jtr/ar_Jpr) - 1.
+   virtual double EvalW(const DenseMatrix &Jpt) const;
+
+   virtual void EvalP(const DenseMatrix &Jpt, DenseMatrix &P) const
+   { MFEM_ABORT("Not implemented"); }
+
+   virtual void AssembleH(const DenseMatrix &Jpt, const DenseMatrix &DS,
+                          const double weight, DenseMatrix &A) const
+   { MFEM_ABORT("Not implemented"); }
+};
+
+/// Aspect ratio metric, 3D.
+class TMOP_Metric_aspratio3D : public TMOP_QualityMetric
+{
+public:
+   // W = 1/3 sum [0.5 (ar_Jpr_i/ar_Jtr_i + ar_Jtr_i/ar_Jpr_i) - 1], i = 1..3.
    virtual double EvalW(const DenseMatrix &Jpt) const;
 
    virtual void EvalP(const DenseMatrix &Jpt, DenseMatrix &P) const


### PR DESCRIPTION
Skew-only and aspect ratio-only metrics in 2D and 3D, without derivatives. The computations can be optimized by directly accessing the entries of the 2x2 and 3x3 matrices, let me know if you prefer that.