### PR TITLE
Fix face-neighbor-data for nonconforming AMR meshes

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -55,7 +55,7 @@ Other meshing improvements
 - The TMOP mesh optimization algorithms were extended to support user-defined
   space-dependent limiting terms. Improved the TMOP objective functions by
   more accurate normalization of the different terms.
-  
+
 Discretization improvements
 ---------------------------
 - Added support for derefinement of vector (RT + ND) spaces.

--- a/mesh/pmesh.cpp
+++ b/mesh/pmesh.cpp
@@ -2988,6 +2988,8 @@ void ParMesh::NonconformingRefinement(const Array<Refinement> &refinements,
                  "serial Mesh)");
    }
 
+   DeleteFaceNbrData();
+
    // NOTE: no check of !refinements.Size(), in parallel we would have to reduce
 
    // do the refinements


### PR DESCRIPTION
In `ParMesh::NonconformingRefinement`, delete the face-neighbor-data so that it can be reconstructed correctly when needed.

This should resolve issue #739.