### PR TITLE
Add copy constructor (deep copy data) to HypreParMatrix

### DIFF
--- a/linalg/hypre.cpp
+++ b/linalg/hypre.cpp
@@ -818,6 +818,21 @@ HypreParMatrix::HypreParMatrix(MPI_Comm comm, int nrows, HYPRE_Int glob_nrows,
    width = GetNumCols();
 }
 
+HypreParMatrix::HypreParMatrix(const HypreParMatrix &P)
+{
+   hypre_ParCSRMatrix *Ph = static_cast<hypre_ParCSRMatrix *>(P);
+
+   Init();
+
+   // Clone the structure
+   A = hypre_ParCSRMatrixCompleteClone(Ph);
+   // Make a deep copy of the data from the source
+   hypre_ParCSRMatrixCopy(Ph, A, 1);
+
+   height = GetNumRows();
+   width = GetNumCols();
+}
+
 void HypreParMatrix::MakeRef(const HypreParMatrix &master)
 {
    Destroy();

--- a/linalg/hypre.cpp
+++ b/linalg/hypre.cpp
@@ -831,6 +831,13 @@ HypreParMatrix::HypreParMatrix(const HypreParMatrix &P)
 
    height = GetNumRows();
    width = GetNumCols();
+
+   CopyRowStarts();
+   CopyColStarts();
+
+   hypre_ParCSRMatrixSetNumNonzeros(A);
+
+   hypre_MatvecCommPkgCreate(A);
 }
 
 void HypreParMatrix::MakeRef(const HypreParMatrix &master)

--- a/linalg/hypre.hpp
+++ b/linalg/hypre.hpp
@@ -325,7 +325,7 @@ public:
                   double *data, HYPRE_Int *rows,
                   HYPRE_Int *cols); // constructor with 9 arguments
 
-   /** @brief Copy constructor for a CSR matrix which creates a deep copy of
+   /** @brief Copy constructor for a ParCSR matrix which creates a deep copy of
        structure and data from @a P. */
    HypreParMatrix(const HypreParMatrix &P);
 

--- a/linalg/hypre.hpp
+++ b/linalg/hypre.hpp
@@ -325,6 +325,10 @@ public:
                   double *data, HYPRE_Int *rows,
                   HYPRE_Int *cols); // constructor with 9 arguments
 
+   /** @brief Copy constructor for a CSR matrix which creates a deep copy of
+       structure and data from @a P. */
+   HypreParMatrix(const HypreParMatrix &P);
+
    /// Make this HypreParMatrix a reference to 'master'
    void MakeRef(const HypreParMatrix &master);
 


### PR DESCRIPTION
This adds a simple copy constructor to HypreParMatrix which creates a deep copy of structure and data of the origin. This can be useful for keeping track of several restriction or prolongation matrices and avoids rebuilding them when dealing with several mesh hierarchies.