### PR TITLE
LinearSolve(A,X) convenience method

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -103,10 +103,6 @@ Discretization improvements
 
 Linear and nonlinear solvers
 ----------------------------
-- Added a LinearSolve(A,X) convenience method to solve linear systems. In the
-  trivial cases, i.e., square matrices of size N=1 or N=2, the system is solved
-  directly, otherwise, LU factorization is employed.
-
 - Added a general interface for specifying and solving nonlinear constrained
   optimization problems through the new classes OptimizationProblem and
   OptimizationSolver, see linalg/solver.hpp
@@ -122,6 +118,10 @@ Linear and nonlinear solvers
 
 - Added a block ILU(0) preconditioner for DG-type discretizations. Example 9
   (DG advection) now takes advantage of this for implicit time integration.
+
+- Added a LinearSolve(A,X) convenience method to solve dense linear systems. In
+  the trivial cases, i.e., square matrices of size 1 or 2, the system is solved
+  directly, otherwise, LU factorization is employed.
 
 New and updated examples and miniapps
 -------------------------------------

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -103,11 +103,8 @@ Discretization improvements
 
 Linear and nonlinear solvers
 ----------------------------
-- LUFactors::Factor() now returns a status that is equal to 0 if the LU factoriazation
-  is successful, non-zero otherwise.
-
 - Added a LinearSolve(A,X) convenience method to solve linear systems. In the trivial
-  cases, i.e., square matrices of size N=1 or N=2, the system is solve directly,
+  cases, i.e., square matrices of size N=1 or N=2, the system is solved directly,
   otherwise, LU Factorization is employed.
 
 - Added a general interface for specifying and solving nonlinear constrained

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -103,9 +103,9 @@ Discretization improvements
 
 Linear and nonlinear solvers
 ----------------------------
-- Added a LinearSolve(A,X) convenience method to solve linear systems. In the trivial
-  cases, i.e., square matrices of size N=1 or N=2, the system is solved directly,
-  otherwise, LU Factorization is employed.
+- Added a LinearSolve(A,X) convenience method to solve linear systems. In the
+  trivial cases, i.e., square matrices of size N=1 or N=2, the system is solved
+  directly, otherwise, LU factorization is employed.
 
 - Added a general interface for specifying and solving nonlinear constrained
   optimization problems through the new classes OptimizationProblem and

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -103,6 +103,13 @@ Discretization improvements
 
 Linear and nonlinear solvers
 ----------------------------
+- LUFactors::Factor() now returns a status that is equal to 0 if the LU factoriazation
+  is successful, non-zero otherwise.
+
+- Added a LinearSolve(A,X) convenience method to solve linear systems. In the trivial
+  cases, i.e., square matrices of size N=1 or N=2, the system is solve directly,
+  otherwise, LU Factorization is employed.
+
 - Added a general interface for specifying and solving nonlinear constrained
   optimization problems through the new classes OptimizationProblem and
   OptimizationSolver, see linalg/solver.hpp

--- a/linalg/densemat.cpp
+++ b/linalg/densemat.cpp
@@ -3115,7 +3115,7 @@ bool LinearSolve(DenseMatrix& A, double* X, double TOL)
          Array<int> ipiv(N);
          LUFactors lu(A.Data(), ipiv);
 
-         if (!lu.Factor(N)) { return false; } // singular
+         if (!lu.Factor(N,TOL)) { return false; } // singular
 
          lu.Solve(N, 1, X);
       }

--- a/linalg/densemat.cpp
+++ b/linalg/densemat.cpp
@@ -2905,20 +2905,34 @@ void DenseMatrix::SetCol(int col, double value)
    }
 }
 
-void DenseMatrix::SetRow(int r, const Vector &row)
+void DenseMatrix::SetRow(int r, const double* row)
 {
+   MFEM_ASSERT( row != nullptr, "supplied row pointer is null" );
    for (int j = 0; j < Width(); j++)
    {
       (*this)(r, j) = row[j];
    }
 }
 
-void DenseMatrix::SetCol(int c, const Vector &col)
+void DenseMatrix::SetRow(int r, const Vector &row)
 {
+   MFEM_ASSERT( Width()==row.Size(), "" );
+   SetRow( r, row.GetData() );
+}
+
+void DenseMatrix::SetCol(int c, const double* col)
+{
+   MFEM_ASSERT( col != nullptr, "supplied column pointer is null" );
    for (int i = 0; i < Height(); i++)
    {
       (*this)(i, c) = col[i];
    }
+}
+
+void DenseMatrix::SetCol(int c, const Vector &col)
+{
+   MFEM_ASSERT( Height()==col.Size(), "" );
+   SetCol( c, col.GetData() );
 }
 
 void DenseMatrix::Threshold(double eps)

--- a/linalg/densemat.cpp
+++ b/linalg/densemat.cpp
@@ -3973,12 +3973,15 @@ void AddMult_a_VVt(const double a, const Vector &v, DenseMatrix &VVt)
 }
 
 
