### PR TITLE
Updates in the examples, class BilinearForm and related [okina-bilinearform-updates]

### DIFF
--- a/examples/ex1.cpp
+++ b/examples/ex1.cpp
@@ -26,12 +26,12 @@
 //               ex1 -m ../data/mobius-strip.mesh -o -1 -sc
 //
 // Device sample runs:
-//             > ex1 -p -d cuda
-//             > ex1 -p -d raja-cuda
-//             > ex1 -p -d occa-cuda
-//             > ex1 -p -d raja-omp
-//             > ex1 -p -d occa-omp
-//             > ex1 -m ../data/beam-hex.mesh -p -d cuda
+//             > ex1 -pa -d cuda
+//             > ex1 -pa -d raja-cuda
+//             > ex1 -pa -d occa-cuda
+//             > ex1 -pa -d raja-omp
+//             > ex1 -pa -d occa-omp
+//             > ex1 -m ../data/beam-hex.mesh -pa -d cuda
 //
 // Description:  This example code demonstrates the use of MFEM to define a
 //               simple finite element discretization of the Laplace problem
@@ -73,8 +73,8 @@ int main(int argc, char *argv[])
                   " isoparametric space.");
    args.AddOption(&static_cond, "-sc", "--static-condensation", "-no-sc",
                   "--no-static-condensation", "Enable static condensation.");
-   args.AddOption(&pa, "-p", "--pa", "-no-p", "--no-pa",
-                  "Enable Partial Assembly.");
+   args.AddOption(&pa, "-pa", "--partial-assembly", "-no-pa",
+                  "--no-partial-assembly", "Enable Partial Assembly.");
    args.AddOption(&device, "-d", "--device",
                   "Device configuration string, see Device::Configure().");
    args.AddOption(&visualization, "-vis", "--visualization", "-no-vis",
@@ -93,7 +93,6 @@ int main(int argc, char *argv[])
    //    the same code.
    Mesh *mesh = new Mesh(mesh_file, 1, 1);
    int dim = mesh->Dimension();
-   if (pa) { mesh->EnsureNodes(); }
 
    // 3. Refine the mesh to increase the resolution. In this example we do
    //    'ref_levels' of uniform refinement. We choose 'ref_levels' to be the
@@ -164,8 +163,8 @@ int main(int argc, char *argv[])
    // 9. Set up the bilinear form a(.,.) on the finite element space
    //    corresponding to the Laplacian operator -Delta, by adding the Diffusion
    //    domain integrator.
-   AssemblyLevel assembly = (pa) ? AssemblyLevel::PARTIAL : AssemblyLevel::FULL;
-   BilinearForm *a = new BilinearForm(fespace, assembly);
+   BilinearForm *a = new BilinearForm(fespace);
+   if (pa) { a->SetAssemblyLevel(AssemblyLevel::PARTIAL); }
    a->AddDomainIntegrator(new DiffusionIntegrator(one));
 
    // 10. Assemble the bilinear form and the corresponding linear system,
@@ -176,31 +175,30 @@ int main(int argc, char *argv[])
    a->Assemble();
 
    Vector B, X;
-   Operator *A;
-   if (!pa) { A = new SparseMatrix; }
+   OperatorHandle Ah;
+   a->FormLinearSystem(ess_tdof_list, x, *b, Ah, X, B);
+   Operator &A = *Ah.Ptr();
 
-   a->FormLinearSystem(ess_tdof_list, x, *b, A, X, B);
-
-   cout << "Size of linear system: " << A->Height() << endl;
+   cout << "Size of linear system: " << A.Height() << endl;
 
    // 11. Solve the linear system A X = B.
    if (!pa)
    {
 #ifndef MFEM_USE_SUITESPARSE
       // Use a simple symmetric Gauss-Seidel preconditioner with PCG.
-      GSSmoother M(*(SparseMatrix*)A);
-      PCG(*A, M, B, X, 1, 200, 1e-12, 0.0);
+      GSSmoother M((SparseMatrix&)A);
+      PCG(A, M, B, X, 1, 200, 1e-12, 0.0);
 #else
       // If MFEM was compiled with SuiteSparse, use UMFPACK to solve the system.
       UMFPackSolver umf_solver;
       umf_solver.Control[UMFPACK_ORDERING] = UMFPACK_ORDERING_METIS;
-      umf_solver.SetOperator(*A);
+      umf_solver.SetOperator(A);
       umf_solver.Mult(B, X);
 #endif
    }
    else // No preconditioning for now in partial assembly mode.
    {
-      CG(*A, B, X, 1, 2000, 1e-12, 0.0);
+      CG(A, B, X, 1, 2000, 1e-12, 0.0);
    }
 
    // 12. Recover the solution as a finite element grid function.
@@ -229,7 +227,6 @@ int main(int argc, char *argv[])
    }
 
    // 16. Free the used memory.
-   delete A;
    delete a;
    delete b;
    delete fespace;

--- a/examples/ex1p.cpp
+++ b/examples/ex1p.cpp
@@ -203,9 +203,9 @@ int main(int argc, char *argv[])
    if (static_cond) { a->EnableStaticCondensation(); }
    a->Assemble();
 
+   OperatorPtr A;
    Vector B, X;
-   OperatorHandle Ah;
-   a->FormLinearSystem(ess_tdof_list, x, *b, Ah, X, B);
+   a->FormLinearSystem(ess_tdof_list, x, *b, A, X, B);
 
    // 13. Solve the linear system A X = B.
    //     * With full assembly, use the BoomerAMG preconditioner from hypre.
@@ -217,7 +217,7 @@ int main(int argc, char *argv[])
    cg.SetMaxIter(2000);
    cg.SetPrintLevel(1);
    if (prec) { cg.SetPreconditioner(*prec); }
-   cg.SetOperator(*Ah.Ptr());
+   cg.SetOperator(*A);
    cg.Mult(B, X);
    delete prec;
 

--- a/examples/ex6.cpp
+++ b/examples/ex6.cpp
@@ -16,9 +16,9 @@
 //               ex6 -m ../data/amr-quad.mesh
 //
 // Device sample runs:
-//             > ex6 -p -d cuda
-//             > ex6 -p -d occa
-//             > ex6 -p -d raja-omp
+//             > ex6 -pa -d cuda
+//             > ex6 -pa -d occa-cuda
+//             > ex6 -pa -d raja-omp
 //
 // Description:  This is a version of Example 1 with a simple adaptive mesh
 //               refinement loop. The problem being solved is again the Laplace
@@ -57,8 +57,8 @@ int main(int argc, char *argv[])
                   "Mesh file to use.");
    args.AddOption(&order, "-o", "--order",
                   "Finite element order (polynomial degree).");
