### PR TITLE
ParaView improvements [paraview-improvements]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,7 +54,7 @@ examples/displaced.mesh
 examples/mesh.*
 examples/ex5.mesh
 examples/Example5*
-examples/PVExample*
+examples/PV
 examples/Example9*
 examples/Example15*
 examples/Example16*

--- a/.gitignore
+++ b/.gitignore
@@ -54,7 +54,7 @@ examples/displaced.mesh
 examples/mesh.*
 examples/ex5.mesh
 examples/Example5*
-examples/PV
+examples/ParaView
 examples/Example9*
 examples/Example15*
 examples/Example16*

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -182,10 +182,10 @@ Miscellaneous
   complete rework of the interface and requires changes at the application
   level. Example usage of the new interface can be found in examples/sundials.
 
-- Added support for output in the ParaView XML format. Both low-order and 
+- Added support for output in the ParaView XML format. Both low-order and
   high-order Lagrange elements are supported. Output can be in ASCII or binary
-  format. Binary output can be compressed if MFEM is compiled with gzstream 
-  enabled (MFEM_USE_GZSTREAM). See Examples 5/5p, 9/9p and the new 
+  format. Binary output can be compressed if MFEM is compiled with gzstream
+  enabled (MFEM_USE_GZSTREAM). See Examples 5/5p, 9/9p and the new
   ParaViewDataCollection class.
 
 - Collected object files from the miniapps/common directory into a new library,

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -182,8 +182,11 @@ Miscellaneous
   complete rework of the interface and requires changes at the application
   level. Example usage of the new interface can be found in examples/sundials.
 
-- Added support for output in the ParaView XML format. See Examples 5/5p, 9/9p
-  and the new ParaViewDataCollection class.
+- Added support for output in the ParaView XML format. Both low-order and 
+  high-order Lagrange elements are supported. Output can be in ASCII or binary
+  format. Binary output can be compressed if MFEM is compiled with gzstream 
+  enabled (MFEM_USE_GZSTREAM). See Examples 5/5p, 9/9p and the new 
+  ParaViewDataCollection class.
 
 - Collected object files from the miniapps/common directory into a new library,
   libmfem-common for the convenience of application developers. The new library

--- a/examples/ex5.cpp
+++ b/examples/ex5.cpp
@@ -268,11 +268,8 @@ int main(int argc, char *argv[])
    ParaViewDataCollection paraview_dc("Example5", mesh);
    paraview_dc.SetPrefixPath("ParaView");
    paraview_dc.SetLevelsOfDetail(order);
-   paraview_dc.SetCycle(1);
+   paraview_dc.SetCycle(0);
    paraview_dc.SetDataFormat(VTUFormat::BINARY);
-#ifdef MFEM_USE_GZSTREAM
-   paraview_dc.SetCompression(true);
-#endif
    paraview_dc.SetHighOrderOutput(true);
    paraview_dc.SetTime(0.0); // set the time
    paraview_dc.RegisterField("velocity",&u);

--- a/examples/ex5.cpp
+++ b/examples/ex5.cpp
@@ -269,7 +269,7 @@ int main(int argc, char *argv[])
    paraview_dc.SetPrefixPath("ParaView");
    paraview_dc.SetLevelsOfDetail(order);
    paraview_dc.SetCycle(0);
-   paraview_dc.SetDataFormat(VTUFormat::BINARY);
+   paraview_dc.SetDataFormat(VTKFormat::BINARY);
    paraview_dc.SetHighOrderOutput(true);
    paraview_dc.SetTime(0.0); // set the time
    paraview_dc.RegisterField("velocity",&u);

--- a/examples/ex5.cpp
+++ b/examples/ex5.cpp
@@ -265,7 +265,8 @@ int main(int argc, char *argv[])
    visit_dc.Save();
 
    // 14. Save data in the ParaView format
-   ParaViewDataCollection paraview_dc("PVExample5S", mesh);
+   ParaViewDataCollection paraview_dc("Example5", mesh);
+   paraview_dc.SetPrefixPath("ParaView");
    paraview_dc.SetLevelsOfDetail(order);
    paraview_dc.SetCycle(1);
    paraview_dc.SetDataFormat(VTUFormat::BINARY);

--- a/examples/ex5.cpp
+++ b/examples/ex5.cpp
@@ -268,7 +268,8 @@ int main(int argc, char *argv[])
    ParaViewDataCollection paraview_dc("PVExample5S", mesh);
    paraview_dc.SetLevelsOfDetail(order);
    paraview_dc.SetCycle(1);
-   paraview_dc.SetDataFormat(ParaViewDataCollection::BINARY);
+   paraview_dc.SetDataFormat(VTUFormat::BINARY);
+   paraview_dc.SetCompression(true);
    paraview_dc.SetHighOrderOutput(true);
    paraview_dc.SetTime(0.0); // set the time
    paraview_dc.RegisterField("velocity",&u);

--- a/examples/ex5.cpp
+++ b/examples/ex5.cpp
@@ -269,7 +269,9 @@ int main(int argc, char *argv[])
    paraview_dc.SetLevelsOfDetail(order);
    paraview_dc.SetCycle(1);
    paraview_dc.SetDataFormat(VTUFormat::BINARY);
+#ifdef MFEM_USE_GZSTREAM
    paraview_dc.SetCompression(true);
+#endif
    paraview_dc.SetHighOrderOutput(true);
    paraview_dc.SetTime(0.0); // set the time
    paraview_dc.RegisterField("velocity",&u);

--- a/examples/ex5.cpp
+++ b/examples/ex5.cpp
@@ -266,9 +266,10 @@ int main(int argc, char *argv[])
 
    // 14. Save data in the ParaView format
    ParaViewDataCollection paraview_dc("PVExample5S", mesh);
-   paraview_dc.SetLevelsOfDetail(2);
+   paraview_dc.SetLevelsOfDetail(order);
    paraview_dc.SetCycle(1);
    paraview_dc.SetDataFormat(ParaViewDataCollection::BINARY);
+   paraview_dc.SetHighOrderOutput(true);
    paraview_dc.SetTime(0.0); // set the time
    paraview_dc.RegisterField("velocity",&u);
    paraview_dc.RegisterField("pressure",&p);

--- a/examples/ex5.cpp
+++ b/examples/ex5.cpp
@@ -268,6 +268,7 @@ int main(int argc, char *argv[])
    ParaViewDataCollection paraview_dc("PVExample5S", mesh);
    paraview_dc.SetLevelsOfDetail(2);
    paraview_dc.SetCycle(1);
+   paraview_dc.SetDataFormat(ParaViewDataCollection::BINARY);
    paraview_dc.SetTime(0.0); // set the time
    paraview_dc.RegisterField("velocity",&u);
    paraview_dc.RegisterField("pressure",&p);

--- a/examples/ex5p.cpp
+++ b/examples/ex5p.cpp
@@ -330,9 +330,6 @@ int main(int argc, char *argv[])
    paraview_dc.SetPrefixPath("ParaView");
    paraview_dc.SetLevelsOfDetail(order);
    paraview_dc.SetDataFormat(VTUFormat::BINARY);
-#ifdef MFEM_USE_GZSTREAM
-   paraview_dc.SetCompression(true);
-#endif
    paraview_dc.SetHighOrderOutput(true);
    paraview_dc.SetCycle(0);
    paraview_dc.SetTime(0.0);

--- a/examples/ex5p.cpp
+++ b/examples/ex5p.cpp
@@ -329,7 +329,7 @@ int main(int argc, char *argv[])
    ParaViewDataCollection paraview_dc("Example5P", pmesh);
    paraview_dc.SetPrefixPath("ParaView");
    paraview_dc.SetLevelsOfDetail(order);
-   paraview_dc.SetDataFormat(VTUFormat::BINARY);
+   paraview_dc.SetDataFormat(VTKFormat::BINARY);
    paraview_dc.SetHighOrderOutput(true);
    paraview_dc.SetCycle(0);
    paraview_dc.SetTime(0.0);

--- a/examples/ex5p.cpp
+++ b/examples/ex5p.cpp
@@ -326,7 +326,8 @@ int main(int argc, char *argv[])
    visit_dc.Save();
 
    // 16. Save data in the ParaView format
-   ParaViewDataCollection paraview_dc("PVExample5P", pmesh);
+   ParaViewDataCollection paraview_dc("Example5P", pmesh);
+   paraview_dc.SetPrefixPath("ParaView");
    paraview_dc.SetLevelsOfDetail(1);
    paraview_dc.SetCycle(1);
    paraview_dc.SetTime(0.0);

--- a/examples/ex5p.cpp
+++ b/examples/ex5p.cpp
@@ -328,8 +328,13 @@ int main(int argc, char *argv[])
    // 16. Save data in the ParaView format
    ParaViewDataCollection paraview_dc("Example5P", pmesh);
    paraview_dc.SetPrefixPath("ParaView");
-   paraview_dc.SetLevelsOfDetail(1);
-   paraview_dc.SetCycle(1);
+   paraview_dc.SetLevelsOfDetail(order);
+   paraview_dc.SetDataFormat(VTUFormat::BINARY);
+#ifdef MFEM_USE_GZSTREAM
+   paraview_dc.SetCompression(true);
+#endif
+   paraview_dc.SetHighOrderOutput(true);
+   paraview_dc.SetCycle(0);
    paraview_dc.SetTime(0.0);
    paraview_dc.RegisterField("velocity",u);
    paraview_dc.RegisterField("pressure",p);

--- a/examples/ex9.cpp
+++ b/examples/ex9.cpp
@@ -315,7 +315,7 @@ int main(int argc, char *argv[])
       pd->SetPrefixPath("ParaView");
       pd->RegisterField("solution", &u);
       pd->SetLevelsOfDetail(order);
-      pd->SetDataFormat(VTUFormat::BINARY);
+      pd->SetDataFormat(VTKFormat::BINARY);
       pd->SetHighOrderOutput(true);
       pd->SetCycle(0);
       pd->SetTime(0.0);

--- a/examples/ex9.cpp
+++ b/examples/ex9.cpp
@@ -311,11 +311,15 @@ int main(int argc, char *argv[])
    ParaViewDataCollection *pd = NULL;
    if (paraview)
    {
-      pd = new ParaViewDataCollection("PVExample9S", &mesh);
+      pd = new ParaViewDataCollection("Example9", &mesh);
+      pd->SetPrefixPath("ParaView");
       pd->RegisterField("solution", &u);
-      pd->SetLevelsOfDetail(2);
+      pd->SetLevelsOfDetail(order);
+      pd->SetDataFormat(VTUFormat::BINARY);
+      pd->SetHighOrderOutput(true);
       pd->SetCycle(0);
       pd->SetTime(0.0);
+      pd->Save();
    }
 
    socketstream sout;

--- a/examples/ex9p.cpp
+++ b/examples/ex9p.cpp
@@ -370,7 +370,7 @@ int main(int argc, char *argv[])
       pd->SetPrefixPath("ParaView");
       pd->RegisterField("solution", u);
       pd->SetLevelsOfDetail(order);
-      pd->SetDataFormat(VTUFormat::BINARY);
+      pd->SetDataFormat(VTKFormat::BINARY);
       pd->SetHighOrderOutput(true);
       pd->SetCycle(0);
       pd->SetTime(0.0);

--- a/examples/ex9p.cpp
+++ b/examples/ex9p.cpp
@@ -366,9 +366,12 @@ int main(int argc, char *argv[])
    ParaViewDataCollection *pd = NULL;
    if (paraview)
    {
-      pd = new ParaViewDataCollection("PVExample9P", pmesh);
+      pd = new ParaViewDataCollection("Example9P", pmesh);
+      pd->SetPrefixPath("ParaView");
       pd->RegisterField("solution", u);
-      pd->SetLevelsOfDetail(2);
+      pd->SetLevelsOfDetail(order);
+      pd->SetDataFormat(VTUFormat::BINARY);
+      pd->SetHighOrderOutput(true);
       pd->SetCycle(0);
       pd->SetTime(0.0);
       pd->Save();

--- a/examples/makefile
+++ b/examples/makefile
@@ -124,7 +124,7 @@ clean-build:
 
 clean-exec:
 	@rm -f refined.mesh displaced.mesh mesh.* ex5.mesh
-	@rm -rf Example5* Example9* Example15* Example16* PVExample*
+	@rm -rf Example5* Example9* Example15* Example16* ParaView
 	@rm -f sphere_refined.* sol.* sol_u.* sol_p.* sol_r.* sol_i.*
 	@rm -f ex9.mesh ex9-mesh.* ex9-init.* ex9-final.*
 	@rm -f deformed.* velocity.* elastic_energy.* mode_*

--- a/fem/datacollection.cpp
+++ b/fem/datacollection.cpp
@@ -731,7 +731,7 @@ ParaViewDataCollection::ParaViewDataCollection(const std::string&
                                                Mesh *mesh_)
    : DataCollection(collection_name, mesh_),
      levels_of_detail(1),
-     pv_data_format(VTUFormat::BINARY),
+     pv_data_format(VTKFormat::BINARY),
      high_order_output(false)
 {
 #ifdef MFEM_USE_GZSTREAM
@@ -973,11 +973,11 @@ void ParaViewDataCollection::SaveGFieldVTU(std::ostream &out, int ref_,
          it->second->GetValues(i, RefG->RefPts, val, pmat);
          for (int j = 0; j < val.Size(); j++)
          {
-            if (pv_data_format == VTUFormat::ASCII)
+            if (pv_data_format == VTKFormat::ASCII)
             {
                out << val(j) << '\n';
             }
-            else if (pv_data_format == VTUFormat::BINARY)
+            else if (pv_data_format == VTKFormat::BINARY)
             {
                bin_io::AppendBytes(buf, val(j));
             }
@@ -1006,11 +1006,11 @@ void ParaViewDataCollection::SaveGFieldVTU(std::ostream &out, int ref_,
          {
             for (int ii = 0; ii < vval.Height(); ii++)
             {
-               if (pv_data_format == VTUFormat::ASCII)
+               if (pv_data_format == VTKFormat::ASCII)
                {
                   out << vval(ii,jj) << ' ';
                }
-               else if (pv_data_format == VTUFormat::BINARY)
+               else if (pv_data_format == VTKFormat::BINARY)
                {
                   bin_io::AppendBytes(buf, vval(ii,jj));
                }
@@ -1019,27 +1019,27 @@ void ParaViewDataCollection::SaveGFieldVTU(std::ostream &out, int ref_,
                   bin_io::AppendBytes<float>(buf, float(vval(ii,jj)));
                }
             }
-            if (pv_data_format == VTUFormat::ASCII) { out << '\n'; }
+            if (pv_data_format == VTKFormat::ASCII) { out << '\n'; }
          }
       }
    }
 
    if (IsBinaryFormat())
    {
-      bin_io::WriteEncodedCompressed(out,buf.data(),buf.size(),compression);
+      WriteVTKEncodedCompressed(out,buf.data(),buf.size(),compression);
       out << '\n';
    }
    out << "</DataArray>" << std::endl;
 }
 
-void ParaViewDataCollection::SetDataFormat(VTUFormat fmt)
+void ParaViewDataCollection::SetDataFormat(VTKFormat fmt)
 {
    pv_data_format = fmt;
 }
 
 bool ParaViewDataCollection::IsBinaryFormat() const
 {
-   return pv_data_format != VTUFormat::ASCII;
+   return pv_data_format != VTKFormat::ASCII;
 }
 
 void ParaViewDataCollection::SetHighOrderOutput(bool high_order_output_)
@@ -1067,7 +1067,7 @@ void ParaViewDataCollection::SetCompression(bool compression_)
 
 const char *ParaViewDataCollection::GetDataFormatString() const
 {
-   if (pv_data_format == VTUFormat::ASCII)
+   if (pv_data_format == VTKFormat::ASCII)
    {
       return "ascii";
    }
@@ -1079,7 +1079,7 @@ const char *ParaViewDataCollection::GetDataFormatString() const
 
 const char *ParaViewDataCollection::GetDataTypeString() const
 {
-   if (pv_data_format==VTUFormat::ASCII || pv_data_format==VTUFormat::BINARY)
+   if (pv_data_format==VTKFormat::ASCII || pv_data_format==VTKFormat::BINARY)
    {
       return "Float64";
    }

--- a/fem/datacollection.cpp
+++ b/fem/datacollection.cpp
@@ -825,7 +825,7 @@ void ParaViewDataCollection::Save()
       // initialize the file
       pvd_stream << "<?xml version=\"1.0\"?>\n";
       pvd_stream << "<VTKFile type=\"Collection\" version=\"0.1\"";
-      pvd_stream << " byte_order=\"LittleEndian\">\n";
+      pvd_stream << " byte_order=\"" << VTKByteOrder() << "\">\n";
       pvd_stream << "<Collection>" << std::endl;
    }
 
@@ -848,7 +848,7 @@ void ParaViewDataCollection::Save()
 
       out << "<?xml version=\"1.0\"?>\n";
       out << "<VTKFile type=\"PUnstructuredGrid\"";
-      out << " version =\"0.1\" byte_order=\"LittleEndian\">\n";
+      out << " version =\"0.1\" byte_order=\"" << VTKByteOrder() << "\">\n";
       out << "<PUnstructuredGrid GhostLevel=\"0\">\n";
 
       out << "<PPoints>\n";
@@ -916,7 +916,7 @@ void ParaViewDataCollection::SaveDataVTU(std::ostream &out, int ref)
    {
       out << " compressor=\"vtkZLibDataCompressor\"";
    }
-   out << " version=\"0.1\" byte_order=\"LittleEndian\">\n";
+   out << " version=\"0.1\" byte_order=\"" << VTKByteOrder() << "\">\n";
    out << "<UnstructuredGrid>\n";
    mesh->PrintVTU(out,ref,pv_data_format,high_order_output,compression);
 

--- a/fem/datacollection.cpp
+++ b/fem/datacollection.cpp
@@ -1011,7 +1011,7 @@ void ParaViewDataCollection::SaveGFieldVTU(std::ostream &out, int ref_,
             }
             else
             {
-               bin_io::AppendBytes<float>(buf, val(j));
+               bin_io::AppendBytes<float>(buf, float(val(j)));
             }
          }
       }
@@ -1044,7 +1044,7 @@ void ParaViewDataCollection::SaveGFieldVTU(std::ostream &out, int ref_,
                }
                else
                {
-                  bin_io::AppendBytes<float>(buf, vval(ii,jj));
+                  bin_io::AppendBytes<float>(buf, float(vval(ii,jj)));
                }
             }
             if (pv_data_format == VTUFormat::ASCII) { out << '\n'; }

