### PR TITLE
GeometryExtension in the Mesh [yohann/mesh_ext]

### DIFF
--- a/fem/bilininteg.hpp
+++ b/fem/bilininteg.hpp
@@ -1648,17 +1648,17 @@ private:
    MatrixCoefficient *MQ;
    // PA extension
    DofToQuad *maps;
-   GeometryExtension *geom;
+   XTMesh *xtmesh;
    int dim, ne, dofs1D, quad1D;
 public:
    /// Construct a diffusion integrator with coefficient Q = 1
-   DiffusionIntegrator() { Q = NULL; MQ = NULL; maps = NULL; geom = NULL; }
+   DiffusionIntegrator() { Q = NULL; MQ = NULL; maps = NULL; xtmesh = NULL; }
 
    /// Construct a diffusion integrator with a scalar coefficient q
-   DiffusionIntegrator (Coefficient &q) : Q(&q) { MQ = NULL; maps = NULL; geom = NULL; }
+   DiffusionIntegrator (Coefficient &q) : Q(&q) { MQ = NULL; maps = NULL; xtmesh = NULL; }
 
    /// Construct a diffusion integrator with a matrix coefficient q
-   DiffusionIntegrator (MatrixCoefficient &q) : MQ(&q) { Q = NULL; maps = NULL; geom = NULL; }
+   DiffusionIntegrator (MatrixCoefficient &q) : MQ(&q) { Q = NULL; maps = NULL; xtmesh = NULL; }
 
    /** Given a particular Finite Element
        computes the element stiffness matrix elmat. */
@@ -1704,14 +1704,14 @@ protected:
    // PA extension
    Vector vec;
    DofToQuad *maps;
-   GeometryExtension *geom;
+   XTMesh *xtmesh;
    int dim, ne, nq, dofs1D, quad1D;
 public:
    MassIntegrator(const IntegrationRule *ir = NULL)
-      : BilinearFormIntegrator(ir) { Q = NULL; maps = NULL; geom = NULL; }
+      : BilinearFormIntegrator(ir) { Q = NULL; maps = NULL; xtmesh = NULL; }
    /// Construct a mass integrator with coefficient q
    MassIntegrator(Coefficient &q, const IntegrationRule *ir = NULL)
-      : BilinearFormIntegrator(ir), Q(&q) { maps = NULL; geom = NULL; }
+      : BilinearFormIntegrator(ir), Q(&q) { maps = NULL; xtmesh = NULL; }
 
    /** Given a particular Finite Element
        computes the element mass matrix elmat. */

--- a/fem/bilininteg.hpp
+++ b/fem/bilininteg.hpp
@@ -16,6 +16,7 @@
 #include "nonlininteg.hpp"
 #include "fespace.hpp"
 #include "bilininteg_ext.hpp"
