### PR TITLE
View boundary attributes in `mesh-explorer` [view-bdr-dev]

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -93,6 +93,9 @@ New and updated examples and miniapps
 
 - New options to reorder and partition the mesh in the mesh-explorer miniapp.
 
+- The mesh-explorer miniapp now supports visualization of boundary attributes of
+  3D meshes (key 'b').
+
 - The (p)mesh-optimizer miniapp has been updated to demonstrate mesh
   optimization for an AMR mesh.
 

--- a/mesh/mesh.cpp
+++ b/mesh/mesh.cpp
@@ -1130,6 +1130,11 @@ void Mesh::AddVertex(const double *x)
    NumOfVertices++;
 }
 
+void Mesh::AddSegment(const int *vi, int attr)
+{
+   elements[NumOfElements++] = new Segment(vi, attr);
+}
+
 void Mesh::AddTri(const int *vi, int attr)
 {
    elements[NumOfElements++] = new Triangle(vi, attr);

--- a/mesh/mesh.hpp
+++ b/mesh/mesh.hpp
@@ -490,6 +490,7 @@ public:
    Element *NewElement(int geom);
 
    void AddVertex(const double *);
+   void AddSegment(const int *vi, int attr = 1);
    void AddTri(const int *vi, int attr = 1);
    void AddTriangle(const int *vi, int attr = 1);
    void AddQuad(const int *vi, int attr = 1);

--- a/miniapps/meshing/mesh-explorer.cpp
+++ b/miniapps/meshing/mesh-explorer.cpp
@@ -118,6 +118,7 @@ Mesh *read_par_mesh(int np, const char *mesh_prefix)
    return mesh;
 }
 
+// Given a 3D mesh, produce a 2D mesh consisting of its boundary elements.
 Mesh *skin_mesh(Mesh *mesh)
 {
    // Determine mapping from vertex to boundary vertex

--- a/miniapps/meshing/mesh-explorer.cpp
+++ b/miniapps/meshing/mesh-explorer.cpp
@@ -888,12 +888,14 @@ int main (int argc, char *argv[])
                {
                   mesh->Print(sol_sock);
                }
-	       else if (mk == 'b')
-	       {
-		 bdr_mesh->Print(sol_sock);
-		 bdr_attr.Save(sol_sock);
-		 sol_sock << "maaA\n";		 
-	       }
+               else if (mk == 'b')
+               {
+                 bdr_mesh->Print(sol_sock);
+                 bdr_attr.Save(sol_sock);
+                 sol_sock << "mcaaA";
+                 // Switch to a discrete color scale
+                 sol_sock << "pppppp" << "pppppp" << "pppppp";
+               }
                else
                {
                   // NURBS meshes do not support PrintWithPartitioning


### PR DESCRIPTION
This is a smallish change to the `mesh-explorer` miniapp which views boundary attributes by skinning a 3D mesh to produce a 2D mesh consisting of its boundary elements.

Currently this mesh skinning function does not support mesh nodes defined using a discontinuous grid function.  This limitation can be revisited after merging PR #716 or PR #1194.

| PR | Author | Editor | Reviewers  | Assignment | Approval | Merge |
| --- | --- | --- | ---  | --- | --- | --- |
| https://github.com/mfem/mfem/pull/1231 | @mlstowell   | @tzanio | @drzisga + @bslazarov | 01/13/20 | 02/03/20 | ⌛due 02/10/20 | 