### PR TITLE
Fix bug in superlu.cpp [benyee:superlu-interface-fix]

### DIFF
--- a/linalg/superlu.cpp
+++ b/linalg/superlu.cpp
@@ -141,7 +141,7 @@ SuperLURowLocMatrix::SuperLURowLocMatrix( const HypreParMatrix & hypParMat )
    width  = m_loc;
 
    double * nzval  = csr_op->data;
-   int    * colind = csr_op->j;
+   int    * colind = csr_op->big_j;
    int    * rowptr = NULL;
 
    // The "i" array cannot be stolen from the hypre_CSRMatrix so we'll copy it


### PR DESCRIPTION
hypre ParCSRMatrix objects have attributes j and big_j.  In commit [84d50104](https://github.com/hypre-space/hypre/commit/84d50104d98180ff5b214de383535f62af161d72) (February 2019) of the Hypre master branch, the function hypre_MergeDiagAndOffd in hypre was changed so that the attribute big_j is used but not j, leaving j uninitialized.  However, superlu.cpp in mfem was not updated to account for this, so it ends up passing a null pointer to SuperLU.  Changing superlu.cpp::144 to use big_j instead of j seems to fix the problem.