### PR TITLE
Bugfixes for PetscSolvers

### DIFF
--- a/linalg/petsc.cpp
+++ b/linalg/petsc.cpp
@@ -3784,7 +3784,7 @@ static PetscErrorCode __mfem_ts_ijacobian(TS ts, PetscReal t, Vec x,
    PetscBool isnest;
    ierr = PetscObjectTypeCompare((PetscObject)P,MATNEST,&isnest);
    CHKERRQ(ierr);
-   if (isnest) P->nonzerostate = nonzerostate + 1;
+   if (isnest) { P->nonzerostate = nonzerostate + 1; }
 
    // Jacobian reusage
    ierr = PetscObjectStateGet((PetscObject)P,&ts_ctx->cached_ijacstate);
@@ -4051,7 +4051,7 @@ static PetscErrorCode __mfem_ts_rhsjacobian(TS ts, PetscReal t, Vec x,
    PetscBool isnest;
    ierr = PetscObjectTypeCompare((PetscObject)P,MATNEST,&isnest);
    CHKERRQ(ierr);
-   if (isnest) P->nonzerostate = nonzerostate + 1;
+   if (isnest) { P->nonzerostate = nonzerostate + 1; }
 
    // Matrix-free case
    if (A && A != P)
@@ -4178,7 +4178,7 @@ static PetscErrorCode __mfem_snes_jacobian(SNES snes, Vec x, Mat A, Mat P,
    PetscBool isnest;
    ierr = PetscObjectTypeCompare((PetscObject)P,MATNEST,&isnest);
    CHKERRQ(ierr);
-   if (isnest) P->nonzerostate = nonzerostate + 1;
+   if (isnest) { P->nonzerostate = nonzerostate + 1; }
 
    // Matrix-free case
    if (A && A != P)

--- a/linalg/petsc.cpp
+++ b/linalg/petsc.cpp
@@ -2309,17 +2309,6 @@ void PetscLinearSolver::SetOperator(const Operator &op)
                               (dynamic_cast<const PetscParMatrix *>(&op));
    const Operator       *oA = dynamic_cast<const Operator *>(&op);
 
-   // Preserve Pmat if already set
-   KSP ksp = (KSP)obj;
-   Mat P = NULL;
-   PetscBool pmat;
-   ierr = KSPGetOperatorsSet(ksp,NULL,&pmat); PCHKERRQ(ksp,ierr);
-   if (pmat)
-   {
-      ierr = KSPGetOperators(ksp,NULL,&P); PCHKERRQ(ksp,ierr);
-      ierr = PetscObjectReference((PetscObject)P); PCHKERRQ(ksp,ierr);
-   }
-
    // update base classes: Operator, Solver, PetscLinearSolver
    bool delete_pA = false;
    if (!pA)
@@ -2342,6 +2331,7 @@ void PetscLinearSolver::SetOperator(const Operator &op)
    MFEM_VERIFY(pA, "Unsupported operation!");
 
    // Set operators into PETSc KSP
+   KSP ksp = (KSP)obj;
    Mat A = pA->A;
    if (operatorset)
    {
@@ -2362,15 +2352,7 @@ void PetscLinearSolver::SetOperator(const Operator &op)
          wrap = false;
       }
    }
-   if (P)
-   {
-      ierr = KSPSetOperators(ksp,A,P); PCHKERRQ(ksp,ierr);
-      ierr = MatDestroy(&P); PCHKERRQ(ksp,ierr);
-   }
-   else
-   {
-      ierr = KSPSetOperators(ksp,A,A); PCHKERRQ(ksp,ierr);
-   }
+   ierr = KSPSetOperators(ksp,A,A); PCHKERRQ(ksp,ierr);
 
    // Update PetscSolver
    operatorset = true;

--- a/linalg/petsc.hpp
+++ b/linalg/petsc.hpp
@@ -618,6 +618,8 @@ public:
                      const std::string &prefix = std::string());
    virtual ~PetscLinearSolver();
 
+   /// Sets the operator to be used for mat-vec operations and
+   /// for the construction of the preconditioner
    virtual void SetOperator(const Operator &op);
 
    /// Allows to prescribe a different operator (@a pop) to construct
@@ -625,6 +627,7 @@ public:
    void SetOperator(const Operator &op, const Operator &pop);
 
    /// Sets the solver to perform preconditioning
+   /// preserves the linear operator for the mat-vec
    void SetPreconditioner(Solver &precond);
 
    /// Application of the solver.


### PR DESCRIPTION
PetscLinearSolver::SetOperator behaves exactly as for other iterative solvers, see https://github.com/mfem/mfem/issues/1180
Fix Jacobian callbacks to circumvent an issue with blocked operators and command line specification of the PC type as `-pc_ytpe fieldsplit`
For a proper fix of all the PCFIELDSPLIT cases, we also need this to be merged into PETSc maint branch https://gitlab.com/petsc/petsc/merge_requests/2364/

| PR | Author | Editor | Reviewers  | Assignment | Approval | Merge |
| --- | --- | --- | ---  | --- | --- | --- |
| https://github.com/mfem/mfem/pull/1186 | @stefanozampini  | @tzanio | @jandrej + @psocratis | 12/09/19 | 12/12/19 | ⌛due 12/19/19 |
