### PR TITLE
OCCA all modes [okina-allin]

### DIFF
--- a/examples/ex1.cpp
+++ b/examples/ex1.cpp
@@ -26,8 +26,10 @@
 //               ex1 -m ../data/mobius-strip.mesh -o -1 -sc
 //
 // Device runs:  ex1 -p -d cuda
+//               ex1 -p -d 'cuda raja'
 //               ex1 -p -d 'cuda occa'
-//               ex1 -p -d 'raja omp'
+//               ex1 -p -d 'omp raja'
+//               ex1 -p -d 'omp occa'
 //               ex1 -m ../data/beam-hex.mesh -p -d cuda
 //
 // Description:  This example code demonstrates the use of MFEM to define a

--- a/examples/ex1.cpp
+++ b/examples/ex1.cpp
@@ -25,9 +25,10 @@
 //               ex1 -m ../data/mobius-strip.mesh
 //               ex1 -m ../data/mobius-strip.mesh -o -1 -sc
 //
-// Device runs:  ex1 -d cuda
-//               ex1 -d occa
-//               ex1 -d 'raja omp'
+// Device runs:  ex1 -p -d cuda
+//               ex1 -p -d 'cuda occa'
+//               ex1 -p -d 'raja omp'
+//               ex1 -m ../data/beam-hex.mesh -p -d cuda
 //
 // Description:  This example code demonstrates the use of MFEM to define a
 //               simple finite element discretization of the Laplace problem

--- a/fem/defines.okl
+++ b/fem/defines.okl
@@ -1,0 +1,43 @@
+// Copyright (c) 2010, Lawrence Livermore National Security, LLC. Produced at
+// the Lawrence Livermore National Laboratory. LLNL-CODE-443211. All Rights
+// reserved. See file COPYRIGHT for details.
+//
+// This file is part of the MFEM library. For more information and source code
+// availability see http://mfem.org.
+//
+// MFEM is free software; you can redistribute it and/or modify it under the
+// terms of the GNU Lesser General Public License (as published by the Free
+// Software Foundation) version 2.1 dated February 1999.
+
+typedef double* DofToQuad_t @dim(Q1D, D1D);
+typedef double* QuadToDof_t @dim(D1D, Q1D);
+
+typedef double* SymmOperator2D_t @dim(3, NUM_QUAD_2D, numElements);
+typedef double* SymmOperator3D_t @dim(6, NUM_QUAD_3D, numElements);
+
+typedef double* DLocal2D_t @dim(D1D, D1D, numElements);
+typedef double* DLocal3D_t @dim(D1D, D1D, D1D, numElements);
+
+typedef double* Jacobian2D_t @dim(2, 2, NUM_QUAD_2D, numElements);
+typedef double* Jacobian3D_t @dim(3, 3, NUM_QUAD_3D, numElements);
+
+typedef double* QLocal2D_t @dim(Q1D, Q1D, numElements);
+typedef double* QLocal3D_t @dim(Q1D, Q1D, Q1D, numElements);
+
+#if Q1D < D1D
+#  define NUM_MAX_1D D1D
+#else
+#  define NUM_MAX_1D Q1D
+#endif
+
+#define NUM_MAX_2D (NUM_MAX_1D * NUM_MAX_1D)
+
+#define NUM_QUAD_DOFS_1D (Q1D * D1D)
+
+#define QUAD_2D_ID(X, Y) (X + ((Y) * Q1D))
+#define DOFS_2D_ID(X, Y) (X + ((Y) * D1D))
+
+#define QUAD_3D_ID(X, Y, Z) (X + ((Y) * Q1D) + ((Z) * NUM_QUAD_2D))
+#define DOFS_3D_ID(X, Y, Z) (X + ((Y) * D1D) + ((Z) * NUM_DOFS_2D))
+
+#define M2_ELEMENT_BATCH 32

--- a/fem/diffusion.okl
+++ b/fem/diffusion.okl
@@ -9,33 +9,7 @@
 // terms of the GNU Lesser General Public License (as published by the Free
 // Software Foundation) version 2.1 dated February 1999.
 
