### PR TITLE
L2_TetrahedronElement ProjectDelta fix [fem-tetra-fix]

### DIFF
--- a/fem/fe.cpp
+++ b/fem/fe.cpp
@@ -9635,6 +9635,7 @@ void L2_TetrahedronElement::ProjectDelta(int vertex, Vector &dofs) const
             const IntegrationPoint &ip = Nodes.IntPoint(i);
             dofs[i] = pow(ip.y, Order);
          }
+         break;
       case 3:
          for (int i = 0; i < Dof; i++)
          {


### PR DESCRIPTION
Add one missing `break` in `L2_TetrahedronElement::ProjectDelta`.

| PR | Author | Editor | Reviewers  | Assignment | Approval | Merge |
| --- | --- | --- | ---  | --- | --- | --- |
| https://github.com/mfem/mfem/pull/1169 | @camierjs | @tzanio | @jandrej + @homijan | 11/23/19 | 12/5/19 | ⌛due 12/12/19 | 