### PR TITLE
Adapt FGMRESSolver print behavior

### DIFF
--- a/linalg/solvers.cpp
+++ b/linalg/solvers.cpp
@@ -803,9 +803,11 @@ void FGMRESSolver::Mult(const Vector &b, Vector &x) const
    }
 
    if (print_level == 1)
+   {
       mfem::out << "   Pass : " << setw(2) << 1
                 << "   Iteration : " << setw(3) << 0
                 << "  || r || = " << beta << endl;
+   }
 
    Array<Vector*> v(m+1);
    Array<Vector*> z(m+1);
@@ -862,9 +864,11 @@ void FGMRESSolver::Mult(const Vector &b, Vector &x) const
          double resid = fabs(s(i+1));
          MFEM_ASSERT(IsFinite(resid), "resid = " << resid);
          if (print_level == 1)
+         {
             mfem::out << "   Pass : " << setw(2) << (j-1)/m+1
                       << "   Iteration : " << setw(3) << j
                       << "  || r || = " << resid << endl;
+         }
 
          if (resid <= final_norm)
          {

--- a/linalg/solvers.cpp
+++ b/linalg/solvers.cpp
@@ -802,7 +802,7 @@ void FGMRESSolver::Mult(const Vector &b, Vector &x) const
       return;
    }
 
-   if (print_level>=0)
+   if (print_level == 1)
       mfem::out << "   Pass : " << setw(2) << 1
                 << "   Iteration : " << setw(3) << 0
                 << "  || r || = " << beta << endl;
@@ -861,17 +861,23 @@ void FGMRESSolver::Mult(const Vector &b, Vector &x) const
 
          double resid = fabs(s(i+1));
          MFEM_ASSERT(IsFinite(resid), "resid = " << resid);
-         if (print_level >= 0)
+         if (print_level == 1)
             mfem::out << "   Pass : " << setw(2) << (j-1)/m+1
                       << "   Iteration : " << setw(3) << j
                       << "  || r || = " << resid << endl;
 
-         if ( resid <= final_norm)
+         if (resid <= final_norm)
          {
             Update(x, i, H, s, z);
             final_norm = resid;
             final_iter = j;
             converged = 1;
+
+            if (print_level == 2)
+            {
+               mfem::out << "Number of FGMRES iterations: " << final_iter << endl;
+            }
+
             for (i= 0; i<=m; i++)
             {
                if (v[i]) { delete v[i]; }
@@ -881,7 +887,7 @@ void FGMRESSolver::Mult(const Vector &b, Vector &x) const
          }
       }
 
-      if (print_level>=0)
+      if (print_level == 1)
       {
          mfem::out << "Restarting..." << endl;
       }
@@ -892,11 +898,17 @@ void FGMRESSolver::Mult(const Vector &b, Vector &x) const
       subtract(b,r,r);
       beta = Norm(r);
       MFEM_ASSERT(IsFinite(beta), "beta = " << beta);
-      if ( beta <= final_norm)
+      if (beta <= final_norm)
       {
          final_norm = beta;
          final_iter = j;
          converged = 1;
+
+         if (print_level == 2)
+         {
+            mfem::out << "Number of FGMRES iterations: " << final_iter << endl;
+         }
+
          for (i= 0; i<=m; i++)
          {
             if (v[i]) { delete v[i]; }
@@ -912,8 +924,13 @@ void FGMRESSolver::Mult(const Vector &b, Vector &x) const
       if (z[i]) { delete z[i]; }
    }
    converged = 0;
-   return;
 
+   if (print_level >= 0)
+   {
+      mfem::out << "FGMRES: No convergence!" << endl;
+   }
+
+   return;
 }
 
 


### PR DESCRIPTION
This PR adapts the `print_level` behavior of `FGMRESSolver` to the one in `CGSolver`. E.g. 
* Iteration information on `print_level == 1`
* compact info on `print_level == 2`
* no info, except failure, `print_level == 0`
* "silence" with `print_level <= 0`

Addresses #1201.

| PR | Author | Editor | Reviewers  | Assignment | Approval | Merge |
| --- | --- | --- | ---  | --- | --- | --- |
| https://github.com/mfem/mfem/pull/1253 | @jandrej | @tzanio | @tzanio + @v-dobrev | 01/24/21 | 01/27/20 | ⌛due 01/31/20 |