### PR TITLE
Adding point charges to Volta miniapp [volta-point-charge-dev]

### DIFF
--- a/miniapps/electromagnetics/volta.cpp
+++ b/miniapps/electromagnetics/volta.cpp
@@ -31,6 +31,11 @@
 //
 // Sample runs:
 //
+//   Three point charges within a large metal enclosure:
+//      mpirun -np 4 volta -m ../../data/inline-quad.mesh
+//                         -pc '0.5 0.42 20 0.5 0.5 -12 0.5 0.545 15'
+//                         -dbcs '1 2 3 4' -dbcv '0 0 0 0'
+//
 //   A cylinder at constant voltage in a square, grounded metal pipe:
 //      mpirun -np 4 volta -m ../../data/square-disc.mesh
 //                         -dbcs '1 2 3 4 5 6 7 8' -dbcv '0 0 0 0 1 1 1 1'
@@ -77,6 +82,9 @@ double dielectric_sphere(const Vector &);
 static Vector cs_params_(0);  // Center, Radius, and Total Charge
 //                               of charged sphere
 double charged_sphere(const Vector &);
+
+// Point Charges
+static Vector pc_params_(0); // Point charge locations and charges
 
 // Polarization
 static Vector vp_params_(0);  // Axis Start, Axis End, Cylinder Radius,
@@ -131,6 +139,8 @@ int main(int argc, char *argv[])
                   "Center, Radius, and Permittivity of Dielectric Sphere");
    args.AddOption(&cs_params_, "-cs", "--charged-sphere-params",
                   "Center, Radius, and Total Charge of Charged Sphere");
+   args.AddOption(&pc_params_, "-pc", "--point-charge-params",
+                  "Charges and locations of Point Charges");
    args.AddOption(&vp_params_, "-vp", "--voltaic-pile-params",
                   "Axis End Points, Radius, and "
                   "Polarization of Cylindrical Voltaic Pile");
@@ -242,7 +252,8 @@ int main(int argc, char *argv[])
    VoltaSolver Volta(pmesh, order, dbcs, dbcv, nbcs, nbcv, *epsCoef,
                      ( e_uniform_.Size() > 0 ) ? phi_bc_uniform    : NULL,
                      ( cs_params_.Size() > 0 ) ? charged_sphere    : NULL,
-                     ( vp_params_.Size() > 0 ) ? voltaic_pile      : NULL);
+                     ( vp_params_.Size() > 0 ) ? voltaic_pile      : NULL,
+                     pc_params_);
 
    // Initialize GLVis visualization
    if (visualization)

--- a/miniapps/electromagnetics/volta_solver.hpp
+++ b/miniapps/electromagnetics/volta_solver.hpp
@@ -40,7 +40,8 @@ public:
                Coefficient & epsCoef,
                double (*phi_bc )(const Vector&),
                double (*rho_src)(const Vector&),
-               void   (*p_src  )(const Vector&, Vector&));
+               void   (*p_src  )(const Vector&, Vector&),
+               Vector & point_charges);
    ~VoltaSolver();
 
    HYPRE_Int GetProblemSize();
@@ -93,11 +94,12 @@ private:
    ParMixedBilinearForm * hCurlHDiv_;    // For computing D from E and P
    ParMixedBilinearForm * weakDiv_;      // For computing the source term from P
 
+   ParLinearForm * rhod_; // Dual of Volumetric Charge Density
+
    ParDiscreteGradOperator * grad_; // For Computing E from phi
 
    ParGridFunction * phi_; // Electric Scalar Potential
    ParGridFunction * rho_; // Volumetric Charge Density
-   ParGridFunction * rhod_; // Dual of Volumetric Charge Density
    ParGridFunction * sigma_; // Surface Charge Density
    ParGridFunction * e_; // Electric Field
    ParGridFunction * d_; // Electric Flux Density (aka Dielectric Flux)
@@ -112,6 +114,10 @@ private:
    double (*phi_bc_ )(const Vector&);          // Scalar Potential BC
    double (*rho_src_)(const Vector&);          // Volumetric Charge Density
    void   (*p_src_  )(const Vector&, Vector&); // Polarization Field
+
+   const Vector & point_charge_params_;
+
+   std::vector<DeltaCoefficient*> point_charges_;
 
    std::map<std::string,socketstream*> socks_; // Visualization sockets
 


### PR DESCRIPTION
This PR adds the capability to place point charges using DeltaCoefficients.  Any number of point charges can be defined.  I also added a new sample run which mimics one of Maxwell's figures (Fig. IV, Art. 121). 

BTW: I think the results are quite stunning.  Thanks, @stefanozampini and @v-dobrev, for adding DeltaCoefficient support to the LinearForms!  I realize this isn't exactly a new feature but it is perfectly suited to this electrostatic miniapp.
