### PR TITLE
Renamed Example 22 to Example 21 [ex22-rename]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,9 +82,9 @@ examples/ex20.dat
 examples/ex20p_?????.dat
 examples/gnuplot_ex20.inp
 examples/gnuplot_ex20p.inp
-examples/ex22*.mesh
-examples/ex22*.sol
-examples/ex22p_*.*
+examples/ex21*.mesh
+examples/ex21*.sol
+examples/ex21p_*.*
 
 examples/sundials/ex9
 examples/sundials/ex1[06]

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -61,7 +61,7 @@ Discretization improvements
 
 - Added element flux, and flux energy computation in class ElasticityIntegrator,
   allowing for the use of Zienkiewicz-Zhu type error estimators with the
-  integrator. For an illustration of this addition, see the new Example 22.
+  integrator. For an illustration of this addition, see the new Example 21.
 
 - Added a variety of coefficients which are sums or products of existing
   coefficients as well as grid function coefficients which return the
@@ -132,7 +132,7 @@ New and updated examples and miniapps
   from a Hamiltonian. The example demonstrates the use of the variable order,
   symplectic integration algorithm implemented in class SIAVSolver.
 
-- Added a new example, Example 22/22p, that illustrates the use of AMR to solve
+- Added a new example, Example 21/21p, that illustrates the use of AMR to solve
   a linear elasticity problem. This is an extension of Example 2/2p.
 
 New and improved solvers and preconditioners

--- a/doc/CodeDocumentation.dox
+++ b/doc/CodeDocumentation.dox
@@ -77,8 +77,8 @@ namespace mfem {
  * - <a class="el" href="ex19p_8cpp_source.html">Example 19p</a>: parallel incompressible nonlinear elasticity
  * - <a class="el" href="ex20_8cpp_source.html">Example 20</a>: symplectic ODE integration
  * - <a class="el" href="ex20p_8cpp_source.html">Example 20p</a>: parallel symplectic ODE integration
- * - <a class="el" href="ex22_8cpp_source.html">Example 22</a>: adaptive mesh refinement for linear elasticity
- * - <a class="el" href="ex22p_8cpp_source.html">Example 22p</a>: parallel adaptive mesh refinement for linear elasticity
+ * - <a class="el" href="ex21_8cpp_source.html">Example 21</a>: adaptive mesh refinement for linear elasticity
+ * - <a class="el" href="ex21p_8cpp_source.html">Example 21p</a>: parallel adaptive mesh refinement for linear elasticity
  *
  * <H4>SUNDIALS Examples</H4>
  * - Variants of Examples

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -27,7 +27,7 @@ list(APPEND ALL_EXE_SRCS
   ex18.cpp
   ex19.cpp
   ex20.cpp
-  ex22.cpp
+  ex21.cpp
   )
 
 if (MFEM_USE_MPI)
@@ -52,7 +52,7 @@ if (MFEM_USE_MPI)
     ex18p.cpp
     ex19p.cpp
     ex20p.cpp
-    ex22p.cpp
+    ex21p.cpp
     )
 endif()
 

--- a/examples/ex21.cpp
+++ b/examples/ex21.cpp
@@ -1,16 +1,16 @@
-//                                MFEM Example 22
+//                                MFEM Example 21
 //
-// Compile with: make ex22
+// Compile with: make ex21
 //
-// Sample runs:  ex22
-//               ex22 -o 3
-//               ex22 -m ../data/beam-quad.mesh
-//               ex22 -m ../data/beam-quad.mesh -o 3
-//               ex22 -m ../data/beam-quad.mesh -o 3 -f 1
-//               ex22 -m ../data/beam-tet.mesh
-//               ex22 -m ../data/beam-tet.mesh -o 2
-//               ex22 -m ../data/beam-hex.mesh
-//               ex22 -m ../data/beam-hex.mesh -o 2
+// Sample runs:  ex21
+//               ex21 -o 3
+//               ex21 -m ../data/beam-quad.mesh
+//               ex21 -m ../data/beam-quad.mesh -o 3
+//               ex21 -m ../data/beam-quad.mesh -o 3 -f 1
+//               ex21 -m ../data/beam-tet.mesh
+//               ex21 -m ../data/beam-tet.mesh -o 2
+//               ex21 -m ../data/beam-hex.mesh
+//               ex21 -m ../data/beam-hex.mesh -o 2
 //
 // Description:  This is a version of Example 2 with a simple adaptive mesh
 //               refinement loop. The problem being solved is again the linear
