### PR TITLE
Add AssembleDiagonal to VectorMass and VectorDiffusion

### DIFF
--- a/fem/bilininteg.hpp
+++ b/fem/bilininteg.hpp
@@ -2008,6 +2008,7 @@ public:
                                        DenseMatrix &elmat);
    using BilinearFormIntegrator::AssemblePA;
    virtual void AssemblePA(const FiniteElementSpace &fes);
+   virtual void AssembleDiagonalPA(Vector &diag);
    virtual void AddMultPA(const Vector &x, Vector &y) const;
 };
 
@@ -2322,6 +2323,7 @@ public:
                                       const Vector &elfun, Vector &elvect);
    using BilinearFormIntegrator::AssemblePA;
    virtual void AssemblePA(const FiniteElementSpace &fes);
+   virtual void AssembleDiagonalPA(Vector &diag);
    virtual void AddMultPA(const Vector &x, Vector &y) const;
 };
 

--- a/fem/bilininteg_vecdiffusion.cpp
+++ b/fem/bilininteg_vecdiffusion.cpp
@@ -659,20 +659,10 @@ static void PAVectorDiffusionDiagonal3D(const int NE,
                         temp += L * QDD[qx][dy][dz] * R;
                      }
                      Y(dx, dy, dz, 0, e) += temp;
+                     Y(dx, dy, dz, 1, e) += temp;
+                     Y(dx, dy, dz, 2, e) += temp;
                   }
                }
-            }
-         }
-      }
-
-      for (int dz = 0; dz < D1D; ++dz)
-      {
-         for (int dy = 0; dy < D1D; ++dy)
-         {
-            for (int dx = 0; dx < D1D; ++dx)
-            {
-               Y(dx, dy, dz, 1, e) += Y(dx, dy, dz, 0, e);
-               Y(dx, dy, dz, 2, e) += Y(dx, dy, dz, 0, e);
             }
          }
       }

--- a/fem/bilininteg_vecdiffusion.cpp
+++ b/fem/bilininteg_vecdiffusion.cpp
@@ -552,14 +552,16 @@ static void PAVectorDiffusionDiagonal2D(const int NE,
       {
          for (int dx = 0; dx < D1D; ++dx)
          {
+            double temp = 0.0;
             for (int qx = 0; qx < Q1D; ++qx)
             {
-               Y(dx,dy,0,e) += G(qx, dx) * G(qx, dx) * QD0[qx][dy];
-               Y(dx,dy,0,e) += G(qx, dx) * B(qx, dx) * QD1[qx][dy];
-               Y(dx,dy,0,e) += B(qx, dx) * G(qx, dx) * QD1[qx][dy];
-               Y(dx,dy,0,e) += B(qx, dx) * B(qx, dx) * QD2[qx][dy];
+               temp += G(qx, dx) * G(qx, dx) * QD0[qx][dy];
+               temp += G(qx, dx) * B(qx, dx) * QD1[qx][dy];
+               temp += B(qx, dx) * G(qx, dx) * QD1[qx][dy];
+               temp += B(qx, dx) * B(qx, dx) * QD2[qx][dy];
             }
-            Y(dx,dy,1,e) += Y(dx,dy,0,e);
+            Y(dx,dy,0,e) += temp;
+            Y(dx,dy,1,e) += temp;
          }
       }
    });
@@ -647,14 +649,16 @@ static void PAVectorDiffusionDiagonal3D(const int NE,
                {
                   for (int dx = 0; dx < D1D; ++dx)
                   {
+                     double temp = 0.0;
                      for (int qx = 0; qx < Q1D; ++qx)
                      {
                         const double Bx = B(qx,dx);
                         const double Gx = G(qx,dx);
                         const double L = i==0 ? Gx : Bx;
                         const double R = j==0 ? Gx : Bx;
-                        Y(dx, dy, dz, 0, e) += L * QDD[qx][dy][dz] * R;
+                        temp += L * QDD[qx][dy][dz] * R;
                      }
+                     Y(dx, dy, dz, 0, e) += temp;
                   }
                }
             }

--- a/fem/bilininteg_vecdiffusion.cpp
+++ b/fem/bilininteg_vecdiffusion.cpp
@@ -692,7 +692,7 @@ static void PAVectorDiffusionAssembleDiagonal(const int dim,
    {
       return PAVectorDiffusionDiagonal3D(NE, B, G, op, y, D1D, Q1D);
    }
-   MFEM_ABORT("Unknown kernel.");
+   MFEM_ABORT("Dimension not implemented.");
 }
 
 void VectorDiffusionIntegrator::AssembleDiagonalPA(Vector &diag)

