### PR TITLE
Optional flag to copy row starts/col starts when using ParMult() [parmult_pr]

### DIFF
--- a/linalg/hypre.cpp
+++ b/linalg/hypre.cpp
@@ -1577,15 +1577,21 @@ HypreParMatrix *Add(double alpha, const HypreParMatrix &A,
    return C;
 }
 
-HypreParMatrix * ParMult(const HypreParMatrix *A, const HypreParMatrix *B)
+HypreParMatrix * ParMult(const HypreParMatrix *A, const HypreParMatrix *B,
+                         bool own_matrix)
 {
    hypre_ParCSRMatrix * ab;
    ab = hypre_ParMatmul(*A,*B);
    hypre_ParCSRMatrixSetNumNonzeros(ab);
 
    hypre_MatvecCommPkgCreate(ab);
-
-   return new HypreParMatrix(ab);
+   HypreParMatrix *C = new HypreParMatrix(ab);
+   if (own_matrix)
+   {
+      C->CopyRowStarts();
+      C->CopyColStarts();
+   }
+   return C;
 }
 
 HypreParMatrix * ParAdd(const HypreParMatrix *A, const HypreParMatrix *B)

--- a/linalg/hypre.hpp
+++ b/linalg/hypre.hpp
@@ -555,10 +555,10 @@ public:
 HypreParMatrix *Add(double alpha, const HypreParMatrix &A,
                     double beta,  const HypreParMatrix &B);
 
-/** Returns the matrix \@ A * \@ B. Returned matrix does not necessarily own
-    row or column starts unless the bool own_matrix is set to true. */
+/** Returns the matrix @a A * @a B. Returned matrix does not necessarily own
+    row or column starts unless the bool @a own_matrix is set to true. */
 HypreParMatrix * ParMult(const HypreParMatrix *A, const HypreParMatrix *B,
-                         bool own_matrix=false);
+                         bool own_matrix = false);
 /// Returns the matrix A + B
 /** It is assumed that both matrices use the same row and column partitions and
     the same col_map_offd arrays. */

--- a/linalg/hypre.hpp
+++ b/linalg/hypre.hpp
@@ -555,9 +555,8 @@ public:
 HypreParMatrix *Add(double alpha, const HypreParMatrix &A,
                     double beta,  const HypreParMatrix &B);
 
-/// Returns the matrix A * B
-/** Returned matrix does not own row or column starts unless the bool
-    own_matrix is set to true. */
+/** Returns the matrix \@ A * \@ B. Returned matrix does not necessarily own
+    row or column starts unless the bool own_matrix is set to true. */
 HypreParMatrix * ParMult(const HypreParMatrix *A, const HypreParMatrix *B,
                          bool own_matrix=false);
 /// Returns the matrix A + B

--- a/linalg/hypre.hpp
+++ b/linalg/hypre.hpp
@@ -556,7 +556,10 @@ HypreParMatrix *Add(double alpha, const HypreParMatrix &A,
                     double beta,  const HypreParMatrix &B);
 
 /// Returns the matrix A * B
-HypreParMatrix * ParMult(const HypreParMatrix *A, const HypreParMatrix *B);
+/** Returned matrix does not own row or column starts unless the bool
+    own_matrix is set to true. */
+HypreParMatrix * ParMult(const HypreParMatrix *A, const HypreParMatrix *B,
+                         bool own_matrix=false);
 /// Returns the matrix A + B
 /** It is assumed that both matrices use the same row and column partitions and
     the same col_map_offd arrays. */


### PR DESCRIPTION

<!--GHEX{"id":1297,"author":"ben-s-southworth","editor":"tzanio","reviewers":["psocratis","kmittal2"],"assignment":"2020-02-22T16:44:49-08:00","approval":"2020-02-25T17:41:31.145Z","merge":"2020-02-27T17:26:40.489Z"}XEHG--><!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge| 
 | --- | --- | --- | --- | --- | --- | --- | 
| [#1297](https://github.com/mfem/mfem/pull/1297) | @ben-s-southworth | @tzanio | @psocratis + @kmittal2 | 02/22/20 | 02/25/20 | 02/27/20 | |
<!--ELBATXEHG-->