-   args.AddOption(&pa, "-p", "--pa", "-no-p", "--no-pa",
-                  "Enable Partial Assembly.");
+   args.AddOption(&pa, "-pa", "--partial-assembly", "-no-pa",
+                  "--no-partial-assembly", "Enable Partial Assembly.");
    args.AddOption(&device, "-d", "--device",
                   "Device configuration string, see Device::Configure().");
    args.AddOption(&visualization, "-vis", "--visualization", "-no-vis",
@@ -78,7 +78,6 @@ int main(int argc, char *argv[])
    Mesh mesh(mesh_file, 1, 1);
    int dim = mesh.Dimension();
    int sdim = mesh.SpaceDimension();
-   if (pa) { mesh.EnsureNodes(); }
 
    // 3. Since a NURBS mesh can currently only be refined uniformly, we need to
    //    convert it to a piecewise-polynomial curved mesh. First we refine the
@@ -104,8 +103,8 @@ int main(int argc, char *argv[])
    // 6. As in Example 1, we set up bilinear and linear forms corresponding to
    //    the Laplace problem -\Delta u = 1. We don't assemble the discrete
    //    problem yet, this will be done in the main loop.
-   AssemblyLevel assembly = (pa) ? AssemblyLevel::PARTIAL : AssemblyLevel::FULL;
-   BilinearForm a(&fespace, assembly);
+   BilinearForm a(&fespace);
+   if (pa) { a.SetAssemblyLevel(AssemblyLevel::PARTIAL); }
    LinearForm b(&fespace);
 
    ConstantCoefficient one(1.0);
@@ -177,30 +176,30 @@ int main(int argc, char *argv[])
       //     hanging nodes and possibly apply other transformations. The system
       //     will be solved for true (unconstrained) DOFs only.
       Vector B, X;
-      Operator *A;
-      if (!pa) { A = new SparseMatrix; }
+      OperatorHandle Ah;
 
       const int copy_interior = 1;
-      a.FormLinearSystem(ess_tdof_list, x, b, A, X, B, copy_interior);
+      a.FormLinearSystem(ess_tdof_list, x, b, Ah, X, B, copy_interior);
+      Operator &A = *Ah.Ptr();
 
       // 17. Solve the linear system A X = B.
       if (!pa)
       {
 #ifndef MFEM_USE_SUITESPARSE
          // Use a simple symmetric Gauss-Seidel preconditioner with PCG.
-         GSSmoother M(*(SparseMatrix*)A);
-         PCG(*A, M, B, X, 3, 200, 1e-12, 0.0);
+         GSSmoother M((SparseMatrix&)A);
+         PCG(A, M, B, X, 3, 200, 1e-12, 0.0);
 #else
          // If MFEM was compiled with SuiteSparse, use UMFPACK to solve the system.
          UMFPackSolver umf_solver;
          umf_solver.Control[UMFPACK_ORDERING] = UMFPACK_ORDERING_METIS;
-         umf_solver.SetOperator(*A);
+         umf_solver.SetOperator(A);
          umf_solver.Mult(B, X);
 #endif
       }
       else // No preconditioning for now in partial assembly mode.
       {
-         CG(*A, B, X, 3, 2000, 1e-12, 0.0);
+         CG(A, B, X, 3, 2000, 1e-12, 0.0);
       }
 
       // 18. After solving the linear system, reconstruct the solution as a
@@ -219,7 +218,6 @@ int main(int argc, char *argv[])
       if (cdofs > max_dofs)
       {
          cout << "Reached the maximum number of dofs. Stop." << endl;
-         delete A;
          break;
       }
 
@@ -231,7 +229,6 @@ int main(int argc, char *argv[])
       if (refiner.Stop())
       {
          cout << "Stopping criterion satisfied. Stop." << endl;
-         delete A;
          break;
       }
 
@@ -248,9 +245,6 @@ int main(int argc, char *argv[])
       //     changed.
       a.Update();
       b.Update();
-
-      // 23. Free the used memory.
-      delete A;
    }
 
    return 0;

--- a/examples/ex6p.cpp
+++ b/examples/ex6p.cpp
@@ -16,9 +16,9 @@
 //               mpirun -np 4 ex6p -m ../data/amr-quad.mesh
 //
 // Device sample runs:
-//             > mpirun -np 4 ex6p -p -d cuda
-//             > mpirun -np 4 ex6p -p -d occa
-//             > mpirun -np 4 ex6p -p -d raja-omp
+//             > mpirun -np 4 ex6p -pa -d cuda
+//             > mpirun -np 4 ex6p -pa -d occa-cuda
+//             > mpirun -np 4 ex6p -pa -d raja-omp
 //
 // Description:  This is a version of Example 1 with a simple adaptive mesh
 //               refinement loop. The problem being solved is again the Laplace
@@ -63,8 +63,8 @@ int main(int argc, char *argv[])
                   "Mesh file to use.");
    args.AddOption(&order, "-o", "--order",
                   "Finite element order (polynomial degree).");