--- a/fem/bilininteg_vecdiffusion.cpp
+++ b/fem/bilininteg_vecdiffusion.cpp
@@ -500,4 +500,211 @@ void VectorDiffusionIntegrator::AddMultPA(const Vector &x, Vector &y) const
                           pa_data, x, y);
 }
 
+template<int T_D1D = 0, int T_Q1D = 0>
+static void PAVectorDiffusionDiagonal2D(const int NE,
+                                        const Array<double> &b,
+                                        const Array<double> &g,
+                                        const Vector &d,
+                                        Vector &y,
+                                        const int d1d = 0,
+                                        const int q1d = 0)
+{
+   const int D1D = T_D1D ? T_D1D : d1d;
+   const int Q1D = T_Q1D ? T_Q1D : q1d;
+   MFEM_VERIFY(D1D <= MAX_D1D, "");
+   MFEM_VERIFY(Q1D <= MAX_Q1D, "");
+   auto B = Reshape(b.Read(), Q1D, D1D);
+   auto G = Reshape(g.Read(), Q1D, D1D);
+   // note the different shape for D, this is a (symmetric) matrix so we only
+   // store necessary entries
+   auto D = Reshape(d.Read(), Q1D*Q1D, 3, NE);
+   auto Y = Reshape(y.ReadWrite(), D1D, D1D, 2, NE);
+   MFEM_FORALL(e, NE,
+   {
+      const int D1D = T_D1D ? T_D1D : d1d;
+      const int Q1D = T_Q1D ? T_Q1D : q1d;
+      constexpr int MD1 = T_D1D ? T_D1D : MAX_D1D;
+      constexpr int MQ1 = T_Q1D ? T_Q1D : MAX_Q1D;
+      // gradphi \cdot Q \gradphi has four terms
+      double QD0[MQ1][MD1];
+      double QD1[MQ1][MD1];
+      double QD2[MQ1][MD1];
+      for (int qx = 0; qx < Q1D; ++qx)
+      {
+         for (int dy = 0; dy < D1D; ++dy)
+         {
+            QD0[qx][dy] = 0.0;
+            QD1[qx][dy] = 0.0;
+            QD2[qx][dy] = 0.0;
+            for (int qy = 0; qy < Q1D; ++qy)
+            {
+               const int q = qx + qy * Q1D;
+               const double D0 = D(q,0,e);
+               const double D1 = D(q,1,e);
+               const double D2 = D(q,2,e);
+               QD0[qx][dy] += B(qy, dy) * B(qy, dy) * D0;
+               QD1[qx][dy] += B(qy, dy) * G(qy, dy) * D1;
+               QD2[qx][dy] += G(qy, dy) * G(qy, dy) * D2;
+            }
+         }
+      }
+      for (int dy = 0; dy < D1D; ++dy)
+      {
+         for (int dx = 0; dx < D1D; ++dx)
+         {
+            for (int qx = 0; qx < Q1D; ++qx)
+            {
+               Y(dx,dy,0,e) += G(qx, dx) * G(qx, dx) * QD0[qx][dy];
+               Y(dx,dy,0,e) += G(qx, dx) * B(qx, dx) * QD1[qx][dy];
+               Y(dx,dy,0,e) += B(qx, dx) * G(qx, dx) * QD1[qx][dy];
+               Y(dx,dy,0,e) += B(qx, dx) * B(qx, dx) * QD2[qx][dy];
+            }
+            Y(dx,dy,1,e) += Y(dx,dy,0,e);
+         }
+      }
+   });
+}
+
+template<int T_D1D = 0, int T_Q1D = 0>
+static void PAVectorDiffusionDiagonal3D(const int NE,
+                                        const Array<double> &b,
+                                        const Array<double> &g,
+                                        const Vector &d,
+                                        Vector &y,
+                                        const int d1d = 0,
+                                        const int q1d = 0)
+{
+   constexpr int DIM = 3;
+   const int D1D = T_D1D ? T_D1D : d1d;
+   const int Q1D = T_Q1D ? T_Q1D : q1d;
+   constexpr int MQ1 = T_Q1D ? T_Q1D : MAX_Q1D;
+   constexpr int MD1 = T_D1D ? T_D1D : MAX_D1D;
+   MFEM_VERIFY(D1D <= MD1, "");
+   MFEM_VERIFY(Q1D <= MQ1, "");
+   auto B = Reshape(b.Read(), Q1D, D1D);
+   auto G = Reshape(g.Read(), Q1D, D1D);
+   auto Q = Reshape(d.Read(), Q1D*Q1D*Q1D, 6, NE);
+   auto Y = Reshape(y.ReadWrite(), D1D, D1D, D1D, 3, NE);
+   MFEM_FORALL(e, NE,
+   {
+      const int D1D = T_D1D ? T_D1D : d1d;
+      const int Q1D = T_Q1D ? T_Q1D : q1d;
+      constexpr int MD1 = T_D1D ? T_D1D : MAX_D1D;
+      constexpr int MQ1 = T_Q1D ? T_Q1D : MAX_Q1D;
+      double QQD[MQ1][MQ1][MD1];
+      double QDD[MQ1][MD1][MD1];
+      for (int i = 0; i < DIM; ++i)
+      {
+         for (int j = 0; j < DIM; ++j)
+         {
+            // first tensor contraction, along z direction
+            for (int qx = 0; qx < Q1D; ++qx)
+            {
+               for (int qy = 0; qy < Q1D; ++qy)
+               {
+                  for (int dz = 0; dz < D1D; ++dz)
+                  {
+                     QQD[qx][qy][dz] = 0.0;
+                     for (int qz = 0; qz < Q1D; ++qz)
+                     {
+                        const int q = qx + (qy + qz * Q1D) * Q1D;
+                        const int k = j >= i ?
+                        3 - (3-i)*(2-i)/2 + j:
+                        3 - (3-j)*(2-j)/2 + i;
+                        const double O = Q(q,k,e);
+                        const double Bz = B(qz,dz);
+                        const double Gz = G(qz,dz);
+                        const double L = i==2 ? Gz : Bz;
+                        const double R = j==2 ? Gz : Bz;
+                        QQD[qx][qy][dz] += L * O * R;
+                     }
+                  }
+               }
+            }
+            // second tensor contraction, along y direction
+            for (int qx = 0; qx < Q1D; ++qx)
+            {
+               for (int dz = 0; dz < D1D; ++dz)
+               {
+                  for (int dy = 0; dy < D1D; ++dy)
+                  {
+                     QDD[qx][dy][dz] = 0.0;
+                     for (int qy = 0; qy < Q1D; ++qy)
+                     {
+                        const double By = B(qy,dy);
+                        const double Gy = G(qy,dy);
+                        const double L = i==1 ? Gy : By;
+                        const double R = j==1 ? Gy : By;
+                        QDD[qx][dy][dz] += L * QQD[qx][qy][dz] * R;
+                     }
+                  }
+               }
+            }
+            // third tensor contraction, along x direction
+            for (int dz = 0; dz < D1D; ++dz)
+            {
+               for (int dy = 0; dy < D1D; ++dy)
+               {
+                  for (int dx = 0; dx < D1D; ++dx)
+                  {
+                     for (int qx = 0; qx < Q1D; ++qx)
+                     {
+                        const double Bx = B(qx,dx);
+                        const double Gx = G(qx,dx);
+                        const double L = i==0 ? Gx : Bx;
+                        const double R = j==0 ? Gx : Bx;
+                        Y(dx, dy, dz, 0, e) += L * QDD[qx][dy][dz] * R;
+                     }
+                  }
+               }
+            }
+         }
+      }
+
+      for (int dz = 0; dz < D1D; ++dz)
+      {
+         for (int dy = 0; dy < D1D; ++dy)
+         {
+            for (int dx = 0; dx < D1D; ++dx)
+            {
+               Y(dx, dy, dz, 1, e) += Y(dx, dy, dz, 0, e);
+               Y(dx, dy, dz, 2, e) += Y(dx, dy, dz, 0, e);
+            }
+         }
+      }
+   });
+}
+
+static void PAVectorDiffusionAssembleDiagonal(const int dim,
+                                              const int D1D,
+                                              const int Q1D,
+                                              const int NE,
+                                              const Array<double> &B,
+                                              const Array<double> &G,
+                                              const Vector &op,
+                                              Vector &y)
+{
+   if (dim == 2)
+   {
+      return PAVectorDiffusionDiagonal2D(NE, B, G, op, y, D1D, Q1D);
+   }
+   else if (dim == 3)
+   {
+      return PAVectorDiffusionDiagonal3D(NE, B, G, op, y, D1D, Q1D);
+   }
+   MFEM_ABORT("Unknown kernel.");
+}
+
+void VectorDiffusionIntegrator::AssembleDiagonalPA(Vector &diag)
+{
+   PAVectorDiffusionAssembleDiagonal(dim,
+                                     dofs1D,
+                                     quad1D,
+                                     ne,
+                                     maps->B,
+                                     maps->G,
+                                     pa_data,
+                                     diag);
+}
+
 } // namespace mfem

