### PR TITLE
Memory overlap in MPI_Allreduce [load-dc-bugfix-dev]

### DIFF
--- a/miniapps/tools/load-dc.cpp
+++ b/miniapps/tools/load-dc.cpp
@@ -94,7 +94,8 @@ int main(int argc, char *argv[])
       bool succeeded = sol_sock.good();
 #ifdef MFEM_USE_MPI
       bool all_succeeded;
-      MPI_Allreduce(&succeeded, &all_succeeded, 1, MPI_INT, MPI_MIN, MPI_COMM_WORLD);
+      MPI_Allreduce(&succeeded, &all_succeeded, 1,
+                    MPI_C_BOOL, MPI_LAND, MPI_COMM_WORLD);
       succeeded = all_succeeded;
 #endif
       if (!succeeded)


### PR DESCRIPTION
The bool datatype is smaller than an MPI_INT (on some architectures at least) so this lead to an overlap in the arguments to MPI_Allreduce.

| PR | Author | Editor | Reviewers  | Assignment | Approval | Merge |
| --- | --- | --- | ---  | --- | --- | --- |
| https://github.com/mfem/mfem/pull/1242 | @mlstowell | @tzanio | @termi-official + @akgillette | 01/19/20 | 01/22/20 | ⌛due 01/29/20 |