### PR TITLE
Implement LOR-to-HO transfer operator [lor2ho-dev]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -169,6 +169,7 @@ miniapps/performance/sol.*
 miniapps/tools/display-basis
 miniapps/tools/load-dc
 miniapps/tools/convert-dc
+miniapps/tools/lor-transfer
 
 miniapps/nurbs/ex1
 miniapps/nurbs/ex1p

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -55,9 +55,17 @@ Other meshing improvements
 - The TMOP mesh optimization algorithms were extended to support user-defined
   space-dependent limiting terms. Improved the TMOP objective functions by
   more accurate normalization of the different terms.
-  
+
 Discretization improvements
 ---------------------------
+- Added support for a general "low-order refined"-to-"high-order" transfer of
+  GridFunction and true-dof data from a "low-order refined" (LOR) space defined
+  on a refined mesh to a "high-order" (HO) finite element space defined on a
+  coarse mesh. See the new classes L2Projection and L2Prolongation providing
+  accurate and conservative HO->LOR and LOR->HO maps respectively, the method
+  FiniteElementSpace::GetReverseTransferOperator and the new LOR Transfer
+  miniapp in miniapp/tools.
+
 - Added support for derefinement of vector (RT + ND) spaces.
 
 - Added element flux, and flux energy computation in class ElasticityIntegrator,
@@ -81,6 +89,9 @@ New and updated examples and miniapps
 
 - Added a new meshing miniapp, Extruder, that demonstrates the capability to
   produce 3D meshes by extruding 2D meshes.
+
+- Added a simple miniapp, lor-transfer, for visualizing the actions of the
+  transfer operators between a high-order and a low-order refined spaces.
 
 - Added a new example, Example 20/20p, that solves a system of 1D ODEs derived
   from a Hamiltonian. The example demonstrates the use of the variable order,

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -59,12 +59,10 @@ Other meshing improvements
 Discretization improvements
 ---------------------------
 - Added support for a general "low-order refined"-to-"high-order" transfer of
-  GridFunction and true-dof data from a "low-order refined" (LOR) space defined
-  on a refined mesh to a "high-order" (HO) finite element space defined on a
-  coarse mesh. See the new classes L2Projection and L2Prolongation providing
-  accurate and conservative HO->LOR and LOR->HO maps respectively, the method
-  FiniteElementSpace::GetReverseTransferOperator and the new LOR Transfer
-  miniapp in miniapp/tools.
+  GridFunction data from a "low-order refined" (LOR) space defined on a refined
+  mesh to a "high-order" (HO) finite element space defined on a coarse mesh. See
+  the new classes InterpolationGridTransfer and L2ProjectionGridTransfer and the
+  new LOR Transfer miniapp: miniapps/tools/lor-transfer.cpp.
 
 - Added support for derefinement of vector (RT + ND) spaces.
 

--- a/doc/CodeDocumentation.dox
+++ b/doc/CodeDocumentation.dox
@@ -124,6 +124,7 @@ namespace mfem {
  * - <a class="el" href="display-basis_8cpp_source.html">Display Basis</a>: visualize finite element basis functions
  * - <a class="el" href="load-dc_8cpp_source.html">Load DC</a>: visualize fields saved via DataCollection classes
  * - <a class="el" href="convert-dc_8cpp_source.html">Convert DC</a>: convert between diffirent DataCollection formats
+ * - <a class="el" href="lor-transfer_8cpp_source.html">LOR Transfer</a>: map functions between high-order and low-order refined spaces
  * - <a class="el" href="miniapps_2performance_2ex1_8cpp_source.html">HPC Example 1</a>: high-performance nodal H1 FEM for the Laplace problem
  * - <a class="el" href="miniapps_2performance_2ex1p_8cpp_source.html">HPC Example 1p</a>: high-performance parallel nodal H1 FEM for the Laplace problem
  *

--- a/fem/fespace.cpp
+++ b/fem/fespace.cpp
@@ -2194,7 +2194,7 @@ L2Projection::L2Projection(const FiniteElementSpace &fes_ho_,
    nref = nel_lor/nel_ho;
 
    // Construct the mapping from HO to LOR and reverse
-   // lor2ho[ilor] will give the unique HO coarse element cotaining the ilor
+   // lor2ho[ilor] will give the unique HO coarse element containing the ilor
    // ho2lor.GetRow(iho) will give all the LOR elements contained in iho
    lor2ho.SetSize(nel_lor);
    ho2lor.SetSize(nel_ho, nref);

--- a/fem/fespace.cpp
+++ b/fem/fespace.cpp
@@ -977,7 +977,7 @@ void FiniteElementSpace::RefinementOperator
 
 FiniteElementSpace::DerefinementOperator::DerefinementOperator(
    const FiniteElementSpace *f_fes, const FiniteElementSpace *c_fes,
-   BilinearFormIntegrator &mass_integ)
+   BilinearFormIntegrator *mass_integ)
    : Operator(c_fes->GetVSize(), f_fes->GetVSize()),
      fine_fes(f_fes)
 {
@@ -1011,7 +1011,7 @@ FiniteElementSpace::DerefinementOperator::DerefinementOperator(
          // Get the local interpolation matrix for this refinement type
          fine_fe->GetTransferMatrix(*coarse_fe, emb_tr, lP(i));
          // Get the local mass matrix for this refinement type
-         mass_integ.AssembleElementMatrix(*fine_fe, emb_tr, lM(i));
+         mass_integ->AssembleElementMatrix(*fine_fe, emb_tr, lM(i));
       }
    }
 
@@ -1832,13 +1832,6 @@ void FiniteElementSpace::GetTransferOperator(
    }
 }
 
-void FiniteElementSpace::GetReverseTransferOperator(
-   BilinearFormIntegrator &mass_integ, const FiniteElementSpace &coarse_fes,
-   OperatorHandle &R) const
-{
-   R.Reset(new DerefinementOperator(this, &coarse_fes, mass_integ));
-}
-
 void FiniteElementSpace::GetTrueTransferOperator(
    const FiniteElementSpace &coarse_fes, OperatorHandle &T) const
 {
@@ -2181,33 +2174,250 @@ void QuadratureSpace::Save(std::ostream &out) const
        << "Order: " << order << '\n';
 }
 
