### PR TITLE
Adding  user-supplied "keys" to `VisualizeField` [vis-keys-dev] 

### DIFF
--- a/miniapps/common/fem_extras.cpp
+++ b/miniapps/common/fem_extras.cpp
@@ -56,9 +56,44 @@ RT_FESpace::~RT_FESpace()
    delete FEC_;
 }
 
+void VisualizeMesh(socketstream &sock, const char *vishost, int visport,
+                   Mesh &mesh, const char *title,
+                   int x, int y, int w, int h, const char * keys, bool vec)
+{
+   bool newly_opened = false;
+   int connection_failed;
+
+   do
+   {
+      if (!sock.is_open() || !sock)
+      {
+         sock.open(vishost, visport);
+         sock.precision(8);
+         newly_opened = true;
+      }
+      sock << "solution\n";
+
+      mesh.Print(sock);
+
+      if (newly_opened)
+      {
+         sock << "window_title '" << title << "'\n"
+              << "window_geometry "
+              << x << " " << y << " " << w << " " << h << "\n";
+         if ( keys ) { sock << "keys " << keys << "\n"; }
+         else { sock << "keys maaAc\n"; }
+         if ( vec ) { sock << "vvv"; }
+         sock << endl;
+      }
+
+      connection_failed = !sock && !newly_opened;
+   }
+   while (connection_failed);
+}
+
 void VisualizeField(socketstream &sock, const char *vishost, int visport,
                     GridFunction &gf, const char *title,
-                    int x, int y, int w, int h, bool vec)
+                    int x, int y, int w, int h, const char * keys, bool vec)
 {
    Mesh &mesh = *gf.FESpace()->GetMesh();
 
@@ -82,8 +117,9 @@ void VisualizeField(socketstream &sock, const char *vishost, int visport,
       {
          sock << "window_title '" << title << "'\n"
               << "window_geometry "
-              << x << " " << y << " " << w << " " << h << "\n"
-              << "keys maaAc";
+              << x << " " << y << " " << w << " " << h << "\n";
+         if ( keys ) { sock << "keys " << keys << "\n"; }
+         else { sock << "keys maaAc\n"; }
          if ( vec ) { sock << "vvv"; }
          sock << endl;
       }

--- a/miniapps/common/fem_extras.hpp
+++ b/miniapps/common/fem_extras.hpp
@@ -66,13 +66,21 @@ private:
 };
 
 
+/// Visualize the given mesh object, using a GLVis server on the
+/// specified host and port. Set the visualization window title, and optionally,
+/// its geometry.
+void VisualizeMesh(socketstream &sock, const char *vishost, int visport,
+                   Mesh &mesh, const char *title,
+                   int x = 0, int y = 0, int w = 400, int h = 400,
+                   const char *keys = NULL);
+
 /// Visualize the given grid function, using a GLVis server on the
 /// specified host and port. Set the visualization window title, and optionally,
 /// its geometry.
 void VisualizeField(socketstream &sock, const char *vishost, int visport,
                     GridFunction &gf, const char *title,
                     int x = 0, int y = 0, int w = 400, int h = 400,
-                    bool vec = false);
+                    const char *keys = NULL, bool vec = false);
 
 } // namespace miniapps
 

--- a/miniapps/common/pfem_extras.cpp
+++ b/miniapps/common/pfem_extras.cpp
@@ -261,9 +261,57 @@ DivergenceFreeProjector::Update()
    this->IrrotationalProjector::Update();
 }
 
+void VisualizeMesh(socketstream &sock, const char *vishost, int visport,
+                   ParMesh &pmesh, const char *title,
+                   int x, int y, int w, int h, const char *keys, bool vec)
+{
+   MPI_Comm comm = pmesh.GetComm();
+
+   int num_procs, myid;
+   MPI_Comm_size(comm, &num_procs);
+   MPI_Comm_rank(comm, &myid);
+
+   bool newly_opened = false;
+   int connection_failed;
+
+   do
+   {
+      if (myid == 0)
+      {
+         if (!sock.is_open() || !sock)
+         {
+            sock.open(vishost, visport);
+            sock.precision(8);
+            newly_opened = true;
+         }
+         sock << "solution\n";
+      }
+
+      pmesh.PrintAsOne(sock);
+
+      if (myid == 0 && newly_opened)
+      {
+         sock << "window_title '" << title << "'\n"
+              << "window_geometry "
+              << x << " " << y << " " << w << " " << h << "\n";
+         if ( keys ) { sock << "keys " << keys << "\n"; }
+         else { sock << "keys maaAc"; }
+         if ( vec ) { sock << "vvv"; }
+         sock << endl;
+      }
+
+      if (myid == 0)
+      {
+         connection_failed = !sock && !newly_opened;
+      }
+      MPI_Bcast(&connection_failed, 1, MPI_INT, 0, comm);
+   }
+   while (connection_failed);
+}
+
 void VisualizeField(socketstream &sock, const char *vishost, int visport,
                     ParGridFunction &gf, const char *title,
-                    int x, int y, int w, int h, bool vec)
+                    int x, int y, int w, int h, const char *keys, bool vec)
 {
    ParMesh &pmesh = *gf.ParFESpace()->GetParMesh();
    MPI_Comm comm = pmesh.GetComm();
@@ -295,8 +343,9 @@ void VisualizeField(socketstream &sock, const char *vishost, int visport,
       {
          sock << "window_title '" << title << "'\n"
               << "window_geometry "
-              << x << " " << y << " " << w << " " << h << "\n"
-              << "keys maaAc";
+              << x << " " << y << " " << w << " " << h << "\n";
+         if ( keys ) { sock << "keys " << keys << "\n"; }
+         else { sock << "keys maaAc"; }
          if ( vec ) { sock << "vvv"; }
          sock << endl;
       }

--- a/miniapps/common/pfem_extras.hpp
+++ b/miniapps/common/pfem_extras.hpp
@@ -185,13 +185,21 @@ public:
 };
 
 
+/// Visualize the given parallel mesh object, using a GLVis server on the
+/// specified host and port. Set the visualization window title, and optionally,
+/// its geometry.
+void VisualizeMesh(socketstream &sock, const char *vishost, int visport,
+                   ParMesh &pmesh, const char *title,
+                   int x = 0, int y = 0, int w = 400, int h = 400,
+                   const char *keys = NULL);
+
 /// Visualize the given parallel grid function, using a GLVis server on the
 /// specified host and port. Set the visualization window title, and optionally,
 /// its geometry.
 void VisualizeField(socketstream &sock, const char *vishost, int visport,
                     ParGridFunction &gf, const char *title,
                     int x = 0, int y = 0, int w = 400, int h = 400,
-                    bool vec = false);
+                    const char *keys = NULL, bool vec = false);
 
 } // namespace miniapps
 

--- a/miniapps/tools/display-basis.cpp
+++ b/miniapps/tools/display-basis.cpp
@@ -849,7 +849,7 @@ update_basis(vector<socketstream*> & sock,  const VisWinLayout & vwl,
          VisualizeField(*sock[i], vishost, visport, *x[i], oss.str().c_str(),
                         (i % vwl.nx) * offx, ((i / vwl.nx) % vwl.ny) * offy,
                         vwl.w, vwl.h,
-                        vec);
+                        "aaAc", vec);
       }
    }
 


### PR DESCRIPTION
The main purpose of these changes is to give miniapp developers more control over how fields are displayed in GLVis.

Also adds a similar `VisualizeMesh` function for convenience.  This can be useful in "meshing" miniapps for example.