--- a/fem/datacollection.cpp
+++ b/fem/datacollection.cpp
@@ -944,12 +944,12 @@ void ParaViewDataCollection::SaveDataVTU(std::ostream &out, int ref)
    {
       out << " compressor=\"vtkZLibDataCompressor\"";
    }
-   out << " version=\"0.1\" byte_order=\"LittleEndian\">" << std::endl;
-   out << "<UnstructuredGrid>" << std::endl;
+   out << " version=\"0.1\" byte_order=\"LittleEndian\">\n";
+   out << "<UnstructuredGrid>\n";
    mesh->PrintVTU(out,ref,pv_data_format,high_order_output,compress_output);
 
    // dump out the grid functions as point data
-   out << "<PointData >" << std::endl;
+   out << "<PointData >\n";
    // save the grid functions
    // iterate over all grid functions
    for (FieldMapIterator it=field_map.begin(); it!=field_map.end(); ++it)
@@ -966,10 +966,10 @@ void ParaViewDataCollection::SaveDataVTU(std::ostream &out, int ref)
       // this one is not implemented yet
       SaveQFieldVTU(out,ref,it);
    }
-   out << "</PointData>" << std::endl;
+   out << "</PointData>\n";
    // close the mesh
-   out << "</Piece>" << std::endl; // close the piece open in the PrintVTU method
-   out << "</UnstructuredGrid>" << std::endl;
+   out << "</Piece>\n"; // close the piece open in the PrintVTU method
+   out << "</UnstructuredGrid>\n";
    out << "</VTKFile>" << std::endl;
 }
 
