### PR TITLE
[okina] CUDA guards for non-nvcc builds [feature/okina-cuda-guards]

### DIFF
--- a/config/defaults.mk
+++ b/config/defaults.mk
@@ -305,8 +305,8 @@ ifeq ($(MFEM_USE_CUDA),YES)
    ifndef CUDA_DIR
       CUDA_DIR := @MFEM_DIR@/../cuda
    endif
-   CUDA_LIB := -L$(CUDA_DIR)/lib64 -lcuda -lcudart
    CUDA_OPT := -I$(CUDA_DIR)/include
+   CUDA_LIB := -L$(CUDA_DIR)/lib64 -lcuda -lcudart
 endif
 
 # MPI library configuration
@@ -333,9 +333,9 @@ ifeq ($(MFEM_USE_RAJA),YES)
       RAJA_DIR := @MFEM_DIR@/../raja
    endif
    ifdef CUB_DIR
-     RAJA_OPT := -I$(RAJA_DIR)/include -I$(CUB_DIR)
+      RAJA_OPT := -I$(RAJA_DIR)/include -I$(CUB_DIR)
    else
-     RAJA_OPT := -I$(RAJA_DIR)/include
+      RAJA_OPT := -I$(RAJA_DIR)/include
    endif
    RAJA_LIB := $(MFEM_XARCHIVE) -Wl,-rpath,$(RAJA_DIR)/lib -L$(RAJA_DIR)/lib -lRAJA
 endif

--- a/config/defaults.mk
+++ b/config/defaults.mk
@@ -306,6 +306,7 @@ ifeq ($(MFEM_USE_CUDA),YES)
       CUDA_DIR := @MFEM_DIR@/../cuda
    endif
    CUDA_LIB := -L$(CUDA_DIR)/lib64 -lcuda -lcudart
+   CUDA_OPT := -I$(CUDA_DIR)/include
 endif
 
 # MPI library configuration
@@ -331,7 +332,11 @@ ifeq ($(MFEM_USE_RAJA),YES)
    ifndef RAJA_DIR
       RAJA_DIR := @MFEM_DIR@/../raja
    endif
-   RAJA_OPT := -I$(RAJA_DIR)/include
+   ifdef CUB_DIR
+     RAJA_OPT := -I$(RAJA_DIR)/include -I$(CUB_DIR)
+   else
+     RAJA_OPT := -I$(RAJA_DIR)/include
+   endif
    RAJA_LIB := $(MFEM_XARCHIVE) -Wl,-rpath,$(RAJA_DIR)/lib -L$(RAJA_DIR)/lib -lRAJA
 endif
 

