### PR TITLE
Replace non-portable calls to Fortran BLAS and LAPACK with calls to CBLAS and LAPACKE, respectively [feature/use-cblas-and-lapacke] 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -177,8 +177,8 @@ endif()
 
 # BLAS, LAPACK
 if (MFEM_USE_LAPACK)
-  find_package(BLAS REQUIRED)
-  find_package(LAPACK REQUIRED)
+  find_package(BLAS 3.4.0 REQUIRED)
+  find_package(LAPACK 3.4.0 REQUIRED)
 endif()
 
 # OpenMP

--- a/INSTALL
+++ b/INSTALL
@@ -454,10 +454,11 @@ The specific libraries and their options are:
   Options: METIS_OPT, METIS_LIB.
 
 - LAPACK (optional), used when MFEM_USE_LAPACK = YES. Alternative, optimized
-  implementations can also be used, e.g. the ATLAS project.
+  implementations can also be used, e.g. the ATLAS project. The implementation
+  must implement LAPACK version 3.4.0 or later.
   URL: http://www.netlib.org/lapack (LAPACK)
        http://math-atlas.sourceforge.net (ATLAS)
-  Options: LAPACK_OPT (currently not used/needed), LAPACK_LIB.
+  Options: LAPACK_OPT, LAPACK_LIB.
 
 - OpenMP (optional), usually part of compiler, used when either MFEM_USE_OPENMP
   or MFEM_USE_LEGACY_OPENMP is set to YES.

--- a/config/defaults.mk
+++ b/config/defaults.mk
@@ -162,8 +162,9 @@ else
 endif
 
 # LAPACK library configuration
-LAPACK_OPT =
-LAPACK_LIB = $(if $(NOTMAC),-llapack -lblas,-framework Accelerate)
+LAPACK_DIR = /usr
+LAPACK_OPT = -I$(LAPACK_DIR)/include
+LAPACK_LIB = -L$(LAPACK_DIR)/lib -llapack -lblas
 
 # OpenMP configuration
 OPENMP_OPT = $(XCOMPILER)-fopenmp

--- a/linalg/densemat.cpp
+++ b/linalg/densemat.cpp
@@ -31,9 +31,7 @@
 
 
 #ifdef MFEM_USE_LAPACK
-extern "C" void
-dgemm_(char *, char *, int *, int *, int *, double *, double *,
-       int *, double *, int *, double *, double *, int *);
+#include "cblas.h"
 extern "C" void
 dgetrf_(int *, int *, double *, int *, int *, int *);
 extern "C" void
@@ -3067,12 +3065,16 @@ void Mult(const DenseMatrix &b, const DenseMatrix &c, DenseMatrix &a)
                b.Width() == c.Height(), "incompatible dimensions");
 
 #ifdef MFEM_USE_LAPACK
-   static char transa = 'N', transb = 'N';
-   static double alpha = 1.0, beta = 0.0;
-   int m = b.Height(), n = c.Width(), k = b.Width();
-
-   dgemm_(&transa, &transb, &m, &n, &k, &alpha, b.Data(), &m,
-          c.Data(), &k, &beta, a.Data(), &m);
+   const CBLAS_LAYOUT layout = CblasColMajor;
+   const CBLAS_TRANSPOSE transa = CblasNoTrans;
+   const CBLAS_TRANSPOSE transb = CblasNoTrans;
+   const double alpha = 1.0;
+   const double beta = 0.0;
+   const int m = b.Height();
+   const int n = c.Width();
+   const int k = b.Width();
+   cblas_dgemm(layout, transa, transb, m, n, k, alpha, b.Data(), m,
+               c.Data(), k, beta, a.Data(), m);
 #else
    const int ah = a.Height();
    const int aw = a.Width();
@@ -3103,12 +3105,16 @@ void AddMult(const DenseMatrix &b, const DenseMatrix &c, DenseMatrix &a)
                b.Width() == c.Height(), "incompatible dimensions");
 
 #ifdef MFEM_USE_LAPACK
-   static char transa = 'N', transb = 'N';
-   static double alpha = 1.0, beta = 1.0;
-   int m = b.Height(), n = c.Width(), k = b.Width();
-
-   dgemm_(&transa, &transb, &m, &n, &k, &alpha, b.Data(), &m,
-          c.Data(), &k, &beta, a.Data(), &m);
+   const CBLAS_LAYOUT layout = CblasColMajor;
+   const CBLAS_TRANSPOSE transa = CblasNoTrans;
+   const CBLAS_TRANSPOSE transb = CblasNoTrans;
+   const double alpha = 1.0;
+   const double beta = 1.0;
+   const int m = b.Height();
+   const int n = c.Width();
+   const int k = b.Width();
+   cblas_dgemm(layout, transa, transb, m, n, k, alpha, b.Data(), m,
+               c.Data(), k, beta, a.Data(), m);
 #else
    const int ah = a.Height();
    const int aw = a.Width();
