### PR TITLE
Okina fcoeff [okina-fcoeff]

### DIFF
--- a/fem/bilininteg_ext.cpp
+++ b/fem/bilininteg_ext.cpp
@@ -601,7 +601,6 @@ void DiffusionIntegrator::MultAssembled(Vector &x, Vector &y)
                             vec, x, y);
 }
 
-
 // PA Mass Assemble kernel
 void MassIntegrator::Assemble(const FiniteElementSpace &fes)
 {

--- a/fem/bilininteg_ext.cpp
+++ b/fem/bilininteg_ext.cpp
@@ -654,9 +654,9 @@ void MassIntegrator::Assemble(const FiniteElementSpace &fes)
             const double detJ = (J11*J22)-(J21*J12);
             const DeviceVector3 Xq(x(0,q,e), x(1,q,e));
             const double coeff =
-               const_coeff ? constant
-               : function_coeff ? function(Xq)
-               : 0.0;
+            const_coeff ? constant
+            : function_coeff ? function(Xq)
+            : 0.0;
             v(q,e) =  w[q] * coeff * detJ;
          }
       });
@@ -696,9 +696,9 @@ void MassIntegrator::Assemble(const FiniteElementSpace &fes)
             (J13 * J22 * J31) - (J12 * J21 * J33) - (J11 * J23 * J32));
             const DeviceVector3 Xq(x(0,q,e), x(1,q,e), x(2,q,e));
             const double coeff =
-               const_coeff ? constant
-               : function_coeff ? function(Xq)
-               : 0.0;
+            const_coeff ? constant
+            : function_coeff ? function(Xq)
+            : 0.0;
             v(q,e) = W(q) * coeff * detJ;
          }
       });

--- a/fem/bilininteg_ext.cpp
+++ b/fem/bilininteg_ext.cpp
@@ -631,7 +631,7 @@ void MassIntegrator::Assemble(const FiniteElementSpace &fes)
       }
       else if (function_coeff)
       {
-         function = function_coeff->GetFunction();
+         function = function_coeff->GetDeviceFunction();
       }
       else
       {
@@ -639,9 +639,8 @@ void MassIntegrator::Assemble(const FiniteElementSpace &fes)
       }
       const int NE = ne;
       const int NQ = nq;
-      const int dims = el.GetDim();
       const DeviceVector w(maps->W.GetData(), NQ);
-      const DeviceTensor<3> x(geo->X.GetData(), 3,NQ,NE);
+      const DeviceTensor<3> x(geo->X.GetData(), 2,NQ,NE);
       const DeviceTensor<4> J(geo->J.GetData(), 2,2,NQ,NE);
       DeviceMatrix v(vec.GetData(), NQ, NE);
       MFEM_FORALL(e, NE,
@@ -653,12 +652,11 @@ void MassIntegrator::Assemble(const FiniteElementSpace &fes)
             const double J21 = J(0,1,q,e);
             const double J22 = J(1,1,q,e);
             const double detJ = (J11*J22)-(J21*J12);
-            const int offset = dims*NQ*e+q;
+            const DeviceVector3 Xq(x(0,q,e), x(1,q,e));
             const double coeff =
-            const_coeff ? constant:
-            function_coeff ?
-            function(DeviceVector3(x[offset], x[offset+1], x[offset+2])):
-            0.0;
+               const_coeff ? constant
+               : function_coeff ? function(Xq)
+               : 0.0;
             v(q,e) =  w[q] * coeff * detJ;
          }
       });
@@ -673,7 +671,7 @@ void MassIntegrator::Assemble(const FiniteElementSpace &fes)
       }
       else if (function_coeff)
       {
-         function = function_coeff->GetFunction();
+         function = function_coeff->GetDeviceFunction();
       }
       else
       {
@@ -696,12 +694,11 @@ void MassIntegrator::Assemble(const FiniteElementSpace &fes)
             const double detJ =
             ((J11 * J22 * J33) + (J12 * J23 * J31) + (J13 * J21 * J32) -
             (J13 * J22 * J31) - (J12 * J21 * J33) - (J11 * J23 * J32));
-            const int offset = dims*NQ*e+q;
+            const DeviceVector3 Xq(x(0,q,e), x(1,q,e), x(2,q,e));
             const double coeff =
-            const_coeff ? constant:
-            function_coeff ?
-            function(DeviceVector3(x[offset], x[offset+1], x[offset+2])):
-            0.0;
+               const_coeff ? constant
+               : function_coeff ? function(Xq)
+               : 0.0;
             v(q,e) = W(q) * coeff * detJ;
          }
       });
