### PR TITLE
Add documentation for Parse() function of OptionsParser

### DIFF
--- a/general/optparser.hpp
+++ b/general/optparser.hpp
@@ -117,7 +117,10 @@ public:
                             required));
    }
 
-
+   /** Parse the command-line options. Note that this function expects all the
+       options provided through the command line to have a corresponding
+       AddOption. In particular, this function cannot be used for partial
+       parsing. */
    void Parse();
    bool Good() const { return (error_type == 0); }
    bool Help() const { return (error_type == 1); }


### PR DESCRIPTION
I was trying to use this function to do partial parsing of command-line options but this not how you are supposed to use the function. Extend the documentation to make this clear.

| PR | Author | Editor | Reviewers  | Assignment | Approval | Merge |
| --- | --- | --- | ---  | --- | --- | --- |
| https://github.com/mfem/mfem/pull/1191 | @Rombur | @v-dobrev | @v-dobrev + @mlstowell | 12/13/19 | 12/16/19 | ⌛due 12/23/19 |