--- a/fem/bilininteg_vecmass.cpp
+++ b/fem/bilininteg_vecmass.cpp
@@ -409,8 +409,8 @@ static void PAVectorMassAssembleDiagonal2D(const int NE,
             {
                temp1 += B(qx, dx) * B(qx, dx) * temp[qx][dy];
             }
-            y(dx, dy, 0, e) = temp1;
-            y(dx, dy, 1, e) = temp1;
+            y(dx, dy, 0, e) += temp1;
+            y(dx, dy, 1, e) += temp1;
          }
       }
    });
@@ -483,9 +483,9 @@ static void PAVectorMassAssembleDiagonal3D(const int NE,
                   temp3 += B(qx, dx) * B(qx, dx)
                            * temp2[qx][dy][dz];
                }
-               y(dx, dy, dz, 0, e) = temp3;
-               y(dx, dy, dz, 1, e) = temp3;
-               y(dx, dy, dz, 2, e) = temp3;
+               y(dx, dy, dz, 0, e) += temp3;
+               y(dx, dy, dz, 1, e) += temp3;
+               y(dx, dy, dz, 2, e) += temp3;
             }
          }
       }

--- a/fem/bilininteg_vecmass.cpp
+++ b/fem/bilininteg_vecmass.cpp
@@ -409,8 +409,8 @@ static void PAVectorMassAssembleDiagonal2D(const int NE,
             {
                temp1 += B(qx, dx) * B(qx, dx) * temp[qx][dy];
             }
-            y(dx, dy, 0, e) += temp1;
-            y(dx, dy, 1, e) += temp1;
+            y(dx, dy, 0, e) = temp1;
+            y(dx, dy, 1, e) = temp1;
          }
       }
    });
