### PR TITLE
Load balancing with custom partitioning [custom-rebalance-dev]

### DIFF
--- a/general/communication.hpp
+++ b/general/communication.hpp
@@ -316,12 +316,23 @@ struct VarMessage
    std::string data;
    MPI_Request send_request;
 
-   /// Non-blocking send to processor 'rank'.
+   /** Non-blocking send to processor 'rank'. Returns immediately. Completion
+       (as tested by MPI_Wait/Test) does not mean the message was received --
+       it may be on its way or just buffered locally. */
    void Isend(int rank, MPI_Comm comm)
    {
       Encode(rank);
       MPI_Isend((void*) data.data(), data.length(), MPI_BYTE, rank, Tag, comm,
                 &send_request);
+   }
+
+   /** Non-blocking synchronous send to processor 'rank'. Returns immediately.
+       Completion (MPI_Wait/Test) means that the message was received. */
+   void Issend(int rank, MPI_Comm comm)
+   {
+      Encode(rank);
+      MPI_Issend((void*) data.data(), data.length(), MPI_BYTE, rank, Tag, comm,
+                 &send_request);
    }
 
    /// Helper to send all messages in a rank-to-message map container.

--- a/mesh/pmesh.cpp
+++ b/mesh/pmesh.cpp
@@ -3082,7 +3082,18 @@ bool ParMesh::NonconformingDerefinement(Array<double> &elem_error,
    return true;
 }
 
+
 void ParMesh::Rebalance()
+{
+   RebalanceImpl(NULL); // default SFC-based partition
+}
+
+void ParMesh::Rebalance(const Array<int> &partition)
+{
+   RebalanceImpl(&partition);
+}
+
+void ParMesh::RebalanceImpl(const Array<int> *partition)
 {
    if (Conforming())
    {
@@ -3109,7 +3120,7 @@ void ParMesh::Rebalance()
 
    DeleteFaceNbrData();
 
-   pncmesh->Rebalance();
+   pncmesh->Rebalance(partition);
 
    ParMesh* pmesh2 = new ParMesh(*pncmesh);
    pncmesh->OnMeshUpdated(pmesh2);

--- a/mesh/pmesh.hpp
+++ b/mesh/pmesh.hpp
@@ -141,6 +141,9 @@ protected:
    virtual bool NonconformingDerefinement(Array<double> &elem_error,
                                           double threshold, int nc_limit = 0,
                                           int op = 1);
+
+   void RebalanceImpl(const Array<int> *partition);
+
    void DeleteFaceNbrData();
 
    bool WantSkipSharedMaster(const NCMesh::Master &master) const;
@@ -286,8 +289,14 @@ public:
    /// Utility function: sum integers from all processors (Allreduce).
    virtual long ReduceInt(int value) const;
 
-   /// Load balance the mesh. NC meshes only.
+   /** Load balance the mesh by equipartitioning the global space-filling
+       sequence of elements. Works for nonconforming meshes only. */
    void Rebalance();
+
+   /** Load balance a nonconforming mesh using a user-defined partition.
+       Each local element 'i' is migrated to processor rank 'partition[i]',
+       for 0 <= i < GetNE(). */
+   void Rebalance(const Array<int> &partition);
 
    /** Print the part of the mesh in the calling processor adding the interface
        as boundary (for visualization purposes) using the mfem v1.0 format. */

--- a/mesh/pncmesh.hpp
+++ b/mesh/pncmesh.hpp
@@ -510,7 +510,10 @@ protected: // implementation
 
    /** Assign new Element::rank to leaf elements and send them to their new
        owners, keeping the ghost layer up to date. Used by Rebalance() and
-       Derefine(). */
+       Derefine(). 'target_elements' is the number of elements this rank
+       is supposed to own after the exchange. If this number is not known
+       apriori, the parameter can be set to -1, but more expensive communication
+       (synchronous sends and a barrier) will be used in that case. */
    void RedistributeElements(Array<int> &new_ranks, int target_elements,
                              bool record_comm);
 

--- a/mesh/pncmesh.hpp
+++ b/mesh/pncmesh.hpp
@@ -87,8 +87,12 @@ public:
    virtual void Derefine(const Array<int> &derefs);
 
    /** Migrate leaf elements of the global refinement hierarchy (including ghost
-       elements) so that each processor owns the same number of leaves (+-1). */
-   void Rebalance();
+       elements) so that each processor owns the same number of leaves (+-1).
+       The default partitioning strategy is based on equal splitting of the
+       space-filling sequence of leaf elements (custom_partition == NULL).
+       Alternatively, a used-defined element-rank assignemnt array can be
+       passed. */
+   void Rebalance(const Array<int> *custom_partition = NULL);
 
 
    // interface for ParFiniteElementSpace


### PR DESCRIPTION
This PR addresses the request for user-defined ParNCMesh partitioning in #958.

A new overload `ParMesh::Rebalance(const Array<int> &partition)` is added. It takes an array of element-rank assignments which is used to migrate elements in any way the user needs. 

The old function `ParMesh::Rebalance()` should work exactly as before, with the default SFC based partitioning, like this for example (ex15p):

![custom-part-0](https://user-images.githubusercontent.com/1349371/62309521-efe72b80-b487-11e9-9704-4fb9d43491e9.png)

However, the user can now specify any destination rank for each element, for example based on the X coordinate of the center of each element (surely a better algorithm can be devised):

![custom-part-4](https://user-images.githubusercontent.com/1349371/62309818-7d2a8000-b488-11e9-9b73-e229e45b4876.png)

Custom partitioning may be more expensive than the default SFC algorithm, because it needs synchronous sends and a barrier. I have only tested this on a desktop.