### PR TITLE
Adjustments for diffusion template orders

### DIFF
--- a/fem/bilininteg_diffusion.cpp
+++ b/fem/bilininteg_diffusion.cpp
@@ -1543,7 +1543,9 @@ static void PADiffusionApply(const int dim,
          case 0x23: return SmemPADiffusionApply3D<2,3>(NE,B,G,Bt,Gt,D,X,Y);
          case 0x34: return SmemPADiffusionApply3D<3,4>(NE,B,G,Bt,Gt,D,X,Y);
          case 0x45: return SmemPADiffusionApply3D<4,5>(NE,B,G,Bt,Gt,D,X,Y);
+         case 0x46: return SmemPADiffusionApply3D<4,6>(NE,B,G,Bt,Gt,D,X,Y);
          case 0x56: return SmemPADiffusionApply3D<5,6>(NE,B,G,Bt,Gt,D,X,Y);
+         case 0x58: return SmemPADiffusionApply3D<5,8>(NE,B,G,Bt,Gt,D,X,Y);
          case 0x67: return SmemPADiffusionApply3D<6,7>(NE,B,G,Bt,Gt,D,X,Y);
          case 0x78: return SmemPADiffusionApply3D<7,8>(NE,B,G,Bt,Gt,D,X,Y);
          case 0x89: return SmemPADiffusionApply3D<8,9>(NE,B,G,Bt,Gt,D,X,Y);

--- a/general/forall.hpp
+++ b/general/forall.hpp
@@ -32,8 +32,8 @@ namespace mfem
 {
 
 // Maximum size of dofs and quads in 1D.
-const int MAX_D1D = 16;
-const int MAX_Q1D = 16;
+const int MAX_D1D = 14;
+const int MAX_Q1D = 14;
 
 // Implementation of MFEM's "parallel for" (forall) device/host kernel
 // interfaces supporting RAJA, CUDA, OpenMP, and sequential backends.


### PR DESCRIPTION
Folks, my GPU ran out of memory with the current MAX_D1D/MAX_Q1D combination. I would like to propose scaling it back a bit. Could we also template the diffusion  PA operator for the orders I've specified in this PR? 

<!--GHEX{"id":1289,"author":"artv3","editor":"tzanio","reviewers":["v-dobrev","camierjs"],"assignment":"2020-02-16","approval":"2020-02-21T01:25:47.648Z","merge":"2020-02-23T23:01:35.081Z"}XEHG--><!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge| 
 | --- | --- | --- | --- | --- | --- | --- | 
| [#1289](https://github.com/mfem/mfem/pull/1289) | @artv3 | @tzanio | @v-dobrev + @camierjs | 02/16/20 | 02/20/20 | 02/23/20 | |
<!--ELBATXEHG-->