### PR TITLE
Fix issue #938

### DIFF
--- a/config/tconfig.hpp
+++ b/config/tconfig.hpp
@@ -43,15 +43,14 @@
 #define MFEM_ALIGN_SIZE(size,type) \
    MFEM_ROUNDUP(size,(MFEM_SIMD_SIZE)/sizeof(type))
 
+#ifdef MFEM_COUNT_FLOPS
 namespace mfem
 {
 namespace internal
 {
-long long flop_count;
+extern long long flop_count;
 }
 }
-
-#ifdef MFEM_COUNT_FLOPS
 #define MFEM_FLOPS_RESET() (mfem::internal::flop_count = 0)
 #define MFEM_FLOPS_ADD(cnt) (mfem::internal::flop_count += (cnt))
 #define MFEM_FLOPS_GET() (mfem::internal::flop_count)

--- a/general/globals.cpp
+++ b/general/globals.cpp
@@ -31,6 +31,9 @@ std::string MakeParFilename(const std::string &prefix, const int myid,
    return fname.str();
 }
 
+#ifdef MFEM_COUNT_FLOPS
+long long flop_count;
+#endif
 
 #ifdef MFEM_USE_MPI
 

--- a/general/globals.cpp
+++ b/general/globals.cpp
@@ -32,7 +32,10 @@ std::string MakeParFilename(const std::string &prefix, const int myid,
 }
 
 #ifdef MFEM_COUNT_FLOPS
+namespace internal
+{
 long long flop_count;
+}
 #endif
 
 #ifdef MFEM_USE_MPI


### PR DESCRIPTION
Global variable defined in tconfig.hpp would cause duplicate
symbol errors when linking.