### PR TITLE
ExchangeFaceNbrData for VectorFE [vfe-dev]

### DIFF
--- a/fem/pbilinearform.cpp
+++ b/fem/pbilinearform.cpp
@@ -203,7 +203,14 @@ void ParBilinearForm::AssembleSharedFaces(int skip_zeros)
       vdofs1.Copy(vdofs_all);
       for (int j = 0; j < vdofs2.Size(); j++)
       {
-         vdofs2[j] += height;
+         if (vdofs2[j] >= 0)
+         {
+            vdofs2[j] += height;
+         } 
+         else 
+         {
+            vdofs2[j] -= height;
+         }
       }
       vdofs_all.Append(vdofs2);
       for (int k = 0; k < fbfi.Size(); k++)

--- a/fem/pbilinearform.cpp
+++ b/fem/pbilinearform.cpp
@@ -206,8 +206,8 @@ void ParBilinearForm::AssembleSharedFaces(int skip_zeros)
          if (vdofs2[j] >= 0)
          {
             vdofs2[j] += height;
-         } 
-         else 
+         }
+         else
          {
             vdofs2[j] -= height;
          }

--- a/fem/pfespace.cpp
+++ b/fem/pfespace.cpp
@@ -903,7 +903,6 @@ void ParFiniteElementSpace::ExchangeFaceNbrData()
          GetElementVDofs(my_elems[i], ldofs);
          for (int j = 0; j < ldofs.Size(); j++)
          {
-
             int ldof = (ldofs[j] >= 0 ? ldofs[j] : -1-ldofs[j]);
 
             if (ldof_marker[ldof] != fn)
@@ -1032,7 +1031,6 @@ void ParFiniteElementSpace::ExchangeFaceNbrData()
 
       for ( ; j < j_end; j++)
       {
-
          if (recv_J[j] >= 0)
          {
             recv_J[j] += shift;
@@ -1090,7 +1088,6 @@ void ParFiniteElementSpace::ExchangeFaceNbrData()
    {
       for (int j_end = face_nbr_ldof.GetI()[fn+1]; j < j_end; j++)
       {
-
          int ldof = face_nbr_ldof.GetJ()[j];
          if (ldof < 0)
          {

--- a/fem/pfespace.cpp
+++ b/fem/pfespace.cpp
@@ -901,12 +901,16 @@ void ParFiniteElementSpace::ExchangeFaceNbrData()
       for (int i = 0; i < num_my_elems; i++)
       {
          GetElementVDofs(my_elems[i], ldofs);
-         for (int j = 0; j < ldofs.Size(); j++)
-            if (ldof_marker[ldofs[j]] != fn)
+         for (int j = 0; j < ldofs.Size(); j++) {
+            
+            int ldof = (ldofs[j] >= 0 ? ldofs[j] : -1-ldofs[j]);
+         
+            if (ldof_marker[ldof] != fn)
             {
-               ldof_marker[ldofs[j]] = fn;
+               ldof_marker[ldof] = fn;
                send_face_nbr_ldof.AddAColumnInRow(fn);
             }
+         }
          send_nbr_elem_dof.AddColumnsInRow(send_el_off[fn] + i, ldofs.Size());
       }
 
@@ -960,9 +964,11 @@ void ParFiniteElementSpace::ExchangeFaceNbrData()
          GetElementVDofs(my_elems[i], ldofs);
          for (int j = 0; j < ldofs.Size(); j++)
          {
-            if (ldof_marker[ldofs[j]] != fn)
+            int ldof = (ldofs[j] >= 0 ? ldofs[j] : -1-ldofs[j]);
+            
+            if (ldof_marker[ldof] != fn)
             {
-               ldof_marker[ldofs[j]] = fn;
+               ldof_marker[ldof] = fn;
                send_face_nbr_ldof.AddConnection(fn, ldofs[j]);
             }
          }
@@ -983,12 +989,14 @@ void ParFiniteElementSpace::ExchangeFaceNbrData()
 
       for (int i = 0; i < num_ldofs; i++)
       {
-         ldof_marker[ldofs[i]] = i;
+         int ldof = (ldofs[i] >= 0 ? ldofs[i] : -1-ldofs[i]);
+         ldof_marker[ldof] = i;
       }
 
       for ( ; j < j_end; j++)
       {
-         send_J[j] = ldof_marker[send_J[j]];
+         int ldof = (send_J[j] >= 0 ? send_J[j] : -1-send_J[j]);
+         send_J[j] = (send_J[j] >= 0 ? ldof_marker[ldof] : -1-ldof_marker[ldof]);
       }
    }
 
@@ -1023,7 +1031,12 @@ void ParFiniteElementSpace::ExchangeFaceNbrData()
 
       for ( ; j < j_end; j++)
       {
-         recv_J[j] += shift;
+         
+         if (recv_J[j] >= 0) {
+            recv_J[j] += shift;
+         } else {
+            recv_J[j] -= shift;
+         }
       }
    }
 
@@ -1071,14 +1084,19 @@ void ParFiniteElementSpace::ExchangeFaceNbrData()
    // the face-neighbor dofs
    for (int fn = 0, j = 0; fn < num_face_nbrs; fn++)
    {
-      for (int j_end = face_nbr_ldof.GetI()[fn+1]; j < j_end; j++)
-         face_nbr_glob_dof_map[j] =
-            dof_face_nbr_offsets[fn] + face_nbr_ldof.GetJ()[j];
+      for (int j_end = face_nbr_ldof.GetI()[fn+1]; j < j_end; j++) {
+         
+         int ldof = face_nbr_ldof.GetJ()[j];
+         if (ldof < 0)
+            ldof = -1-ldof;
+         
+         face_nbr_glob_dof_map[j] = dof_face_nbr_offsets[fn] + ldof;
+      }
    }
 
    MPI_Waitall(num_face_nbrs, send_requests, statuses);
 
-   delete [] statuses;
+   delete [] statuses;  
    delete [] requests;
 }
 

--- a/fem/pfespace.cpp
+++ b/fem/pfespace.cpp
@@ -901,10 +901,11 @@ void ParFiniteElementSpace::ExchangeFaceNbrData()
       for (int i = 0; i < num_my_elems; i++)
       {
          GetElementVDofs(my_elems[i], ldofs);
-         for (int j = 0; j < ldofs.Size(); j++) {
-            
+         for (int j = 0; j < ldofs.Size(); j++)
+         {
+
             int ldof = (ldofs[j] >= 0 ? ldofs[j] : -1-ldofs[j]);
-         
+
             if (ldof_marker[ldof] != fn)
             {
                ldof_marker[ldof] = fn;
@@ -965,7 +966,7 @@ void ParFiniteElementSpace::ExchangeFaceNbrData()
          for (int j = 0; j < ldofs.Size(); j++)
          {
             int ldof = (ldofs[j] >= 0 ? ldofs[j] : -1-ldofs[j]);
-            
+
             if (ldof_marker[ldof] != fn)
             {
                ldof_marker[ldof] = fn;
@@ -1031,10 +1032,13 @@ void ParFiniteElementSpace::ExchangeFaceNbrData()
 
       for ( ; j < j_end; j++)
       {
-         
-         if (recv_J[j] >= 0) {
+
+         if (recv_J[j] >= 0)
+         {
             recv_J[j] += shift;
-         } else {
+         }
+         else
+         {
             recv_J[j] -= shift;
          }
       }
@@ -1084,19 +1088,22 @@ void ParFiniteElementSpace::ExchangeFaceNbrData()
    // the face-neighbor dofs
    for (int fn = 0, j = 0; fn < num_face_nbrs; fn++)
    {
-      for (int j_end = face_nbr_ldof.GetI()[fn+1]; j < j_end; j++) {
-         
+      for (int j_end = face_nbr_ldof.GetI()[fn+1]; j < j_end; j++)
+      {
+
          int ldof = face_nbr_ldof.GetJ()[j];
          if (ldof < 0)
+         {
             ldof = -1-ldof;
-         
+         }
+
          face_nbr_glob_dof_map[j] = dof_face_nbr_offsets[fn] + ldof;
       }
    }
 
    MPI_Waitall(num_face_nbrs, send_requests, statuses);
 
-   delete [] statuses;  
+   delete [] statuses;
    delete [] requests;
 }
 


### PR DESCRIPTION
Hello

For VectorFiniteElement, the indexing of dofs can be negative integers, so it should be handled suitably. I have fixed some indexing related bugs in pfespace and pbilinearform for vector finite elements.

Suggestion: 
I did not completely read through the `pAllocMat` routine in `ParBilinearForm`, but I think some changes would also need to be added there when the precompute_sparsity flag is on.

Resolves #830.