### PR TITLE
[DISCUSS] Added possibility to link with CVODES

### DIFF
--- a/config/defaults.mk
+++ b/config/defaults.mk
@@ -157,7 +157,13 @@ POSIX_CLOCKS_LIB = -lrt
 SUNDIALS_DIR = @MFEM_DIR@/../sundials-3.0.0
 SUNDIALS_OPT = -I$(SUNDIALS_DIR)/include
 SUNDIALS_LIB = -Wl,-rpath,$(SUNDIALS_DIR)/lib -L$(SUNDIALS_DIR)/lib\
- -lsundials_arkode -lsundials_cvode -lsundials_nvecserial -lsundials_kinsol
+ -lsundials_arkode -lsundials_nvecserial -lsundials_kinsol
+SUNDIALS_CVODES = YES
+ifeq ($(SUNDIALS_CVODES),YES)
+   SUNDIALS_LIB += -lsundials_cvodes
+else
+   SUNDIALS_LIB += -lsundials_cvode
+endif
 
 ifeq ($(MFEM_USE_MPI),YES)
    SUNDIALS_LIB += -lsundials_nvecparhyp -lsundials_nvecparallel

--- a/linalg/sundials.hpp
+++ b/linalg/sundials.hpp
@@ -23,7 +23,11 @@
 #include "ode.hpp"
 #include "solvers.hpp"
 
+#ifdef SUNDIALS_CVODES
+#include <cvodes/cvodes.h>
+#else
 #include <cvode/cvode.h>
+#endif
 #include <arkode/arkode.h>
 #include <kinsol/kinsol.h>
 


### PR DESCRIPTION
This PR adds the possibility to link with CVODES instead of CVODE. It does not enhance functionality, since the new release of Sundials introduces a new interface for solvers and I am not sure what the correct way of coupling with MFEM would look like.

I wanted to get an opinion from the devs if this option is intended to reside in the library or if we should keep a local patch because it may be too specific.

**Todo**
- [X] GNU Make
- [ ] CMake
- [ ] Default to NO