### PR TITLE
Adding support for 1D meshes in ParMesh::PrintAsOne [print-as-one-1d-dev]

### DIFF
--- a/mesh/pmesh.cpp
+++ b/mesh/pmesh.cpp
@@ -4010,6 +4010,7 @@ void ParMesh::PrintAsOne(std::ostream &out)
           "# SQUARE      = 3\n"
           "# TETRAHEDRON = 4\n"
           "# CUBE        = 5\n"
+          "# PRISM       = 6\n"
           "#\n";
 
       out << "\ndimension\n" << Dim;
@@ -4108,6 +4109,15 @@ void ParMesh::PrintAsOne(std::ostream &out)
    {
       switch (Dim)
       {
+         case 1:
+            for (i = 0; i < svert_lvert.Size(); i++)
+            {
+               ints.Append(Geometry::POINT);
+               ints.Append(svert_lvert[i]);
+               ne++;
+            }
+            break;
+
          case 2:
             for (i = 0; i < shared_edges.Size(); i++)
             {


### PR DESCRIPTION
I didn't find anything that uses this method for 1D meshes in the master branch of MFEM.  However, I did run into this problem while developing a miniapp in another branch because `ParMesh::PrintAsOne` is used by the function `VisualizeMesh` in `miniapps/common/pfem_extras.cpp`.

This PR addresses issue #826 .

| PR | Author | Editor | Reviewers  | Assignment | Approval | Merge |
| --- | --- | --- | ---  | --- | --- | --- |
| https://github.com/mfem/mfem/pull/892 | @mlstowell  | @tzanio | @jakubcerveny + @psocratis | 11/23/19 | 12/1/19 | ⌛due 12/8/19 | 