### PR TITLE
Add forall to mfem.hpp and guard when not using cuda [okina-build-fix]

### DIFF
--- a/general/cuda.hpp
+++ b/general/cuda.hpp
@@ -15,7 +15,7 @@
 #include "../config/config.hpp"
 #include "error.hpp"
 
-#ifdef MFEM_USE_CUDA
+#if defined(__NVCC__) && defined(MFEM_USE_CUDA)
 #include <cuda_runtime.h>
 #include <cuda.h>
 #endif
@@ -23,7 +23,7 @@
 // CUDA block size used by MFEM.
 #define MFEM_CUDA_BLOCKS 256
 
-#ifdef MFEM_USE_CUDA
+#if defined(__NVCC__) && defined(MFEM_USE_CUDA)
 #define MFEM_ATTR_DEVICE __device__
 #define MFEM_ATTR_HOST_DEVICE __host__ __device__
 // Define the CUDA debug macros:

--- a/general/forall.hpp
+++ b/general/forall.hpp
@@ -90,7 +90,7 @@ void RajaSeqWrap(const int N, HBODY &&h_body)
 
 
 /// CUDA backend
-#if defined(__NVCC_) && defined(MFEM_USE_CUDA)
+#if defined(__NVCC__) && defined(MFEM_USE_CUDA)
 
 template <typename BODY> __global__ static
 void CuKernel(const int N, BODY body)

--- a/general/forall.hpp
+++ b/general/forall.hpp
@@ -57,7 +57,7 @@ void OmpWrap(const int N, HBODY &&h_body)
 template <int BLOCKS, typename DBODY>
 void RajaCudaWrap(const int N, DBODY &&d_body)
 {
-#if defined(MFEM_USE_RAJA) && defined(RAJA_ENABLE_CUDA)
+#if defined(__NVCC__) && defined(MFEM_USE_RAJA) && defined(RAJA_ENABLE_CUDA)
    RAJA::forall<RAJA::cuda_exec<BLOCKS>>(RAJA::RangeSegment(0,N),d_body);
 #else
    MFEM_ABORT("RAJA::Cuda requested but RAJA::Cuda is not enabled!");
@@ -90,7 +90,7 @@ void RajaSeqWrap(const int N, HBODY &&h_body)
 
 
 /// CUDA backend
-#ifdef MFEM_USE_CUDA
+#if defined(__NVCC_) && defined(MFEM_USE_CUDA)
 
 template <typename BODY> __global__ static
 void CuKernel(const int N, BODY body)

--- a/mfem.hpp
+++ b/mfem.hpp
@@ -17,6 +17,7 @@
 #include "general/error.hpp"
 #include "general/device.hpp"
 #include "general/array.hpp"
+#include "general/forall.hpp"
 #include "general/sets.hpp"
 #include "general/hash.hpp"
 #include "general/mem_alloc.hpp"


### PR DESCRIPTION
With this PR users will be able to use MFEM_FORALL to create mfem kernels, for example

```
#include <iostream>
#include "mfem.hpp"

using namespace mfem;

int main(int argc, char* argv[]) {

  const char *device = "cpu";
  Device::Configure(device);
  Device::Print();
  Device::Enable();

  MFEM_FORALL(i, 1, printf("Hello \n"););

  Device::Disable();

  return 0;
}
```

 Additionally, I included guards to enable building with a host compiler when mfem is configured with CUDA.  