### PR TITLE
Fix Pconf allows CUDA => DEVICE_MASK

### DIFF
--- a/fem/pfespace.cpp
+++ b/fem/pfespace.cpp
@@ -859,7 +859,7 @@ const Operator *ParFiniteElementSpace::GetProlongationMatrix() const
    {
       if (!Pconf)
       {
-         if (!Device::Allows(Backend::CUDA))
+         if (!Device::Allows(Backend::DEVICE_MASK))
          {
             Pconf = new ConformingProlongationOperator(*this);
          }


### PR DESCRIPTION
Allow to use the DeviceConformingProlongationOperator for all devices, instead of just CUDA.