### PR TITLE
Add const iterators to Array class

### DIFF
--- a/general/array.hpp
+++ b/general/array.hpp
@@ -254,6 +254,8 @@ public:
    // STL-like begin/end
    inline T* begin() { return data; }
    inline T* end() { return data + size; }
+   inline const T* begin() const { return data; }
+   inline const T* end() const { return data + size; }
 
    long MemoryUsage() const { return Capacity() * sizeof(T); }
 


### PR DESCRIPTION
Add const version of `begin` and `end` for STL-style iterators to `Array` class