### PR TITLE
Stefanozampini/fix int64build

### DIFF
--- a/linalg/handle.cpp
+++ b/linalg/handle.cpp
@@ -78,7 +78,7 @@ void OperatorHandle::MakeSquareBlockDiag(MPI_Comm comm, HYPRE_Int glob_size,
       case Operator::PETSC_MATAIJ:
       case Operator::PETSC_MATIS:
          // Assuming that PetscInt is the same size as HYPRE_Int, checked above.
-         oper = new PetscParMatrix(comm, glob_size, row_starts, diag, type_id);
+         oper = new PetscParMatrix(comm, glob_size, (PetscInt*)row_starts, diag, type_id);
          break;
 #endif
       default: MFEM_ABORT(not_supported_msg << type_id);
@@ -110,7 +110,7 @@ MakeRectangularBlockDiag(MPI_Comm comm, HYPRE_Int glob_num_rows,
       case Operator::PETSC_MATIS:
          // Assuming that PetscInt is the same size as HYPRE_Int, checked above.
          oper = new PetscParMatrix(comm, glob_num_rows, glob_num_cols,
-                                   row_starts, col_starts, diag, type_id);
+                                   (PetscInt*)row_starts, (PetscInt*)col_starts, diag, type_id);
          break;
 #endif
       default: MFEM_ABORT(not_supported_msg << type_id);

--- a/linalg/handle.cpp
+++ b/linalg/handle.cpp
@@ -78,7 +78,8 @@ void OperatorHandle::MakeSquareBlockDiag(MPI_Comm comm, HYPRE_Int glob_size,
       case Operator::PETSC_MATAIJ:
       case Operator::PETSC_MATIS:
          // Assuming that PetscInt is the same size as HYPRE_Int, checked above.
-         oper = new PetscParMatrix(comm, glob_size, (PetscInt*)row_starts, diag, type_id);
+         oper = new PetscParMatrix(comm, glob_size, (PetscInt*)row_starts, diag,
+                                   type_id);
          break;
 #endif
       default: MFEM_ABORT(not_supported_msg << type_id);

--- a/linalg/hypre.cpp
+++ b/linalg/hypre.cpp
@@ -3328,7 +3328,7 @@ HypreLOBPCG::SetPreconditioner(Solver & precond)
 void
 HypreLOBPCG::SetOperator(Operator & A)
 {
-   int locSize = A.Width();
+   HYPRE_Int locSize = A.Width();
 
    if (HYPRE_AssumedPartitionCheck())
    {
@@ -3344,7 +3344,7 @@ HypreLOBPCG::SetOperator(Operator & A)
    {
       part = new HYPRE_Int[numProcs+1];
 
-      MPI_Allgather(&locSize, 1, MPI_INT,
+      MPI_Allgather(&locSize, 1, HYPRE_MPI_INT,
                     &part[1], 1, HYPRE_MPI_INT, comm);
 
       part[0] = 0;

--- a/linalg/petsc.cpp
+++ b/linalg/petsc.cpp
@@ -708,15 +708,21 @@ BlockDiagonalConstructor(MPI_Comm comm,
       // Copy SparseMatrix into PETSc SeqAIJ format
       Mat lA;
       ierr = MatISGetLocalMat(A,&lA); PCHKERRQ(A,ierr);
-      if (sizeof(PetscInt) == sizeof(int))
-      {
-         ierr = MatSeqAIJSetPreallocationCSR(lA,diag->GetI(),diag->GetJ(),
-                                             diag->GetData()); PCHKERRQ(lA,ierr);
-      }
-      else
-      {
-         MFEM_ABORT("64bit indices not yet supported");
-      }
+      int *II = diag->GetI();
+      int *JJ = diag->GetJ();
+#if defined(PETSC_USE_64BIT_INDICES)
+      PetscInt *pII,*pJJ;
+      int m = diag->Height()+1, nnz = II[diag->Height()];
+      ierr = PetscMalloc2(m,&pII,nnz,&pJJ); PCHKERRQ(lA,ierr);
+      for (int i = 0; i < m; i++) pII[i] = II[i];
+      for (int i = 0; i < nnz; i++) pJJ[i] = JJ[i];
+      ierr = MatSeqAIJSetPreallocationCSR(lA,pII,pJJ,
+                                          diag->GetData()); PCHKERRQ(lA,ierr);
+      ierr = PetscFree2(pII,pJJ); PCHKERRQ(lA,ierr);
+#else
+      ierr = MatSeqAIJSetPreallocationCSR(lA,II,JJ,
+                                          diag->GetData()); PCHKERRQ(lA,ierr);
+#endif
    }
    else
    {
@@ -736,13 +742,16 @@ BlockDiagonalConstructor(MPI_Comm comm,
          CCHKERRQ(PETSC_COMM_SELF,ierr);
          ierr = PetscMemcpy(djj,diag->GetJ(),nnz*sizeof(PetscInt));
          CCHKERRQ(PETSC_COMM_SELF,ierr);
-         ierr = PetscMemcpy(da,diag->GetData(),nnz*sizeof(PetscScalar));
-         CCHKERRQ(PETSC_COMM_SELF,ierr);
       }
       else
       {
-         MFEM_ABORT("64bit indices not yet supported");
+         int *iii = diag->GetI();
+         int *jjj = diag->GetJ();
+         for (int i = 0; i < m; i++) dii[i] = iii[i];
+         for (int i = 0; i < nnz; i++) djj[i] = jjj[i];
       }
+      ierr = PetscMemcpy(da,diag->GetData(),nnz*sizeof(PetscScalar));
+      CCHKERRQ(PETSC_COMM_SELF,ierr);
       ierr = PetscCalloc1(m,&oii);
       CCHKERRQ(PETSC_COMM_SELF,ierr);
       if (commsize > 1)
@@ -1051,7 +1060,7 @@ void PetscParMatrix::ConvertOperator(MPI_Comm comm, const Operator &op, Mat* A,
          ierr = MatConvert(*A,MATIS,MAT_INPLACE_MATRIX,A); CCHKERRQ(comm,ierr);
 
          mfem::Array<Mat> *vmatsl2l = new mfem::Array<Mat>(nr);
-         for (PetscInt i=0; i<nr; i++) { (*vmatsl2l)[i] = matsl2l[i]; }
+         for (int i=0; i<(int)nr; i++) { (*vmatsl2l)[i] = matsl2l[i]; }
          ierr = PetscFree(matsl2l); CCHKERRQ(PETSC_COMM_SELF,ierr);
 
          PetscContainer c;
@@ -2150,7 +2159,7 @@ void PetscBCHandler::ApplyBC(const Vector &x, Vector &y)
    y = x;
    if (bctype == ZERO)
    {
-      for (PetscInt i = 0; i < ess_tdof_list.Size(); ++i)
+      for (int i = 0; i < ess_tdof_list.Size(); ++i)
       {
          y[ess_tdof_list[i]] = 0.0;
       }
@@ -2162,7 +2171,7 @@ void PetscBCHandler::ApplyBC(const Vector &x, Vector &y)
          Eval(eval_t,eval_g);
          eval_t_cached = eval_t;
       }
-      for (PetscInt i = 0; i < ess_tdof_list.Size(); ++i)
+      for (int i = 0; i < ess_tdof_list.Size(); ++i)
       {
          y[ess_tdof_list[i]] = eval_g[ess_tdof_list[i]];
       }
@@ -2174,7 +2183,7 @@ void PetscBCHandler::ApplyBC(Vector &x)
    (*this).SetUp(x.Size());
    if (bctype == ZERO)
    {
-      for (PetscInt i = 0; i < ess_tdof_list.Size(); ++i)
+      for (int i = 0; i < ess_tdof_list.Size(); ++i)
       {
          x[ess_tdof_list[i]] = 0.0;
       }
@@ -2186,7 +2195,7 @@ void PetscBCHandler::ApplyBC(Vector &x)
          Eval(eval_t,eval_g);
          eval_t_cached = eval_t;
       }
-      for (PetscInt i = 0; i < ess_tdof_list.Size(); ++i)
+      for (int i = 0; i < ess_tdof_list.Size(); ++i)
       {
          x[ess_tdof_list[i]] = eval_g[ess_tdof_list[i]];
       }
@@ -2198,14 +2207,14 @@ void PetscBCHandler::FixResidualBC(const Vector& x, Vector& y)
    (*this).SetUp(x.Size());
    if (bctype == ZERO)
    {
-      for (PetscInt i = 0; i < ess_tdof_list.Size(); ++i)
+      for (int i = 0; i < ess_tdof_list.Size(); ++i)
       {
          y[ess_tdof_list[i]] = x[ess_tdof_list[i]];
       }
    }
    else
    {
-      for (PetscInt i = 0; i < ess_tdof_list.Size(); ++i)
+      for (int i = 0; i < ess_tdof_list.Size(); ++i)
       {
          y[ess_tdof_list[i]] = x[ess_tdof_list[i]] - eval_g[ess_tdof_list[i]];
       }
@@ -4222,7 +4231,21 @@ static PetscErrorCode Convert_Vmarks_IS(MPI_Comm comm,
                          (const PetscInt**)&jj,&done); CHKERRQ(ierr);
       MFEM_VERIFY(done,"Unable to perform MatGetRowIJ on " << i << " l2l matrix");
       ierr = MatGetSize(pl2l[i],NULL,&n); CHKERRQ(ierr);
+#if defined(PETSC_USE_64BIT_INDICES)
+      int  nnz = (int)ii[m];
+      int *mii = new int[m+1];
+      int *mjj = new int[nnz];
+      for (int j = 0; j < m+1; j++) mii[j] = (int)ii[j];
+      for (int j = 0; j < nnz; j++) mjj[j] = (int)jj[j];
+      l2l[i] = new mfem::SparseMatrix(mii,mjj,NULL,m,n,true,true,true);
+#else
       l2l[i] = new mfem::SparseMatrix(ii,jj,NULL,m,n,false,true,true);
+#endif
+      ierr = MatRestoreRowIJ(pl2l[i],0,PETSC_FALSE,PETSC_FALSE,&m,
+                             (const PetscInt**)&ii,
+                             (const PetscInt**)&jj,&done); CHKERRQ(ierr);
+      MFEM_VERIFY(done,"Unable to perform MatRestoreRowIJ on "
+                  << i << " l2l matrix");
    }
    nl = 0;
    for (int i = 0; i < l2l.Size(); i++) { nl += l2l[i]->Width(); }
@@ -4242,14 +4265,6 @@ static PetscErrorCode Convert_Vmarks_IS(MPI_Comm comm,
    ierr = Convert_Array_IS(comm,false,&sub_dof_marker,st,is); CCHKERRQ(comm,ierr);
    for (int i = 0; i < pl2l.Size(); i++)
    {
-      PetscInt  m = l2l[i]->Height();
-      PetscInt  *ii = l2l[i]->GetI(),*jj = l2l[i]->GetJ();
-      PetscBool done;
-      ierr = MatRestoreRowIJ(pl2l[i],0,PETSC_FALSE,PETSC_FALSE,&m,
-                             (const PetscInt**)&ii,
-                             (const PetscInt**)&jj,&done); CHKERRQ(ierr);
-      MFEM_VERIFY(done,"Unable to perform MatRestoreRowIJ on "
-                  << i << " l2l matrix");
       delete l2l[i];
    }
    PetscFunctionReturn(0);

--- a/linalg/petsc.cpp
+++ b/linalg/petsc.cpp
@@ -3875,7 +3875,7 @@ static PetscErrorCode __mfem_snes_postcheck(SNESLineSearch ls,Vec X,Vec Y,Vec W,
                                             PetscBool *cy,PetscBool *cw, void* ctx)
 {
    __mfem_snes_ctx* snes_ctx = (__mfem_snes_ctx*)ctx;
-   bool lcy,lcw;
+   bool lcy = false,lcw = false;
 
    PetscFunctionBeginUser;
    mfem::PetscParVector x(X,true);

--- a/linalg/petsc.cpp
+++ b/linalg/petsc.cpp
@@ -714,8 +714,8 @@ BlockDiagonalConstructor(MPI_Comm comm,
       PetscInt *pII,*pJJ;
       int m = diag->Height()+1, nnz = II[diag->Height()];
       ierr = PetscMalloc2(m,&pII,nnz,&pJJ); PCHKERRQ(lA,ierr);
-      for (int i = 0; i < m; i++) pII[i] = II[i];
-      for (int i = 0; i < nnz; i++) pJJ[i] = JJ[i];
+      for (int i = 0; i < m; i++) { pII[i] = II[i]; }
+      for (int i = 0; i < nnz; i++) { pJJ[i] = JJ[i]; }
       ierr = MatSeqAIJSetPreallocationCSR(lA,pII,pJJ,
                                           diag->GetData()); PCHKERRQ(lA,ierr);
       ierr = PetscFree2(pII,pJJ); PCHKERRQ(lA,ierr);
@@ -747,8 +747,8 @@ BlockDiagonalConstructor(MPI_Comm comm,
       {
          int *iii = diag->GetI();
          int *jjj = diag->GetJ();
-         for (int i = 0; i < m; i++) dii[i] = iii[i];
-         for (int i = 0; i < nnz; i++) djj[i] = jjj[i];
+         for (int i = 0; i < m; i++) { dii[i] = iii[i]; }
+         for (int i = 0; i < nnz; i++) { djj[i] = jjj[i]; }
       }
       ierr = PetscMemcpy(da,diag->GetData(),nnz*sizeof(PetscScalar));
       CCHKERRQ(PETSC_COMM_SELF,ierr);
@@ -4235,8 +4235,8 @@ static PetscErrorCode Convert_Vmarks_IS(MPI_Comm comm,
       int  nnz = (int)ii[m];
       int *mii = new int[m+1];
       int *mjj = new int[nnz];
-      for (int j = 0; j < m+1; j++) mii[j] = (int)ii[j];
-      for (int j = 0; j < nnz; j++) mjj[j] = (int)jj[j];
+      for (int j = 0; j < m+1; j++) { mii[j] = (int)ii[j]; }
+      for (int j = 0; j < nnz; j++) { mjj[j] = (int)jj[j]; }
       l2l[i] = new mfem::SparseMatrix(mii,mjj,NULL,m,n,true,true,true);
 #else
       l2l[i] = new mfem::SparseMatrix(ii,jj,NULL,m,n,false,true,true);

--- a/mesh/mesh.cpp
+++ b/mesh/mesh.cpp
@@ -33,6 +33,7 @@
 
 // METIS 4 prototypes
 #if defined(MFEM_USE_METIS) && !defined(MFEM_USE_METIS_5)
+typedef int idx_t;
 typedef int idxtype;
 extern "C" {
    void METIS_PartGraphRecursive(int*, idxtype*, idxtype*, idxtype*, idxtype*,
@@ -4899,21 +4900,42 @@ int *Mesh::GeneratePartitioning(int nparts, int part_method)
    }
    else
    {
-      int *I, *J, n;
+      idx_t *I, *J, n;
 #ifndef MFEM_USE_METIS_5
-      int wgtflag = 0;
-      int numflag = 0;
-      int options[5];
+      idx_t wgtflag = 0;
+      idx_t numflag = 0;
+      idx_t options[5];
 #else
-      int ncon = 1;
-      int err;
-      int options[40];
+      idx_t ncon = 1;
+      idx_t err;
+      idx_t options[40];
 #endif
-      int edgecut;
+      idx_t edgecut;
+
+      // In case METIS have been compiled with 64bit indices
+      bool freedata = false;
+      idx_t mparts = (idx_t) nparts;
+      idx_t *mpartitioning;
 
       n = NumOfElements;
-      I = el_to_el->GetI();
-      J = el_to_el->GetJ();
+      if (sizeof(idx_t) == sizeof(int))
+      {
+         I = (idx_t*) el_to_el->GetI();
+         J = (idx_t*) el_to_el->GetJ();
+         mpartitioning = (idx_t*) partitioning;
+      }
+      else
+      {
+         int *iI = el_to_el->GetI();
+         int *iJ = el_to_el->GetJ();
+         int m = iI[n];
+         I = new idx_t[n+1];
+         J = new idx_t[m];
+         for (int k = 0; k < n+1; k++) I[k] = iI[k];
+         for (int k = 0; k < m; k++) J[k] = iJ[k];
+         mpartitioning = new idx_t[n];
+         freedata = true;
+      }
 #ifndef MFEM_USE_METIS_5
       options[0] = 0;
 #else
@@ -4930,7 +4952,7 @@ int *Mesh::GeneratePartitioning(int nparts, int part_method)
             // std::sort(J+I[i], J+I[i+1]);
 
             // Sort in decreasing order, as in previous versions of MFEM.
-            std::sort(J+I[i], J+I[i+1], std::greater<int>());
+            std::sort(J+I[i], J+I[i+1], std::greater<idx_t>());
          }
       }
 
@@ -4940,30 +4962,30 @@ int *Mesh::GeneratePartitioning(int nparts, int part_method)
       {
 #ifndef MFEM_USE_METIS_5
          METIS_PartGraphRecursive(&n,
-                                  (idxtype *) I,
-                                  (idxtype *) J,
-                                  (idxtype *) NULL,
-                                  (idxtype *) NULL,
+                                  I,
+                                  J,
+                                  NULL,
+                                  NULL,
                                   &wgtflag,
                                   &numflag,
-                                  &nparts,
+                                  &mparts,
                                   options,
                                   &edgecut,
-                                  (idxtype *) partitioning);
+                                  mpartitioning);
 #else
          err = METIS_PartGraphRecursive(&n,
                                         &ncon,
                                         I,
                                         J,
-                                        (idx_t *) NULL,
-                                        (idx_t *) NULL,
-                                        (idx_t *) NULL,
-                                        &nparts,
-                                        (real_t *) NULL,
-                                        (real_t *) NULL,
+                                        NULL,
+                                        NULL,
+                                        NULL,
+                                        &mparts,
+                                        NULL,
+                                        NULL,
                                         options,
                                         &edgecut,
-                                        partitioning);
+                                        mpartitioning);
          if (err != 1)
             mfem_error("Mesh::GeneratePartitioning: "
                        " error in METIS_PartGraphRecursive!");
@@ -4976,30 +4998,30 @@ int *Mesh::GeneratePartitioning(int nparts, int part_method)
       {
 #ifndef MFEM_USE_METIS_5
          METIS_PartGraphKway(&n,
-                             (idxtype *) I,
-                             (idxtype *) J,
-                             (idxtype *) NULL,
-                             (idxtype *) NULL,
+                             I,
+                             J,
+                             NULL,
+                             NULL,
                              &wgtflag,
                              &numflag,
-                             &nparts,
+                             &mparts,
                              options,
                              &edgecut,
-                             (idxtype *) partitioning);
+                             mpartitioning);
 #else
          err = METIS_PartGraphKway(&n,
                                    &ncon,
                                    I,
                                    J,
-                                   (idx_t *) NULL,
-                                   (idx_t *) NULL,
-                                   (idx_t *) NULL,
-                                   &nparts,
-                                   (real_t *) NULL,
-                                   (real_t *) NULL,
+                                   NULL,
+                                   NULL,
+                                   NULL,
+                                   &mparts,
+                                   NULL,
+                                   NULL,
                                    options,
                                    &edgecut,
-                                   partitioning);
+                                   mpartitioning);
          if (err != 1)
             mfem_error("Mesh::GeneratePartitioning: "
                        " error in METIS_PartGraphKway!");
@@ -5012,31 +5034,31 @@ int *Mesh::GeneratePartitioning(int nparts, int part_method)
       {
 #ifndef MFEM_USE_METIS_5
          METIS_PartGraphVKway(&n,
-                              (idxtype *) I,
-                              (idxtype *) J,
-                              (idxtype *) NULL,
-                              (idxtype *) NULL,
+                              I,
+                              J,
+                              NULL,
+                              NULL,
                               &wgtflag,
                               &numflag,
-                              &nparts,
+                              &mparts,
                               options,
                               &edgecut,
-                              (idxtype *) partitioning);
+                              mpartitioning);
 #else
          options[METIS_OPTION_OBJTYPE] = METIS_OBJTYPE_VOL;
          err = METIS_PartGraphKway(&n,
                                    &ncon,
                                    I,
                                    J,
-                                   (idx_t *) NULL,
-                                   (idx_t *) NULL,
-                                   (idx_t *) NULL,
-                                   &nparts,
-                                   (real_t *) NULL,
-                                   (real_t *) NULL,
+                                   NULL,
+                                   NULL,
+                                   NULL,
+                                   &mparts,
+                                   NULL,
+                                   NULL,
                                    options,
                                    &edgecut,
-                                   partitioning);
+                                   mpartitioning);
          if (err != 1)
             mfem_error("Mesh::GeneratePartitioning: "
                        " error in METIS_PartGraphKway!");
@@ -5047,6 +5069,17 @@ int *Mesh::GeneratePartitioning(int nparts, int part_method)
       mfem::out << "Mesh::GeneratePartitioning(...): edgecut = "
                 << edgecut << endl;
 #endif
+      nparts = (int) mparts;
+      if (mpartitioning != (idx_t*)partitioning)
+      {
+         for (int k = 0; k<NumOfElements; k++) partitioning[k] = mpartitioning[k];
+      }
+      if (freedata)
+      {
+         delete[] I;
+         delete[] J;
+         delete[] mpartitioning;
+      }
    }
 
    if (el_to_el)

--- a/mesh/mesh.cpp
+++ b/mesh/mesh.cpp
@@ -4931,8 +4931,8 @@ int *Mesh::GeneratePartitioning(int nparts, int part_method)
          int m = iI[n];
          I = new idx_t[n+1];
          J = new idx_t[m];
-         for (int k = 0; k < n+1; k++) I[k] = iI[k];
-         for (int k = 0; k < m; k++) J[k] = iJ[k];
+         for (int k = 0; k < n+1; k++) { I[k] = iI[k]; }
+         for (int k = 0; k < m; k++) { J[k] = iJ[k]; }
          mpartitioning = new idx_t[n];
          freedata = true;
       }
@@ -5072,7 +5072,7 @@ int *Mesh::GeneratePartitioning(int nparts, int part_method)
       nparts = (int) mparts;
       if (mpartitioning != (idx_t*)partitioning)
       {
-         for (int k = 0; k<NumOfElements; k++) partitioning[k] = mpartitioning[k];
+         for (int k = 0; k<NumOfElements; k++) { partitioning[k] = mpartitioning[k]; }
       }
       if (freedata)
       {

--- a/mesh/nurbs.cpp
+++ b/mesh/nurbs.cpp
@@ -1668,12 +1668,14 @@ void NURBSExtension::ConnectBoundaries()
 
 void NURBSExtension::ConnectBoundaries2D(int bnd0, int bnd1)
 {
-   int idx0, idx1;
+   int idx0 = -1, idx1 = -1;
    for (int b = 0; b < GetNBP(); b++)
    {
       if (bnd0 == patchTopo->GetBdrAttribute(b)) { idx0 = b; }
       if (bnd1 == patchTopo->GetBdrAttribute(b)) { idx1 = b; }
    }
+   MFEM_VERIFY(idx0 != -1,"Bdr 0 not found");
+   MFEM_VERIFY(idx1 != -1,"Bdr 1 not found");
 
    NURBSPatchMap p2g0(this);
    NURBSPatchMap p2g1(this);
@@ -1742,12 +1744,14 @@ void NURBSExtension::ConnectBoundaries2D(int bnd0, int bnd1)
 
 void NURBSExtension::ConnectBoundaries3D(int bnd0, int bnd1)
 {
-   int idx0, idx1;
+   int idx0 = -1, idx1 = -1;
    for (int b = 0; b < GetNBP(); b++)
    {
       if (bnd0 == patchTopo->GetBdrAttribute(b)) { idx0 = b; }
       if (bnd1 == patchTopo->GetBdrAttribute(b)) { idx1 = b; }
    }
+   MFEM_VERIFY(idx0 != -1,"Bdr 0 not found");
+   MFEM_VERIFY(idx1 != -1,"Bdr 1 not found");
 
    NURBSPatchMap p2g0(this);
    NURBSPatchMap p2g1(this);


### PR DESCRIPTION
This PR addresses build issues when using PETSc and METIS both compiled with 64bit indices

There's an error with ex12p (unrelated to PETSc and METIS) that I was not able to fix with this particular configuration. The same example  runs fine with 32bit indices.

[szampini@localhost examples]$ valgrind ./ex12p
Options used:
   --mesh ../data/beam-tri.mesh
   --order 1
   --num-eigs 5
   --seed 75
   --amg-for-systems
   --visualization
Number of unknowns: 1170
Assembling: matrix ... done.
==39345== Invalid read of size 8
==39345==    at 0x48336E: mfem::HypreParVector::HypreParVector(int, long long, double*, long long*) (/home/szampini/Devel/mfem/linalg/hypre.cpp:116)
==39345==    by 0x4836FA: mfem::HypreLOBPCG::SetOperator(mfem::Operator&) (/home/szampini/Devel/mfem/linalg/hypre.cpp:3365)
==39345==    by 0x451270: main (/home/szampini/Devel/mfem/examples/ex12p.cpp:242)
==39345==  Address 0x30 is not stack'd, malloc'd or (recently) free'd