@@ -483,9 +483,9 @@ static void PAVectorMassAssembleDiagonal3D(const int NE,
                   temp3 += B(qx, dx) * B(qx, dx)
                            * temp2[qx][dy][dz];
                }
-               y(dx, dy, dz, 0, e) += temp3;
-               y(dx, dy, dz, 1, e) += temp3;
-               y(dx, dy, dz, 2, e) += temp3;
+               y(dx, dy, dz, 0, e) = temp3;
+               y(dx, dy, dz, 1, e) = temp3;
+               y(dx, dy, dz, 2, e) = temp3;
             }
          }
       }

--- a/fem/bilininteg_vecmass.cpp
+++ b/fem/bilininteg_vecmass.cpp
@@ -404,11 +404,13 @@ static void PAVectorMassAssembleDiagonal2D(const int NE,
       {
          for (int dx = 0; dx < D1D; ++dx)
          {
+            double temp1 = 0.0;
             for (int qx = 0; qx < Q1D; ++qx)
             {
-               y(dx, dy, 0, e) += B(qx, dx) * B(qx, dx) * temp[qx][dy];
+               temp1 += B(qx, dx) * B(qx, dx) * temp[qx][dy];
             }
-            y(dx, dy, 1, e) = y(dx, dy, 0, e);
+            y(dx, dy, 0, e) = temp1;
+            y(dx, dy, 1, e) = temp1;
          }
       }
    });
@@ -475,13 +477,15 @@ static void PAVectorMassAssembleDiagonal3D(const int NE,
          {
             for (int dx = 0; dx < D1D; ++dx)
             {
+               double temp3 = 0.0;
                for (int qx = 0; qx < Q1D; ++qx)
                {
-                  y(dx, dy, dz, 0, e) += B(qx, dx) * B(qx, dx)
-                                         * temp2[qx][dy][dz];
+                  temp3 += B(qx, dx) * B(qx, dx)
+                           * temp2[qx][dy][dz];
                }
-               y(dx, dy, dz, 1, e) = y(dx, dy, dz, 0, e);
-               y(dx, dy, dz, 2, e) = y(dx, dy, dz, 0, e);
+               y(dx, dy, dz, 0, e) = temp3;
+               y(dx, dy, dz, 1, e) = temp3;
+               y(dx, dy, dz, 2, e) = temp3;
             }
          }
       }