@@ -3458,12 +3464,16 @@ void MultABt(const DenseMatrix &A, const DenseMatrix &B, DenseMatrix &ABt)
 #endif
 
 #ifdef MFEM_USE_LAPACK
-   static char transa = 'N', transb = 'T';
-   static double alpha = 1.0, beta = 0.0;
-   int m = A.Height(), n = B.Height(), k = A.Width();
-
-   dgemm_(&transa, &transb, &m, &n, &k, &alpha, A.Data(), &m,
-          B.Data(), &n, &beta, ABt.Data(), &m);
+   const CBLAS_LAYOUT layout = CblasColMajor;
+   const CBLAS_TRANSPOSE transa = CblasNoTrans;
+   const CBLAS_TRANSPOSE transb = CblasTrans;
+   const double alpha = 1.0;
+   const double beta = 0.0;
+   const int m = A.Height();
+   const int n = B.Height();
+   const int k = A.Width();
+   cblas_dgemm(layout, transa, transb, m, n, k, alpha, A.Data(), m,
+               B.Data(), n, beta, ABt.Data(), m);
 #elif 1
    const int ah = A.Height();
    const int bh = B.Height();
@@ -3581,12 +3591,16 @@ void AddMultABt(const DenseMatrix &A, const DenseMatrix &B, DenseMatrix &ABt)
 #endif
 
 #ifdef MFEM_USE_LAPACK
-   static char transa = 'N', transb = 'T';
-   static double alpha = 1.0, beta = 1.0;
-   int m = A.Height(), n = B.Height(), k = A.Width();
-
-   dgemm_(&transa, &transb, &m, &n, &k, &alpha, A.Data(), &m,
-          B.Data(), &n, &beta, ABt.Data(), &m);
+   const CBLAS_LAYOUT layout = CblasColMajor;
+   const CBLAS_TRANSPOSE transa = CblasNoTrans;
+   const CBLAS_TRANSPOSE transb = CblasTrans;
+   const double alpha = 1.0;
+   const double beta = 1.0;
+   const int m = A.Height();
+   const int n = B.Height();
+   const int k = A.Width();
+   cblas_dgemm(layout, transa, transb, m, n, k, alpha, A.Data(), m,
+               B.Data(), n, beta, ABt.Data(), m);
 #elif 1
    const int ah = A.Height();
    const int bh = B.Height();