-   args.AddOption(&pa, "-p", "--pa", "-no-p", "--no-pa",
-                  "Enable Partial Assembly.");
+   args.AddOption(&pa, "-pa", "--partial-assembly", "-no-pa",
+                  "--no-partial-assembly", "Enable Partial Assembly.");
    args.AddOption(&device, "-d", "--device",
                   "Device configuration string, see Device::Configure().");
    args.AddOption(&visualization, "-vis", "--visualization", "-no-vis",
@@ -91,7 +91,6 @@ int main(int argc, char *argv[])
    Mesh *mesh = new Mesh(mesh_file, 1, 1);
    int dim = mesh->Dimension();
    int sdim = mesh->SpaceDimension();
-   if (pa) { mesh->EnsureNodes(); }
 
    // 4. Refine the serial mesh on all processors to increase the resolution.
    //    Also project a NURBS mesh to a piecewise-quadratic curved mesh. Make
@@ -125,8 +124,8 @@ int main(int argc, char *argv[])
    // 8. As in Example 1p, we set up bilinear and linear forms corresponding to
    //    the Laplace problem -\Delta u = 1. We don't assemble the discrete
    //    problem yet, this will be done in the main loop.
-   AssemblyLevel assembly = (pa) ? AssemblyLevel::PARTIAL : AssemblyLevel::FULL;
-   ParBilinearForm a(&fespace, assembly);
+   ParBilinearForm a(&fespace);
+   if (pa) { a.SetAssemblyLevel(AssemblyLevel::PARTIAL); }
    ParLinearForm b(&fespace);
 
    ConstantCoefficient one(1.0);
@@ -211,37 +210,24 @@ int main(int argc, char *argv[])
       // 16. Create the parallel linear system: eliminate boundary conditions.
       //     The system will be solved for true (unconstrained/unique) DOFs only.
       Vector B, X;
-      Operator *A;
-      if (!pa) { A = new HypreParMatrix(); }
+      OperatorHandle Ah;
 
       const int copy_interior = 1;
-      a.FormLinearSystem(ess_tdof_list, x, b, A, X, B, copy_interior);
+      a.FormLinearSystem(ess_tdof_list, x, b, Ah, X, B, copy_interior);
 
       // 17. Solve the linear system A X = B.
-      if (!pa)
-      {
-         // Parallel PCG solver with the BoomerAMG preconditioner from hypre.
-         HypreParMatrix &H = *static_cast<HypreParMatrix*>(A);
-         HypreBoomerAMG amg;
-         amg.SetPrintLevel(0);
-         CGSolver pcg(H.GetComm());
-         pcg.SetPreconditioner(amg);
-         pcg.SetOperator(H);
-         pcg.SetRelTol(1e-6);
-         pcg.SetMaxIter(200);
-         pcg.SetPrintLevel(3); // print the first and the last iterations only
-         pcg.Mult(B, X);
-      }
-      else
-      {
-         // No preconditioning for now in partial assembly mode.
-         CGSolver cg(MPI_COMM_WORLD);
-         cg.SetRelTol(1e-12);
-         cg.SetMaxIter(2000);
-         cg.SetPrintLevel(3);
-         cg.SetOperator(*A);
-         cg.Mult(B, X);
-      }
+      //     * With full assembly, use the BoomerAMG preconditioner from hypre.
+      //     * With partial assembly, use no preconditioner, for now.
+      HypreBoomerAMG *amg = NULL;
+      if (!pa) { amg = new HypreBoomerAMG; amg->SetPrintLevel(0); }
+      CGSolver cg(MPI_COMM_WORLD);
+      cg.SetRelTol(1e-6);
+      cg.SetMaxIter(2000);
+      cg.SetPrintLevel(3);
+      if (amg) { cg.SetPreconditioner(*amg); }
+      cg.SetOperator(*Ah.Ptr());
+      cg.Mult(B, X);
+      delete amg;
 
       // 18. Switch back to the host and extract the parallel grid function
       //     corresponding to the finite element approximation X. This is the
@@ -262,7 +248,6 @@ int main(int argc, char *argv[])
          {
             cout << "Reached the maximum number of dofs. Stop." << endl;
          }
-         delete A;
          break;
       }
 
@@ -277,7 +262,6 @@ int main(int argc, char *argv[])
          {
             cout << "Stopping criterion satisfied. Stop." << endl;
          }
-         delete A;
          break;
       }
 
@@ -305,7 +289,6 @@ int main(int argc, char *argv[])
       //     changed.
       a.Update();
       b.Update();
-      delete A;
    }
 
    MPI_Finalize();

--- a/examples/ex6p.cpp
+++ b/examples/ex6p.cpp
@@ -209,11 +209,11 @@ int main(int argc, char *argv[])
 
       // 16. Create the parallel linear system: eliminate boundary conditions.
       //     The system will be solved for true (unconstrained/unique) DOFs only.
+      OperatorPtr A;
       Vector B, X;
-      OperatorHandle Ah;
 
       const int copy_interior = 1;
-      a.FormLinearSystem(ess_tdof_list, x, b, Ah, X, B, copy_interior);
+      a.FormLinearSystem(ess_tdof_list, x, b, A, X, B, copy_interior);
 
       // 17. Solve the linear system A X = B.
       //     * With full assembly, use the BoomerAMG preconditioner from hypre.
@@ -225,7 +225,7 @@ int main(int argc, char *argv[])
       cg.SetMaxIter(2000);
       cg.SetPrintLevel(3); // print the first and the last iterations only
       if (amg) { cg.SetPreconditioner(*amg); }
-      cg.SetOperator(*Ah.Ptr());
+      cg.SetOperator(*A);
       cg.Mult(B, X);
       delete amg;
 

--- a/examples/ex6p.cpp
+++ b/examples/ex6p.cpp
@@ -223,7 +223,7 @@ int main(int argc, char *argv[])
       CGSolver cg(MPI_COMM_WORLD);
       cg.SetRelTol(1e-6);
       cg.SetMaxIter(2000);
-      cg.SetPrintLevel(3);
+      cg.SetPrintLevel(3); // print the first and the last iterations only
       if (amg) { cg.SetPreconditioner(*amg); }
       cg.SetOperator(*Ah.Ptr());
       cg.Mult(B, X);

--- a/fem/bilinearform.cpp
+++ b/fem/bilinearform.cpp
@@ -94,6 +94,10 @@ BilinearForm::BilinearForm (FiniteElementSpace * f, BilinearForm * bf, int ps)
    precompute_sparsity = ps;
    diag_policy = DIAG_KEEP;
 
+   assembly = AssemblyLevel::FULL;
+   batch = 1;
+   ext = NULL;
+
    // Copy the pointers to the integrators
    dbfi = bf->dbfi;
 

--- a/fem/bilinearform.cpp
+++ b/fem/bilinearform.cpp
@@ -63,8 +63,7 @@ void BilinearForm::AllocMat()
    dof_dof.LoseData();
 }
 
-BilinearForm::BilinearForm (FiniteElementSpace * f,
-                            AssemblyLevel assembly_level, int elem_batch)
+BilinearForm::BilinearForm(FiniteElementSpace * f)
    : Matrix (f->GetVSize())
 {
    fes = f;
@@ -77,32 +76,9 @@ BilinearForm::BilinearForm (FiniteElementSpace * f,
    precompute_sparsity = 0;
    diag_policy = DIAG_KEEP;
 
-   assembly = assembly_level;
-   batch = elem_batch;
-
-   fa = NULL; ea = NULL; pa = NULL; mf = NULL;
-
-   switch (assembly)
-   {
-      case AssemblyLevel::FULL:
-         if (Device::IsEnabled())
-         {
-            mfem_error("Full assembly not supported yet in device mode!");
-         }
-         // Use the original BilinearForm implementation for now
-         break;
-      case AssemblyLevel::ELEMENT:
-         mfem_error("Element assembly not supported yet... stay tuned!");
-         break;
-      case AssemblyLevel::PARTIAL:
-         pa = new PABilinearFormExtension(this);
-         break;
-      case AssemblyLevel::NONE:
-         mfem_error("Matrix-free action not supported yet... stay tuned!");
-         break;
-      default:
-         mfem_error("Unknown assembly level");
-   }
+   assembly = AssemblyLevel::FULL;
+   batch = 1;
+   ext = NULL;
 }
 
 BilinearForm::BilinearForm (FiniteElementSpace * f, BilinearForm * bf, int ps)
@@ -130,6 +106,39 @@ BilinearForm::BilinearForm (FiniteElementSpace * f, BilinearForm * bf, int ps)
    bfbfi_marker = bf->bfbfi_marker;
 
    AllocMat();
+}
+
+void BilinearForm::SetAssemblyLevel(AssemblyLevel assembly_level)
+{
+   if (ext)
+   {
+      MFEM_ABORT("the assembly level has already been set!");
+   }
+   assembly = assembly_level;
+   switch (assembly)
+   {
+      case AssemblyLevel::FULL:
+         if (Device::IsEnabled())
+         {
+            mfem_error("Full assembly not supported yet in device mode!");
+            // ext = new FABilinearFormExtension(this);
+         }
+         // Use the original BilinearForm implementation for now
+         break;
+      case AssemblyLevel::ELEMENT:
+         mfem_error("Element assembly not supported yet... stay tuned!");
+         // ext = new EABilinearFormExtension(this);
+         break;
+      case AssemblyLevel::PARTIAL:
+         ext = new PABilinearFormExtension(this);
+         break;
+      case AssemblyLevel::NONE:
+         mfem_error("Matrix-free action not supported yet... stay tuned!");
+         // ext = new MFBilinearFormExtension(this);
+         break;
+      default:
+         mfem_error("Unknown assembly level");
+   }
 }
 
 void BilinearForm::EnableStaticCondensation()
