### PR TITLE
Fixed boundary attribute marker in LinearForm [najlkin:pr9]

### DIFF
--- a/fem/linearform.cpp
+++ b/fem/linearform.cpp
@@ -138,7 +138,11 @@ void LinearForm::Assemble()
          eltrans = fes -> GetBdrElementTransformation (i);
          for (int k=0; k < blfi.Size(); k++)
          {
+            if (blfi_marker[k] &&
+                (*blfi_marker[k])[bdr_attr-1] == 0) { continue; }
+
             blfi[k]->AssembleRHSElementVect(*fes->GetBE(i), *eltrans, elemvect);
+
             AddElementVector (vdofs, elemvect);
          }
       }


### PR DESCRIPTION
LinearForm was ignoring boundary attribute markers set in `AddBoundaryIntegrator()`. It only merged them together checking that at least one is set, but it was then applying all boundary integrators even when they did not have the marker set there. This can be considered a critical bug for certain applications.