### PR TITLE
Remove const from hostreadwrite [artv3/hostreadwrite-fix]

### DIFF
--- a/general/device.hpp
+++ b/general/device.hpp
@@ -285,7 +285,7 @@ inline T *ReadWrite(Memory<T> &mem, int size, bool on_dev = true)
 
 /** @brief Shortcut to ReadWrite(const Memory<T> &mem, int size, false) */
 template <typename T>
-inline T *HostReadWrite(const Memory<T> &mem, int size)
+inline T *HostReadWrite(Memory<T> &mem, int size)
 {
    return mfem::ReadWrite(mem, size, false);
 }

--- a/general/device.hpp
+++ b/general/device.hpp
@@ -283,7 +283,7 @@ inline T *ReadWrite(Memory<T> &mem, int size, bool on_dev = true)
    }
 }
 
-/** @brief Shortcut to ReadWrite(const Memory<T> &mem, int size, false) */
+/** @brief Shortcut to ReadWrite(Memory<T> &mem, int size, false) */
 template <typename T>
 inline T *HostReadWrite(Memory<T> &mem, int size)
 {

--- a/general/device.hpp
+++ b/general/device.hpp
@@ -285,7 +285,7 @@ inline T *ReadWrite(Memory<T> &mem, int size, bool on_dev = true)
 
 /** @brief Shortcut to ReadWrite(const Memory<T> &mem, int size, false) */
 template <typename T>
-inline const T *HostReadWrite(const Memory<T> &mem, int size)
+inline T *HostReadWrite(const Memory<T> &mem, int size)
 {
    return mfem::ReadWrite(mem, size, false);
 }


### PR DESCRIPTION
I'm not sure we want the const since we would like to modify contents. 
```
double *  data = mfem::HostReadWrite(....) 
data[0] += 1.0;
 ```