### PR TITLE
Force rebuilding of face nbr data after derefinement [bugfix/derefine-face-nbr]

### DIFF
--- a/mesh/pmesh.cpp
+++ b/mesh/pmesh.cpp
@@ -3056,7 +3056,7 @@ bool ParMesh::NonconformingDerefinement(Array<double> &elem_error,
    if (!glob_size) { return false; }
 
    DeleteFaceNbrData();
-   
+
    pncmesh->Derefine(derefs);
 
    ParMesh* mesh2 = new ParMesh(*pncmesh);

--- a/mesh/pmesh.cpp
+++ b/mesh/pmesh.cpp
@@ -3055,6 +3055,7 @@ bool ParMesh::NonconformingDerefinement(Array<double> &elem_error,
    long glob_size = ReduceInt(derefs.Size());
    if (!glob_size) { return false; }
 
+   // Destroy face-neighbor data only when actually de-refining.
    DeleteFaceNbrData();
 
    pncmesh->Derefine(derefs);

--- a/mesh/pmesh.cpp
+++ b/mesh/pmesh.cpp
@@ -3055,6 +3055,8 @@ bool ParMesh::NonconformingDerefinement(Array<double> &elem_error,
    long glob_size = ReduceInt(derefs.Size());
    if (!glob_size) { return false; }
 
+   DeleteFaceNbrData();
+   
    pncmesh->Derefine(derefs);
 
    ParMesh* mesh2 = new ParMesh(*pncmesh);


### PR DESCRIPTION
While working on a time stepping code which uses refinement/derefinement of a high-order DG field on a quadrilateral mesh I saw crashes in `ParFiniteElementSpace::ExchangeFaceNbrData`.  I traced the problem to calls to the `GetElementVDofs()` method which were using outdated element indices that were larger than the size of the `elem_dof` table.  Deleting the face neighbor data during calls to `ParMesh::NonconformingDerefinement` seems to have corrected the problem.  This follows the example set in `ParMesh::NonconformingRefinement` and `ParMesh::Rebalance` which both delete face neighbor data.
