### PR TITLE
L2ElementRestriction for DG spaces and LOR periodic meshes

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -22,10 +22,14 @@ GPU support
 
 Miscellaneous
 -------------
-- Upgraded the SUNDIALS interface to utilize SUNDIALS version 5.0.  This 
+- Upgraded the SUNDIALS interface to utilize SUNDIALS version 5.0.  This
   necessitated a complete rework of the interface and requires changes at
   the application level.  Example usage of this new interface can be found
   in the examples/sundials directory.
+
+- Added support for creating refined versions of periodic meshes, making use of
+  the new L2ElementRestriction class. This class also allows for computing
+  geometric factors on periodic meshes using partial assembly.
 
 
 Version 4.0, released on May 24, 2019

--- a/fem/fespace.cpp
+++ b/fem/fespace.cpp
@@ -791,8 +791,14 @@ const Operator *FiniteElementSpace::GetElementRestriction(
 {
    // Check if we have a discontinuous space using the FE collection:
    const L2_FECollection *dg_space = dynamic_cast<const L2_FECollection*>(fec);
-   if (dg_space) { return NULL; }
-   // TODO: support other DG collections.
+   if (dg_space)
+   {
+      if (L2E_nat.Ptr() == NULL)
+      {
+         L2E_nat.Reset(new L2ElementRestriction(*this));
+      }
+      return L2E_nat.Ptr();
+   }
    if (e_ordering == ElementDofOrdering::LEXICOGRAPHIC)
    {
       if (L2E_lex.Ptr() == NULL)
@@ -2637,6 +2643,39 @@ const Operator &L2ProjectionGridTransfer::BackwardOperator()
    return *B;
 }
 
+L2ElementRestriction::L2ElementRestriction(const FiniteElementSpace &fes)
+   : ne(fes.GetNE()),
+     vdim(fes.GetVDim()),
+     byvdim(fes.GetOrdering() == Ordering::byVDIM),
+     ndof(ne > 0 ? fes.GetFE(0)->GetDof() : 0)
+{ }
+
+void L2ElementRestriction::Mult(const Vector &x, Vector &y) const
+{
+   for (int iel=0; iel<ne; ++iel)
+   {
+      for (int vd=0; vd<vdim; ++vd)
+      {
+         for (int idof=0; idof<ndof; ++idof)
+         {
+            // E-vector dimensions (dofs, vdim, elements)
+            // L-vector dimensions: byVDIM:  (vdim, dofs, element)
+            //                      byNODES: (dofs, elements, vdim)
+            int yidx = iel*vdim*ndof + vd*ndof + idof;
+            int xidx;
+            if (byvdim)
+            {
+               xidx = iel*ndof*vdim + idof*vdim + vd;
+            }
+            else
+            {
+               xidx = vd*ne*ndof + iel*ndof + idof;
+            }
+            y[yidx] = x[xidx];
+         }
+      }
+   }
+}
 
 ElementRestriction::ElementRestriction(const FiniteElementSpace &f,
                                        ElementDofOrdering e_ordering)

--- a/fem/fespace.cpp
+++ b/fem/fespace.cpp
@@ -2648,7 +2648,10 @@ L2ElementRestriction::L2ElementRestriction(const FiniteElementSpace &fes)
      vdim(fes.GetVDim()),
      byvdim(fes.GetOrdering() == Ordering::byVDIM),
      ndof(ne > 0 ? fes.GetFE(0)->GetDof() : 0)
-{ }
+{
+   height = vdim*ne*ndof;
+   width = vdim*ne*ndof;
+}
 
 void L2ElementRestriction::Mult(const Vector &x, Vector &y) const
 {
@@ -2670,6 +2673,34 @@ void L2ElementRestriction::Mult(const Vector &x, Vector &y) const
             else
             {
                xidx = vd*ne*ndof + iel*ndof + idof;
+            }
+            y[yidx] = x[xidx];
+         }
+      }
+   }
+}
+
+void L2ElementRestriction::MultTranspose(const Vector &x, Vector &y) const
+{
+   // Since this restriction is a permutation, the transpose is the inverse
+   for (int iel=0; iel<ne; ++iel)
+   {
+      for (int vd=0; vd<vdim; ++vd)
+      {
+         for (int idof=0; idof<ndof; ++idof)
+         {
+            // E-vector dimensions (dofs, vdim, elements)
+            // L-vector dimensions: byVDIM:  (vdim, dofs, element)
+            //                      byNODES: (dofs, elements, vdim)
+            int xidx = iel*vdim*ndof + vd*ndof + idof;
+            int yidx;
+            if (byvdim)
+            {
+               yidx = iel*ndof*vdim + idof*vdim + vd;
+            }
+            else
+            {
+               yidx = vd*ne*ndof + iel*ndof + idof;
             }
             y[yidx] = x[xidx];
          }

--- a/fem/fespace.hpp
+++ b/fem/fespace.hpp
@@ -911,6 +911,7 @@ class L2ElementRestriction : public Operator
 public:
    L2ElementRestriction(const FiniteElementSpace&);
    void Mult(const Vector &x, Vector &y) const;
+   void MultTranspose(const Vector &x, Vector &y) const;
 };
 
 /** @brief A class that performs interpolation from an E-vector to quadrature

--- a/fem/fespace.hpp
+++ b/fem/fespace.hpp
@@ -304,8 +304,9 @@ public:
        The parameter @a e_ordering describes how the local DOFs in each element
        should be ordered, see ElementDofOrdering.
 
-       For discontinuous spaces, where the element-restriction is the identity,
-       this method will return NULL.
+       For discontinuous spaces, the element restriction corresponds to a
+       permutation of the degrees of freedom, implemented by the
+       L2ElementRestriction class.
 
        The returned Operator is owned by the FiniteElementSpace. */
    const Operator *GetElementRestriction(ElementDofOrdering e_ordering) const;
@@ -896,6 +897,21 @@ public:
    void MultTranspose(const Vector &x, Vector &y) const;
 };
 
+/// Operator that converts L2 FiniteElementSpace L-vectors to E-vectors.
+/** Objects of this type are typically created and owned by FiniteElementSpace
+    objects, see FiniteElementSpace::GetElementRestriction(). L-vectors
+    corresponding to grid functions in L2 finite element spaces differ from
+    E-vectors only in the ordering of the degrees of freedom. */
+class L2ElementRestriction : public Operator
+{
+   const int ne;
+   const int vdim;
+   const bool byvdim;
+   const int ndof;
+public:
+   L2ElementRestriction(const FiniteElementSpace&);
+   void Mult(const Vector &x, Vector &y) const;
+};
 
 /** @brief A class that performs interpolation from an E-vector to quadrature
     point values and/or derivatives (Q-vectors). */


### PR DESCRIPTION
This PR creates a new `L2ElementRestriction` class so that calling `GetElementRestriction` with an L2 finite element space no longer returns NULL. In particular, this allows for using the `GeometricFactors` on periodic meshes (cf. PR #914).

Additionally, this PR adds support for periodic meshes to the mesh refinement constructor (`Mesh::Mesh(Mesh *orig_mesh, int ref_factor, int ref_type)`). This allows for using LOR on periodic meshes, fixing #1067. 

Resolves #1067.

Thanks to @jandrej for his work on this.