--- a/fem/bilininteg_vecmass.cpp
+++ b/fem/bilininteg_vecmass.cpp
@@ -429,7 +429,6 @@ static void PAVectorMassAssembleDiagonal3D(const int NE,
    MFEM_VERIFY(D1D <= MAX_D1D, "");
    MFEM_VERIFY(Q1D <= MAX_Q1D, "");
    auto B = Reshape(_B.Read(), Q1D, D1D);
-   // auto Bt = Reshape(_Bt.Read(), D1D, Q1D); // ?? (TODO atb@llnl.gov)
    auto op = Reshape(_op.Read(), Q1D, Q1D, Q1D, NE);
    auto y = Reshape(_diag.ReadWrite(), D1D, D1D, D1D, VDIM, NE);
    MFEM_FORALL(e, NE,
@@ -506,7 +505,7 @@ static void PAVectorMassAssembleDiagonal(const int dim,
    {
       return PAVectorMassAssembleDiagonal3D(NE, B, Bt, op, y, D1D, Q1D);
    }
-   MFEM_ABORT("Unknown kernel.");
+   MFEM_ABORT("Dimension not implemented.");
 }
 
 void VectorMassIntegrator::AssembleDiagonalPA(Vector &diag)

--- a/fem/bilininteg_vecmass.cpp
+++ b/fem/bilininteg_vecmass.cpp
@@ -364,4 +364,161 @@ void VectorMassIntegrator::AddMultPA(const Vector &x, Vector &y) const
    PAVectorMassApply(dim, dofs1D, quad1D, ne, maps->B, maps->Bt, pa_data, x, y);
 }
 
+template<const int T_D1D = 0, const int T_Q1D = 0>
+static void PAVectorMassAssembleDiagonal2D(const int NE,
+                                           const Array<double> &_B,
+                                           const Array<double> &_Bt,
+                                           const Vector &_op,
+                                           Vector &_diag,
+                                           const int d1d = 0,
+                                           const int q1d = 0)
+{
+   const int D1D = T_D1D ? T_D1D : d1d;
+   const int Q1D = T_Q1D ? T_Q1D : q1d;
+   constexpr int VDIM = 2;
+   MFEM_VERIFY(D1D <= MAX_D1D, "");
+   MFEM_VERIFY(Q1D <= MAX_Q1D, "");
+   auto B = Reshape(_B.Read(), Q1D, D1D);
+   auto op = Reshape(_op.Read(), Q1D, Q1D, NE);
+   auto y = Reshape(_diag.ReadWrite(), D1D, D1D, VDIM, NE);
+   MFEM_FORALL(e, NE,
+   {
+      const int D1D = T_D1D ? T_D1D : d1d;
+      const int Q1D = T_Q1D ? T_Q1D : q1d;
+      constexpr int max_D1D = T_D1D ? T_D1D : MAX_D1D;
+      constexpr int max_Q1D = T_Q1D ? T_Q1D : MAX_Q1D;
+
+      double temp[max_Q1D][max_D1D];
+      for (int qx = 0; qx < Q1D; ++qx)
+      {
+         for (int dy = 0; dy < D1D; ++dy)
+         {
+            temp[qx][dy] = 0.0;
+            for (int qy = 0; qy < Q1D; ++qy)
+            {
+               temp[qx][dy] += B(qy, dy) * B(qy, dy) * op(qx, qy, e);
+            }
+         }
+      }
+      for (int dy = 0; dy < D1D; ++dy)
+      {
+         for (int dx = 0; dx < D1D; ++dx)
+         {
+            for (int qx = 0; qx < Q1D; ++qx)
+            {
+               y(dx, dy, 0, e) += B(qx, dx) * B(qx, dx) * temp[qx][dy];
+            }
+            y(dx, dy, 1, e) = y(dx, dy, 0, e);
+         }
+      }
+   });
+}
+
+template<const int T_D1D = 0, const int T_Q1D = 0>
+static void PAVectorMassAssembleDiagonal3D(const int NE,
+                                           const Array<double> &_B,
+                                           const Array<double> &_Bt,
+                                           const Vector &_op,
+                                           Vector &_diag,
+                                           const int d1d = 0,
+                                           const int q1d = 0)
+{
+   const int D1D = T_D1D ? T_D1D : d1d;
+   const int Q1D = T_Q1D ? T_Q1D : q1d;
+   constexpr int VDIM = 3;
+   MFEM_VERIFY(D1D <= MAX_D1D, "");
+   MFEM_VERIFY(Q1D <= MAX_Q1D, "");
+   auto B = Reshape(_B.Read(), Q1D, D1D);
+   // auto Bt = Reshape(_Bt.Read(), D1D, Q1D); // ?? (TODO atb@llnl.gov)
+   auto op = Reshape(_op.Read(), Q1D, Q1D, Q1D, NE);
+   auto y = Reshape(_diag.ReadWrite(), D1D, D1D, D1D, VDIM, NE);
+   MFEM_FORALL(e, NE,
+   {
+      const int D1D = T_D1D ? T_D1D : d1d; // nvcc workaround
+      const int Q1D = T_Q1D ? T_Q1D : q1d;
+      // the following variables are evaluated at compile time
+      constexpr int max_D1D = T_D1D ? T_D1D : MAX_D1D;
+      constexpr int max_Q1D = T_Q1D ? T_Q1D : MAX_Q1D;
+
+      double temp[max_Q1D][max_Q1D][max_D1D];
+      for (int qx = 0; qx < Q1D; ++qx)
+      {
+         for (int qy = 0; qy < Q1D; ++qy)
+         {
+            for (int dz = 0; dz < D1D; ++dz)
+            {
+               temp[qx][qy][dz] = 0.0;
+               for (int qz = 0; qz < Q1D; ++qz)
+               {
+                  temp[qx][qy][dz] += B(qz, dz) * B(qz, dz) * op(qx, qy, qz, e);
+               }
+            }
+         }
+      }
+      double temp2[max_Q1D][max_D1D][max_D1D];
+      for (int qx = 0; qx < Q1D; ++qx)
+      {
+         for (int dz = 0; dz < D1D; ++dz)
+         {
+            for (int dy = 0; dy < D1D; ++dy)
+            {
+               temp2[qx][dy][dz] = 0.0;
+               for (int qy = 0; qy < Q1D; ++qy)
+               {
+                  temp2[qx][dy][dz] += B(qy, dy) * B(qy, dy) * temp[qx][qy][dz];
+               }
+            }
+         }
+      }
+      for (int dz = 0; dz < D1D; ++dz)
+      {
+         for (int dy = 0; dy < D1D; ++dy)
+         {
+            for (int dx = 0; dx < D1D; ++dx)
+            {
+               for (int qx = 0; qx < Q1D; ++qx)
+               {
+                  y(dx, dy, dz, 0, e) += B(qx, dx) * B(qx, dx)
+                                         * temp2[qx][dy][dz];
+               }
+               y(dx, dy, dz, 1, e) = y(dx, dy, dz, 0, e);
+               y(dx, dy, dz, 2, e) = y(dx, dy, dz, 0, e);
+            }
+         }
+      }
+   });
+}
+
+static void PAVectorMassAssembleDiagonal(const int dim,
+                                         const int D1D,
+                                         const int Q1D,
+                                         const int NE,
+                                         const Array<double> &B,
+                                         const Array<double> &Bt,
+                                         const Vector &op,
+                                         Vector &y)
+{
+   if (dim == 2)
+   {
+      return PAVectorMassAssembleDiagonal2D(NE, B, Bt, op, y, D1D, Q1D);
+   }
+   else if (dim == 3)
+   {
+      return PAVectorMassAssembleDiagonal3D(NE, B, Bt, op, y, D1D, Q1D);
+   }
+   MFEM_ABORT("Unknown kernel.");
+}
+
+void VectorMassIntegrator::AssembleDiagonalPA(Vector &diag)
+{
+   PAVectorMassAssembleDiagonal(dim,
+                                dofs1D,
+                                quad1D,
+                                ne,
+                                maps->B,
+                                maps->Bt,
+                                pa_data,
+                                diag);
+}
+
 } // namespace mfem

