### PR TITLE
Minor Block ILU compilation bugfix

### DIFF
--- a/linalg/solvers.cpp
+++ b/linalg/solvers.cpp
@@ -1861,7 +1861,7 @@ struct WeightMinHeap
    void push(size_t i)
    {
       double val = w[i];
-      c.push_back(-1);
+      c.push_back(0);
       size_t pos = c.size()-1;
       pos = percolate_up(pos, val);
       c[pos] = i;

--- a/linalg/solvers.hpp
+++ b/linalg/solvers.hpp
@@ -13,7 +13,7 @@
 #define MFEM_SOLVERS
 
 #include "../config/config.hpp"
-#include "operator.hpp"
+#include "densemat.hpp"
 
 #ifdef MFEM_USE_MPI
 #include <mpi.h>
@@ -542,7 +542,7 @@ public:
 
 private:
    /// Set up the block CSR structure corresponding to a sparse matrix @a A
-   void CreateBlockPattern(const SparseMatrix &A);
+   void CreateBlockPattern(const class SparseMatrix &A);
 
    /// Perform the block ILU factorization
    void Factorize();


### PR DESCRIPTION
Fixes two minor compilation issues with the recent Block ILU solver (reported by @vladotomov and @camierjs):
1) Resolves compilation errors when compiling with Sundials support
2) Fixes a signed integer warning when compiling with nvcc

| PR | Author | Editor | Reviewers  | Assignment | Approval | Merge |
| --- | --- | --- | ---  | --- | --- | --- |
| https://github.com/mfem/mfem/pull/1275 | @pazner | @v-dobrev | @vladotomov + @camierjs | 01/31/20 | 02/03/20 | ⌛due 02/10/20 |