--- a/general/cuda.cpp
+++ b/general/cuda.cpp
@@ -16,7 +16,7 @@ namespace mfem
 
 void* CuMemAlloc(void** dptr, size_t bytes)
 {
-#if defined(MFEM_USE_CUDA) && defined(__NVCC__)
+#ifdef MFEM_USE_CUDA
    if (CUDA_SUCCESS != ::cuMemAlloc((CUdeviceptr*)dptr, bytes))
    {
       mfem_error("Error in CuMemAlloc");
@@ -27,7 +27,7 @@ void* CuMemAlloc(void** dptr, size_t bytes)
 
 void* CuMemFree(void *dptr)
 {
-#if defined(MFEM_USE_CUDA) && defined(__NVCC__)
+#ifdef MFEM_USE_CUDA
    if (CUDA_SUCCESS != ::cuMemFree((CUdeviceptr)dptr))
    {
       mfem_error("Error in CuMemFree");
@@ -38,7 +38,7 @@ void* CuMemFree(void *dptr)
 
 void* CuMemcpyHtoD(void* dst, const void* src, size_t bytes)
 {
-#if defined(MFEM_USE_CUDA) && defined(__NVCC__)
+#ifdef MFEM_USE_CUDA
    if (CUDA_SUCCESS != ::cuMemcpyHtoD((CUdeviceptr)dst, src, bytes))
    {
       mfem_error("Error in CuMemcpyHtoD");
@@ -49,7 +49,7 @@ void* CuMemcpyHtoD(void* dst, const void* src, size_t bytes)
 
 void* CuMemcpyHtoDAsync(void* dst, const void* src, size_t bytes, void *s)
 {
-#if defined(MFEM_USE_CUDA) && defined(__NVCC__)
+#ifdef MFEM_USE_CUDA
    if (CUDA_SUCCESS !=
        ::cuMemcpyHtoDAsync((CUdeviceptr)dst, src, bytes, (CUstream)s))
    {
@@ -61,7 +61,7 @@ void* CuMemcpyHtoDAsync(void* dst, const void* src, size_t bytes, void *s)
 
 void* CuMemcpyDtoD(void* dst, void* src, size_t bytes)
 {
-#if defined(MFEM_USE_CUDA) && defined(__NVCC__)
+#ifdef MFEM_USE_CUDA
    if (CUDA_SUCCESS !=
        ::cuMemcpyDtoD((CUdeviceptr)dst, (CUdeviceptr)src, bytes))
    {
@@ -73,7 +73,7 @@ void* CuMemcpyDtoD(void* dst, void* src, size_t bytes)
 
 void* CuMemcpyDtoDAsync(void* dst, void* src, size_t bytes, void *s)
 {
-#if defined(MFEM_USE_CUDA) && defined(__NVCC__)
+#ifdef MFEM_USE_CUDA
    if (CUDA_SUCCESS !=
        ::cuMemcpyDtoDAsync((CUdeviceptr)dst, (CUdeviceptr)src,
                            bytes, (CUstream)s))
@@ -86,7 +86,7 @@ void* CuMemcpyDtoDAsync(void* dst, void* src, size_t bytes, void *s)
 
 void* CuMemcpyDtoH(void *dst, void *src, size_t bytes)
 {
-#if defined(MFEM_USE_CUDA) && defined(__NVCC__)
+#ifdef MFEM_USE_CUDA
    if (CUDA_SUCCESS != ::cuMemcpyDtoH(dst, (CUdeviceptr)src, bytes))
    {
       mfem_error("Error in CuMemcpyDtoH");
@@ -97,7 +97,7 @@ void* CuMemcpyDtoH(void *dst, void *src, size_t bytes)
 
 void* CuMemcpyDtoHAsync(void* dst, void* src, size_t bytes, void *s)
 {
-#if defined(MFEM_USE_CUDA) && defined(__NVCC__)
+#ifdef MFEM_USE_CUDA
    if (CUDA_SUCCESS !=
        ::cuMemcpyDtoHAsync(dst, (CUdeviceptr)src, bytes, (CUstream)s))
    {

--- a/general/cuda.cpp
+++ b/general/cuda.cpp
@@ -16,7 +16,7 @@ namespace mfem
 
 void* CuMemAlloc(void** dptr, size_t bytes)
 {
-#ifdef MFEM_USE_CUDA
+#if defined(MFEM_USE_CUDA) && defined(__NVCC__)
    if (CUDA_SUCCESS != ::cuMemAlloc((CUdeviceptr*)dptr, bytes))
    {
       mfem_error("Error in CuMemAlloc");
@@ -27,7 +27,7 @@ void* CuMemAlloc(void** dptr, size_t bytes)
 
 void* CuMemFree(void *dptr)
 {
-#ifdef MFEM_USE_CUDA
+#if defined(MFEM_USE_CUDA) && defined(__NVCC__)
    if (CUDA_SUCCESS != ::cuMemFree((CUdeviceptr)dptr))
    {
       mfem_error("Error in CuMemFree");
@@ -38,7 +38,7 @@ void* CuMemFree(void *dptr)
 
 void* CuMemcpyHtoD(void* dst, const void* src, size_t bytes)
 {
-#ifdef MFEM_USE_CUDA
+#if defined(MFEM_USE_CUDA) && defined(__NVCC__)
    if (CUDA_SUCCESS != ::cuMemcpyHtoD((CUdeviceptr)dst, src, bytes))
    {
       mfem_error("Error in CuMemcpyHtoD");
@@ -49,7 +49,7 @@ void* CuMemcpyHtoD(void* dst, const void* src, size_t bytes)
 
 void* CuMemcpyHtoDAsync(void* dst, const void* src, size_t bytes, void *s)
 {
-#ifdef MFEM_USE_CUDA
+#if defined(MFEM_USE_CUDA) && defined(__NVCC__)
    if (CUDA_SUCCESS !=
        ::cuMemcpyHtoDAsync((CUdeviceptr)dst, src, bytes, (CUstream)s))
    {
@@ -61,7 +61,7 @@ void* CuMemcpyHtoDAsync(void* dst, const void* src, size_t bytes, void *s)
 
 void* CuMemcpyDtoD(void* dst, void* src, size_t bytes)
 {
-#ifdef MFEM_USE_CUDA
+#if defined(MFEM_USE_CUDA) && defined(__NVCC__)
    if (CUDA_SUCCESS !=
        ::cuMemcpyDtoD((CUdeviceptr)dst, (CUdeviceptr)src, bytes))
    {
@@ -73,7 +73,7 @@ void* CuMemcpyDtoD(void* dst, void* src, size_t bytes)
 
 void* CuMemcpyDtoDAsync(void* dst, void* src, size_t bytes, void *s)
 {
-#ifdef MFEM_USE_CUDA
+#if defined(MFEM_USE_CUDA) && defined(__NVCC__)
    if (CUDA_SUCCESS !=
        ::cuMemcpyDtoDAsync((CUdeviceptr)dst, (CUdeviceptr)src,
                            bytes, (CUstream)s))
@@ -86,7 +86,7 @@ void* CuMemcpyDtoDAsync(void* dst, void* src, size_t bytes, void *s)
 
 void* CuMemcpyDtoH(void *dst, void *src, size_t bytes)
 {
-#ifdef MFEM_USE_CUDA
+#if defined(MFEM_USE_CUDA) && defined(__NVCC__)
    if (CUDA_SUCCESS != ::cuMemcpyDtoH(dst, (CUdeviceptr)src, bytes))
    {
       mfem_error("Error in CuMemcpyDtoH");
@@ -97,7 +97,7 @@ void* CuMemcpyDtoH(void *dst, void *src, size_t bytes)
 
 void* CuMemcpyDtoHAsync(void* dst, void* src, size_t bytes, void *s)
 {
-#ifdef MFEM_USE_CUDA
+#if defined(MFEM_USE_CUDA) && defined(__NVCC__)
    if (CUDA_SUCCESS !=
        ::cuMemcpyDtoHAsync(dst, (CUdeviceptr)src, bytes, (CUstream)s))
    {

--- a/general/cuda.hpp
+++ b/general/cuda.hpp
@@ -14,7 +14,7 @@
 
 #include <cstddef>
 
-#if defined(__NVCC__) && defined(MFEM_USE_CUDA)
+#if defined(MFEM_USE_CUDA) && defined(__NVCC__)
 #include <cuda.h>
 #endif
 

--- a/general/cuda.hpp
+++ b/general/cuda.hpp
@@ -14,14 +14,14 @@
 
 #include <cstddef>
 
-#ifdef MFEM_USE_CUDA
+#if defined(__NVCC__) && defined(MFEM_USE_CUDA)
 #include <cuda.h>
 #endif
 
 namespace mfem
 {
 
-#ifdef MFEM_USE_CUDA
+#if defined (MFEM_USE_CUDA) && defined (__NVCC__)
 #define MFEM_DEVICE __device__
 #define MFEM_HOST_DEVICE __host__ __device__
 inline void CuCheck(const unsigned int c)

--- a/general/occa.hpp
+++ b/general/occa.hpp
@@ -12,10 +12,9 @@
 #ifndef MFEM_OCCA_HPP
 #define MFEM_OCCA_HPP
 
-#include "./cuda.hpp"
-
 #ifdef MFEM_USE_OCCA
 #include <occa.hpp>
+#include "./cuda.hpp"
 
 #ifdef MFEM_USE_CUDA
 #include <occa/mode/cuda/utils.hpp>

--- a/general/occa.hpp
+++ b/general/occa.hpp
@@ -14,7 +14,6 @@
 
 #ifdef MFEM_USE_OCCA
 #include <occa.hpp>
-#include "./cuda.hpp"
 
 #ifdef MFEM_USE_CUDA
 #include <occa/mode/cuda/utils.hpp>

--- a/general/occa.hpp
+++ b/general/occa.hpp
@@ -12,9 +12,10 @@
 #ifndef MFEM_OCCA_HPP
 #define MFEM_OCCA_HPP
 
+#include "./cuda.hpp"
+
 #ifdef MFEM_USE_OCCA
 #include <occa.hpp>
-#include "./cuda.hpp"
 
 #ifdef MFEM_USE_CUDA
 #include <occa/mode/cuda/utils.hpp>

--- a/general/okina.hpp
+++ b/general/okina.hpp
@@ -19,7 +19,10 @@
 #include <cstring>
 #include <iostream>
 
+#ifdef __NVCC__
 #include "cuda.hpp"
+#endif
+
 #include "occa.hpp"
 #include "mm.hpp"
 #include "device.hpp"
@@ -63,7 +66,7 @@ void OmpWrap(const int N, HBODY &&h_body)
 template <int BLOCKS, typename DBODY>
 void RajaCudaWrap(const int N, DBODY &&d_body)
 {
-#if defined(MFEM_USE_RAJA) && defined(RAJA_ENABLE_CUDA)
+#if defined(__NVCC__) && defined(MFEM_USE_RAJA) && defined(RAJA_ENABLE_CUDA)
    RAJA::forall<RAJA::cuda_exec<BLOCKS>>(RAJA::RangeSegment(0,N),d_body);
 #else
    MFEM_ABORT("RAJA::Cuda requested but RAJA::Cuda is not enabled!");
@@ -93,7 +96,7 @@ void RajaSeqWrap(const int N, HBODY &&h_body)
 }
 
 /// CUDA backend
-#ifdef MFEM_USE_CUDA
+#if defined(MFEM_USE_CUDA) && defined(__NVCC__)
 template <typename BODY> __global__ static
 void CuKernel(const int N, BODY body)
 {

--- a/general/okina.hpp
+++ b/general/okina.hpp
@@ -19,10 +19,7 @@
 #include <cstring>
 #include <iostream>
 
-#ifdef __NVCC__
 #include "cuda.hpp"
-#endif
-
 #include "occa.hpp"
 #include "mm.hpp"
 #include "device.hpp"
@@ -66,7 +63,7 @@ void OmpWrap(const int N, HBODY &&h_body)
 template <int BLOCKS, typename DBODY>
 void RajaCudaWrap(const int N, DBODY &&d_body)
 {
-#if defined(__NVCC__) && defined(MFEM_USE_RAJA) && defined(RAJA_ENABLE_CUDA)
+#if defined(MFEM_USE_RAJA) && defined(RAJA_ENABLE_CUDA) && defined(__NVCC__)
    RAJA::forall<RAJA::cuda_exec<BLOCKS>>(RAJA::RangeSegment(0,N),d_body);
 #else
    MFEM_ABORT("RAJA::Cuda requested but RAJA::Cuda is not enabled!");


### PR DESCRIPTION
By adding a few checks, this PR enables users to maintain one build of CUDA enabled MFEM and be compatible with strict host code and CUDA code. This was motivated by an application which compiled packages which depended on MFEM with both nvcc and host compilers.