### PR TITLE
Bug in pnonlinearform

### DIFF
--- a/fem/pnonlinearform.cpp
+++ b/fem/pnonlinearform.cpp
@@ -46,7 +46,6 @@ double ParNonlinearForm::GetParGridFunctionEnergy(const Vector &x) const
 void ParNonlinearForm::Mult(const Vector &x, Vector &y) const
 {
    NonlinearForm::Mult(x, y); // x --(P)--> aux1 --(A_local)--> aux2
-   aux2.HostReadWrite();
 
    if (fnfi.Size())
    {
@@ -79,14 +78,14 @@ void ParNonlinearForm::Mult(const Vector &x, Vector &y) const
          for (int k = 0; k < fnfi.Size(); k++)
          {
             fnfi[k]->AssembleFaceVector(*fe1, *fe2, *tr, el_x, el_y);
-            aux2.AddElementVector(vdofs1, el_y.HostReadWrite());
+            aux2.AddElementVector(vdofs1, el_y.GetData());
          }
       }
    }
 
    P->MultTranspose(aux2, y);
-   y.HostReadWrite();
 
+   y.HostReadWrite();
    for (int i = 0; i < ess_tdof_list.Size(); i++)
    {
       y(ess_tdof_list[i]) = 0.0;

--- a/fem/pnonlinearform.cpp
+++ b/fem/pnonlinearform.cpp
@@ -46,7 +46,7 @@ double ParNonlinearForm::GetParGridFunctionEnergy(const Vector &x) const
 void ParNonlinearForm::Mult(const Vector &x, Vector &y) const
 {
    NonlinearForm::Mult(x, y); // x --(P)--> aux1 --(A_local)--> aux2
-   Y.MakeRef(aux2, 0); // aux2 contains A_local.P.x
+   aux2.HostReadWrite();
 
    if (fnfi.Size())
    {
@@ -58,8 +58,8 @@ void ParNonlinearForm::Mult(const Vector &x, Vector &y) const
       Array<int> vdofs1, vdofs2;
       Vector el_x, el_y;
 
+      aux1.HostReadWrite();
       X.MakeRef(aux1, 0); // aux1 contains P.x
-      X.ExchangeFaceNbrData();
       const int n_shared_faces = pmesh->GetNSharedFaces();
       for (int i = 0; i < n_shared_faces; i++)
       {
@@ -78,12 +78,13 @@ void ParNonlinearForm::Mult(const Vector &x, Vector &y) const
          for (int k = 0; k < fnfi.Size(); k++)
          {
             fnfi[k]->AssembleFaceVector(*fe1, *fe2, *tr, el_x, el_y);
-            Y.AddElementVector(vdofs1, el_y.GetData());
+            aux2.AddElementVector(vdofs1, el_y.HostReadWrite());
          }
       }
    }
 
-   P->MultTranspose(Y, y);
+   P->MultTranspose(aux2, y);
+   y.HostReadWrite();
 
    for (int i = 0; i < ess_tdof_list.Size(); i++)
    {

--- a/fem/pnonlinearform.cpp
+++ b/fem/pnonlinearform.cpp
@@ -60,6 +60,7 @@ void ParNonlinearForm::Mult(const Vector &x, Vector &y) const
 
       aux1.HostReadWrite();
       X.MakeRef(aux1, 0); // aux1 contains P.x
+      X.ExchangeFaceNbrData();
       const int n_shared_faces = pmesh->GetNSharedFaces();
       for (int i = 0; i < n_shared_faces; i++)
       {


### PR DESCRIPTION
An alias was trying to be registered when using the cuda backend. Issue occurred in the AddElementVector method. Could we just use the object directly in this case?

| PR | Author | Editor | Reviewers  | Assignment | Approval | Merge |
| --- | --- | --- | ---  | --- | --- | --- |
| https://github.com/mfem/mfem/pull/1251 | @artv3 | @v-dobrev | @v-dobrev + @camierjs | 01/28/20 | 01/31/20 | ⌛due 02/07/20 |
