### PR TITLE
[okina] Hold off on okinafying the densemat mult method [artv3/okina-densemat-mult]

### DIFF
--- a/linalg/kernels/densemat.cpp
+++ b/linalg/kernels/densemat.cpp
@@ -289,7 +289,6 @@ void MultWidth0(const size_t height, double *y)
 void Mult(const size_t height, const size_t width,
           const double *data, const double *x, double *y)
 {
-
   MFEM_GPU_CANNOT_PASS;
   for(int i=0; i<height; ++i) {
     double sum = 0.0;
@@ -299,7 +298,11 @@ void Mult(const size_t height, const size_t width,
       }
     y[i] = sum;
   }
-
+   
+  // Carrying out mult on the GPU breaks the 
+  // ComputeL2Error method in the gridfunction class                                                                                                                                                                                          
+  // as certain pointers are not being tracked by the memory manager.
+  // This is a temporary workaround. 
 #if 0
    GET_CONST_PTR(data);
    GET_CONST_PTR(x);
@@ -314,7 +317,6 @@ void Mult(const size_t height, const size_t width,
       d_y[i] = sum;
    });
 #endif
-
 }
 
 // *****************************************************************************

--- a/linalg/kernels/densemat.cpp
+++ b/linalg/kernels/densemat.cpp
@@ -289,6 +289,18 @@ void MultWidth0(const size_t height, double *y)
 void Mult(const size_t height, const size_t width,
           const double *data, const double *x, double *y)
 {
+
+  MFEM_GPU_CANNOT_PASS;
+  for(int i=0; i<height; ++i) {
+    double sum = 0.0;
+    for (size_t j=0; j<width; j+=1)
+      {
+        sum += x[j]*data[i+j*height];
+      }
+    y[i] = sum;
+  }
+
+#if 0
    GET_CONST_PTR(data);
    GET_CONST_PTR(x);
    GET_PTR(y);
@@ -301,6 +313,8 @@ void Mult(const size_t height, const size_t width,
       }
       d_y[i] = sum;
    });
+#endif
+
 }
 
 // *****************************************************************************


### PR DESCRIPTION
Regarding issue #761 , I think we can maintain interoperability with the ComputeL2Error grid function method (on the CPU) by holding off on okinafying the densemat mult method. Certain allocations of memory are not being managed by the okina memory manager and this causes issues when the densemat mult method is called inside the  ComputeL2Error method. 

A temporary solution could be to keep dense matrix multiplication on the CPU until the ComputeL2Error grid function method gets reworked. 