@@ -993,7 +993,7 @@ void ParaViewDataCollection::SaveGFieldVTU(std::ostream &out, int ref_,
       out << "<DataArray type=\"" << GetDataTypeString()
           << "\" Name=\"" << it->first;
       out << "\" NumberOfComponents=\"1\" format=\""
-          << GetDataFormatString() << "\" >" << std::endl;
+          << GetDataFormatString() << "\" >\n";
       for (int i = 0; i < mesh->GetNE(); i++)
       {
          RefG = GlobGeometryRefiner.Refine(

--- a/fem/datacollection.cpp
+++ b/fem/datacollection.cpp
@@ -1092,19 +1092,6 @@ ParaViewDataCollection::ParaViewDataCollection(const std::string&
    MPI_Comm_rank(lcomm, &myrank);
    MPI_Comm_size(lcomm, &nprocs);
    levels_of_detail = 1;
-
-   std::string dpath = GenerateCollectionPath();
-   std::string pvdname = dpath+"/"+GeneratePVDFileName();
-   int err = create_directory(dpath,myrank,lcomm);
-   if (err) { MFEM_ABORT("Cannot create the directory:"<<dpath);}
-   if (myrank==0)
-   {
-      pvd_stream.open(pvdname.c_str(),std::ios::out);
-      pvd_stream << "<?xml version=\"1.0\"?>" << std::endl;
-      pvd_stream << "<VTKFile type=\"Collection\" version=\"0.1\"" << std::endl;
-      pvd_stream << "     byte_order=\"LittleEndian\">" << std::endl;
-      pvd_stream << "<Collection>" << std::endl;
-   }
 }
 
 int ParaViewDataCollection::create_directory(const std::string &dir_name,

--- a/fem/datacollection.cpp
+++ b/fem/datacollection.cpp
@@ -940,13 +940,13 @@ void ParaViewDataCollection::Save()
 void ParaViewDataCollection::SaveDataVTU(std::ostream &out, int ref)
 {
    out << "<VTKFile type=\"UnstructuredGrid\"";
-   if (compression_level != 0)
+   if (compression != 0)
    {
       out << " compressor=\"vtkZLibDataCompressor\"";
    }
    out << " version=\"0.1\" byte_order=\"LittleEndian\">\n";
    out << "<UnstructuredGrid>\n";
-   mesh->PrintVTU(out,ref,pv_data_format,high_order_output,compression_level);
+   mesh->PrintVTU(out,ref,pv_data_format,high_order_output,compression);
 
    // dump out the grid functions as point data
    out << "<PointData >\n";
@@ -1054,7 +1054,7 @@ void ParaViewDataCollection::SaveGFieldVTU(std::ostream &out, int ref_,
 
    if (IsBinaryFormat())
    {
-      bin_io::WriteEncodedCompressed(out,buf.data(),buf.size(),compression_level);
+      bin_io::WriteEncodedCompressed(out,buf.data(),buf.size(),compression);
       out << '\n';
    }
    out << "</DataArray>" << std::endl;
@@ -1098,13 +1098,15 @@ void ParaViewDataCollection::SetCompressionLevel(int compression_level_)
 {
    MFEM_ASSERT(compression_level_ >= -1 && compression_level_ <= 9,
                "Compression level must be between -1 and 9 (inclusive).");
-   compression_level = compression_level_;
+   compression = compression_level_;
 }
 
-void ParaViewDataCollection::SetCompression(bool compression)
+void ParaViewDataCollection::SetCompression(bool compression_)
 {
-   DataCollection::SetCompression(compression);
-   if (compression && compression_level == 0)
+   // If we are enabling compression, and it was disabled previously, use the
+   // default compression level. Otherwise, leave the compression level
+   // unchanged.
+   if (compression_ && compression == 0)
    {
       SetCompressionLevel(-1);
    }

--- a/fem/datacollection.cpp
+++ b/fem/datacollection.cpp
@@ -1035,9 +1035,8 @@ void ParaViewDataCollection::SaveGFieldVTU(std::ostream &out, int ref_,
    {
       // First write the size of the buffer in bytes, as a uint32_t encoded with
       // base 64
-      std::vector<char> sz_buf;
-      bin_io::AppendBytes(sz_buf, uint32_t(buf.size()));
-      bin_io::WriteBase64(out, sz_buf.data(), sz_buf.size());
+      uint32_t sz = buf.size();
+      bin_io::WriteBase64(out, &sz, sizeof(sz));
       // Then write all the double values, encoded with base 64
       bin_io::WriteBase64(out, buf.data(), buf.size());
       out << '\n';
@@ -1068,7 +1067,8 @@ int ParaViewDataCollection::create_directory(const std::string &dir_name)
 ParaViewDataCollection::ParaViewDataCollection(const std::string&
                                                collection_name,
                                                mfem::ParMesh *mesh_)
-   :DataCollection(collection_name,mesh_)
+   : DataCollection(collection_name,mesh_),
+     pv_data_format(BINARY)
 {
    lcomm = mesh_->GetComm();
    MPI_Comm_rank(lcomm, &myrank);

--- a/fem/datacollection.cpp
+++ b/fem/datacollection.cpp
@@ -940,13 +940,13 @@ void ParaViewDataCollection::Save()
 void ParaViewDataCollection::SaveDataVTU(std::ostream &out, int ref)
 {
    out << "<VTKFile type=\"UnstructuredGrid\"";
-   if (compress_output)
+   if (compression_level > 0)
    {
       out << " compressor=\"vtkZLibDataCompressor\"";
    }
    out << " version=\"0.1\" byte_order=\"LittleEndian\">\n";
    out << "<UnstructuredGrid>\n";
-   mesh->PrintVTU(out,ref,pv_data_format,high_order_output,compress_output);
+   mesh->PrintVTU(out,ref,pv_data_format,high_order_output,compression_level);
 
    // dump out the grid functions as point data
    out << "<PointData >\n";
@@ -1054,7 +1054,7 @@ void ParaViewDataCollection::SaveGFieldVTU(std::ostream &out, int ref_,
 
    if (IsBinaryFormat())
    {
-      bin_io::WriteEncodedCompressed(out,buf.data(),buf.size(),compress_output);
+      bin_io::WriteEncodedCompressed(out,buf.data(),buf.size(),compression_level);
       out << '\n';
    }
    out << "</DataArray>" << std::endl;
@@ -1143,9 +1143,11 @@ void ParaViewDataCollection::SetHighOrderOutput(bool high_order_output_)
    high_order_output = high_order_output_;
 }
 
-void ParaViewDataCollection::SetCompression(bool compress_output_)
+void ParaViewDataCollection::SetCompressionLevel(int compression_level_)
 {
-   compress_output = compress_output_;
+   MFEM_ASSERT(compression_level_ >= 0 && compression_level_ <= 9,
+               "Compression level must be between 0 and 9 (inclusive).");
+   compression_level = compression_level_;
 }
 
 const char *ParaViewDataCollection::GetDataFormatString() const

--- a/fem/datacollection.cpp
+++ b/fem/datacollection.cpp
@@ -165,7 +165,7 @@ void DataCollection::SetFormat(int fmt)
 void DataCollection::SetCompression(bool comp)
 {
    compression = comp;
-#ifdef MFEM_USE_GZSTREAM
+#ifndef MFEM_USE_GZSTREAM
    MFEM_ASSERT(!compression, "GZStream not enabled in MFEM build.");
 #endif
 }

--- a/fem/datacollection.cpp
+++ b/fem/datacollection.cpp
@@ -742,7 +742,8 @@ ParaViewDataCollection::ParaViewDataCollection(const std::string&
                                                collection_name,
                                                mfem::Mesh *mesh_)
    : DataCollection(collection_name, mesh_),
-     pv_data_format(BINARY)
+     pv_data_format(BINARY),
+     high_order_output(false)
 {
    myrank = 0;
    nprocs = 1;
@@ -935,7 +936,7 @@ void ParaViewDataCollection::SaveDataVTU(std::ostream &out, int ref)
    out << "<VTKFile type=\"UnstructuredGrid\" ";
    out << " version=\"0.1\" byte_order=\"LittleEndian\">" << std::endl;
    out << "<UnstructuredGrid>" << std::endl;
-   mesh->PrintVTU(out,ref,pv_data_format == BINARY);
+   mesh->PrintVTU(out,ref,pv_data_format == BINARY,high_order_output);
 
    // dump out the grid functions as point data
    out << "<PointData >" << std::endl;
@@ -1068,7 +1069,8 @@ ParaViewDataCollection::ParaViewDataCollection(const std::string&
                                                collection_name,
                                                mfem::ParMesh *mesh_)
    : DataCollection(collection_name,mesh_),
-     pv_data_format(BINARY)
+     pv_data_format(BINARY),
+     high_order_output(false)
 {
    lcomm = mesh_->GetComm();
    MPI_Comm_rank(lcomm, &myrank);
@@ -1127,6 +1129,11 @@ void ParaViewDataCollection::SetMesh(MPI_Comm comm, mfem::Mesh *new_mesh)
 void ParaViewDataCollection::SetDataFormat(DataFormat fmt)
 {
    pv_data_format = fmt;
+}
+
+void ParaViewDataCollection::SetHighOrderOutput(bool high_order_output_)
+{
+   high_order_output = high_order_output_;
 }
 
 const char *ParaViewDataCollection::GetDataFormatString() const

--- a/fem/datacollection.cpp
+++ b/fem/datacollection.cpp
@@ -940,7 +940,7 @@ void ParaViewDataCollection::Save()
 void ParaViewDataCollection::SaveDataVTU(std::ostream &out, int ref)
 {
    out << "<VTKFile type=\"UnstructuredGrid\"";
-   if (compression_level > 0)
+   if (compression_level != 0)
    {
       out << " compressor=\"vtkZLibDataCompressor\"";
    }
@@ -1145,9 +1145,18 @@ void ParaViewDataCollection::SetHighOrderOutput(bool high_order_output_)
 
 void ParaViewDataCollection::SetCompressionLevel(int compression_level_)
 {
-   MFEM_ASSERT(compression_level_ >= 0 && compression_level_ <= 9,
-               "Compression level must be between 0 and 9 (inclusive).");
+   MFEM_ASSERT(compression_level_ >= -1 && compression_level_ <= 9,
+               "Compression level must be between -1 and 9 (inclusive).");
    compression_level = compression_level_;
+}
+
+void ParaViewDataCollection::SetCompression(bool compression)
+{
+   DataCollection::SetCompression(compression);
+   if (compression && compression_level == 0)
+   {
+      SetCompressionLevel(-1);
+   }
 }
 
 const char *ParaViewDataCollection::GetDataFormatString() const

--- a/fem/datacollection.cpp
+++ b/fem/datacollection.cpp
@@ -726,16 +726,6 @@ void VisItDataCollection::ParseVisItRootString(const std::string& json)
    }
 }
 
-
-ParaViewDataCollection::~ParaViewDataCollection()
-{
-   if (myid==0)
-   {
-      // Close the data collection
-      pvd_stream.close();
-   }
-}
-
 ParaViewDataCollection::ParaViewDataCollection(const std::string&
                                                collection_name,
                                                Mesh *mesh_)

--- a/fem/datacollection.hpp
+++ b/fem/datacollection.hpp
@@ -475,7 +475,7 @@ class ParaViewDataCollection : public DataCollection
 private:
    int levels_of_detail;
    std::fstream pvd_stream;
-   VTUFormat pv_data_format;
+   VTKFormat pv_data_format;
    bool high_order_output;
 
 protected:
@@ -514,10 +514,10 @@ public:
    virtual void Save() override;
 
    /// Set the data format for the ParaView output files. Possible options are
-   /// VTUFormat::ASCII, VTUFormat::BINARY, and VTUFormat::BINARY32.
+   /// VTKFormat::ASCII, VTKFormat::BINARY, and VTKFormat::BINARY32.
    /// The ASCII and BINARY options output double precision data, whereas the
    /// BINARY32 option outputs single precision data.
-   void SetDataFormat(VTUFormat fmt);
+   void SetDataFormat(VTKFormat fmt);
 
    /// Set the zlib compression level. 0 indicates no compression, -1 indicates
    /// the default compression level. Otherwise, specify a number between 1 and

--- a/fem/datacollection.hpp
+++ b/fem/datacollection.hpp
@@ -526,7 +526,7 @@ public:
    /// be compiled with MFEM_USE_GZSTREAM = YES.
    void SetCompressionLevel(int compression_level_);
 
-   /// Enable or diable zlib compression. If the input is true, use the default
+   /// Enable or disable zlib compression. If the input is true, use the default
    /// zlib compression level (unless the compression level has previously been
    /// set by calling SetCompressionLevel).
    void SetCompression(bool compression_) override;

--- a/fem/datacollection.hpp
+++ b/fem/datacollection.hpp
@@ -349,7 +349,7 @@ public:
    virtual void SetFormat(int fmt);
 
    /// Set the flag for use of gz compressed files
-   void SetCompression(bool comp);
+   virtual void SetCompression(bool comp);
 
    /// Set the path where the DataCollection will be saved.
    void SetPrefixPath(const std::string &prefix);
@@ -482,7 +482,7 @@ private:
    std::fstream pvd_stream;
    VTUFormat pv_data_format;
    bool high_order_output;
-   bool compression_level;
+   int compression_level;
 
 protected:
    void SaveDataVTU(std::ostream &out, int ref);
@@ -541,10 +541,17 @@ public:
    /// BINARY32 option outputs single precision data.
    void SetDataFormat(VTUFormat fmt);
 
-   /// Enable or diable zlib compression. Compression only takes effect if the
-   /// output format is BINARY or BINARY32. MFEM must be compiled with
-   /// MFEM_USE_GZSTREAM = YES.
+   /// Set the zlib compression level. 0 indicates no compression, -1 indicates
+   /// the default compression level. Otherwise, specify a number between 1 and
+   /// 9, 1 being the fastest, and 9 being the best compression. Compression
+   /// only takes effect if the output format is BINARY or BINARY32. MFEM must
+   /// be compiled with MFEM_USE_GZSTREAM = YES.
    void SetCompressionLevel(int compression_level_);
+
+   /// Enable or diable zlib compression. If the input is true, use the default
+   /// zlib compression level (unless the compression level has previously been
+   /// set by calling SetCompressionLevel).
+   void SetCompression(bool compression) override;
 
    /// Returns true if the output format is BINARY or BINARY32, false if ASCII.
    bool IsBinaryFormat() const;

--- a/fem/datacollection.hpp
+++ b/fem/datacollection.hpp
@@ -482,6 +482,7 @@ private:
    std::fstream pvd_stream;
    VTUFormat pv_data_format;
    bool high_order_output;
+   bool compress_output;
 
 protected:
    void SaveDataVTU(std::ostream &out, int ref);
@@ -539,6 +540,11 @@ public:
    /// The ASCII and BINARY options output double precision data, whereas the
    /// BINARY32 option outputs single precision data.
    void SetDataFormat(VTUFormat fmt);
+
+   /// Enable or diable zlib compression. Compression only takes effect if the
+   /// output format is BINARY or BINARY32. MFEM must be compiled with
+   /// MFEM_USE_GZSTREAM = YES.
+   void SetCompression(bool compress_output_);
 
    /// Returns true if the output format is BINARY or BINARY32, false if ASCII.
    bool IsBinaryFormat() const;

--- a/fem/datacollection.hpp
+++ b/fem/datacollection.hpp
@@ -472,6 +472,12 @@ public:
 /// Helper class for ParaView visualization data
 class ParaViewDataCollection : public DataCollection
 {
+public:
+   enum DataFormat
+   {
+      ASCII,
+      BINARY
+   };
 private:
 #ifdef MFEM_USE_MPI
    MPI_Comm lcomm;
@@ -480,6 +486,7 @@ private:
    int nprocs;
    int levels_of_detail;
    std::fstream pvd_stream;
+   DataFormat pv_data_format;
 
 protected:
    void SaveDataVTU(std::ostream &out, int ref);
@@ -529,6 +536,10 @@ public:
    /// Save the collection - the directory name is constructed based on the
    /// cycle value
    virtual void Save() override;
+
+   void SetDataFormat(DataFormat fmt);
+
+   const char *GetDataFormatString() const;
 
    /// Load the collection - not implemented in the ParaView writer
    virtual void Load(int cycle_ = 0) override;

--- a/fem/datacollection.hpp
+++ b/fem/datacollection.hpp
@@ -473,11 +473,6 @@ public:
 class ParaViewDataCollection : public DataCollection
 {
 private:
-#ifdef MFEM_USE_MPI
-   MPI_Comm lcomm;
-#endif
-   int myrank;
-   int nprocs;
    int levels_of_detail;
    std::fstream pvd_stream;
    VTUFormat pv_data_format;
@@ -501,26 +496,12 @@ protected:
 public:
    /// Constructor. The collection name is used when saving the data.
    /** If @a mesh_ is NULL, then the mesh can be set later by calling SetMesh().
-       The constructor works only in serial. */
+       Before saving the data collection, some parameters in the collection can
+       be adjusted, e.g. SetPadDigits(), SetPrefixPath(), etc. */
    ParaViewDataCollection(const std::string& collection_name,
                           mfem::Mesh *mesh_ = NULL);
 
-#ifdef MFEM_USE_MPI
-   /// Construct a parallel ParaViewDataCollection.
-   /** Before saving the data collection, some parameters in the collection can
-       be adjusted, e.g. SetPadDigits(), SetPrefixPath(), etc. */
-   ParaViewDataCollection(const std::string& collection_name,
-                          mfem::ParMesh *mesh_ = NULL);
-#endif
-
    virtual ~ParaViewDataCollection() override;
-
-   virtual void SetMesh(mfem::Mesh * new_mesh) override;
-
-#ifdef MFEM_USE_MPI
-   /// Set/change the mesh associated with the collection.
-   virtual void SetMesh(MPI_Comm comm, mfem::Mesh *new_mesh) override;
-#endif
 
    /// Add a grid function to the collection
    virtual void RegisterField(const std::string& field_name,
@@ -561,13 +542,6 @@ public:
 
    /// Load the collection - not implemented in the ParaView writer
    virtual void Load(int cycle_ = 0) override;
-
-   static int create_directory(const std::string &dir_name);
-
-#ifdef MFEM_USE_MPI
-   static int create_directory(const std::string &dir_name, int myid,
-                               MPI_Comm mycom);
-#endif
 };
 
 }

--- a/fem/datacollection.hpp
+++ b/fem/datacollection.hpp
@@ -501,8 +501,6 @@ public:
    ParaViewDataCollection(const std::string& collection_name,
                           mfem::Mesh *mesh_ = NULL);
 
-   virtual ~ParaViewDataCollection() override;
-
    /// Add a grid function to the collection
    virtual void RegisterField(const std::string& field_name,
                               mfem::GridFunction *gf) override;

--- a/fem/datacollection.hpp
+++ b/fem/datacollection.hpp
@@ -206,7 +206,7 @@ protected:
 
    /// Output mesh format: see the #Format enumeration
    int format;
-   bool compression;
+   int compression;
 
    /// Should the collection delete its mesh and fields
    bool own_data;
@@ -482,7 +482,6 @@ private:
    std::fstream pvd_stream;
    VTUFormat pv_data_format;
    bool high_order_output;
-   int compression_level;
 
 protected:
    void SaveDataVTU(std::ostream &out, int ref);
@@ -551,7 +550,7 @@ public:
    /// Enable or diable zlib compression. If the input is true, use the default
    /// zlib compression level (unless the compression level has previously been
    /// set by calling SetCompressionLevel).
-   void SetCompression(bool compression) override;
+   void SetCompression(bool compression_) override;
 
    /// Returns true if the output format is BINARY or BINARY32, false if ASCII.
    bool IsBinaryFormat() const;

--- a/fem/datacollection.hpp
+++ b/fem/datacollection.hpp
@@ -472,12 +472,6 @@ public:
 /// Helper class for ParaView visualization data
 class ParaViewDataCollection : public DataCollection
 {
-public:
-   enum DataFormat
-   {
-      ASCII,
-      BINARY
-   };
 private:
 #ifdef MFEM_USE_MPI
    MPI_Comm lcomm;
@@ -486,7 +480,7 @@ private:
    int nprocs;
    int levels_of_detail;
    std::fstream pvd_stream;
-   DataFormat pv_data_format;
+   VTUFormat pv_data_format;
    bool high_order_output;
 
 protected:
@@ -538,11 +532,15 @@ public:
    /// cycle value
    virtual void Save() override;
 
-   void SetDataFormat(DataFormat fmt);
+   void SetDataFormat(VTUFormat fmt);
+
+   bool IsBinaryFormat() const;
 
    void SetHighOrderOutput(bool high_order_output_);
 
    const char *GetDataFormatString() const;
+
+   const char *GetDataTypeString() const;
 
    /// Load the collection - not implemented in the ParaView writer
    virtual void Load(int cycle_ = 0) override;

--- a/fem/datacollection.hpp
+++ b/fem/datacollection.hpp
@@ -482,7 +482,7 @@ private:
    std::fstream pvd_stream;
    VTUFormat pv_data_format;
    bool high_order_output;
-   bool compress_output;
+   bool compression_level;
 
 protected:
    void SaveDataVTU(std::ostream &out, int ref);
@@ -544,7 +544,7 @@ public:
    /// Enable or diable zlib compression. Compression only takes effect if the
    /// output format is BINARY or BINARY32. MFEM must be compiled with
    /// MFEM_USE_GZSTREAM = YES.
-   void SetCompression(bool compress_output_);
+   void SetCompressionLevel(int compression_level_);
 
    /// Returns true if the output format is BINARY or BINARY32, false if ASCII.
    bool IsBinaryFormat() const;

--- a/fem/datacollection.hpp
+++ b/fem/datacollection.hpp
@@ -487,6 +487,7 @@ private:
    int levels_of_detail;
    std::fstream pvd_stream;
    DataFormat pv_data_format;
+   bool high_order_output;
 
 protected:
    void SaveDataVTU(std::ostream &out, int ref);
@@ -538,6 +539,8 @@ public:
    virtual void Save() override;
 
    void SetDataFormat(DataFormat fmt);
+
+   void SetHighOrderOutput(bool high_order_output_);
 
    const char *GetDataFormatString() const;
 

--- a/fem/datacollection.hpp
+++ b/fem/datacollection.hpp
@@ -487,6 +487,8 @@ protected:
    void SaveDataVTU(std::ostream &out, int ref);
    void SaveGFieldVTU(std::ostream& out, int ref_, const FieldMapIterator& it);
    void SaveQFieldVTU(std::ostream &out, int ref, const QFieldMapIterator& it);
+   const char *GetDataFormatString() const;
+   const char *GetDataTypeString() const;
 
    std::string  GenerateCollectionPath();
    std::string  GenerateVTUFileName();
@@ -532,15 +534,18 @@ public:
    /// cycle value
    virtual void Save() override;
 
+   /// Set the data format for the ParaView output files. Possible options are
+   /// VTUFormat::ASCII, VTUFormat::BINARY, and VTUFormat::BINARY32.
+   /// The ASCII and BINARY options output double precision data, whereas the
+   /// BINARY32 option outputs single precision data.
    void SetDataFormat(VTUFormat fmt);
 
+   /// Returns true if the output format is BINARY or BINARY32, false if ASCII.
    bool IsBinaryFormat() const;
 
+   /// Sets whether or not to output the data as high-order elements (false
+   /// by default). Reading high-order data requires ParaView 5.5 or later.
    void SetHighOrderOutput(bool high_order_output_);
-
-   const char *GetDataFormatString() const;
-
-   const char *GetDataTypeString() const;
 
    /// Load the collection - not implemented in the ParaView writer
    virtual void Load(int cycle_ = 0) override;

--- a/general/CMakeLists.txt
+++ b/general/CMakeLists.txt
@@ -11,6 +11,7 @@
 
 list(APPEND SRCS
   array.cpp
+  binaryio.cpp
   cuda.cpp
   device.cpp
   error.cpp

--- a/general/binaryio.cpp
+++ b/general/binaryio.cpp
@@ -56,9 +56,9 @@ void WriteBase64(std::ostream &out, const void *bytes, size_t nbytes)
 }
 
 void WriteEncodedCompressed(std::ostream &out, const void *bytes,
-                            uint32_t nbytes, bool compressed)
+                            uint32_t nbytes, int compression_level)
 {
-   if (!compressed)
+   if (compression_level == 0)
    {
       // First write size of buffer (as uint32_t), encoded with base 64
       WriteBase64(out, &nbytes, sizeof(nbytes));
@@ -68,9 +68,12 @@ void WriteEncodedCompressed(std::ostream &out, const void *bytes,
    else
    {
 #ifdef MFEM_USE_GZSTREAM
+      MFEM_ASSERT(compression_level >= 0 && compression_level <= 9,
+                  "Compression level must be between 0 and 9 (inclusive).");
       uLongf buf_sz = compressBound(nbytes);
       std::vector<unsigned char> buf(buf_sz);
-      compress(buf.data(), &buf_sz, static_cast<const Bytef *>(bytes), nbytes);
+      compress2(buf.data(), &buf_sz, static_cast<const Bytef *>(bytes), nbytes,
+                compression_level);
 
       // Write the header
       std::vector<uint32_t> header(4);

--- a/general/binaryio.cpp
+++ b/general/binaryio.cpp
@@ -1,0 +1,55 @@
+// Copyright (c) 2010, Lawrence Livermore National Security, LLC. Produced at
+// the Lawrence Livermore National Laboratory. LLNL-CODE-443211. All Rights
+// reserved. See file COPYRIGHT for details.
+//
+// This file is part of the MFEM library. For more information and source code
+// availability see http://mfem.org.
+//
+// MFEM is free software; you can redistribute it and/or modify it under the
+// terms of the GNU Lesser General Public License (as published by the Free
+// Software Foundation) version 2.1 dated February 1999.
+
+#include "binaryio.hpp"
+
+namespace mfem
+{
+namespace bin_io
+{
+
+static const char *b64str
+   = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+     "abcdefghijklmnopqrstuvwxyz"
+     "0123456789+/";
+
+void WriteBase64(std::ostream &out, const void *bytes, size_t length)
+{
+   const unsigned char *in = static_cast<const unsigned char *>(bytes);
+   const unsigned char *end = in + length;
+   while (end - in >= 3)
+   {
+      out << b64str[in[0] >> 2];
+      out << b64str[((in[0] & 0x03) << 4) | (in[1] >> 4)];
+      out << b64str[((in[1] & 0x0f) << 2) | (in[2] >> 6)];
+      out << b64str[in[2] & 0x3f];
+      in += 3;
+   }
+   if (end - in > 0)
+   {
+      out << b64str[in[0] >> 2];
+      if (end - in == 1)
+      {
+         out << b64str[(in[0] & 0x03) << 4];
+         out << '=';
+      }
+      else
+      {
+         out << b64str[((in[0] & 0x03) << 4) |
+            (in[1] >> 4)];
+         out << b64str[(in[1] & 0x0f) << 2];
+      }
+      out << '=';
+   }
+}
+
+} // namespace mfem::bin_io
+} // namespace mfem

--- a/general/binaryio.cpp
+++ b/general/binaryio.cpp
@@ -68,8 +68,8 @@ void WriteEncodedCompressed(std::ostream &out, const void *bytes,
    else
    {
 #ifdef MFEM_USE_GZSTREAM
-      MFEM_ASSERT(compression_level >= 0 && compression_level <= 9,
-                  "Compression level must be between 0 and 9 (inclusive).");
+      MFEM_ASSERT(compression_level >= -1 && compression_level <= 9,
+                  "Compression level must be between -1 and 9 (inclusive).");
       uLongf buf_sz = compressBound(nbytes);
       std::vector<unsigned char> buf(buf_sz);
       compress2(buf.data(), &buf_sz, static_cast<const Bytef *>(bytes), nbytes,

--- a/general/binaryio.cpp
+++ b/general/binaryio.cpp
@@ -10,6 +10,11 @@
 // Software Foundation) version 2.1 dated February 1999.
 
 #include "binaryio.hpp"
+#include "error.hpp"
+#ifdef MFEM_USE_GZSTREAM
+#include <vector>
+#include <zlib.h>
+#endif
 
 namespace mfem
 {
@@ -47,6 +52,39 @@ void WriteBase64(std::ostream &out, const void *bytes, size_t nbytes)
          out << b64str[(in[1] & 0x0f) << 2];
       }
       out << '=';
+   }
+}
+
+void WriteEncodedCompressed(std::ostream &out, const void *bytes,
+                            uint32_t nbytes, bool compressed)
+{
+   if (!compressed)
+   {
+      // First write size of buffer (as uint32_t), encoded with base 64
+      WriteBase64(out, &nbytes, sizeof(nbytes));
+      // Then write all the bytes in the buffer, encoded with base 64
+      WriteBase64(out, bytes, nbytes);
+   }
+   else
+   {
+#ifdef MFEM_USE_GZSTREAM
+      uLongf buf_sz = compressBound(nbytes);
+      std::vector<unsigned char> buf(buf_sz);
+      compress(buf.data(), &buf_sz, static_cast<const Bytef *>(bytes), nbytes);
+
+      // Write the header
+      std::vector<uint32_t> header(4);
+      header[0] = 1; // number of blocks
+      header[1] = nbytes; // uncompressed size
+      header[2] = 0; // size of partial block
+      header[3] = buf_sz; // compressed size
+      WriteBase64(out, header.data(), header.size()*sizeof(uint32_t));
+      // Write the compressed data
+      WriteBase64(out, buf.data(), buf_sz);
+#else
+      MFEM_ABORT("MFEM must be compiled with gzstream support to output "
+                 "compressed binary data.")
+#endif
    }
 }
 

--- a/general/binaryio.cpp
+++ b/general/binaryio.cpp
@@ -21,10 +21,10 @@ static const char *b64str
      "abcdefghijklmnopqrstuvwxyz"
      "0123456789+/";
 
-void WriteBase64(std::ostream &out, const void *bytes, size_t length)
+void WriteBase64(std::ostream &out, const void *bytes, size_t nbytes)
 {
    const unsigned char *in = static_cast<const unsigned char *>(bytes);
-   const unsigned char *end = in + length;
+   const unsigned char *end = in + nbytes;
    while (end - in >= 3)
    {
       out << b64str[in[0] >> 2];
@@ -33,7 +33,7 @@ void WriteBase64(std::ostream &out, const void *bytes, size_t length)
       out << b64str[in[2] & 0x3f];
       in += 3;
    }
-   if (end - in > 0)
+   if (end - in > 0) // Padding
    {
       out << b64str[in[0] >> 2];
       if (end - in == 1)
@@ -41,10 +41,9 @@ void WriteBase64(std::ostream &out, const void *bytes, size_t length)
          out << b64str[(in[0] & 0x03) << 4];
          out << '=';
       }
-      else
+      else // end - in == 2
       {
-         out << b64str[((in[0] & 0x03) << 4) |
-            (in[1] >> 4)];
+         out << b64str[((in[0] & 0x03) << 4) | (in[1] >> 4)];
          out << b64str[(in[1] & 0x0f) << 2];
       }
       out << '=';

--- a/general/binaryio.hpp
+++ b/general/binaryio.hpp
@@ -48,9 +48,6 @@ void AppendBytes(std::vector<char> &vec, const T &val)
 
 void WriteBase64(std::ostream &out, const void *bytes, size_t length);
 
-void WriteEncodedCompressed(std::ostream &out, const void *bytes,
-                            uint32_t nbytes, int compression_level);
-
 } // namespace mfem::bin_io
 
 } // namespace mfem

--- a/general/binaryio.hpp
+++ b/general/binaryio.hpp
@@ -42,11 +42,8 @@ inline T read(std::istream& is)
 template <typename T>
 void AppendBytes(std::vector<char> &vec, const T &val)
 {
-   for(char ib=0; ib<sizeof(T); ++ib)
-   {
-      char byte = *(reinterpret_cast<const char*>(&val) + ib);
-      vec.push_back(byte);
-   }
+   const char *ptr = reinterpret_cast<const char*>(&val);
+   vec.insert(vec.end(), ptr, ptr + sizeof(T));
 }
 
 void WriteBase64(std::ostream &out, const void *bytes, size_t length);

--- a/general/binaryio.hpp
+++ b/general/binaryio.hpp
@@ -49,7 +49,7 @@ void AppendBytes(std::vector<char> &vec, const T &val)
 void WriteBase64(std::ostream &out, const void *bytes, size_t length);
 
 void WriteEncodedCompressed(std::ostream &out, const void *bytes,
-                            uint32_t nbytes, bool compressed);
+                            uint32_t nbytes, int compression_level);
 
 } // namespace mfem::bin_io
 

--- a/general/binaryio.hpp
+++ b/general/binaryio.hpp
@@ -15,6 +15,7 @@
 #include "../config/config.hpp"
 
 #include <iostream>
+#include <vector>
 
 namespace mfem
 {
@@ -37,6 +38,18 @@ inline T read(std::istream& is)
    is.read((char*) &value, sizeof(T));
    return value;
 }
+
+template <typename T>
+void AppendBytes(std::vector<char> &vec, const T &val)
+{
+   for(char ib=0; ib<sizeof(T); ++ib)
+   {
+      char byte = *(reinterpret_cast<const char*>(&val) + ib);
+      vec.push_back(byte);
+   }
+}
+
+void WriteBase64(std::ostream &out, const void *bytes, size_t length);
 
 } // namespace mfem::bin_io
 

--- a/general/binaryio.hpp
+++ b/general/binaryio.hpp
@@ -48,6 +48,9 @@ void AppendBytes(std::vector<char> &vec, const T &val)
 
 void WriteBase64(std::ostream &out, const void *bytes, size_t length);
 
+void WriteEncodedCompressed(std::ostream &out, const void *bytes,
+                            uint32_t nbytes, bool compressed);
+
 } // namespace mfem::bin_io
 
 } // namespace mfem

--- a/mesh/CMakeLists.txt
+++ b/mesh/CMakeLists.txt
@@ -23,6 +23,7 @@ set(SRCS
   tetrahedron.cpp
   triangle.cpp
   vertex.cpp
+  vtk.cpp
   wedge.cpp
   )
 
@@ -41,6 +42,7 @@ set(HDRS
   tmesh.hpp
   triangle.hpp
   vertex.hpp
+  vtk.hpp
   wedge.hpp
   )
 

--- a/mesh/mesh.cpp
+++ b/mesh/mesh.cpp
@@ -8567,7 +8567,7 @@ void Mesh::PrintVTU(std::string fname,
    {
       out << " compressor=\"vtkZLibDataCompressor\"";
    }
-   out << " byte_order=\"LittleEndian\">\n";
+   out << " byte_order=\"" << VTKByteOrder() << "\">\n";
    out << "<UnstructuredGrid>\n";
    PrintVTU(out, ref, format, high_order_output, compression_level);
    out << "</Piece>\n"; // need to close the piece open in the PrintVTU method

--- a/mesh/mesh.cpp
+++ b/mesh/mesh.cpp
@@ -8555,7 +8555,7 @@ void Mesh::PrintVTK(std::ostream &out)
 }
 
 void Mesh::PrintVTU(std::string fname,
-                    VTUFormat format,
+                    VTKFormat format,
                     bool high_order_output,
                     int compression_level)
 {
@@ -8579,9 +8579,9 @@ void Mesh::PrintVTU(std::string fname,
 
 template <typename T>
 void WriteBinaryOrASCII(std::ostream &out, std::vector<char> &buf, const T &val,
-                        const char *suffix, VTUFormat format)
+                        const char *suffix, VTKFormat format)
 {
-   if (format == VTUFormat::ASCII) { out << val << suffix; }
+   if (format == VTKFormat::ASCII) { out << val << suffix; }
    else { bin_io::AppendBytes(buf, val); }
 }
 
@@ -8589,22 +8589,22 @@ void WriteBinaryOrASCII(std::ostream &out, std::vector<char> &buf, const T &val,
 template <>
 void WriteBinaryOrASCII<uint8_t>(std::ostream &out, std::vector<char> &buf,
                                  const uint8_t &val, const char *suffix,
-                                 VTUFormat format)
+                                 VTKFormat format)
 {
-   if (format == VTUFormat::ASCII) { out << static_cast<int>(val) << suffix; }
+   if (format == VTKFormat::ASCII) { out << static_cast<int>(val) << suffix; }
    else { bin_io::AppendBytes(buf, val); }
 }
 
 template <>
 void WriteBinaryOrASCII<double>(std::ostream &out, std::vector<char> &buf,
                                 const double &val, const char *suffix,
-                                VTUFormat format)
+                                VTKFormat format)
 {
-   if (format == VTUFormat::BINARY32)
+   if (format == VTKFormat::BINARY32)
    {
       bin_io::AppendBytes<float>(buf, float(val));
    }
-   else if (format == VTUFormat::BINARY)
+   else if (format == VTKFormat::BINARY)
    {
       bin_io::AppendBytes(buf, val);
    }
@@ -8617,426 +8617,29 @@ void WriteBinaryOrASCII<double>(std::ostream &out, std::vector<char> &buf,
 template <>
 void WriteBinaryOrASCII<float>(std::ostream &out, std::vector<char> &buf,
                                const float &val, const char *suffix,
-                               VTUFormat format)
+                               VTKFormat format)
 {
-   if (format == VTUFormat::BINARY) { bin_io::AppendBytes<double>(buf, val); }
-   else if (format == VTUFormat::BINARY32) { bin_io::AppendBytes(buf, val); }
+   if (format == VTKFormat::BINARY) { bin_io::AppendBytes<double>(buf, val); }
+   else if (format == VTKFormat::BINARY32) { bin_io::AppendBytes(buf, val); }
    else { out << val << suffix; }
 }
 
 void WriteBase64WithSizeAndClear(std::ostream &out, std::vector<char> &buf,
                                  int compression_level)
 {
-   bin_io::WriteEncodedCompressed(out, buf.data(), buf.size(), compression_level);
+   WriteVTKEncodedCompressed(out, buf.data(), buf.size(), compression_level);
    out << '\n';
    buf.clear();
 }
 
-int BarycentricToVTKTriangle(int *b, int ref)
-{
-   // Cf. https://git.io/JvW8f
-   int max = ref;
-   int min = 0;
-   int bmin = std::min(std::min(b[0], b[1]), b[2]);
-   int idx = 0;
-
-   // scope into the correct triangle
-   while (bmin > min)
-   {
-      idx += 3*ref;
-      max -= 2;
-      ++min;
-      ref -= 3;
-   }
-   for (int d=0; d<3; ++d)
-   {
-      if (b[(d+2)%3] == max)
-      {
-         // we are on a vertex
-         return idx;
-      }
-      ++idx;
-   }
-   for (int d=0; d<3; ++d)
-   {
-      if (b[(d+1)%3] == min)
-      {
-         // we are on an edge
-         return idx + b[d] - (min + 1);
-      }
-      idx += max - (min + 1);
-   }
-   return idx;
-}
-
-int BarycentricToVTKTetra(int *b, int ref)
-{
-   // Cf. https://git.io/JvW8c
-   int idx = 0;
-
-   int max = ref;
-   int min = 0;
-
-   int bmin = std::min(std::min(std::min(b[0], b[1]), b[2]), b[3]);
-
-   // scope into the correct tetra
-   while (bmin > min)
-   {
-      idx += 2*(ref*ref + 1);
-      max -= 3;
-      min++;
-      ref -= 4;
-   }
-
-   // When a linearized tetra vertex is cast into barycentric coordinates, one of
-   // its coordinates is maximal and the other three are minimal. These are the
-   // indices of the maximal barycentric coordinate for each vertex.
-   static const int VertexMaxCoords[4] = {3,0,1,2};
-   // Each linearized tetra edge holds two barycentric tetra coordinates constant
-   // and varies the other two. These are the coordinates that are held constant
-   // for each edge.
-   static const int EdgeMinCoords[6][2] = {{1,2},{2,3},{0,2}, {0,1},{1,3},{0,3}};
-   // The coordinate that increments when traversing an edge (i.e. the coordinate
-   // of the nonzero component of the second vertex of the edge).
-   static const int EdgeCountingCoord[6] = {0,1,3,2,2,2};
-   // When describing a linearized tetra face, there is a mapping between the
-   // four-component barycentric tetra system and the three-component barycentric
-   // triangle system. These are the constant indices within the four-component
-   // system for each face (e.g. face 0 holds barycentric tetra coordinate 1
-   // constant).
-   static const int FaceMinCoord[4] = {1,3,0,2};
-   // When describing a linearized tetra face, there is a mapping between the
-   // four-component barycentric tetra system and the three-component barycentric
-   // triangle system. These are the relevant indices within the four-component
-   // system for each face (e.g. face 0 varies across the barycentric tetra
-   // coordinates 0, 2 and 3).
-   static const int FaceBCoords[4][3] = {{0,2,3}, {2,0,1}, {2,1,3}, {1,0,3}};
-
-
-   for (int vertex = 0; vertex < 4; vertex++)
-   {
-      if (b[VertexMaxCoords[vertex]] == max)
-      {
-         // we are on a vertex
-         return idx;
-      }
-      idx++;
-   }
-
-   for (int edge = 0; edge < 6; edge++)
-   {
-      if (b[EdgeMinCoords[edge][0]] == min && b[EdgeMinCoords[edge][1]] == min)
-      {
-         // we are on an edge
-         return idx + b[EdgeCountingCoord[edge]] - (min + 1);
-      }
-      idx += max - (min + 1);
-   }
-
-   for (int face = 0; face < 4; face++)
-   {
-      if (b[FaceMinCoord[face]] == min)
-      {
-         // we are on a face
-         int projectedb[3];
-         for (int i = 0; i < 3; i++)
-         {
-            projectedb[i] = b[FaceBCoords[face][i]] - min;
-         }
-         // we must subtract the indices of the face's vertices and edges, which
-         // total to 3*ref
-         return (idx + BarycentricToVTKTriangle(projectedb, ref) - 3*ref);
-      }
-      idx += (ref+1)*(ref+2)/2 - 3*ref;
-   }
-   return idx;
-}
-
-int VTKTriangleDOFOffset(int ref, int i, int j)
-{
-   return i + ref*(j - 1) - (j*(j + 1))/2;
-}
-
-int CartesianToVTKPrism(int i, int j, int k, int ref)
-{
-   // Cf. https://git.io/JvW0M
-   int om1 = ref - 1;
-   int ibdr = (i == 0);
-   int jbdr = (j == 0);
-   int ijbdr = (i + j == ref);
-   int kbdr = (k == 0 || k == ref);
-   // How many boundaries do we lie on at once?
-   int nbdr = ibdr + jbdr + ijbdr + kbdr;
-
-   // Return an invalid index given invalid coordinates
-   if (i < 0 || i > ref || j < 0 || j > ref || i + j > ref || k < 0 || k > ref)
-   {
-      MFEM_ABORT("Invalid index")
-   }
-
-   if (nbdr == 3) // Vertex DOF
-   {
-      // ijk is a corner node. Return the proper index (somewhere in [0,5]):
-      return (ibdr && jbdr ? 0 : (jbdr && ijbdr ? 1 : 2)) + (k ? 3 : 0);
-   }
-
-   int offset = 6;
-   if (nbdr == 2) // Edge DOF
-   {
-      if (!kbdr)
-      {
-         // Must be on a vertical edge and 2 of {ibdr, jbdr, ijbdr} are true
-         offset += om1*6;
-         return offset + (k-1)
-                + ((ibdr && jbdr) ? 0 : (jbdr && ijbdr ? 1 : 2))*om1;
-      }
-      else
-      {
-         // Must be on a horizontal edge and kbdr plus 1 of {ibdr, jbdr, ijbdr} is true
-         // Skip past first 3 edges if we are on the top (k = ref) face:
-         offset += (k == ref ? 3*om1 : 0);
-         if (jbdr)
-         {
-            return offset + i - 1;
-         }
-         offset += om1; // Skip the i-axis edge
-         if (ijbdr)
-         {
-            return offset + j - 1;
-         }
-         offset += om1; // Skip the ij-axis edge
-         // if (ibdr)
-         return offset + (ref - j - 1);
-      }
-   }
-
-   offset += 9*om1; // Skip all the edges
-
-   // Number of points on a triangular face (but not on edge/corner):
-   int ntfdof = (om1 - 1)*om1/2;
-   int nqfdof = om1*om1;
-   if (nbdr == 1) // Face DOF
-   {
-      if (kbdr)
-      {
-         // We are on a triangular face.
-         if (k > 0)
-         {
-            offset += ntfdof;
-         }
-         return offset + VTKTriangleDOFOffset(ref, i, j);
-      }
-      // Not a k-normal face, so skip them:
-      offset += 2*ntfdof;
-
-      // Face is quadrilateral (ref - 1) x (ref - 1)
-      // First face is i-normal, then ij-normal, then j-normal
-      if (jbdr) // On i-normal face
-      {
-         return offset + (i - 1) + om1*(k - 1);
-      }
-      offset += nqfdof; // Skip i-normal face
-      if (ijbdr) // on ij-normal face
-      {
-         return offset + (ref - i - 1) + om1*(k - 1);
-      }
-      offset += nqfdof; // Skip ij-normal face
-      return offset + j - 1 + om1*(k - 1);
-   }
-
-   // Skip all face DOF
-   offset += 2*ntfdof + 3*nqfdof;
-
-   // nbdr == 0: Body DOF
-   return offset + VTKTriangleDOFOffset(ref, i, j) + ntfdof*(k - 1);
-   // (i - 1) + (ref-1)*((j - 1) + (ref - 1)*(k - 1)));
-}
-
-int CartesianToVTKTensor(int idx_in, int ref, Geometry::Type geom)
-{
-   int n = ref + 1;
-   switch (geom)
-   {
-      case Geometry::POINT:
-         return idx_in;
-      case Geometry::SEGMENT:
-         if (idx_in == 0 || idx_in == ref)
-         {
-            return idx_in ? 1 : 0;
-         }
-         return idx_in + 1;
-      case Geometry::SQUARE:
-      {
-         // Cf: https://git.io/JvZLT
-         int i = idx_in % n;
-         int j = idx_in / n;
-         // Do we lie on any of the edges
-         bool ibdr = (i == 0 || i == ref);
-         bool jbdr = (j == 0 || j == ref);
-         if (ibdr && jbdr) // Vertex DOF
-         {
-            return (i ? (j ? 2 : 1) : (j ? 3 : 0));
-         }
-         int offset = 4;
-         if (jbdr) // Edge DOF on j==0 or j==ref
-         {
-            return (i - 1) + (j ? ref - 1 + ref - 1 : 0) + offset;
-         }
-         else if (ibdr) // Edge DOF on i==0 or i==ref
-         {
-            return (j - 1) + (i ? ref - 1 : 2 * (ref - 1) + ref - 1) + offset;
-         }
-         else // Interior DOF
-         {
-            offset += 2 * (ref - 1 + ref - 1);
-            return offset + (i - 1) + (ref - 1) * ((j - 1));
-         }
-      }
-      case Geometry::CUBE:
-      {
-         // Cf: https://git.io/JvZLe
-         int i = idx_in % n;
-         int j = (idx_in / n) % n;
-         int k = idx_in / (n*n);
-         bool ibdr = (i == 0 || i == ref);
-         bool jbdr = (j == 0 || j == ref);
-         bool kbdr = (k == 0 || k == ref);
-         // How many boundaries do we lie on at once?
-         int nbdr = (ibdr ? 1 : 0) + (jbdr ? 1 : 0) + (kbdr ? 1 : 0);
-         if (nbdr == 3) // Vertex DOF
-         {
-            // ijk is a corner node. Return the proper index (in [0,7])
-            return (i ? (j ? 2 : 1) : (j ? 3 : 0)) + (k ? 4 : 0);
-         }
-
-         int offset = 8;
-         if (nbdr == 2) // Edge DOF
-         {
-            if (!ibdr)
-            {
-               // On i axis
-               return (i - 1) +
-                      (j ? ref - 1 + ref - 1 : 0) +
-                      (k ? 2*(ref - 1 + ref - 1) : 0) +
-                      offset;
-            }
-            if (!jbdr)
-            {
-               // On j axis
-               return (j - 1) +
-                      (i ? ref - 1 : 2*(ref - 1) + ref - 1) +
-                      (k ? 2*(ref - 1 + ref - 1) : 0) +
-                      offset;
-            }
-            // !kbdr, On k axis
-            offset += 4*(ref - 1) + 4*(ref - 1);
-            return (k - 1) + (ref - 1)*(i ? (j ? 3 : 1) : (j ? 2 : 0))
-                   + offset;
-         }
-
-         offset += 4*(ref - 1 + ref - 1 + ref - 1);
-         if (nbdr == 1) // Face DOF
-         {
-            if (ibdr) // On i-normal face
-            {
-               return (j - 1) + ((ref - 1)*(k - 1))
-                      + (i ? (ref - 1)*(ref - 1) : 0) + offset;
-            }
-            offset += 2*(ref - 1)*(ref - 1);
-            if (jbdr) // On j-normal face
-            {
-               return (i - 1)
-                      + ((ref - 1)*(k - 1))
-                      + (j ? (ref - 1)*(ref - 1) : 0) + offset;
-            }
-            offset += 2*(ref - 1)*(ref - 1);
-            // kbdr, On k-normal face
-            return (i - 1) + ((ref - 1)*(j - 1))
-                   + (k ? (ref - 1)*(ref - 1) : 0) + offset;
-         }
-
-         // nbdr == 0: Interior DOF
-         offset += 2*((ref - 1)*(ref - 1) +
-                      (ref - 1)*(ref - 1) +
-                      (ref - 1)*(ref - 1));
-         return offset + (i - 1) + (ref - 1)*((j - 1) + (ref - 1)*(k - 1));
-      }
-      default:
-         MFEM_ABORT("CartesianToVTKOrderingTensor only supports tensor"
-                    " geometries.");
-         return -1;
-   }
-}
-
-void CreateVTKElementConnectivity(Array<int> &con, Geometry::Type geom, int ref)
-{
-
-   RefinedGeometry *RefG = GlobGeometryRefiner.Refine(geom, ref, 1);
-   int nnodes = RefG->RefPts.GetNPoints();
-   con.SetSize(nnodes);
-   if (geom == Geometry::TRIANGLE)
-   {
-      int b[3];
-      int idx = 0;
-      for (b[1]=0; b[1]<=ref; ++b[1])
-      {
-         for (b[0]=0; b[0]<=ref-b[1]; ++b[0])
-         {
-            b[2] = ref - b[0] - b[1];
-            con[BarycentricToVTKTriangle(b, ref)] = idx++;
-         }
-      }
-   }
-   else if (geom == Geometry::TETRAHEDRON)
-   {
-      int idx = 0;
-      int b[4];
-      for (int k=0; k<=ref; k++)
-      {
-         for (int j=0; j<=k; j++)
-         {
-            for (int i=0; i<=j; i++)
-            {
-               b[0] = k-j;
-               b[1] = i;
-               b[2] = j-i;
-               b[3] = ref-b[0]-b[1]-b[2];
-               con[BarycentricToVTKTetra(b, ref)] = idx++;
-            }
-         }
-      }
-   }
-   else if (geom == Geometry::PRISM)
-   {
-      int idx = 0;
-      for (int k=0; k<=ref; k++)
-      {
-         for (int j=0; j<=ref; j++)
-         {
-            for (int i=0; i<=ref-j; i++)
-            {
-               con[CartesianToVTKPrism(i, j, k, ref)] = idx++;
-            }
-         }
-      }
-   }
-   else
-   {
-      for (int idx=0; idx<nnodes; ++idx)
-      {
-         con[CartesianToVTKTensor(idx, ref, geom)] = idx;
-      }
-   }
-}
-
-void Mesh::PrintVTU(std::ostream &out, int ref, VTUFormat format,
+void Mesh::PrintVTU(std::ostream &out, int ref, VTKFormat format,
                     bool high_order_output, int compression_level)
 {
    RefinedGeometry *RefG;
    DenseMatrix pmat;
 
-   const char *fmt_str = (format == VTUFormat::ASCII) ? "ascii" : "binary";
-   const char *type_str = (format != VTUFormat::BINARY32) ? "Float64" : "Float32";
+   const char *fmt_str = (format == VTKFormat::ASCII) ? "ascii" : "binary";
+   const char *type_str = (format != VTKFormat::BINARY32) ? "Float64" : "Float32";
    std::vector<char> buf;
 
    // count the points, cells, size
@@ -9084,10 +8687,10 @@ void Mesh::PrintVTU(std::ostream &out, int ref, VTUFormat format,
          {
             WriteBinaryOrASCII(out, buf, 0.0, "", format);
          }
-         if (format == VTUFormat::ASCII) { out << '\n'; }
+         if (format == VTKFormat::ASCII) { out << '\n'; }
       }
    }
-   if (format != VTUFormat::ASCII)
+   if (format != VTKFormat::ASCII)
    {
       WriteBase64WithSizeAndClear(out, buf, compression_level);
    }
@@ -9113,7 +8716,7 @@ void Mesh::PrintVTU(std::ostream &out, int ref, VTUFormat format,
          {
             WriteBinaryOrASCII(out, buf, np+local_connectivity[i], " ", format);
          }
-         if (format == VTUFormat::ASCII) { out << '\n'; }
+         if (format == VTKFormat::ASCII) { out << '\n'; }
          np += nnodes;
          offset.push_back(np);
       }
@@ -9137,12 +8740,12 @@ void Mesh::PrintVTU(std::ostream &out, int ref, VTUFormat format,
             {
                WriteBinaryOrASCII(out, buf, np + RG[j], " ", format);
             }
-            if (format == VTUFormat::ASCII) { out << '\n'; }
+            if (format == VTKFormat::ASCII) { out << '\n'; }
          }
          np += RefG->RefPts.GetNPoints();
       }
    }
-   if (format != VTUFormat::ASCII)
+   if (format != VTKFormat::ASCII)
    {
       WriteBase64WithSizeAndClear(out, buf, compression_level);
    }
@@ -9155,7 +8758,7 @@ void Mesh::PrintVTU(std::ostream &out, int ref, VTUFormat format,
    {
       WriteBinaryOrASCII(out, buf, offset[ii], "\n", format);
    }
-   if (format != VTUFormat::ASCII)
+   if (format != VTKFormat::ASCII)
    {
       WriteBase64WithSizeAndClear(out, buf, compression_level);
    }
@@ -9166,9 +8769,6 @@ void Mesh::PrintVTU(std::ostream &out, int ref, VTUFormat format,
    for (int i = 0; i < GetNE(); i++)
    {
       Geometry::Type geom = GetElementBaseGeometry(i);
-      int nv = Geometries.GetVertices(geom)->GetNPoints();
-      RefG = GlobGeometryRefiner.Refine(geom, ref, 1);
-      Array<int> &RG = RefG->RefGeoms;
       uint8_t vtk_cell_type = 5;
 
       // VTK element types defined at: https://git.io/JvZLm
@@ -9206,13 +8806,16 @@ void Mesh::PrintVTU(std::ostream &out, int ref, VTUFormat format,
       }
       else
       {
+         int nv = Geometries.GetVertices(geom)->GetNPoints();
+         RefG = GlobGeometryRefiner.Refine(geom, ref, 1);
+         Array<int> &RG = RefG->RefGeoms;
          for (int j = 0; j < RG.Size(); j += nv)
          {
             WriteBinaryOrASCII(out, buf, vtk_cell_type, "\n", format);
          }
       }
    }
-   if (format != VTUFormat::ASCII)
+   if (format != VTKFormat::ASCII)
    {
       WriteBase64WithSizeAndClear(out, buf, compression_level);
    }
@@ -9224,9 +8827,6 @@ void Mesh::PrintVTU(std::ostream &out, int ref, VTUFormat format,
        << fmt_str << "\">" << std::endl;
    for (int i = 0; i < GetNE(); i++)
    {
-      Geometry::Type geom = GetElementBaseGeometry(i);
-      int nv = Geometries.GetVertices(geom)->GetNPoints();
-      RefG = GlobGeometryRefiner.Refine(geom, ref, 1);
       int attr = GetAttribute(i);
       if (high_order_output)
       {
@@ -9234,13 +8834,16 @@ void Mesh::PrintVTU(std::ostream &out, int ref, VTUFormat format,
       }
       else
       {
+         Geometry::Type geom = GetElementBaseGeometry(i);
+         int nv = Geometries.GetVertices(geom)->GetNPoints();
+         RefG = GlobGeometryRefiner.Refine(geom, ref, 1);
          for (int j = 0; j < RefG->RefGeoms.Size(); j += nv)
          {
             WriteBinaryOrASCII(out, buf, attr, "\n", format);
          }
       }
    }
-   if (format != VTUFormat::ASCII)
+   if (format != VTKFormat::ASCII)
    {
       WriteBase64WithSizeAndClear(out, buf, compression_level);
    }

--- a/mesh/mesh.cpp
+++ b/mesh/mesh.cpp
@@ -8603,13 +8603,10 @@ void WriteBinaryOrASCII<float>(std::ostream &out, std::vector<char> &buf,
    else { out << val << suffix; }
 }
 
-void WriteBase64WithSizeAndClear(std::ostream &out, std::vector<char> &buf)
+void WriteBase64WithSizeAndClear(std::ostream &out, std::vector<char> &buf,
+                                 bool compressed)
 {
-   // First write size of buffer (as uint32_t), encoded with base 64
-   uint32_t sz = buf.size();
-   bin_io::WriteBase64(out, &sz, sizeof(sz));
-   // Then write all the bytes in the buffer, encoded with base 64
-   bin_io::WriteBase64(out, buf.data(), buf.size());
+   bin_io::WriteEncodedCompressed(out, buf.data(), buf.size(), compressed);
    out << '\n';
    buf.clear();
 }
@@ -9011,7 +9008,7 @@ void CreateVTKElementConnectivity(Array<int> &con, Geometry::Type geom, int ref)
 }
 
 void Mesh::PrintVTU(std::ostream &out, int ref, VTUFormat format,
-                    bool high_order_output)
+                    bool high_order_output, bool compressed)
 {
    RefinedGeometry *RefG;
    DenseMatrix pmat;
@@ -9068,7 +9065,10 @@ void Mesh::PrintVTU(std::ostream &out, int ref, VTUFormat format,
          if (format == VTUFormat::ASCII) { out << '\n'; }
       }
    }
-   if (format != VTUFormat::ASCII) { WriteBase64WithSizeAndClear(out, buf); }
+   if (format != VTUFormat::ASCII)
+   {
+      WriteBase64WithSizeAndClear(out, buf, compressed);
+   }
    out << "</DataArray>" << std::endl;
    out << "</Points>" << std::endl;
 
@@ -9120,7 +9120,10 @@ void Mesh::PrintVTU(std::ostream &out, int ref, VTUFormat format,
          np += RefG->RefPts.GetNPoints();
       }
    }
-   if (format != VTUFormat::ASCII) { WriteBase64WithSizeAndClear(out, buf); }
+   if (format != VTUFormat::ASCII)
+   {
+      WriteBase64WithSizeAndClear(out, buf, compressed);
+   }
    out << "</DataArray>" << std::endl;
 
    out << "<DataArray type=\"Int32\" Name=\"offsets\" format=\""
@@ -9130,7 +9133,10 @@ void Mesh::PrintVTU(std::ostream &out, int ref, VTUFormat format,
    {
       WriteBinaryOrASCII(out, buf, offset[ii], "\n", format);
    }
-   if (format != VTUFormat::ASCII) { WriteBase64WithSizeAndClear(out, buf); }
+   if (format != VTUFormat::ASCII)
+   {
+      WriteBase64WithSizeAndClear(out, buf, compressed);
+   }
    out << "</DataArray>" << std::endl;
    out << "<DataArray type=\"UInt8\" Name=\"types\" format=\""
        << fmt_str << "\">" << std::endl;
@@ -9184,7 +9190,10 @@ void Mesh::PrintVTU(std::ostream &out, int ref, VTUFormat format,
          }
       }
    }
-   if (format != VTUFormat::ASCII) { WriteBase64WithSizeAndClear(out, buf); }
+   if (format != VTUFormat::ASCII)
+   {
+      WriteBase64WithSizeAndClear(out, buf, compressed);
+   }
    out << "</DataArray>" << std::endl;
    out << "</Cells>" << std::endl;
 
@@ -9209,7 +9218,10 @@ void Mesh::PrintVTU(std::ostream &out, int ref, VTUFormat format,
          }
       }
    }
-   if (format != VTUFormat::ASCII) { WriteBase64WithSizeAndClear(out, buf); }
+   if (format != VTUFormat::ASCII)
+   {
+      WriteBase64WithSizeAndClear(out, buf, compressed);
+   }
    out << "</DataArray>" << std::endl;
    out << "</CellData>" << std::endl;
 }

--- a/mesh/mesh.cpp
+++ b/mesh/mesh.cpp
@@ -8720,7 +8720,7 @@ int BarycentricToVTKTetra(int *b, int ref)
          int projectedb[3];
          for (int i = 0; i < 3; i++)
          {
-         projectedb[i] = b[FaceBCoords[face][i]] - min;
+            projectedb[i] = b[FaceBCoords[face][i]] - min;
          }
          // we must subtract the indices of the face's vertices and edges, which
          // total to 3*ref
@@ -8733,7 +8733,7 @@ int BarycentricToVTKTetra(int *b, int ref)
 
 int VTKTriangleDOFOffset(int ref, int i, int j)
 {
-  return i + ref*(j - 1) - (j*(j + 1))/2;
+   return i + ref*(j - 1) - (j*(j + 1))/2;
 }
 
 int CartesianToVTKPrism(int i, int j, int k, int ref)
@@ -8767,7 +8767,7 @@ int CartesianToVTKPrism(int i, int j, int k, int ref)
          // Must be on a vertical edge and 2 of {ibdr, jbdr, ijbdr} are true
          offset += om1*6;
          return offset + (k-1)
-            + ((ibdr && jbdr) ? 0 : (jbdr && ijbdr ? 1 : 2))*om1;
+                + ((ibdr && jbdr) ? 0 : (jbdr && ijbdr ? 1 : 2))*om1;
       }
       else
       {
@@ -8797,7 +8797,8 @@ int CartesianToVTKPrism(int i, int j, int k, int ref)
    if (nbdr == 1) // Face DOF
    {
       if (kbdr)
-      { // We are on a triangular face.
+      {
+         // We are on a triangular face.
          if (k > 0)
          {
             offset += ntfdof;

--- a/mesh/mesh.cpp
+++ b/mesh/mesh.cpp
@@ -8569,14 +8569,18 @@ template <typename T>
 void WriteBinaryOrASCII(std::ostream &out, std::vector<char> &buf, const T &val,
                         const char *suffix, bool binary)
 {
-   if (binary)
-   {
-      bin_io::AppendBytes(buf, val);
-   }
-   else
-   {
-      out << val << suffix;
-   }
+   if (binary) { bin_io::AppendBytes(buf, val); }
+   else { out << val << suffix; }
+}
+
+// Ensure ASCII output of uint8_t to stream is integer rather than character
+template <>
+void WriteBinaryOrASCII<uint8_t>(std::ostream &out, std::vector<char> &buf,
+                                 const uint8_t &val, const char *suffix,
+                                 bool binary)
+{
+   if (binary) { bin_io::AppendBytes(buf, val); }
+   else { out << static_cast<int>(val) << suffix; }
 }
 
 void WriteBase64WithSizeAndClear(std::ostream &out, std::vector<char> &buf)

--- a/mesh/mesh.cpp
+++ b/mesh/mesh.cpp
@@ -8600,9 +8600,18 @@ void WriteBinaryOrASCII<double>(std::ostream &out, std::vector<char> &buf,
                                 const double &val, const char *suffix,
                                 VTUFormat format)
 {
-   if (format == VTUFormat::BINARY32) { bin_io::AppendBytes<float>(buf, val); }
-   else if (format == VTUFormat::BINARY) { bin_io::AppendBytes(buf, val); }
-   else { out << val << suffix; }
+   if (format == VTUFormat::BINARY32)
+   {
+      bin_io::AppendBytes<float>(buf, float(val));
+   }
+   else if (format == VTUFormat::BINARY)
+   {
+      bin_io::AppendBytes(buf, val);
+   }
+   else
+   {
+      out << val << suffix;
+   }
 }
 
 template <>

--- a/mesh/mesh.cpp
+++ b/mesh/mesh.cpp
@@ -8554,17 +8554,24 @@ void Mesh::PrintVTK(std::ostream &out)
    out.flush();
 }
 
-void Mesh::PrintVTU(std::string fname)
+void Mesh::PrintVTU(std::string fname,
+                    VTUFormat format,
+                    bool high_order_output,
+                    int compression_level)
 {
+   int ref = (high_order_output && Nodes) ? Nodes->FESpace()->GetOrder(0) : 1;
    fname = fname + ".vtu";
    std::fstream out(fname.c_str(),std::ios::out);
-   out << "<VTKFile type=\"UnstructuredGrid\" version=\"0.1\" byte_order=\"LittleEndian\">"
-       << std::endl;
-   out << "<UnstructuredGrid>" << std::endl;
-   PrintVTU(out,1);
-   out << "</Piece>" <<
-       std::endl; // needed to close the piece open in the PrintVTU method
-   out << "</UnstructuredGrid>" << std::endl;
+   out << "<VTKFile type=\"UnstructuredGrid\" version=\"0.1\"";
+   if (compression_level != 0)
+   {
+      out << " compressor=\"vtkZLibDataCompressor\"";
+   }
+   out << " byte_order=\"LittleEndian\">\n";
+   out << "<UnstructuredGrid>\n";
+   PrintVTU(out, ref, format, high_order_output, compression_level);
+   out << "</Piece>\n"; // need to close the piece open in the PrintVTU method
+   out << "</UnstructuredGrid>\n";
    out << "</VTKFile>" << std::endl;
 
    out.close();

--- a/mesh/mesh.cpp
+++ b/mesh/mesh.cpp
@@ -8741,7 +8741,7 @@ int VTKTriangleDOFOffset(int ref, int i, int j)
 
 int CartesianToVTKPrism(int i, int j, int k, int ref)
 {
-   // Cf. https://git.io/JvW4P
+   // Cf. https://git.io/JvW0M
    int om1 = ref - 1;
    int ibdr = (i == 0);
    int jbdr = (j == 0);

--- a/mesh/mesh.cpp
+++ b/mesh/mesh.cpp
@@ -8581,10 +8581,10 @@ void WriteBinaryOrASCII(std::ostream &out, std::vector<char> &buf, const T &val,
 
 void WriteBase64WithSizeAndClear(std::ostream &out, std::vector<char> &buf)
 {
-   std::vector<char> sz_buf;
-   bin_io::AppendBytes(sz_buf, uint32_t(buf.size()));
-   bin_io::WriteBase64(out, sz_buf.data(), sz_buf.size());
-   // Then write all the double values, encoded with base 64
+   // First write size of buffer (as uint32_t), encoded with base 64
+   uint32_t sz = buf.size();
+   bin_io::WriteBase64(out, &sz, sizeof(sz));
+   // Then write all the bytes in the buffer, encoded with base 64
    bin_io::WriteBase64(out, buf.data(), buf.size());
    out << '\n';
    buf.clear();

--- a/mesh/mesh.cpp
+++ b/mesh/mesh.cpp
@@ -8590,7 +8590,7 @@ void WriteBinaryOrASCII<double>(std::ostream &out, std::vector<char> &buf,
 {
    if (format == VTUFormat::BINARY32) { bin_io::AppendBytes<float>(buf, val); }
    else if (format == VTUFormat::BINARY) { bin_io::AppendBytes(buf, val); }
-   else { out << static_cast<int>(val) << suffix; }
+   else { out << val << suffix; }
 }
 
 template <>
@@ -8600,7 +8600,7 @@ void WriteBinaryOrASCII<float>(std::ostream &out, std::vector<char> &buf,
 {
    if (format == VTUFormat::BINARY) { bin_io::AppendBytes<double>(buf, val); }
    else if (format == VTUFormat::BINARY32) { bin_io::AppendBytes(buf, val); }
-   else { out << static_cast<int>(val) << suffix; }
+   else { out << val << suffix; }
 }
 
 void WriteBase64WithSizeAndClear(std::ostream &out, std::vector<char> &buf)

--- a/mesh/mesh.cpp
+++ b/mesh/mesh.cpp
@@ -8609,9 +8609,9 @@ void WriteBinaryOrASCII<float>(std::ostream &out, std::vector<char> &buf,
 }
 
 void WriteBase64WithSizeAndClear(std::ostream &out, std::vector<char> &buf,
-                                 bool compressed)
+                                 int compression_level)
 {
-   bin_io::WriteEncodedCompressed(out, buf.data(), buf.size(), compressed);
+   bin_io::WriteEncodedCompressed(out, buf.data(), buf.size(), compression_level);
    out << '\n';
    buf.clear();
 }
@@ -9014,7 +9014,7 @@ void CreateVTKElementConnectivity(Array<int> &con, Geometry::Type geom, int ref)
 }
 
 void Mesh::PrintVTU(std::ostream &out, int ref, VTUFormat format,
-                    bool high_order_output, bool compressed)
+                    bool high_order_output, int compression_level)
 {
    RefinedGeometry *RefG;
    DenseMatrix pmat;
@@ -9073,7 +9073,7 @@ void Mesh::PrintVTU(std::ostream &out, int ref, VTUFormat format,
    }
    if (format != VTUFormat::ASCII)
    {
-      WriteBase64WithSizeAndClear(out, buf, compressed);
+      WriteBase64WithSizeAndClear(out, buf, compression_level);
    }
    out << "</DataArray>" << std::endl;
    out << "</Points>" << std::endl;
@@ -9128,7 +9128,7 @@ void Mesh::PrintVTU(std::ostream &out, int ref, VTUFormat format,
    }
    if (format != VTUFormat::ASCII)
    {
-      WriteBase64WithSizeAndClear(out, buf, compressed);
+      WriteBase64WithSizeAndClear(out, buf, compression_level);
    }
    out << "</DataArray>" << std::endl;
 
@@ -9141,7 +9141,7 @@ void Mesh::PrintVTU(std::ostream &out, int ref, VTUFormat format,
    }
    if (format != VTUFormat::ASCII)
    {
-      WriteBase64WithSizeAndClear(out, buf, compressed);
+      WriteBase64WithSizeAndClear(out, buf, compression_level);
    }
    out << "</DataArray>" << std::endl;
    out << "<DataArray type=\"UInt8\" Name=\"types\" format=\""
@@ -9198,7 +9198,7 @@ void Mesh::PrintVTU(std::ostream &out, int ref, VTUFormat format,
    }
    if (format != VTUFormat::ASCII)
    {
-      WriteBase64WithSizeAndClear(out, buf, compressed);
+      WriteBase64WithSizeAndClear(out, buf, compression_level);
    }
    out << "</DataArray>" << std::endl;
    out << "</Cells>" << std::endl;
@@ -9226,7 +9226,7 @@ void Mesh::PrintVTU(std::ostream &out, int ref, VTUFormat format,
    }
    if (format != VTUFormat::ASCII)
    {
-      WriteBase64WithSizeAndClear(out, buf, compressed);
+      WriteBase64WithSizeAndClear(out, buf, compression_level);
    }
    out << "</DataArray>" << std::endl;
    out << "</CellData>" << std::endl;

--- a/mesh/mesh.cpp
+++ b/mesh/mesh.cpp
@@ -8604,6 +8604,7 @@ int ConvertToVTKOrdering(int idx_in, int ref, Geometry::Type geom)
          return idx_in;
       case Geometry::SQUARE:
       {
+         // Cf: https://git.io/JvZLT
          int i = idx_in % n;
          int j = idx_in / n;
          // Do we lie on any of the edges
@@ -8630,6 +8631,7 @@ int ConvertToVTKOrdering(int idx_in, int ref, Geometry::Type geom)
       }
       case Geometry::CUBE:
       {
+         // Cf: https://git.io/JvZLe
          int i = idx_in % n;
          int j = (idx_in / n) % n;
          int k = idx_in / (n*n);
@@ -8777,11 +8779,8 @@ void Mesh::PrintVTU(std::ostream &out, int ref, bool binary,
       for (int iel = 0; iel < GetNE(); iel++)
       {
          Geometry::Type geom = GetElementBaseGeometry(iel);
-         int geom_dim = Geometry::Dimension[geom];
-         int ni = ref+1;
-         int nj = geom_dim > 1 ? ref+1 : 1;
-         int nk = geom_dim > 2 ? ref+1 : 1;
-         int nnodes = ni*nj*nk;
+         RefG = GlobGeometryRefiner.Refine(geom, ref, 1);
+         int nnodes = RefG->RefPts.GetNPoints();
          local_connectivity.SetSize(nnodes);
          for (int i=0; i<nnodes; ++i)
          {
@@ -8844,6 +8843,7 @@ void Mesh::PrintVTU(std::ostream &out, int ref, bool binary,
       Array<int> &RG = RefG->RefGeoms;
       uint8_t vtk_cell_type = 5;
 
+      // VTK element types defined at: https://git.io/JvZLm
       switch (geom)
       {
          case Geometry::POINT:

--- a/mesh/mesh.cpp
+++ b/mesh/mesh.cpp
@@ -8600,8 +8600,13 @@ int ConvertToVTKOrdering(int idx_in, int ref, Geometry::Type geom)
    switch (geom)
    {
       case Geometry::POINT:
-      case Geometry::SEGMENT:
          return idx_in;
+      case Geometry::SEGMENT:
+         if (idx_in == 0 || idx_in == ref)
+         {
+            return idx_in ? 1 : 0;
+         }
+         return idx_in + 1;
       case Geometry::SQUARE:
       {
          // Cf: https://git.io/JvZLT

--- a/mesh/mesh.hpp
+++ b/mesh/mesh.hpp
@@ -18,6 +18,7 @@
 #include "triangle.hpp"
 #include "tetrahedron.hpp"
 #include "vertex.hpp"
+#include "vtk.hpp"
 #include "ncmesh.hpp"
 #include "../fem/eltrans.hpp"
 #include "../fem/coefficient.hpp"
@@ -40,13 +41,6 @@ struct Refinement;
 class ParMesh;
 class ParNCMesh;
 #endif
-
-enum class VTUFormat
-{
-   ASCII,
-   BINARY,
-   BINARY32
-};
 
 class Mesh
 {
@@ -1180,12 +1174,12 @@ public:
        subdivision number (useful for high order fields and curved meshes). */
    void PrintVTU(std::ostream &out,
                  int ref=1,
-                 VTUFormat format=VTUFormat::ASCII,
+                 VTKFormat format=VTKFormat::ASCII,
                  bool high_order_output=false,
                  int compression_level=0);
    /** Print the mesh in VTU format with file name fname. */
    void PrintVTU(std::string fname,
-                 VTUFormat format=VTUFormat::ASCII,
+                 VTKFormat format=VTKFormat::ASCII,
                  bool high_order_output=false,
                  int compression_level=0);
 

--- a/mesh/mesh.hpp
+++ b/mesh/mesh.hpp
@@ -1171,7 +1171,8 @@ public:
    void PrintVTK(std::ostream &out, int ref, int field_data=0);
    /** Print the mesh in VTU format. The parameter ref > 0 specifies an element
        subdivision number (useful for high order fields and curved meshes). */
-   void PrintVTU(std::ostream &out, int ref=1, bool binary=false);
+   void PrintVTU(std::ostream &out, int ref=1, bool binary=false,
+                 bool high_order_output=false);
    /** Print the mesh in VTU format with file name fname. */
    void PrintVTU(std::string fname);
 

--- a/mesh/mesh.hpp
+++ b/mesh/mesh.hpp
@@ -1181,7 +1181,7 @@ public:
    void PrintVTU(std::ostream &out, int ref=1,
                  VTUFormat format=VTUFormat::ASCII,
                  bool high_order_output=false,
-                 bool compressed=false);
+                 int compression_level=0);
    /** Print the mesh in VTU format with file name fname. */
    void PrintVTU(std::string fname);
 

--- a/mesh/mesh.hpp
+++ b/mesh/mesh.hpp
@@ -1178,12 +1178,16 @@ public:
    void PrintVTK(std::ostream &out, int ref, int field_data=0);
    /** Print the mesh in VTU format. The parameter ref > 0 specifies an element
        subdivision number (useful for high order fields and curved meshes). */
-   void PrintVTU(std::ostream &out, int ref=1,
+   void PrintVTU(std::ostream &out,
+                 int ref=1,
                  VTUFormat format=VTUFormat::ASCII,
                  bool high_order_output=false,
                  int compression_level=0);
    /** Print the mesh in VTU format with file name fname. */
-   void PrintVTU(std::string fname);
+   void PrintVTU(std::string fname,
+                 VTUFormat format=VTUFormat::ASCII,
+                 bool high_order_output=false,
+                 int compression_level=0);
 
    void GetElementColoring(Array<int> &colors, int el0 = 0);
 

--- a/mesh/mesh.hpp
+++ b/mesh/mesh.hpp
@@ -1179,7 +1179,8 @@ public:
        subdivision number (useful for high order fields and curved meshes). */
    void PrintVTU(std::ostream &out, int ref=1,
                  VTUFormat format=VTUFormat::ASCII,
-                 bool high_order_output=false);
+                 bool high_order_output=false,
+                 bool compressed=false);
    /** Print the mesh in VTU format with file name fname. */
    void PrintVTU(std::string fname);
 

--- a/mesh/mesh.hpp
+++ b/mesh/mesh.hpp
@@ -41,6 +41,12 @@ class ParMesh;
 class ParNCMesh;
 #endif
 
+enum class VTUFormat
+{
+   ASCII,
+   BINARY,
+   BINARY32
+};
 
 class Mesh
 {
@@ -1171,7 +1177,8 @@ public:
    void PrintVTK(std::ostream &out, int ref, int field_data=0);
    /** Print the mesh in VTU format. The parameter ref > 0 specifies an element
        subdivision number (useful for high order fields and curved meshes). */
-   void PrintVTU(std::ostream &out, int ref=1, bool binary=false,
+   void PrintVTU(std::ostream &out, int ref=1,
+                 VTUFormat format=VTUFormat::ASCII,
                  bool high_order_output=false);
    /** Print the mesh in VTU format with file name fname. */
    void PrintVTU(std::string fname);

--- a/mesh/mesh.hpp
+++ b/mesh/mesh.hpp
@@ -1171,7 +1171,7 @@ public:
    void PrintVTK(std::ostream &out, int ref, int field_data=0);
    /** Print the mesh in VTU format. The parameter ref > 0 specifies an element
        subdivision number (useful for high order fields and curved meshes). */
-   void PrintVTU(std::ostream &out, int ref=1);
+   void PrintVTU(std::ostream &out, int ref=1, bool binary=false);
    /** Print the mesh in VTU format with file name fname. */
    void PrintVTU(std::string fname);
 

--- a/mesh/vtk.cpp
+++ b/mesh/vtk.cpp
@@ -451,4 +451,34 @@ void WriteVTKEncodedCompressed(std::ostream &out, const void *bytes,
    }
 }
 
+enum class Endianness
+{
+   LITTLE,
+   BIG
+};
+
+Endianness DetermineEndianness()
+{
+   int16_t x16 = 1;
+   int8_t *x8 = reinterpret_cast<int8_t *>(&x16);
+
+   // Assume big endian and little endian are the only options
+   if ((int)*x8) { return Endianness::LITTLE; }
+   else { return Endianness::BIG; }
+}
+
+const char *VTKByteOrder()
+{
+   Endianness e = DetermineEndianness();
+   if (e == Endianness::BIG)
+   {
+      return "BigEndian";
+   }
+   else
+   {
+      return "LittleEndian";
+   }
+
+}
+
 } // namespace mfem

--- a/mesh/vtk.cpp
+++ b/mesh/vtk.cpp
@@ -1,0 +1,454 @@
+// Copyright (c) 2010, Lawrence Livermore National Security, LLC. Produced at
+// the Lawrence Livermore National Laboratory. LLNL-CODE-443211. All Rights
+// reserved. See file COPYRIGHT for details.
+//
+// This file is part of the MFEM library. For more information and source code
+// availability see http://mfem.org.
+//
+// MFEM is free software; you can redistribute it and/or modify it under the
+// terms of the GNU Lesser General Public License (as published by the Free
+// Software Foundation) version 2.1 dated February 1999.
+
+#include "vtk.hpp"
+#include "../general/binaryio.hpp"
+#ifdef MFEM_USE_GZSTREAM
+#include <zlib.h>
+#endif
+
+namespace mfem
+{
+
+int BarycentricToVTKTriangle(int *b, int ref)
+{
+   // Cf. https://git.io/JvW8f
+   int max = ref;
+   int min = 0;
+   int bmin = std::min(std::min(b[0], b[1]), b[2]);
+   int idx = 0;
+
+   // scope into the correct triangle
+   while (bmin > min)
+   {
+      idx += 3*ref;
+      max -= 2;
+      ++min;
+      ref -= 3;
+   }
+   for (int d=0; d<3; ++d)
+   {
+      if (b[(d+2)%3] == max)
+      {
+         // we are on a vertex
+         return idx;
+      }
+      ++idx;
+   }
+   for (int d=0; d<3; ++d)
+   {
+      if (b[(d+1)%3] == min)
+      {
+         // we are on an edge
+         return idx + b[d] - (min + 1);
+      }
+      idx += max - (min + 1);
+   }
+   return idx;
+}
+
+int BarycentricToVTKTetra(int *b, int ref)
+{
+   // Cf. https://git.io/JvW8c
+   int idx = 0;
+
+   int max = ref;
+   int min = 0;
+
+   int bmin = std::min(std::min(std::min(b[0], b[1]), b[2]), b[3]);
+
+   // scope into the correct tetra
+   while (bmin > min)
+   {
+      idx += 2*(ref*ref + 1);
+      max -= 3;
+      min++;
+      ref -= 4;
+   }
+
+   // When a linearized tetra vertex is cast into barycentric coordinates, one of
+   // its coordinates is maximal and the other three are minimal. These are the
+   // indices of the maximal barycentric coordinate for each vertex.
+   static const int VertexMaxCoords[4] = {3,0,1,2};
+   // Each linearized tetra edge holds two barycentric tetra coordinates constant
+   // and varies the other two. These are the coordinates that are held constant
+   // for each edge.
+   static const int EdgeMinCoords[6][2] = {{1,2},{2,3},{0,2}, {0,1},{1,3},{0,3}};
+   // The coordinate that increments when traversing an edge (i.e. the coordinate
+   // of the nonzero component of the second vertex of the edge).
+   static const int EdgeCountingCoord[6] = {0,1,3,2,2,2};
+   // When describing a linearized tetra face, there is a mapping between the
+   // four-component barycentric tetra system and the three-component barycentric
+   // triangle system. These are the constant indices within the four-component
+   // system for each face (e.g. face 0 holds barycentric tetra coordinate 1
+   // constant).
+   static const int FaceMinCoord[4] = {1,3,0,2};
+   // When describing a linearized tetra face, there is a mapping between the
+   // four-component barycentric tetra system and the three-component barycentric
+   // triangle system. These are the relevant indices within the four-component
+   // system for each face (e.g. face 0 varies across the barycentric tetra
+   // coordinates 0, 2 and 3).
+   static const int FaceBCoords[4][3] = {{0,2,3}, {2,0,1}, {2,1,3}, {1,0,3}};
+
+
+   for (int vertex = 0; vertex < 4; vertex++)
+   {
+      if (b[VertexMaxCoords[vertex]] == max)
+      {
+         // we are on a vertex
+         return idx;
+      }
+      idx++;
+   }
+
+   for (int edge = 0; edge < 6; edge++)
+   {
+      if (b[EdgeMinCoords[edge][0]] == min && b[EdgeMinCoords[edge][1]] == min)
+      {
+         // we are on an edge
+         return idx + b[EdgeCountingCoord[edge]] - (min + 1);
+      }
+      idx += max - (min + 1);
+   }
+
+   for (int face = 0; face < 4; face++)
+   {
+      if (b[FaceMinCoord[face]] == min)
+      {
+         // we are on a face
+         int projectedb[3];
+         for (int i = 0; i < 3; i++)
+         {
+            projectedb[i] = b[FaceBCoords[face][i]] - min;
+         }
+         // we must subtract the indices of the face's vertices and edges, which
+         // total to 3*ref
+         return (idx + BarycentricToVTKTriangle(projectedb, ref) - 3*ref);
+      }
+      idx += (ref+1)*(ref+2)/2 - 3*ref;
+   }
+   return idx;
+}
+
+int VTKTriangleDOFOffset(int ref, int i, int j)
+{
+   return i + ref*(j - 1) - (j*(j + 1))/2;
+}
+
+int CartesianToVTKPrism(int i, int j, int k, int ref)
+{
+   // Cf. https://git.io/JvW0M
+   int om1 = ref - 1;
+   int ibdr = (i == 0);
+   int jbdr = (j == 0);
+   int ijbdr = (i + j == ref);
+   int kbdr = (k == 0 || k == ref);
+   // How many boundaries do we lie on at once?
+   int nbdr = ibdr + jbdr + ijbdr + kbdr;
+
+   // Return an invalid index given invalid coordinates
+   if (i < 0 || i > ref || j < 0 || j > ref || i + j > ref || k < 0 || k > ref)
+   {
+      MFEM_ABORT("Invalid index")
+   }
+
+   if (nbdr == 3) // Vertex DOF
+   {
+      // ijk is a corner node. Return the proper index (somewhere in [0,5]):
+      return (ibdr && jbdr ? 0 : (jbdr && ijbdr ? 1 : 2)) + (k ? 3 : 0);
+   }
+
+   int offset = 6;
+   if (nbdr == 2) // Edge DOF
+   {
+      if (!kbdr)
+      {
+         // Must be on a vertical edge and 2 of {ibdr, jbdr, ijbdr} are true
+         offset += om1*6;
+         return offset + (k-1)
+                + ((ibdr && jbdr) ? 0 : (jbdr && ijbdr ? 1 : 2))*om1;
+      }
+      else
+      {
+         // Must be on a horizontal edge and kbdr plus 1 of {ibdr, jbdr, ijbdr} is true
+         // Skip past first 3 edges if we are on the top (k = ref) face:
+         offset += (k == ref ? 3*om1 : 0);
+         if (jbdr)
+         {
+            return offset + i - 1;
+         }
+         offset += om1; // Skip the i-axis edge
+         if (ijbdr)
+         {
+            return offset + j - 1;
+         }
+         offset += om1; // Skip the ij-axis edge
+         // if (ibdr)
+         return offset + (ref - j - 1);
+      }
+   }
+
+   offset += 9*om1; // Skip all the edges
+
+   // Number of points on a triangular face (but not on edge/corner):
+   int ntfdof = (om1 - 1)*om1/2;
+   int nqfdof = om1*om1;
+   if (nbdr == 1) // Face DOF
+   {
+      if (kbdr)
+      {
+         // We are on a triangular face.
+         if (k > 0)
+         {
+            offset += ntfdof;
+         }
+         return offset + VTKTriangleDOFOffset(ref, i, j);
+      }
+      // Not a k-normal face, so skip them:
+      offset += 2*ntfdof;
+
+      // Face is quadrilateral (ref - 1) x (ref - 1)
+      // First face is i-normal, then ij-normal, then j-normal
+      if (jbdr) // On i-normal face
+      {
+         return offset + (i - 1) + om1*(k - 1);
+      }
+      offset += nqfdof; // Skip i-normal face
+      if (ijbdr) // on ij-normal face
+      {
+         return offset + (ref - i - 1) + om1*(k - 1);
+      }
+      offset += nqfdof; // Skip ij-normal face
+      return offset + j - 1 + om1*(k - 1);
+   }
+
+   // Skip all face DOF
+   offset += 2*ntfdof + 3*nqfdof;
+
+   // nbdr == 0: Body DOF
+   return offset + VTKTriangleDOFOffset(ref, i, j) + ntfdof*(k - 1);
+   // (i - 1) + (ref-1)*((j - 1) + (ref - 1)*(k - 1)));
+}
+
+int CartesianToVTKTensor(int idx_in, int ref, Geometry::Type geom)
+{
+   int n = ref + 1;
+   switch (geom)
+   {
+      case Geometry::POINT:
+         return idx_in;
+      case Geometry::SEGMENT:
+         if (idx_in == 0 || idx_in == ref)
+         {
+            return idx_in ? 1 : 0;
+         }
+         return idx_in + 1;
+      case Geometry::SQUARE:
+      {
+         // Cf: https://git.io/JvZLT
+         int i = idx_in % n;
+         int j = idx_in / n;
+         // Do we lie on any of the edges
+         bool ibdr = (i == 0 || i == ref);
+         bool jbdr = (j == 0 || j == ref);
+         if (ibdr && jbdr) // Vertex DOF
+         {
+            return (i ? (j ? 2 : 1) : (j ? 3 : 0));
+         }
+         int offset = 4;
+         if (jbdr) // Edge DOF on j==0 or j==ref
+         {
+            return (i - 1) + (j ? ref - 1 + ref - 1 : 0) + offset;
+         }
+         else if (ibdr) // Edge DOF on i==0 or i==ref
+         {
+            return (j - 1) + (i ? ref - 1 : 2 * (ref - 1) + ref - 1) + offset;
+         }
+         else // Interior DOF
+         {
+            offset += 2 * (ref - 1 + ref - 1);
+            return offset + (i - 1) + (ref - 1) * ((j - 1));
+         }
+      }
+      case Geometry::CUBE:
+      {
+         // Cf: https://git.io/JvZLe
+         int i = idx_in % n;
+         int j = (idx_in / n) % n;
+         int k = idx_in / (n*n);
+         bool ibdr = (i == 0 || i == ref);
+         bool jbdr = (j == 0 || j == ref);
+         bool kbdr = (k == 0 || k == ref);
+         // How many boundaries do we lie on at once?
+         int nbdr = (ibdr ? 1 : 0) + (jbdr ? 1 : 0) + (kbdr ? 1 : 0);
+         if (nbdr == 3) // Vertex DOF
+         {
+            // ijk is a corner node. Return the proper index (in [0,7])
+            return (i ? (j ? 2 : 1) : (j ? 3 : 0)) + (k ? 4 : 0);
+         }
+
+         int offset = 8;
+         if (nbdr == 2) // Edge DOF
+         {
+            if (!ibdr)
+            {
+               // On i axis
+               return (i - 1) +
+                      (j ? ref - 1 + ref - 1 : 0) +
+                      (k ? 2*(ref - 1 + ref - 1) : 0) +
+                      offset;
+            }
+            if (!jbdr)
+            {
+               // On j axis
+               return (j - 1) +
+                      (i ? ref - 1 : 2*(ref - 1) + ref - 1) +
+                      (k ? 2*(ref - 1 + ref - 1) : 0) +
+                      offset;
+            }
+            // !kbdr, On k axis
+            offset += 4*(ref - 1) + 4*(ref - 1);
+            return (k - 1) + (ref - 1)*(i ? (j ? 3 : 1) : (j ? 2 : 0))
+                   + offset;
+         }
+
+         offset += 4*(ref - 1 + ref - 1 + ref - 1);
+         if (nbdr == 1) // Face DOF
+         {
+            if (ibdr) // On i-normal face
+            {
+               return (j - 1) + ((ref - 1)*(k - 1))
+                      + (i ? (ref - 1)*(ref - 1) : 0) + offset;
+            }
+            offset += 2*(ref - 1)*(ref - 1);
+            if (jbdr) // On j-normal face
+            {
+               return (i - 1)
+                      + ((ref - 1)*(k - 1))
+                      + (j ? (ref - 1)*(ref - 1) : 0) + offset;
+            }
+            offset += 2*(ref - 1)*(ref - 1);
+            // kbdr, On k-normal face
+            return (i - 1) + ((ref - 1)*(j - 1))
+                   + (k ? (ref - 1)*(ref - 1) : 0) + offset;
+         }
+
+         // nbdr == 0: Interior DOF
+         offset += 2*((ref - 1)*(ref - 1) +
+                      (ref - 1)*(ref - 1) +
+                      (ref - 1)*(ref - 1));
+         return offset + (i - 1) + (ref - 1)*((j - 1) + (ref - 1)*(k - 1));
+      }
+      default:
+         MFEM_ABORT("CartesianToVTKOrderingTensor only supports tensor"
+                    " geometries.");
+         return -1;
+   }
+}
+
+void CreateVTKElementConnectivity(Array<int> &con, Geometry::Type geom, int ref)
+{
+
+   RefinedGeometry *RefG = GlobGeometryRefiner.Refine(geom, ref, 1);
+   int nnodes = RefG->RefPts.GetNPoints();
+   con.SetSize(nnodes);
+   if (geom == Geometry::TRIANGLE)
+   {
+      int b[3];
+      int idx = 0;
+      for (b[1]=0; b[1]<=ref; ++b[1])
+      {
+         for (b[0]=0; b[0]<=ref-b[1]; ++b[0])
+         {
+            b[2] = ref - b[0] - b[1];
+            con[BarycentricToVTKTriangle(b, ref)] = idx++;
+         }
+      }
+   }
+   else if (geom == Geometry::TETRAHEDRON)
+   {
+      int idx = 0;
+      int b[4];
+      for (int k=0; k<=ref; k++)
+      {
+         for (int j=0; j<=k; j++)
+         {
+            for (int i=0; i<=j; i++)
+            {
+               b[0] = k-j;
+               b[1] = i;
+               b[2] = j-i;
+               b[3] = ref-b[0]-b[1]-b[2];
+               con[BarycentricToVTKTetra(b, ref)] = idx++;
+            }
+         }
+      }
+   }
+   else if (geom == Geometry::PRISM)
+   {
+      int idx = 0;
+      for (int k=0; k<=ref; k++)
+      {
+         for (int j=0; j<=ref; j++)
+         {
+            for (int i=0; i<=ref-j; i++)
+            {
+               con[CartesianToVTKPrism(i, j, k, ref)] = idx++;
+            }
+         }
+      }
+   }
+   else
+   {
+      for (int idx=0; idx<nnodes; ++idx)
+      {
+         con[CartesianToVTKTensor(idx, ref, geom)] = idx;
+      }
+   }
+}
+
+void WriteVTKEncodedCompressed(std::ostream &out, const void *bytes,
+                               uint32_t nbytes, int compression_level)
+{
+   if (compression_level == 0)
+   {
+      // First write size of buffer (as uint32_t), encoded with base 64
+      bin_io::WriteBase64(out, &nbytes, sizeof(nbytes));
+      // Then write all the bytes in the buffer, encoded with base 64
+      bin_io::WriteBase64(out, bytes, nbytes);
+   }
+   else
+   {
+#ifdef MFEM_USE_GZSTREAM
+      MFEM_ASSERT(compression_level >= -1 && compression_level <= 9,
+                  "Compression level must be between -1 and 9 (inclusive).");
+      uLongf buf_sz = compressBound(nbytes);
+      std::vector<unsigned char> buf(buf_sz);
+      compress2(buf.data(), &buf_sz, static_cast<const Bytef *>(bytes), nbytes,
+                compression_level);
+
+      // Write the header
+      std::vector<uint32_t> header(4);
+      header[0] = 1; // number of blocks
+      header[1] = nbytes; // uncompressed size
+      header[2] = 0; // size of partial block
+      header[3] = buf_sz; // compressed size
+      bin_io::WriteBase64(out, header.data(), header.size()*sizeof(uint32_t));
+      // Write the compressed data
+      bin_io::WriteBase64(out, buf.data(), buf_sz);
+#else
+      MFEM_ABORT("MFEM must be compiled with gzstream support to output "
+                 "compressed binary data.")
+#endif
+   }
+}
+
+} // namespace mfem

--- a/mesh/vtk.cpp
+++ b/mesh/vtk.cpp
@@ -451,26 +451,16 @@ void WriteVTKEncodedCompressed(std::ostream &out, const void *bytes,
    }
 }
 
-enum class Endianness
-{
-   LITTLE,
-   BIG
-};
-
-Endianness DetermineEndianness()
+bool IsBigEndian()
 {
    int16_t x16 = 1;
    int8_t *x8 = reinterpret_cast<int8_t *>(&x16);
-
-   // Assume big endian and little endian are the only options
-   if ((int)*x8) { return Endianness::LITTLE; }
-   else { return Endianness::BIG; }
+   return !*x8;
 }
 
 const char *VTKByteOrder()
 {
-   Endianness e = DetermineEndianness();
-   if (e == Endianness::BIG)
+   if (IsBigEndian())
    {
       return "BigEndian";
    }

--- a/mesh/vtk.hpp
+++ b/mesh/vtk.hpp
@@ -37,6 +37,8 @@ void CreateVTKElementConnectivity(Array<int> &con, Geometry::Type geom,
 void WriteVTKEncodedCompressed(std::ostream &out, const void *bytes,
                                uint32_t nbytes, int compression_level);
 
+const char *VTKByteOrder();
+
 } // namespace mfem
 
 #endif

--- a/mesh/vtk.hpp
+++ b/mesh/vtk.hpp
@@ -1,0 +1,41 @@
+// Copyright (c) 2010, Lawrence Livermore National Security, LLC. Produced at
+// the Lawrence Livermore National Laboratory. LLNL-CODE-443211. All Rights
+// reserved. See file COPYRIGHT for details.
+//
+// This file is part of the MFEM library. For more information and source code
+// availability see http://mfem.org.
+//
+// MFEM is free software; you can redistribute it and/or modify it under the
+// terms of the GNU Lesser General Public License (as published by the Free
+// Software Foundation) version 2.1 dated February 1999.
+
+#ifndef MFEM_VTK
+#define MFEM_VTK
+
+#include "../fem/geom.hpp"
+
+namespace mfem
+{
+
+// Helpers for writing to the VTK format
+
+enum class VTKFormat
+{
+   ASCII,
+   BINARY,
+   BINARY32
+};
+
+/// Create the VTK element connectivity array for a given element geometry and 
+/// refinement level. Converts node numbers from MFEM to VTK ordering.
+void CreateVTKElementConnectivity(Array<int> &con, Geometry::Type geom, int ref);
+
+/// Outputs encoded binary data in the format needed by VTK. The binary data
+/// will be base 64 encoded, and compressed if @a compression_level is not 
+/// zero. The proper header will be prepended to the data.
+void WriteVTKEncodedCompressed(std::ostream &out, const void *bytes,
+                               uint32_t nbytes, int compression_level);
+
+} // namespace mfem
+
+#endif

--- a/mesh/vtk.hpp
+++ b/mesh/vtk.hpp
@@ -26,12 +26,13 @@ enum class VTKFormat
    BINARY32
 };
 
-/// Create the VTK element connectivity array for a given element geometry and 
+/// Create the VTK element connectivity array for a given element geometry and
 /// refinement level. Converts node numbers from MFEM to VTK ordering.
-void CreateVTKElementConnectivity(Array<int> &con, Geometry::Type geom, int ref);
+void CreateVTKElementConnectivity(Array<int> &con, Geometry::Type geom,
+                                  int ref);
 
 /// Outputs encoded binary data in the format needed by VTK. The binary data
-/// will be base 64 encoded, and compressed if @a compression_level is not 
+/// will be base 64 encoded, and compressed if @a compression_level is not
 /// zero. The proper header will be prepended to the data.
 void WriteVTKEncodedCompressed(std::ostream &out, const void *bytes,
                                uint32_t nbytes, int compression_level);


### PR DESCRIPTION
This PR adds several new features and makes some improvements to the `ParaViewDataCollection` class:

- High-order output for all element types: tensor products, simplices, and prisms
- Option to output in binary format (either Float64 or Float32)
- Compressed binary output if compiled with gzstream support
- Write files in a way that allows ParaView to read “partially written” data collections (i.e. during time stepping, before completion)
- Allow for output of high-order VTU format meshes
- Code reorganization: avoid duplicating pre-existing functionality from the `DataCollection` base class
- Bug fix: respect precision option for ASCII output
- Bug fix: respect prefix path for data collection (fixes #1284)

Related to #678 and GLVis/glvis#64.

An example of the high-order visualization:

![tri](https://user-images.githubusercontent.com/11493037/74488346-cb2c3180-4e76-11ea-9b8f-746934d4537b.png)

<!--GHEX{"id":1296,"author":"pazner","editor":"tzanio","reviewers":["bslazarov","jandrej"],"assignment":"2020-02-16","approval":"2020-02-24T14:51:11.568Z","merge":"2020-02-27T17:19:51.660Z"}XEHG--><!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge| 
 | --- | --- | --- | --- | --- | --- | --- | 
| [#1296](https://github.com/mfem/mfem/pull/1296) | @pazner | @tzanio | @bslazarov + @jandrej | 02/16/20 | 02/24/20 | 02/27/20 | |
<!--ELBATXEHG-->