### PR TITLE
Small fixes when running a matrix-free code (MATSHELL)

### DIFF
--- a/linalg/petsc.cpp
+++ b/linalg/petsc.cpp
@@ -3819,6 +3819,14 @@ static PetscErrorCode __mfem_ts_ijacobian(TS ts, PetscReal t, Vec x,
    // Jacobian reusage
    ierr = PetscObjectStateGet((PetscObject)P,&ts_ctx->cached_ijacstate);
    CHKERRQ(ierr);
+
+   // Fool DM
+   DM dm;
+   MatType mtype;
+   ierr = MatGetType(P,&mtype); CHKERRQ(ierr);
+   ierr = TSGetDM(ts,&dm); CHKERRQ(ierr);
+   ierr = DMSetMatType(dm,mtype); CHKERRQ(ierr);
+   ierr = DMShellSetMatrix(dm,P); CHKERRQ(ierr);
    PetscFunctionReturn(0);
 }
 
@@ -3845,7 +3853,6 @@ static PetscErrorCode __mfem_ts_computesplits(TS ts,PetscReal t,Vec x,Vec xp,
    ierr = PetscObjectStateGet((PetscObject)Jxp,&state); CHKERRQ(ierr);
    if (ts_ctx->type == mfem::PetscODESolver::ODE_SOLVER_LINEAR &&
        state == ts_ctx->cached_splits_xdotstate) { rxp = PETSC_FALSE; }
-
    if (!rx && !rxp) { PetscFunctionReturn(0); }
 
    // update time
@@ -4097,6 +4104,14 @@ static PetscErrorCode __mfem_ts_rhsjacobian(TS ts, PetscReal t, Vec x,
    }
    ierr = PetscObjectStateGet((PetscObject)A,&ts_ctx->cached_rhsjacstate);
    CHKERRQ(ierr);
+
+   // Fool DM
+   DM dm;
+   MatType mtype;
+   ierr = MatGetType(P,&mtype); CHKERRQ(ierr);
+   ierr = TSGetDM(ts,&dm); CHKERRQ(ierr);
+   ierr = DMSetMatType(dm,mtype); CHKERRQ(ierr);
+   ierr = DMShellSetMatrix(dm,P); CHKERRQ(ierr);
    PetscFunctionReturn(0);
 }
 
@@ -4216,6 +4231,14 @@ static PetscErrorCode __mfem_snes_jacobian(SNES snes, Vec x, Mat A, Mat P,
       ierr = MatAssemblyBegin(A,MAT_FINAL_ASSEMBLY); CHKERRQ(ierr);
       ierr = MatAssemblyEnd(A,MAT_FINAL_ASSEMBLY); CHKERRQ(ierr);
    }
+
+   // Fool DM
+   DM dm;
+   MatType mtype;
+   ierr = MatGetType(P,&mtype); CHKERRQ(ierr);
+   ierr = SNESGetDM(snes,&dm); CHKERRQ(ierr);
+   ierr = DMSetMatType(dm,mtype); CHKERRQ(ierr);
+   ierr = DMShellSetMatrix(dm,P); CHKERRQ(ierr);
    PetscFunctionReturn(0);
 }
 

--- a/linalg/petsc.cpp
+++ b/linalg/petsc.cpp
@@ -4374,7 +4374,7 @@ static PetscErrorCode __mfem_mat_shell_apply(Mat A, Vec x, Vec y)
 
    PetscFunctionBeginUser;
    ierr = MatShellGetContext(A,(void **)&op); CHKERRQ(ierr);
-   if (!op) SETERRQ(PetscObjectComm((PetscObject)A),PETSC_ERR_LIB,"Missing operator");
+   if (!op) { SETERRQ(PetscObjectComm((PetscObject)A),PETSC_ERR_LIB,"Missing operator"); }
    mfem::PetscParVector xx(x,true);
    mfem::PetscParVector yy(y,true);
    op->Mult(xx,yy);
@@ -4390,7 +4390,7 @@ static PetscErrorCode __mfem_mat_shell_apply_transpose(Mat A, Vec x, Vec y)
 
    PetscFunctionBeginUser;
    ierr = MatShellGetContext(A,(void **)&op); CHKERRQ(ierr);
-   if (!op) SETERRQ(PetscObjectComm((PetscObject)A),PETSC_ERR_LIB,"Missing operator");
+   if (!op) { SETERRQ(PetscObjectComm((PetscObject)A),PETSC_ERR_LIB,"Missing operator"); }
    mfem::PetscParVector xx(x,true);
    mfem::PetscParVector yy(y,true);
    op->MultTranspose(xx,yy);
@@ -4406,7 +4406,7 @@ static PetscErrorCode __mfem_mat_shell_copy(Mat A, Mat B, MatStructure str)
 
    PetscFunctionBeginUser;
    ierr = MatShellGetContext(A,(void **)&op); CHKERRQ(ierr);
-   if (!op) SETERRQ(PetscObjectComm((PetscObject)A),PETSC_ERR_LIB,"Missing operator");
+   if (!op) { SETERRQ(PetscObjectComm((PetscObject)A),PETSC_ERR_LIB,"Missing operator"); }
    ierr = MatShellSetContext(B,(void *)op); CHKERRQ(ierr);
    PetscFunctionReturn(0);
 }


### PR DESCRIPTION
We need a couple of fixes when the user (in this case myself) wants to use a `MATSHELL`, i.e. by specifying as jacobian type for the nonlinear solvers either `Operator::ANY_TYPE` (in combination with a Jacobian operator which is not a `PetscParMatrix`) or `Operator::PETSC_MATSHELL`

First, we need to tell the DM we are using a matrix type (`MATSHELL`) for which `DMSHELL` has poor support. Second, we need to change the way the `MATSHELL` uses its context
Since it is barely impossible to do reference counting on void* memory, this branch reverts back the context of the `MATSHELL` as it was initially for MFEM, only a pointer to the `mfem::Operator`.



<!--GHEX{"id":1278,"author":"stefanozampini","editor":"tzanio","reviewers":["tzanio","jandrej"],"assignment":"2020-02-03","approval":"2020-02-20T00:31:24.665Z","merge":"2020-02-23T23:02:17.606Z"}XEHG--><!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge| 
 | --- | --- | --- | --- | --- | --- | --- | 
| [#1278](https://github.com/mfem/mfem/pull/1278) | @stefanozampini | @tzanio | @tzanio + @jandrej | 02/03/20 | 02/19/20 | 02/23/20 | |
<!--ELBATXEHG-->