### PR TITLE
Fix an issue in class OperatorJacobiSmoother [operator-jacobi-fix]

### DIFF
--- a/fem/bilinearform.cpp
+++ b/fem/bilinearform.cpp
@@ -612,12 +612,11 @@ void BilinearForm::AssembleDiagonal(Vector &diag) const
 {
    if (ext)
    {
-      MFEM_ASSERT(diag.Size() == fes->GetNConformingDofs(),
+      MFEM_ASSERT(diag.Size() == fes->GetTrueVSize(),
                   "Vector for holding diagonal has wrong size!");
-      const SparseMatrix *P = fes->GetConformingProlongation();
+      const Operator *P = fes->GetProlongationMatrix();
       if (P)
       {
-         MFEM_WARNING("Partial assembly diagonal may be incorrect with AMR!");
          Vector local_diag(P->Height());
          ext->AssembleDiagonal(local_diag);
          P->MultTranspose(local_diag, diag);

--- a/fem/bilinearform.hpp
+++ b/fem/bilinearform.hpp
@@ -324,7 +324,7 @@ public:
        For adaptively refined meshes, this returns P^T d_e, where d_e is the
        locally assembled diagonal on each element and P^T is the transpose of
        the conforming prolongation. In general this is not the correct diagonal
-       for an AMR mesh, and the code will give a warning. */
+       for an AMR mesh. */
    void AssembleDiagonal(Vector &diag) const;
 
    /// Get the finite element space prolongation matrix

--- a/fem/pbilinearform.cpp
+++ b/fem/pbilinearform.cpp
@@ -246,21 +246,6 @@ void ParBilinearForm::Assemble(int skip_zeros)
    }
 }
 
-void ParBilinearForm::AssembleDiagonal(Vector &diag) const
-{
-   Vector local(pfes->GetVSize());
-   BilinearForm::AssembleDiagonal(local);
-   const Operator* p_mat = pfes->GetProlongationMatrix();
-   if (p_mat)
-   {
-      p_mat->MultTranspose(local, diag);
-   }
-   else
-   {
-      diag = local;
-   }
-}
-
 void ParBilinearForm
 ::ParallelEliminateEssentialBC(const Array<int> &bdr_attr_is_ess,
                                HypreParMatrix &A, const HypreParVector &X,

--- a/fem/pbilinearform.hpp
+++ b/fem/pbilinearform.hpp
@@ -89,9 +89,6 @@ public:
    /// Assemble the local matrix
    void Assemble(int skip_zeros = 1);
 
-   /// Assemble local diagonal (on truedofs)
-   void AssembleDiagonal(Vector &diag) const;
-
    /// Returns the matrix assembled on the true dofs, i.e. P^t A P.
    /** The returned matrix has to be deleted by the caller. */
    HypreParMatrix *ParallelAssemble() { return ParallelAssemble(mat); }

--- a/fem/pfespace.cpp
+++ b/fem/pfespace.cpp
@@ -876,7 +876,7 @@ const Operator *ParFiniteElementSpace::GetProlongationMatrix() const
 {
    if (Conforming())
    {
-      if (!Pconf)
+      if (!Pconf && NRanks > 1)
       {
          if (!Device::Allows(Backend::DEVICE_MASK))
          {
@@ -884,10 +884,7 @@ const Operator *ParFiniteElementSpace::GetProlongationMatrix() const
          }
          else
          {
-            if (NRanks > 1)
-            {
-               Pconf = new DeviceConformingProlongationOperator(*this);
-            }
+            Pconf = new DeviceConformingProlongationOperator(*this);
          }
       }
       return Pconf;

--- a/linalg/solvers.cpp
+++ b/linalg/solvers.cpp
@@ -109,8 +109,8 @@ OperatorJacobiSmoother::OperatorJacobiSmoother(const BilinearForm &a,
                                                const Array<int> &ess_tdofs,
                                                const double dmpng)
    :
-   Solver(a.Size()),
-   N(a.Size()),
+   Solver(a.FESpace()->GetTrueVSize()),
+   N(height),
    dinv(N),
    damping(dmpng),
    ess_tdof_list(ess_tdofs),
@@ -149,6 +149,9 @@ void OperatorJacobiSmoother::Setup(const Vector &diag)
 
 void OperatorJacobiSmoother::Mult(const Vector &x, Vector &y) const
 {
+   MFEM_ASSERT(x.Size() == N, "invalid input vector");
+   MFEM_ASSERT(y.Size() == N, "invalid output vector");
+
    if (iterative_mode && oper)
    {
       oper->Mult(y, residual);  // r = A x


### PR DESCRIPTION
This PR fixes an issue with the `Operator` size in class `OperatorJacobiSmoother`.

This was causing the CG in `ex1p` to converge slower than without preconditioning.

| PR | Author | Editor | Reviewers  | Assignment | Approval | Merge |
| --- | --- | --- | ---  | --- | --- | --- |
| https://github.com/mfem/mfem/pull/1223 | @v-dobrev  | @tzanio | @barker29 + @tzanio  | 01/09/20 |  01/10/20 | ⌛due 01/17/20 | 