@@ -221,26 +230,9 @@ void BilinearForm::Finalize (int skip_zeros)
    if (hybridization) { hybridization->Finalize(); }
 }
 
-void BilinearForm::AddDomainIntegrator (BilinearFormIntegrator * bfi)
+void BilinearForm::AddDomainIntegrator(BilinearFormIntegrator *bfi)
 {
-   switch (assembly)
-   {
-      case AssemblyLevel::FULL:
-         // Use the original BilinearForm implementation for now
-         dbfi.Append(bfi);
-         break;
-      case AssemblyLevel::ELEMENT:
-         mfem_error("Not supported yet... stay tuned!");
-         break;
-      case AssemblyLevel::PARTIAL:
-         pa->AddDomainIntegrator(bfi);
-         break;
-      case AssemblyLevel::NONE:
-         mfem_error("Not supported yet... stay tuned!");
-         break;
-      default:
-         mfem_error("Unknown assembly level");
-   }
+   dbfi.Append(bfi);
 }
 
 void BilinearForm::AddBoundaryIntegrator (BilinearFormIntegrator * bfi)
@@ -348,22 +340,10 @@ void BilinearForm::AssembleBdrElementMatrix(
 
 void BilinearForm::Assemble(int skip_zeros)
 {
-   switch (assembly)
+   if (ext)
    {
-      case AssemblyLevel::FULL:
-         // Use the original BilinearForm implementation for now
-         break;
-      case AssemblyLevel::ELEMENT:
-         mfem_error("Not supported yet... stay tuned!");
-         return;
-      case AssemblyLevel::PARTIAL:
-         pa->Assemble();
-         return;
-      case AssemblyLevel::NONE:
-         mfem_error("Not supported yet... stay tuned!");
-         return;
-      default:
-         mfem_error("Unknown assembly level");
+      ext->Assemble();
+      return;
    }
 
    ElementTransformation *eltrans;
@@ -595,11 +575,16 @@ void BilinearForm::ConformingAssemble()
    width = mat->Width();
 }
 
-void BilinearForm::FormLinearSystem(const Array<int> &ess_tdof_list,
-                                    Vector &x, Vector &b,
-                                    SparseMatrix &A, Vector &X, Vector &B,
-                                    int copy_interior)
+void BilinearForm::FormLinearSystem(const Array<int> &ess_tdof_list, Vector &x,
+                                    Vector &b, OperatorHandle &A, Vector &X,
+                                    Vector &B, int copy_interior)
 {
+   if (ext)
+   {
+      ext->FormLinearSystem(ess_tdof_list, x, b, A, X, B, copy_interior);
+      return;
+   }
+
    const SparseMatrix *P = fes->GetConformingProlongation();
 
    FormSystemMatrix(ess_tdof_list, A);
@@ -662,8 +647,14 @@ void BilinearForm::FormLinearSystem(const Array<int> &ess_tdof_list,
 }
 
 void BilinearForm::FormSystemMatrix(const Array<int> &ess_tdof_list,
-                                    SparseMatrix &A)
+                                    OperatorHandle &A)
 {
+   if (ext)
+   {
+      ext->FormSystemMatrix(ess_tdof_list, A);
+      return;
+   }
+
    // Finish the matrix assembly and perform BC elimination, storing the
    // eliminated part of the matrix.
    if (static_cond)
@@ -675,7 +666,7 @@ void BilinearForm::FormSystemMatrix(const Array<int> &ess_tdof_list,
          static_cond->EliminateReducedTrueDofs(diag_policy);
          static_cond->Finalize(); // finalize eliminated part
       }
-      A.MakeRef(static_cond->GetMatrix());
+      A.Reset(&static_cond->GetMatrix(), false);
    }
    else
    {
@@ -689,90 +680,22 @@ void BilinearForm::FormSystemMatrix(const Array<int> &ess_tdof_list,
       }
       if (hybridization)
       {
-         A.MakeRef(hybridization->GetMatrix());
+         A.Reset(&hybridization->GetMatrix(), false);
       }
       else
       {
-         A.MakeRef(*mat);
+         A.Reset(mat, false);
       }
-   }
-}
-
-void BilinearForm::FormLinearSystem(const Array<int> &ess_tdof_list,
-                                    Vector &x, Vector &b,
-                                    Operator *&opA, Vector &X, Vector &B,
-                                    int copy_interior)
-{
-   switch (assembly)
-   {
-      case AssemblyLevel::FULL:
-      {
-         // Use the original BilinearForm implementation for now
-         SparseMatrix *Ap = static_cast<SparseMatrix*>(opA);
-         SparseMatrix &A = *Ap;
-         FormLinearSystem(ess_tdof_list, x, b, A, X, B, copy_interior);
-         break;
-      }
-      case AssemblyLevel::ELEMENT:
-         mfem_error("Not supported yet... stay tuned!");
-         break;
-      case AssemblyLevel::PARTIAL:
-         pa->FormLinearSystem(ess_tdof_list, x, b, opA, X, B, copy_interior);
-         break;
-      case AssemblyLevel::NONE:
-         mfem_error("Not supported yet... stay tuned!");
-         break;
-      default:
-         mfem_error("Unknown assembly level");
-   }
-}
-
-void BilinearForm::FormSystemOperator(const Array<int> &ess_tdof_list,
-                                      Operator *&opA)
-{
-   switch (assembly)
-   {
-      case AssemblyLevel::FULL:
-      {
-         // Use the original BilinearForm implementation for now
-         SparseMatrix *Ap = static_cast<SparseMatrix*>(opA);
-         SparseMatrix &A = *Ap;
-         FormSystemMatrix(ess_tdof_list, A);
-         break;
-      }
-      case AssemblyLevel::ELEMENT:
-         mfem_error("Not supported yet... stay tuned!");
-         break;
-      case AssemblyLevel::PARTIAL:
-         pa->FormSystemOperator(ess_tdof_list, opA);
-         break;
-      case AssemblyLevel::NONE:
-         mfem_error("Not supported yet... stay tuned!");
-         break;
-      default:
-         mfem_error("Unknown assembly level");
    }
 }
 
 void BilinearForm::RecoverFEMSolution(const Vector &X,
                                       const Vector &b, Vector &x)
 {
-   switch (assembly)
+   if (ext)
    {
-      case AssemblyLevel::FULL:
-         // Use the original BilinearForm implementation for now
-         break;
-      case AssemblyLevel::ELEMENT:
-         mfem_error("Not supported yet... stay tuned!");
-         return;
-      case AssemblyLevel::PARTIAL:
-         pa->RecoverFEMSolution(X, b, x);
-         return;
-      case AssemblyLevel::NONE:
-         mfem_error("Not supported yet... stay tuned!");
-         return;
-      default:
-         mfem_error("Unknown assembly level");
+      ext->RecoverFEMSolution(X, b, x);
+      return;
    }
 
    const SparseMatrix *P = fes->GetConformingProlongation();
@@ -1038,7 +961,8 @@ void BilinearForm::Update(FiniteElementSpace *nfes)
    }
 
    height = width = fes->GetVSize();
