### PR TITLE
Okina fallback kernels [okina-fallback-kernels]

### DIFF
--- a/examples/ex1.cpp
+++ b/examples/ex1.cpp
@@ -166,8 +166,7 @@ int main(int argc, char *argv[])
    //    domain integrator.
    AssemblyLevel assembly = (pa) ? AssemblyLevel::PARTIAL : AssemblyLevel::FULL;
    BilinearForm *a = new BilinearForm(fespace, assembly);
-   //a->AddDomainIntegrator(new DiffusionIntegrator(one));
-   a->AddDomainIntegrator(new MassIntegrator(one));
+   a->AddDomainIntegrator(new DiffusionIntegrator(one));
 
    // 10. Assemble the bilinear form and the corresponding linear system,
    //     applying any necessary transformations such as: eliminating boundary

--- a/examples/ex1.cpp
+++ b/examples/ex1.cpp
@@ -166,7 +166,8 @@ int main(int argc, char *argv[])
    //    domain integrator.
    AssemblyLevel assembly = (pa) ? AssemblyLevel::PARTIAL : AssemblyLevel::FULL;
    BilinearForm *a = new BilinearForm(fespace, assembly);
-   a->AddDomainIntegrator(new DiffusionIntegrator(one));
+   //a->AddDomainIntegrator(new DiffusionIntegrator(one));
+   a->AddDomainIntegrator(new MassIntegrator(one));
 
    // 10. Assemble the bilinear form and the corresponding linear system,
    //     applying any necessary transformations such as: eliminating boundary