-typedef double* DofToQuad_t @dim(Q1D, D1D);
-typedef double* QuadToDof_t @dim(D1D, Q1D);
-typedef double* SymmOperator2D_t @dim(3, NUM_QUAD_2D, numElements);
-typedef double* SymmOperator3D_t @dim(6, NUM_QUAD_3D, numElements);
-typedef double* DLocal2D_t @dim(D1D, D1D, numElements);
-typedef double* Jacobian2D_t @dim(2, 2, NUM_QUAD_2D, numElements);
-typedef double* Jacobian3D_t @dim(3, 3, NUM_QUAD_3D, numElements);
-
-typedef double* DLocal3D_t @dim(D1D, D1D, D1D, numElements);
-
-#if Q1D < D1D
-#  define NUM_MAX_1D D1D
-#else
-#  define NUM_MAX_1D Q1D
-#endif
-
-#define NUM_MAX_2D (NUM_MAX_1D * NUM_MAX_1D)
-
-#define NUM_QUAD_DOFS_1D (Q1D * D1D)
-
-#define QUAD_2D_ID(X, Y) (X + ((Y) * Q1D))
-#define DOFS_2D_ID(X, Y) (X + ((Y) * D1D))
-
-#define QUAD_3D_ID(X, Y, Z) (X + ((Y) * Q1D) + ((Z) * NUM_QUAD_2D))
-#define DOFS_3D_ID(X, Y, Z) (X + ((Y) * D1D) + ((Z) * NUM_DOFS_2D))
-
-#define M2_ELEMENT_BATCH 32
+#include "occa://fem/defines.okl"
 
 @kernel void Assemble2D(const int numElements,
                         @restrict const double * quadWeights,

--- a/fem/diffusion.okl
+++ b/fem/diffusion.okl
@@ -12,8 +12,12 @@
 typedef double* DofToQuad_t @dim(Q1D, D1D);
 typedef double* QuadToDof_t @dim(D1D, Q1D);
 typedef double* SymmOperator2D_t @dim(3, NUM_QUAD_2D, numElements);
+typedef double* SymmOperator3D_t @dim(6, NUM_QUAD_3D, numElements);
 typedef double* DLocal2D_t @dim(D1D, D1D, numElements);
 typedef double* Jacobian2D_t @dim(2, 2, NUM_QUAD_2D, numElements);
+typedef double* Jacobian3D_t @dim(3, 3, NUM_QUAD_3D, numElements);
+
+typedef double* DLocal3D_t @dim(D1D, D1D, D1D, numElements);
 
 #if Q1D < D1D
 #  define NUM_MAX_1D D1D
@@ -46,6 +50,46 @@ typedef double* Jacobian2D_t @dim(2, 2, NUM_QUAD_2D, numElements);
       oper(0, q, e) =  c_detJ * (J21*J21 + J22*J22); // (1,1)
       oper(1, q, e) = -c_detJ * (J21*J11 + J22*J12); // (1,2), (2,1)
       oper(2, q, e) =  c_detJ * (J11*J11 + J12*J12); // (2,2)
+    }
+  }
+}
+
+@kernel void Assemble3D(const int numElements,
+                        @restrict const double * quadWeights,
+                        @restrict const Jacobian3D_t J,
+                        const double COEFF,
+                        @restrict SymmOperator3D_t oper) {
+  for (int e = 0; e < numElements; ++e; @outer) {
+    for (int q = 0; q < NUM_QUAD_3D; ++q; @inner) {
+      const double J11 = J(0, 0, q, e), J12 = J(1, 0, q, e), J13 = J(2, 0, q, e);
+      const double J21 = J(0, 1, q, e), J22 = J(1, 1, q, e), J23 = J(2, 1, q, e);
+      const double J31 = J(0, 2, q, e), J32 = J(1, 2, q, e), J33 = J(2, 2, q, e);
+
+      const double detJ = ((J11 * J22 * J33) + (J12 * J23 * J31) + (J13 * J21 * J32) -
+                           (J13 * J22 * J31) - (J12 * J21 * J33) - (J11 * J23 * J32));
+
+      const double c_detJ = quadWeights[q] * COEFF / detJ;
+
+      // adj(J)
+      const double A11 = (J22 * J33) - (J23 * J32);
+      const double A12 = (J23 * J31) - (J21 * J33);
+      const double A13 = (J21 * J32) - (J22 * J31);
+
+      const double A21 = (J13 * J32) - (J12 * J33);
+      const double A22 = (J11 * J33) - (J13 * J31);
+      const double A23 = (J12 * J31) - (J11 * J32);
+
+      const double A31 = (J12 * J23) - (J13 * J22);
+      const double A32 = (J13 * J21) - (J11 * J23);
+      const double A33 = (J11 * J22) - (J12 * J21);
+
+      // adj(J)^Tadj(J)
+      oper(0, q, e) = c_detJ * (A11*A11 + A21*A21 + A31*A31); // (1,1)
+      oper(1, q, e) = c_detJ * (A11*A12 + A21*A22 + A31*A32); // (1,2), (2,1)
+      oper(2, q, e) = c_detJ * (A11*A13 + A21*A23 + A31*A33); // (1,3), (3,1)
+      oper(3, q, e) = c_detJ * (A12*A12 + A22*A22 + A32*A32); // (2,2)
+      oper(4, q, e) = c_detJ * (A12*A13 + A22*A23 + A32*A33); // (2,3), (3,2)
+      oper(5, q, e) = c_detJ * (A13*A13 + A23*A23 + A33*A33); // (3,3)
     }
   }
 }
@@ -254,4 +298,318 @@ typedef double* Jacobian2D_t @dim(2, 2, NUM_QUAD_2D, numElements);
          }
       }
    }
