### PR TITLE
Fixed synchronization issue in load-dc miniapp. 

### DIFF
--- a/miniapps/tools/load-dc.cpp
+++ b/miniapps/tools/load-dc.cpp
@@ -91,7 +91,13 @@ int main(int argc, char *argv[])
         it != fields.end() || fields.begin() == fields.end(); ++it)
    {
       socketstream sol_sock(vishost, visport);
-      if (!sol_sock)
+      bool succeeded = sol_sock.good();
+#ifdef MFEM_USE_MPI
+      bool all_succeeded;
+      MPI_Allreduce(&succeeded, &all_succeeded, 1, MPI_INT, MPI_MIN, MPI_COMM_WORLD);
+      succeeded = all_succeeded;
+#endif
+      if (!succeeded)
       {
          mfem::out << "Connection to " << vishost << ':' << visport
                    << " failed." << endl;


### PR DESCRIPTION
This PR fixes an issue with the load-dc miniapp. 

Without the introduced synchronization GLVis crashes sometimes, if a VisIt datacollection with multiple small fields is loaded (in parallel). The other apps are not affected by this issue, since either no parallel implementation is present (lor-transfer, display-basis) or no GLVIs connection is made (convert-dc).

| PR | Author | Editor | Reviewers  | Assignment | Approval | Merge |
| --- | --- | --- | ---  | --- | --- | --- |
| https://github.com/mfem/mfem/pull/1209 | @termi-official | @tzanio | @bslazarov + @jandrej | 12/27/19 | 01/08/20 | ⌛due 01/15/20  |