@@ -3675,13 +3689,16 @@ void AddMult_a_ABt(double a, const DenseMatrix &A, const DenseMatrix &B,
 #endif
 
 #ifdef MFEM_USE_LAPACK
-   static char transa = 'N', transb = 'T';
-   double alpha = a;
-   static double beta = 1.0;
-   int m = A.Height(), n = B.Height(), k = A.Width();
-
-   dgemm_(&transa, &transb, &m, &n, &k, &alpha, A.Data(), &m,
-          B.Data(), &n, &beta, ABt.Data(), &m);
+   const CBLAS_LAYOUT layout = CblasColMajor;
+   const CBLAS_TRANSPOSE transa = CblasNoTrans;
+   const CBLAS_TRANSPOSE transb = CblasTrans;
+   const double alpha = a; // Unnecessary; left here for review
+   const double beta = 1.0;
+   const int m = A.Height();
+   const int n = B.Height();
+   const int k = A.Width();
+   cblas_dgemm(layout, transa, transb, m, n, k, alpha, A.Data(), m,
+               B.Data(), n, beta, ABt.Data(), m);
 #elif 1
    const int ah = A.Height();
    const int bh = B.Height();
@@ -3733,12 +3750,16 @@ void MultAtB(const DenseMatrix &A, const DenseMatrix &B, DenseMatrix &AtB)
 #endif
 
 #ifdef MFEM_USE_LAPACK
-   static char transa = 'T', transb = 'N';
-   static double alpha = 1.0, beta = 0.0;
-   int m = A.Width(), n = B.Width(), k = A.Height();
-
-   dgemm_(&transa, &transb, &m, &n, &k, &alpha, A.Data(), &k,
-          B.Data(), &k, &beta, AtB.Data(), &m);
+   const CBLAS_LAYOUT layout = CblasColMajor;
+   const CBLAS_TRANSPOSE transa = CblasTrans;
+   const CBLAS_TRANSPOSE transb = CblasNoTrans;
+   const double alpha = 1.0;
+   const double beta = 0.0;
+   const int m = A.Width();
+   const int n = B.Width();
+   const int k = A.Height();
+   cblas_dgemm(layout, transa, transb, m, n, k, alpha, A.Data(), k,
+               B.Data(), k, beta, AtB.Data(), m);
 #elif 1
    const int ah = A.Height();
    const int aw = A.Width();

--- a/linalg/densemat.hpp
+++ b/linalg/densemat.hpp
@@ -606,9 +606,8 @@ class DenseMatrixEigensystem
    int n;
 
 #ifdef MFEM_USE_LAPACK
-   double *work;
    char jobz, uplo;
-   int lwork, info;
+   int info;
 #endif
 
 public:
@@ -634,9 +633,8 @@ class DenseMatrixSVD
    int m, n;
 
 #ifdef MFEM_USE_LAPACK
-   double *work;
    char jobu, jobvt;
-   int lwork, info;
+   int info;
 #endif
 
    void Init();


### PR DESCRIPTION
Fixes #397, #1002. 

# Rationale

As discussed in #1002, this set of patches is the simplest way to achieve portability of BLAS and LAPACK calls because it sidesteps the Fortran name-mangling issue by replacing calls to Fortran with calls to the C language interfaces to BLAS and LAPACK.

# Alternatives

- *Preserve the status quo:* As @v-dobrev [notes](https://github.com/mfem/mfem/issues/397#issuecomment-353158665) in #397, most MFEM use cases do not require LAPACK, and it could be argued that there is no reason to support LAPACK in MFEM on uncommon OS/compiler/processor architecture configurations. This decision is the prerogative of the maintainers, but such a decision should probably be noted in documentation. It also complicates a common development workflow: porting non-scalable code on a laptop or workstation to an HPC machine like a BG/Q for debugging, and as a starting point for replacing non-scalable algorithms with scalable ones like AMG or BLOPEX. A development workflow in this spirit led to #397.

- *Attempt to generate portable macros for Fortran name mangling:* This PR avoids tackling the general issue of portably name mangling Fortran function and subroutine calls for simplicity and expediency. If MFEM plans on using more Fortran APIs, portable name mangling macros would be preferable.

# Incompatibilities

This PR requires LAPACK 3.4.0 and BLAS 3.4.0, because LAPACKE first appears in LAPACK 3.4.0. Notably, merging this change into MFEM will mean that MFEM _cannot_ link to the macOS Accelerate framework, which is Apple's vendor BLAS/LAPACK library. Accelerate is based on LAPACK 3.2.1, and appears to be unmaintained, which is [why libraries like SciPy have dropped support for Accelerate](https://github.com/scipy/scipy/wiki/Dropping-support-for-Accelerate), and [Homebrew formulas now link to OpenBLAS instead of Accelerate plus `veclibfort`](https://discourse.brew.sh/t/is-there-a-reason-math-formulas-use-veclibfort-instead-of-openblas/4658). This change will also require changes to the [suggested macOS `packages.yaml` configuration file for Spack](https://ceed.exascaleproject.org/spack/ceed1-darwin-x86_64-packages.yaml) discussed on the [CEED 1.0 Software Distribution website](https://ceed.exascaleproject.org/ceed-1.0/). Notably, Accelerate uses the C language LAPACK interface in CLAPACK, which is obsolete and essentially the output of `f2c` applied to LAPACK. I do not see a compelling reason to support CLAPACK.

In the event that a vendor BLAS/LAPACK library implements LAPACK 3.4.0 or later, but does not include LAPACKE, this PR will be incompatible with such a library. In this case, [LAPACKE could be copied from reference LAPACK](https://sourceforge.net/p/math-atlas/mailman/message/30690449/) to supply the necessary functionality. To the best of my knowledge, the following BLAS/LAPACK implementations do _not_ ship LAPACKE:

- Apple Accelerate (see above)
- ATLAS

The following BLAS/LAPACK library implementations do ship LAPACKE:

- Reference LAPACK
- OpenBLAS
- Intel MKL
- BLIS/libFLAME
- ACML (AMD)
- ESSL (IBM)
- libsci (Cray)

In other words, nearly all of the major BLAS/LAPACK implementations ship LAPACKE, so using it should not be an issue.