### PR TITLE
makefile: add missing parenthesis to conditional

### DIFF
--- a/makefile
+++ b/makefile
@@ -346,7 +346,7 @@ ifneq (,$(filter install,$(MAKECMDGOALS)))
       @MFEM_EXT_LIBS@
    MFEM_LIB_FILE = @MFEM_LIB_DIR@/libmfem.$(if $(shared),$(SO_VER),a)
    ifeq ($(MFEM_USE_OCCA),YES)
-      ifneq ($(MFEM_INSTALL_DIR),$(abspath $(PREFIX))
+      ifneq ($(MFEM_INSTALL_DIR),$(abspath $(PREFIX)))
          $(error OCCA is enabled: PREFIX must be set during configuration!)
       endif
    endif


### PR DESCRIPTION
This commit adds a missing parenthesis to a conditional in the MFEM
makefile that checks if PREFIX is set when MFEM_USE_OCCA equals YES.

Fixes #1042.