-   if (pa) { pa->Update(fes); }
+
+   if (ext) { ext->Update(); }
 }
 
 void BilinearForm::SetDiagonalPolicy(DiagonalPolicy policy)
@@ -1063,10 +987,7 @@ BilinearForm::~BilinearForm()
       for (k=0; k < bfbfi.Size(); k++) { delete bfbfi[k]; }
    }
 
-   if (fa) { delete fa; }
-   if (ea) { delete ea; }
-   if (pa) { delete pa; }
-   if (mf) { delete mf; }
+   delete ext;
 }
 
 

--- a/fem/bilinearform.hpp
+++ b/fem/bilinearform.hpp
@@ -117,6 +117,9 @@ protected:
       static_cond = NULL; hybridization = NULL;
       precompute_sparsity = 0;
       diag_policy = DIAG_KEEP;
+      assembly = AssemblyLevel::FULL;
+      batch = 1;
+      ext = NULL;
    }
 
 private:

--- a/fem/bilinearform.hpp
+++ b/fem/bilinearform.hpp
@@ -43,15 +43,11 @@ enum class AssemblyLevel
    NONE,
 };
 
+
 /** Class for bilinear form - "Matrix" with associated FE space and
     BLFIntegrators. */
 class BilinearForm : public Matrix
 {
-   friend class FABilinearFormExtension;
-   friend class EABilinearFormExtension;
-   friend class PABilinearFormExtension;
-   friend class MFBilinearFormExtension;
-
 protected:
    /// Sparse matrix to be associated with the form. Owned.
    SparseMatrix *mat;
@@ -66,14 +62,9 @@ protected:
    AssemblyLevel assembly;
    /// Element batch size used in the form action (1, 8, num_elems, etc.)
    int batch;
-   /// Data and methods specific for Full Assembly (FA)
-   FABilinearFormExtension *fa;
-   /// Data and methods specific for Element Assembly (EA)
-   EABilinearFormExtension *ea;
-   /// Data and methods specific for Partial Assembly (PA)
-   PABilinearFormExtension *pa;
-   /// Data and methods specific for Matrix Free assembly (MF)
-   MFBilinearFormExtension *mf;
+   /** Extension for supporting Full Assembly (FA), Element Assembly (EA),
+       Partial Assembly (PA), or Matrix Free assembly (MF). */
+   BilinearFormExtension *ext;
 
    /// Indicates the Mesh::sequence corresponding to the current state of the
    /// BilinearForm.
@@ -138,9 +129,7 @@ private:
 public:
    /// Creates bilinear form associated with FE space @a *f.
    /** The pointer @a f is not owned by the newly constructed object. */
-   BilinearForm(FiniteElementSpace *f,
-                AssemblyLevel assembly_level = AssemblyLevel::FULL,
-                int elem_batch = 1);
+   BilinearForm(FiniteElementSpace *f);
 
    /** @brief Create a BilinearForm on the FiniteElementSpace @a f, using the
        same integrators as the BilinearForm @a bf.
@@ -156,6 +145,10 @@ public:
 
    /// Get the size of the BilinearForm as a square matrix.
    int Size() const { return height; }
+
+   /// Set the desired assembly level. The default is AssemblyLevel::FULL.
+   /** This method must be called before assembly. */
+   void SetAssemblyLevel(AssemblyLevel assembly_level);
 
    /** Enable the use of static condensation. For details see the description
        for class StaticCondensation in fem/staticcond.hpp This method should be
@@ -330,11 +323,12 @@ public:
    virtual const Operator *GetRestriction() const
    { return fes->GetConformingRestriction(); }
 
-   /// Form a linear system, A X = B.
-   /** Form the linear system A X = B, corresponding to the current bilinear
-       form and b(.), by applying any necessary transformations such as:
-       eliminating boundary conditions; applying conforming constraints for
-       non-conforming AMR; static condensation; hybridization.
+   /** @brief Form the linear system A X = B, corresponding to this bilinear
+       form and the linear form @a b(.). */
+   /** This method applies any necessary transformations to the linear system
+       such as: eliminating boundary conditions; applying conforming constraints
+       for non-conforming AMR; parallel assembly; static condensation;
+       hybridization.
 
        The GridFunction-size vector @a x must contain the essential b.c. The
        BilinearForm and the LinearForm-size vector @a b must be assembled.
@@ -355,43 +349,52 @@ public:
 
        NOTE: If there are no transformations, @a X simply reuses the data of
              @a x. */
+   virtual void FormLinearSystem(const Array<int> &ess_tdof_list, Vector &x,
+                                 Vector &b, OperatorHandle &A, Vector &X,
+                                 Vector &B, int copy_interior = 0);
+
+   /** @brief Form the linear system A X = B, corresponding to this bilinear
+       form and the linear form @a b(.). */
+   /** Version of the method FormLinearSystem() where the system matrix is
+       returned in the variable @a A, of type OpType, holding a *reference* to
+       the system matrix (created with the method OpType::MakeRef()). The
+       reference will be invalidated when SetOperatorType(), Update(), or the
+       destructor is called.
+
+       Currently, this method can be used only with AssemblyLevel::FULL. */
+   template <typename OpType>
    void FormLinearSystem(const Array<int> &ess_tdof_list, Vector &x, Vector &b,
-                         SparseMatrix &A, Vector &X, Vector &B,
-                         int copy_interior = 0);
+                         OpType &A, Vector &X, Vector &B,
+                         int copy_interior = 0)
+   {
+      OperatorHandle Ah;
+      FormLinearSystem(ess_tdof_list, x, b, Ah, X, B, copy_interior);
+      OpType *A_ptr = Ah.Is<OpType>();
+      MFEM_VERIFY(A_ptr, "invalid OpType used");
+      A.MakeRef(*A_ptr);
+   }
+
+   /// Form the linear system matrix @a A, see FormLinearSystem() for details.
+   virtual void FormSystemMatrix(const Array<int> &ess_tdof_list,
+                                 OperatorHandle &A);
 
    /// Form the linear system matrix A, see FormLinearSystem() for details.
