### PR TITLE
Increase default quadrature in vector linear forms [lininteg-quadrature-order]

### DIFF
--- a/fem/lininteg.cpp
+++ b/fem/lininteg.cpp
@@ -181,7 +181,7 @@ void VectorDomainLFIntegrator::AssembleRHSElementVect(
    const IntegrationRule *ir = IntRule;
    if (ir == NULL)
    {
-      int intorder = el.GetOrder() + 1;
+      int intorder = 2*el.GetOrder();
       ir = &IntRules.Get(el.GetGeomType(), intorder);
    }
 
@@ -240,7 +240,7 @@ void VectorBoundaryLFIntegrator::AssembleRHSElementVect(
    const IntegrationRule *ir = IntRule;
    if (ir == NULL)
    {
-      int intorder = el.GetOrder() + 1;
+      int intorder = 2*el.GetOrder();
       ir = &IntRules.Get(el.GetGeomType(), intorder);
    }
 
@@ -275,7 +275,7 @@ void VectorBoundaryLFIntegrator::AssembleRHSElementVect(
    const IntegrationRule *ir = IntRule;
    if (ir == NULL)
    {
-      int intorder = el.GetOrder() + 1;
+      int intorder = 2*el.GetOrder();
       ir = &IntRules.Get(Tr.FaceGeom, intorder);
    }
 


### PR DESCRIPTION
To ensure h^{p+1} convergence, the quadrature used for the right-hand side needs to be sufficiently accurate. This minor PR makes the vector versions of `LinearFormIntegrator` use the same degree of exactness as the scalar versions. The previous version would result in degraded convergence for e.g. high-order (> 4) vector diffusion problems

We should also consider adding (high-order) convergence tests to the regression test suites