### PR TITLE
Handle special case where B_offd is empty [bugfix/csr-mat-sum]

### DIFF
--- a/linalg/hypre.hpp
+++ b/linalg/hypre.hpp
@@ -468,13 +468,16 @@ public:
    { internal::hypre_ParCSRMatrixSetConstantValues(A, value); return *this; }
 
    /** Perform the operation `*this += B`, assuming that both matrices use the
-       same row and column partitions and the same col_map_offd arrays. We also
-       assume that the sparsity pattern of `*this` contains that of `B`. */
+       same row and column partitions and the same col_map_offd arrays, or B has
+       an empty off-diagonal block. We also assume that the sparsity pattern of
+       `*this` contains that of `B`. */
    HypreParMatrix &operator+=(const HypreParMatrix &B) { return Add(1.0, B); }
 
    /** Perform the operation `*this += beta*B`, assuming that both matrices use
-       the same row and column partitions and the same col_map_offd arrays. We
-       also assume that the sparsity pattern of `*this` contains that of `B`. */
+       the same row and column partitions and the same col_map_offd arrays, or
+       B has an empty off-diagonal block. We also assume that the sparsity
+       pattern of `*this` contains that of `B`. For a more general case consider
+       the stand-alone function ParAdd described below. */
    HypreParMatrix &Add(const double beta, const HypreParMatrix &B)
    {
       MFEM_VERIFY(internal::hypre_ParCSRMatrixSum(A, beta, B.A) == 0,

--- a/linalg/hypre_parcsr.cpp
+++ b/linalg/hypre_parcsr.cpp
@@ -1520,10 +1520,14 @@ hypre_ParCSRMatrixSum(hypre_ParCSRMatrix *A,
    hypre_CSRMatrix *A_offd = hypre_ParCSRMatrixOffd(A);
    hypre_CSRMatrix *B_diag = hypre_ParCSRMatrixDiag(B);
    hypre_CSRMatrix *B_offd = hypre_ParCSRMatrixOffd(B);
+   HYPRE_Int ncols_B_offd  = hypre_CSRMatrixNumCols(B_offd);
    HYPRE_Int error;
 
    error = hypre_CSRMatrixSum(A_diag, beta, B_diag);
-   error = error ? error : hypre_CSRMatrixSum(A_offd, beta, B_offd);
+   if (ncols_B_offd > 0) /* treat B_offd as zero if it has no columns */
+   {
+      error = error ? error : hypre_CSRMatrixSum(A_offd, beta, B_offd);
+   }
 
    return error;
 }

--- a/linalg/hypre_parcsr.hpp
+++ b/linalg/hypre_parcsr.hpp
@@ -115,8 +115,9 @@ hypre_ParCSRMatrixAdd(hypre_ParCSRMatrix *A,
                       hypre_ParCSRMatrix *B);
 
 /** Perform the operation A += beta*B, assuming that both matrices use the same
-    row and column partitions and the same col_map_offd arrays. We also assume
-    that the sparsity pattern of A contains that of B. */
+    row and column partitions and the same col_map_offd arrays, or B has an empty
+    off-diagonal block. We also assume that the sparsity pattern of A contains
+    that of B. */
 HYPRE_Int
 hypre_ParCSRMatrixSum(hypre_ParCSRMatrix *A,
                       HYPRE_Complex       beta,


### PR DESCRIPTION
When computing `A.HypreParCSRMatrix::Add(beta, B);` the code currently produces an error if `B_offd` is empty but `A_offd` is not.  Technically this may be considered correct since the sparsity patterns are different.  However, it's simple to handle this situation in a mathematically correct manner by treating `B_offd` as zero.

This issue presented itself when computing `M+dt*S` where `M` is a mass matrix and `S` is a stiffness matrix and the basis is DG.  In this situation `M` is block diagonal and therefore has no off-diagonal portion.