-   void FormSystemMatrix(const Array<int> &ess_tdof_list, SparseMatrix &A);
+   /** Version of the method FormSystemMatrix() where the system matrix is
+       returned in the variable @a A, of type OpType, holding a *reference* to
+       the system matrix (created with the method OpType::MakeRef()). The
+       reference will be invalidated when SetOperatorType(), Update(), or the
+       destructor is called.
 
-   /** Form the linear system @a A @a X = @a B, corresponding to the bilinear
-       form and the r.h.s. linear form (vector) @a b, by applying any necessary
-       transformations such as: eliminating boundary conditions; applying
-       conforming constraints for non-conforming AMR; parallel assembly; static
-       condensation; hybridization.
-
-       The GridFunction-size vector @a x must contain the essential b.c. The
-       BilinearForm and the LinearForm-size vector @a b must be assembled.
-
-       The vector @a X is initialized with a suitable initial guess: when using
-       hybridization, the vector @a X is set to zero; otherwise, the essential
-       entries of @a X are set to the corresponding b.c. and all other entries
-       are set to zero (if @a copy_interior == 0) or copied from @a x (if
-       @a copy_interior != 0).
-
-       This method can be called multiple times (with the same @a ess_tdof_list
-       array) to initialize different right-hand sides and boundary condition
-       values.
-
-       After solving the linear system, the finite element solution @a x can be
-       recovered by calling RecoverFEMSolution() (with the same vectors @a X,
-       @a b, and @a x). */
-   virtual void FormLinearSystem(const Array<int> &ess_tdof_list,
-                                 Vector &x, Vector &b,
-                                 Operator *&A, Vector &X, Vector &B,
-                                 int copy_interior = 0);
-
-   /// Form the linear system operator @a A, see FormLinearSystem() for details.
-   virtual void FormSystemOperator(const Array<int> &ess_tdof_list,
-                                   Operator *&A);
+       Currently, this method can be used only with AssemblyLevel::FULL. */
+   template <typename OpType>
+   void FormSystemMatrix(const Array<int> &ess_tdof_list, OpType &A)
+   {
+      OperatorHandle Ah;
+      FormSystemMatrix(ess_tdof_list, Ah);
+      OpType *A_ptr = Ah.Is<OpType>();
+      MFEM_VERIFY(A_ptr, "invalid OpType used");
+      A.MakeRef(*A_ptr);
+   }
 
    /// Recover the solution of a linear system formed with FormLinearSystem().
    /** Call this method after solving a linear system constructed using the

--- a/fem/bilinearform_ext.hpp
+++ b/fem/bilinearform_ext.hpp
@@ -39,99 +39,108 @@ public:
    void MultTranspose(const Vector &x, Vector &y) const;
 };
 
-/// Data and methods for fully-assembled bilinear forms
-class FABilinearFormExtension : public Operator
+
+class BilinearFormExtension : public Operator
 {
-private:
-   BilinearForm *a;
+protected:
+   BilinearForm *a; ///< Not owned
+
 public:
-   FABilinearFormExtension(BilinearForm *form);
+   BilinearFormExtension(BilinearForm *form);
+
+   /// Get the finite element space prolongation matrix
+   virtual const Operator *GetProlongation() const;
+
+   /// Get the finite element space restriction matrix
+   virtual const Operator *GetRestriction() const;
+
+   virtual void Assemble() = 0;
+   virtual void FormSystemMatrix(const Array<int> &ess_tdof_list,
+                                 OperatorHandle &A) = 0;
+   virtual void FormLinearSystem(const Array<int> &ess_tdof_list,
+                                 Vector &x, Vector &b,
+                                 OperatorHandle &A, Vector &X, Vector &B,
+                                 int copy_interior = 0) = 0;
+   virtual void Update() = 0;
+};
+
+/// Data and methods for fully-assembled bilinear forms
+class FABilinearFormExtension : public BilinearFormExtension
+{
+public:
+   FABilinearFormExtension(BilinearForm *form)
+      : BilinearFormExtension(form) { }
 
    /// TODO
-   void AddDomainIntegrator(BilinearFormIntegrator*) {}
    void Assemble() {}
-   void FormSystemOperator(const Array<int> &ess_tdof_list, Operator *&A) {}
+   void FormSystemMatrix(const Array<int> &ess_tdof_list, OperatorHandle &A) {}
    void FormLinearSystem(const Array<int> &ess_tdof_list,
                          Vector &x, Vector &b,
-                         Operator *&A, Vector &X, Vector &B,
+                         OperatorHandle &A, Vector &X, Vector &B,
                          int copy_interior = 0) {}
-   void RecoverFEMSolution(const Vector &X, const Vector &b, Vector &x) {}
    void Mult(const Vector &x, Vector &y) const {}
    void MultTranspose(const Vector &x, Vector &y) const {}
    ~FABilinearFormExtension() {}
 };
 
 /// Data and methods for element-assembled bilinear forms
-class EABilinearFormExtension : public Operator
+class EABilinearFormExtension : public BilinearFormExtension
 {
-private:
-   BilinearForm *a;
 public:
-   EABilinearFormExtension(BilinearForm *form);
+   EABilinearFormExtension(BilinearForm *form)
+      : BilinearFormExtension(form) { }
 
    /// TODO
-   void AddDomainIntegrator(BilinearFormIntegrator*) {}
    void Assemble() {}
-   void FormSystemOperator(const Array<int> &ess_tdof_list, Operator *&A) {}
+   void FormSystemMatrix(const Array<int> &ess_tdof_list, OperatorHandle &A) {}
    void FormLinearSystem(const Array<int> &ess_tdof_list,
                          Vector &x, Vector &b,
-                         Operator *&A, Vector &X, Vector &B,
+                         OperatorHandle &A, Vector &X, Vector &B,
                          int copy_interior = 0) {}
-   void RecoverFEMSolution(const Vector &X, const Vector &b, Vector &x) {}
    void Mult(const Vector &x, Vector &y) const {}
    void MultTranspose(const Vector &x, Vector &y) const {}
    ~EABilinearFormExtension() {}
 };
 
 /// Data and methods for partially-assembled bilinear forms
-class PABilinearFormExtension : public Operator
+class PABilinearFormExtension : public BilinearFormExtension
 {
-private:
-   BilinearForm *a;
+protected:
    const FiniteElementSpace *trialFes, *testFes;
-   Array<BilinearFormIntegrator*> integrators;
    mutable Vector localX, localY;
    ElemRestriction *elem_restrict;
 
 public:
    PABilinearFormExtension(BilinearForm*);
-   void AddDomainIntegrator(BilinearFormIntegrator*);
-   // void AddBoundaryIntegrator(BilinearFormIntegrator*);
-   // void AddInteriorFaceIntegrator(BilinearFormIntegrator*);
-   // void AddBoundaryFaceIntegrator(BilinearFormIntegrator*);
 
    void Assemble();
-   void FormSystemOperator(const Array<int> &ess_tdof_list, Operator *&A);
+   void FormSystemMatrix(const Array<int> &ess_tdof_list, OperatorHandle &A);
    void FormLinearSystem(const Array<int> &ess_tdof_list,
                          Vector &x, Vector &b,
-                         Operator *&A, Vector &X, Vector &B,
+                         OperatorHandle &A, Vector &X, Vector &B,
                          int copy_interior = 0);
-   void RecoverFEMSolution(const Vector &X, const Vector &b, Vector &x);
 
    void Mult(const Vector &x, Vector &y) const;
    void MultTranspose(const Vector &x, Vector &y) const;
-   void Update(FiniteElementSpace *fes);
+   void Update();
 
    ~PABilinearFormExtension();
 };
 
 /// Data and methods for matrix-free bilinear forms
-class MFBilinearFormExtension : public Operator
+class MFBilinearFormExtension : public BilinearFormExtension
 {
-private:
-   BilinearForm *a;
 public:
-   MFBilinearFormExtension(BilinearForm *form);
+   MFBilinearFormExtension(BilinearForm *form)
+      : BilinearFormExtension(form) { }
 
    /// TODO
-   void AddDomainIntegrator(BilinearFormIntegrator*) {}
    void Assemble() {}
-   void FormSystemOperator(const Array<int> &ess_tdof_list, Operator *&A) {}
+   void FormSystemMatrix(const Array<int> &ess_tdof_list, OperatorHandle &A) {}
    void FormLinearSystem(const Array<int> &ess_tdof_list,
                          Vector &x, Vector &b,
-                         Operator *&A, Vector &X, Vector &B,
+                         OperatorHandle &A, Vector &X, Vector &B,
                          int copy_interior = 0) {}
-   void RecoverFEMSolution(const Vector &X, const Vector &b, Vector &x) {}
    void Mult(const Vector &x, Vector &y) const {}
    void MultTranspose(const Vector &x, Vector &y) const {}
    ~MFBilinearFormExtension() {}

--- a/fem/bilininteg_ext.cpp
+++ b/fem/bilininteg_ext.cpp
@@ -1781,7 +1781,12 @@ GeometryExtension* GeometryExtension::Get(const FiniteElementSpace& fes,
       if (geom) { delete geom; }
       geom = new GeometryExtension();
    }
+
+   const bool dev_enabled = Device::IsEnabled();
+   if (dev_enabled) { Device::Disable(); }
    mesh->EnsureNodes();
+   if (dev_enabled) { Device::Enable(); }
+
    const GridFunction *nodes = mesh->GetNodes();
    const mfem::FiniteElementSpace *fespace = nodes->FESpace();
    const mfem::FiniteElement *fe = fespace->GetFE(0);

--- a/fem/gridfunc.hpp
+++ b/fem/gridfunc.hpp
@@ -104,7 +104,9 @@ public:
    GridFunction &operator=(const GridFunction &rhs)
    { return operator=((const Vector &)rhs); }
 
-   /// Make the GridFunction the owner of 'fec' and 'fes'
+   /// Make the GridFunction the owner of #fec and #fes.
+   /** If the new FiniteElementCollection, @a _fec, is NULL, ownership of #fec
+       and #fes is taken away. */
    void MakeOwner(FiniteElementCollection *_fec) { fec = _fec; }
 
    FiniteElementCollection *OwnFEC() { return fec; }