-void LUFactors::Factor(int m)
+int LUFactors::Factor(int m)
 {
+  constexpr int LU_SUCCESS = 0;
+  constexpr int LU_FAILED  = -1;
+
 #ifdef MFEM_USE_LAPACK
    int info = 0;
    if (m) { dgetrf_(&m, &m, data, &m, ipiv, &info); }
-   MFEM_VERIFY(!info, "LAPACK: error in DGETRF");
+   return (info!=0) ? LU_FAILED : LU_SUCCESS;
 #else
    // compiling without LAPACK
    double *data = this->data;
@@ -4007,7 +4010,13 @@ void LUFactors::Factor(int m)
             }
          }
       }
-      MFEM_ASSERT(data[i+i*m] != 0.0, "division by zero");
+
+      if ( abs(data[i+i*m]-0.0) <= 1.e-9 )
+      {
+        mfem_warning( "LUFactors::Factor: division by zero!" );
+        return LU_FAILED;
+      }
+
       const double a_ii_inv = 1.0/data[i+i*m];
       for (int j = i+1; j < m; j++)
       {
@@ -4023,6 +4032,8 @@ void LUFactors::Factor(int m)
       }
    }
 #endif
+
+   return LU_SUCCESS;
 }
 
 double LUFactors::Det(int m) const

--- a/linalg/densemat.cpp
+++ b/linalg/densemat.cpp
@@ -3077,14 +3077,14 @@ void Add(double alpha, const DenseMatrix &A,
    Add(alpha, A.GetData(), beta, B.GetData(), C);
 }
 
-int LinearSolve(DenseMatrix& A, double* X)
+bool LinearSolve(DenseMatrix& A, double* X)
 {
    MFEM_VERIFY(A.IsSquare(), "A must be a square matrix!");
    MFEM_ASSERT(A.NumCols() > 0, "supplied matrix, A, is empty!");
    MFEM_ASSERT(X != nullptr, "supplied vector, X, is null!");
 
    constexpr double TOL = 1.e-9;
-   constexpr int SINGULAR = -1;
+   constexpr bool SINGULAR = false;
    const int N = A.NumCols();
 
    switch (N)
@@ -3118,11 +3118,10 @@ int LinearSolve(DenseMatrix& A, double* X)
       default:
       {
          // default to LU factorization for the general case
-         constexpr int LU_SUCCESS = 0;
          int* ipiv = new int [N];
          LUFactors lu(A.Data(), ipiv);
 
-         if (lu.Factor( N ) != LU_SUCCESS)
+         if (!lu.Factor(N))
          {
             return SINGULAR;
          }
@@ -3134,7 +3133,7 @@ int LinearSolve(DenseMatrix& A, double* X)
 
    } // END switch
 
-   return 0;
+   return true;
 }
 
 void Mult(const DenseMatrix &b, const DenseMatrix &c, DenseMatrix &a)
@@ -4046,10 +4045,10 @@ void AddMult_a_VVt(const double a, const Vector &v, DenseMatrix &VVt)
 }
 
 
-int LUFactors::Factor(int m, double TOL)
+bool LUFactors::Factor(int m, double TOL)
 {
-   constexpr int LU_SUCCESS = 0;
-   constexpr int LU_FAILED  = -1;
+   constexpr bool LU_SUCCESS = true;
+   constexpr bool LU_FAILED  = false;
 
 #ifdef MFEM_USE_LAPACK
    int info = 0;

--- a/linalg/densemat.cpp
+++ b/linalg/densemat.cpp
@@ -4078,7 +4078,6 @@ int LUFactors::Factor(int m)
 
       if ( abs(data[i+i*m]-0.0) <= 1.e-9 )
       {
-        mfem_warning( "LUFactors::Factor: division by zero!" );
         return LU_FAILED;
       }
 

--- a/linalg/densemat.cpp
+++ b/linalg/densemat.cpp
@@ -3103,15 +3103,11 @@ bool LinearSolve(DenseMatrix& A, double* X, double TOL)
 
          const double invdet = 1. / det;
 
-         const double& a00 = A(0,0);
-         const double& a01 = A(0,1);
-         const double& a10 = A(1,0);
-         const double& a11 = A(1,1);
          const double b0   = X[0];
          const double b1   = X[1];
 
-         X[0] = (  a11*b0 - a01*b1 ) * invdet;
-         X[1] = ( -a10*b0 + a00*b1 ) * invdet;
+         X[0] = (  A(1,1)*b0 - A(0,1)*b1 ) * invdet;
+         X[1] = ( -A(1,0)*b0 + A(0,0)*b1 ) * invdet;
          break;
       }
       default:

--- a/linalg/densemat.cpp
+++ b/linalg/densemat.cpp
@@ -3077,13 +3077,12 @@ void Add(double alpha, const DenseMatrix &A,
    Add(alpha, A.GetData(), beta, B.GetData(), C);
 }
 