--- a/tests/unit/fem/test_assemblediagonalpa.cpp
+++ b/tests/unit/fem/test_assemblediagonalpa.cpp
@@ -115,7 +115,7 @@ TEST_CASE("diffusiondiag")
 }
 
 template <typename INTEGRATOR>
-double test_vectorintegratordiagonalpa(int dim, int order)
+double test_vdiagpa(int dim, int order)
 {
    Mesh *mesh = nullptr;
    if (dim == 2)
@@ -157,20 +157,20 @@ TEST_CASE("Vector Mass Diagonal PA", "[PartialAssembly], [AssembleDiagonal]")
 {
    SECTION("2D")
    {
-      REQUIRE(test_vectorintegratordiagonalpa<VectorMassIntegrator>(2, 2) == Approx(
-                 0.0));
+      REQUIRE(test_vdiagpa<VectorMassIntegrator>(2,
+                                                 2) == Approx(0.0));
 
-      REQUIRE(test_vectorintegratordiagonalpa<VectorMassIntegrator>(2, 3) == Approx(
-                 0.0));
+      REQUIRE(test_vdiagpa<VectorMassIntegrator>(2,
+                                                 3) == Approx(0.0));
    }
 
    SECTION("3D")
    {
-      REQUIRE(test_vectorintegratordiagonalpa<VectorMassIntegrator>(3, 2) == Approx(
-                 0.0));
+      REQUIRE(test_vdiagpa<VectorMassIntegrator>(3,
+                                                 2) == Approx(0.0));
 
-      REQUIRE(test_vectorintegratordiagonalpa<VectorMassIntegrator>(3, 3) == Approx(
-                 0.0));
+      REQUIRE(test_vdiagpa<VectorMassIntegrator>(3,
+                                                 3) == Approx(0.0));
    }
 }
 
@@ -180,24 +180,20 @@ TEST_CASE("Vector Diffusion Diagonal PA",
    SECTION("2D")
    {
       REQUIRE(
-         test_vectorintegratordiagonalpa<VectorDiffusionIntegrator>(2,
-                                                                    2) == Approx(
-            0.0));
+         test_vdiagpa<VectorDiffusionIntegrator>(2,
+                                                 2) == Approx(0.0));
 
-      REQUIRE(test_vectorintegratordiagonalpa<VectorDiffusionIntegrator>(2,
-                                                                         3) == Approx(
-                 0.0));
+      REQUIRE(test_vdiagpa<VectorDiffusionIntegrator>(2,
+                                                      3) == Approx(0.0));
    }
 
    SECTION("3D")
    {
-      REQUIRE(test_vectorintegratordiagonalpa<VectorDiffusionIntegrator>(3,
-                                                                         2) == Approx(
-                 0.0));
+      REQUIRE(test_vdiagpa<VectorDiffusionIntegrator>(3,
+                                                      2) == Approx(0.0));
 
-      REQUIRE(test_vectorintegratordiagonalpa<VectorDiffusionIntegrator>(3,
-                                                                         3) == Approx(
-                 0.0));
+      REQUIRE(test_vdiagpa<VectorDiffusionIntegrator>(3,
+                                                      3) == Approx(0.0));
    }
 }
 

