### PR TITLE
Add const to Data method in DenseTensor

### DIFF
--- a/linalg/densemat.hpp
+++ b/linalg/densemat.hpp
@@ -731,7 +731,7 @@ public:
    double *GetData(int k) { return tdata+k*Mk.Height()*Mk.Width(); }
 
    double *Data() { return tdata; }
-   
+
    const double *Data() const { return tdata; }
 
    /** Matrix-vector product from unassembled element matrices, assuming both

--- a/linalg/densemat.hpp
+++ b/linalg/densemat.hpp
@@ -730,7 +730,9 @@ public:
 
    double *GetData(int k) { return tdata+k*Mk.Height()*Mk.Width(); }
 
-   double *Data() const { return tdata; }
+   double *Data() { return tdata; }
+   
+   const double *Data() const { return tdata; }
 
    /** Matrix-vector product from unassembled element matrices, assuming both
        'x' and 'y' use the same elem_dof table. */

--- a/linalg/densemat.hpp
+++ b/linalg/densemat.hpp
@@ -730,7 +730,7 @@ public:
 
    double *GetData(int k) { return tdata+k*Mk.Height()*Mk.Width(); }
 
-   double *Data() { return tdata; }
+   double *Data() const { return tdata; }
 
    /** Matrix-vector product from unassembled element matrices, assuming both
        'x' and 'y' use the same elem_dof table. */


### PR DESCRIPTION
I have an application where I pass in a const reference of a DenseTensor into a function, i.e. 
``void myFun(const DenseTensor &A) 
{
     const double * A_ptr = A.Data();
     GET_CONST_PTR(A_ptr); 
} `` 

Currently, I need access to the pointer so I can get the corresponding device pointer from the okina memory manager. I was wondering if we could add const to the method. 