### PR TITLE
Adding ParMesh::SetAttributes method [para-attr-dev]

### DIFF
--- a/mesh/mesh.hpp
+++ b/mesh/mesh.hpp
@@ -555,7 +555,7 @@ public:
        Mesh vertices or nodes are set. */
    virtual void Finalize(bool refine = false, bool fix_orientation = false);
 
-   void SetAttributes();
+   virtual void SetAttributes();
 
 #ifdef MFEM_USE_GECKO
    /** This is our integration with the Gecko library.  This will call the

--- a/mesh/pmesh.hpp
+++ b/mesh/pmesh.hpp
@@ -193,6 +193,8 @@ protected:
    void BuildSharedVertMapping(int nvert, const Table* vert_element,
                                const Array<int> &vert_global_local);
 
+   /// Ensure that bdr_attributes and attributes agree across processors
+   void DistributeAttributes(Array<int> &attr);
 
 public:
    /** Copy constructor. Performs a deep copy of (almost) all data, so that the
@@ -222,6 +224,8 @@ public:
    ParMesh(ParMesh *orig_mesh, int ref_factor, int ref_type);
 
    virtual void Finalize(bool refine = false, bool fix_orientation = false);
+
+   virtual void SetAttributes();
 
    MPI_Comm GetComm() const { return MyComm; }
    int GetNRanks() const { return NRanks; }

--- a/miniapps/electromagnetics/makefile
+++ b/miniapps/electromagnetics/makefile
@@ -76,6 +76,10 @@ RUN_MPI = $(MFEM_MPIEXEC) $(MFEM_MPIEXEC_NP) $(MFEM_MPI_NP)
 volta-test-par: volta
 	@$(call mfem-test,$<, $(RUN_MPI), Electromagnetic miniapp,\
 	-maxit 2 -dbcs 1 -dbcg -ds '0.0 0.0 0.0 0.2 8.0')
+volta-1-test-par: volta
+	@$(call mfem-test,$<, $(RUN_MPI), Electromagnetic miniapp,\
+	-maxit 2 -m ../../data/square-disc.mesh \
+	-dbcs '1 2 3 4 5 6 7 8' -dbcv '0 0 0 0 1 1 1 1')
 tesla-test-par: tesla
 	@$(call mfem-test,$<, $(RUN_MPI), Electromagnetic miniapp,\
 	-maxit 2 -cr '0 0 -0.2 0 0 0.2 0.2 0.4 1')

--- a/miniapps/electromagnetics/volta_solver.cpp
+++ b/miniapps/electromagnetics/volta_solver.cpp
@@ -88,10 +88,7 @@ VoltaSolver::VoltaSolver(ParMesh & pmesh, int order,
    ess_bdr_ = 0;   // Deselect all outer surfaces
    for (int i=0; i<dbcs_->Size(); i++)
    {
-      if ((*dbcs_)[i] <= ess_bdr_.Size())
-      {
-         ess_bdr_[(*dbcs_)[i]-1] = 1;
-      }
+      ess_bdr_[(*dbcs_)[i]-1] = 1;
    }
 
    // Setup various coefficients


### PR DESCRIPTION
This pull request ensures that each process uses a common list of attributes for both elements and boundary elements.  This allows material regions or boundary conditions to be declared the same way on all processors even when certain attributes may not be represented in the local portion of a mesh.  

When a common list of attributes is not used it's possible to over index arrays which may have been allocated using a size of `attributes.Max()`.

This PR is meant to address issue #1178.

<!--GHEX{"id":1222,"author":"mlstowell","editor":"tzanio","reviewers":["rcarson3","tzanio"],"assignment":"2020-01-19","approval":"2020-02-16","merge":"2020-02-20T00:49:31.902Z"}XEHG--><!--GHEXTABLE-->
| PR | Author | Editor | Reviewers | Assignment | Approval | Merge| 
 | --- | --- | --- | --- | --- | --- | --- | 
| [#1222](https://github.com/mfem/mfem/pull/1222) | @mlstowell | @tzanio | @rcarson3 + @tzanio | 01/19/20 | 02/16/20 | 02/19/20 | |
<!--ELBATXEHG-->