### PR TITLE
Bugfix: delete faces_tbl not otherwise deleted [bugfix/delete-faces-table]

### DIFF
--- a/mesh/pmesh.cpp
+++ b/mesh/pmesh.cpp
@@ -3616,6 +3616,7 @@ void ParMesh::UniformRefinement3D()
    // update the groups
    UniformRefineGroups3D(old_nv, old_nedges, v_to_v, *faces_tbl,
                          f2qf.Size() ? &f2qf : NULL);
+   delete faces_tbl;
 
    UpdateNodes();
 }


### PR DESCRIPTION
In `UniformRefinement3D()` in pmesh.cpp, the `faces_tbl` is created with `new` in `GetFacesTable()` and never deleted. This one-line PR fixes this.