### PR TITLE
[okina]  Enable atomics to be usable on host when MFEM_USE_CUDA is defined [bugfix/artv3/okina-atomic]

### DIFF
--- a/general/cuda.hpp
+++ b/general/cuda.hpp
@@ -47,17 +47,21 @@ static __device__ double atomicAdd(double* address, double val)
    return __longlong_as_double(old);
 }
 #endif // __CUDA_ARCH__ < 600
-template<typename T> MFEM_HOST_DEVICE
-inline T AtomicAdd(T* address, T val)
-{
-   return atomicAdd(address, val);
-}
 #else // MFEM_USE_CUDA
 #define MFEM_DEVICE
 #define MFEM_HOST_DEVICE
 typedef int CUdevice;
 typedef int CUcontext;
 typedef void* CUstream;
+#endif // MFEM_USE_CUDA
+
+#ifdef __CUDA_ARCH__
+template<typename T> MFEM_DEVICE
+inline T AtomicAdd(T* address, T val)
+{
+   return atomicAdd(address, val);
+}
+#else
 template<typename T> inline T AtomicAdd(T* address, T val)
 {
 #if defined(_OPENMP)
@@ -66,7 +70,7 @@ template<typename T> inline T AtomicAdd(T* address, T val)
    *address += val;
    return *address;
 }
-#endif // MFEM_USE_CUDA
+#endif
 
 /// Allocates device memory
 void* CuMemAlloc(void **d_ptr, size_t bytes);

--- a/general/cuda.hpp
+++ b/general/cuda.hpp
@@ -55,13 +55,13 @@ typedef int CUcontext;
 typedef void* CUstream;
 #endif // MFEM_USE_CUDA
 
-#ifdef __CUDA_ARCH__
+#ifdef __NVCC__
 template<typename T> MFEM_DEVICE
 inline T AtomicAdd(T* address, T val)
 {
    return atomicAdd(address, val);
 }
-#else
+#else // __NVCC__
 template<typename T> inline T AtomicAdd(T* address, T val)
 {
 #if defined(_OPENMP)
@@ -70,7 +70,7 @@ template<typename T> inline T AtomicAdd(T* address, T val)
    *address += val;
    return *address;
 }
-#endif
+#endif // __NVCC__
 
 /// Allocates device memory
 void* CuMemAlloc(void **d_ptr, size_t bytes);

--- a/general/cuda.hpp
+++ b/general/cuda.hpp
@@ -57,12 +57,12 @@ typedef void* CUstream;
 
 #ifdef __CUDA_ARCH__
 template<typename T> MFEM_DEVICE
-inline T AtomicAdd(T* address, T val)
+inline T AtomicAdd(T volatile *address, T val)
 {
-   return atomicAdd(address, val);
+  return atomicAdd((T *)address, val);
 }
 #else // __CUDA_ARCH__
-template<typename T> inline T AtomicAdd(T* address, T val)
+template<typename T> inline T AtomicAdd(T volatile *address, T val)
 {
 #if defined(_OPENMP)
    #pragma omp atomic

--- a/general/cuda.hpp
+++ b/general/cuda.hpp
@@ -55,13 +55,13 @@ typedef int CUcontext;
 typedef void* CUstream;
 #endif // MFEM_USE_CUDA
 
-#ifdef __NVCC__
+#ifdef __CUDA_ARCH__
 template<typename T> MFEM_DEVICE
 inline T AtomicAdd(T* address, T val)
 {
    return atomicAdd(address, val);
 }
-#else // __NVCC__
+#else // __CUDA_ARCH__
 template<typename T> inline T AtomicAdd(T* address, T val)
 {
 #if defined(_OPENMP)
@@ -70,7 +70,7 @@ template<typename T> inline T AtomicAdd(T* address, T val)
    *address += val;
    return *address;
 }
-#endif // __NVCC__
+#endif // __CUDA_ARCH__
 
 /// Allocates device memory
 void* CuMemAlloc(void **d_ptr, size_t bytes);

--- a/general/occa.cpp
+++ b/general/occa.cpp
@@ -35,8 +35,8 @@ OccaMemory OccaDeviceMalloc(OccaDevice device, const size_t bytes)
 OccaMemory OccaWrapMemory(const OccaDevice device, const void *d_adrs,
                           const size_t bytes)
 {
-   void *adrs = const_cast<void*>(d_adrs);
 #if defined(MFEM_USE_OCCA) && defined(MFEM_USE_CUDA)
+   void *adrs = const_cast<void*>(d_adrs);
    // OCCA & UsingCuda => occa::cuda
    if (Device::UsingCuda())
    {
@@ -46,7 +46,7 @@ OccaMemory OccaWrapMemory(const OccaDevice device, const void *d_adrs,
    return occa::cpu::wrapMemory(device, adrs, bytes);
 #else // MFEM_USE_OCCA && MFEM_USE_CUDA
 #if defined(MFEM_USE_OCCA)
-   return occa::cpu::wrapMemory(device, adrs, bytes);
+   return occa::cpu::wrapMemory(device, const_cast<void*>(d_adrs), bytes);
 #else
    return (void*)NULL;
 #endif

--- a/linalg/sparsemat.cpp
+++ b/linalg/sparsemat.cpp
@@ -663,7 +663,6 @@ void SparseMatrix::AddMultTranspose(const Vector &x, Vector &y,
    const DeviceVector d_A(A);
    const DeviceVector d_x(x, x.Size());
    DeviceVector d_y(y, y.Size());
-   const bool device = Device::UsingDevice();
    MFEM_FORALL(i, d_height,
    {
       const double xi = a * d_x[i];
@@ -671,14 +670,7 @@ void SparseMatrix::AddMultTranspose(const Vector &x, Vector &y,
       for (int j = d_I[i]; j < end; j++)
       {
          const int Jj = d_J[j];
-         if (device)
-         {
-            AtomicAdd(&d_y[Jj], d_A[j] * xi);
-         }
-         else
-         {
-            d_y[Jj] += d_A[j] * xi;
-         }
+         AtomicAdd(&d_y[Jj], d_A[j] * xi);
       }
    });
 }


### PR DESCRIPTION
This PR enables users to use atomics on the host when MFEM_USE_CUDA is defined. 
With the existing implementation the cuda atomics would always be used when MFEM_USE_CUDA is defined.  