### PR TITLE
Add indices to integration points. [intpoint-indices-dev]

### DIFF
--- a/fem/intrules.cpp
+++ b/fem/intrules.cpp
@@ -95,7 +95,8 @@ const Array<double> &IntegrationRule::GetWeights() const
    return weights;
 }
 
-void IntegrationRule::SetPointIndices() {
+void IntegrationRule::SetPointIndices()
+{
    for (int i = 0; i < Size(); i++)
    {
       IntPoint(i).index = i;

--- a/fem/intrules.cpp
+++ b/fem/intrules.cpp
@@ -48,6 +48,8 @@ IntegrationRule::IntegrationRule(IntegrationRule &irx, IntegrationRule &iry)
          ip.weight = ipx.weight * ipy.weight;
       }
    }
+
+   SetPointIndices();
 }
 
 IntegrationRule::IntegrationRule(IntegrationRule &irx, IntegrationRule &iry,
@@ -76,6 +78,8 @@ IntegrationRule::IntegrationRule(IntegrationRule &irx, IntegrationRule &iry,
          }
       }
    }
+
+   SetPointIndices();
 }
 
 const Array<double> &IntegrationRule::GetWeights() const
@@ -89,6 +93,13 @@ const Array<double> &IntegrationRule::GetWeights() const
       }
    }
    return weights;
+}
+
+void IntegrationRule::SetPointIndices() {
+   for (int i = 0; i < Size(); i++)
+   {
+      IntPoint(i).index = i;
+   }
 }
 
 void IntegrationRule::GrundmannMollerSimplexRule(int s, int n)

--- a/fem/intrules.hpp
+++ b/fem/intrules.hpp
@@ -96,9 +96,7 @@ private:
        by request with the method GetWeights(). */
    mutable Array<double> weights;
 
-   /**
-    * @brief      Sets the indices of each quadrature point on initialization.
-    */
+   /// Sets the indices of each quadrature point on initialization.
    void SetPointIndices();
 
    /// Define n-simplex rule (triangle/tetrahedron for n=2/3) of order (2s+1)

--- a/fem/intrules.hpp
+++ b/fem/intrules.hpp
@@ -26,8 +26,12 @@ class IntegrationPoint
 {
 public:
    double x, y, z, weight;
+   int index;
 
-   void Init() { x = y = z = weight = 0.0; }
+   void Init(int const i) {
+      x = y = z = weight = 0.0;
+      index = i;
+   }
 
    void Set(const double *p, const int dim)
    {
@@ -90,6 +94,11 @@ private:
    /** @brief The quadrature weights gathered as a contiguous array. Created
        by request with the method GetWeights(). */
    mutable Array<double> weights;
+
+   /**
+    * @brief      Sets the indices of each quadrature point on initialization.
+    */
+   void SetPointIndices();
 
    /// Define n-simplex rule (triangle/tetrahedron for n=2/3) of order (2s+1)
    void GrundmannMollerSimplexRule(int s, int n = 3);
@@ -215,7 +224,7 @@ public:
    {
       for (int i = 0; i < this->Size(); i++)
       {
-         (*this)[i].Init();
+         (*this)[i].Init(i);
       }
    }
 

--- a/fem/intrules.hpp
+++ b/fem/intrules.hpp
@@ -28,7 +28,8 @@ public:
    double x, y, z, weight;
    int index;
 
-   void Init(int const i) {
+   void Init(int const i)
+   {
       x = y = z = weight = 0.0;
       index = i;
    }

--- a/tests/unit/fem/test_intrules.cpp
+++ b/tests/unit/fem/test_intrules.cpp
@@ -70,6 +70,14 @@ TEST_CASE("Integration rule container with no refinement", "[IntegrationRules]")
       REQUIRE(true);
    }
 
+   SECTION("setting the integration point index works")
+   {
+      ir = &my_intrules.Get(Geometry::CUBE, 5);
+      for (int i = 0; i < ir->Size(); i++) {
+         REQUIRE(ir->IntPoint(i).index == i);
+      }
+   }
+
    SECTION("intrules up to order 16 accessible")
    {
       for (int order = 0; order <= 16; order ++)

--- a/tests/unit/fem/test_intrules.cpp
+++ b/tests/unit/fem/test_intrules.cpp
@@ -73,7 +73,8 @@ TEST_CASE("Integration rule container with no refinement", "[IntegrationRules]")
    SECTION("setting the integration point index works")
    {
       ir = &my_intrules.Get(Geometry::CUBE, 5);
-      for (int i = 0; i < ir->Size(); i++) {
+      for (int i = 0; i < ir->Size(); i++)
+      {
          REQUIRE(ir->IntPoint(i).index == i);
       }
    }


### PR DESCRIPTION
Following up from the conversation [here](https://github.com/mfem/mfem/issues/900), this is meant to give `IntPoint`s with an index that represents their position in the linear `Array`. This can be used to index into per-quadrature-point data that is stored outside of the `IntegrationRule` class. 

I'm open to suggestions if there are better ways to test or better places to put the test.

| PR | Author | Editor | Reviewers  | Assignment | Approval | Merge |
| --- | --- | --- | ---  | --- | --- | --- |
| https://github.com/mfem/mfem/pull/1215 | @ataber | @tzanio | @jakubcerveny + @stefanozampini  | 01/03/20 | 01/14/20 | ⌛due 01/21/20 |