### PR TITLE
GetProlongationMatrix returns IdentityOperator when NRanks ==1 [pfespace-fix]

### DIFF
--- a/fem/bilinearform.cpp
+++ b/fem/bilinearform.cpp
@@ -615,7 +615,7 @@ void BilinearForm::AssembleDiagonal(Vector &diag) const
       MFEM_ASSERT(diag.Size() == fes->GetTrueVSize(),
                   "Vector for holding diagonal has wrong size!");
       const Operator *P = fes->GetProlongationMatrix();
-      if (P)
+      if (!IsIdentityProlongation(P))
       {
          Vector local_diag(P->Height());
          ext->AssembleDiagonal(local_diag);

--- a/fem/pfespace.cpp
+++ b/fem/pfespace.cpp
@@ -878,7 +878,10 @@ const Operator *ParFiniteElementSpace::GetProlongationMatrix() const
    {
       if (Pconf) { return Pconf; }
 
-      if (NRanks == 1) { Pconf = new IdentityOperator(GetTrueVSize()); }
+      if (NRanks == 1)
+      {
+         Pconf = new IdentityOperator(GetTrueVSize());
+      }
       else
       {
          if (!Device::Allows(Backend::DEVICE_MASK))

--- a/fem/pfespace.cpp
+++ b/fem/pfespace.cpp
@@ -876,7 +876,10 @@ const Operator *ParFiniteElementSpace::GetProlongationMatrix() const
 {
    if (Conforming())
    {
-      if (!Pconf && NRanks > 1)
+      if (Pconf) { return Pconf; }
+
+      if (NRanks == 1) { Pconf = new IdentityOperator(GetTrueVSize()); }
+      else
       {
          if (!Device::Allows(Backend::DEVICE_MASK))
          {

--- a/fem/pfespace.hpp
+++ b/fem/pfespace.hpp
@@ -72,7 +72,7 @@ private:
    /// The matrix P (interpolation from true dof to dof). Owned.
    mutable HypreParMatrix *P;
    /// Optimized action-only prolongation operator for conforming meshes. Owned.
-   mutable class ConformingProlongationOperator *Pconf;
+   mutable Operator *Pconf;
 
    /// The (block-diagonal) matrix R (restriction of dof to true dof). Owned.
    mutable SparseMatrix *R;

--- a/linalg/operator.cpp
+++ b/linalg/operator.cpp
@@ -31,7 +31,7 @@ void Operator::FormLinearSystem(const Array<int> &ess_tdof_list,
    const Operator *P = this->GetProlongation();
    const Operator *R = this->GetRestriction();
 
-   if (P)
+   if (!IsIdentityProlongation(P))
    {
       // Variational restriction with P
       B.SetSize(P->Width(), b);

--- a/linalg/operator.hpp
+++ b/linalg/operator.hpp
@@ -415,7 +415,8 @@ public:
    virtual void MultTranspose(const Vector &x, Vector &y) const { y = x; }
 };
 
-/// Returns true if the P operator identity.
+/// Returns true if P is the identity prolongation, i.e. if it is either NULL or
+/// an IdentityOperator.
 inline bool IsIdentityProlongation(const Operator *P)
 {
    return !P || dynamic_cast<const IdentityOperator*>(P);

--- a/linalg/operator.hpp
+++ b/linalg/operator.hpp
@@ -415,6 +415,11 @@ public:
    virtual void MultTranspose(const Vector &x, Vector &y) const { y = x; }
 };
 
+/// Returns true if the P operator identity.
+inline bool IsIdentityProlongation(const Operator *P)
+{
+   return !P || dynamic_cast<const IdentityOperator*>(P);
+}
 
 /// Scaled Operator B: x -> a A(x).
 class ScaledOperator : public Operator


### PR DESCRIPTION
Add IsIdentityProlongation in operator.hpp


| PR | Author | Editor | Reviewers  | Assignment | Approval | Merge |
| --- | --- | --- | ---  | --- | --- | --- |
| https://github.com/mfem/mfem/pull/1239 | @camierjs  | @tzanio | @v-dobrev + @pazner | 01/16/20 | 01/16/20 | ⌛due 01/23/20 | 