### PR TITLE
Implemented projection of VectorDeltaCoefficient on GridFunction [najlkin:pr12]

### DIFF
--- a/fem/coefficient.hpp
+++ b/fem/coefficient.hpp
@@ -503,7 +503,10 @@ public:
    DeltaCoefficient& GetDeltaCoefficient() { return d; }
 
    void SetScale(double s) { d.SetScale(s); }
+   void SetTol(double tol) { d.SetTol(tol); }
+
    void SetDirection(const Vector& _d);
+   void GetDirection(Vector &_d) { _d = dir; }
 
    void SetDeltaCenter(const Vector& center) { d.SetDeltaCenter(center); }
    void GetDeltaCenter(Vector& center) { d.GetDeltaCenter(center); }

--- a/fem/gridfunc.hpp
+++ b/fem/gridfunc.hpp
@@ -52,6 +52,11 @@ protected:
    void ProjectDeltaCoefficient(DeltaCoefficient &delta_coeff,
                                 double &integral);
 
+   // Project the vector delta coefficient without scaling and return the
+   // (local) integral of the projection.
+   void ProjectVectorDeltaCoefficient(VectorDeltaCoefficient &vdelta_coeff,
+                                      double &integral);
+
    // Sum fluxes to vertices and count element contributions
    void SumFluxAndCount(BilinearFormIntegrator &blfi,
                         GridFunction &flux,


### PR DESCRIPTION
Unlike `DeltaCoefficient`, `GridFunction` missed implementation of projection of `VectorDeltaCoefficient` in `ProjectCoefficient(VectorCoefficient &vcoeff)` method. A try to call the method with this argument led to crash as delta coefficients cannot be evaluated point-wise. The proposed solution works only for scalar finite elements. It would be desirable to implement the projection also for the vector elements, but it would require rather groundwork of implementing the `ProjectDelta` for the elements (using vdofs instead of dofs probably). If someone is willing to do that, it will be perfect, but the pull request can be merged even without that, I think.
Besides that, the commit fixes the problem when the integral over the domain is zero (e.g. when tolerance is of the delta coefficient is exceeded), which led to division by zero in `ProjectCoefficient()`.