-bool LinearSolve(DenseMatrix& A, double* X)
+bool LinearSolve(DenseMatrix& A, double* X, double TOL)
 {
    MFEM_VERIFY(A.IsSquare(), "A must be a square matrix!");
    MFEM_ASSERT(A.NumCols() > 0, "supplied matrix, A, is empty!");
    MFEM_ASSERT(X != nullptr, "supplied vector, X, is null!");
 
-   constexpr double TOL = 1.e-9;
    constexpr bool SINGULAR = false;
    const int N = A.NumCols();
 

--- a/linalg/densemat.cpp
+++ b/linalg/densemat.cpp
@@ -2916,7 +2916,7 @@ void DenseMatrix::SetRow(int r, const double* row)
 
 void DenseMatrix::SetRow(int r, const Vector &row)
 {
-   MFEM_ASSERT(Width()==row.Size(), "");
+   MFEM_ASSERT(Width() == row.Size(), "");
    SetRow(r, row.GetData());
 }
 
@@ -2931,7 +2931,7 @@ void DenseMatrix::SetCol(int c, const double* col)
 
 void DenseMatrix::SetCol(int c, const Vector &col)
 {
-   MFEM_ASSERT(Height()==col.Size(), "");
+   MFEM_ASSERT(Height() == col.Size(), "");
    SetCol(c, col.GetData());
 }
 

--- a/linalg/densemat.cpp
+++ b/linalg/densemat.cpp
@@ -3112,14 +3112,12 @@ bool LinearSolve(DenseMatrix& A, double* X, double TOL)
       default:
       {
          // default to LU factorization for the general case
-         int* ipiv = new int[N];
+         Array<int> ipiv(N);
          LUFactors lu(A.Data(), ipiv);
 
          if (!lu.Factor(N)) { return false; } // singular
 
          lu.Solve(N, 1, X);
-
-         delete [] ipiv;
       }
 
    } // END switch

--- a/linalg/densemat.hpp
+++ b/linalg/densemat.hpp
@@ -262,8 +262,12 @@ public:
    void GetColumnReference(int c, Vector &col)
    { col.SetDataAndSize(data + c * height, height); }
 
+   void SetRow(int r, const double* row );
    void SetRow(int r, const Vector &row);
+
+   void SetCol(int c, const double* col );
    void SetCol(int c, const Vector &col);
+
 
    /// Set all entries of a row to the specified value.
    void SetRow(int row, double value);

