### PR TITLE
Updates for RAJA 0.10

### DIFF
--- a/general/forall.hpp
+++ b/general/forall.hpp
@@ -103,7 +103,7 @@ void RajaCudaWrap2D(const int N, DBODY &&d_body,
    const int G = (N+BZ-1)/BZ;
    RAJA::kernel<RAJA::KernelPolicy<
    RAJA::statement::CudaKernel<
-   RAJA::statement::For<0, RAJA::cuda_block_x_loop,
+   RAJA::statement::For<0, RAJA::cuda_block_x_direct,
         RAJA::statement::For<1, RAJA::cuda_thread_x_direct,
         RAJA::statement::For<2, RAJA::cuda_thread_y_direct,
         RAJA::statement::For<3, RAJA::cuda_thread_z_direct,
@@ -115,7 +115,6 @@ void RajaCudaWrap2D(const int N, DBODY &&d_body,
       const int k = n*BZ + threadIdx.z;
       if (k >= N) { return; }
       d_body(k);
-      MFEM_SYNC_THREAD;
    });
    MFEM_GPU_CHECK(cudaGetLastError());
 }
@@ -127,14 +126,14 @@ void RajaCudaWrap3D(const int N, DBODY &&d_body,
    MFEM_VERIFY(N>0, "");
    RAJA::kernel<RAJA::KernelPolicy<
    RAJA::statement::CudaKernel<
-   RAJA::statement::For<0, RAJA::cuda_block_x_loop,
+   RAJA::statement::For<0, RAJA::cuda_block_x_direct,
         RAJA::statement::For<1, RAJA::cuda_thread_x_direct,
         RAJA::statement::For<2, RAJA::cuda_thread_y_direct,
         RAJA::statement::For<3, RAJA::cuda_thread_z_direct,
         RAJA::statement::Lambda<0, Segs<0>>>>>>>>>
         (RAJA::make_tuple(RAJA::RangeSegment(0,N), RAJA::RangeSegment(0,X),
                           RAJA::RangeSegment(0,Y), RAJA::RangeSegment(0,Z)),
-   [=] RAJA_DEVICE (const int k) { d_body(k); MFEM_SYNC_THREAD; });
+   [=] RAJA_DEVICE (const int k) { d_body(k); });
    MFEM_GPU_CHECK(cudaGetLastError());
 }
 
@@ -147,33 +146,9 @@ void RajaCudaWrap3D(const int N, DBODY &&d_body,
 using RAJA::statement::Segs;
 
 template <typename HBODY>
-void RajaOmpWrap1D(const int N, HBODY &&h_body)
+void RajaOmpWrap(const int N, HBODY &&h_body)
 {
    RAJA::forall<RAJA::omp_parallel_for_exec>(RAJA::RangeSegment(0,N), h_body);
-}
-
-template <typename HBODY>
-void RajaOmpWrap2D(const int N, HBODY &&h_body,
-                   const int X, const int Y, const int BZ)
-{
-   RAJA::kernel<RAJA::KernelPolicy<
-   RAJA::statement::For<0, RAJA::omp_parallel_for_exec,
-        RAJA::statement::Lambda<0, Segs<0>>>>>
-        (RAJA::make_tuple(RAJA::RangeSegment(0,N), RAJA::RangeSegment(0,X),
-                          RAJA::RangeSegment(0,Y), RAJA::RangeSegment(0,BZ)),
-   [=] (int k) { h_body(k); });
-}
-
-template <typename HBODY>
-void RajaOmpWrap3D(const int N, HBODY &&h_body,
-                   const int X, const int Y, const int Z)
-{
-   RAJA::kernel<RAJA::KernelPolicy<
-   RAJA::statement::For<0, RAJA::omp_parallel_for_exec,
-        RAJA::statement::Lambda<0, Segs<0>>>>>
-        (RAJA::make_tuple(RAJA::RangeSegment(0,N), RAJA::RangeSegment(0,X),
-                          RAJA::RangeSegment(0,Y), RAJA::RangeSegment(0,Z)),
-   [=] (int k) { h_body(k); });
 }
 
 #endif
@@ -361,13 +336,7 @@ inline void ForallWrap(const bool use_dev, const int N,
 #if defined(MFEM_USE_RAJA) && defined(RAJA_ENABLE_OPENMP)
    // Handle all allowed OpenMP backends except Backend::OMP
    if (DIM == 1 && Device::Allows(Backend::OMP_MASK & ~Backend::OMP))
-   { return RajaOmpWrap1D(N, h_body); }
-
-   if (DIM == 2 && Device::Allows(Backend::OMP_MASK & ~Backend::OMP))
-   { return RajaOmpWrap2D(N, h_body, X, Y, Z); }
-
-   if (DIM == 3 && Device::Allows(Backend::OMP_MASK & ~Backend::OMP))
-   { return RajaOmpWrap3D(N, h_body, X, Y, Z); }
+   { return RajaOmpWrap(N, h_body); }
 #endif
 
 #ifdef MFEM_USE_OPENMP


### PR DESCRIPTION
We added a new policy, Block_direct, to directly map loop iterates to cuda thread blocks.
This will be added in RAJA 0.10 - PR is currently in review 
https://github.com/LLNL/RAJA/pull/668