### PR TITLE
Flexible handling of hypre errors [hypre-errors-dev]

### DIFF
--- a/linalg/hypre.cpp
+++ b/linalg/hypre.cpp
@@ -2755,7 +2755,10 @@ void HypreBoomerAMG::SetElasticityOptions(ParFiniteElementSpace *fespace)
    RecomputeRBMs();
    HYPRE_BoomerAMGSetInterpVectors(amg_precond, rbms.Size(), rbms.GetData());
 
-   // See the documentation of SetErrorMode() for explanation:
+   // The above BoomerAMG options may result in singular matrices on the coarse
+   // grids, which are handled correctly in hypre's Solve method, but can produce
+   // hypre errors in the Setup (specifically in the l1 row norm computation).
+   // See the documentation of SetErrorMode() for more details.
    error_mode = IGNORE_HYPRE_ERRORS;
 }
 
@@ -2947,6 +2950,12 @@ HypreAMS::HypreAMS(HypreParMatrix &A, ParFiniteElementSpace *edge_fespace)
                                theta, amg_interp_type, amg_Pmax);
    HYPRE_AMSSetBetaAMGOptions(ams, amg_coarsen_type, amg_agg_levels, amg_rlx_type,
                               theta, amg_interp_type, amg_Pmax);
+
+   // The AMS preconditioner may sometimes require inverting singular matrices
+   // with BoomerAMG, which are handled correctly in hypre's Solve method, but
+   // can produce hypre errors in the Setup (specifically in the l1 row norm
+   // computation). See the documentation of SetErrorMode() for more details.
+   error_mode = IGNORE_HYPRE_ERRORS;
 }
 
 HypreAMS::~HypreAMS()
@@ -3186,7 +3195,10 @@ HypreADS::HypreADS(HypreParMatrix &A, ParFiniteElementSpace *face_fespace)
    HYPRE_ADSSetAMSOptions(ads, ams_cycle_type, amg_coarsen_type, amg_agg_levels,
                           amg_rlx_type, theta, amg_interp_type, amg_Pmax);
 
-   // See the documentation of SetErrorMode() for explanation:
+   // The ADS preconditioner requires inverting singular matrices with BoomerAMG,
+   // which are handled correctly in hypre's Solve method, but can produce hypre
+   // errors in the Setup (specifically in the l1 row norm computation). See the
+   // documentation of SetErrorMode() for more details.
    error_mode = IGNORE_HYPRE_ERRORS;
 }
 

--- a/linalg/hypre.cpp
+++ b/linalg/hypre.cpp
@@ -2097,6 +2097,7 @@ HypreSolver::HypreSolver()
    A = NULL;
    setup_called = 0;
    B = X = NULL;
+   error_mode = ABORT_HYPRE_ERRORS;
 }
 
 HypreSolver::HypreSolver(HypreParMatrix *_A)
@@ -2105,6 +2106,7 @@ HypreSolver::HypreSolver(HypreParMatrix *_A)
    A = _A;
    setup_called = 0;
    B = X = NULL;
+   error_mode = ABORT_HYPRE_ERRORS;
 }
 
 void HypreSolver::Mult(const HypreParVector &b, HypreParVector &x) const
@@ -2118,8 +2120,15 @@ void HypreSolver::Mult(const HypreParVector &b, HypreParVector &x) const
    if (!setup_called)
    {
       err = SetupFcn()(*this, *A, b, x);
-      MFEM_VERIFY(!err, "HypreSolver::Mult (...) : Error during setup! error code "
-                  << err);
+      if (error_mode == WARN_HYPRE_ERRORS)
+      {
+         if (err) { MFEM_WARNING("Error during setup! Error code: " << err); }
+      }
+      else if (error_mode == ABORT_HYPRE_ERRORS)
+      {
+         MFEM_VERIFY(!err, "Error during setup! Error code: " << err);
+      }
+      hypre_error_flag = 0;
       setup_called = 1;
    }
 
@@ -2128,8 +2137,15 @@ void HypreSolver::Mult(const HypreParVector &b, HypreParVector &x) const
       x = 0.0;
    }
    err = SolveFcn()(*this, *A, b, x);
-   MFEM_VERIFY(!err,"HypreSolver::Mult (...) : Error during solve! error code "
-               << err);
+   if (error_mode == WARN_HYPRE_ERRORS)
+   {
+      if (err) { MFEM_WARNING("Error during solve! Error code: " << err); }
+   }
+   else if (error_mode == ABORT_HYPRE_ERRORS)
+   {
+      MFEM_VERIFY(!err, "Error during solve! Error code: " << err);
+   }
+   hypre_error_flag = 0;
 }
 
 void HypreSolver::Mult(const Vector &b, Vector &x) const
@@ -2738,6 +2754,9 @@ void HypreBoomerAMG::SetElasticityOptions(ParFiniteElementSpace *fespace)
 
    RecomputeRBMs();
    HYPRE_BoomerAMGSetInterpVectors(amg_precond, rbms.Size(), rbms.GetData());
