### PR TITLE
Fix reading quadratic hex meshes from cubit [fix-quadratic-cubit-hex]

### DIFF
--- a/mesh/mesh_readers.cpp
+++ b/mesh/mesh_readers.cpp
@@ -1972,27 +1972,7 @@ void Mesh::ReadCubit(const char *filename, int &curved, int &read_gf)
          }
       }
 
-      // Generate faces and edges so that we can define quadratic
-      // FE space on the mesh
-
-      // Generate faces
-      if (Dim > 2)
-      {
-         GetElementToFaceTable();
-         GenerateFaces();
-      }
-      else
-      {
-         NumOfFaces = 0;
-      }
-
-      // Generate edges
-      el_to_edge = new Table;
-      NumOfEdges = GetElementToEdgeTable(*el_to_edge, be_to_edge);
-      if (Dim == 2)
-      {
-         GenerateFaces(); // 'Faces' in 2D refers to the edges
-      }
+      FinalizeTopology();
 
       // Define quadratic FE space
       FiniteElementCollection *fec = new H1_FECollection(2,3);


### PR DESCRIPTION
This PR fixes the issue that reading a quadratic hex mesh created by cubit crashes mfem. Quadratic tet elements seem to work properly without the fix.

CC @Dan2997925