+}
+
+@kernel void MultAdd3D_CPU(const int numElements,
+                           @restrict const DofToQuad_t dofToQuad,
+                           @restrict const DofToQuad_t dofToQuadD,
+                           @restrict const QuadToDof_t quadToDof,
+                           @restrict const QuadToDof_t quadToDofD,
+                           @restrict const SymmOperator3D_t oper,
+                           @restrict const DLocal3D_t solIn,
+                           @restrict DLocal3D_t solOut) {
+  // Iterate over elements
+  for (int e = 0; e < numElements; ++e; @outer) {
+    for (int dummy = 0; dummy < 1; ++dummy; @inner) {
+      double grad[Q1D][Q1D][Q1D][4];
+      for (int qz = 0; qz < Q1D; ++qz) {
+        for (int qy = 0; qy < Q1D; ++qy) {
+          for (int qx = 0; qx < Q1D; ++qx) {
+            grad[qz][qy][qx][0] = 0;
+            grad[qz][qy][qx][1] = 0;
+            grad[qz][qy][qx][2] = 0;
+          }
+        }
+      }
+
+      for (int dz = 0; dz < D1D; ++dz) {
+        double gradXY[Q1D][Q1D][4];
+        for (int qy = 0; qy < Q1D; ++qy) {
+          for (int qx = 0; qx < Q1D; ++qx) {
+            gradXY[qy][qx][0] = 0;
+            gradXY[qy][qx][1] = 0;
+            gradXY[qy][qx][2] = 0;
+          }
+        }
+
+        for (int dy = 0; dy < D1D; ++dy) {
+          double gradX[Q1D][2];
+          for (int qx = 0; qx < Q1D; ++qx) {
+            gradX[qx][0] = 0;
+            gradX[qx][1] = 0;
+          }
+
+          for (int dx = 0; dx < D1D; ++dx) {
+            const double s = solIn(dx, dy, dz, e);
+            for (int qx = 0; qx < Q1D; ++qx) {
+              gradX[qx][0] += s * dofToQuad(qx, dx);
+              gradX[qx][1] += s * dofToQuadD(qx, dx);
+            }
+          }
+
+          for (int qy = 0; qy < Q1D; ++qy) {
+            const double wy  = dofToQuad(qy, dy);
+            const double wDy = dofToQuadD(qy, dy);
+            for (int qx = 0; qx < Q1D; ++qx) {
+              const double wx  = gradX[qx][0];
+              const double wDx = gradX[qx][1];
+              gradXY[qy][qx][0] += wDx * wy;
+              gradXY[qy][qx][1] += wx  * wDy;
+              gradXY[qy][qx][2] += wx  * wy;
+            }
+          }
+        }
+
+        for (int qz = 0; qz < Q1D; ++qz) {
+          const double wz  = dofToQuad(qz, dz);
+          const double wDz = dofToQuadD(qz, dz);
+          for (int qy = 0; qy < Q1D; ++qy) {
+            for (int qx = 0; qx < Q1D; ++qx) {
+              grad[qz][qy][qx][0] += gradXY[qy][qx][0] * wz;
+              grad[qz][qy][qx][1] += gradXY[qy][qx][1] * wz;
+              grad[qz][qy][qx][2] += gradXY[qy][qx][2] * wDz;
+            }
+          }
+        }
+      }
+
+      // Calculate Dxyz, xDyz, xyDz in plane
+      for (int qz = 0; qz < Q1D; ++qz) {
+        for (int qy = 0; qy < Q1D; ++qy) {
+          for (int qx = 0; qx < Q1D; ++qx) {
+            const int q = QUAD_3D_ID(qx, qy, qz);
+            const double O11 = oper(0, q, e);
+            const double O12 = oper(1, q, e);
+            const double O13 = oper(2, q, e);
+            const double O22 = oper(3, q, e);
+            const double O23 = oper(4, q, e);
+            const double O33 = oper(5, q, e);
+
+            const double gradX = grad[qz][qy][qx][0];
+            const double gradY = grad[qz][qy][qx][1];
+            const double gradZ = grad[qz][qy][qx][2];
+
+            grad[qz][qy][qx][0] = (O11 * gradX) + (O12 * gradY) + (O13 * gradZ);
+            grad[qz][qy][qx][1] = (O12 * gradX) + (O22 * gradY) + (O23 * gradZ);
+            grad[qz][qy][qx][2] = (O13 * gradX) + (O23 * gradY) + (O33 * gradZ);
+          }
+        }
+      }
+
+      for (int qz = 0; qz < Q1D; ++qz) {
+        double gradXY[D1D][D1D][4];
+        for (int dy = 0; dy < D1D; ++dy) {
+          for (int dx = 0; dx < D1D; ++dx) {
+            gradXY[dy][dx][0] = 0;
+            gradXY[dy][dx][1] = 0;
+            gradXY[dy][dx][2] = 0;
+          }
+        }
+
+        for (int qy = 0; qy < Q1D; ++qy) {
+          double gradX[D1D][4];
+          for (int dx = 0; dx < D1D; ++dx) {
+            gradX[dx][0] = 0;
+            gradX[dx][1] = 0;
+            gradX[dx][2] = 0;
+          }
+
+          for (int qx = 0; qx < Q1D; ++qx) {
+            const double gX = grad[qz][qy][qx][0];
+            const double gY = grad[qz][qy][qx][1];
+            const double gZ = grad[qz][qy][qx][2];
+            for (int dx = 0; dx < D1D; ++dx) {
+              const double wx  = quadToDof(dx, qx);
+              const double wDx = quadToDofD(dx, qx);
+              gradX[dx][0] += gX * wDx;
+              gradX[dx][1] += gY * wx;
+              gradX[dx][2] += gZ * wx;
+            }
+          }
+
+          for (int dy = 0; dy < D1D; ++dy) {
+            const double wy  = quadToDof(dy, qy);
+            const double wDy = quadToDofD(dy, qy);
+            for (int dx = 0; dx < D1D; ++dx) {
+              gradXY[dy][dx][0] += gradX[dx][0] * wy;
+              gradXY[dy][dx][1] += gradX[dx][1] * wDy;
+              gradXY[dy][dx][2] += gradX[dx][2] * wy;
+            }
+          }
+        }
+
+        for (int dz = 0; dz < D1D; ++dz) {
+          const double wz  = quadToDof(dz, qz);
+          const double wDz = quadToDofD(dz, qz);
+          for (int dy = 0; dy < D1D; ++dy) {
+            for (int dx = 0; dx < D1D; ++dx) {
+              solOut(dx, dy, dz, e) += ((gradXY[dy][dx][0] * wz) +
+                                        (gradXY[dy][dx][1] * wz) +
+                                        (gradXY[dy][dx][2] * wDz));
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+@kernel void MultAdd3D_GPU(const int numElements,
+                           @restrict const DofToQuad_t dofToQuad,
+                           @restrict const DofToQuad_t dofToQuadD,
+                           @restrict const QuadToDof_t quadToDof,
+                           @restrict const QuadToDof_t quadToDofD,
+                           @restrict const SymmOperator3D_t oper,
+                           @restrict const DLocal3D_t solIn,
+                           @restrict DLocal3D_t solOut) {
+  // Iterate over elements
+  for (int e = 0; e < numElements; ++e; @outer) {
+    // Store dof <--> quad mappings
+    @shared double s_dofToQuad[NUM_QUAD_DOFS_1D] @dim(Q1D, D1D);
+    @shared double s_dofToQuadD[NUM_QUAD_DOFS_1D] @dim(Q1D, D1D);
+    @shared double s_quadToDof[NUM_QUAD_DOFS_1D] @dim(D1D, Q1D);
+    @shared double s_quadToDofD[NUM_QUAD_DOFS_1D] @dim(D1D, Q1D);
+
+    // Store xy planes in @shared memory
+    @shared double s_z[NUM_MAX_2D] @dim(NUM_MAX_1D, NUM_MAX_1D);
+    @shared double s_Dz[NUM_MAX_2D] @dim(NUM_MAX_1D, NUM_MAX_1D);
+    @shared double s_xyDz[NUM_QUAD_2D] @dim(Q1D, Q1D);
+
+    // Store z axis as registers
+    @exclusive double r_qz[Q1D];
+    @exclusive double r_qDz[Q1D];
+    @exclusive double r_dDxyz[D1D];
+    @exclusive double r_dxDyz[D1D];
+    @exclusive double r_dxyDz[D1D];
+
+    for (int y = 0; y < NUM_MAX_1D; ++y; @inner) {
+      for (int x = 0; x < NUM_MAX_1D; ++x; @inner) {
+        const int id = (y * NUM_MAX_1D) + x;
+        // Fetch Q <--> D maps
+        if (id < NUM_QUAD_DOFS_1D) {
+          s_dofToQuad[id]  = dofToQuad[id];
+          s_dofToQuadD[id] = dofToQuadD[id];
+          s_quadToDof[id]  = quadToDof[id];
+          s_quadToDofD[id] = quadToDofD[id];
+        }
+        // Initialize our Z axis
+        for (int qz = 0; qz < Q1D; ++qz) {
+          r_qz[qz] = 0;
+          r_qDz[qz] = 0;
+        }
+        // Initialize our solution updates in the Z axis
+        for (int dz = 0; dz < D1D; ++dz) {
+          r_dDxyz[dz] = 0;
+          r_dxDyz[dz] = 0;
+          r_dxyDz[dz] = 0;
+        }
+      }
+    }
+
+    for (int dy = 0; dy < NUM_MAX_1D; ++dy; @inner) {
+      for (int dx = 0; dx < NUM_MAX_1D; ++dx; @inner) {
+        if ((dx < D1D) && (dy < D1D)) {
+          for (int dz = 0; dz < D1D; ++dz) {
+            const double s = solIn(dx, dy, dz, e);
+            // Calculate D -> Q in the Z axis
+            for (int qz = 0; qz < Q1D; ++qz) {
+              r_qz[qz]  += s * s_dofToQuad(qz, dz);
+              r_qDz[qz] += s * s_dofToQuadD(qz, dz);
+            }
+          }
+        }
+      }
+    }
+    // For each xy plane
+    for (int qz = 0; qz < Q1D; ++qz) {
+      // Fill xy plane at given z position
+      for (int dy = 0; dy < NUM_MAX_1D; ++dy; @inner) {
+        for (int dx = 0; dx < NUM_MAX_1D; ++dx; @inner) {
+          if ((dx < D1D) && (dy < D1D)) {
+            s_z(dx, dy)  = r_qz[qz];
+            s_Dz(dx, dy) = r_qDz[qz];
+          }
+        }
+      }
+      // Calculate Dxyz, xDyz, xyDz in plane
+      for (int qy = 0; qy < NUM_MAX_1D; ++qy; @inner) {
+        for (int qx = 0; qx < NUM_MAX_1D; ++qx; @inner) {
+          if ((qx < Q1D) && (qy < Q1D)) {
+            double Dxyz = 0;
+            double xDyz = 0;
+            double xyDz = 0;
+            for (int dy = 0; dy < D1D; ++dy) {
+              const double wy  = s_dofToQuad(qy, dy);
+              const double wDy = s_dofToQuadD(qy, dy);
+              for (int dx = 0; dx < D1D; ++dx) {
+                const double wx  = s_dofToQuad(qx, dx);
+                const double wDx = s_dofToQuadD(qx, dx);
+                const double z  = s_z(dx, dy);
+                const double Dz = s_Dz(dx, dy);
+                Dxyz += wDx * wy  * z;
+                xDyz += wx  * wDy * z;
+                xyDz += wx  * wy  * Dz;
+              }
+            }
+
+            const int q = QUAD_3D_ID(qx, qy, qz);
+            const double O11 = oper(0, q, e);
+            const double O12 = oper(1, q, e);
+            const double O13 = oper(2, q, e);
+            const double O22 = oper(3, q, e);
+            const double O23 = oper(4, q, e);
+            const double O33 = oper(5, q, e);
+
+            const double qDxyz = (O11 * Dxyz) + (O12 * xDyz) + (O13 * xyDz);
+            const double qxDyz = (O12 * Dxyz) + (O22 * xDyz) + (O23 * xyDz);
+            const double qxyDz = (O13 * Dxyz) + (O23 * xDyz) + (O33 * xyDz);
+
+            for (int dz = 0; dz < D1D; ++dz) {
+              const double wz  = s_quadToDof(dz, qz);
+              const double wDz = s_quadToDofD(dz, qz);
+              r_dDxyz[dz] += wz  * qDxyz;
+              r_dxDyz[dz] += wz  * qxDyz;
+              r_dxyDz[dz] += wDz * qxyDz;
+            }
+          }
+        }
+      }
+    }
+    // Iterate over xy planes to compute solution
+    for (int dz = 0; dz < D1D; ++dz) {
+      // Place xy plane in @shared memory
+      for (int qy = 0; qy < NUM_MAX_1D; ++qy; @inner) {
+        for (int qx = 0; qx < NUM_MAX_1D; ++qx; @inner) {
+          if ((qx < Q1D) && (qy < Q1D)) {
+            s_z(qx, qy)    = r_dDxyz[dz];
+            s_Dz(qx, qy)   = r_dxDyz[dz];
+            s_xyDz(qx, qy) = r_dxyDz[dz];
+          }
+        }
+      }
+      // Finalize solution in xy plane
+      for (int dy = 0; dy < NUM_MAX_1D; ++dy; @inner) {
+        for (int dx = 0; dx < NUM_MAX_1D; ++dx; @inner) {
+          if ((dx < D1D) && (dy < D1D)) {
+            double solZ = 0;
+            for (int qy = 0; qy < Q1D; ++qy) {
+              const double wy  = s_quadToDof(dy, qy);
+              const double wDy = s_quadToDofD(dy, qy);
+              for (int qx = 0; qx < Q1D; ++qx) {
+                const double wx  = s_quadToDof(dx, qx);
+                const double wDx = s_quadToDofD(dx, qx);
+                const double Dxyz = s_z(qx, qy);
+                const double xDyz = s_Dz(qx, qy);
+                const double xyDz = s_xyDz(qx, qy);
+                solZ += ((wDx * wy  * Dxyz) +
+                         (wx  * wDy * xDyz) +
+                         (wx  * wy  * xyDz));
+              }
+            }
+            solOut(dx, dy, dz, e) += solZ;
+          }
+        }
+      }
+    }
+  }
 }

--- a/fem/mass.okl
+++ b/fem/mass.okl
@@ -13,9 +13,7 @@
 
 @kernel void MultAdd2D_CPU(const int numElements,
                            @restrict const DofToQuad_t dofToQuad,
-                           @restrict const DofToQuad_t dofToQuadD,
                            @restrict const QuadToDof_t quadToDof,
-                           @restrict const QuadToDof_t quadToDofD,
                            @restrict const QLocal2D_t oper,
                            @restrict const DLocal2D_t solIn,
                            @restrict DLocal2D_t solOut) {
@@ -82,9 +80,7 @@
 
 @kernel void MultAdd3D_CPU(const int numElements,
                            @restrict const DofToQuad_t dofToQuad,
-                           @restrict const DofToQuad_t dofToQuadD,
                            @restrict const QuadToDof_t quadToDof,
-                           @restrict const QuadToDof_t quadToDofD,
                            @restrict const QLocal3D_t oper,
                            @restrict const DLocal3D_t solIn,
                            @restrict DLocal3D_t solOut) {
@@ -191,9 +187,7 @@
 
 @kernel void MultAdd2D_GPU(const int numElements,
                            @restrict const DofToQuad_t dofToQuad,
-                           @restrict const DofToQuad_t dofToQuadD,
                            @restrict const QuadToDof_t quadToDof,
-                           @restrict const QuadToDof_t quadToDofD,
                            @restrict const QLocal2D_t oper,
                            @restrict const DLocal2D_t solIn,
                            @restrict DLocal2D_t solOut) {
@@ -282,9 +276,7 @@
 
 @kernel void MultAdd3D_GPU(const int numElements,
                            @restrict const DofToQuad_t dofToQuad,
-                           @restrict const DofToQuad_t dofToQuadD,
                            @restrict const QuadToDof_t quadToDof,
-                           @restrict const QuadToDof_t quadToDofD,
                            @restrict const QLocal3D_t oper,
                            @restrict const DLocal3D_t solIn,
                            @restrict DLocal3D_t solOut) {

--- a/fem/mass.okl
+++ b/fem/mass.okl
@@ -1,0 +1,396 @@
+// Copyright (c) 2010, Lawrence Livermore National Security, LLC. Produced at
+// the Lawrence Livermore National Laboratory. LLNL-CODE-443211. All Rights
+// reserved. See file COPYRIGHT for details.
+//
+// This file is part of the MFEM library. For more information and source code
+// availability see http://mfem.org.
+//
+// MFEM is free software; you can redistribute it and/or modify it under the
+// terms of the GNU Lesser General Public License (as published by the Free
+// Software Foundation) version 2.1 dated February 1999.
+
+#include "occa://fem/defines.okl"
+
+@kernel void MultAdd2D_CPU(const int numElements,
+                           @restrict const DofToQuad_t dofToQuad,
+                           @restrict const DofToQuad_t dofToQuadD,
+                           @restrict const QuadToDof_t quadToDof,
+                           @restrict const QuadToDof_t quadToDofD,
+                           @restrict const QLocal2D_t oper,
+                           @restrict const DLocal2D_t solIn,
+                           @restrict DLocal2D_t solOut) {
+  for (int e = 0; e < numElements; ++e; @outer) {
+    for (int dummy = 0; dummy < 1; ++dummy; @inner) {
+      double sol_xy[Q1D][Q1D];
+
+      for (int qy = 0; qy < Q1D; ++qy) {
+        for (int qx = 0; qx < Q1D; ++qx) {
+          sol_xy[qy][qx] = 0;
+        }
+      }
+
+      for (int dy = 0; dy < D1D; ++dy) {
+        double sol_x[Q1D];
+        for (int qy = 0; qy < Q1D; ++qy) {
+          sol_x[qy] = 0;
+        }
+
+        for (int dx = 0; dx < D1D; ++dx) {
+          const double s = solIn(dx, dy, e);
+          for (int qx = 0; qx < Q1D; ++qx) {
+            sol_x[qx] += dofToQuad(qx, dx) * s;
+          }
+        }
+
+        for (int qy = 0; qy < Q1D; ++qy) {
+          const double d2q = dofToQuad(qy, dy);
+          for (int qx = 0; qx < Q1D; ++qx) {
+            sol_xy[qy][qx] += d2q * sol_x[qx];
+          }
+        }
+      }
+
+      for (int qy = 0; qy < Q1D; ++qy) {
+        for (int qx = 0; qx < Q1D; ++qx) {
+          sol_xy[qy][qx] *= oper(qx, qy, e);
+        }
+      }
+
+      for (int qy = 0; qy < Q1D; ++qy) {
+        double sol_x[D1D];
+        for (int dx = 0; dx < D1D; ++dx) {
+          sol_x[dx] = 0;
+        }
+
+        for (int qx = 0; qx < Q1D; ++qx) {
+          const double s = sol_xy[qy][qx];
+          for (int dx = 0; dx < D1D; ++dx) {
+            sol_x[dx] += quadToDof(dx, qx) * s;
+          }
+        }
+
+        for (int dy = 0; dy < D1D; ++dy) {
+          const double q2d = quadToDof(dy, qy);
+          for (int dx = 0; dx < D1D; ++dx) {
+            solOut(dx, dy, e) += q2d * sol_x[dx];
+          }
+        }
+      }
+    }
+  }
+}
+
+@kernel void MultAdd3D_CPU(const int numElements,
+                           @restrict const DofToQuad_t dofToQuad,
+                           @restrict const DofToQuad_t dofToQuadD,
+                           @restrict const QuadToDof_t quadToDof,
+                           @restrict const QuadToDof_t quadToDofD,
+                           @restrict const QLocal3D_t oper,
+                           @restrict const DLocal3D_t solIn,
+                           @restrict DLocal3D_t solOut) {
+  // Iterate over elements
+  for (int e = 0; e < numElements; ++e; @outer) {
+    for (int dummy = 0; dummy < 1; ++dummy; @inner) {
+      double sol_xyz[Q1D][Q1D][Q1D];
+      for (int qz = 0; qz < Q1D; ++qz) {
+        for (int qy = 0; qy < Q1D; ++qy) {
+          for (int qx = 0; qx < Q1D; ++qx) {
+            sol_xyz[qz][qy][qx] = 0;
+          }
+        }
+      }
+
+      for (int dz = 0; dz < D1D; ++dz) {
+        double sol_xy[Q1D][Q1D];
+        for (int qy = 0; qy < Q1D; ++qy) {
+          for (int qx = 0; qx < Q1D; ++qx) {
+            sol_xy[qy][qx] = 0;
+          }
+        }
+
+        for (int dy = 0; dy < D1D; ++dy) {
+          double sol_x[Q1D];
+          for (int qx = 0; qx < Q1D; ++qx) {
+            sol_x[qx] = 0;
+          }
+
+          for (int dx = 0; dx < D1D; ++dx) {
+            const double s = solIn(dx, dy, dz, e);
+            for (int qx = 0; qx < Q1D; ++qx) {
+              sol_x[qx] += dofToQuad(qx, dx) * s;
+            }
+          }
+
+          for (int qy = 0; qy < Q1D; ++qy) {
+            const double wy = dofToQuad(qy, dy);
+            for (int qx = 0; qx < Q1D; ++qx) {
+              sol_xy[qy][qx] += wy * sol_x[qx];
+            }
+          }
+        }
+
+        for (int qz = 0; qz < Q1D; ++qz) {
+          const double wz = dofToQuad(qz, dz);
+          for (int qy = 0; qy < Q1D; ++qy) {
+            for (int qx = 0; qx < Q1D; ++qx) {
+              sol_xyz[qz][qy][qx] += wz * sol_xy[qy][qx];
+            }
+          }
+        }
+      }
+
+      for (int qz = 0; qz < Q1D; ++qz) {
+        for (int qy = 0; qy < Q1D; ++qy) {
+          for (int qx = 0; qx < Q1D; ++qx) {
+            sol_xyz[qz][qy][qx] *= oper(qx, qy, qz, e);
+          }
+        }
+      }
+
+      for (int qz = 0; qz < Q1D; ++qz) {
+        double sol_xy[D1D][D1D];
+        for (int dy = 0; dy < D1D; ++dy) {
+          for (int dx = 0; dx < D1D; ++dx) {
+            sol_xy[dy][dx] = 0;
+          }
+        }
+
+        for (int qy = 0; qy < Q1D; ++qy) {
+          double sol_x[D1D];
+          for (int dx = 0; dx < D1D; ++dx) {
+            sol_x[dx] = 0;
+          }
+
+          for (int qx = 0; qx < Q1D; ++qx) {
+            const double s = sol_xyz[qz][qy][qx];
+            for (int dx = 0; dx < D1D; ++dx) {
+              sol_x[dx] += quadToDof(dx, qx) * s;
+            }
+          }
+
+          for (int dy = 0; dy < D1D; ++dy) {
+            const double wy = quadToDof(dy, qy);
+            for (int dx = 0; dx < D1D; ++dx) {
+              sol_xy[dy][dx] += wy * sol_x[dx];
+            }
+          }
+        }
+
+        for (int dz = 0; dz < D1D; ++dz) {
+          const double wz = quadToDof(dz, qz);
+          for (int dy = 0; dy < D1D; ++dy) {
+            for (int dx = 0; dx < D1D; ++dx) {
+              solOut(dx, dy, dz, e) += wz * sol_xy[dy][dx];
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+@kernel void MultAdd2D_GPU(const int numElements,
+                           @restrict const DofToQuad_t dofToQuad,
+                           @restrict const DofToQuad_t dofToQuadD,
+                           @restrict const QuadToDof_t quadToDof,
+                           @restrict const QuadToDof_t quadToDofD,
+                           @restrict const QLocal2D_t oper,
+                           @restrict const DLocal2D_t solIn,
+                           @restrict DLocal2D_t solOut) {
+  // Iterate over elements
+  for (int eOff = 0; eOff < numElements; eOff += M2_ELEMENT_BATCH; @outer) {
+    // Store dof <--> quad mappings
+    @shared double s_dofToQuad[NUM_QUAD_DOFS_1D] @dim(Q1D, D1D);
+    @shared double s_quadToDof[NUM_QUAD_DOFS_1D] @dim(D1D, Q1D);
+
+    // Store xy planes in @shared memory
+    @shared double s_xy[NUM_QUAD_DOFS_1D] @dim(D1D, Q1D);
+    @shared double s_xy2[NUM_QUAD_2D] @dim(Q1D, Q1D);
+
+    @exclusive double r_x[NUM_MAX_1D];
+
+    for (int x = 0; x < NUM_MAX_1D; ++x; @inner) {
+      for (int id = x; id < NUM_QUAD_DOFS_1D; id += NUM_MAX_1D) {
+        s_dofToQuad[id]  = dofToQuad[id];
+        s_quadToDof[id]  = quadToDof[id];
+      }
+    }
+
+    for (int e = eOff; e < (eOff + M2_ELEMENT_BATCH); ++e) {
+      if (e < numElements) {
+        for (int dx = 0; dx < NUM_MAX_1D; ++dx; @inner) {
+          if (dx < D1D) {
+            for (int qy = 0; qy < Q1D; ++qy) {
+              s_xy(dx, qy) = 0;
+            }
+            for (int dy = 0; dy < D1D; ++dy) {
+              r_x[dy] = solIn(dx, dy, e);
+            }
+            for (int qy = 0; qy < Q1D; ++qy) {
+              double xy = 0;
+              for (int dy = 0; dy < D1D; ++dy) {
+                xy += r_x[dy] * s_dofToQuad(qy, dy);
+              }
+              s_xy(dx, qy) = xy;
+            }
+          }
+        }
+        for (int qy = 0; qy < NUM_MAX_1D; ++qy; @inner) {
+          if (qy < Q1D) {
+            for (int qx = 0; qx < Q1D; ++qx) {
+              double s = 0;
+              for (int dx = 0; dx < D1D; ++dx) {
+                s += s_xy(dx, qy) * s_dofToQuad(qx, dx);
+              }
+              s_xy2(qx, qy) = s * oper(qx, qy, e);
+            }
+          }
+        }
+
+        for (int qx = 0; qx < NUM_MAX_1D; ++qx; @inner) {
+          if (qx < Q1D) {
+            for (int dy = 0; dy < D1D; ++dy) {
+              s_xy(dy, qx) = 0;
+            }
+            for (int qy = 0; qy < Q1D; ++qy) {
+              r_x[qy] = s_xy2(qx, qy);
+            }
+            for (int dy = 0; dy < D1D; ++dy) {
+              double s = 0;
+              for (int qy = 0; qy < Q1D; ++qy) {
+                s += r_x[qy] * s_quadToDof(dy, qy);
+              }
+              s_xy(dy, qx) = s;
+            }
+          }
+        }
+        for (int dx = 0; dx < NUM_MAX_1D; ++dx; @inner) {
+          if (dx < D1D) {
+            for (int dy = 0; dy < D1D; ++dy) {
+              double s = 0;
+              for (int qx = 0; qx < Q1D; ++qx) {
+                s += (s_xy(dy, qx) * s_quadToDof(dx, qx));
+              }
+              solOut(dx, dy, e) += s;
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+@kernel void MultAdd3D_GPU(const int numElements,
+                           @restrict const DofToQuad_t dofToQuad,
+                           @restrict const DofToQuad_t dofToQuadD,
+                           @restrict const QuadToDof_t quadToDof,
+                           @restrict const QuadToDof_t quadToDofD,
+                           @restrict const QLocal3D_t oper,
+                           @restrict const DLocal3D_t solIn,
+                           @restrict DLocal3D_t solOut) {
+  // Iterate over elements
+  for (int e = 0; e < numElements; ++e; @outer) {
+    // Store dof <--> quad mappings
+    @shared double s_dofToQuad[NUM_QUAD_DOFS_1D] @dim(Q1D, D1D);
+    @shared double s_quadToDof[NUM_QUAD_DOFS_1D] @dim(D1D, Q1D);
+
+    // Store xy planes in @shared memory
+    @shared double s_xy[NUM_MAX_2D] @dim(NUM_MAX_1D, NUM_MAX_1D);
+
+    // Store z axis as registers
+    @exclusive double r_z[Q1D];
+    @exclusive double r_z2[D1D];
+
+    for (int y = 0; y < NUM_MAX_1D; ++y; @inner) {
+      for (int x = 0; x < NUM_MAX_1D; ++x; @inner) {
+        const int id = (y * NUM_MAX_1D) + x;
+        // Fetch Q <--> D maps
+        if (id < NUM_QUAD_DOFS_1D) {
+          s_dofToQuad[id]  = dofToQuad[id];
+          s_quadToDof[id]  = quadToDof[id];
+        }
+        // Initialize our Z axis
+        for (int qz = 0; qz < Q1D; ++qz) {
+          r_z[qz] = 0;
+        }
+        for (int dz = 0; dz < D1D; ++dz) {
+          r_z2[dz] = 0;
+        }
+      }
+    }
+
+    for (int dy = 0; dy < NUM_MAX_1D; ++dy; @inner) {
+      for (int dx = 0; dx < NUM_MAX_1D; ++dx; @inner) {
+        if ((dx < D1D) && (dy < D1D)) {
+          for (int dz = 0; dz < D1D; ++dz) {
+            const double s = solIn(dx, dy, dz, e);
+            // Calculate D -> Q in the Z axis
+            for (int qz = 0; qz < Q1D; ++qz) {
+              r_z[qz] += s * s_dofToQuad(qz, dz);
+            }
+          }
+        }
+      }
+    }
+    // For each xy plane
+    for (int qz = 0; qz < Q1D; ++qz) {
+      // Fill xy plane at given z position
+      for (int dy = 0; dy < NUM_MAX_1D; ++dy; @inner) {
+        for (int dx = 0; dx < NUM_MAX_1D; ++dx; @inner) {
+          if ((dx < D1D) && (dy < D1D)) {
+            s_xy(dx, dy) = r_z[qz];
+          }
+        }
+      }
+      // Calculate Dxyz, xDyz, xyDz in plane
+      for (int qy = 0; qy < NUM_MAX_1D; ++qy; @inner) {
+        for (int qx = 0; qx < NUM_MAX_1D; ++qx; @inner) {
+          if ((qx < Q1D) && (qy < Q1D)) {
+            double s = 0;
+            for (int dy = 0; dy < D1D; ++dy) {
+              const double wy = s_dofToQuad(qy, dy);
+              for (int dx = 0; dx < D1D; ++dx) {
+                const double wx = s_dofToQuad(qx, dx);
+                s += wx * wy * s_xy(dx, dy);
+              }
+            }
+
+            s *= oper(qx, qy, qz, e);
+
+            for (int dz = 0; dz < D1D; ++dz) {
+              const double wz  = s_quadToDof(dz, qz);
+              r_z2[dz] += wz * s;
+            }
+          }
+        }
+      }
+    }
+    // Iterate over xy planes to compute solution
+    for (int dz = 0; dz < D1D; ++dz) {
+      // Place xy plane in @shared memory
+      for (int qy = 0; qy < NUM_MAX_1D; ++qy; @inner) {
+        for (int qx = 0; qx < NUM_MAX_1D; ++qx; @inner) {
+          if ((qx < Q1D) && (qy < Q1D)) {
+            s_xy(qx, qy) = r_z2[dz];
+          }
+        }
+      }
+      // Finalize solution in xy plane
+      for (int dy = 0; dy < NUM_MAX_1D; ++dy; @inner) {
+        for (int dx = 0; dx < NUM_MAX_1D; ++dx; @inner) {
+          if ((dx < D1D) && (dy < D1D)) {
+            double solZ = 0;
+            for (int qy = 0; qy < Q1D; ++qy) {
+              const double wy = s_quadToDof(dy, qy);
+              for (int qx = 0; qx < Q1D; ++qx) {
+                const double wx = s_quadToDof(dx, qx);
+                solZ += wx * wy * s_xy(qx, qy);
+              }
+            }
+            solOut(dx, dy, dz, e) += solZ;
+          }
+        }
+      }
+    }
+  }
+}

--- a/general/device.cpp
+++ b/general/device.cpp
@@ -11,9 +11,6 @@
 
 #include "okina.hpp"
 
-#include <string.h>
-#define __FILENAME__ (strrchr(__FILE__, '/') ? strrchr(__FILE__, '/') + 1 : __FILE__)
-
 namespace mfem
 {
 

--- a/general/mm.cpp
+++ b/general/mm.cpp
@@ -279,7 +279,7 @@ static OccaMemory occaMemory(mm::ledger &maps, const void *ptr)
    const size_t bytes = base.bytes;
    const bool gpu = Device::UsingDevice();
    if (host && !gpu) { return OccaWrapMemory(occaDevice, ptr, bytes); }
-   if (!gpu) { mfem_error("occaMemor: !gpu"); }
+   if (!gpu) { mfem_error("occaMemory: !gpu"); }
    if (!base.d_ptr)
    {
       CuMemAlloc(&base.d_ptr, bytes);
@@ -287,7 +287,6 @@ static OccaMemory occaMemory(mm::ledger &maps, const void *ptr)
       base.host = false;
    }
    return OccaWrapMemory(occaDevice, base.d_ptr, bytes);
-   
 }
 
 OccaMemory mm::Memory(const void *ptr) { return occaMemory(maps, ptr); }

--- a/general/occa.hpp
+++ b/general/occa.hpp
@@ -32,9 +32,8 @@ typedef occa::memory OccaMemory;
    static occa::kernel ker = NULL;                                      \
    if (ker==NULL) {                                                     \
       OccaDevice device = Device::GetOccaDevice();                      \
-      const std::string fdk = "occa://" #library "/" #filename;         \
-      const std::string odk = occa::io::occaFileOpener().expand(fdk);   \
-      ker = device.buildKernel(odk, #ker, props);                       \
+      ker = device.buildKernel("occa://" #library "/" #filename,        \
+                               #ker, props);                            \
    }
 
 #else // MFEM_USE_OCCA
@@ -49,7 +48,7 @@ namespace mfem
 
 OccaDevice OccaWrapDevice(CUdevice device, CUcontext context);
 OccaMemory OccaDeviceMalloc(OccaDevice device, const size_t bytes);
-OccaMemory OccaWrapMemory(const OccaDevice device, void *d_adrs,
+OccaMemory OccaWrapMemory(const OccaDevice device, const void *d_adrs,
                           const size_t bytes);
 void *OccaMemoryPtr(OccaMemory o_mem);
 void OccaCopyFrom(OccaMemory o_mem, const void *h_adrs);


### PR DESCRIPTION
Adds OCCA mass kernels
Allow OCCA with all modes: CUDA, OpenMP, Serial in a `pcuda` build with OCCA, RAJA and OpenMP
Adds missing kernels for orders up to 4 for ex1