-L2Projection::L2Projection(const FiniteElementSpace &fes_ho_,
-                           const FiniteElementSpace &fes_lor_)
+
+GridTransfer::GridTransfer(FiniteElementSpace &dom_fes_,
+                           FiniteElementSpace &ran_fes_)
+   : dom_fes(dom_fes_), ran_fes(ran_fes_),
+     oper_type(Operator::ANY_TYPE),
+     fw_t_oper(), bw_t_oper()
+{
+#ifdef MFEM_USE_MPI
+   const bool par_dom = dynamic_cast<ParFiniteElementSpace*>(&dom_fes);
+   const bool par_ran = dynamic_cast<ParFiniteElementSpace*>(&ran_fes);
+   MFEM_VERIFY(par_dom == par_ran, "the domain and range FE spaces must both"
+               " be either serial or parallel");
+   parallel = par_dom;
+#endif
+}
+
+const Operator &GridTransfer::MakeTrueOperator(
+   FiniteElementSpace &fes_in, FiniteElementSpace &fes_out,
+   const Operator &oper, OperatorHandle &t_oper)
+{
+   if (t_oper.Ptr())
+   {
+      return *t_oper.Ptr();
+   }
+
+   if (!Parallel())
+   {
+      const SparseMatrix *in_cP = fes_in.GetConformingProlongation();
+      const SparseMatrix *out_cR = fes_out.GetConformingRestriction();
+      if (oper_type == Operator::MFEM_SPARSEMAT)
+      {
+         const SparseMatrix *mat = dynamic_cast<const SparseMatrix *>(&oper);
+         MFEM_VERIFY(mat != NULL, "Operator is not a SparseMatrix");
+         if (!out_cR)
+         {
+            t_oper.Reset(const_cast<SparseMatrix*>(mat), false);
+         }
+         else
+         {
+            t_oper.Reset(mfem::Mult(*out_cR, *mat));
+         }
+         if (in_cP)
+         {
+            t_oper.Reset(mfem::Mult(*t_oper.As<SparseMatrix>(), *in_cP));
+         }
+      }
+      else if (oper_type == Operator::ANY_TYPE)
+      {
+         const int RP_case = bool(out_cR) + 2*bool(in_cP);
+         switch (RP_case)
+         {
+            case 0:
+               t_oper.Reset(const_cast<Operator*>(&oper), false);
+               break;
+            case 1:
+               t_oper.Reset(
+                  new ProductOperator(out_cR, &oper, false, false));
+               break;
+            case 2:
+               t_oper.Reset(
+                  new ProductOperator(&oper, in_cP, false, false));
+               break;
+            case 3:
+               t_oper.Reset(
+                  new TripleProductOperator(
+                     out_cR, &oper, in_cP, false, false, false));
+               break;
+         }
+      }
+      else
+      {
+         MFEM_ABORT("Operator::Type is not supported: " << oper_type);
+      }
+   }
+   else // Parallel() == true
+   {
+#ifdef MFEM_USE_MPI
+      const SparseMatrix *out_R = fes_out.GetRestrictionMatrix();
+      if (oper_type == Operator::Hypre_ParCSR)
+      {
+         const ParFiniteElementSpace *pfes_in =
+            dynamic_cast<const ParFiniteElementSpace *>(&fes_in);
+         const ParFiniteElementSpace *pfes_out =
+            dynamic_cast<const ParFiniteElementSpace *>(&fes_out);
+         const SparseMatrix *sp_mat = dynamic_cast<const SparseMatrix *>(&oper);
+         const HypreParMatrix *hy_mat;
+         if (sp_mat)
+         {
+            SparseMatrix *RA = mfem::Mult(*out_R, *sp_mat);
+            t_oper.Reset(pfes_in->Dof_TrueDof_Matrix()->
+                         LeftDiagMult(*RA, pfes_out->GetTrueDofOffsets()));
+            delete RA;
+         }
+         else if ((hy_mat = dynamic_cast<const HypreParMatrix *>(&oper)))
+         {
+            HypreParMatrix *RA =
+               hy_mat->LeftDiagMult(*out_R, pfes_out->GetTrueDofOffsets());
+            t_oper.Reset(mfem::ParMult(RA, pfes_in->Dof_TrueDof_Matrix()));
+            delete RA;
+         }
+         else
+         {
+            MFEM_ABORT("unknown Operator type");
+         }
+      }
+      else if (oper_type == Operator::ANY_TYPE)
+      {
+         t_oper.Reset(new TripleProductOperator(
+                         out_R, &oper, fes_in.GetProlongationMatrix(),
+                         false, false, false));
+      }
+      else
+      {
+         MFEM_ABORT("Operator::Type is not supported: " << oper_type);
+      }
+#endif
+   }
+
+   return *t_oper.Ptr();
+}
+
+
+InterpolationGridTransfer::~InterpolationGridTransfer()
+{
+   if (own_mass_integ) { delete mass_integ; }
+}
+
+void InterpolationGridTransfer::SetMassIntegrator(
+   BilinearFormIntegrator *mass_integ_, bool own_mass_integ_)
+{
+   if (own_mass_integ) { delete mass_integ; }
+
+   mass_integ = mass_integ_;
+   own_mass_integ = own_mass_integ_;
+}
+
+const Operator &InterpolationGridTransfer::ForwardOperator()
+{
+   if (F.Ptr())
+   {
+      return *F.Ptr();
+   }
+
+   // Costruct F
+   if (oper_type == Operator::ANY_TYPE)
+   {
+      F.Reset(new FiniteElementSpace::RefinementOperator(&ran_fes, &dom_fes));
+   }
+   else if (oper_type == Operator::MFEM_SPARSEMAT)
+   {
+      Mesh::GeometryList elem_geoms(*ran_fes.GetMesh());
+
+      DenseTensor localP[Geometry::NumGeom];
+      for (int i = 0; i < elem_geoms.Size(); i++)
+      {
+         ran_fes.GetLocalRefinementMatrices(dom_fes, elem_geoms[i],
+                                            localP[elem_geoms[i]]);
+      }
+      F.Reset(ran_fes.RefinementMatrix_main(
+                 dom_fes.GetNDofs(), dom_fes.GetElementToDofTable(), localP));
+   }
+   else
+   {
+      MFEM_ABORT("Operator::Type is not supported: " << oper_type);
+   }
+
+   return *F.Ptr();
+}
+
+const Operator &InterpolationGridTransfer::BackwardOperator()
+{
+   if (B.Ptr())
+   {
+      return *B.Ptr();
+   }
+
+   // Construct B
+   // If not set, define a suitable mass_integ
+   if (!mass_integ && ran_fes.GetNE() > 0)
+   {
+      const FiniteElement *f_fe_0 = ran_fes.GetFE(0);
+      const int map_type = f_fe_0->GetMapType();
+      if (map_type == FiniteElement::VALUE ||
+          map_type == FiniteElement::INTEGRAL)
+      {
+         mass_integ = new MassIntegrator;
+      }
+      else if (map_type == FiniteElement::H_DIV ||
+               map_type == FiniteElement::H_CURL)
+      {
+         mass_integ = new VectorFEMassIntegrator;
+      }
+      else
+      {
+         MFEM_ABORT("unknown type of FE space");
+      }
+      own_mass_integ = true;
+   }
+   if (oper_type == Operator::ANY_TYPE)
+   {
+      B.Reset(new FiniteElementSpace::DerefinementOperator(
+                 &ran_fes, &dom_fes, mass_integ));
+   }
+   else
+   {
+      MFEM_ABORT("Operator::Type is not supported: " << oper_type);
+   }
+
+   return *B.Ptr();
+}
+
+
+L2ProjectionGridTransfer::L2Projection::L2Projection(
+   const FiniteElementSpace &fes_ho_, const FiniteElementSpace &fes_lor_)
    : fes_ho(fes_ho_), fes_lor(fes_lor_)
 {
-   ndof_lor = fes_lor.GetFE(0)->GetDof();
-   ndof_ho = fes_ho.GetFE(0)->GetDof();
+   Mesh *mesh_ho = fes_ho.GetMesh();
+   MFEM_VERIFY(mesh_ho->GetNumGeometries(mesh_ho->Dimension()) <= 1,
+               "mixed meshes are not supported");
 
-   nel_lor = fes_lor.GetNE();
-   nel_ho = fes_ho.GetNE();
+   // If the local mesh is empty, skip all computations
+   if (mesh_ho->GetNE() == 0) { return; }
+
+   const FiniteElement *fe_lor = fes_lor.GetFE(0);
+   const FiniteElement *fe_ho = fes_ho.GetFE(0);
+   ndof_lor = fe_lor->GetDof();
+   ndof_ho = fe_ho->GetDof();
+
+   const int nel_lor = fes_lor.GetNE();
+   const int nel_ho = fes_ho.GetNE();
 
    nref = nel_lor/nel_ho;
 
-   // Construct the mapping from HO to LOR and reverse
-   // lor2ho[ilor] will give the unique HO coarse element containing the ilor
+   // Construct the mapping from HO to LOR
    // ho2lor.GetRow(iho) will give all the LOR elements contained in iho
-   lor2ho.SetSize(nel_lor);
    ho2lor.SetSize(nel_ho, nref);
-   const CoarseFineTransformations &cf_tr
-      = fes_lor.GetMesh()->GetRefinementTransforms();
+   const CoarseFineTransformations &cf_tr =
+      fes_lor.GetMesh()->GetRefinementTransforms();
    for (int ilor=0; ilor<nel_lor; ++ilor)
    {
       int iho = cf_tr.embeddings[ilor].parent;
-      lor2ho[ilor] = iho;
       ho2lor.AddConnection(iho, ilor);
    }
    ho2lor.ShiftUpI();
-   ho2lor.Finalize();
 
    // R will contain the restriction (L^2 projection operator) defined on
    // each coarse HO element (and corresponding patch of LOR elements)
@@ -2231,25 +2441,24 @@ L2Projection::L2Projection(const FiniteElementSpace &fes_ho_,
    DenseMatrix RtMlorR(ndof_ho, ndof_ho);
    DenseMatrixInverse RtMlorR_inv(&RtMlorR);
 
-   IsoparametricTransformation emb_tr;
+   IntegrationPointTransformation ip_tr;
+   IsoparametricTransformation &emb_tr = ip_tr.Transf;
 
    Vector shape_ho(ndof_ho);
    Vector shape_lor(ndof_lor);
 
+   const Geometry::Type geom = fe_ho->GetGeomType();
+   const DenseTensor &pmats = cf_tr.GetPointMatrices(geom);
+   emb_tr.SetIdentityTransformation(geom);
+
    for (int iho=0; iho<nel_ho; ++iho)
    {
-      const Geometry::Type geom = fes_ho.GetFE(iho)->GetGeomType();
-      const DenseTensor &pmats = cf_tr.GetPointMatrices(geom);
-      const FiniteElement *fe_lor = fes_lor.FEColl()->FiniteElementForGeometry(geom);
-      const FiniteElement *fe_ho = fes_ho.FEColl()->FiniteElementForGeometry(geom);
-      emb_tr.SetIdentityTransformation(geom);
       for (int iref=0; iref<nref; ++iref)
       {
          // Assemble the low-order refined mass matrix and invert locally
          int ilor = ho2lor.GetRow(iho)[iref];
-         mi.AssembleElementMatrix(*fe_lor,
-                                  *fes_lor.GetElementTransformation(ilor),
-                                  M_lor_el);
+         ElementTransformation *el_tr = fes_lor.GetElementTransformation(ilor);
+         mi.AssembleElementMatrix(*fe_lor, *el_tr, M_lor_el);
          M_lor.CopyMN(M_lor_el, iref*ndof_lor, iref*ndof_lor);
          Minv_lor_el.Factor();
          Minv_lor_el.GetInverseMatrix(M_lor_el);
@@ -2264,10 +2473,7 @@ L2Projection::L2Projection(const FiniteElementSpace &fes_ho_,
          // within the coarse high-order element in reference space
          emb_tr.GetPointMat() = pmats(iref);
          emb_tr.FinalizeTransformation();
-         IntegrationPointTransformation ip_tr;
-         ip_tr.Transf = emb_tr;
 
-         ElementTransformation *el_tr = fes_lor.GetElementTransformation(ilor);
          int order = fe_lor->GetOrder() + fe_ho->GetOrder() + el_tr->OrderW();
          const IntegrationRule *ir = &IntRules.Get(geom, order);
          M_mixed_el = 0.0;
@@ -2296,49 +2502,74 @@ L2Projection::L2Projection(const FiniteElementSpace &fes_ho_,
    }
 }
 
-void L2Projection::Mult(const Vector &x, Vector &y) const
+void L2ProjectionGridTransfer::L2Projection::Mult(
+   const Vector &x, Vector &y) const
 {
+   int vdim = fes_ho.GetVDim();
    Array<int> vdofs;
-   Vector xel(ndof_ho);
-   Vector yel(ndof_lor*nref);
+   DenseMatrix xel_mat(ndof_ho, vdim);
+   DenseMatrix yel_mat(ndof_lor*nref, vdim);
    for (int iho=0; iho<fes_ho.GetNE(); ++iho)
    {
       fes_ho.GetElementVDofs(iho, vdofs);
-      x.GetSubVector(vdofs, xel.GetData());
-      R(iho).Mult(xel, yel);
+      x.GetSubVector(vdofs, xel_mat.GetData());
+      mfem::Mult(R(iho), xel_mat, yel_mat);
       // Place result correctly into low-order vector
       for (int iref=0; iref<nref; ++iref)
       {
          int ilor = ho2lor.GetRow(iho)[iref];
-         fes_lor.GetElementVDofs(ilor, vdofs);
-         y.SetSubVector(vdofs, yel.GetData() + iref*ndof_lor);
+         for (int vd=0; vd<vdim; ++vd)
+         {
+            fes_lor.GetElementDofs(ilor, vdofs);
+            fes_lor.DofsToVDofs(vd, vdofs);
+            y.SetSubVector(vdofs, &yel_mat(iref*ndof_lor,vd));
+         }
       }
    }
 }
 
-void L2Projection::Prolongate(const Vector &x, Vector &y) const
+void L2ProjectionGridTransfer::L2Projection::Prolongate(
+   const Vector &x, Vector &y) const
 {
+   int vdim = fes_ho.GetVDim();
    Array<int> vdofs;
-   Vector xel(ndof_lor*nref);
-   Vector yel(ndof_ho);
+   DenseMatrix xel_mat(ndof_lor*nref, vdim);
+   DenseMatrix yel_mat(ndof_ho, vdim);
    for (int iho=0; iho<fes_ho.GetNE(); ++iho)
    {
       // Extract the LOR DOFs
       for (int iref=0; iref<nref; ++iref)
       {
          int ilor = ho2lor.GetRow(iho)[iref];
-         fes_lor.GetElementVDofs(ilor, vdofs);
-         x.GetSubVector(vdofs, &xel[iref*ndof_lor]);
+         for (int vd=0; vd<vdim; ++vd)
+         {
+            fes_lor.GetElementDofs(ilor, vdofs);
+            fes_lor.DofsToVDofs(vd, vdofs);
+            x.GetSubVector(vdofs, &xel_mat(iref*ndof_lor, vd));
+         }
       }
       // Locally prolongate
-      P(iho).Mult(xel, yel);
+      mfem::Mult(P(iho), xel_mat, yel_mat);
       // Place the result in the HO vector
       fes_ho.GetElementVDofs(iho, vdofs);
-      y.SetSubVector(vdofs, yel);
+      y.SetSubVector(vdofs, yel_mat.GetData());
    }
 }
 
+const Operator &L2ProjectionGridTransfer::ForwardOperator()
+{
+   if (!F) { F = new L2Projection(dom_fes, ran_fes); }
+   return *F;
+}
 
-
+const Operator &L2ProjectionGridTransfer::BackwardOperator()
+{
+   if (!B)
+   {
+      if (!F) { F = new L2Projection(dom_fes, ran_fes); }
+      B = new L2Prolongation(*F);
+   }
+   return *B;
+}
 
 } // namespace mfem

--- a/fem/fespace.hpp
+++ b/fem/fespace.hpp
@@ -739,7 +739,7 @@ public:
     coarse and fine FE spaces can have different orders, however, in order for
     the backward operator to be well-defined, the number of the fine dofs (in a
     coarse element) should not be smaller than the number of coarse dofs.
-    
+
     If used on H1 finite element spaces, the transfer will be performed locally,
     and the value of shared (interface) degrees of freedom will be determined by
     the value of the last transfer to be performed (according to the element

--- a/fem/fespace.hpp
+++ b/fem/fespace.hpp
@@ -499,7 +499,8 @@ public:
        GridFunction data from @a this FE space, defined on a fine mesh, to @a
        coarse_fes, defined on a coarse mesh. */
    /** This method returns a left inverse of the Operator returned by
-       GetTransferOperator().
+       GetTransferOperator(), which is assumed to be full column rank, i.e. we
+       asssume that @a coarse_fes is of smaller dimension than this FE space.
 
        The @a mass_integ must be compatible with @a this FE space.
 
@@ -609,10 +610,9 @@ public:
 };
 
 /** Class representing projection operator between a high-order L2 finite
-  * element space on a coarse mesh, and a low-order L2 finite element space on a
-  * refined mesh (LOR). This class assumes that the low-order space @a fes_lor
-  * lives on a mesh obtained by refining the mesh of the high-order space
-  * @a fes_ho. */
+    element space on a coarse mesh, and a low-order L2 finite element space on a
+    refined mesh (LOR). We assume that the low-order space, fes_lor, lives on a
+    mesh obtained by refining the mesh of the high-order space, fes_ho. */
 class L2Projection : public Operator
 {
    const FiniteElementSpace &fes_ho;
@@ -635,8 +635,8 @@ public:
    virtual ~L2Projection() { }
 };
 
-/** Mass-conservative prolongation operator going in the opposite direction
-  * as L2Projection. This operator is a left inverse to the L2Projection. */
+/** Mass-conservative prolongation operator going in the opposite direction as
+    L2Projection. This operator is a left inverse to the L2Projection. */
 class L2Prolongation : public Operator
 {
    const L2Projection &l2proj;

--- a/fem/fespace.hpp
+++ b/fem/fespace.hpp
@@ -68,6 +68,8 @@ class BilinearFormIntegrator;
     mesh, mainly managing the set of degrees of freedom. */
 class FiniteElementSpace
 {
+   friend class InterpolationGridTransfer;
+
 protected:
    /// The mesh that FE space lives on (not owned).
    Mesh *mesh;
@@ -153,7 +155,7 @@ protected:
       virtual ~RefinementOperator();
    };
 
-   // Derefinement operator, used by GetReverseTransferOperator().
+   // Derefinement operator, used by the friend class InterpolationGridTransfer.
    class DerefinementOperator : public Operator
    {
       const FiniteElementSpace *fine_fes; // Not owned.
@@ -167,7 +169,7 @@ protected:
    public:
       DerefinementOperator(const FiniteElementSpace *f_fes,
                            const FiniteElementSpace *c_fes,
-                           BilinearFormIntegrator &mass_integ);
+                           BilinearFormIntegrator *mass_integ);
       virtual void Mult(const Vector &x, Vector &y) const;
       virtual ~DerefinementOperator();
    };
@@ -496,20 +498,6 @@ public:
                             OperatorHandle &T) const;
 
    /** @brief Construct and return an Operator that can be used to transfer
-       GridFunction data from @a this FE space, defined on a fine mesh, to @a
-       coarse_fes, defined on a coarse mesh. */
-   /** This method returns a left inverse of the Operator returned by
-       GetTransferOperator(), which is assumed to be full column rank, i.e. we
-       asssume that @a coarse_fes is of smaller dimension than this FE space.
-
-       The @a mass_integ must be compatible with @a this FE space.
-
-       At the moment, the type of @a R is ignored. */
-   void GetReverseTransferOperator(BilinearFormIntegrator &mass_integ,
-                                   const FiniteElementSpace &coarse_fes,
-                                   OperatorHandle &R) const;
-
-   /** @brief Construct and return an Operator that can be used to transfer
        true-dof data from @a coarse_fes, defined on a coarse mesh, to @a this FE
        space, defined on a refined mesh.
 
@@ -609,44 +597,213 @@ public:
    void Save(std::ostream &out) const;
 };
 
-/** Class representing projection operator between a high-order L2 finite
-    element space on a coarse mesh, and a low-order L2 finite element space on a
-    refined mesh (LOR). We assume that the low-order space, fes_lor, lives on a
-    mesh obtained by refining the mesh of the high-order space, fes_ho. */
-class L2Projection : public Operator
+
+/** @brief Base class for transfer algorithms that construct transfer Operator%s
+    between two finite element (FE) spaces. */
+/** Generally, the two FE spaces (domain and range) can be defined on different
+    meshes. */
+class GridTransfer
 {
-   const FiniteElementSpace &fes_ho;
-   const FiniteElementSpace &fes_lor;
+protected:
+   FiniteElementSpace &dom_fes; ///< Domain FE space
+   FiniteElementSpace &ran_fes; ///< Range FE space
 
-   int ndof_lor, ndof_ho, nel_lor, nel_ho, nref;
+   /** @brief Desired Operator::Type for the construction of all operators
+       defined by the underlying transfer algorithm. It can be ignored by
+       derived classes. */
+   Operator::Type oper_type;
 
-   Array<int> lor2ho;
-   Table ho2lor;
+   OperatorHandle fw_t_oper; ///< Forward true-dof operator
+   OperatorHandle bw_t_oper; ///< Backward true-dof operator
 
-   DenseTensor R, P;
+#ifdef MFEM_USE_MPI
+   bool parallel;
+#endif
+   bool Parallel() const
+   {
+#ifndef MFEM_USE_MPI
+      return false;
+#else
+      return parallel;
+#endif
+   }
+
+   const Operator &MakeTrueOperator(FiniteElementSpace &fes_in,
+                                    FiniteElementSpace &fes_out,
+                                    const Operator &oper,
+                                    OperatorHandle &t_oper);
+
 public:
-   L2Projection(const FiniteElementSpace &fes_ho_,
-                const FiniteElementSpace &fes_lor_);
-   /// Perform the L2 projection onto the LOR space
-   virtual void Mult(const Vector &x, Vector &y) const;
-   /// Perform the mass conservative left-inverse prolongation operation.
-   /// This functionality is also provided as an Operator by L2Prolongation.
-   void Prolongate(const Vector &x, Vector &y) const;
-   virtual ~L2Projection() { }
+   /** Construct a transfer algorithm between the domain, @a dom_fes_, and
+       range, @a ran_fes_, FE spaces. */
+   GridTransfer(FiniteElementSpace &dom_fes_, FiniteElementSpace &ran_fes_);
+
+   /// Virtual destructor
+   virtual ~GridTransfer() { }
+
+   /** @brief Set the desired Operator::Type for the construction of all
+       operators defined by the underlying transfer algorithm. */
+   /** The default value is Operator::ANY_TYPE which typically corresponds to
+       a matrix-free operator representation. Note that derived classes are not
+       required to support this setting and can ignore it. */
+   void SetOperatorType(Operator::Type type) { oper_type = type; }
+
+   /** @brief Return an Operator that transfers GridFunction%s from the domain
+       FE space to GridFunction%s in the range FE space. */
+   virtual const Operator &ForwardOperator() = 0;
+
+   /** @brief Return an Operator that transfers GridFunction%s from the range
+       FE space back to GridFunction%s in the domain FE space. */
+   virtual const Operator &BackwardOperator() = 0;
+
+   /** @brief Return an Operator that transfers true-dof Vector%s from the
+       domain FE space to true-dof Vector%s in the range FE space. */
+   /** This method is implemented in the base class, based on ForwardOperator(),
+       however, derived classes can overload the construction, if necessary. */
+   virtual const Operator &TrueForwardOperator()
+   {
+      return MakeTrueOperator(dom_fes, ran_fes, ForwardOperator(), fw_t_oper);
+   }
+
+   /** @brief Return an Operator that transfers true-dof Vector%s from the
+       range FE space back to true-dof Vector%s in the domain FE space. */
+   /** This method is implemented in the base class, based on
+       BackwardOperator(), however, derived classes can overload the
+       construction, if necessary. */
+   virtual const Operator &TrueBackwardOperator()
+   {
+      return MakeTrueOperator(ran_fes, dom_fes, BackwardOperator(), bw_t_oper);
+   }
 };
 
-/** Mass-conservative prolongation operator going in the opposite direction as
-    L2Projection. This operator is a left inverse to the L2Projection. */
-class L2Prolongation : public Operator
+
+/** @brief Transfer data between a coarse mesh and an embedded refined mesh
+    using interpolation. */
+/** The forward, coarse-to-fine, transfer uses nodal interpolation. The
+    backward, fine-to-coarse, transfer is defined locally (on a coarse element)
+    as B = (F^t M_f F)^{-1} F^t M_f, where F is the forward transfer matrix, and
+    M_f is a mass matrix on the union of all fine elements comprising the coarse
+    element. Note that the backward transfer operator, B, is a left inverse of
+    the forward transfer operator, F, i.e. B F = I. Both F and B are defined in
+    reference space and do not depend on the actual physical shape of the mesh
+    elements.
+
+    It is assumed that both the coarse and the fine FiniteElementSpace%s use
+    compatible types of elements, e.g. finite elements with the same map-type
+    (VALUE, INTEGRAL, H_DIV, H_CURL - see class FiniteElement). Generally, the
+    FE spaces can have different orders, however, in order for the backward
+    operator to be well-defined, the (local) number of the fine dofs should not
+    be smaller than the number of coarse dofs. */
+class InterpolationGridTransfer : public GridTransfer
 {
-   const L2Projection &l2proj;
+protected:
+   BilinearFormIntegrator *mass_integ; ///< Ownership depends on #own_mass_integ
+   bool own_mass_integ; ///< Ownership flag for #mass_integ
+
+   OperatorHandle F; ///< Forward, coarse-to-fine, operator
+   OperatorHandle B; ///< Backward, fine-to-coarse, operator
+
 public:
-   L2Prolongation(const L2Projection &l2proj_) : l2proj(l2proj_) { }
-   void Mult(const Vector &x, Vector &y) const
+   InterpolationGridTransfer(FiniteElementSpace &coarse_fes,
+                             FiniteElementSpace &fine_fes)
+      : GridTransfer(coarse_fes, fine_fes),
+        mass_integ(NULL), own_mass_integ(false)
+   { }
+
+   virtual ~InterpolationGridTransfer();
+
+   /** @brief Assign a mass integrator to be used in the construction of the
+       backward, fine-to-coarse, transfer operator. */
+   void SetMassIntegrator(BilinearFormIntegrator *mass_integ_,
+                          bool own_mass_integ_ = true);
+
+   virtual const Operator &ForwardOperator();
+
+   virtual const Operator &BackwardOperator();
+};
+
+
+/** @brief Transfer data between a coarse mesh and an embedded refined mesh
+    using L2 projection. */
+/** The forward, coarse-to-fine, transfer uses L2 projection. The backward,
+    fine-to-coarse, transfer is defined locally (on a coarse element) as
+    B = (F^t M_f F)^{-1} F^t M_f, where F is the forward transfer matrix, and
+    M_f is the mass matrix on the union of all fine elements comprising the
+    coarse element. Note that the backward transfer operator, B, is a left
+    inverse of the forward transfer operator, F, i.e. B F = I. Both F and B are
+    defined in physical space and, generally, vary between different mesh
+    elements.
+
+    This class currently only fully supports L2 finite element spaces and fine
+    meshes that are a uniform refinement of the coarse mesh. Generally, the
+    coarse and fine FE spaces can have different orders, however, in order for
+    the backward operator to be well-defined, the number of the fine dofs (in a
+    coarse element) should not be smaller than the number of coarse dofs.
+    
+    If used on H1 finite element spaces, the transfer will be performed locally,
+    and the value of shared (interface) degrees of freedom will be determined by
+    the value of the last transfer to be performed (according to the element
+    numbering in the finite element space). As a consequence, the mass
+    conservation properties for this operator from the L2 case do not carry over
+    to H1 spaces. */
+class L2ProjectionGridTransfer : public GridTransfer
+{
+protected:
+   /** Class representing projection operator between a high-order L2 finite
+       element space on a coarse mesh, and a low-order L2 finite element space
+       on a refined mesh (LOR). We assume that the low-order space, fes_lor,
+       lives on a mesh obtained by refining the mesh of the high-order space,
+       fes_ho. */
+   class L2Projection : public Operator
    {
-      l2proj.Prolongate(x, y);
-   }
-   virtual ~L2Prolongation() { }
+      const FiniteElementSpace &fes_ho;
+      const FiniteElementSpace &fes_lor;
+
+      int ndof_lor, ndof_ho, nref;
+
+      Table ho2lor;
+
+      DenseTensor R, P;
+
+   public:
+      L2Projection(const FiniteElementSpace &fes_ho_,
+                   const FiniteElementSpace &fes_lor_);
+      /// Perform the L2 projection onto the LOR space
+      virtual void Mult(const Vector &x, Vector &y) const;
+      /// Perform the mass conservative left-inverse prolongation operation.
+      /// This functionality is also provided as an Operator by L2Prolongation.
+      void Prolongate(const Vector &x, Vector &y) const;
+      virtual ~L2Projection() { }
+   };
+
+   /** Mass-conservative prolongation operator going in the opposite direction
+       as L2Projection. This operator is a left inverse to the L2Projection. */
+   class L2Prolongation : public Operator
+   {
+      const L2Projection &l2proj;
+
+   public:
+      L2Prolongation(const L2Projection &l2proj_) : l2proj(l2proj_) { }
+      void Mult(const Vector &x, Vector &y) const
+      {
+         l2proj.Prolongate(x, y);
+      }
+      virtual ~L2Prolongation() { }
+   };
+
+   L2Projection   *F; ///< Forward, coarse-to-fine, operator
+   L2Prolongation *B; ///< Backward, fine-to-coarse, operator
+
+public:
+   L2ProjectionGridTransfer(FiniteElementSpace &coarse_fes,
+                            FiniteElementSpace &fine_fes)
+      : GridTransfer(coarse_fes, fine_fes),
+        F(NULL), B(NULL)
+   { }
+
+   virtual const Operator &ForwardOperator();
+
+   virtual const Operator &BackwardOperator();
 };
 
 }

--- a/linalg/densemat.hpp
+++ b/linalg/densemat.hpp
@@ -580,6 +580,9 @@ public:
    /// Multiply the inverse matrix by another matrix: X = A^{-1} B.
    void Mult(const DenseMatrix &B, DenseMatrix &X) const;
 
+   /// Multiply the inverse matrix by another matrix: X <- A^{-1} X.
+   void Mult(DenseMatrix &X) const { lu.Solve(width, X.Width(), X.Data()); }
+
    /// Compute and return the inverse matrix in Ainv.
    void GetInverseMatrix(DenseMatrix &Ainv) const
    {

--- a/mesh/ncmesh.cpp
+++ b/mesh/ncmesh.cpp
@@ -15,6 +15,7 @@
 #include <string>
 #include <cmath>
 #include <climits> // INT_MAX
+#include <map>
 
 namespace mfem
 {
@@ -29,6 +30,118 @@ const DenseTensor &CoarseFineTransformations::GetPointMatrices(
                "cannot find point matrices for geometry type \"" << geom
                << "\"");
    return pm_it->second;
+}
+
+namespace internal
+{
+
+// Used in CoarseFineTransformations::GetCoarseToFineMap() below.
+struct RefType
+{
+   Geometry::Type geom;
+   int num_children;
+   const Pair<int,int> *children;
+
+   RefType(Geometry::Type g, int n, const Pair<int,int> *c)
+      : geom(g), num_children(n), children(c) { }
+
+   bool operator<(const RefType &other) const
+   {
+      if (geom < other.geom) { return true; }
+      if (geom > other.geom) { return false; }
+      if (num_children < other.num_children) { return true; }
+      if (num_children > other.num_children) { return false; }
+      for (int i = 0; i < num_children; i++)
+      {
+         if (children[i].one < other.children[i].one) { return true; }
+         if (children[i].one > other.children[i].one) { return false; }
+      }
+      return false; // everything is equal
+   }
+};
+
+}
+
+void CoarseFineTransformations::GetCoarseToFineMap(
+   const mfem::Mesh &fine_mesh, Table &coarse_to_fine,
+   Array<int> &coarse_to_ref_type, Table &ref_type_to_matrix,
+   Array<mfem::Geometry::Type> &ref_type_to_geom) const
+{
+   const int fine_ne = embeddings.Size();
+   int coarse_ne = -1;
+   for (int i = 0; i < fine_ne; i++)
+   {
+      coarse_ne = std::max(coarse_ne, embeddings[i].parent);
+   }
+   coarse_ne++;
+
+   coarse_to_ref_type.SetSize(coarse_ne);
+   coarse_to_fine.SetDims(coarse_ne, fine_ne);
+
+   Array<int> cf_i(coarse_to_fine.GetI(), coarse_ne+1);
+   Array<Pair<int,int> > cf_j(fine_ne);
+   cf_i = 0;
+   for (int i = 0; i < fine_ne; i++)
+   {
+      cf_i[embeddings[i].parent+1]++;
+   }
+   cf_i.PartialSum();
+   MFEM_ASSERT(cf_i.Last() == cf_j.Size(), "internal error");
+   for (int i = 0; i < fine_ne; i++)
+   {
+      const Embedding &e = embeddings[i];
+      cf_j[cf_i[e.parent]].one = e.matrix; // used as sort key below
+      cf_j[cf_i[e.parent]].two = i;
+      cf_i[e.parent]++;
+   }
+   std::copy_backward(cf_i.begin(), cf_i.end()-1, cf_i.end());
+   cf_i[0] = 0;
+   for (int i = 0; i < coarse_ne; i++)
+   {
+      std::sort(&cf_j[cf_i[i]], &cf_j[cf_i[i+1]]);
+   }
+   for (int i = 0; i < fine_ne; i++)
+   {
+      coarse_to_fine.GetJ()[i] = cf_j[i].two;
+   }
+
+   using internal::RefType;
+   using std::map;
+   using std::pair;
+
+   map<RefType,int> ref_type_map;
+   for (int i = 0; i < coarse_ne; i++)
+   {
+      const int num_children = cf_i[i+1]-cf_i[i];
+      MFEM_ASSERT(num_children > 0, "");
+      const int fine_el = cf_j[cf_i[i]].two;
+      // Assuming the coarse and the fine elements have the same geometry:
+      const Geometry::Type geom = fine_mesh.GetElementBaseGeometry(fine_el);
+      const RefType ref_type(geom, num_children, &cf_j[cf_i[i]]);
+      pair<map<RefType,int>::iterator,bool> res =
+         ref_type_map.insert(
+            pair<const RefType,int>(ref_type, (int)ref_type_map.size()));
+      coarse_to_ref_type[i] = res.first->second;
+   }
+   ref_type_to_matrix.MakeI((int)ref_type_map.size());
+   ref_type_to_geom.SetSize((int)ref_type_map.size());
+   for (map<RefType,int>::iterator it = ref_type_map.begin();
+        it != ref_type_map.end(); ++it)
+   {
+      ref_type_to_matrix.AddColumnsInRow(it->second, it->first.num_children);
+      ref_type_to_geom[it->second] = it->first.geom;
+   }
+   ref_type_to_matrix.MakeJ();
+   for (map<RefType,int>::iterator it = ref_type_map.begin();
+        it != ref_type_map.end(); ++it)
+   {
+      const RefType &rt = it->first;
+      for (int j = 0; j < rt.num_children; j++)
+      {
+         ref_type_to_matrix.AddConnection(it->second, rt.children[j].one);
+      }
+   }
+   ref_type_to_matrix.ShiftUpI();
 }
 
 NCMesh::GeomInfo NCMesh::GI[Geometry::NumGeom];

--- a/mesh/ncmesh.cpp
+++ b/mesh/ncmesh.cpp
@@ -99,9 +99,7 @@ void CoarseFineTransformations::GetCoarseToFineMap(
    cf_i[0] = 0;
    for (int i = 0; i < coarse_ne; i++)
    {
-      Pair<int,int> *end =
-         (cf_i[i+1] == cf_j.Size()) ? cf_j.end() :  &cf_j[cf_i[i+1]];
-      std::sort(&cf_j[cf_i[i]], end);
+      std::sort(&cf_j[cf_i[i]], cf_j.GetData() + cf_i[i+1]);
    }
    for (int i = 0; i < fine_ne; i++)
    {

--- a/mesh/ncmesh.cpp
+++ b/mesh/ncmesh.cpp
@@ -99,7 +99,9 @@ void CoarseFineTransformations::GetCoarseToFineMap(
    cf_i[0] = 0;
    for (int i = 0; i < coarse_ne; i++)
    {
-      std::sort(&cf_j[cf_i[i]], &cf_j[cf_i[i+1]]);
+      Pair<int,int> *end =
+         (cf_i[i+1] == cf_j.Size()) ? cf_j.end() :  &cf_j[cf_i[i+1]];
+      std::sort(&cf_j[cf_i[i]], end);
    }
    for (int i = 0; i < fine_ne; i++)
    {

--- a/mesh/ncmesh.cpp
+++ b/mesh/ncmesh.cpp
@@ -11,6 +11,7 @@
 
 #include "mesh_headers.hpp"
 #include "../fem/fem.hpp"
+#include "../general/sort_pairs.hpp"
 
 #include <string>
 #include <cmath>

--- a/mesh/ncmesh.hpp
+++ b/mesh/ncmesh.hpp
@@ -60,6 +60,13 @@ struct CoarseFineTransformations
    Array<Embedding> embeddings;
 
    const DenseTensor &GetPointMatrices(Geometry::Type geom) const;
+
+   void GetCoarseToFineMap(const Mesh &fine_mesh,
+                           Table &coarse_to_fine,
+                           Array<int> &coarse_to_ref_type,
+                           Table &ref_type_to_matrix,
+                           Array<Geometry::Type> &ref_type_to_geom) const;
+
    void Clear() { point_matrices.clear(); embeddings.DeleteAll(); }
    long MemoryUsage() const;
 };

--- a/miniapps/tools/CMakeLists.txt
+++ b/miniapps/tools/CMakeLists.txt
@@ -19,3 +19,6 @@ add_mfem_miniapp(load-dc
 
 add_mfem_miniapp(convert-dc
   MAIN convert-dc.cpp LIBRARIES mfem)
+
+add_mfem_miniapp(lor-transfer
+  MAIN lor-transfer.cpp LIBRARIES mfem)

--- a/miniapps/tools/lor-transfer.cpp
+++ b/miniapps/tools/lor-transfer.cpp
@@ -1,0 +1,212 @@
+#include "mfem.hpp"
+#include <fstream>
+#include <iostream>
+
+using namespace std;
+using namespace mfem;
+
+int problem = 1; // problem type
+
+int Wx = 0, Wy = 0; // window position
+int Ww = 286, Wh = 286; // window size
+int offx = Ww+2, offy = Wh+25; // window offsets
+
+// Exact functions to project
+double RHO_exact(const Vector &x);
+
+// Helper functions
+void visualize(VisItDataCollection &, string, int, int, int, int);
+double compute_mass(FiniteElementSpace *, double, VisItDataCollection &,
+                    string);
+
+int main(int argc, char *argv[])
+{
+   // Parse command-line options.
+   const char *mesh_file = "../../data/star.mesh";
+   int order = 4;
+   int lref = order;
+   int lorder = 0;
+   bool visualization = true;
+   bool useH1 = false;
+   bool use_transfer = false;
+
+   OptionsParser args(argc, argv);
+   args.AddOption(&mesh_file, "-m", "--mesh",
+                  "Mesh file to use.");
+   args.AddOption(&problem, "-p", "--problem",
+                  "Problem type (see the *_exact functions.");
+   args.AddOption(&order, "-o", "--order",
+                  "Finite element order (polynomial degree) or -1 for"
+                  " isoparametric space.");
+   args.AddOption(&lref, "-lref", "--lor-ref-level", "LOR refinement level.");
+   args.AddOption(&lorder, "-lo", "--lor-order",
+                  "LOR refinement order (polynomial degree, zero by default).");
+   args.AddOption(&visualization, "-vis", "--visualization", "-no-vis",
+                  "--no-visualization",
+                  "Enable or disable GLVis visualization.");
+   args.AddOption(&useH1, "-h1", "--use-h1", "-l2", "--use-l2",
+                  "Use H1 spaces instead of L2.");
+   args.AddOption(&use_transfer, "-t", "--use-pointwise-transfer", "-no-t",
+                  "--dont-use-pointwise-transfer",
+                  "Use pointwise transfer operators instead of L2 projection.");
+   args.Parse();
+   if (!args.Good())
+   {
+      args.PrintUsage(cout);
+      return 1;
+   }
+   args.PrintOptions(cout);
+
+   // Read the mesh from the given mesh file.
+   Mesh mesh(mesh_file, 1, 1);
+   int dim = mesh.Dimension();
+
+   // Create the low-order refined mesh
+   int basis_lor = BasisType::GaussLobatto; // BasisType::ClosedUniform;
+   Mesh mesh_lor(&mesh, lref, basis_lor);
+
+   // Create spaces
+   FiniteElementCollection *fec, *fec_lor;
+   if (useH1)
+   {
+      fec = new H1_FECollection(order-1, dim);
+      fec_lor = new H1_FECollection(lorder, dim);
+   }
+   else
+   {
+      fec = new L2_FECollection(order-1, dim);
+      fec_lor = new L2_FECollection(lorder, dim);
+   }
+
+   FiniteElementSpace fespace(&mesh, fec);
+   FiniteElementSpace fespace_lor(&mesh_lor, fec_lor);
+
+   GridFunction rho(&fespace);
+   GridFunction rho_lor(&fespace_lor);
+
+   // Data collections for vis/analysis
+   VisItDataCollection HO_dc("HO", &mesh);
+   HO_dc.RegisterField("density", &rho);
+   VisItDataCollection LOR_dc("LOR", &mesh_lor);
+   LOR_dc.RegisterField("density", &rho_lor);
+
+   // HO projections
+   FunctionCoefficient RHO(RHO_exact);
+   rho.ProjectCoefficient(RHO);
+   double ho_mass = compute_mass(&fespace, -1.0, HO_dc, "HO       ");
+
+   L2Projection R_L2(fespace, fespace_lor);
+   L2Prolongation P_L2(R_L2);
+   OperatorHandle R_transfer, P_transfer;
+   fespace_lor.GetTransferOperator(fespace, R_transfer);
+   fespace_lor.GetReverseTransferOperator(*(new MassIntegrator),
+                                          fespace, P_transfer);
+   Operator *R = use_transfer ? R_transfer.Ptr() : &R_L2;
+   Operator *P = use_transfer ? P_transfer.Ptr() : &P_L2;
+
+   // HO->LOR restriction
+   R->Mult(rho, rho_lor);
+   compute_mass(&fespace_lor, ho_mass, LOR_dc, "R(HO)    ");
+
+   // LOR-HO prolongation
+   GridFunction rho_prev = rho;
+   P->Mult(rho_lor, rho);
+   compute_mass(&fespace, ho_mass, HO_dc, "P(R(HO)) ");
+
+   rho_prev -= rho;
+   cout.precision(12);
+   cout << "HO - P(R(HO))       = " << rho_prev.Normlinf() << endl << endl;
+
+   // LOR projections
+   rho_lor.ProjectCoefficient(RHO);
+   GridFunction rho_lor_prev = rho_lor;
+   double lor_mass = compute_mass(&fespace_lor, -1.0, LOR_dc, "LOR      ");
+
+   // Prolongate to HO space
+   P->Mult(rho_lor, rho);
+   compute_mass(&fespace, lor_mass, HO_dc, "P(LOR)   ");
+
+   // Restrict back to LOR space. This won't give the original function
+   // because the rho_lor doesn't necessarily live in the range of R.
+   R->Mult(rho, rho_lor);
+   rho_lor_prev -= rho_lor;
+   cout.precision(12);
+   cout << "LOR - R(P(LOR))     = " << rho_lor_prev.Normlinf() << endl;
+
+   // Visualization:
+   if (visualization)
+   {
+      visualize(HO_dc, "HO", Wx, Wy, Ww, Wh);
+      Wx += offx;
+      visualize(LOR_dc, "R(HO)", Wx, Wy, Ww, Wh);
+      Wx += offx;
+      visualize(HO_dc, "P(R(HO))", Wx, Wy, Ww, Wh);
+
+      Wx = 0;
+      Wy += offy;
+
+      visualize(LOR_dc, "LOR", Wx, Wy, Ww, Wh);
+      Wx += offx;
+      visualize(HO_dc, "P(LOR)", Wx, Wy, Ww, Wh);
+   }
+
+   delete fec;
+   delete fec_lor;
+
+   return 0;
+}
+
+
+double RHO_exact(const Vector &x)
+{
+   switch (problem)
+   {
+      case 1: // smooth field
+         return x(1)+0.25*cos(2*M_PI*x.Norml2());
+      case 2: // cubic function
+         return x(1)*x(1)*x(1) + 2*x(0)*x(1) + x(0);
+      case 3: // sharp gradient
+         return M_PI/2-atan(5*(2*x.Norml2()-1));
+      default:
+         return 1.0;
+   }
+}
+
+
+void visualize(VisItDataCollection &dc, string prefix,
+               int x, int y, int w, int h)
+{
+   char vishost[] = "localhost";
+   int  visport   = 19916;
+
+   socketstream sol_sockL2(vishost, visport);
+   sol_sockL2.precision(8);
+   sol_sockL2 << "solution\n" << *dc.GetMesh() << *dc.GetField("density")
+              << "window_geometry " << x << " " << y << " " << w << " " << h
+              << "plot_caption 'L2 " << prefix << " Density'"
+              << "window_title 'L2 " << prefix << " Density'" << flush;
+}
+
+
+double compute_mass(FiniteElementSpace *L2, double massL2,
+                    VisItDataCollection &dc, string prefix)
+{
+   ConstantCoefficient one(1.0);
+   BilinearForm ML2(L2);
+   ML2.AddDomainIntegrator(new MassIntegrator(one));
+   ML2.Assemble();
+
+   GridFunction rhoone(L2);
+   rhoone = 1.0;
+
+   double newmass = ML2.InnerProduct(*dc.GetField("density"),rhoone);
+   cout.precision(12);
+   cout << "L2 " << prefix << " mass   = " << newmass;
+   if (massL2 >= 0)
+   {
+      cout.precision(4);
+      cout << " ("  << fabs(newmass-massL2)*100/massL2 << "%)";
+   }
+   cout << endl;
+   return newmass;
+}

--- a/miniapps/tools/lor-transfer.cpp
+++ b/miniapps/tools/lor-transfer.cpp
@@ -1,3 +1,43 @@
+// Copyright (c) 2010, Lawrence Livermore National Security, LLC. Produced at
+// the Lawrence Livermore National Laboratory. LLNL-CODE-443211. All Rights
+// reserved. See file COPYRIGHT for details.
+//
+// This file is part of the MFEM library. For more information and source code
+// availability see http://mfem.org.
+//
+// MFEM is free software; you can redistribute it and/or modify it under the
+// terms of the GNU Lesser General Public License (as published by the Free
+// Software Foundation) version 2.1 dated February 1999.
+//
+//       --------------------------------------------------------------
+//       LOR Transfer Miniapp:  Map functions between HO and LOR spaces
+//       --------------------------------------------------------------
+//
+// This miniapp visualizes the maps between a high-order (HO) finite element
+// space, typically using high-order functions on a high-order mesh, and a
+// low-order refined (LOR) finite element space, typically defined by 0th or 1st
+// order functions on a low-order refinement of the HO mesh.
+//
+// Two main operators are illustrated:
+//
+//  1. R: HO -> LOR, defined by FiniteElementSpace::GetTransferOperator
+//  2. P: LOR -> HO, defined by FiniteElementSpace::GetReverseTransferOperator
+//
+// While defined generally, these operators have some nice properties for
+// particular finite element spaces. For example they satisfy PR=I, plus mass
+// conservation in both directions for L2 fields.
+//
+// Compile with: make lor-transfer
+//
+// Sample runs:  lor-transfer
+//               lor-transfer -h1
+//               lor-transfer -t
+//               lor-transfer -m ../../data/star-q2.mesh -lref 5 -p 4
+//               lor-transfer -lref 4 -o 4 -lo 0 -p 1
+//               lor-transfer -lref 5 -o 4 -lo 0 -p 1
+//               lor-transfer -lref 5 -o 4 -lo 3 -p 2
+//               lor-transfer -lref 5 -o 4 -lo 0 -p 3
+
 #include "mfem.hpp"
 #include <fstream>
 #include <iostream>
@@ -8,14 +48,17 @@ using namespace mfem;
 int problem = 1; // problem type
 
 int Wx = 0, Wy = 0; // window position
-int Ww = 286, Wh = 286; // window size
-int offx = Ww+2, offy = Wh+25; // window offsets
+int Ww = 350, Wh = 350; // window size
+int offx = Ww+5, offy = Wh+25; // window offsets
+
+string space;
+string direction;
 
 // Exact functions to project
 double RHO_exact(const Vector &x);
 
 // Helper functions
-void visualize(VisItDataCollection &, string, int, int, int, int);
+void visualize(VisItDataCollection &, string, int, int);
 double compute_mass(FiniteElementSpace *, double, VisItDataCollection &,
                     string);
 
@@ -26,7 +69,7 @@ int main(int argc, char *argv[])
    int order = 4;
    int lref = order;
    int lorder = 0;
-   bool visualization = true;
+   bool vis = true;
    bool useH1 = false;
    bool use_transfer = false;
 
@@ -34,14 +77,14 @@ int main(int argc, char *argv[])
    args.AddOption(&mesh_file, "-m", "--mesh",
                   "Mesh file to use.");
    args.AddOption(&problem, "-p", "--problem",
-                  "Problem type (see the *_exact functions.");
+                  "Problem type (see the RHO_exact function).");
    args.AddOption(&order, "-o", "--order",
                   "Finite element order (polynomial degree) or -1 for"
                   " isoparametric space.");
    args.AddOption(&lref, "-lref", "--lor-ref-level", "LOR refinement level.");
    args.AddOption(&lorder, "-lo", "--lor-order",
-                  "LOR refinement order (polynomial degree, zero by default).");
-   args.AddOption(&visualization, "-vis", "--visualization", "-no-vis",
+                  "LOR space order (polynomial degree, zero by default).");
+   args.AddOption(&vis, "-vis", "--visualization", "-no-vis",
                   "--no-visualization",
                   "Enable or disable GLVis visualization.");
    args.AddOption(&useH1, "-h1", "--use-h1", "-l2", "--use-l2",
@@ -69,11 +112,18 @@ int main(int argc, char *argv[])
    FiniteElementCollection *fec, *fec_lor;
    if (useH1)
    {
+      space = "H1";
+      if (lorder == 0)
+      {
+         lorder = 1;
+         cerr << "Switching the H1 LOR space order from 0 to 1\n";
+      }
       fec = new H1_FECollection(order-1, dim);
       fec_lor = new H1_FECollection(lorder, dim);
    }
    else
    {
+      space = "L2";
       fec = new L2_FECollection(order-1, dim);
       fec_lor = new L2_FECollection(lorder, dim);
    }
@@ -90,10 +140,13 @@ int main(int argc, char *argv[])
    VisItDataCollection LOR_dc("LOR", &mesh_lor);
    LOR_dc.RegisterField("density", &rho_lor);
 
+
    // HO projections
+   direction = "HO -> LOR @ HO";
    FunctionCoefficient RHO(RHO_exact);
    rho.ProjectCoefficient(RHO);
    double ho_mass = compute_mass(&fespace, -1.0, HO_dc, "HO       ");
+   if (vis) { visualize(HO_dc, "HO", Wx, Wy); Wx += offx; }
 
    L2Projection R_L2(fespace, fespace_lor);
    L2Prolongation P_L2(R_L2);
@@ -105,50 +158,45 @@ int main(int argc, char *argv[])
    Operator *P = use_transfer ? P_transfer.Ptr() : &P_L2;
 
    // HO->LOR restriction
+   direction = "HO -> LOR @ LOR";
    R->Mult(rho, rho_lor);
    compute_mass(&fespace_lor, ho_mass, LOR_dc, "R(HO)    ");
+   if (vis) { visualize(LOR_dc, "R(HO)", Wx, Wy); Wx += offx; }
 
-   // LOR-HO prolongation
+   // LOR->HO prolongation
+   direction = "HO -> LOR @ HO";
    GridFunction rho_prev = rho;
    P->Mult(rho_lor, rho);
    compute_mass(&fespace, ho_mass, HO_dc, "P(R(HO)) ");
+   if (vis) { visualize(HO_dc, "P(R(HO))", Wx, Wy); Wx = 0; Wy += offy; }
 
    rho_prev -= rho;
    cout.precision(12);
-   cout << "HO - P(R(HO))       = " << rho_prev.Normlinf() << endl << endl;
+   cout << "|HO - P(R(HO))|_∞   = " << rho_prev.Normlinf() << endl << endl;
 
    // LOR projections
+   direction = "LOR -> HO @ LOR";
    rho_lor.ProjectCoefficient(RHO);
    GridFunction rho_lor_prev = rho_lor;
    double lor_mass = compute_mass(&fespace_lor, -1.0, LOR_dc, "LOR      ");
+   if (vis) { visualize(LOR_dc, "LOR", Wx, Wy); Wx += offx; }
 
    // Prolongate to HO space
+   direction = "LOR -> HO @ HO";
    P->Mult(rho_lor, rho);
    compute_mass(&fespace, lor_mass, HO_dc, "P(LOR)   ");
+   if (vis) { visualize(HO_dc, "P(LOR)", Wx, Wy); Wx += offx; }
 
-   // Restrict back to LOR space. This won't give the original function
-   // because the rho_lor doesn't necessarily live in the range of R.
+   // Restrict back to LOR space. This won't give the original function because
+   // the rho_lor doesn't necessarily live in the range of R.
+   direction = "LOR -> HO @ LOR";
    R->Mult(rho, rho_lor);
+   compute_mass(&fespace_lor, lor_mass, LOR_dc, "R(P(LOR))");
+   if (vis) { visualize(LOR_dc, "R(P(LOR))", Wx, Wy); }
+
    rho_lor_prev -= rho_lor;
    cout.precision(12);
-   cout << "LOR - R(P(LOR))     = " << rho_lor_prev.Normlinf() << endl;
-
-   // Visualization:
-   if (visualization)
-   {
-      visualize(HO_dc, "HO", Wx, Wy, Ww, Wh);
-      Wx += offx;
-      visualize(LOR_dc, "R(HO)", Wx, Wy, Ww, Wh);
-      Wx += offx;
-      visualize(HO_dc, "P(R(HO))", Wx, Wy, Ww, Wh);
-
-      Wx = 0;
-      Wy += offy;
-
-      visualize(LOR_dc, "LOR", Wx, Wy, Ww, Wh);
-      Wx += offx;
-      visualize(HO_dc, "P(LOR)", Wx, Wy, Ww, Wh);
-   }
+   cout << "|LOR - R(P(LOR))|_∞ = " << rho_lor_prev.Normlinf() << endl;
 
    delete fec;
    delete fec_lor;
@@ -167,15 +215,18 @@ double RHO_exact(const Vector &x)
          return x(1)*x(1)*x(1) + 2*x(0)*x(1) + x(0);
       case 3: // sharp gradient
          return M_PI/2-atan(5*(2*x.Norml2()-1));
+      case 4: // basis function
+         return (x.Norml2() < 0.1) ? 1 : 0;
       default:
          return 1.0;
    }
 }
 
 
-void visualize(VisItDataCollection &dc, string prefix,
-               int x, int y, int w, int h)
+void visualize(VisItDataCollection &dc, string prefix, int x, int y)
 {
+   int w = Ww, h = Wh;
+
    char vishost[] = "localhost";
    int  visport   = 19916;
 
@@ -183,8 +234,8 @@ void visualize(VisItDataCollection &dc, string prefix,
    sol_sockL2.precision(8);
    sol_sockL2 << "solution\n" << *dc.GetMesh() << *dc.GetField("density")
               << "window_geometry " << x << " " << y << " " << w << " " << h
-              << "plot_caption 'L2 " << prefix << " Density'"
-              << "window_title 'L2 " << prefix << " Density'" << flush;
+              << "plot_caption '" << space << " " << prefix << " Density'"
+              << "window_title '" << direction << "'" << flush;
 }
 
 
@@ -200,8 +251,8 @@ double compute_mass(FiniteElementSpace *L2, double massL2,
    rhoone = 1.0;
 
    double newmass = ML2.InnerProduct(*dc.GetField("density"),rhoone);
-   cout.precision(12);
-   cout << "L2 " << prefix << " mass   = " << newmass;
+   cout.precision(18);
+   cout << space << " " << prefix << " mass   = " << newmass;
    if (massL2 >= 0)
    {
       cout.precision(4);

--- a/miniapps/tools/makefile
+++ b/miniapps/tools/makefile
@@ -22,7 +22,7 @@ MFEM_LIB_FILE = mfem_is_not_built
 -include $(CONFIG_MK)
 
 
-SEQ_MINIAPPS = display-basis load-dc convert-dc
+SEQ_MINIAPPS = display-basis load-dc convert-dc lor-transfer
 PAR_MINIAPPS =
 ifeq ($(MFEM_USE_MPI),NO)
    MINIAPPS = $(SEQ_MINIAPPS)

--- a/miniapps/tools/makefile
+++ b/miniapps/tools/makefile
@@ -66,8 +66,8 @@ RUN_MPI = $(MFEM_MPIEXEC) $(MFEM_MPIEXEC_NP) $(MFEM_MPI_NP)
 	@$(call mfem-test,$<,, Tools miniapp)
 
 # Testing: Specific execution options
-# Do not test: display-basis, load-dc, convert-dc:
-NO_TEST_APPS = display-basis load-dc convert-dc
+# Do not test: display-basis, load-dc, convert-dc, lor-transfer
+NO_TEST_APPS = display-basis load-dc convert-dc lor-transfer
 $(foreach app,$(NO_TEST_APPS),$(app)-test-seq $(app)-test-par):
 	@true
 


### PR DESCRIPTION
The LOR-to-HO transfer operator is returned by the new method `FiniteElementSpace::GetReverseTransferOperator()`.

TODO:
- [x] Fix Travis errors
- [x] Update `CHANGELOG` 
- [x] Add an example?