### PR TITLE
implement an interface to derefine by element number

### DIFF
--- a/mesh/mesh.hpp
+++ b/mesh/mesh.hpp
@@ -1103,6 +1103,9 @@ public:
    bool RefineByError(const Vector &elem_error, double threshold,
                       int nonconforming = -1, int nc_limit = 0);
 
+   /** Derefine specified elements (and associated children as required) */
+   bool GeneralDerefinement(Array<int> &el);
+
    /** Derefine the mesh based on an error measure associated with each
        element. A derefinement is performed if the sum of errors of its fine
        elements is smaller than 'threshold'. If 'nc_limit' > 0, derefinements


### PR DESCRIPTION
This isn't ready to merge, but is more to start a conversation about this idea.

This implements a way to derefine by element number.  This is parallel to how refinements are specified in GeneralRefinement interface, so I called it GeneralDerefinement.  I think this is something we'd like to have in the DRL context, and could very well be useful for creating more general derefinement schemes in user code.

Not every element can be derefined, and you can't "partially" derefine an element, so what this does is it uses the derefinement table to determine which children need to be derefined to encompass the set of derefinements specified.

The method can fail if an element that can't be derefined is specified (exists at the base level, for example.)  There is no parallel implementation yet.

Thoughts?