--- a/tests/unit/fem/test_assemblediagonalpa.cpp
+++ b/tests/unit/fem/test_assemblediagonalpa.cpp
@@ -115,7 +115,7 @@ TEST_CASE("diffusiondiag")
 }
 
 template <typename INTEGRATOR>
-double test_vectorintegratordiagonalpa(int dim)
+double test_vectorintegratordiagonalpa(int dim, int order)
 {
    Mesh *mesh = nullptr;
    if (dim == 2)
@@ -126,8 +126,6 @@ double test_vectorintegratordiagonalpa(int dim)
    {
       mesh = new Mesh(2, 2, 2, Element::HEXAHEDRON, 0, 1.0, 1.0, 1.0);
    }
-
-   int order = 2;
 
    H1_FECollection fec(order, dim);
    FiniteElementSpace fes(mesh, &fec, dim);
@@ -159,13 +157,19 @@ TEST_CASE("Vector Mass Diagonal PA", "[PartialAssembly], [AssembleDiagonal]")
 {
    SECTION("2D")
    {
-      REQUIRE(test_vectorintegratordiagonalpa<VectorMassIntegrator>(2) == Approx(
+      REQUIRE(test_vectorintegratordiagonalpa<VectorMassIntegrator>(2, 2) == Approx(
+                 0.0));
+
+      REQUIRE(test_vectorintegratordiagonalpa<VectorMassIntegrator>(2, 3) == Approx(
                  0.0));
    }
 
    SECTION("3D")
    {
-      REQUIRE(test_vectorintegratordiagonalpa<VectorMassIntegrator>(3) == Approx(
+      REQUIRE(test_vectorintegratordiagonalpa<VectorMassIntegrator>(3, 2) == Approx(
+                 0.0));
+
+      REQUIRE(test_vectorintegratordiagonalpa<VectorMassIntegrator>(3, 3) == Approx(
                  0.0));
    }
 }
@@ -175,13 +179,24 @@ TEST_CASE("Vector Diffusion Diagonal PA",
 {
    SECTION("2D")
    {
-      REQUIRE(test_vectorintegratordiagonalpa<VectorDiffusionIntegrator>(2) == Approx(
+      REQUIRE(
+         test_vectorintegratordiagonalpa<VectorDiffusionIntegrator>(2,
+                                                                    2) == Approx(
+            0.0));
+
+      REQUIRE(test_vectorintegratordiagonalpa<VectorDiffusionIntegrator>(2,
+                                                                         3) == Approx(
                  0.0));
    }
 
    SECTION("3D")
    {
-      REQUIRE(test_vectorintegratordiagonalpa<VectorDiffusionIntegrator>(3) == Approx(
+      REQUIRE(test_vectorintegratordiagonalpa<VectorDiffusionIntegrator>(3,
+                                                                         2) == Approx(
+                 0.0));
+
+      REQUIRE(test_vectorintegratordiagonalpa<VectorDiffusionIntegrator>(3,
+                                                                         3) == Approx(
                  0.0));
    }
 }

--- a/tests/unit/fem/test_assemblediagonalpa.cpp
+++ b/tests/unit/fem/test_assemblediagonalpa.cpp
@@ -114,4 +114,76 @@ TEST_CASE("diffusiondiag")
    }
 }
 
+template <typename INTEGRATOR>
+double test_vectorintegratordiagonalpa(int dim)
+{
+   Mesh *mesh = nullptr;
+   if (dim == 2)
+   {
+      mesh = new Mesh(2, 2, Element::QUADRILATERAL, 0, 1.0, 1.0);
+   }
+   else if (dim == 3)
+   {
+      mesh = new Mesh(2, 2, 2, Element::HEXAHEDRON, 0, 1.0, 1.0, 1.0);
+   }
+
+   int order = 2;
+
+   H1_FECollection fec(order, dim);
+   FiniteElementSpace fes(mesh, &fec, dim);
+
+   BilinearForm form(&fes);
+   form.SetAssemblyLevel(AssemblyLevel::PARTIAL);
+   form.AddDomainIntegrator(new INTEGRATOR);
+   form.Assemble();
+
+   Vector diag(fes.GetVSize());
+   form.AssembleDiagonal(diag);
+
+   BilinearForm form_full(&fes);
+   form_full.AddDomainIntegrator(new INTEGRATOR);
+   form_full.Assemble();
+   form_full.Finalize();
+
+   Vector diag_full(fes.GetVSize());
+   form_full.SpMat().GetDiag(diag_full);
+
+   diag_full -= diag;
+
+   delete mesh;
+
+   return diag_full.Norml2();
+}
+
+TEST_CASE("Vector Mass Diagonal PA", "[PartialAssembly], [AssembleDiagonal]")
+{
+   SECTION("2D")
+   {
+      REQUIRE(test_vectorintegratordiagonalpa<VectorMassIntegrator>(2) == Approx(
+                 0.0));
+   }
+
+   SECTION("3D")
+   {
+      REQUIRE(test_vectorintegratordiagonalpa<VectorMassIntegrator>(3) == Approx(
+                 0.0));
+   }
+}
+
+TEST_CASE("Vector Diffusion Diagonal PA",
+          "[PartialAssembly], [AssembleDiagonal]")
+{
+   SECTION("2D")
+   {
+      REQUIRE(test_vectorintegratordiagonalpa<VectorDiffusionIntegrator>(2) == Approx(
+                 0.0));
+   }
+
+   SECTION("3D")
+   {
+      REQUIRE(test_vectorintegratordiagonalpa<VectorDiffusionIntegrator>(3) == Approx(
+                 0.0));
+   }
+}
+
 } // namespace assemblediagonalpa


### PR DESCRIPTION
This PR adds the `AssembleDiagonalPA` method to the `VectorMassIntegrator` as well as `VectorDiffusionIntegrator`.

<!--GHEX{"id":1257,"author":"jandrej","editor":"v-dobrev","reviewers":["barker29","YohannDudouit"],"assignment":"2020-01-28","approval":"2020-02-20T00:39:54.737Z","merge":"2020-02-24T01:59:04.930Z"}XEHG--><!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge| 
 | --- | --- | --- | --- | --- | --- | --- | 
| [#1257](https://github.com/mfem/mfem/pull/1257) | @jandrej | @v-dobrev | @barker29 + @YohannDudouit | 01/28/20 | 02/19/20 | 02/23/20 | |
<!--ELBATXEHG-->