### PR TITLE
Add missing files to cmake

### DIFF
--- a/fem/CMakeLists.txt
+++ b/fem/CMakeLists.txt
@@ -14,6 +14,8 @@ set(SRCS
   bilinearform_ext.cpp
   bilininteg.cpp
   bilininteg_diffusion.cpp
+  bilininteg_divergence.cpp
+  bilininteg_gradient.cpp
   bilininteg_mass.cpp
   bilininteg_vecdiffusion.cpp
   bilininteg_vecmass.cpp


### PR DESCRIPTION
This adds the missing files that are missing in the cmake build.

Fixes #1264

| PR | Author | Editor | Reviewers  | Assignment | Approval | Merge |
| --- | --- | --- | ---  | --- | --- | --- |
| https://github.com/mfem/mfem/pull/1265 | @jandrej  | @tzanio | @tzanio  + @adrienbernede   | 01/27/20 | 01/27/20 | 01/27/20 |