@@ -287,11 +287,11 @@ int main(int argc, char *argv[])
    }
 
    {
-      ofstream mesh_ref_out("ex22_reference.mesh");
+      ofstream mesh_ref_out("ex21_reference.mesh");
       mesh_ref_out.precision(16);
       mesh.Print(mesh_ref_out);
 
-      ofstream mesh_out("ex22_deformed.mesh");
+      ofstream mesh_out("ex21_deformed.mesh");
       mesh_out.precision(16);
       GridFunction nodes(&fespace), *nodes_p = &nodes;
       mesh.GetNodes(nodes);
@@ -301,7 +301,7 @@ int main(int argc, char *argv[])
       mesh.Print(mesh_out);
       mesh.SwapNodes(nodes_p, own_nodes);
 
-      ofstream x_out("ex22_displacement.sol");
+      ofstream x_out("ex21_displacement.sol");
       x_out.precision(16);
       x.Save(x_out);
    }

--- a/examples/ex21p.cpp
+++ b/examples/ex21p.cpp
@@ -1,15 +1,15 @@
-//                                MFEM Example 22
+//                                MFEM Example 21
 //
-// Compile with: make ex22p
+// Compile with: make ex21p
 //
-// Sample runs:  mpirun -np 4 ex22p
-//               mpirun -np 4 ex22p -o 3
-//               mpirun -np 4 ex22p -m ../data/beam-quad.mesh
-//               mpirun -np 4 ex22p -m ../data/beam-quad.mesh -o 3
-//               mpirun -np 4 ex22p -m ../data/beam-tet.mesh
-//               mpirun -np 4 ex22p -m ../data/beam-tet.mesh -o 2
-//               mpirun -np 4 ex22p -m ../data/beam-hex.mesh
-//               mpirun -np 4 ex22p -m ../data/beam-hex.mesh -o 2
+// Sample runs:  mpirun -np 4 ex21p
+//               mpirun -np 4 ex21p -o 3
+//               mpirun -np 4 ex21p -m ../data/beam-quad.mesh
+//               mpirun -np 4 ex21p -m ../data/beam-quad.mesh -o 3
+//               mpirun -np 4 ex21p -m ../data/beam-tet.mesh
+//               mpirun -np 4 ex21p -m ../data/beam-tet.mesh -o 2
+//               mpirun -np 4 ex21p -m ../data/beam-hex.mesh
+//               mpirun -np 4 ex21p -m ../data/beam-hex.mesh -o 2
 //
 // Description:  This is a version of Example 2p with a simple adaptive mesh
 //               refinement loop. The problem being solved is again the linear
@@ -330,7 +330,7 @@ int main(int argc, char *argv[])
          x.Update();
       }
 
-      // 22. Inform also the bilinear and linear forms that the space has
+      // 21. Inform also the bilinear and linear forms that the space has
       //     changed.
       a.Update();
       b.Update();
@@ -338,9 +338,9 @@ int main(int argc, char *argv[])
 
    {
       ostringstream mref_name, mesh_name, sol_name;
-      mref_name << "ex22p_reference_mesh." << setfill('0') << setw(6) << myid;
-      mesh_name << "ex22p_deformed_mesh." << setfill('0') << setw(6) << myid;
-      sol_name << "ex22p_displacement." << setfill('0') << setw(6) << myid;
+      mref_name << "ex21p_reference_mesh." << setfill('0') << setw(6) << myid;
+      mesh_name << "ex21p_deformed_mesh." << setfill('0') << setw(6) << myid;
+      sol_name << "ex21p_displacement." << setfill('0') << setw(6) << myid;
 
       ofstream mesh_ref_out(mref_name.str().c_str());
       mesh_ref_out.precision(16);

--- a/examples/makefile
+++ b/examples/makefile
@@ -22,9 +22,9 @@ MFEM_LIB_FILE = mfem_is_not_built
 -include $(CONFIG_MK)
 
 SEQ_EXAMPLES = ex1 ex2 ex3 ex4 ex5 ex6 ex7 ex8 ex9 ex10 ex14 ex15 ex16 ex17\
-  ex18 ex19 ex20 ex22
+  ex18 ex19 ex20 ex21
 PAR_EXAMPLES = ex1p ex2p ex3p ex4p ex5p ex6p ex7p ex8p ex9p ex10p ex11p ex12p\
- ex13p ex14p ex15p ex16p ex17p ex18p ex19p ex20p ex22p
+ ex13p ex14p ex15p ex16p ex17p ex18p ex19p ex20p ex21p
 
 ifeq ($(MFEM_USE_MPI),NO)
    EXAMPLES = $(SEQ_EXAMPLES)
@@ -125,4 +125,4 @@ clean-exec:
 	@rm -f vortex-mesh.* vortex.mesh vortex-?-init.* vortex-?-final.*
 	@rm -f deformation.* pressure.*
 	@rm -f ex20.dat ex20p_?????.dat gnuplot_ex20.inp gnuplot_ex20p.inp
-	@rm -f ex22*.mesh ex22*.sol ex22p_*.*
+	@rm -f ex21*.mesh ex21*.sol ex21p_*.*


### PR DESCRIPTION
(to close the gap in numbering before the mfem-4.0 release)