### PR TITLE
Fix SuperLU interfacing bug with recent hypre version [fix-superlu-hypre2160]

### DIFF
--- a/linalg/superlu.cpp
+++ b/linalg/superlu.cpp
@@ -131,6 +131,8 @@ SuperLURowLocMatrix::SuperLURowLocMatrix( const HypreParMatrix & hypParMat )
    hypre_CSRMatrix * csr_op = hypre_MergeDiagAndOffd(parcsr_op);
    hypre_CSRMatrixSetDataOwner(csr_op,0);
 #if MFEM_HYPRE_VERSION >= 21600
+   MFEM_VERIFY(csr_op->num_rows < INT_MAX,"SuperLU: number of local rows "
+               "is too large to store as an integer.");
    hypre_CSRMatrixBigJtoJ(csr_op);
 #endif
 

--- a/linalg/superlu.cpp
+++ b/linalg/superlu.cpp
@@ -130,6 +130,9 @@ SuperLURowLocMatrix::SuperLURowLocMatrix( const HypreParMatrix & hypParMat )
    // hypre_CSRMatrix.
    hypre_CSRMatrix * csr_op = hypre_MergeDiagAndOffd(parcsr_op);
    hypre_CSRMatrixSetDataOwner(csr_op,0);
+#if MFEM_HYPRE_VERSION >= 21600
+   hypre_CSRMatrixBigJtoJ(csr_op);
+#endif
 
    int m         = parcsr_op->global_num_rows;
    int n         = parcsr_op->global_num_cols;


### PR DESCRIPTION
This fixes a bug where the column indices are not created with the recent hypre release 2.16.0. Please check if the version checking here is correct.

Resolves #983

| PR | Author | Editor | Reviewers  | Assignment | Approval | Merge |
| --- | --- | --- | ---  | --- | --- | --- |
| https://github.com/mfem/mfem/pull/988 | @jandrej | @tzanio | @tzanio + @mlstowell | 11/23/19 | 12/5/19 | ⌛due 12/12/19 | 