@@ -1287,6 +1284,7 @@ static void NodeCopyByVDim(const int elements,
 template<const int D1D,
          const int Q1D> static
 void PAGeom2D(const int NE,
+              const double* _B,
               const double* _G,
               const double* _X,
               double* _Xq,
@@ -1296,6 +1294,7 @@ void PAGeom2D(const int NE,
 {
    const int ND = D1D*D1D;
    const int NQ = Q1D*Q1D;
+   const DeviceTensor<2> B(_B, NQ,ND);
    const DeviceTensor<3> G(_G, 2,NQ,ND);
    const DeviceTensor<3> X(_X, 2,ND,NE);
    DeviceTensor<3> Xq(_Xq, 2,NQ,NE);
@@ -1315,17 +1314,21 @@ void PAGeom2D(const int NE,
       }
       for (int q = 0; q < NQ; ++q)
       {
+         double X0  = 0; double X1  = 0;
          double J11 = 0; double J12 = 0;
          double J21 = 0; double J22 = 0;
          for (int d = 0; d < ND; ++d)
          {
+            const double b = B(q,d);
             const double wx = G(0,q,d);
             const double wy = G(1,q,d);
             const double x = s_X[0+d*2];
             const double y = s_X[1+d*2];
             J11 += (wx * x); J12 += (wx * y);
             J21 += (wy * x); J22 += (wy * y);
+            X0 += b*x; X1 += b*y;
          }
+         Xq(0,q,e) = X0; Xq(1,q,e) = X1;
          const double r_detJ = (J11 * J22)-(J12 * J21);
          J(0,0,q,e) = J11;
          J(1,0,q,e) = J12;
@@ -1344,6 +1347,7 @@ void PAGeom2D(const int NE,
 template<const int D1D,
          const int Q1D> static
 void PAGeom3D(const int NE,
+              const double* _B,
               const double* _G,
               const double* _X,
               double* _Xq,
@@ -1353,6 +1357,7 @@ void PAGeom3D(const int NE,
 {
    const int ND = D1D*D1D*D1D;
    const int NQ = Q1D*Q1D*Q1D;
+   const DeviceTensor<2> B(_B, NQ,NE);
    const DeviceTensor<3> G(_G, 3,NQ,NE);
    const DeviceTensor<3> X(_X, 3,ND,NE);
    DeviceTensor<3> Xq(_Xq, 3,NQ,NE);
@@ -1378,6 +1383,7 @@ void PAGeom3D(const int NE,
          double J31 = 0; double J32 = 0; double J33 = 0;
          for (int d = 0; d < ND; ++d)
          {
+            const double b = B(q,d);
             const double wx = G(0,q,d);
             const double wy = G(1,q,d);
             const double wz = G(2,q,d);
@@ -1387,6 +1393,7 @@ void PAGeom3D(const int NE,
             J11 += (wx * x); J12 += (wx * y); J13 += (wx * z);
             J21 += (wy * x); J22 += (wy * y); J23 += (wy * z);
             J31 += (wz * x); J32 += (wz * y); J33 += (wz * z);
+            Xq(0,q,e) = b*x; Xq(1,q,e) = b*y; Xq(2,q,e) = b*z;
          }
          const double r_detJ = ((J11 * J22 * J33) + (J12 * J23 * J31) +
                                 (J13 * J21 * J32) - (J13 * J22 * J31) -
@@ -1416,13 +1423,14 @@ void PAGeom3D(const int NE,
 }
 
 typedef void (*fIniGeom)(const int ne,
-                         const double *G, const double *X,
+                         const double *B, const double *G, const double *X,
                          double *x, double *J, double *invJ, double *detJ);
 
 static void PAGeom(const int dim,
                    const int D1D,
                    const int Q1D,
                    const int NE,
+                   const double* B,
                    const double* G,
                    const double* X,
                    double* Xq,
@@ -1454,7 +1462,7 @@ static void PAGeom(const int dim,
              __FILE__, __LINE__, dim, D1D, Q1D);
       mfem_error("PA Geometry kernel not instanciated");
    }
-   call[id](NE, G, X, Xq, J, invJ, detJ);
+   call[id](NE, B, G, X, Xq, J, invJ, detJ);
 }
 
 GeometryExtension* GeometryExtension::Get(const FiniteElementSpace& fes,
@@ -1475,7 +1483,7 @@ GeometryExtension* GeometryExtension::Get(const FiniteElementSpace& fes,
    const DofToQuad* maps = DofToQuad::GetSimplexMaps(*fe, ir);
    NodeCopyByVDim(elements,numDofs,ndofs,dims,geom->eMap,Sx,geom->nodes);
    PAGeom(dims, D1D, Q1D, elements,
-          maps->G, geom->nodes,
+          maps->B, maps->G, geom->nodes,
           geom->X, geom->J, geom->invJ, geom->detJ);
    return geom;
 }
@@ -1531,7 +1539,7 @@ GeometryExtension* GeometryExtension::Get(const FiniteElementSpace& fes,
    }
    const DofToQuad* maps = DofToQuad::GetSimplexMaps(*fe, ir);
    PAGeom(dims, D1D, Q1D, elements,
-          maps->G, geom->nodes,
+          maps->B, maps->G, geom->nodes,
           geom->X, geom->J, geom->invJ, geom->detJ);
    return geom;
 }

--- a/fem/coefficient.cpp
+++ b/fem/coefficient.cpp
@@ -28,6 +28,11 @@ double PWConstCoefficient::Eval(ElementTransformation & T,
    return (constants(att-1));
 }
 
+double (*FunctionCoefficient::GetDeviceFunction())(const DeviceVector3&)
+{
+   return DeviceFunction;
+}
+
 double FunctionCoefficient::Eval(ElementTransformation & T,
                                  const IntegrationPoint & ip)
 {

--- a/fem/coefficient.cpp
+++ b/fem/coefficient.cpp
@@ -40,6 +40,10 @@ double FunctionCoefficient::Eval(ElementTransformation & T,
    {
       return ((*Function)(transip));
    }
+   else if (DeviceFunction)
+   {
+      return ((*DeviceFunction)(DeviceVector3(x)));
+   }
    else
    {
       return (*TDFunction)(transip, GetTime());

--- a/fem/coefficient.hpp
+++ b/fem/coefficient.hpp
@@ -129,19 +129,20 @@ public:
       DeviceFunction = NULL;
    }
 
-   FunctionCoefficient(double (*f)(const DeviceVector3 &))
-   {
-      Function = NULL;
-      TDFunction = NULL;
-      DeviceFunction = f;
-   }
-
    /// Define a time-dependent coefficient from a C-function
    FunctionCoefficient(double (*tdf)(const Vector &, double))
    {
       Function = NULL;
       TDFunction = tdf;
       DeviceFunction = NULL;
+   }
+
+   /// Define a time-independent coefficient from a device-function
+   FunctionCoefficient(double (*df)(const DeviceVector3 &))
+   {
+      Function = NULL;
+      TDFunction = NULL;
+      DeviceFunction = df;
    }
 
    /// (DEPRECATED) Define a time-independent coefficient from a C-function
@@ -169,7 +170,7 @@ public:
                        const IntegrationPoint &ip);
 
    /// Return the coefficient's device-function
-   double (*GetDeviceFunction())(const DeviceVector3&) { return DeviceFunction; }
+   double (*GetDeviceFunction())(const DeviceVector3&);
 };
 
 class GridFunction;

--- a/fem/coefficient.hpp
+++ b/fem/coefficient.hpp
@@ -118,6 +118,7 @@ class FunctionCoefficient : public Coefficient
 protected:
    double (*Function)(const Vector &);
    double (*TDFunction)(const Vector &, double);
+   double (*DeviceFunction)(const DeviceVector3&);
 
 public:
    /// Define a time-independent coefficient from a C-function
@@ -125,6 +126,14 @@ public:
    {
       Function = f;
       TDFunction = NULL;
+      DeviceFunction = NULL;
+   }
+
+   FunctionCoefficient(double (*f)(const DeviceVector3 &))
+   {
+      Function = NULL;
+      TDFunction = NULL;
+      DeviceFunction = f;
    }
 
    /// Define a time-dependent coefficient from a C-function
@@ -132,6 +141,7 @@ public:
    {
       Function = NULL;
       TDFunction = tdf;
+      DeviceFunction = NULL;
    }
 
    /// (DEPRECATED) Define a time-independent coefficient from a C-function
@@ -141,6 +151,7 @@ public:
    {
       Function = reinterpret_cast<double(*)(const Vector&)>(f);
       TDFunction = NULL;
+      DeviceFunction = NULL;
    }
 
    /// (DEPRECATED) Define a time-dependent coefficient from a C-function
@@ -150,17 +161,15 @@ public:
    {
       Function = NULL;
       TDFunction = reinterpret_cast<double(*)(const Vector&,double)>(tdf);
+      DeviceFunction = NULL;
    }
 
    /// Evaluate coefficient
    virtual double Eval(ElementTransformation &T,
                        const IntegrationPoint &ip);
 
-   /// Return the coefficient's C-function
-   double (*GetFunction())(const DeviceVector3&)
-   {
-      return reinterpret_cast<double(*)(const DeviceVector3&)>(Function);
-   }
+   /// Return the coefficient's device-function
+   double (*GetDeviceFunction())(const DeviceVector3&) { return DeviceFunction; }
 };
 
 class GridFunction;

--- a/general/cuda.hpp
+++ b/general/cuda.hpp
@@ -22,6 +22,7 @@ namespace mfem
 {
 
 #ifdef MFEM_USE_CUDA
+#define MFEM_DEVICE __device__
 #define MFEM_HOST_DEVICE __host__ __device__
 inline void CuCheck(const unsigned int c)
 {
@@ -52,13 +53,11 @@ inline T AtomicAdd(T* address, T val)
    return atomicAdd(address, val);
 }
 #else // MFEM_USE_CUDA
-#define __host__
-#define __device__
-#define __constant__
+#define MFEM_DEVICE
+#define MFEM_HOST_DEVICE
 typedef int CUdevice;
 typedef int CUcontext;
 typedef void* CUstream;
-#define MFEM_HOST_DEVICE
 template<typename T> inline T AtomicAdd(T* address, T val)
 {
 #if defined(_OPENMP)

--- a/general/okina.hpp
+++ b/general/okina.hpp
@@ -41,8 +41,8 @@ namespace mfem
 #define MFEM_FORALL(i,N,...) MFEM_FORALL_K(i,N,MFEM_BLOCKS,__VA_ARGS__)
 #define MFEM_FORALL_K(i,N,BLOCKS,...)                                   \
    OkinaWrap<BLOCKS>(N,                                                 \
-                     [=] __device__ (int i) {__VA_ARGS__},              \
-                     [&]            (int i) {__VA_ARGS__})
+                     [=] MFEM_DEVICE (int i) {__VA_ARGS__},             \
+                     [&]             (int i) {__VA_ARGS__})
 
 /// OpenMP backend
 template <typename HBODY>

--- a/linalg/dtensor.hpp
+++ b/linalg/dtensor.hpp
@@ -29,10 +29,11 @@ public:
    DeviceVector3(const double *r) { data[0]=r[0]; data[1]=r[1]; data[2]=r[2]; }
    DeviceVector3(const double r0, const double r1, const double r2)
    { data[0]=r0; data[1]=r1; data[2]=r2; }
-   ~DeviceVector3() {}
    inline operator double* () { return data; }
    inline operator const double* () const { return data; }
-   inline double& operator[](const size_t x) { return data[x]; }
+   inline double& operator[](const size_t i) { return data[i]; }
+   inline double& operator()(const int i) { return data[i]; }
+   inline const double& operator()(const int i) const { return data[i]; }
 };
 
 /// A Class to compute the real index from the multi-indices of a tensor

--- a/linalg/dtensor.hpp
+++ b/linalg/dtensor.hpp
@@ -27,7 +27,7 @@ private:
 public:
    DeviceVector3() {}
    DeviceVector3(const double *r) { data[0]=r[0]; data[1]=r[1]; data[2]=r[2]; }
-   DeviceVector3(const double r0, const double r1, const double r2)
+   DeviceVector3(const double r0, const double r1, const double r2 = 0.0)
    { data[0]=r0; data[1]=r1; data[2]=r2; }
    inline operator double* () { return data; }
    inline operator const double* () const { return data; }


### PR DESCRIPTION
Allows to use ```double rho0(const DeviceVector3 &x)``` like coefficient functions on the `host` during the setup of Laghos.
