### PR TITLE
Fix bug for L2 projection on simplices [bugfix-l2proj]

### DIFF
--- a/fem/fespace.cpp
+++ b/fem/fespace.cpp
@@ -2536,7 +2536,7 @@ L2ProjectionGridTransfer::L2Projection::L2Projection(
 
          // Create the transformation that embeds the fine low-order element
          // within the coarse high-order element in reference space
-         emb_tr.GetPointMat() = pmats(iref);
+         emb_tr.GetPointMat() = pmats(cf_tr.embeddings[ilor].matrix);
          emb_tr.FinalizeTransformation();
 
          int order = fe_lor->GetOrder() + fe_ho->GetOrder() + el_tr->OrderW();


### PR DESCRIPTION
`L2ProjectionGridTransfer` would assume an ordering of the point matrices in the coarse to fine transformation that happened to be valid for tensor-product meshes, but was not valid for simplicial meshes. This bug fix uses `embeddings[i].matrix` to ensure that the correct point matrix is always used.