+#include "../mesh/mesh_ext.hpp"
 
 namespace mfem
 {

--- a/fem/bilininteg_ext.cpp
+++ b/fem/bilininteg_ext.cpp
@@ -238,7 +238,7 @@ static void PADiffusionSetup(const int dim,
 
 void DiffusionIntegrator::Assemble(const FiniteElementSpace &fes)
 {
-   const Mesh *mesh = fes.GetMesh();
+   Mesh *mesh = fes.GetMesh();
    const IntegrationRule *rule = IntRule;
    const FiniteElement &el = *fes.GetFE(0);
    const IntegrationRule *ir = rule?rule:&DefaultGetRule(el,el);
@@ -249,7 +249,7 @@ void DiffusionIntegrator::Assemble(const FiniteElementSpace &fes)
    ne = fes.GetNE();
    dofs1D = el.GetOrder() + 1;
    quad1D = IntRules.Get(Geometry::SEGMENT, ir->GetOrder()).GetNPoints();
-   geom = GeometryExtension::Get(fes,*ir);
+   geom = mesh->GetGeometryExtension(*ir);
    maps = DofToQuad::Get(fes, fes, *ir);
    vec.SetSize(symmDims * nq * ne);
    const double coeff = static_cast<ConstantCoefficient*>(Q)->constant;
@@ -359,9 +359,6 @@ static void OccaPADiffusionApply3D(const int D1D,
 
 #define QUAD_2D_ID(X, Y) (X + ((Y) * Q1D))
 #define QUAD_3D_ID(X, Y, Z) (X + ((Y) * Q1D) + ((Z) * Q1D*Q1D))
-
-const int MAX_Q1D = 10;
-const int MAX_D1D = 10;
 
 // PA Diffusion Apply 2D kernel
 template<int T_D1D = 0, int T_Q1D = 0> static
@@ -745,7 +742,7 @@ DiffusionIntegrator::~DiffusionIntegrator()
 // PA Mass Assemble kernel
 void MassIntegrator::Assemble(const FiniteElementSpace &fes)
 {
-   const Mesh *mesh = fes.GetMesh();
+   Mesh *mesh = fes.GetMesh();
    const IntegrationRule *rule = IntRule;
    const FiniteElement &el = *fes.GetFE(0);
    const IntegrationRule *ir = rule?rule:&DefaultGetRule(el,el);
@@ -754,7 +751,7 @@ void MassIntegrator::Assemble(const FiniteElementSpace &fes)
    nq = ir->GetNPoints();
    dofs1D = el.GetOrder() + 1;
    quad1D = IntRules.Get(Geometry::SEGMENT, ir->GetOrder()).GetNPoints();
-   geom = GeometryExtension::Get(fes,*ir);
+   geom = mesh->GetGeometryExtension(*ir);
    maps = DofToQuad::Get(fes, fes, *ir);
    vec.SetSize(ne*nq);
    ConstantCoefficient *const_coeff = dynamic_cast<ConstantCoefficient*>(Q);
@@ -1503,401 +1500,5 @@ DofToQuad* DofToQuad::GetD2QSimplexMaps(const FiniteElement& fe,
    return maps;
 }
 
-
-static long sequence = -1;
-static GeometryExtension *geom = NULL;
-
-static void GeomFill(const int vdim,
-                     const int NE, const int ND, const int NX,
-                     const int* elementMap, int* eMap,
-                     const double *_X, double *meshNodes)
-{
-   const DeviceArray d_elementMap(elementMap, ND*NE);
-   DeviceArray d_eMap(eMap, ND*NE);
-   const DeviceVector X(_X, NX);
-   DeviceVector d_meshNodes(meshNodes, vdim*ND*NE);
-   MFEM_FORALL(e, NE,
-   {
-      for (int d = 0; d < ND; ++d)
-      {
-         const int lid = d+ND*e;
-         const int gid = d_elementMap[lid];
-         d_eMap[lid] = gid;
-         for (int v = 0; v < vdim; ++v)
-         {
-            const int moffset = v+vdim*lid;
-            const int xoffset = v+vdim*gid;
-            d_meshNodes[moffset] = X[xoffset];
-         }
-      }
-   });
-}
-
-static void NodeCopyByVDim(const int elements,
-                           const int numDofs,
-                           const int ndofs,
-                           const int dims,
-                           const int* eMap,
-                           const double* Sx,
-                           double* nodes)
-{
-   MFEM_FORALL(e,elements,
-   {
-      for (int dof = 0; dof < numDofs; ++dof)
-      {
-         const int lid = dof+numDofs*e;
-         const int gid = eMap[lid];
-         for (int v = 0; v < dims; ++v)
-         {
-            const int moffset = v+dims*lid;
-            const int voffset = gid+v*ndofs;
-            nodes[moffset] = Sx[voffset];
-         }
-      }
-   });
-}
-
-template<int T_D1D = 0, int T_Q1D = 0> static
-void PAGeom2D(const int NE,
-              const double* _B,
-              const double* _G,
-              const double* _X,
-              double* _Xq,
-              double* _J,
-              double* _invJ,
-              double* _detJ,
-              const int d1d = 0,
-              const int q1d = 0)
-{
-   const int D1D = T_D1D ? T_D1D : d1d;
-   const int Q1D = T_Q1D ? T_Q1D : q1d;
-   MFEM_VERIFY(D1D <= MAX_D1D, "");
-   MFEM_VERIFY(Q1D <= MAX_Q1D, "");
-   const int ND = D1D*D1D;
-   const int NQ = Q1D*Q1D;
-
-   const DeviceTensor<2> B(_B, NQ, ND);
-   const DeviceTensor<3> G(_G, 2,NQ, ND);
-   const DeviceTensor<3> X(_X, 2,ND, NE);
-   DeviceTensor<3> Xq(_Xq, 2, NQ, NE);
-   DeviceTensor<4> J(_J, 2, 2, NQ, NE);
-   DeviceTensor<4> invJ(_invJ, 2, 2, NQ, NE);
-   DeviceMatrix detJ(_detJ, NQ, NE);
-
-   MFEM_FORALL(e, NE,
-   {
-      const int D1D = T_D1D ? T_D1D : d1d; // nvcc workaround
-      const int Q1D = T_Q1D ? T_Q1D : q1d;
-      const int ND = D1D*D1D;
-      const int NQ = Q1D*Q1D;
-
-      double s_X[2*MAX_D1D*MAX_D1D];
-      for (int q = 0; q < NQ; ++q)
-      {
-         for (int d = q; d < ND; d +=NQ)
-         {
-            s_X[0+d*2] = X(0,d,e);
-            s_X[1+d*2] = X(1,d,e);
-         }
-      }
-      for (int q = 0; q < NQ; ++q)
-      {
-         double X0  = 0; double X1  = 0;
-         double J11 = 0; double J12 = 0;
-         double J21 = 0; double J22 = 0;
-         for (int d = 0; d < ND; ++d)
-         {
-            const double b = B(q,d);
-            const double wx = G(0,q,d);
-            const double wy = G(1,q,d);
-            const double x = s_X[0+d*2];
-            const double y = s_X[1+d*2];
-            J11 += (wx * x); J12 += (wx * y);
-            J21 += (wy * x); J22 += (wy * y);
-            X0 += b*x; X1 += b*y;
-         }
-         Xq(0,q,e) = X0; Xq(1,q,e) = X1;
-         const double r_detJ = (J11 * J22)-(J12 * J21);
-         J(0,0,q,e) = J11;
-         J(1,0,q,e) = J12;
-         J(0,1,q,e) = J21;
-         J(1,1,q,e) = J22;
-         const double r_idetJ = 1.0 / r_detJ;
-         invJ(0,0,q,e) =  J22 * r_idetJ;
-         invJ(1,0,q,e) = -J12 * r_idetJ;
-         invJ(0,1,q,e) = -J21 * r_idetJ;
-         invJ(1,1,q,e) =  J11 * r_idetJ;
-         detJ(q,e) = r_detJ;
-      }
-   });
-}
-
-template<int T_D1D = 0, int T_Q1D = 0> static
-void PAGeom3D(const int NE,
-              const double* _B,
-              const double* _G,
-              const double* _X,
-              double* _Xq,
-              double* _J,
-              double* _invJ,
-              double* _detJ,
-              const int d1d = 0,
-              const int q1d = 0)
-{
-   const int D1D = T_D1D ? T_D1D : d1d;
-   const int Q1D = T_Q1D ? T_Q1D : q1d;
-   MFEM_VERIFY(D1D <= MAX_D1D, "");
-   MFEM_VERIFY(Q1D <= MAX_Q1D, "");
-   const int ND = D1D*D1D*D1D;
-   const int NQ = Q1D*Q1D*Q1D;
-
-   const DeviceTensor<2> B(_B, NQ, NE);
-   const DeviceTensor<3> G(_G, 3, NQ, NE);
-   const DeviceTensor<3> X(_X, 3, ND, NE);
-   DeviceTensor<3> Xq(_Xq, 3, NQ, NE);
-   DeviceTensor<4> J(_J, 3, 3, NQ, NE);
-   DeviceTensor<4> invJ(_invJ, 3, 3, NQ, NE);
-   DeviceMatrix detJ(_detJ, NQ, NE);
-
-   MFEM_FORALL(e,NE,
-   {
-      const int D1D = T_D1D ? T_D1D : d1d; // nvcc workaround
-      const int Q1D = T_Q1D ? T_Q1D : q1d;
-      const int ND = D1D*D1D*D1D;
-      const int NQ = Q1D*Q1D*Q1D;
-
-      double s_nodes[3*MAX_D1D*MAX_D1D*MAX_D1D];
-      for (int q = 0; q < NQ; ++q)
-      {
-         for (int d = q; d < ND; d += NQ)
-         {
-            s_nodes[0+d*3] = X(0,d,e);
-            s_nodes[1+d*3] = X(1,d,e);
-            s_nodes[2+d*3] = X(2,d,e);
-         }
-      }
-      for (int q = 0; q < NQ; ++q)
-      {
-         double J11 = 0; double J12 = 0; double J13 = 0;
-         double J21 = 0; double J22 = 0; double J23 = 0;
-         double J31 = 0; double J32 = 0; double J33 = 0;
-         for (int d = 0; d < ND; ++d)
-         {
-            const double b = B(q,d);
-            const double wx = G(0,q,d);
-            const double wy = G(1,q,d);
-            const double wz = G(2,q,d);
-            const double x = s_nodes[0+d*3];
-            const double y = s_nodes[1+d*3];
-            const double z = s_nodes[2+d*3];
-            J11 += (wx * x); J12 += (wx * y); J13 += (wx * z);
-            J21 += (wy * x); J22 += (wy * y); J23 += (wy * z);
-            J31 += (wz * x); J32 += (wz * y); J33 += (wz * z);
-            Xq(0,q,e) = b*x; Xq(1,q,e) = b*y; Xq(2,q,e) = b*z;
-         }
-         const double r_detJ = ((J11 * J22 * J33) + (J12 * J23 * J31) +
-                                (J13 * J21 * J32) - (J13 * J22 * J31) -
-                                (J12 * J21 * J33) - (J11 * J23 * J32));
-         J(0,0,q,e) = J11;
-         J(1,0,q,e) = J12;
-         J(2,0,q,e) = J13;
-         J(0,1,q,e) = J21;
-         J(1,1,q,e) = J22;
-         J(2,1,q,e) = J23;
-         J(0,2,q,e) = J31;
-         J(1,2,q,e) = J32;
-         J(2,2,q,e) = J33;
-         const double r_idetJ = 1.0 / r_detJ;
-         invJ(0,0,q,e) = r_idetJ * ((J22 * J33)-(J23 * J32));
-         invJ(1,0,q,e) = r_idetJ * ((J32 * J13)-(J33 * J12));
-         invJ(2,0,q,e) = r_idetJ * ((J12 * J23)-(J13 * J22));
-         invJ(0,1,q,e) = r_idetJ * ((J23 * J31)-(J21 * J33));
-         invJ(1,1,q,e) = r_idetJ * ((J33 * J11)-(J31 * J13));
-         invJ(2,1,q,e) = r_idetJ * ((J13 * J21)-(J11 * J23));
-         invJ(0,2,q,e) = r_idetJ * ((J21 * J32)-(J22 * J31));
-         invJ(1,2,q,e) = r_idetJ * ((J31 * J12)-(J32 * J11));
-         invJ(2,2,q,e) = r_idetJ * ((J11 * J22)-(J12 * J21));
-         detJ(q,e) = r_detJ;
-      }
-   });
-}
-
-static void PAGeom(const int dim,
-                   const int D1D,
-                   const int Q1D,
-                   const int NE,
-                   const double* B,
-                   const double* G,
-                   const double* X,
-                   double* Xq,
-                   double* J,
-                   double* invJ,
-                   double* detJ)
-{
-   if (dim == 2)
-   {
-      switch ((D1D << 4) | Q1D)
-      {
-         case 0x22: PAGeom2D<2,2>(NE, B, G, X, Xq, J, invJ, detJ); break;
-         case 0x23: PAGeom2D<2,3>(NE, B, G, X, Xq, J, invJ, detJ); break;
-         case 0x24: PAGeom2D<2,4>(NE, B, G, X, Xq, J, invJ, detJ); break;
-         case 0x25: PAGeom2D<2,5>(NE, B, G, X, Xq, J, invJ, detJ); break;
-         case 0x32: PAGeom2D<3,2>(NE, B, G, X, Xq, J, invJ, detJ); break;
-         case 0x34: PAGeom2D<3,4>(NE, B, G, X, Xq, J, invJ, detJ); break;
-         case 0x42: PAGeom2D<4,2>(NE, B, G, X, Xq, J, invJ, detJ); break;
-         case 0x44: PAGeom2D<4,4>(NE, B, G, X, Xq, J, invJ, detJ); break;
-         case 0x45: PAGeom2D<4,5>(NE, B, G, X, Xq, J, invJ, detJ); break;
-         case 0x46: PAGeom2D<4,6>(NE, B, G, X, Xq, J, invJ, detJ); break;
-         case 0x58: PAGeom2D<5,8>(NE, B, G, X, Xq, J, invJ, detJ); break;
-         default: PAGeom2D(NE, B, G, X, Xq, J, invJ, detJ, D1D, Q1D); break;
-      }
-      return;
-   }
-   if (dim == 3)
-   {
-      switch ((D1D << 4) | Q1D)
-      {
-         case 0x23: PAGeom3D<2,3>(NE, B, G, X, Xq, J, invJ, detJ); break;
-         case 0x24: PAGeom3D<2,4>(NE, B, G, X, Xq, J, invJ, detJ); break;
-         case 0x25: PAGeom3D<2,5>(NE, B, G, X, Xq, J, invJ, detJ); break;
-         case 0x26: PAGeom3D<2,6>(NE, B, G, X, Xq, J, invJ, detJ); break;
-         case 0x34: PAGeom3D<3,4>(NE, B, G, X, Xq, J, invJ, detJ); break;
-         default: PAGeom3D(NE, B, G, X, Xq, J, invJ, detJ, D1D, Q1D); break;
-      }
-      return;
-   }
-   MFEM_ABORT("Unknown kernel.");
-}
-
-GeometryExtension* GeometryExtension::Get(const FiniteElementSpace& fes,
-                                          const IntegrationRule& ir,
-                                          const Vector& Sx)
-{
-   const Mesh *mesh = fes.GetMesh();
-   const GridFunction *nodes = mesh->GetNodes();
-   const FiniteElementSpace *fespace = nodes->FESpace();
-   const FiniteElement *fe = fespace->GetFE(0);
-   const IntegrationRule& ir1D = IntRules.Get(Geometry::SEGMENT,ir.GetOrder());
-   const int dims     = fe->GetDim();
-   const int numDofs  = fe->GetDof();
-   const int D1D      = fe->GetOrder() + 1;
-   const int Q1D      = ir1D.GetNPoints();
-   const int elements = fespace->GetNE();
-   const int ndofs    = fespace->GetNDofs();
-   const DofToQuad* maps = DofToQuad::GetSimplexMaps(*fe, ir);
-   NodeCopyByVDim(elements,numDofs,ndofs,dims,geom->eMap,Sx,geom->nodes);
-   PAGeom(dims, D1D, Q1D, elements,
-          maps->B, maps->G, geom->nodes,
-          geom->X, geom->J, geom->invJ, geom->detJ);
-   return geom;
-}
-
-GeometryExtension* GeometryExtension::Get(const FiniteElementSpace& fes,
-                                          const IntegrationRule& ir)
-{
-   Mesh *mesh = fes.GetMesh();
-   const bool geom_to_allocate = sequence < fes.GetSequence();
-   sequence = fes.GetSequence();
-   if (geom_to_allocate)
-   {
-      if (geom) { delete geom; }
-      geom = new GeometryExtension();
-   }
-
-   const bool dev_enabled = Device::IsEnabled();
-   if (dev_enabled) { Device::Disable(); }
-   mesh->EnsureNodes();
-   if (dev_enabled) { Device::Enable(); }
-
-   const GridFunction *nodes = mesh->GetNodes();
-   const mfem::FiniteElementSpace *fespace = nodes->FESpace();
-   const mfem::FiniteElement *fe = fespace->GetFE(0);
-   const IntegrationRule& ir1D = IntRules.Get(Geometry::SEGMENT,ir.GetOrder());
-   const int dims     = fe->GetDim();
-   const int elements = fespace->GetNE();
-   const int numDofs  = fe->GetDof();
-   const int D1D      = fe->GetOrder() + 1;
-   const int Q1D      = ir1D.GetNPoints();
-   const int numQuad  = ir.GetNPoints();
-   const bool orderedByNODES = (fespace->GetOrdering() == Ordering::byNODES);
-   if (orderedByNODES) { ReorderByVDim(nodes); }
-   const int asize = dims*numDofs*elements;
-   mfem::Array<double> meshNodes(asize);
-   const Table& e2dTable = fespace->GetElementToDofTable();
-   const int* elementMap = e2dTable.GetJ();
-   mfem::Array<int> eMap(numDofs*elements);
-   GeomFill(dims,
-            elements,
-            numDofs,
-            nodes->Size(),
-            elementMap,
-            eMap,
-            nodes->GetData(),
-            meshNodes);
-   if (geom_to_allocate)
-   {
-      geom->nodes.SetSize(dims*numDofs*elements);
-      geom->eMap.SetSize(numDofs*elements);
-   }
-   geom->nodes = meshNodes;
-   geom->eMap = eMap;
-   // Reorder the original gf back
-   if (orderedByNODES) { ReorderByNodes(nodes); }
-   if (geom_to_allocate)
-   {
-      geom->X.SetSize(dims*numQuad*elements);
-      geom->J.SetSize(dims*dims*numQuad*elements);
-      geom->invJ.SetSize(dims*dims*numQuad*elements);
-      geom->detJ.SetSize(numQuad*elements);
-   }
-   const DofToQuad* maps = DofToQuad::GetSimplexMaps(*fe, ir);
-   PAGeom(dims, D1D, Q1D, elements,
-          maps->B, maps->G, geom->nodes,
-          geom->X, geom->J, geom->invJ, geom->detJ);
-   delete maps;
-   return geom;
-}
-
-void GeometryExtension::ReorderByVDim(const GridFunction *nodes)
-{
-   const mfem::FiniteElementSpace *fes = nodes->FESpace();
-   const int size = nodes->Size();
-   const int vdim = fes->GetVDim();
-   const int ndofs = fes->GetNDofs();
-   double *data = nodes->GetData();
-   double *temp = new double[size];
-   int k=0;
-   for (int d = 0; d < ndofs; d++)
-      for (int v = 0; v < vdim; v++)
-      {
-         temp[k++] = data[d+v*ndofs];
-      }
-   for (int i = 0; i < size; i++)
-   {
-      data[i] = temp[i];
-   }
-   delete [] temp;
-}
-
-void GeometryExtension::ReorderByNodes(const GridFunction *nodes)
-{
-   const mfem::FiniteElementSpace *fes = nodes->FESpace();
-   const int size = nodes->Size();
-   const int vdim = fes->GetVDim();
-   const int ndofs = fes->GetNDofs();
-   double *data = nodes->GetData();
-   double *temp = new double[size];
-   int k = 0;
-   for (int j = 0; j < ndofs; j++)
-      for (int i = 0; i < vdim; i++)
-      {
-         temp[j+i*ndofs] = data[k++];
-      }
-   for (int i = 0; i < size; i++)
-   {
-      data[i] = temp[i];
-   }
-   delete [] temp;
-}
 
 } // namespace mfem

--- a/fem/bilininteg_ext.cpp
+++ b/fem/bilininteg_ext.cpp
@@ -12,6 +12,7 @@
 #include "../general/forall.hpp"
 #include "bilininteg.hpp"
 #include "gridfunc.hpp"
+#include "../mesh/mesh_ext.hpp"
 
 #include <map>
 #include <cmath>
@@ -249,7 +250,7 @@ void DiffusionIntegrator::Assemble(const FiniteElementSpace &fes)
    ne = fes.GetNE();
    dofs1D = el.GetOrder() + 1;
    quad1D = IntRules.Get(Geometry::SEGMENT, ir->GetOrder()).GetNPoints();
-   xtmesh = mesh->GetXTMesh(*ir);
+   xtmesh = mesh->GetXTMesh(*ir, XTMesh::Compute::_J_);
    maps = DofToQuad::Get(fes, fes, *ir);
    vec.SetSize(symmDims * nq * ne);
    const double coeff = static_cast<ConstantCoefficient*>(Q)->constant;
@@ -751,7 +752,7 @@ void MassIntegrator::Assemble(const FiniteElementSpace &fes)
    nq = ir->GetNPoints();
    dofs1D = el.GetOrder() + 1;
    quad1D = IntRules.Get(Geometry::SEGMENT, ir->GetOrder()).GetNPoints();
-   xtmesh = mesh->GetXTMesh(*ir);
+   xtmesh = mesh->GetXTMesh(*ir, XTMesh::Compute::_X_ | XTMesh::Compute::_J_);
    maps = DofToQuad::Get(fes, fes, *ir);
    vec.SetSize(ne*nq);
    ConstantCoefficient *const_coeff = dynamic_cast<ConstantCoefficient*>(Q);

--- a/fem/bilininteg_ext.cpp
+++ b/fem/bilininteg_ext.cpp
@@ -249,11 +249,11 @@ void DiffusionIntegrator::Assemble(const FiniteElementSpace &fes)
    ne = fes.GetNE();
    dofs1D = el.GetOrder() + 1;
    quad1D = IntRules.Get(Geometry::SEGMENT, ir->GetOrder()).GetNPoints();
-   geom = mesh->GetGeometryExtension(*ir);
+   xtmesh = mesh->GetXTMesh(*ir);
    maps = DofToQuad::Get(fes, fes, *ir);
    vec.SetSize(symmDims * nq * ne);
    const double coeff = static_cast<ConstantCoefficient*>(Q)->constant;
-   PADiffusionSetup(dim, dofs1D, quad1D, ne, maps->W, geom->J, coeff, vec);
+   PADiffusionSetup(dim, dofs1D, quad1D, ne, maps->W, xtmesh->J, coeff, vec);
 }
 
 #ifdef MFEM_USE_OCCA
@@ -735,7 +735,7 @@ void DiffusionIntegrator::MultAssembled(Vector &x, Vector &y)
 
 DiffusionIntegrator::~DiffusionIntegrator()
 {
-   delete geom;
+   delete xtmesh;
    delete maps;
 }
 
@@ -751,7 +751,7 @@ void MassIntegrator::Assemble(const FiniteElementSpace &fes)
    nq = ir->GetNPoints();
    dofs1D = el.GetOrder() + 1;
    quad1D = IntRules.Get(Geometry::SEGMENT, ir->GetOrder()).GetNPoints();
-   geom = mesh->GetGeometryExtension(*ir);
+   xtmesh = mesh->GetXTMesh(*ir);
    maps = DofToQuad::Get(fes, fes, *ir);
    vec.SetSize(ne*nq);
    ConstantCoefficient *const_coeff = dynamic_cast<ConstantCoefficient*>(Q);
@@ -777,8 +777,8 @@ void MassIntegrator::Assemble(const FiniteElementSpace &fes)
       const int NE = ne;
       const int NQ = nq;
       const DeviceVector w(maps->W.GetData(), NQ);
-      const DeviceTensor<3> x(geom->X.GetData(), 2,NQ,NE);
-      const DeviceTensor<4> J(geom->J.GetData(), 2,2,NQ,NE);
+      const DeviceTensor<3> x(xtmesh->X, 2,NQ,NE);
+      const DeviceTensor<4> J(xtmesh->J, 2,2,NQ,NE);
       DeviceMatrix v(vec.GetData(), NQ, NE);
       MFEM_FORALL(e, NE,
       {
@@ -817,8 +817,8 @@ void MassIntegrator::Assemble(const FiniteElementSpace &fes)
       const int NE = ne;
       const int NQ = nq;
       const DeviceVector W(maps->W.GetData(), NQ);
-      const DeviceTensor<3> x(geom->X.GetData(), 3,NQ,NE);
-      const DeviceTensor<4> J(geom->J.GetData(), 3,3,NQ,NE);
+      const DeviceTensor<3> x(xtmesh->X, 3,NQ,NE);
+      const DeviceTensor<4> J(xtmesh->J, 3,3,NQ,NE);
       DeviceMatrix v(vec.GetData(), NQ,NE);
       MFEM_FORALL(e, NE,
       {
@@ -1237,7 +1237,7 @@ void MassIntegrator::MultAssembled(Vector &x, Vector &y)
 
 MassIntegrator::~MassIntegrator()
 {
-   delete geom;
+   delete xtmesh;
    delete maps;
 }
 

--- a/fem/bilininteg_ext.hpp
+++ b/fem/bilininteg_ext.hpp
@@ -17,22 +17,6 @@
 namespace mfem
 {
 
-/// GeometryExtension
-class GeometryExtension
-{
-public:
-   Array<int> eMap;
-   Array<double> nodes;
-   Array<double> X, J, invJ, detJ;
-   static GeometryExtension* Get(const FiniteElementSpace&,
-                                 const IntegrationRule&);
-   static GeometryExtension* Get(const FiniteElementSpace&,
-                                 const IntegrationRule&,
-                                 const Vector&);
-   static void ReorderByVDim(const GridFunction*);
-   static void ReorderByNodes(const GridFunction*);
-};
-
 /// DofToQuad
 class DofToQuad
 {

--- a/general/forall.hpp
+++ b/general/forall.hpp
@@ -30,6 +30,9 @@
 namespace mfem
 {
 
+const int MAX_Q1D = 10;
+const int MAX_D1D = 10;
+
 // Implementation of MFEM's "parallel for" (forall) device/host kernel
 // interfaces supporting RAJA, CUDA, OpenMP, and sequential backends.
 

--- a/mesh/CMakeLists.txt
+++ b/mesh/CMakeLists.txt
@@ -13,6 +13,7 @@ set(SRCS
   element.cpp
   hexahedron.cpp
   mesh.cpp
+  mesh_ext.cpp
   mesh_operators.cpp
   mesh_readers.cpp
   ncmesh.cpp
@@ -30,6 +31,7 @@ set(HDRS
   element.hpp
   hexahedron.hpp
   mesh.hpp
+  mesh_ext.hpp
   mesh_headers.hpp
   mesh_operators.hpp
   ncmesh.hpp

--- a/mesh/mesh.cpp
+++ b/mesh/mesh.cpp
@@ -15,6 +15,7 @@
 #include "../fem/fem.hpp"
 #include "../general/sort_pairs.hpp"
 #include "../general/text.hpp"
+#include "../general/forall.hpp"
 
 #include <iostream>
 #include <sstream>
@@ -749,6 +750,17 @@ void Mesh::GetLocalQuadToWdgTransformation(
       locpm(2, j) = vert.z;
    }
    Transf.FinalizeTransformation();
+}
+
+GeometryExtension* Mesh::GetGeometryExtension(const IntegrationRule& ir,
+                                        const Vector& Sx) {
+   GeometryExtension::Get(this, ir, Sx, geom);
+   return geom;   
+}
+
+GeometryExtension* Mesh::GetGeometryExtension(const IntegrationRule& ir) {
+   GeometryExtension::Get(this, ir, geom);
+   return geom;
 }
 
 void Mesh::GetLocalFaceTransformation(

--- a/mesh/mesh.cpp
+++ b/mesh/mesh.cpp
@@ -753,12 +753,14 @@ void Mesh::GetLocalQuadToWdgTransformation(
 }
 
 GeometryExtension* Mesh::GetGeometryExtension(const IntegrationRule& ir,
-                                        const Vector& Sx) {
+                                              const Vector& Sx)
+{
    GeometryExtension::Get(this, ir, Sx, geom);
-   return geom;   
+   return geom;
 }
 
-GeometryExtension* Mesh::GetGeometryExtension(const IntegrationRule& ir) {
+GeometryExtension* Mesh::GetGeometryExtension(const IntegrationRule& ir)
+{
    GeometryExtension::Get(this, ir, geom);
    return geom;
 }

--- a/mesh/mesh.cpp
+++ b/mesh/mesh.cpp
@@ -752,18 +752,18 @@ void Mesh::GetLocalQuadToWdgTransformation(
    Transf.FinalizeTransformation();
 }
 
-XTMesh* Mesh::GetXTMesh(const IntegrationRule& ir)
+XTMesh* Mesh::GetXTMesh(const IntegrationRule& ir, const int flags)
 {
    const bool dev_enabled = Device::IsEnabled();
    if (dev_enabled) { Device::Disable(); }
    this->EnsureNodes();
    if (dev_enabled) { Device::Enable(); }
-   if (!xtmesh) { return xtmesh = new XTMesh(this, ir); }
+   if (!xtmesh) { return xtmesh = new XTMesh(this, ir, flags); }
    const bool new_sequence = (xtmesh->GetSequence() < this->GetSequence());
    xtmesh->GetSequence() = this->GetSequence();
    if (!new_sequence) { return xtmesh; }
    delete xtmesh;
-   return xtmesh = new XTMesh(this, ir);
+   return xtmesh = new XTMesh(this, ir, flags);
 }
 
 void Mesh::GetLocalFaceTransformation(

--- a/mesh/mesh.hpp
+++ b/mesh/mesh.hpp
@@ -30,11 +30,11 @@ namespace mfem
 
 // Data type mesh
 
+class XTMesh;
 class KnotVector;
 class NURBSExtension;
 class FiniteElementSpace;
 class GridFunction;
-class GeometryExtension;
 struct Refinement;
 
 #ifdef MFEM_USE_MPI
@@ -60,7 +60,6 @@ protected:
 
    int meshgen; // see MeshGenerator()
    int mesh_geoms; // sum of (1 << geom) for all geom of all dimensions
-   GeometryExtension *geom = NULL;
 
    // Counter for Mesh transformations: refinement, derefinement, rebalancing.
    // Used for checking during Update operations on objects depending on the
@@ -179,6 +178,7 @@ public:
 
    NURBSExtension *NURBSext; ///< Optional NURBS mesh extension.
    NCMesh *ncmesh;           ///< Optional non-conforming mesh extension.
+   XTMesh *xtmesh;           ///< Optional partial assembly mesh extension.
 
    // Global parameter that can be used to control the removal of unused
    // vertices performed when reading a mesh in MFEM format. The default value
@@ -691,10 +691,8 @@ public:
    /// Return the total (global) number of elements.
    long GetGlobalNE() const { return ReduceInt(NumOfElements); }
 
-   GeometryExtension* GetGeometryExtension(const IntegrationRule& ir,
-                                           const Vector& Sx);
-
-   GeometryExtension* GetGeometryExtension(const IntegrationRule& ir);
+   /// Return the mesh extension coresponding to the given integration rule.
+   XTMesh* GetXTMesh(const IntegrationRule& ir);
 
    /// Equals 1 + num_holes - num_loops
    inline int EulerNumber() const

--- a/mesh/mesh.hpp
+++ b/mesh/mesh.hpp
@@ -690,7 +690,7 @@ public:
 
    /// Return the total (global) number of elements.
    long GetGlobalNE() const { return ReduceInt(NumOfElements); }
-   
+
    GeometryExtension* GetGeometryExtension(const IntegrationRule& ir,
                                            const Vector& Sx);
 

--- a/mesh/mesh.hpp
+++ b/mesh/mesh.hpp
@@ -692,7 +692,7 @@ public:
    long GetGlobalNE() const { return ReduceInt(NumOfElements); }
 
    /// Return the mesh extension coresponding to the given integration rule.
-   XTMesh* GetXTMesh(const IntegrationRule& ir);
+   XTMesh* GetXTMesh(const IntegrationRule& ir, const int flags);
 
    /// Equals 1 + num_holes - num_loops
    inline int EulerNumber() const

--- a/mesh/mesh.hpp
+++ b/mesh/mesh.hpp
@@ -22,6 +22,7 @@
 #include "../fem/eltrans.hpp"
 #include "../fem/coefficient.hpp"
 #include "../general/gzstream.hpp"
+#include "mesh_ext.hpp"
 #include <iostream>
 
 namespace mfem
@@ -33,6 +34,7 @@ class KnotVector;
 class NURBSExtension;
 class FiniteElementSpace;
 class GridFunction;
+class GeometryExtension;
 struct Refinement;
 
 #ifdef MFEM_USE_MPI
@@ -58,6 +60,7 @@ protected:
 
    int meshgen; // see MeshGenerator()
    int mesh_geoms; // sum of (1 << geom) for all geom of all dimensions
+   GeometryExtension *geom = NULL;
 
    // Counter for Mesh transformations: refinement, derefinement, rebalancing.
    // Used for checking during Update operations on objects depending on the
@@ -687,6 +690,11 @@ public:
 
    /// Return the total (global) number of elements.
    long GetGlobalNE() const { return ReduceInt(NumOfElements); }
+   
+   GeometryExtension* GetGeometryExtension(const IntegrationRule& ir,
+                                           const Vector& Sx);
+
+   GeometryExtension* GetGeometryExtension(const IntegrationRule& ir);
 
    /// Equals 1 + num_holes - num_loops
    inline int EulerNumber() const

--- a/mesh/mesh_ext.cpp
+++ b/mesh/mesh_ext.cpp
@@ -1,0 +1,420 @@
+// Copyright (c) 2010, Lawrence Livermore National Security, LLC. Produced at
+// the Lawrence Livermore National Laboratory. LLNL-CODE-443211. All Rights
+// reserved. See file COPYRIGHT for details.
+//
+// This file is part of the MFEM library. For more information and source code
+// availability see http://mfem.org.
+//
+// MFEM is free software; you can redistribute it and/or modify it under the
+// terms of the GNU Lesser General Public License (as published by the Free
+// Software Foundation) version 2.1 dated February 1999.
+
+#include "../general/forall.hpp"
+#include "../fem/fespace.hpp"
+#include "mesh_ext.hpp"
+#include "../fem/bilininteg.hpp"
+#include "../fem/gridfunc.hpp"
+
+using namespace std;
+
+namespace mfem
+{
+
+static void GeomFill(const int vdim,
+                     const int NE, const int ND, const int NX,
+                     const int* elementMap, int* eMap,
+                     const double *_X, double *meshNodes)
+{
+   const DeviceArray d_elementMap(elementMap, ND*NE);
+   DeviceArray d_eMap(eMap, ND*NE);
+   const DeviceVector X(_X, NX);
+   DeviceVector d_meshNodes(meshNodes, vdim*ND*NE);
+   MFEM_FORALL(e, NE,
+   {
+      for (int d = 0; d < ND; ++d)
+      {
+         const int lid = d+ND*e;
+         const int gid = d_elementMap[lid];
+         d_eMap[lid] = gid;
+         for (int v = 0; v < vdim; ++v)
+         {
+            const int moffset = v+vdim*lid;
+            const int xoffset = v+vdim*gid;
+            d_meshNodes[moffset] = X[xoffset];
+         }
+      }
+   });
+}
+
+static void NodeCopyByVDim(const int elements,
+                           const int numDofs,
+                           const int ndofs,
+                           const int dims,
+                           const int* eMap,
+                           const double* Sx,
+                           double* nodes)
+{
+   MFEM_FORALL(e,elements,
+   {
+      for (int dof = 0; dof < numDofs; ++dof)
+      {
+         const int lid = dof+numDofs*e;
+         const int gid = eMap[lid];
+         for (int v = 0; v < dims; ++v)
+         {
+            const int moffset = v+dims*lid;
+            const int voffset = gid+v*ndofs;
+            nodes[moffset] = Sx[voffset];
+         }
+      }
+   });
+}
+
+template<int T_D1D = 0, int T_Q1D = 0> static
+void PAGeom2D(const int NE,
+              const double* _B,
+              const double* _G,
+              const double* _X,
+              double* _Xq,
+              double* _J,
+              double* _invJ,
+              double* _detJ,
+              const int d1d = 0,
+              const int q1d = 0)
+{
+   const int D1D = T_D1D ? T_D1D : d1d;
+   const int Q1D = T_Q1D ? T_Q1D : q1d;
+   MFEM_VERIFY(D1D <= MAX_D1D, "");
+   MFEM_VERIFY(Q1D <= MAX_Q1D, "");
+   const int ND = D1D*D1D;
+   const int NQ = Q1D*Q1D;
+
+   const DeviceTensor<2> B(_B, NQ, ND);
+   const DeviceTensor<3> G(_G, 2,NQ, ND);
+   const DeviceTensor<3> X(_X, 2,ND, NE);
+   DeviceTensor<3> Xq(_Xq, 2, NQ, NE);
+   DeviceTensor<4> J(_J, 2, 2, NQ, NE);
+   DeviceTensor<4> invJ(_invJ, 2, 2, NQ, NE);
+   DeviceMatrix detJ(_detJ, NQ, NE);
+
+   MFEM_FORALL(e, NE,
+   {
+      const int D1D = T_D1D ? T_D1D : d1d; // nvcc workaround
+      const int Q1D = T_Q1D ? T_Q1D : q1d;
+      const int ND = D1D*D1D;
+      const int NQ = Q1D*Q1D;
+
+      double s_X[2*MAX_D1D*MAX_D1D];
+      for (int q = 0; q < NQ; ++q)
+      {
+         for (int d = q; d < ND; d +=NQ)
+         {
+            s_X[0+d*2] = X(0,d,e);
+            s_X[1+d*2] = X(1,d,e);
+         }
+      }
+      for (int q = 0; q < NQ; ++q)
+      {
+         double X0  = 0; double X1  = 0;
+         double J11 = 0; double J12 = 0;
+         double J21 = 0; double J22 = 0;
+         for (int d = 0; d < ND; ++d)
+         {
+            const double b = B(q,d);
+            const double wx = G(0,q,d);
+            const double wy = G(1,q,d);
+            const double x = s_X[0+d*2];
+            const double y = s_X[1+d*2];
+            J11 += (wx * x); J12 += (wx * y);
+            J21 += (wy * x); J22 += (wy * y);
+            X0 += b*x; X1 += b*y;
+         }
+         Xq(0,q,e) = X0; Xq(1,q,e) = X1;
+         const double r_detJ = (J11 * J22)-(J12 * J21);
+         J(0,0,q,e) = J11;
+         J(1,0,q,e) = J12;
+         J(0,1,q,e) = J21;
+         J(1,1,q,e) = J22;
+         const double r_idetJ = 1.0 / r_detJ;
+         invJ(0,0,q,e) =  J22 * r_idetJ;
+         invJ(1,0,q,e) = -J12 * r_idetJ;
+         invJ(0,1,q,e) = -J21 * r_idetJ;
+         invJ(1,1,q,e) =  J11 * r_idetJ;
+         detJ(q,e) = r_detJ;
+      }
+   });
+}
+
+template<int T_D1D = 0, int T_Q1D = 0> static
+void PAGeom3D(const int NE,
+              const double* _B,
+              const double* _G,
+              const double* _X,
+              double* _Xq,
+              double* _J,
+              double* _invJ,
+              double* _detJ,
+              const int d1d = 0,
+              const int q1d = 0)
+{
+   const int D1D = T_D1D ? T_D1D : d1d;
+   const int Q1D = T_Q1D ? T_Q1D : q1d;
+   MFEM_VERIFY(D1D <= MAX_D1D, "");
+   MFEM_VERIFY(Q1D <= MAX_Q1D, "");
+   const int ND = D1D*D1D*D1D;
+   const int NQ = Q1D*Q1D*Q1D;
+
+   const DeviceTensor<2> B(_B, NQ, NE);
+   const DeviceTensor<3> G(_G, 3, NQ, NE);
+   const DeviceTensor<3> X(_X, 3, ND, NE);
+   DeviceTensor<3> Xq(_Xq, 3, NQ, NE);
+   DeviceTensor<4> J(_J, 3, 3, NQ, NE);
+   DeviceTensor<4> invJ(_invJ, 3, 3, NQ, NE);
+   DeviceMatrix detJ(_detJ, NQ, NE);
+
+   MFEM_FORALL(e,NE,
+   {
+      const int D1D = T_D1D ? T_D1D : d1d; // nvcc workaround
+      const int Q1D = T_Q1D ? T_Q1D : q1d;
+      const int ND = D1D*D1D*D1D;
+      const int NQ = Q1D*Q1D*Q1D;
+
+      double s_nodes[3*MAX_D1D*MAX_D1D*MAX_D1D];
+      for (int q = 0; q < NQ; ++q)
+      {
+         for (int d = q; d < ND; d += NQ)
+         {
+            s_nodes[0+d*3] = X(0,d,e);
+            s_nodes[1+d*3] = X(1,d,e);
+            s_nodes[2+d*3] = X(2,d,e);
+         }
+      }
+      for (int q = 0; q < NQ; ++q)
+      {
+         double J11 = 0; double J12 = 0; double J13 = 0;
+         double J21 = 0; double J22 = 0; double J23 = 0;
+         double J31 = 0; double J32 = 0; double J33 = 0;
+         for (int d = 0; d < ND; ++d)
+         {
+            const double b = B(q,d);
+            const double wx = G(0,q,d);
+            const double wy = G(1,q,d);
+            const double wz = G(2,q,d);
+            const double x = s_nodes[0+d*3];
+            const double y = s_nodes[1+d*3];
+            const double z = s_nodes[2+d*3];
+            J11 += (wx * x); J12 += (wx * y); J13 += (wx * z);
+            J21 += (wy * x); J22 += (wy * y); J23 += (wy * z);
+            J31 += (wz * x); J32 += (wz * y); J33 += (wz * z);
+            Xq(0,q,e) = b*x; Xq(1,q,e) = b*y; Xq(2,q,e) = b*z;
+         }
+         const double r_detJ = ((J11 * J22 * J33) + (J12 * J23 * J31) +
+                                (J13 * J21 * J32) - (J13 * J22 * J31) -
+                                (J12 * J21 * J33) - (J11 * J23 * J32));
+         J(0,0,q,e) = J11;
+         J(1,0,q,e) = J12;
+         J(2,0,q,e) = J13;
+         J(0,1,q,e) = J21;
+         J(1,1,q,e) = J22;
+         J(2,1,q,e) = J23;
+         J(0,2,q,e) = J31;
+         J(1,2,q,e) = J32;
+         J(2,2,q,e) = J33;
+         const double r_idetJ = 1.0 / r_detJ;
+         invJ(0,0,q,e) = r_idetJ * ((J22 * J33)-(J23 * J32));
+         invJ(1,0,q,e) = r_idetJ * ((J32 * J13)-(J33 * J12));
+         invJ(2,0,q,e) = r_idetJ * ((J12 * J23)-(J13 * J22));
+         invJ(0,1,q,e) = r_idetJ * ((J23 * J31)-(J21 * J33));
+         invJ(1,1,q,e) = r_idetJ * ((J33 * J11)-(J31 * J13));
+         invJ(2,1,q,e) = r_idetJ * ((J13 * J21)-(J11 * J23));
+         invJ(0,2,q,e) = r_idetJ * ((J21 * J32)-(J22 * J31));
+         invJ(1,2,q,e) = r_idetJ * ((J31 * J12)-(J32 * J11));
+         invJ(2,2,q,e) = r_idetJ * ((J11 * J22)-(J12 * J21));
+         detJ(q,e) = r_detJ;
+      }
+   });
+}
+
+static void PAGeom(const int dim,
+                   const int D1D,
+                   const int Q1D,
+                   const int NE,
+                   const double* B,
+                   const double* G,
+                   const double* X,
+                   double* Xq,
+                   double* J,
+                   double* invJ,
+                   double* detJ)
+{
+   if (dim == 2)
+   {
+      switch ((D1D << 4) | Q1D)
+      {
+         case 0x22: PAGeom2D<2,2>(NE, B, G, X, Xq, J, invJ, detJ); break;
+         case 0x23: PAGeom2D<2,3>(NE, B, G, X, Xq, J, invJ, detJ); break;
+         case 0x24: PAGeom2D<2,4>(NE, B, G, X, Xq, J, invJ, detJ); break;
+         case 0x25: PAGeom2D<2,5>(NE, B, G, X, Xq, J, invJ, detJ); break;
+         case 0x32: PAGeom2D<3,2>(NE, B, G, X, Xq, J, invJ, detJ); break;
+         case 0x34: PAGeom2D<3,4>(NE, B, G, X, Xq, J, invJ, detJ); break;
+         case 0x42: PAGeom2D<4,2>(NE, B, G, X, Xq, J, invJ, detJ); break;
+         case 0x44: PAGeom2D<4,4>(NE, B, G, X, Xq, J, invJ, detJ); break;
+         case 0x45: PAGeom2D<4,5>(NE, B, G, X, Xq, J, invJ, detJ); break;
+         case 0x46: PAGeom2D<4,6>(NE, B, G, X, Xq, J, invJ, detJ); break;
+         case 0x58: PAGeom2D<5,8>(NE, B, G, X, Xq, J, invJ, detJ); break;
+         default: PAGeom2D(NE, B, G, X, Xq, J, invJ, detJ, D1D, Q1D); break;
+      }
+      return;
+   }
+   if (dim == 3)
+   {
+      switch ((D1D << 4) | Q1D)
+      {
+         case 0x23: PAGeom3D<2,3>(NE, B, G, X, Xq, J, invJ, detJ); break;
+         case 0x24: PAGeom3D<2,4>(NE, B, G, X, Xq, J, invJ, detJ); break;
+         case 0x25: PAGeom3D<2,5>(NE, B, G, X, Xq, J, invJ, detJ); break;
+         case 0x26: PAGeom3D<2,6>(NE, B, G, X, Xq, J, invJ, detJ); break;
+         case 0x34: PAGeom3D<3,4>(NE, B, G, X, Xq, J, invJ, detJ); break;
+         default: PAGeom3D(NE, B, G, X, Xq, J, invJ, detJ, D1D, Q1D); break;
+      }
+      return;
+   }
+   MFEM_ABORT("Unknown kernel.");
+}
+
+GeometryExtension* GeometryExtension::Get(Mesh* mesh,
+                                          const IntegrationRule& ir,
+                                          const Vector& Sx,
+                                          GeometryExtension*& geom)
+{
+   if (!geom) geom = new GeometryExtension;
+   const GridFunction *nodes = mesh->GetNodes();
+   const FiniteElementSpace *fespace = nodes->FESpace();
+   const FiniteElement *fe = fespace->GetFE(0);
+   const IntegrationRule& ir1D = IntRules.Get(Geometry::SEGMENT,ir.GetOrder());
+   const int dims     = fe->GetDim();
+   const int numDofs  = fe->GetDof();
+   const int D1D      = fe->GetOrder() + 1;
+   const int Q1D      = ir1D.GetNPoints();
+   const int elements = fespace->GetNE();
+   const int ndofs    = fespace->GetNDofs();
+   const DofToQuad* maps = DofToQuad::GetSimplexMaps(*fe, ir);
+   NodeCopyByVDim(elements,numDofs,ndofs,dims,geom->eMap,Sx,geom->nodes);
+   PAGeom(dims, D1D, Q1D, elements,
+          maps->B, maps->G, geom->nodes,
+          geom->X, geom->J, geom->invJ, geom->detJ);
+   return geom;
+}
+
+GeometryExtension* GeometryExtension::Get(Mesh* mesh,
+                                          const IntegrationRule& ir,
+                                          GeometryExtension*& geom)
+{
+   const bool geom_to_allocate = geom ? ( geom->GetSequence() < mesh->GetSequence() ) : true;
+   if (geom)
+   {
+      geom->GetSequence() = mesh->GetSequence();
+   }
+   if (geom_to_allocate)
+   {
+      if (geom) { delete geom; }
+      geom = new GeometryExtension();
+   }
+
+   const bool dev_enabled = Device::IsEnabled();
+   if (dev_enabled) { Device::Disable(); }
+   mesh->EnsureNodes();
+   if (dev_enabled) { Device::Enable(); }
+
+   const GridFunction *nodes = mesh->GetNodes();
+   const mfem::FiniteElementSpace *fespace = nodes->FESpace();
+   const mfem::FiniteElement *fe = fespace->GetFE(0);
+   const IntegrationRule& ir1D = IntRules.Get(Geometry::SEGMENT,ir.GetOrder());
+   const int dims     = fe->GetDim();
+   const int elements = fespace->GetNE();
+   const int numDofs  = fe->GetDof();
+   const int D1D      = fe->GetOrder() + 1;
+   const int Q1D      = ir1D.GetNPoints();
+   const int numQuad  = ir.GetNPoints();
+   const bool orderedByNODES = (fespace->GetOrdering() == Ordering::byNODES);
+   if (orderedByNODES) { ReorderByVDim(nodes); }
+   const int asize = dims*numDofs*elements;
+   mfem::Array<double> meshNodes(asize);
+   const Table& e2dTable = fespace->GetElementToDofTable();
+   const int* elementMap = e2dTable.GetJ();
+   mfem::Array<int> eMap(numDofs*elements);
+   GeomFill(dims,
+            elements,
+            numDofs,
+            nodes->Size(),
+            elementMap,
+            eMap,
+            nodes->GetData(),
+            meshNodes);
+   if (geom_to_allocate)
+   {
+      geom->nodes.SetSize(dims*numDofs*elements);
+      geom->eMap.SetSize(numDofs*elements);
+   }
+   geom->nodes = meshNodes;
+   geom->eMap = eMap;
+   // Reorder the original gf back
+   if (orderedByNODES) { ReorderByNodes(nodes); }
+   if (geom_to_allocate)
+   {
+      geom->X.SetSize(dims*numQuad*elements);
+      geom->J.SetSize(dims*dims*numQuad*elements);
+      geom->invJ.SetSize(dims*dims*numQuad*elements);
+      geom->detJ.SetSize(numQuad*elements);
+   }
+   const DofToQuad* maps = DofToQuad::GetSimplexMaps(*fe, ir);
+   PAGeom(dims, D1D, Q1D, elements,
+          maps->B, maps->G, geom->nodes,
+          geom->X, geom->J, geom->invJ, geom->detJ);
+   delete maps;
+   return geom;
+}
+
+void GeometryExtension::ReorderByVDim(const GridFunction *nodes)
+{
+   const mfem::FiniteElementSpace *fes = nodes->FESpace();
+   const int size = nodes->Size();
+   const int vdim = fes->GetVDim();
+   const int ndofs = fes->GetNDofs();
+   double *data = nodes->GetData();
+   double *temp = new double[size];
+   int k=0;
+   for (int d = 0; d < ndofs; d++)
+      for (int v = 0; v < vdim; v++)
+      {
+         temp[k++] = data[d+v*ndofs];
+      }
+   for (int i = 0; i < size; i++)
+   {
+      data[i] = temp[i];
+   }
+   delete [] temp;
+}
+
+void GeometryExtension::ReorderByNodes(const GridFunction *nodes)
+{
+   const mfem::FiniteElementSpace *fes = nodes->FESpace();
+   const int size = nodes->Size();
+   const int vdim = fes->GetVDim();
+   const int ndofs = fes->GetNDofs();
+   double *data = nodes->GetData();
+   double *temp = new double[size];
+   int k = 0;
+   for (int j = 0; j < ndofs; j++)
+      for (int i = 0; i < vdim; i++)
+      {
+         temp[j+i*ndofs] = data[k++];
+      }
+   for (int i = 0; i < size; i++)
+   {
+      data[i] = temp[i];
+   }
+   delete [] temp;
+}
+
+} // namespace mfem

--- a/mesh/mesh_ext.cpp
+++ b/mesh/mesh_ext.cpp
@@ -287,7 +287,7 @@ GeometryExtension* GeometryExtension::Get(Mesh* mesh,
                                           const Vector& Sx,
                                           GeometryExtension*& geom)
 {
-   if (!geom) geom = new GeometryExtension;
+   if (!geom) { geom = new GeometryExtension; }
    const GridFunction *nodes = mesh->GetNodes();
    const FiniteElementSpace *fespace = nodes->FESpace();
    const FiniteElement *fe = fespace->GetFE(0);
@@ -310,7 +310,8 @@ GeometryExtension* GeometryExtension::Get(Mesh* mesh,
                                           const IntegrationRule& ir,
                                           GeometryExtension*& geom)
 {
-   const bool geom_to_allocate = geom ? ( geom->GetSequence() < mesh->GetSequence() ) : true;
+   const bool geom_to_allocate = geom ? ( geom->GetSequence() <
+                                          mesh->GetSequence() ) : true;
    if (geom)
    {
       geom->GetSequence() = mesh->GetSequence();

--- a/mesh/mesh_ext.cpp
+++ b/mesh/mesh_ext.cpp
@@ -98,6 +98,7 @@ static void PAGeom2D(const int NE,
                      double* _J,
                      double* _invJ,
                      double* _detJ,
+                     const int XJID,
                      const int d1d = 0,
                      const int q1d = 0)
 {
@@ -145,18 +146,32 @@ static void PAGeom2D(const int NE,
             J21 += (wy * x); J22 += (wy * y);
             X0 += b*x; X1 += b*y;
          }
-         Xq(0,q,e) = X0; Xq(1,q,e) = X1;
-         const double r_detJ = (J11 * J22)-(J12 * J21);
-         J(0,0,q,e) = J11;
-         J(1,0,q,e) = J12;
-         J(0,1,q,e) = J21;
-         J(1,1,q,e) = J22;
-         const double r_idetJ = 1.0 / r_detJ;
-         invJ(0,0,q,e) =  J22 * r_idetJ;
-         invJ(1,0,q,e) = -J12 * r_idetJ;
-         invJ(0,1,q,e) = -J21 * r_idetJ;
-         invJ(1,1,q,e) =  J11 * r_idetJ;
-         detJ(q,e) = r_detJ;
+         if (XJID & XTMesh::Compute::_X_)
+         {
+            Xq(0,q,e) = X0; Xq(1,q,e) = X1;
+         }
+         if (XJID & XTMesh::Compute::_J_)
+         {
+            J(0,0,q,e) = J11;
+            J(1,0,q,e) = J12;
+            J(0,1,q,e) = J21;
+            J(1,1,q,e) = J22;
+         }
+         double r_detJ = 0.0;
+         if ((XJID & XTMesh::Compute::_D_)  ||
+             (XJID & XTMesh::Compute::_I_))
+         {
+            r_detJ = (J11 * J22)-(J12 * J21);
+         }
+         if (XJID & XTMesh::Compute::_I_)
+         {
+            const double r_idetJ = 1.0 / r_detJ;
+            invJ(0,0,q,e) =  J22 * r_idetJ;
+            invJ(1,0,q,e) = -J12 * r_idetJ;
+            invJ(0,1,q,e) = -J21 * r_idetJ;
+            invJ(1,1,q,e) =  J11 * r_idetJ;
+         }
+         if (XJID & XTMesh::Compute::_D_) { detJ(q,e) = r_detJ; }
       }
    });
 }
@@ -170,6 +185,7 @@ static void PAGeom3D(const int NE,
                      double* _J,
                      double* _invJ,
                      double* _detJ,
+                     const int XJID,
                      const int d1d = 0,
                      const int q1d = 0)
 {
@@ -219,31 +235,45 @@ static void PAGeom3D(const int NE,
             J11 += (wx * x); J12 += (wx * y); J13 += (wx * z);
             J21 += (wy * x); J22 += (wy * y); J23 += (wy * z);
             J31 += (wz * x); J32 += (wz * y); J33 += (wz * z);
-            Xq(0,q,e) = b*x; Xq(1,q,e) = b*y; Xq(2,q,e) = b*z;
+            if (XJID & XTMesh::Compute::_X_)
+            {
+               Xq(0,q,e) = b*x; Xq(1,q,e) = b*y; Xq(2,q,e) = b*z;
+            }
          }
-         const double r_detJ = ((J11 * J22 * J33) + (J12 * J23 * J31) +
-                                (J13 * J21 * J32) - (J13 * J22 * J31) -
-                                (J12 * J21 * J33) - (J11 * J23 * J32));
-         J(0,0,q,e) = J11;
-         J(1,0,q,e) = J12;
-         J(2,0,q,e) = J13;
-         J(0,1,q,e) = J21;
-         J(1,1,q,e) = J22;
-         J(2,1,q,e) = J23;
-         J(0,2,q,e) = J31;
-         J(1,2,q,e) = J32;
-         J(2,2,q,e) = J33;
-         const double r_idetJ = 1.0 / r_detJ;
-         invJ(0,0,q,e) = r_idetJ * ((J22 * J33)-(J23 * J32));
-         invJ(1,0,q,e) = r_idetJ * ((J32 * J13)-(J33 * J12));
-         invJ(2,0,q,e) = r_idetJ * ((J12 * J23)-(J13 * J22));
-         invJ(0,1,q,e) = r_idetJ * ((J23 * J31)-(J21 * J33));
-         invJ(1,1,q,e) = r_idetJ * ((J33 * J11)-(J31 * J13));
-         invJ(2,1,q,e) = r_idetJ * ((J13 * J21)-(J11 * J23));
-         invJ(0,2,q,e) = r_idetJ * ((J21 * J32)-(J22 * J31));
-         invJ(1,2,q,e) = r_idetJ * ((J31 * J12)-(J32 * J11));
-         invJ(2,2,q,e) = r_idetJ * ((J11 * J22)-(J12 * J21));
-         detJ(q,e) = r_detJ;
+         if (XJID & XTMesh::Compute::_J_)
+         {
+            J(0,0,q,e) = J11;
+            J(1,0,q,e) = J12;
+            J(2,0,q,e) = J13;
+            J(0,1,q,e) = J21;
+            J(1,1,q,e) = J22;
+            J(2,1,q,e) = J23;
+            J(0,2,q,e) = J31;
+            J(1,2,q,e) = J32;
+            J(2,2,q,e) = J33;
+         }
+         double r_detJ = 0.0;
+         if ((XJID & XTMesh::Compute::_D_)  ||
+             (XJID & XTMesh::Compute::_I_))
+         {
+            r_detJ = ((J11 * J22 * J33) + (J12 * J23 * J31) +
+                      (J13 * J21 * J32) - (J13 * J22 * J31) -
+                      (J12 * J21 * J33) - (J11 * J23 * J32));
+         }
+         if (XJID & XTMesh::Compute::_I_)
+         {
+            const double r_idetJ = 1.0 / r_detJ;
+            invJ(0,0,q,e) = r_idetJ * ((J22 * J33)-(J23 * J32));
+            invJ(1,0,q,e) = r_idetJ * ((J32 * J13)-(J33 * J12));
+            invJ(2,0,q,e) = r_idetJ * ((J12 * J23)-(J13 * J22));
+            invJ(0,1,q,e) = r_idetJ * ((J23 * J31)-(J21 * J33));
+            invJ(1,1,q,e) = r_idetJ * ((J33 * J11)-(J31 * J13));
+            invJ(2,1,q,e) = r_idetJ * ((J13 * J21)-(J11 * J23));
+            invJ(0,2,q,e) = r_idetJ * ((J21 * J32)-(J22 * J31));
+            invJ(1,2,q,e) = r_idetJ * ((J31 * J12)-(J32 * J11));
+            invJ(2,2,q,e) = r_idetJ * ((J11 * J22)-(J12 * J21));
+         }
+         if (XJID & XTMesh::Compute::_D_) { detJ(q,e) = r_detJ; }
       }
    });
 }
@@ -258,24 +288,25 @@ static void PAGeom(const int dim,
                    double *Xq,
                    double *J,
                    double *invJ,
-                   double *detJ)
+                   double *detJ,
+                   const int f)
 {
    if (dim == 2)
    {
       switch ((D1D << 4) | Q1D)
       {
-         case 0x22: PAGeom2D<2,2>(NE, B, G, X, Xq, J, invJ, detJ); break;
-         case 0x23: PAGeom2D<2,3>(NE, B, G, X, Xq, J, invJ, detJ); break;
-         case 0x24: PAGeom2D<2,4>(NE, B, G, X, Xq, J, invJ, detJ); break;
-         case 0x25: PAGeom2D<2,5>(NE, B, G, X, Xq, J, invJ, detJ); break;
-         case 0x32: PAGeom2D<3,2>(NE, B, G, X, Xq, J, invJ, detJ); break;
-         case 0x34: PAGeom2D<3,4>(NE, B, G, X, Xq, J, invJ, detJ); break;
-         case 0x42: PAGeom2D<4,2>(NE, B, G, X, Xq, J, invJ, detJ); break;
-         case 0x44: PAGeom2D<4,4>(NE, B, G, X, Xq, J, invJ, detJ); break;
-         case 0x45: PAGeom2D<4,5>(NE, B, G, X, Xq, J, invJ, detJ); break;
-         case 0x46: PAGeom2D<4,6>(NE, B, G, X, Xq, J, invJ, detJ); break;
-         case 0x58: PAGeom2D<5,8>(NE, B, G, X, Xq, J, invJ, detJ); break;
-         default: PAGeom2D(NE, B, G, X, Xq, J, invJ, detJ, D1D, Q1D); break;
+         case 0x22: PAGeom2D<2,2>(NE, B, G, X, Xq, J, invJ, detJ, f); break;
+         case 0x23: PAGeom2D<2,3>(NE, B, G, X, Xq, J, invJ, detJ, f); break;
+         case 0x24: PAGeom2D<2,4>(NE, B, G, X, Xq, J, invJ, detJ, f); break;
+         case 0x25: PAGeom2D<2,5>(NE, B, G, X, Xq, J, invJ, detJ, f); break;
+         case 0x32: PAGeom2D<3,2>(NE, B, G, X, Xq, J, invJ, detJ, f); break;
+         case 0x34: PAGeom2D<3,4>(NE, B, G, X, Xq, J, invJ, detJ, f); break;
+         case 0x42: PAGeom2D<4,2>(NE, B, G, X, Xq, J, invJ, detJ, f); break;
+         case 0x44: PAGeom2D<4,4>(NE, B, G, X, Xq, J, invJ, detJ, f); break;
+         case 0x45: PAGeom2D<4,5>(NE, B, G, X, Xq, J, invJ, detJ, f); break;
+         case 0x46: PAGeom2D<4,6>(NE, B, G, X, Xq, J, invJ, detJ, f); break;
+         case 0x58: PAGeom2D<5,8>(NE, B, G, X, Xq, J, invJ, detJ, f); break;
+         default: PAGeom2D(NE, B, G, X, Xq, J, invJ, detJ, D1D, Q1D, f); break;
       }
       return;
    }
@@ -283,19 +314,20 @@ static void PAGeom(const int dim,
    {
       switch ((D1D << 4) | Q1D)
       {
-         case 0x23: PAGeom3D<2,3>(NE, B, G, X, Xq, J, invJ, detJ); break;
-         case 0x24: PAGeom3D<2,4>(NE, B, G, X, Xq, J, invJ, detJ); break;
-         case 0x25: PAGeom3D<2,5>(NE, B, G, X, Xq, J, invJ, detJ); break;
-         case 0x26: PAGeom3D<2,6>(NE, B, G, X, Xq, J, invJ, detJ); break;
-         case 0x34: PAGeom3D<3,4>(NE, B, G, X, Xq, J, invJ, detJ); break;
-         default: PAGeom3D(NE, B, G, X, Xq, J, invJ, detJ, D1D, Q1D); break;
+         case 0x23: PAGeom3D<2,3>(NE, B, G, X, Xq, J, invJ, detJ, f); break;
+         case 0x24: PAGeom3D<2,4>(NE, B, G, X, Xq, J, invJ, detJ, f); break;
+         case 0x25: PAGeom3D<2,5>(NE, B, G, X, Xq, J, invJ, detJ, f); break;
+         case 0x26: PAGeom3D<2,6>(NE, B, G, X, Xq, J, invJ, detJ, f); break;
+         case 0x34: PAGeom3D<3,4>(NE, B, G, X, Xq, J, invJ, detJ, f); break;
+         default: PAGeom3D(NE, B, G, X, Xq, J, invJ, detJ, D1D, Q1D, f); break;
       }
       return;
    }
    MFEM_ABORT("Unknown kernel.");
 }
 
-XTMesh::XTMesh(const Mesh *mesh, const IntegrationRule &ir) : sequence(-1)
+XTMesh::XTMesh(const Mesh *mesh, const IntegrationRule &ir, const int flags)
+   : sequence(-1), XJID(flags)
 {
    const GridFunction *nodes = mesh->GetNodes();
    const mfem::FiniteElementSpace *fespace = nodes->FESpace();
@@ -315,13 +347,13 @@ XTMesh::XTMesh(const Mesh *mesh, const IntegrationRule &ir) : sequence(-1)
    mfem::Array<int> eMap(DND*NE);
    GeomFill(vdim, NE, DND, nodes->Size(), h_eMap, eMap, nodes->GetData(), Enodes);
    if (byNODES) { ReorderByNodes(nodes); }
-   this->X.SetSize(vdim*QND*NE);
-   this->J.SetSize(vdim*vdim*QND*NE);
-   this->invJ.SetSize(vdim*vdim*QND*NE);
-   this->detJ.SetSize(QND*NE);
+   if (XJID & XTMesh::Compute::_X_) { this->X.SetSize(vdim*QND*NE); }
+   if (XJID & XTMesh::Compute::_J_) { this->J.SetSize(vdim*vdim*QND*NE); }
+   if (XJID & XTMesh::Compute::_I_) { this->invJ.SetSize(vdim*vdim*QND*NE); }
+   if (XJID & XTMesh::Compute::_D_) { this->detJ.SetSize(QND*NE); }
    const DofToQuad* maps = DofToQuad::GetSimplexMaps(*fe, ir);
    PAGeom(vdim, D1D, Q1D, NE, maps->B, maps->G, Enodes,
-          this->X, this->J, this->invJ, this->detJ);
+          this->X, this->J, this->invJ, this->detJ, XJID);
    delete maps;
 }
 

--- a/mesh/mesh_ext.hpp
+++ b/mesh/mesh_ext.hpp
@@ -19,12 +19,12 @@ namespace mfem
 class GeometryExtension
 {
 private:
-  long sequence;
+   long sequence;
 public:
    Array<int> eMap;
    Array<double> nodes;
    Array<double> X, J, invJ, detJ;
-   GeometryExtension():sequence(-1){}
+   GeometryExtension():sequence(-1) {}
    long& GetSequence() {return sequence;}
    static GeometryExtension* Get(Mesh*,
                                  const IntegrationRule&,

--- a/mesh/mesh_ext.hpp
+++ b/mesh/mesh_ext.hpp
@@ -15,26 +15,15 @@
 namespace mfem
 {
 
-/// GeometryExtension
-class GeometryExtension
+/// Mesh Extension
+class XTMesh
 {
 private:
    long sequence;
 public:
-   Array<int> eMap;
-   Array<double> nodes;
    Array<double> X, J, invJ, detJ;
-   GeometryExtension():sequence(-1) {}
+   XTMesh(const Mesh*, const IntegrationRule&);
    long& GetSequence() {return sequence;}
-   static GeometryExtension* Get(Mesh*,
-                                 const IntegrationRule&,
-                                 GeometryExtension*& geom);
-   static GeometryExtension* Get(Mesh*,
-                                 const IntegrationRule&,
-                                 const Vector&,
-                                 GeometryExtension*& geom);
-   static void ReorderByVDim(const GridFunction*);
-   static void ReorderByNodes(const GridFunction*);
 };
 
 }

--- a/mesh/mesh_ext.hpp
+++ b/mesh/mesh_ext.hpp
@@ -1,0 +1,42 @@
+// Copyright (c) 2010, Lawrence Livermore National Security, LLC. Produced at
+// the Lawrence Livermore National Laboratory. LLNL-CODE-443211. All Rights
+// reserved. See file COPYRIGHT for details.
+//
+// This file is part of the MFEM library. For more information and source code
+// availability see http://mfem.org.
+//
+// MFEM is free software; you can redistribute it and/or modify it under the
+// terms of the GNU Lesser General Public License (as published by the Free
+// Software Foundation) version 2.1 dated February 1999.
+
+#ifndef MFEM_MESH_EXT
+#define MFEM_MESH_EXT
+
+namespace mfem
+{
+
+/// GeometryExtension
+class GeometryExtension
+{
+private:
+  long sequence;
+public:
+   Array<int> eMap;
+   Array<double> nodes;
+   Array<double> X, J, invJ, detJ;
+   GeometryExtension():sequence(-1){}
+   long& GetSequence() {return sequence;}
+   static GeometryExtension* Get(Mesh*,
+                                 const IntegrationRule&,
+                                 GeometryExtension*& geom);
+   static GeometryExtension* Get(Mesh*,
+                                 const IntegrationRule&,
+                                 const Vector&,
+                                 GeometryExtension*& geom);
+   static void ReorderByVDim(const GridFunction*);
+   static void ReorderByNodes(const GridFunction*);
+};
+
+}
+
+#endif

--- a/mesh/mesh_ext.hpp
+++ b/mesh/mesh_ext.hpp
@@ -19,10 +19,20 @@ namespace mfem
 class XTMesh
 {
 private:
+   int XJID;
    long sequence;
 public:
+   enum Compute
+   {
+      _X_ = 1 << 0,
+      _J_ = 1 << 1,
+      _I_ = 1 << 2,
+      _D_ = 1 << 3,
+   };
    Array<double> X, J, invJ, detJ;
-   XTMesh(const Mesh*, const IntegrationRule&);
+   XTMesh(const Mesh*,
+          const IntegrationRule&,
+          const int flags = (_X_|_J_|_I_|_D_));
    long& GetSequence() {return sequence;}
 };
 


### PR DESCRIPTION
Try to address some of _https://github.com/mfem/mfem/issues/813#issuecomment-490691572_

- [x] Separate GeometryExtension and puts it in mesh folder
- [x] Members like invJ, detJ, X, should be computed only if used
- [x] Do we need a store the nodes? This is the E-vector derived from the mesh nodes.
- [x] The role of eMap seems to overlap with the role of class ElemRestriction.
- [x] The global static long sequence in bilininteg_ext.cpp - this should not be global.
- [x] The global static GeometryExtension *geom in bilininteg_ext.cpp - this should not be global.