### PR TITLE
Adjustments to the branch-history script [branch-history-dev]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -199,5 +199,9 @@ miniapps/gslib/pfindpts
 tests/unit/output_meshes
 tests/unit/unit_tests
 
+# Test script output
+tests/scripts/branch-history.err
+tests/scripts/branch-history.out
+
 # VPATH builds
 build-*/*

--- a/tests/scripts/branch-history
+++ b/tests/scripts/branch-history
@@ -64,11 +64,11 @@ EOF
 esac
 
 # Maximum number of acceptable commits in the branch
-branch_max_commits=100
+branch_max_commits=200
 # Maximum number of acceptable files changed in any commit in the branch
-commit_max_files_changed=100
+commit_max_files_changed=50
 # Maximum number of acceptable lines changed in any commit in the branch
-commit_max_lines_changed=3000
+commit_max_lines_changed=2000
 # Maximum acceptable size (in K) of any file changed in any commit in the branch
 file_max_size=200
 # Maximum number of acceptable lines added to any file changed in any commit in the branch

--- a/tests/scripts/branch-history.filters
+++ b/tests/scripts/branch-history.filters
@@ -1,0 +1,4 @@
+This branch adds/modifies a large file: mesh/mesh.cpp \(size [0-9]{3}K\)
+This branch adds/modifies a large file: fem/fe.cpp \(size [0-9]{3}K\)
+Commit [0-9a-z]{9} adds/modifies a large file: mesh/mesh.cpp \(size [0-9]{3}K\)
+Commit [0-9a-z]{9} adds/modifies a large file: fem/fe.cpp \(size [0-9]{3}K\)


### PR DESCRIPTION
The [branch-history script](https://github.com/mfem/mfem/blob/master/tests/scripts/branch-history) may be too conservative currently.

In this PR we want discuss adjustments suggested by the team as they use it.

These adjustments, include:
- Adding filtering 
- Changing the default ["acceptable" values](https://github.com/mfem/mfem/blob/master/tests/scripts/branch-history#L66-L77)