--- a/linalg/densemat.hpp
+++ b/linalg/densemat.hpp
@@ -370,6 +370,20 @@ void Add(double alpha, const double *A,
 void Add(double alpha, const DenseMatrix &A,
          double beta,  const DenseMatrix &B, DenseMatrix &C);
 
+/// @brief Solves the linear system, `A * X = B` for `X`
+///
+/// @param [in,out] A the square matrix for the linear system
+/// @param [in,out] X the rhs vector, B, on input, the solution, X, on output.
+///
+/// @return status zero on success, negative number otherwise.
+///
+/// @note This routine may replace the contents of the input Matrix, A, with
+///  the corresponding LU factorization of the matrix.
+///
+/// @pre A.IsSquare() == true
+/// @pre X != nullptr
+int LinearSolve( DenseMatrix& A, double* X );
+
 /// Matrix matrix multiplication.  A = B * C.
 void Mult(const DenseMatrix &b, const DenseMatrix &c, DenseMatrix &a);
 

--- a/linalg/densemat.hpp
+++ b/linalg/densemat.hpp
@@ -374,7 +374,7 @@ void Add(double alpha, const double *A,
 void Add(double alpha, const DenseMatrix &A,
          double beta,  const DenseMatrix &B, DenseMatrix &C);
 
-/// @brief Solves the linear system, `A * X = B` for `X`
+/// @brief Solves the dense linear system, `A * X = B` for `X`
 ///
 /// @param [in,out] A the square matrix for the linear system
 /// @param [in,out] X the rhs vector, B, on input, the solution, X, on output.
@@ -506,7 +506,7 @@ public:
     *
     * @return status set to true if successful, otherwise, false.
     */
-   bool Factor(int m, double TOL = 1.e-9 );
+   bool Factor(int m, double TOL = 1.e-9);
 
    /** Assuming L.U = P.A factored data of size (m x m), compute |A|
        from the diagonal values of U and the permutation information. */

--- a/linalg/densemat.hpp
+++ b/linalg/densemat.hpp
@@ -474,10 +474,16 @@ public:
 
    LUFactors(double *data_, int *ipiv_) : data(data_), ipiv(ipiv_) { }
 
-   /** Factorize the current data of size (m x m) overwriting it with the LU
-       factors. The factorization is such that L.U = P.A, where A is the
-       original matrix and P is a permutation matrix represented by ipiv. */
-   void Factor(int m);
+   /**
+    *  Factorize the current data of size (m x m) overwriting it with
+    *  the LU factors. The factorization is such that L.U = P.A, where A is the
+    *  original matrix and P is a permutation matrix represented by ipiv.
+    *
+    *  @param [in] m size of the square matrix
+    *
+    *  @return status
+    */
+   int Factor(int m);
 
    /** Assuming L.U = P.A factored data of size (m x m), compute |A|
        from the diagonal values of U and the permutation information. */

--- a/linalg/densemat.hpp
+++ b/linalg/densemat.hpp
@@ -506,7 +506,7 @@ public:
     *
     * @return status set to true if successful, otherwise, false.
     */
-   bool Factor(int m, double TOL=1.e-9 );
+   bool Factor(int m, double TOL = 1.e-9 );
 
    /** Assuming L.U = P.A factored data of size (m x m), compute |A|
        from the diagonal values of U and the permutation information. */

--- a/linalg/densemat.hpp
+++ b/linalg/densemat.hpp
@@ -502,11 +502,11 @@ public:
     * original matrix and P is a permutation matrix represented by ipiv.
     *
     * @param [in] m size of the square matrix
-    * @param [in] TOL optional fuzzy comparison tolerance. Defaults to 1e-9.
+    * @param [in] TOL optional fuzzy comparison tolerance. Defaults to 0.0.
     *
     * @return status set to true if successful, otherwise, false.
     */
-   bool Factor(int m, double TOL = 1.e-9);
+   bool Factor(int m, double TOL = 0.0);
 
    /** Assuming L.U = P.A factored data of size (m x m), compute |A|
        from the diagonal values of U and the permutation information. */

--- a/linalg/densemat.hpp
+++ b/linalg/densemat.hpp
@@ -262,10 +262,10 @@ public:
    void GetColumnReference(int c, Vector &col)
    { col.SetDataAndSize(data + c * height, height); }
 
-   void SetRow(int r, const double* row );
+   void SetRow(int r, const double* row);
    void SetRow(int r, const Vector &row);
 
-   void SetCol(int c, const double* col );
+   void SetCol(int c, const double* col);
    void SetCol(int c, const Vector &col);
 
 
@@ -381,12 +381,13 @@ void Add(double alpha, const DenseMatrix &A,
 ///
 /// @return status zero on success, negative number otherwise.
 ///
-/// @note This routine may replace the contents of the input Matrix, A, with
-///  the corresponding LU factorization of the matrix.
+/// @note This routine may replace the contents of the input Matrix, A, with the
+///       corresponding LU factorization of the matrix. Matrices of size 1x1 and
+///       2x2 are handled explicitly.
 ///
 /// @pre A.IsSquare() == true
 /// @pre X != nullptr
-int LinearSolve( DenseMatrix& A, double* X );
+int LinearSolve(DenseMatrix& A, double* X);
 
 /// Matrix matrix multiplication.  A = B * C.
 void Mult(const DenseMatrix &b, const DenseMatrix &c, DenseMatrix &a);
@@ -493,15 +494,18 @@ public:
    LUFactors(double *data_, int *ipiv_) : data(data_), ipiv(ipiv_) { }
 
    /**
-    *  Factorize the current data of size (m x m) overwriting it with
-    *  the LU factors. The factorization is such that L.U = P.A, where A is the
-    *  original matrix and P is a permutation matrix represented by ipiv.
+    * @brief Compute the LU factorization of the current matrix
     *
-    *  @param [in] m size of the square matrix
+    * Factorize the current matrix of size (m x m) overwriting it with the
+    * LU factors. The factorization is such that L.U = P.A, where A is the
+    * original matrix and P is a permutation matrix represented by ipiv.
     *
-    *  @return status
+    * @param [in] m size of the square matrix
+    * @param [in] TOL optional fuzzy comparison tolerance. Defaults to 1e-9.
+    *
+    * @return status returns 0 on success, non-zero return value otherwise.
     */
-   int Factor(int m);
+   int Factor(int m, double TOL=1.e-9 );
 
    /** Assuming L.U = P.A factored data of size (m x m), compute |A|
        from the diagonal values of U and the permutation information. */

--- a/linalg/densemat.hpp
+++ b/linalg/densemat.hpp
@@ -379,7 +379,7 @@ void Add(double alpha, const DenseMatrix &A,
 /// @param [in,out] A the square matrix for the linear system
 /// @param [in,out] X the rhs vector, B, on input, the solution, X, on output.
 ///
-/// @return status zero on success, negative number otherwise.
+/// @return status set to true if successful, otherwise, false.
 ///
 /// @note This routine may replace the contents of the input Matrix, A, with the
 ///       corresponding LU factorization of the matrix. Matrices of size 1x1 and
@@ -387,7 +387,7 @@ void Add(double alpha, const DenseMatrix &A,
 ///
 /// @pre A.IsSquare() == true
 /// @pre X != nullptr
-int LinearSolve(DenseMatrix& A, double* X);
+bool LinearSolve(DenseMatrix& A, double* X);
 
 /// Matrix matrix multiplication.  A = B * C.
 void Mult(const DenseMatrix &b, const DenseMatrix &c, DenseMatrix &a);
@@ -503,9 +503,9 @@ public:
     * @param [in] m size of the square matrix
     * @param [in] TOL optional fuzzy comparison tolerance. Defaults to 1e-9.
     *
-    * @return status returns 0 on success, non-zero return value otherwise.
+    * @return status set to true if successful, otherwise, false.
     */
-   int Factor(int m, double TOL=1.e-9 );
+   bool Factor(int m, double TOL=1.e-9 );
 
    /** Assuming L.U = P.A factored data of size (m x m), compute |A|
        from the diagonal values of U and the permutation information. */

--- a/linalg/densemat.hpp
+++ b/linalg/densemat.hpp
@@ -378,6 +378,7 @@ void Add(double alpha, const DenseMatrix &A,
 ///
 /// @param [in,out] A the square matrix for the linear system
 /// @param [in,out] X the rhs vector, B, on input, the solution, X, on output.
+/// @param [in] TOL optional fuzzy comparison tolerance. Defaults to 1e-9.
 ///
 /// @return status set to true if successful, otherwise, false.
 ///
@@ -387,7 +388,7 @@ void Add(double alpha, const DenseMatrix &A,
 ///
 /// @pre A.IsSquare() == true
 /// @pre X != nullptr
-bool LinearSolve(DenseMatrix& A, double* X);
+bool LinearSolve(DenseMatrix& A, double* X, double TOL = 1.e-9);
 
 /// Matrix matrix multiplication.  A = B * C.
 void Mult(const DenseMatrix &b, const DenseMatrix &c, DenseMatrix &a);

--- a/linalg/matrix.hpp
+++ b/linalg/matrix.hpp
@@ -42,6 +42,9 @@ public:
    /// Creates a matrix of the given height and width.
    explicit Matrix(int h, int w) : Operator(h, w) { }
 
+   /// Returns whether this matrix instanse is a square matrix.
+   bool IsSquare() const { return (height==width); };
+
    /// Returns reference to a_{ij}.
    virtual double &Elem(int i, int j) = 0;
 

--- a/linalg/matrix.hpp
+++ b/linalg/matrix.hpp
@@ -42,7 +42,7 @@ public:
    /// Creates a matrix of the given height and width.
    explicit Matrix(int h, int w) : Operator(h, w) { }
 
-   /// Returns whether this matrix instance is a square matrix.
+   /// Returns whether the matrix is a square matrix.
    bool IsSquare() const { return (height == width); };
 
    /// Returns reference to a_{ij}.

--- a/linalg/matrix.hpp
+++ b/linalg/matrix.hpp
@@ -43,7 +43,7 @@ public:
    explicit Matrix(int h, int w) : Operator(h, w) { }
 
    /// Returns whether this matrix instance is a square matrix.
-   bool IsSquare() const { return (height==width); };
+   bool IsSquare() const { return (height == width); };
 
    /// Returns reference to a_{ij}.
    virtual double &Elem(int i, int j) = 0;

--- a/linalg/matrix.hpp
+++ b/linalg/matrix.hpp
@@ -42,7 +42,7 @@ public:
    /// Creates a matrix of the given height and width.
    explicit Matrix(int h, int w) : Operator(h, w) { }
 
-   /// Returns whether this matrix instanse is a square matrix.
+   /// Returns whether this matrix instance is a square matrix.
    bool IsSquare() const { return (height==width); };
 
    /// Returns reference to a_{ij}.

--- a/tests/unit/linalg/test_densematrix.cpp
+++ b/tests/unit/linalg/test_densematrix.cpp
@@ -14,6 +14,75 @@
 
 using namespace mfem;
 
+TEST_CASE( "DenseMatrix LinearSolve methods",
+           "[DenseMatrix]" )
+{
+  SECTION( "singular_system" )
+  {
+    constexpr int N = 3;
+
+    DenseMatrix A( N );
+    A.SetRow( 0, 0.0 );
+    A.SetRow( 1, 0.0 );
+    A.SetRow( 2, 0.0 );
+
+    double X[3];
+
+    int rc = LinearSolve( A, X );
+    REQUIRE( rc < 0 );
+  }
+
+  SECTION( "1x1_system" )
+  {
+    constexpr int N = 1;
+    DenseMatrix A(N);
+    A(0,0) = 2;
+
+    double X[ 1 ] = { 12 };
+
+    int rc = LinearSolve( A, X );
+    REQUIRE( rc==0 );
+    REQUIRE( X[0] == Approx(6) );
+  }
+
+  SECTION( "2x2_system" )
+  {
+    constexpr int N = 2;
+
+    DenseMatrix A( N );
+    A(0,0)=2. ; A(0,1)=1.;
+    A(1,0)=3. ; A(1,1)=4.;
+
+    double X[ 2 ] = { 1, 14 };
+
+    int rc = LinearSolve( A, X );
+
+    REQUIRE( rc==0 );
+    REQUIRE( X[0] == Approx(-2) );
+    REQUIRE( X[1] == Approx(5) );
+  }
+
+  SECTION( "3x3_system" )
+  {
+    constexpr int N = 3;
+
+    DenseMatrix A( N );
+    A( 0,0 )=4; A( 0,1 )=5; A( 0,2 )=-2;
+    A( 1,0 )=7; A( 1,1 )=-1; A( 1,2 )= 2;
+    A( 2,0 )=3; A( 2,1 )=1; A( 2,2 )= 4;
+
+    double X[ 3 ] = { -14, 42, 28 };
+
+    int rc = LinearSolve( A, X );
+
+    REQUIRE( rc==0 );
+    REQUIRE( X[0] == Approx(4)  );
+    REQUIRE( X[1] == Approx(-4) );
+    REQUIRE( X[2] == Approx(5) );
+  }
+
+}
+
 TEST_CASE("DenseMatrix A*B^T methods",
           "[DenseMatrix]")
 {

--- a/tests/unit/linalg/test_densematrix.cpp
+++ b/tests/unit/linalg/test_densematrix.cpp
@@ -17,69 +17,69 @@ using namespace mfem;
 TEST_CASE( "DenseMatrix LinearSolve methods",
            "[DenseMatrix]" )
 {
-  SECTION( "singular_system" )
-  {
-    constexpr int N = 3;
+   SECTION( "singular_system" )
+   {
+      constexpr int N = 3;
 
-    DenseMatrix A( N );
-    A.SetRow( 0, 0.0 );
-    A.SetRow( 1, 0.0 );
-    A.SetRow( 2, 0.0 );
+      DenseMatrix A( N );
+      A.SetRow( 0, 0.0 );
+      A.SetRow( 1, 0.0 );
+      A.SetRow( 2, 0.0 );
 
-    double X[3];
+      double X[3];
 
-    int rc = LinearSolve( A, X );
-    REQUIRE( rc < 0 );
-  }
+      int rc = LinearSolve( A, X );
+      REQUIRE( rc < 0 );
+   }
 
-  SECTION( "1x1_system" )
-  {
-    constexpr int N = 1;
-    DenseMatrix A(N);
-    A(0,0) = 2;
+   SECTION( "1x1_system" )
+   {
+      constexpr int N = 1;
+      DenseMatrix A(N);
+      A(0,0) = 2;
 
-    double X[ 1 ] = { 12 };
+      double X[ 1 ] = { 12 };
 
-    int rc = LinearSolve( A, X );
-    REQUIRE( rc==0 );
-    REQUIRE( X[0] == Approx(6) );
-  }
+      int rc = LinearSolve( A, X );
+      REQUIRE( rc==0 );
+      REQUIRE( X[0] == Approx(6) );
+   }
 
-  SECTION( "2x2_system" )
-  {
-    constexpr int N = 2;
+   SECTION( "2x2_system" )
+   {
+      constexpr int N = 2;
 
-    DenseMatrix A( N );
-    A(0,0)=2. ; A(0,1)=1.;
-    A(1,0)=3. ; A(1,1)=4.;
+      DenseMatrix A( N );
+      A(0,0)=2. ; A(0,1)=1.;
+      A(1,0)=3. ; A(1,1)=4.;
 
-    double X[ 2 ] = { 1, 14 };
+      double X[ 2 ] = { 1, 14 };
 
-    int rc = LinearSolve( A, X );
+      int rc = LinearSolve( A, X );
 
-    REQUIRE( rc==0 );
-    REQUIRE( X[0] == Approx(-2) );
-    REQUIRE( X[1] == Approx(5) );
-  }
+      REQUIRE( rc==0 );
+      REQUIRE( X[0] == Approx(-2) );
+      REQUIRE( X[1] == Approx(5) );
+   }
 
-  SECTION( "3x3_system" )
-  {
-    constexpr int N = 3;
+   SECTION( "3x3_system" )
+   {
+      constexpr int N = 3;
 
-    DenseMatrix A( N );
-    A( 0,0 )=4; A( 0,1 )=5; A( 0,2 )=-2;
-    A( 1,0 )=7; A( 1,1 )=-1; A( 1,2 )= 2;
-    A( 2,0 )=3; A( 2,1 )=1; A( 2,2 )= 4;
+      DenseMatrix A( N );
+      A( 0,0 )=4; A( 0,1 )=5; A( 0,2 )=-2;
+      A( 1,0 )=7; A( 1,1 )=-1; A( 1,2 )= 2;
+      A( 2,0 )=3; A( 2,1 )=1; A( 2,2 )= 4;
 
-    double X[ 3 ] = { -14, 42, 28 };
+      double X[ 3 ] = { -14, 42, 28 };
 
-    int rc = LinearSolve( A, X );
+      int rc = LinearSolve( A, X );
 
-    REQUIRE( rc==0 );
-    REQUIRE( X[0] == Approx(4)  );
-    REQUIRE( X[1] == Approx(-4) );
-    REQUIRE( X[2] == Approx(5) );
-  }
+      REQUIRE( rc==0 );
+      REQUIRE( X[0] == Approx(4)  );
+      REQUIRE( X[1] == Approx(-4) );
+      REQUIRE( X[2] == Approx(5) );
+   }
 
 }
 

--- a/tests/unit/linalg/test_densematrix.cpp
+++ b/tests/unit/linalg/test_densematrix.cpp
@@ -14,10 +14,10 @@
 
 using namespace mfem;
 
-TEST_CASE( "DenseMatrix LinearSolve methods",
-           "[DenseMatrix]" )
+TEST_CASE("DenseMatrix LinearSolve methods",
+           "[DenseMatrix]")
 {
-   SECTION( "singular_system" )
+   SECTION("singular_system")
    {
       constexpr int N = 3;
 
@@ -31,43 +31,43 @@ TEST_CASE( "DenseMatrix LinearSolve methods",
       REQUIRE_FALSE(LinearSolve(A,X));
    }
 
-   SECTION( "1x1_system" )
+   SECTION("1x1_system")
    {
       constexpr int N = 1;
       DenseMatrix A(N);
       A(0,0) = 2;
 
-      double X[ 1 ] = { 12 };
+      double X[1] = { 12 };
 
       REQUIRE(LinearSolve(A,X));
       REQUIRE(X[0] == Approx(6));
    }
 
-   SECTION( "2x2_system" )
+   SECTION("2x2_system")
    {
       constexpr int N = 2;
 
-      DenseMatrix A( N );
-      A(0,0)=2. ; A(0,1)=1.;
-      A(1,0)=3. ; A(1,1)=4.;
+      DenseMatrix A(N);
+      A(0,0) = 2.0; A(0,1) = 1.0;
+      A(1,0) = 3.0; A(1,1) = 4.0;
 
-      double X[ 2 ] = { 1, 14 };
+      double X[2] = { 1, 14 };
 
       REQUIRE(LinearSolve(A,X));
       REQUIRE(X[0] == Approx(-2));
       REQUIRE(X[1] == Approx(5));
    }
 
-   SECTION( "3x3_system" )
+   SECTION("3x3_system")
    {
       constexpr int N = 3;
 
-      DenseMatrix A( N );
-      A( 0,0 )=4; A( 0,1 )=5; A( 0,2 )=-2;
-      A( 1,0 )=7; A( 1,1 )=-1; A( 1,2 )= 2;
-      A( 2,0 )=3; A( 2,1 )=1; A( 2,2 )= 4;
+      DenseMatrix A(N);
+      A(0,0) = 4; A(0,1) =  5; A(0,2) = -2;
+      A(1,0) = 7; A(1,1) = -1; A(1,2) =  2;
+      A(2,0) = 3; A(2,1) =  1; A(2,2) =  4;
 
-      double X[ 3 ] = { -14, 42, 28 };
+      double X[3] = { -14, 42, 28 };
 
       REQUIRE(LinearSolve(A,X));
       REQUIRE(X[0] == Approx(4));
@@ -114,13 +114,13 @@ TEST_CASE("DenseMatrix A*B^T methods",
       MultABt(A, B, C);
       C.Add(-1.0, Cexact);
 
-      REQUIRE( C.MaxMaxNorm() < tol );
+      REQUIRE(C.MaxMaxNorm() < tol);
 
       Mult(A, Bt, Cexact);
       MultABt(A, B, C);
       C.Add(-1.0, Cexact);
 
-      REQUIRE( C.MaxMaxNorm() < tol );
+      REQUIRE(C.MaxMaxNorm() < tol);
    }
    SECTION("MultADBt")
    {
@@ -137,7 +137,7 @@ TEST_CASE("DenseMatrix A*B^T methods",
       MultADBt(A, D, B, C);
       C.Add(-1.0, Cexact);
 
-      REQUIRE( C.MaxMaxNorm() < tol );
+      REQUIRE(C.MaxMaxNorm() < tol);
    }
    SECTION("AddMultABt")
    {
@@ -154,12 +154,12 @@ TEST_CASE("DenseMatrix A*B^T methods",
       AddMultABt(A, B, C);
       C.Add(-1.0, Cexact);
 
-      REQUIRE( C.MaxMaxNorm() < tol );
+      REQUIRE(C.MaxMaxNorm() < tol);
 
       MultABt(A, B, C);
       C *= -1.0;
       AddMultABt(A, B, C);
-      REQUIRE( C.MaxMaxNorm() < tol );
+      REQUIRE(C.MaxMaxNorm() < tol);
    }
    SECTION("AddMultADBt")
    {
@@ -179,18 +179,18 @@ TEST_CASE("DenseMatrix A*B^T methods",
       AddMultADBt(A, D, B, C);
       C.Add(-1.0, Cexact);
 
-      REQUIRE( C.MaxMaxNorm() < tol );
+      REQUIRE(C.MaxMaxNorm() < tol);
 
       MultADBt(A, D, B, C);
       C *= -1.0;
       AddMultADBt(A, D, B, C);
-      REQUIRE( C.MaxMaxNorm() < tol );
+      REQUIRE(C.MaxMaxNorm() < tol);
 
       DData[0] = 1.0; DData[1] = 1.0; DData[2] = 1.0;
       MultABt(A, B, C);
       C *= -1.0;
       AddMultADBt(A, D, B, C);
-      REQUIRE( C.MaxMaxNorm() < tol );
+      REQUIRE(C.MaxMaxNorm() < tol);
    }
    SECTION("AddMult_a_ABt")
    {
@@ -209,12 +209,12 @@ TEST_CASE("DenseMatrix A*B^T methods",
       AddMult_a_ABt(a, A, B, C);
       C.Add(-1.0, Cexact);
 
-      REQUIRE( C.MaxMaxNorm() < tol );
+      REQUIRE(C.MaxMaxNorm() < tol);
 
       MultABt(A, B, C);
       AddMult_a_ABt(-1.0, A, B, C);
 
-      REQUIRE( C.MaxMaxNorm() < tol );
+      REQUIRE(C.MaxMaxNorm() < tol);
    }
 }
 
@@ -243,5 +243,5 @@ TEST_CASE("LUFactors RightSolve", "[DenseMatrix]")
    Af2.RightSolve(3, 2, B.GetData());
    C -= B;
 
-   REQUIRE( C.MaxMaxNorm() < tol );
+   REQUIRE(C.MaxMaxNorm() < tol);
 }

--- a/tests/unit/linalg/test_densematrix.cpp
+++ b/tests/unit/linalg/test_densematrix.cpp
@@ -21,15 +21,14 @@ TEST_CASE( "DenseMatrix LinearSolve methods",
    {
       constexpr int N = 3;
 
-      DenseMatrix A( N );
-      A.SetRow( 0, 0.0 );
-      A.SetRow( 1, 0.0 );
-      A.SetRow( 2, 0.0 );
+      DenseMatrix A(N);
+      A.SetRow(0, 0.0);
+      A.SetRow(1, 0.0);
+      A.SetRow(2, 0.0);
 
       double X[3];
 
-      int rc = LinearSolve( A, X );
-      REQUIRE( rc < 0 );
+      REQUIRE_FALSE(LinearSolve(A,X));
    }
 
    SECTION( "1x1_system" )
@@ -40,9 +39,8 @@ TEST_CASE( "DenseMatrix LinearSolve methods",
 
       double X[ 1 ] = { 12 };
 
-      int rc = LinearSolve( A, X );
-      REQUIRE( rc==0 );
-      REQUIRE( X[0] == Approx(6) );
+      REQUIRE(LinearSolve(A,X));
+      REQUIRE(X[0] == Approx(6));
    }
 
    SECTION( "2x2_system" )
@@ -55,11 +53,9 @@ TEST_CASE( "DenseMatrix LinearSolve methods",
 
       double X[ 2 ] = { 1, 14 };
 
-      int rc = LinearSolve( A, X );
-
-      REQUIRE( rc==0 );
-      REQUIRE( X[0] == Approx(-2) );
-      REQUIRE( X[1] == Approx(5) );
+      REQUIRE(LinearSolve(A,X));
+      REQUIRE(X[0] == Approx(-2));
+      REQUIRE(X[1] == Approx(5));
    }
 
    SECTION( "3x3_system" )
@@ -73,12 +69,10 @@ TEST_CASE( "DenseMatrix LinearSolve methods",
 
       double X[ 3 ] = { -14, 42, 28 };
 
-      int rc = LinearSolve( A, X );
-
-      REQUIRE( rc==0 );
-      REQUIRE( X[0] == Approx(4)  );
-      REQUIRE( X[1] == Approx(-4) );
-      REQUIRE( X[2] == Approx(5) );
+      REQUIRE(LinearSolve(A,X));
+      REQUIRE(X[0] == Approx(4));
+      REQUIRE(X[1] == Approx(-4));
+      REQUIRE(X[2] == Approx(5));
    }
 
 }

--- a/tests/unit/linalg/test_densematrix.cpp
+++ b/tests/unit/linalg/test_densematrix.cpp
@@ -15,7 +15,7 @@
 using namespace mfem;
 
 TEST_CASE("DenseMatrix LinearSolve methods",
-           "[DenseMatrix]")
+          "[DenseMatrix]")
 {
    SECTION("singular_system")
    {


### PR DESCRIPTION
This PR adds a LinearSolve(A,X) routine to solve linear systems. This is essentially a convenience wrapper around the LUFactors::Factor()/LUFactors::Solve(). 

These changes are needed by PR #1123.

| PR | Author | Editor | Reviewers  | Assignment | Approval | Merge |
| --- | --- | --- | ---  | --- | --- | --- |
| https://github.com/mfem/mfem/pull/1243 | @gzagaris | @tzanio | @jakubcerveny  + @jandrej  | 01/19/20 | 01/30/20 | ⌛due 02/06/20 |