### PR TITLE
Okina memory manager segfault fix 

### DIFF
--- a/general/config.hpp
+++ b/general/config.hpp
@@ -72,7 +72,7 @@ public:
    // **************************************************************************
    static inline void enableGpu(const int dev =0) { Get().MfemDeviceSetup(dev); }
    static inline bool gpuEnabled() { return Get().ngpu > 0; }
-   static inline bool gpuDisabled() { return Get().ngpu < 0; }
+   static inline bool gpuDisabled() { return Get().ngpu == 0; }
    static inline bool gpuHasBeenEnabled() { return Get().ngpu >= 0; }
 
    static inline bool usingGpu() { return gpuEnabled() && Get().mode == GPU; }

--- a/general/config.hpp
+++ b/general/config.hpp
@@ -72,7 +72,7 @@ public:
    // **************************************************************************
    static inline void enableGpu(const int dev =0) { Get().MfemDeviceSetup(dev); }
    static inline bool gpuEnabled() { return Get().ngpu > 0; }
-   static inline bool gpuDisabled() { return Get().ngpu == 0; }
+   static inline bool gpuDisabled() { return Get().ngpu < 1; }
    static inline bool gpuHasBeenEnabled() { return Get().ngpu >= 0; }
 
    static inline bool usingGpu() { return gpuEnabled() && Get().mode == GPU; }

--- a/general/config.hpp
+++ b/general/config.hpp
@@ -72,7 +72,7 @@ public:
    // **************************************************************************
    static inline void enableGpu(const int dev =0) { Get().MfemDeviceSetup(dev); }
    static inline bool gpuEnabled() { return Get().ngpu > 0; }
-   static inline bool gpuDisabled() { return Get().ngpu < 1; }
+   static inline bool gpuDisabled() { return Get().ngpu < 0; }
    static inline bool gpuHasBeenEnabled() { return Get().ngpu >= 0; }
 
    static inline bool usingGpu() { return gpuEnabled() && Get().mode == GPU; }

--- a/general/mm.cpp
+++ b/general/mm.cpp
@@ -108,10 +108,9 @@ void *mm::Erase(void *ptr)
 {
    if (!config::usingMM()) { return ptr; }
    if (config::gpuDisabled()) { return ptr; }
-   if (deleted){ return ptr; }
    const bool known = Known(maps, ptr);
    // if (!known) { BUILTIN_TRAP; }
-   if (!known) { mfem_error("mm::Erase"); }
+   if (!known) { mfem_error("Trying to remove an unknown address!"); }
    MFEM_ASSERT(known, "Trying to remove an unknown address!");
    const memory &mem = maps.memories.at(ptr);
    dbg("\033[33m %p \033[35m(%ldb)", ptr, mem.bytes);

--- a/general/mm.cpp
+++ b/general/mm.cpp
@@ -107,7 +107,8 @@ void* mm::Insert(void *ptr, const size_t bytes)
 void *mm::Erase(void *ptr)
 {
    if (!config::usingMM()) { return ptr; }
-   if (config::gpuDisabled()) { return ptr; } //I think by default the condition should be true.
+   if (config::gpuDisabled()) { return ptr; }
+   if (deleted){ return ptr; }
    const bool known = Known(maps, ptr);
    // if (!known) { BUILTIN_TRAP; }
    if (!known) { mfem_error("mm::Erase"); }
@@ -307,7 +308,7 @@ void mm::Pull(const void *ptr, const size_t bytes)
 
 // *****************************************************************************
 // __attribute__((unused)) // VS doesn't like this in Appveyor
-static void Dump(const mm::ledger &maps)
+/*static void Dump(const mm::ledger &maps)
 {
    if (!getenv("DBG")) { return; }
    const mm::memory_map &mem = maps.memories;
@@ -342,7 +343,7 @@ static void Dump(const mm::ledger &maps)
       fflush(0);
       k++;
    }
-}
+}*/
 
 // *****************************************************************************
 // * Data will be pushed/pulled before the copy happens on the H or the D

--- a/general/mm.cpp
+++ b/general/mm.cpp
@@ -107,7 +107,7 @@ void* mm::Insert(void *ptr, const size_t bytes)
 void *mm::Erase(void *ptr)
 {
    if (!config::usingMM()) { return ptr; }
-   if (config::gpuDisabled()) { return ptr; }
+   if (config::gpuDisabled()) { return ptr; } //I think by default the condition should be true.
    const bool known = Known(maps, ptr);
    // if (!known) { BUILTIN_TRAP; }
    if (!known) { mfem_error("mm::Erase"); }

--- a/general/mm.hpp
+++ b/general/mm.hpp
@@ -111,12 +111,10 @@ public:
 
 private:
    ledger maps;
-   bool deleted = false;
    mm() {}
-   ~mm() { deleted = true; }
    mm(mm const&) = delete;
    void operator=(mm const&) = delete;
-   static inline mm& MM() { static mm singleton; return singleton; }
+   static inline mm& MM() { static mm *singleton = new mm(); return *singleton; }
 
    // **************************************************************************
    void *Insert(void *ptr, const size_t bytes);

--- a/general/mm.hpp
+++ b/general/mm.hpp
@@ -111,10 +111,11 @@ public:
 
 private:
    ledger maps;
-
+   bool deleted = false;
    mm() {}
-   mm(mm const&);
-   void operator=(mm const&);
+   ~mm() { deleted = true; }
+   mm(mm const&) = delete;
+   void operator=(mm const&) = delete;
    static inline mm& MM() { static mm singleton; return singleton; }
 
    // **************************************************************************

--- a/linalg/kernels/densemat.cpp
+++ b/linalg/kernels/densemat.cpp
@@ -342,14 +342,9 @@ void OpEQ(const size_t hw, const double *m, double *data)
 // *****************************************************************************
 double Det2(const double *data)
 {
-   static double *result = mm::malloc<double>(1);
+   MFEM_GPU_CANNOT_PASS;
    GET_CONST_PTR(data);
-   GET_PTR(result);
-   MFEM_FORALL(k, 1,
-               d_result[0] = d_data[0] * d_data[3] - d_data[1] * d_data[2];
-               );
-   return result[0];
-
+   return d_data[0] * d_data[3] - d_data[1] * d_data[2];
 }
 
 // *****************************************************************************


### PR DESCRIPTION
Addresses issue #730 .  By default, config.hpp sets 
``int ngpu = -1;`` 
but we have the following method
static inline bool gpuDisabled() { return Get().ngpu == 0; } which will return false if ngpu doesn't get overwritten to 0.  A possible fix is to change the gpuDisabled criteria to 
``static inline bool gpuDisabled() { return Get().ngpu < 0; }``