--- a/fem/pbilinearform.hpp
+++ b/fem/pbilinearform.hpp
@@ -52,10 +52,8 @@ private:
 public:
    /// Creates parallel bilinear form associated with the FE space @a *pf.
    /** The pointer @a pf is not owned by the newly constructed object. */
-   ParBilinearForm(ParFiniteElementSpace *pf,
-                   AssemblyLevel assembly_level = AssemblyLevel::FULL,
-                   int elem_batch = 1)
-      : BilinearForm(pf,  assembly_level, elem_batch), pfes(pf),
+   ParBilinearForm(ParFiniteElementSpace *pf)
+      : BilinearForm(pf), pfes(pf),
         p_mat(Operator::Hypre_ParCSR), p_mat_e(Operator::Hypre_ParCSR)
    { keep_nbr_block = false; }
 
@@ -77,7 +75,8 @@ public:
        those rows. Must be called before the first Assemble call. */
    void KeepNbrBlock(bool knb = true) { keep_nbr_block = knb; }
 
-   /// Set the operator type id for the parallel matrix/operator.
+   /** @brief Set the operator type id for the parallel matrix/operator when
+       using AssemblyLevel::FULL. */
    /** If using static condensation or hybridization, call this method *after*
        enabling it. */
    void SetOperatorType(Operator::Type tid)
@@ -165,94 +164,15 @@ public:
    virtual const Operator *GetRestriction() const
    { return pfes->GetRestrictionMatrix(); }
 