--- a/fem/bilininteg_ext.cpp
+++ b/fem/bilininteg_ext.cpp
@@ -51,13 +51,13 @@ static const IntegrationRule &DefaultGetRule(const FiniteElement &trial_fe,
 
 // OCCA 2D Assemble kernel
 #ifdef MFEM_USE_OCCA
-static void OccaPADiffusionAssemble2D(const int D1D,
-                                      const int Q1D,
-                                      const int NE,
-                                      const double *W,
-                                      const double *J,
-                                      const double COEFF,
-                                      double *op)
+static void OccaPADiffusionSetup2D(const int D1D,
+                                   const int Q1D,
+                                   const int NE,
+                                   const double *W,
+                                   const double *J,
+                                   const double COEFF,
+                                   double *op)
 {
    occa::properties props;
    props["defines/D1D"] = D1D;
@@ -77,13 +77,13 @@ static void OccaPADiffusionAssemble2D(const int D1D,
    OccaDiffSetup2D_ker.at(id)(NE, o_W, o_J, COEFF, o_op);
 }
 
-static void OccaPADiffusionAssemble3D(const int D1D,
-                                      const int Q1D,
-                                      const int NE,
-                                      const double *W,
-                                      const double *J,
-                                      const double COEFF,
-                                      double *op)
+static void OccaPADiffusionSetup3D(const int D1D,
+                                   const int Q1D,
+                                   const int NE,
+                                   const double *W,
+                                   const double *J,
+                                   const double COEFF,
+                                   double *op)
 {
    occa::properties props;
    props["defines/D1D"] = D1D;
@@ -105,12 +105,12 @@ static void OccaPADiffusionAssemble3D(const int D1D,
 #endif // MFEM_USE_OCCA
 
 // PA Diffusion Assemble 2D kernel
-static void PADiffusionAssemble2D(const int Q1D,
-                                  const int NE,
-                                  const double* w,
-                                  const double* j,
-                                  const double COEFF,
-                                  double* op)
+static void PADiffusionSetup2D(const int Q1D,
+                               const int NE,
+                               const double* w,
+                               const double* j,
+                               const double COEFF,
+                               double* op)
 {
    const int NQ = Q1D*Q1D;
    const DeviceVector W(w, NQ);
@@ -133,12 +133,12 @@ static void PADiffusionAssemble2D(const int Q1D,
 }
 
 // PA Diffusion Assemble 3D kernel
-static void PADiffusionAssemble3D(const int Q1D,
-                                  const int NE,
-                                  const double* w,
-                                  const double* j,
-                                  const double COEFF,
-                                  double* op)
+static void PADiffusionSetup3D(const int Q1D,
+                               const int NE,
+                               const double* w,
+                               const double* j,
+                               const double COEFF,
+                               double* op)
 {
    const int NQ = Q1D*Q1D*Q1D;
    const DeviceVector W(w, NQ);
@@ -201,37 +201,37 @@ static bool DeviceUseOcca()
 
 }
 
-static void PADiffusionAssemble(const int dim,
-                                const int D1D,
-                                const int Q1D,
-                                const int NE,
-                                const double* W,
-                                const double* J,
-                                const double COEFF,
-                                double* op)
+static void PADiffusionSetup(const int dim,
+                             const int D1D,
+                             const int Q1D,
+                             const int NE,
+                             const double* W,
+                             const double* J,
+                             const double COEFF,
+                             double* op)
 {
-   if (dim == 1) { MFEM_ABORT("dim==1 not supported in PADiffusionAssemble"); }
+   if (dim == 1) { MFEM_ABORT("dim==1 not supported in PADiffusionSetup"); }
    if (dim == 2)
    {
 #ifdef MFEM_USE_OCCA
       if (internal::DeviceUseOcca())
       {
-         OccaPADiffusionAssemble2D(D1D, Q1D, NE, W, J, COEFF, op);
+         OccaPADiffusionSetup2D(D1D, Q1D, NE, W, J, COEFF, op);
          return;
       }
 #endif // MFEM_USE_OCCA
-      PADiffusionAssemble2D(Q1D, NE, W, J, COEFF, op);
+      PADiffusionSetup2D(Q1D, NE, W, J, COEFF, op);
    }
    if (dim == 3)
    {
 #ifdef MFEM_USE_OCCA
       if (internal::DeviceUseOcca())
       {
-         OccaPADiffusionAssemble3D(D1D, Q1D, NE, W, J, COEFF, op);
+         OccaPADiffusionSetup3D(D1D, Q1D, NE, W, J, COEFF, op);
          return;
       }
 #endif // MFEM_USE_OCCA
-      PADiffusionAssemble3D(Q1D, NE, W, J, COEFF, op);
+      PADiffusionSetup3D(Q1D, NE, W, J, COEFF, op);
    }
 }
 
@@ -252,21 +252,21 @@ void DiffusionIntegrator::Assemble(const FiniteElementSpace &fes)
    maps = DofToQuad::Get(fes, fes, *ir);
    vec.SetSize(symmDims * nq * ne);
    const double coeff = static_cast<ConstantCoefficient*>(Q)->constant;
-   PADiffusionAssemble(dim, dofs1D, quad1D, ne, maps->W, geom->J, coeff, vec);
+   PADiffusionSetup(dim, dofs1D, quad1D, ne, maps->W, geom->J, coeff, vec);
 }
 
 #ifdef MFEM_USE_OCCA
-// OCCA PA Diffusion MultAdd 2D kernel
-static void OccaPADiffusionMultAdd2D(const int D1D,
-                                     const int Q1D,
-                                     const int NE,
-                                     const double* B,
-                                     const double* G,
-                                     const double* Bt,
-                                     const double* Gt,
-                                     const double* op,
-                                     const double* x,
-                                     double* y)
+// OCCA PA Diffusion Apply 2D kernel
+static void OccaPADiffusionApply2D(const int D1D,
+                                   const int Q1D,
+                                   const int NE,
+                                   const double* B,
+                                   const double* G,
+                                   const double* Bt,
+                                   const double* Gt,
+                                   const double* op,
+                                   const double* x,
+                                   double* y)
 {
    occa::properties props;
    props["defines/D1D"] = D1D;
@@ -305,17 +305,17 @@ static void OccaPADiffusionMultAdd2D(const int D1D,
    }
 }
 
-// OCCA PA Diffusion MultAdd 3D kernel
-static void OccaPADiffusionMultAdd3D(const int D1D,
-                                     const int Q1D,
-                                     const int NE,
-                                     const double* B,
-                                     const double* G,
-                                     const double* Bt,
-                                     const double* Gt,
-                                     const double* op,
-                                     const double* x,
-                                     double* y)
+// OCCA PA Diffusion Apply 3D kernel
+static void OccaPADiffusionApply3D(const int D1D,
+                                   const int Q1D,
+                                   const int NE,
+                                   const double* B,
+                                   const double* G,
+                                   const double* Bt,
+                                   const double* Gt,
+                                   const double* op,
+                                   const double* x,
+                                   double* y)
 {
    occa::properties props;
    props["defines/D1D"] = D1D;
@@ -362,21 +362,23 @@ static void OccaPADiffusionMultAdd3D(const int D1D,
 const int MAX_Q1D = 10;
 const int MAX_D1D = 10;
 
-// PA Diffusion MultAdd 2D kernel
+// PA Diffusion Apply 2D kernel
 template<int T_D1D = 0, int T_Q1D = 0> static
-void PADiffusionMultAssembled2D(const int NE,
-                                const double* b,
-                                const double* g,
-                                const double* bt,
-                                const double* gt,
-                                const double* _op,
-                                const double* _x,
-                                double* _y,
-                                const int d1d = 0,
-                                const int q1d = 0)
+void PADiffusionApply2D(const int NE,
+                        const double* b,
+                        const double* g,
+                        const double* bt,
+                        const double* gt,
+                        const double* _op,
+                        const double* _x,
+                        double* _y,
+                        const int d1d = 0,
+                        const int q1d = 0)
 {
    const int D1D = T_D1D ? T_D1D : d1d;
    const int Q1D = T_Q1D ? T_Q1D : q1d;
+   MFEM_VERIFY(D1D <= MAX_D1D, "");
+   MFEM_VERIFY(Q1D <= MAX_Q1D, "");
    const int NQ = Q1D*Q1D;
 
    const DeviceMatrix B(b,Q1D,D1D);
@@ -386,10 +388,6 @@ void PADiffusionMultAssembled2D(const int NE,
    const DeviceTensor<3> op(_op,3,NQ,NE);
    const DeviceTensor<3> x(_x,D1D,D1D,NE);
    DeviceTensor<3> y(_y,D1D,D1D,NE);
-
-   MFEM_ASSERT(D1D <= MAX_D1D, "");
-   MFEM_ASSERT(Q1D <= MAX_Q1D, "");
-
    MFEM_FORALL(e, NE,
    {
       double grad[MAX_Q1D][MAX_Q1D][2];
@@ -480,20 +478,22 @@ void PADiffusionMultAssembled2D(const int NE,
    });
 }
 
-// PA Diffusion MultAdd 3D kernel
+// PA Diffusion Apply 3D kernel
 template<int T_D1D = 0, int T_Q1D = 0> static
-void PADiffusionMultAssembled3D(const int NE,
-                                const double* b,
-                                const double* g,
-                                const double* bt,
-                                const double* gt,
-                                const double* _op,
-                                const double* _x,
-                                double* _y,
-                                int d1d = 0, int q1d = 0)
+void PADiffusionApply3D(const int NE,
+                        const double* b,
+                        const double* g,
+                        const double* bt,
+                        const double* gt,
+                        const double* _op,
+                        const double* _x,
+                        double* _y,
+                        int d1d = 0, int q1d = 0)
 {
    const int D1D = T_D1D ? T_D1D : d1d;
    const int Q1D = T_Q1D ? T_Q1D : q1d;
+   MFEM_VERIFY(D1D <= MAX_D1D, "");
+   MFEM_VERIFY(Q1D <= MAX_Q1D, "");
    const int NQ = Q1D*Q1D*Q1D;
 
    const DeviceMatrix B(b,Q1D,D1D);
@@ -503,9 +503,6 @@ void PADiffusionMultAssembled3D(const int NE,
    const DeviceTensor<3> op(_op,6,NQ,NE);
    const DeviceTensor<4> x(_x,D1D,D1D,D1D,NE);
    DeviceTensor<4> y(_y,D1D,D1D,D1D,NE);
-
-   MFEM_ASSERT(D1D <= MAX_D1D, "");
-   MFEM_ASSERT(Q1D <= MAX_Q1D, "");
 
    MFEM_FORALL(e, NE,
    {
@@ -669,32 +666,32 @@ void PADiffusionMultAssembled3D(const int NE,
    });
 }
 
-static void PADiffusionMultAssembled(const int dim,
-                                     const int D1D,
-                                     const int Q1D,
-                                     const int NE,
-                                     const double* B,
-                                     const double* G,
-                                     const double* Bt,
-                                     const double* Gt,
-                                     const double* op,
-                                     const double* x,
-                                     double* y)
+static void PADiffusionApply(const int dim,
+                             const int D1D,
+                             const int Q1D,
+                             const int NE,
+                             const double* B,
+                             const double* G,
+                             const double* Bt,
+                             const double* Gt,
+                             const double* op,
+                             const double* x,
+                             double* y)
 {
 #ifdef MFEM_USE_OCCA
    if (internal::DeviceUseOcca())
    {
       if (dim == 2)
       {
-         OccaPADiffusionMultAdd2D(D1D, Q1D, NE, B, G, Bt, Gt, op, x, y);
+         OccaPADiffusionApply2D(D1D, Q1D, NE, B, G, Bt, Gt, op, x, y);
          return;
       }
       if (dim == 3)
       {
-         OccaPADiffusionMultAdd3D(D1D, Q1D, NE, B, G, Bt, Gt, op, x, y);
+         OccaPADiffusionApply3D(D1D, Q1D, NE, B, G, Bt, Gt, op, x, y);
          return;
       }
-      MFEM_ABORT("OCCA PADiffusionMultAssembled unknown kernel!");
+      MFEM_ABORT("OCCA PADiffusionApply unknown kernel!");
    }
 #endif // MFEM_USE_OCCA
 
@@ -702,16 +699,11 @@ static void PADiffusionMultAssembled(const int dim,
    {
       switch ((D1D << 4) | Q1D)
       {
-         case 0x22:
-            PADiffusionMultAssembled2D<2,2>(NE, B, G, Bt, Gt, op, x, y); break;
-         case 0x33:
-            PADiffusionMultAssembled2D<3,3>(NE, B, G, Bt, Gt, op, x, y); break;
-         case 0x44:
-            PADiffusionMultAssembled2D<4,4>(NE, B, G, Bt, Gt, op, x, y); break;
-         case 0x55:
-            PADiffusionMultAssembled2D<5,5>(NE, B, G, Bt, Gt, op, x, y); break;
-         default:
-            PADiffusionMultAssembled2D(NE, B, G, Bt, Gt, op, x, y, D1D, Q1D);
+         case 0x22: PADiffusionApply2D<2,2>(NE, B, G, Bt, Gt, op, x, y); break;
+         case 0x33: PADiffusionApply2D<3,3>(NE, B, G, Bt, Gt, op, x, y); break;
+         case 0x44: PADiffusionApply2D<4,4>(NE, B, G, Bt, Gt, op, x, y); break;
+         case 0x55: PADiffusionApply2D<5,5>(NE, B, G, Bt, Gt, op, x, y); break;
+         default: PADiffusionApply2D(NE, B, G, Bt, Gt, op, x, y, D1D, Q1D);
       }
       return;
    }
@@ -719,28 +711,23 @@ static void PADiffusionMultAssembled(const int dim,
    {
       switch ((D1D << 4) | Q1D)
       {
-         case 0x23:
-            PADiffusionMultAssembled3D<2,3>(NE, B, G, Bt, Gt, op, x, y); break;
-         case 0x34:
-            PADiffusionMultAssembled3D<3,4>(NE, B, G, Bt, Gt, op, x, y); break;
-         case 0x45:
-            PADiffusionMultAssembled3D<4,5>(NE, B, G, Bt, Gt, op, x, y); break;
-         case 0x56:
-            PADiffusionMultAssembled3D<5,6>(NE, B, G, Bt, Gt, op, x, y); break;
-         default:
-            PADiffusionMultAssembled3D(NE, B, G, Bt, Gt, op, x, y, D1D, Q1D);
+         case 0x23: PADiffusionApply3D<2,3>(NE, B, G, Bt, Gt, op, x, y); break;
+         case 0x34: PADiffusionApply3D<3,4>(NE, B, G, Bt, Gt, op, x, y); break;
+         case 0x45: PADiffusionApply3D<4,5>(NE, B, G, Bt, Gt, op, x, y); break;
+         case 0x56: PADiffusionApply3D<5,6>(NE, B, G, Bt, Gt, op, x, y); break;
+         default: PADiffusionApply3D(NE, B, G, Bt, Gt, op, x, y, D1D, Q1D);
       }
       return;
    }
    MFEM_ABORT("Unknown kernel.");
 }
 
-// PA Diffusion MultAdd kernel
+// PA Diffusion Apply kernel
 void DiffusionIntegrator::MultAssembled(Vector &x, Vector &y)
 {
-   PADiffusionMultAssembled(dim, dofs1D, quad1D, ne,
-                            maps->B, maps->G, maps->Bt, maps->Gt,
-                            vec, x, y);
+   PADiffusionApply(dim, dofs1D, quad1D, ne,
+                    maps->B, maps->G, maps->Bt, maps->Gt,
+                    vec, x, y);
 }
 
 DiffusionIntegrator::~DiffusionIntegrator()
@@ -852,15 +839,15 @@ void MassIntegrator::Assemble(const FiniteElementSpace &fes)
 }
 
 #ifdef MFEM_USE_OCCA
-// OCCA PA Mass MultAdd 2D kernel
-static void OccaPAMassMultAdd2D(const int D1D,
-                                const int Q1D,
-                                const int NE,
-                                const double* B,
-                                const double* Bt,
-                                const double* op,
-                                const double* x,
-                                double* y)
+// OCCA PA Mass Apply 2D kernel
+static void OccaPAMassApply2D(const int D1D,
+                              const int Q1D,
+                              const int NE,
+                              const double* B,
+                              const double* Bt,
+                              const double* op,
+                              const double* x,
+                              double* y)
 {
    occa::properties props;
    props["defines/D1D"] = D1D;
@@ -897,15 +884,15 @@ static void OccaPAMassMultAdd2D(const int D1D,
    }
 }
 
-// OCCA PA Mass MultAdd 3D kernel
-static void OccaPAMassMultAdd3D(const int D1D,
-                                const int Q1D,
-                                const int NE,
-                                const double* B,
-                                const double* Bt,
-                                const double* op,
-                                const double* x,
-                                double* y)
+// OCCA PA Mass Apply 3D kernel
+static void OccaPAMassApply3D(const int D1D,
+                              const int Q1D,
+                              const int NE,
+                              const double* B,
+                              const double* Bt,
+                              const double* op,
+                              const double* x,
+                              double* y)
 {
    occa::properties props;
    props["defines/D1D"] = D1D;
@@ -943,23 +930,29 @@ static void OccaPAMassMultAdd3D(const int D1D,
 }
 #endif // MFEM_USE_OCCA
 
-template<const int D1D,
-         const int Q1D> static
-void PAMassMultAdd2D(const int NE,
-                     const double* _B,
-                     const double* _Bt,
-                     const double* _op,
-                     const double* _x,
-                     double* _y)
+template<const int T_D1D = 0, const int T_Q1D = 0> static
+void PAMassApply2D(const int NE,
+                   const double* _B,
+                   const double* _Bt,
+                   const double* _op,
+                   const double* _x,
+                   double* _y,
+                   const int d1d = 0,
+                   const int q1d = 0)
 {
+   const int D1D = T_D1D ? T_D1D : d1d;
+   const int Q1D = T_Q1D ? T_Q1D : q1d;
+   MFEM_VERIFY(D1D <= MAX_D1D, "");
+   MFEM_VERIFY(Q1D <= MAX_Q1D, "");
+
    const DeviceMatrix B(_B, Q1D,D1D);
    const DeviceMatrix Bt(_Bt, D1D,Q1D);
    const DeviceTensor<3> op(_op, Q1D,Q1D,NE);
    const DeviceTensor<3> x(_x, D1D,D1D,NE);
    DeviceTensor<3> y(_y, D1D,D1D,NE);
-   MFEM_FORALL(e,NE,
+   MFEM_FORALL(e, NE,
    {
-      double sol_xy[Q1D][Q1D];
+      double sol_xy[MAX_Q1D][MAX_Q1D];
       for (int qy = 0; qy < Q1D; ++qy)
       {
          for (int qx = 0; qx < Q1D; ++qx)
@@ -969,7 +962,7 @@ void PAMassMultAdd2D(const int NE,
       }
       for (int dy = 0; dy < D1D; ++dy)
       {
-         double sol_x[Q1D];
+         double sol_x[MAX_Q1D];
          for (int qy = 0; qy < Q1D; ++qy)
          {
             sol_x[qy] = 0.0;
@@ -1000,7 +993,7 @@ void PAMassMultAdd2D(const int NE,
       }
       for (int qy = 0; qy < Q1D; ++qy)
       {
-         double sol_x[D1D];
+         double sol_x[MAX_D1D];
          for (int dx = 0; dx < D1D; ++dx)
          {
             sol_x[dx] = 0.0;
@@ -1025,24 +1018,30 @@ void PAMassMultAdd2D(const int NE,
    });
 }
 
-template<const int D1D,
-         const int Q1D> static
-void PAMassMultAdd3D(const int NE,
-                     const double* _B,
-                     const double* _Bt,
-                     const double* _op,
-                     const double* _x,
-                     double* _y)
+template<const int T_D1D = 0, const int T_Q1D = 0> static
+void PAMassApply3D(const int NE,
+                   const double* _B,
+                   const double* _Bt,
+                   const double* _op,
+                   const double* _x,
+                   double* _y,
+                   const int d1d = 0,
+                   const int q1d = 0)
 {
+   const int D1D = T_D1D ? T_D1D : d1d;
+   const int Q1D = T_Q1D ? T_Q1D : q1d;
+   MFEM_VERIFY(D1D <= MAX_D1D, "");
+   MFEM_VERIFY(Q1D <= MAX_Q1D, "");
+
    const DeviceMatrix B(_B, Q1D,D1D);
    const DeviceMatrix Bt(_Bt, D1D,Q1D);
    const DeviceTensor<4> op(_op, Q1D,Q1D,Q1D,NE);
    const DeviceTensor<4> x(_x, D1D,D1D,D1D,NE);
    DeviceTensor<4> y(_y, D1D,D1D,D1D,NE);
 
-   MFEM_FORALL(e,NE,
+   MFEM_FORALL(e, NE,
    {
-      double sol_xyz[Q1D][Q1D][Q1D];
+      double sol_xyz[MAX_Q1D][MAX_Q1D][MAX_Q1D];
       for (int qz = 0; qz < Q1D; ++qz)
       {
          for (int qy = 0; qy < Q1D; ++qy)
@@ -1055,7 +1054,7 @@ void PAMassMultAdd3D(const int NE,
       }
       for (int dz = 0; dz < D1D; ++dz)
       {
-         double sol_xy[Q1D][Q1D];
+         double sol_xy[MAX_Q1D][MAX_Q1D];
          for (int qy = 0; qy < Q1D; ++qy)
          {
             for (int qx = 0; qx < Q1D; ++qx)
@@ -1065,7 +1064,7 @@ void PAMassMultAdd3D(const int NE,
          }
          for (int dy = 0; dy < D1D; ++dy)
          {
-            double sol_x[Q1D];
+            double sol_x[MAX_Q1D];
             for (int qx = 0; qx < Q1D; ++qx)
             {
                sol_x[qx] = 0;
@@ -1111,7 +1110,7 @@ void PAMassMultAdd3D(const int NE,
       }
       for (int qz = 0; qz < Q1D; ++qz)
       {
-         double sol_xy[D1D][D1D];
+         double sol_xy[MAX_D1D][MAX_D1D];
          for (int dy = 0; dy < D1D; ++dy)
          {
             for (int dx = 0; dx < D1D; ++dx)
@@ -1121,7 +1120,7 @@ void PAMassMultAdd3D(const int NE,
          }
          for (int qy = 0; qy < Q1D; ++qy)
          {
-            double sol_x[D1D];
+            double sol_x[MAX_D1D];
             for (int dx = 0; dx < D1D; ++dx)
             {
                sol_x[dx] = 0;
@@ -1158,78 +1157,72 @@ void PAMassMultAdd3D(const int NE,
    });
 }
 
-typedef void (*fMassMultAdd)(const int NE,
-                             const double* B,
-                             const double* Bt,
-                             const double* oper,
-                             const double* x,
-                             double* y);
-
-static void PAMassMultAssembled(const int dim,
-                                const int D1D,
-                                const int Q1D,
-                                const int NE,
-                                const double* B,
-                                const double* Bt,
-                                const double* op,
-                                const double* x,
-                                double* y)
+static void PAMassApply(const int dim,
+                        const int D1D,
+                        const int Q1D,
+                        const int NE,
+                        const double* B,
+                        const double* Bt,
+                        const double* op,
+                        const double* x,
+                        double* y)
 {
 #ifdef MFEM_USE_OCCA
    if (internal::DeviceUseOcca())
    {
       if (dim == 2)
       {
-         OccaPAMassMultAdd2D(D1D, Q1D, NE, B, Bt, op, x, y);
+         OccaPAMassApply2D(D1D, Q1D, NE, B, Bt, op, x, y);
          return;
       }
       if (dim == 3)
       {
-         OccaPAMassMultAdd3D(D1D, Q1D, NE, B, Bt, op, x, y);
+         OccaPAMassApply3D(D1D, Q1D, NE, B, Bt, op, x, y);
          return;
       }
-      MFEM_ABORT("OCCA PA Mass MultAssembled unknown kernel!");
+      MFEM_ABORT("OCCA PA Mass Apply unknown kernel!");
    }
 #endif // MFEM_USE_OCCA
-   const int id = (dim<<8)|((D1D)<<4)|(Q1D);
-   static std::unordered_map<int, fMassMultAdd> call =
+   if (dim == 2)
    {
-      // 2D
-      {0x222,&PAMassMultAdd2D<2,2>},
-      {0x224,&PAMassMultAdd2D<2,4>},
-      {0x233,&PAMassMultAdd2D<3,3>},
-      {0x234,&PAMassMultAdd2D<3,4>},
-      {0x235,&PAMassMultAdd2D<3,5>},
-      {0x236,&PAMassMultAdd2D<3,6>},
-      {0x244,&PAMassMultAdd2D<4,4>},
-      {0x245,&PAMassMultAdd2D<4,5>},
-      {0x246,&PAMassMultAdd2D<4,6>},
-      {0x248,&PAMassMultAdd2D<4,8>},
-      {0x255,&PAMassMultAdd2D<5,5>},
-      {0x258,&PAMassMultAdd2D<5,8>},
-      // 3D
-      {0x323,&PAMassMultAdd3D<2,3>},
-      {0x324,&PAMassMultAdd3D<2,4>},
-      {0x334,&PAMassMultAdd3D<3,4>},
-      {0x345,&PAMassMultAdd3D<4,5>},
-      {0x356,&PAMassMultAdd3D<5,6>},
-   };
-   if (!call[id])
-   {
-      mfem::err << "\nUnknown kernel for PAMassMultAdd with "
-                << "dim = " << dim << ", "
-                << "D1D = " << D1D << ", "
-                << "Q1D = " << Q1D << " (add in fem/bilininteg_ext.cpp).\n";
-      MFEM_ABORT("PAMassMultAssembled kernel not instantiated");
+      switch ((D1D << 4 ) | Q1D)
+      {
+         case 0x22: PAMassApply2D<2,2>(NE, B, Bt, op, x, y); break;
+         case 0x24: PAMassApply2D<2,4>(NE, B, Bt, op, x, y); break;
+         case 0x33: PAMassApply2D<3,3>(NE, B, Bt, op, x, y); break;
+         case 0x34: PAMassApply2D<3,4>(NE, B, Bt, op, x, y); break;
+         case 0x35: PAMassApply2D<3,5>(NE, B, Bt, op, x, y); break;
+         case 0x36: PAMassApply2D<3,6>(NE, B, Bt, op, x, y); break;
+         case 0x44: PAMassApply2D<4,4>(NE, B, Bt, op, x, y); break;
+         case 0x45: PAMassApply2D<4,5>(NE, B, Bt, op, x, y); break;
+         case 0x46: PAMassApply2D<4,6>(NE, B, Bt, op, x, y); break;
+         case 0x48: PAMassApply2D<4,8>(NE, B, Bt, op, x, y); break;
+         case 0x55: PAMassApply2D<5,5>(NE, B, Bt, op, x, y); break;
+         case 0x58: PAMassApply2D<5,8>(NE, B, Bt, op, x, y); break;
+         default: PAMassApply2D(NE, B, Bt, op, x, y, D1D, Q1D);
+      }
+      return;
    }
-   call[id](NE, B, Bt, op, x, y);
+   if (dim == 3)
+   {
+      switch ((D1D << 4 ) | Q1D)
+      {
+         case 0x22: PAMassApply2D<2,2>(NE, B, Bt, op, x, y); break;
+         case 0x23: PAMassApply3D<2,3>(NE, B, Bt, op, x, y); break;
+         case 0x24: PAMassApply3D<2,4>(NE, B, Bt, op, x, y); break;
+         case 0x34: PAMassApply3D<3,4>(NE, B, Bt, op, x, y); break;
+         case 0x45: PAMassApply3D<4,5>(NE, B, Bt, op, x, y); break;
+         case 0x56: PAMassApply3D<5,6>(NE, B, Bt, op, x, y); break;
+         default: PAMassApply3D(NE, B, Bt, op, x, y, D1D, Q1D);
+      }
+      return;
+   }
+   MFEM_ABORT("Unknown kernel.");
 }
 
 void MassIntegrator::MultAssembled(Vector &x, Vector &y)
 {
-   PAMassMultAssembled(dim, dofs1D, quad1D, ne,
-                       maps->B, maps->Bt,
-                       vec, x, y);
+   PAMassApply(dim, dofs1D, quad1D, ne, maps->B, maps->Bt, vec, x, y);
 }
 
 MassIntegrator::~MassIntegrator()
@@ -1565,7 +1558,8 @@ void PAGeom2D(const int NE,
 {
    const int D1D = T_D1D ? T_D1D : d1d;
    const int Q1D = T_Q1D ? T_Q1D : q1d;
-
+   MFEM_VERIFY(D1D <= MAX_D1D, "");
+   MFEM_VERIFY(Q1D <= MAX_Q1D, "");
    const int ND = D1D*D1D;
    const int NQ = Q1D*Q1D;
 
@@ -1634,7 +1628,8 @@ void PAGeom3D(const int NE,
 {
    const int D1D = T_D1D ? T_D1D : d1d;
    const int Q1D = T_Q1D ? T_Q1D : q1d;
-
+   MFEM_VERIFY(D1D <= MAX_D1D, "");
+   MFEM_VERIFY(Q1D <= MAX_Q1D, "");
    const int ND = D1D*D1D*D1D;
    const int NQ = Q1D*Q1D*Q1D;
 
@@ -1733,8 +1728,9 @@ static void PAGeom(const int dim,
          case 0x58: PAGeom2D<5,8>(NE, B, G, X, Xq, J, invJ, detJ); break;
          default: PAGeom2D(NE, B, G, X, Xq, J, invJ, detJ, D1D, Q1D); break;
       }
+      return;
    }
-   else if (dim == 3)
+   if (dim == 3)
    {
       switch ((D1D << 4) | Q1D)
       {
@@ -1745,7 +1741,9 @@ static void PAGeom(const int dim,
          case 0x34: PAGeom3D<3,4>(NE, B, G, X, Xq, J, invJ, detJ); break;
          default: PAGeom3D(NE, B, G, X, Xq, J, invJ, detJ, D1D, Q1D); break;
       }
+      return;
    }
+   MFEM_ABORT("Unknown kernel.");
 }
 
 GeometryExtension* GeometryExtension::Get(const FiniteElementSpace& fes,


### PR DESCRIPTION
This is a proposal for a simple solution to support fallback (run-time sized) kernels, up for discussion.

I didn't run any performance tests but I suspect the newly added `const int D1D = T_D1D ? ...` will actually be treated as compile-time constants, because the code happily compiles with the temporary buffers `double gradXY[Q1D][Q1D][4];`, if instantiated with nonzero `T_Q1D` and `T_D1D`. 

The buffers fail to compile if `Q1D` and `D1D` are run-time sized, of course, which is why I added `MAX_Q1D` and `MAX_D1D`, then it works (albeit with larger buffers than necessary).