### PR TITLE
Fix bug when creating low-order refined meshes in parallel [lor-mesh-bugfix]

### DIFF
--- a/mesh/mesh.cpp
+++ b/mesh/mesh.cpp
@@ -2021,7 +2021,7 @@ void Mesh::FinalizeMesh(int refine, bool fix_orientation)
    Finalize(refine, fix_orientation);
 }
 
-void Mesh::FinalizeTopology()
+void Mesh::FinalizeTopology(bool generate_bdr)
 {
    // Requirements: the following should be defined:
    //   1) Dim
@@ -2046,7 +2046,7 @@ void Mesh::FinalizeTopology()
    {
       GetElementToFaceTable();
       GenerateFaces();
-      if (NumOfBdrElements == 0)
+      if (NumOfBdrElements == 0 && generate_bdr)
       {
          GenerateBoundaryElements();
          GetElementToFaceTable(); // update be_to_face
@@ -2066,7 +2066,7 @@ void Mesh::FinalizeTopology()
       if (Dim == 2)
       {
          GenerateFaces(); // 'Faces' in 2D refers to the edges
-         if (NumOfBdrElements == 0)
+         if (NumOfBdrElements == 0 && generate_bdr)
          {
             GenerateBoundaryElements();
          }
@@ -3370,7 +3370,7 @@ Mesh::Mesh(Mesh *orig_mesh, int ref_factor, int ref_type)
       }
    }
 
-   FinalizeTopology();
+   FinalizeTopology(false);
    sequence = orig_mesh->GetSequence() + 1;
    last_operation = Mesh::REFINE;
 

--- a/mesh/mesh.hpp
+++ b/mesh/mesh.hpp
@@ -539,7 +539,7 @@ public:
 
        After calling this method, setting the Mesh vertices or nodes, it may be
        appropriate to call the method Finalize(). */
-   void FinalizeTopology();
+   void FinalizeTopology(bool generate_bdr = true);
 
    /// Finalize the construction of a general Mesh.
    /** This method will:


### PR DESCRIPTION
When creating a refined Mesh in parallel (via the `Mesh::Mesh(Mesh *orig_mesh, int ref_factor, int ref_type)` constructor), the boundaries are sometimes not treated properly.

In particular, the constructor calls `FinalizeTopology`, which will generate boundary elements if they are missing. However, in parallel, it is possible for mesh partitions to have no boundary elements (e.g. a subdomain contained entirely in the interior of the global mesh). So, the refined mesh will end up having boundary elements and attributes when it shouldn't have any.

This PR addresses this bug by adding a `generate_bdr` flag to `FinalizeTopology` that will ensure that boundary elements are not automatically generated when creating refined meshes.