### PR TITLE
GPU support for L2ElementRestriction

### DIFF
--- a/fem/fespace.cpp
+++ b/fem/fespace.cpp
@@ -2691,56 +2691,63 @@ L2ElementRestriction::L2ElementRestriction(const FiniteElementSpace &fes)
 
 void L2ElementRestriction::Mult(const Vector &x, Vector &y) const
 {
+   const int NE = ne;
+   const int VDIM = vdim;
+   const int NDOF = ndof;
+   const bool BYVDIM = byvdim;
    auto d_x = x.Read();
    auto d_y = y.Write();
-   MFEM_FORALL(iel, ne,
+   MFEM_FORALL(iel, NE,
    {
-      for (int vd=0; vd<vdim; ++vd)
+      for (int vd=0; vd<VDIM; ++vd)
       {
-         for (int idof=0; idof<ndof; ++idof)
+         for (int idof=0; idof<NDOF; ++idof)
          {
             // E-vector dimensions (dofs, vdim, elements)
             // L-vector dimensions: byVDIM:  (vdim, dofs, element)
             //                      byNODES: (dofs, elements, vdim)
-            int yidx = iel*vdim*ndof + vd*ndof + idof;
+            int yidx = iel*VDIM*NDOF + vd*NDOF + idof;
             int xidx;
-            if (byvdim)
+            if (BYVDIM)
             {
-               xidx = iel*ndof*vdim + idof*vdim + vd;
+               xidx = iel*NDOF*VDIM + idof*VDIM + vd;
             }
             else
             {
-               xidx = vd*ne*ndof + iel*ndof + idof;
+               xidx = vd*NE*NDOF + iel*NDOF + idof;
             }
             d_y[yidx] = d_x[xidx];
          }
       }
    });
 }
-
 void L2ElementRestriction::MultTranspose(const Vector &x, Vector &y) const
 {
+   const int NE = ne;
+   const int VDIM = vdim;
+   const int NDOF = ndof;
+   const bool BYVDIM = byvdim;
    auto d_x = x.Read();
    auto d_y = y.Write();
    // Since this restriction is a permutation, the transpose is the inverse
-   MFEM_FORALL(iel, ne,
+   MFEM_FORALL(iel, NE,
    {
-      for (int vd=0; vd<vdim; ++vd)
+      for (int vd=0; vd<VDIM; ++vd)
       {
-         for (int idof=0; idof<ndof; ++idof)
+         for (int idof=0; idof<NDOF; ++idof)
          {
             // E-vector dimensions (dofs, vdim, elements)
             // L-vector dimensions: byVDIM:  (vdim, dofs, element)
             //                      byNODES: (dofs, elements, vdim)
-            int xidx = iel*vdim*ndof + vd*ndof + idof;
+            int xidx = iel*VDIM*NDOF + vd*NDOF + idof;
             int yidx;
-            if (byvdim)
+            if (BYVDIM)
             {
-               yidx = iel*ndof*vdim + idof*vdim + vd;
+               yidx = iel*NDOF*VDIM + idof*VDIM + vd;
             }
             else
             {
-               yidx = vd*ne*ndof + iel*ndof + idof;
+               yidx = vd*NE*NDOF + iel*NDOF + idof;
             }
             d_y[yidx] = d_x[xidx];
          }

--- a/fem/fespace.cpp
+++ b/fem/fespace.cpp
@@ -2691,7 +2691,9 @@ L2ElementRestriction::L2ElementRestriction(const FiniteElementSpace &fes)
 
 void L2ElementRestriction::Mult(const Vector &x, Vector &y) const
 {
-   for (int iel=0; iel<ne; ++iel)
+   auto d_x = x.Read();
+   auto d_y = y.Write();
+   MFEM_FORALL(iel, ne,
    {
       for (int vd=0; vd<vdim; ++vd)
       {
@@ -2710,16 +2712,18 @@ void L2ElementRestriction::Mult(const Vector &x, Vector &y) const
             {
                xidx = vd*ne*ndof + iel*ndof + idof;
             }
-            y[yidx] = x[xidx];
+            d_y[yidx] = d_x[xidx];
          }
       }
-   }
+   });
 }
 
 void L2ElementRestriction::MultTranspose(const Vector &x, Vector &y) const
 {
+   auto d_x = x.Read();
+   auto d_y = y.Write();
    // Since this restriction is a permutation, the transpose is the inverse
-   for (int iel=0; iel<ne; ++iel)
+   MFEM_FORALL(iel, ne,
    {
       for (int vd=0; vd<vdim; ++vd)
       {
@@ -2738,10 +2742,10 @@ void L2ElementRestriction::MultTranspose(const Vector &x, Vector &y) const
             {
                yidx = vd*ne*ndof + iel*ndof + idof;
             }
-            y[yidx] = x[xidx];
+            d_y[yidx] = d_x[xidx];
          }
       }
-   }
+   });
 }
 
 ElementRestriction::ElementRestriction(const FiniteElementSpace &f,


### PR DESCRIPTION
This minor PR adds GPU support for `L2ElementRestriction` (implemented recently in PR #1156).

| PR | Author | Editor | Reviewers  | Assignment | Approval | Merge |
| --- | --- | --- | ---  | --- | --- | --- |
| https://github.com/mfem/mfem/pull/1189 | @pazner | @tzanio | @artv3 + @YohannDudouit  | 12/10/19 | 12/18/19 | ⌛due 12/25/19 |
