### PR TITLE
Fixed Mesh::GetBdrElementTransformation() collisions with the functions for faces [najlkin:pr7]

### DIFF
--- a/mesh/mesh.cpp
+++ b/mesh/mesh.cpp
@@ -410,8 +410,8 @@ ElementTransformation *Mesh::GetElementTransformation(int i)
 
 ElementTransformation *Mesh::GetBdrElementTransformation(int i)
 {
-   GetBdrElementTransformation(i, &FaceTransformation);
-   return &FaceTransformation;
+   GetBdrElementTransformation(i, &BdrTransformation);
+   return &BdrTransformation;
 }
 
 void Mesh::GetBdrElementTransformation(int i, IsoparametricTransformation* ElTr)
@@ -989,7 +989,7 @@ void Mesh::Destroy()
 
    // TODO:
    // IsoparametricTransformations
-   // Transformation, Transformation2, FaceTransformation, EdgeTransformation;
+   // Transformation, Transformation2, BdrTransformation, FaceTransformation, EdgeTransformation;
    // FaceElementTransformations FaceElemTr;
 
    CoarseFineTr.Clear();

--- a/mesh/mesh.hpp
+++ b/mesh/mesh.hpp
@@ -138,6 +138,7 @@ protected:
    mutable Table *edge_vertex;
 
    IsoparametricTransformation Transformation, Transformation2;
+   IsoparametricTransformation BdrTransformation;
    IsoparametricTransformation FaceTransformation, EdgeTransformation;
    FaceElementTransformations FaceElemTr;
 


### PR DESCRIPTION
The method GetBdrElementTransformation() was internally colliding with GetFaceTransformation() and GetBdrFaceTransformations() consequently, because it used the same auxiliary structure. This collision can easily occur in iterations over the boundary elements when you want to examine the faces too (like mixed elements) for example. It makes no sense to share the same structure and the user cannot expect this behaviour.