### PR TITLE
Internal face and boundary face terms in GetEnergy [functional-dev]

### DIFF
--- a/fem/nonlinearform.cpp
+++ b/fem/nonlinearform.cpp
@@ -65,6 +65,8 @@ double NonlinearForm::GetGridFunctionEnergy(const Vector &x) const
    Vector el_x;
    const FiniteElement *fe;
    ElementTransformation *T;
+   Mesh *mesh = fes->GetMesh();
+
    double energy = 0.0;
 
    if (dnfi.Size())
@@ -74,6 +76,7 @@ double NonlinearForm::GetGridFunctionEnergy(const Vector &x) const
          fe = fes->GetFE(i);
          fes->GetElementVDofs(i, vdofs);
          T = fes->GetElementTransformation(i);
+         // Should x be px = Prolongate(x)?
          x.GetSubVector(vdofs, el_x);
          for (int k = 0; k < dnfi.Size(); k++)
          {
@@ -84,12 +87,85 @@ double NonlinearForm::GetGridFunctionEnergy(const Vector &x) const
 
    if (fnfi.Size())
    {
-      MFEM_ABORT("TODO: add energy contribution from interior face terms");
+      FaceElementTransformations *tr;
+      const FiniteElement *fe1, *fe2;
+      Array<int> vdofs2;
+
+      for (int i = 0; i < mesh->GetNumFaces(); i++)
+      {
+         tr = mesh->GetInteriorFaceTransformations(i);
+         if (tr != NULL)
+         {
+            fes->GetElementVDofs(tr->Elem1No, vdofs);
+            fes->GetElementVDofs(tr->Elem2No, vdofs2);
+            vdofs.Append (vdofs2);
+
+            //px.GetSubVector(vdofs, el_x);
+            x.GetSubVector(vdofs, el_x);
+
+            fe1 = fes->GetFE(tr->Elem1No);
+            fe2 = fes->GetFE(tr->Elem2No);
+
+            for (int k = 0; k < fnfi.Size(); k++)
+            {
+               energy += fnfi[k]->GetFaceEnergy(*fe1, *fe2, *tr, el_x);
+            }
+         }
+      }
    }
 
    if (bfnfi.Size())
    {
-      MFEM_ABORT("TODO: add energy contribution from boundary face terms");
+      FaceElementTransformations *tr;
+      const FiniteElement *fe1, *fe2;
+
+      // Which boundary attributes need to be processed?
+      Array<int> bdr_attr_marker(mesh->bdr_attributes.Size() ?
+                                 mesh->bdr_attributes.Max() : 0);
+      bdr_attr_marker = 0;
+      for (int k = 0; k < bfnfi.Size(); k++)
+      {
+         if (bfnfi_marker[k] == NULL)
+         {
+            bdr_attr_marker = 1;
+            break;
+         }
+         Array<int> &bdr_marker = *bfnfi_marker[k];
+         MFEM_ASSERT(bdr_marker.Size() == bdr_attr_marker.Size(),
+                     "invalid boundary marker for boundary face integrator #"
+                     << k << ", counting from zero");
+         for (int i = 0; i < bdr_attr_marker.Size(); i++)
+         {
+            bdr_attr_marker[i] |= bdr_marker[i];
+         }
+      }
+
+      for (int i = 0; i < fes -> GetNBE(); i++)
+      {
+         const int bdr_attr = mesh->GetBdrAttribute(i);
+         if (bdr_attr_marker[bdr_attr-1] == 0) { continue; }
+
+         tr = mesh->GetBdrFaceTransformations (i);
+         if (tr != NULL)
+         {
+            fes->GetElementVDofs(tr->Elem1No, vdofs);
+            //px.GetSubVector(vdofs, el_x);
+            x.GetSubVector(vdofs, el_x);
+
+            fe1 = fes->GetFE(tr->Elem1No);
+            // The fe2 object is really a dummy and not used on the boundaries,
+            // but we can't dereference a NULL pointer, and we don't want to
+            // actually make a fake element.
+            fe2 = fe1;
+            for (int k = 0; k < bfnfi.Size(); k++)
+            {
+               if (bfnfi_marker[k] &&
+                   (*bfnfi_marker[k])[bdr_attr-1] == 0) { continue; }
+
+               energy += bfnfi[k]->GetFaceEnergy(*fe1, *fe2, *tr, el_x);
+            }
+         }
+      }
    }
 
    return energy;

--- a/fem/nonlinearform.hpp
+++ b/fem/nonlinearform.hpp
@@ -111,12 +111,17 @@ public:
        be fes->GetVSize(). */
    double GetGridFunctionEnergy(const Vector &x) const;
 
-   /// Compute the enery corresponding to the state @a x.
+   /// Compute the energy corresponding to the state @a x.
    /** In general, @a x may have non-homogeneous essential boundary values.
 
        The state @a x must be a true-dof vector. */
    virtual double GetEnergy(const Vector &x) const
    { return GetGridFunctionEnergy(Prolongate(x)); }
+
+   /// Compute the functional corresponding to the state @a x.
+   /** This simply wraps GetEnergy */
+   virtual double GetFunctional(const Vector &x) const
+   { return GetEnergy(x); }
 
    /// Evaluate the action of the NonlinearForm.
    /** The input essential dofs in @a x will, generally, be non-zero. However,

--- a/fem/nonlininteg.cpp
+++ b/fem/nonlininteg.cpp
@@ -55,6 +55,14 @@ double NonlinearFormIntegrator::GetElementEnergy(
    return 0.0;
 }
 
+double NonlinearFormIntegrator::GetFaceEnergy(
+   const FiniteElement &el1, const FiniteElement &el2,
+   FaceElementTransformations &Tr, const Vector &elfun)
+{
+   mfem_error("NonlinearFormIntegrator::GetFaceEnergy"
+              " is not overloaded!");
+   return 0.0;
+}
 
 void BlockNonlinearFormIntegrator::AssembleElementVector(
    const Array<const FiniteElement *> &el,

--- a/fem/nonlininteg.hpp
+++ b/fem/nonlininteg.hpp
@@ -63,10 +63,16 @@ public:
                                  FaceElementTransformations &Tr,
                                  const Vector &elfun, DenseMatrix &elmat);
 
-   /// Compute the local energy
+   /// Compute the local energy/functional
    virtual double GetElementEnergy(const FiniteElement &el,
                                    ElementTransformation &Tr,
                                    const Vector &elfun);
+
+   /// Compute the face(s) contribution to the energy/functional
+   virtual double GetFaceEnergy(const FiniteElement &el1,
+                                const FiniteElement &el2,
+                                FaceElementTransformations &Tr,
+                                const Vector &elfun);
 
    virtual ~NonlinearFormIntegrator() { }
 };

--- a/fem/pnonlinearform.hpp
+++ b/fem/pnonlinearform.hpp
@@ -49,6 +49,9 @@ public:
    virtual double GetEnergy(const Vector &x) const
    { return GetParGridFunctionEnergy(Prolongate(x)); }
 
+   virtual double GetFunctional(const Vector &x) const
+   { return GetEnergy(x); }
+
    virtual void Mult(const Vector &x, Vector &y) const;
 
    /// Return the local gradient matrix for the given true-dof vector x.


### PR DESCRIPTION
My first mfem pull request here, so I apologize if I missed something.
* I have added the code in `NonlinearForm::GetGridFunctionEnergy` so that internal and boundary face contributions are included.
* This was basically a *cut-and-paste* from `NonlinearForm::Mult` with some minor changes.
* I also added wrappers `NonlinearForm::GetFunctional` and `ParNonlinearForm::GetFunctional` that call `GetEnergy`, but that are more expressive of the general intent.

**TODO**
- [ ] `ParNonlinearForm::GetParGridFunctionEnergy` does not include shared faces yet.  Any thoughts on how to do that?  We need to avoid double counting the shared face contributions to the global energy.
- [ ] In `NonlinearForm::Mult`, the vector `x` is prolongated first to `px` and then `px` is used in the integrators.  I noticed that this is not done in `NonlinearForm::GetGridFunctionEnergy`.  Should it?