-   /** Form the linear system A X = B, corresponding to the current bilinear
-       form and b(.), by applying any necessary transformations such as:
-       eliminating boundary conditions; applying conforming constraints for
-       non-conforming AMR; parallel assembly; static condensation;
-       hybridization.
+   using BilinearForm::FormLinearSystem;
+   using BilinearForm::FormSystemMatrix;
 
-       The ParGridFunction-size vector x must contain the essential b.c. The
-       ParBilinearForm and the ParLinearForm-size vector b must be assembled.
+   virtual void FormLinearSystem(const Array<int> &ess_tdof_list, Vector &x,
+                                 Vector &b, OperatorHandle &A, Vector &X,
+                                 Vector &B, int copy_interior = 0);
 
-       The vector X is initialized with a suitable initial guess: when using
-       hybridization, the vector X is set to zero; otherwise, the essential
-       entries of X are set to the corresponding b.c. and all other entries are
-       set to zero (copy_interior == 0) or copied from x (copy_interior != 0).
-
-       This method can be called multiple times (with the same ess_tdof_list
-       array) to initialize different right-hand sides and boundary condition
-       values.
-
-       After solving the linear system, the finite element solution x can be
-       recovered by calling RecoverFEMSolution (with the same vectors X, b, and
-       x). */
-   void FormLinearSystem(const Array<int> &ess_tdof_list, Vector &x, Vector &b,
-                         OperatorHandle &A, Vector &X, Vector &B,
-                         int copy_interior = 0);
-
-   /** Version of the method FormLinearSystem() where the system matrix is
-       returned in the variable @a A, of type OpType, holding a *reference* to
-       the system matrix (created with the method OpType::MakeRef()). The
-       reference will be invalidated when SetOperatorType(), Update(), or the
-       destructor is called. */
-   template <typename OpType>
-   void FormLinearSystem(const Array<int> &ess_tdof_list, Vector &x, Vector &b,
-                         OpType &A, Vector &X, Vector &B,
-                         int copy_interior = 0)
-   {
-      OperatorHandle Ah;
-      FormLinearSystem(ess_tdof_list, x, b, Ah, X, B, copy_interior);
-      OpType *A_ptr = Ah.Is<OpType>();
-      MFEM_VERIFY(A_ptr, "invalid OpType used");
-      A.MakeRef(*A_ptr);
-   }
-
-   /// Form the linear system matrix @a A, see FormLinearSystem() for details.
-   void FormSystemMatrix(const Array<int> &ess_tdof_list, OperatorHandle &A);
-
-   /** Form the linear system A X = B, corresponding to the current bilinear
-       form and b(.), by applying any necessary transformations such as:
-       eliminating boundary conditions; applying conforming constraints for
-       non-conforming AMR; parallel assembly; static condensation;
-       hybridization.
-
-       The ParGridFunction-size vector x must contain the essential b.c. The
-       ParBilinearForm and the ParLinearForm-size vector b must be assembled.
-
-       The vector X is initialized with a suitable initial guess: when using
-       hybridization, the vector X is set to zero; otherwise, the essential
-       entries of X are set to the corresponding b.c. and all other entries are
-       set to zero (copy_interior == 0) or copied from x (copy_interior != 0).
-
-       This method can be called multiple times (with the same ess_tdof_list
-       array) to initialize different right-hand sides and boundary condition
-       values.
-
-       After solving the linear system, the finite element solution x can be
-       recovered by calling RecoverFEMSolution (with the same vectors X, b, and
-       x). */
-   void FormLinearSystem(const Array<int> &ess_tdof_list, Vector &x, Vector &b,
-                         Operator *&A, Vector &X, Vector &B,
-                         int copy_interior = 0);
-
-   /// Form the linear system operator @a A, see FormLinearSystem() for details.
-   virtual void FormSystemOperator(const Array<int> &ess_tdof_list,
-                                   Operator *&A);
-
-   /** Version of the method FormSystemMatrix() where the system matrix is
-       returned in the variable @a A, of type OpType, holding a *reference* to
-       the system matrix (created with the method OpType::MakeRef()). The
-       reference will be invalidated when SetOperatorType(), Update(), or the
-       destructor is called. */
-   template <typename OpType>
-   void FormSystemMatrix(const Array<int> &ess_tdof_list, OpType &A)
-   {
-      OperatorHandle Ah;
-      FormSystemMatrix(ess_tdof_list, Ah);
-      OpType *A_ptr = Ah.Is<OpType>();
-      MFEM_VERIFY(A_ptr, "invalid OpType used");
-      A.MakeRef(*A_ptr);
-   }
+   virtual void FormSystemMatrix(const Array<int> &ess_tdof_list,
+                                 OperatorHandle &A);
 
    /** Call this method after solving a linear system constructed using the
        FormLinearSystem method to recover the solution as a ParGridFunction-size

--- a/linalg/handle.hpp
+++ b/linalg/handle.hpp
@@ -81,6 +81,12 @@ public:
    /// Access the underlying Operator pointer.
    Operator *Ptr() const { return oper; }
 
+   /// Support the use of -> to call methods of the underlying Operator.
+   Operator *operator->() const { return oper; }
+
+   /// Access the underlying Operator.
+   Operator &operator*() { return *oper; }
+
    /// Get the currently set operator type id.
    Operator::Type Type() const { return type_id; }
 
@@ -186,6 +192,10 @@ public:
    void EliminateBC(const OperatorHandle &A_e, const Array<int> &ess_dof_list,
                     const Vector &X, Vector &B) const;
 };
+
+
+/// Add an alternative name for OperatorHandle -- OperatorPtr.
+typedef OperatorHandle OperatorPtr;
 
 } // namespace mfem
 

--- a/mesh/pmesh.cpp
+++ b/mesh/pmesh.cpp
@@ -3111,7 +3111,7 @@ void ParMesh::Rebalance()
    sequence++;
 
    // Make sure the Nodes use a ParFiniteElementSpace
-   if (dynamic_cast<ParFiniteElementSpace*>(Nodes->FESpace()) == NULL)
+   if (Nodes && dynamic_cast<ParFiniteElementSpace*>(Nodes->FESpace()) == NULL)
    {
       ParFiniteElementSpace *pfes =
          new ParFiniteElementSpace(*Nodes->FESpace(), *this);

--- a/mesh/pmesh.cpp
+++ b/mesh/pmesh.cpp
@@ -3110,6 +3110,22 @@ void ParMesh::Rebalance()
    last_operation = Mesh::REBALANCE;
    sequence++;
 
+   // Make sure the Nodes use a ParFiniteElementSpace
+   if (dynamic_cast<ParFiniteElementSpace*>(Nodes->FESpace()) == NULL)
+   {
+      ParFiniteElementSpace *pfes =
+         new ParFiniteElementSpace(*Nodes->FESpace(), *this);
+      ParGridFunction *new_nodes = new ParGridFunction(pfes);
+      *new_nodes = *Nodes;
+      if (Nodes->OwnFEC())
+      {
+         new_nodes->MakeOwner(Nodes->OwnFEC());
+         Nodes->MakeOwner(NULL); // takes away ownership of 'fec' and 'fes'
+         delete Nodes->FESpace();
+      }
+      delete Nodes;
+      Nodes = new_nodes;
+   }
    UpdateNodes();
 }
 


### PR DESCRIPTION
Updates in the BilinearForm and related classes. Small updates in ex1, ex1p, ex6, ex6p.

There are still some issues:
* ex6 sometimes fails with 'cuda' (fixed with the mm erase)
* ex6p fails with PA even with 'cpu' (fixed)