+
+   // See the documentation of SetErrorMode() for explanation:
+   error_mode = IGNORE_HYPRE_ERRORS;
 }
 
 HypreBoomerAMG::~HypreBoomerAMG()
@@ -3166,6 +3185,9 @@ HypreADS::HypreADS(HypreParMatrix &A, ParFiniteElementSpace *face_fespace)
                           theta, amg_interp_type, amg_Pmax);
    HYPRE_ADSSetAMSOptions(ads, ams_cycle_type, amg_coarsen_type, amg_agg_levels,
                           amg_rlx_type, theta, amg_interp_type, amg_Pmax);
+
+   // See the documentation of SetErrorMode() for explanation:
+   error_mode = IGNORE_HYPRE_ERRORS;
 }
 
 HypreADS::~HypreADS()

--- a/linalg/hypre.hpp
+++ b/linalg/hypre.hpp
@@ -670,10 +670,10 @@ public:
 class HypreSolver : public Solver
 {
 public:
-   /// How to treat hypre errors.
+   /// How to treat errors returned by hypre function calls.
    enum ErrorMode
    {
-      IGNORE_HYPRE_ERRORS, ///< Ignore hypre errors
+      IGNORE_HYPRE_ERRORS, ///< Ignore hypre errors (see e.g. HypreADS)
       WARN_HYPRE_ERRORS,   ///< Issue warnings on hypre errors
       ABORT_HYPRE_ERRORS   ///< Abort on hypre errors (default in base class)
    };
@@ -711,15 +711,15 @@ public:
    virtual void Mult(const HypreParVector &b, HypreParVector &x) const;
    virtual void Mult(const Vector &b, Vector &x) const;
 
-   /** @brief Set the behavior for treating hypre errors, see ErrorMode. The
-       default mode in the base class is ABORT_HYPRE_ERRORS. */
-   /** There are two cases in derived classes where the error flag is set to
-       IGNORE_HYPRE_ERRORS:
+   /** @brief Set the behavior for treating hypre errors, see the ErrorMode
+       enum. The default mode in the base class is ABORT_HYPRE_ERRORS. */
+   /** Currently, there are three cases in derived classes where the error flag
+       is set to IGNORE_HYPRE_ERRORS:
        * in the method HypreBoomerAMG::SetElasticityOptions(), and
-       * in the constructor of class HypreADS.
-       The reason for this is that the hypre error flag is set when
-       hypre_ParCSRComputeL1Norms() encounters zero rows in a matrix, which is
-       expected in some cases with the above two solvers. */
+       * in the constructor of classes HypreAMS and HypreADS.
+       The reason for this is that a nonzero hypre error is returned) when
+       hypre_ParCSRComputeL1Norms() encounters zero row in a matrix, which is
+       expected in some cases with the above solvers. */
    void SetErrorMode(ErrorMode err_mode) const { error_mode = err_mode; }
 
    virtual ~HypreSolver();

--- a/linalg/hypre.hpp
+++ b/linalg/hypre.hpp
@@ -669,6 +669,15 @@ public:
 /// Abstract class for hypre's solvers and preconditioners
 class HypreSolver : public Solver
 {
+public:
+   /// How to treat hypre errors.
+   enum ErrorMode
+   {
+      IGNORE_HYPRE_ERRORS, ///< Ignore hypre errors
+      WARN_HYPRE_ERRORS,   ///< Issue warnings on hypre errors
+      ABORT_HYPRE_ERRORS   ///< Abort on hypre errors (default in base class)
+   };
+
 protected:
    /// The linear system matrix
    HypreParMatrix *A;
@@ -678,6 +687,9 @@ protected:
 
    /// Was hypre's Setup function called already?
    mutable int setup_called;
+
+   /// How to treat hypre errors.
+   mutable ErrorMode error_mode;
 
 public:
    HypreSolver();
@@ -698,6 +710,17 @@ public:
    /// Solve the linear system Ax=b
    virtual void Mult(const HypreParVector &b, HypreParVector &x) const;
    virtual void Mult(const Vector &b, Vector &x) const;
+
+   /** @brief Set the behavior for treating hypre errors, see ErrorMode. The
+       default mode in the base class is ABORT_HYPRE_ERRORS. */
+   /** There are two cases in derived classes where the error flag is set to
+       IGNORE_HYPRE_ERRORS:
+       * in the method HypreBoomerAMG::SetElasticityOptions(), and
+       * in the constructor of class HypreADS.
+       The reason for this is that the hypre error flag is set when
+       hypre_ParCSRComputeL1Norms() encounters zero rows in a matrix, which is
+       expected in some cases with the above two solvers. */
+   void SetErrorMode(ErrorMode err_mode) const { error_mode = err_mode; }
 
    virtual ~HypreSolver();
 };


### PR DESCRIPTION
Add support for more flexible handling of hypre errors in class `HypreSolver`.

The default is still to abort on hypre errors, except in some special cases -- see the documentation of the new method `HypreSolver::SetErrorMode()` for details.
