### PR TITLE
Allow diff vector as insert vector [nurbs-knotinsert-dev]

### DIFF
--- a/mesh/mesh.cpp
+++ b/mesh/mesh.cpp
@@ -3429,6 +3429,28 @@ void Mesh::KnotInsert(Array<KnotVector *> &kv)
    UpdateNURBS();
 }
 
+void Mesh::KnotInsert(Array<Vector *> &kv)
+{
+   if (NURBSext == NULL)
+   {
+      mfem_error("Mesh::KnotInsert : Not a NURBS mesh!");
+   }
+
+   if (kv.Size() != NURBSext->GetNKV())
+   {
+      mfem_error("Mesh::KnotInsert : KnotVector array size mismatch!");
+   }
+
+   NURBSext->ConvertToPatches(*Nodes);
+
+   NURBSext->KnotInsert(kv);
+
+   last_operation = Mesh::NONE; // FiniteElementSpace::Update is not supported
+   sequence++;
+
+   UpdateNURBS();
+}
+
 void Mesh::NURBSUniformRefinement()
 {
    // do not check for NURBSext since this method is protected

--- a/mesh/mesh.hpp
+++ b/mesh/mesh.hpp
@@ -1122,6 +1122,7 @@ public:
 
    ///@{ @name NURBS mesh refinement methods
    void KnotInsert(Array<KnotVector *> &kv);
+   void KnotInsert(Array<Vector *> &kv);
    /* For each knot vector:
          new_degree = max(old_degree, min(old_degree + rel_degree, degree)). */
    void DegreeElevate(int rel_degree, int degree = 16);

--- a/mesh/nurbs.cpp
+++ b/mesh/nurbs.cpp
@@ -593,7 +593,7 @@ void NURBSPatch::KnotInsert(Array<Vector *> &newkv)
 // Routine from "The NURBS book" - 2nd ed - Piegl and Tiller
 void NURBSPatch::KnotInsert(int dir, const Vector &knot)
 {
-   if (knot.Size() == 0 ) return;
+   if (knot.Size() == 0 ) { return; }
 
    if (dir >= kv.Size() || dir < 0)
    {

--- a/mesh/nurbs.cpp
+++ b/mesh/nurbs.cpp
@@ -582,9 +582,19 @@ void NURBSPatch::KnotInsert(int dir, const KnotVector &newkv)
    }
 }
 
+void NURBSPatch::KnotInsert(Array<Vector *> &newkv)
+{
+   for (int dir = 0; dir < kv.Size(); dir++)
+   {
+      KnotInsert(dir, *newkv[dir]);
+   }
+}
+
 // Routine from "The NURBS book" - 2nd ed - Piegl and Tiller
 void NURBSPatch::KnotInsert(int dir, const Vector &knot)
 {
+   if (knot.Size() == 0 ) return;
+
    if (dir >= kv.Size() || dir < 0)
    {
       mfem_error("NURBSPatch::KnotInsert : Incorrect direction!");
@@ -2981,6 +2991,34 @@ void NURBSExtension::KnotInsert(Array<KnotVector *> &kv)
       patches[p]->KnotInsert(pkv);
    }
 }
+
+void NURBSExtension::KnotInsert(Array<Vector *> &kv)
+{
+   Array<int> edges;
+   Array<int> orient;
+
+   Array<Vector *> pkv(Dimension());
+
+   for (int p = 0; p < patches.Size(); p++)
+   {
+      patchTopo->GetElementEdges(p, edges, orient);
+
+      if (Dimension()==2)
+      {
+         pkv[0] = kv[KnotInd(edges[0])];
+         pkv[1] = kv[KnotInd(edges[1])];
+      }
+      else
+      {
+         pkv[0] = kv[KnotInd(edges[0])];
+         pkv[1] = kv[KnotInd(edges[3])];
+         pkv[2] = kv[KnotInd(edges[8])];
+      }
+
+      patches[p]->KnotInsert(pkv);
+   }
+}
+
 
 void NURBSExtension::GetPatchNets(const Vector &coords, int vdim)
 {

--- a/mesh/nurbs.hpp
+++ b/mesh/nurbs.hpp
@@ -119,7 +119,9 @@ public:
    void KnotInsert   (int dir, const KnotVector &knot);
    void KnotInsert   (int dir, const Vector     &knot);
 
+   void KnotInsert(Array<Vector *> &knot);
    void KnotInsert(Array<KnotVector *> &knot);
+
    void DegreeElevate(int t);
    void UniformRefinement();
 
@@ -389,6 +391,7 @@ public:
    void DegreeElevate(int rel_degree, int degree = 16);
    void UniformRefinement();
    void KnotInsert(Array<KnotVector *> &kv);
+   void KnotInsert(Array<Vector *> &kv);
 };
 
 


### PR DESCRIPTION
This small PR is an small addition to the NURBS capabilities.
It allows  to also use the difference vector to be specified for the knot insertion operator instead of the entire knotvector.