### PR TITLE
Fad -   Forward AD native MFEM class with unit tests

### DIFF
--- a/linalg/fdual.hpp
+++ b/linalg/fdual.hpp
@@ -10,156 +10,155 @@
 // Software Foundation) version 2.1 dated February 1999.
 
 
-
 #ifndef FDUAL_H
 #define FDUAL_H
-
 
 #include <cmath>
 namespace mfem
 {
-    
-namespace ad{
 
+namespace ad
+{
+// Forward AD - simple class
 template<typename tbase>
 class FDual
 {
-	private:
-        tbase pr;
-        tbase du;
-    
-	public:
+private:
+   tbase pr;
+   tbase du;
 
-    FDual():pr(tbase()),du(tbase())
-    {
-        
-    }
-        
-	FDual(tbase pr_):pr(pr_),du(tbase(0))
-	{
+public:
 
-	}
+   FDual():pr(tbase()),du(tbase())
+   {
 
-	FDual(tbase pr_,tbase du_):pr(pr_),du(du_)
-	{
+   }
 
-	}
-	
-	template<typename tbase1>
-	FDual(FDual<tbase1>& f)
-    {
-        pr=f.real();
-        du=f.dual();
-    }
+   FDual(tbase pr_):pr(pr_),du(tbase(0))
+   {
 
-	tbase real() const
-	{
-		return pr;
-	}
+   }
 
-	tbase dual() const
-	{
-		return du;
-	}
-	
-	FDual<tbase> & operator=(tbase sc_)
-    {
-        pr=sc_;
-        du=tbase(0);
-        return *this;
-    }
-    
-    FDual<tbase> & operator+=(tbase sc_)
-    {
-        pr=pr+sc_;
-        return *this;
-    }
-    
-    FDual<tbase> & operator-=(tbase sc_)
-    {
-        pr=pr-sc_;
-        return *this;
-        
-    }
-    
-    FDual<tbase> & operator*=(tbase sc_)
-    {
-        pr=pr*sc_;
-        du=du*sc_;
-        return *this;
-    }
-    
-    FDual<tbase>& operator/=(tbase sc_)
-    {
-        pr=pr/sc_;
-        du=du/sc_;
-        return *this;
-    }
-    
-    template<typename tbase1>
-    FDual<tbase>& operator=(const FDual<tbase1> & f)
-    {
-        pr = f.real(); 
-        du = f.dual(); 
-        return *this;
-    }
-    
-    template<typename tbase1>
-    FDual<tbase>& operator+=(const FDual<tbase1>& f)
-    {
-        pr += f.real(); 
-        du += f.dual(); 
-        return *this;
-    } 
-    
-    template<typename tbase1>
-    FDual<tbase>& operator-=(const FDual<tbase1>& f)
-    {
-        pr -= f.real(); 
-        du -= f.dual(); 
-        return *this;
-    }
-    
-    template<typename tbase1>
-    FDual<tbase>& operator*=(const FDual<tbase1>& f)
-    {
-        du = du * f.real();
-        du = du+ pr * f.dual();
-        pr = pr * f.real(); 
-        return *this;
-    }
-    
-    template<typename tbase1>
-    FDual<tbase>& operator/=(const FDual<tbase1>& f_)
-    {
-        pr = pr / f_.real(); 
-        du = du - pr * f_.dual();
-        du = du / f_.real();
-        return *this;
-    }
+   FDual(tbase pr_,tbase du_):pr(pr_),du(du_)
+   {
+
+   }
+
+   template<typename tbase1>
+   FDual(FDual<tbase1>& f)
+   {
+      pr=f.real();
+      du=f.dual();
+   }
+
+   tbase real() const
+   {
+      return pr;
+   }
+
+   tbase dual() const
+   {
+      return du;
+   }
+
+   FDual<tbase> & operator=(tbase sc_)
+   {
+      pr=sc_;
+      du=tbase(0);
+      return *this;
+   }
+
+   FDual<tbase> & operator+=(tbase sc_)
+   {
+      pr=pr+sc_;
+      return *this;
+   }
+
+   FDual<tbase> & operator-=(tbase sc_)
+   {
+      pr=pr-sc_;
+      return *this;
+
+   }
+
+   FDual<tbase> & operator*=(tbase sc_)
+   {
+      pr=pr*sc_;
+      du=du*sc_;
+      return *this;
+   }
+
+   FDual<tbase>& operator/=(tbase sc_)
+   {
+      pr=pr/sc_;
+      du=du/sc_;
+      return *this;
+   }
+
+   template<typename tbase1>
+   FDual<tbase>& operator=(const FDual<tbase1> & f)
+   {
+      pr = f.real();
+      du = f.dual();
+      return *this;
+   }
+
+   template<typename tbase1>
+   FDual<tbase>& operator+=(const FDual<tbase1>& f)
+   {
+      pr += f.real();
+      du += f.dual();
+      return *this;
+   }
+
+   template<typename tbase1>
+   FDual<tbase>& operator-=(const FDual<tbase1>& f)
+   {
+      pr -= f.real();
+      du -= f.dual();
+      return *this;
+   }
+
+   template<typename tbase1>
+   FDual<tbase>& operator*=(const FDual<tbase1>& f)
+   {
+      du = du * f.real();
+      du = du+ pr * f.dual();
+      pr = pr * f.real();
+      return *this;
+   }
+
+   template<typename tbase1>
+   FDual<tbase>& operator/=(const FDual<tbase1>& f_)
+   {
+      pr = pr / f_.real();
+      du = du - pr * f_.dual();
+      du = du / f_.real();
+      return *this;
+   }
 };
 
 // non-member functions
 // boolean operations
-template <typename tbase1, typename tbase2> 
+template <typename tbase1, typename tbase2>
 inline
 bool operator==(const FDual<tbase1>& a1, const FDual<tbase2>& a2)
 {
-    return a1.real() == a2.real();
+   return a1.real() == a2.real();
 }
 
-template <typename tbase> 
+template <typename tbase>
 inline
 bool operator==(tbase a, const FDual<tbase>& f_)
 {
-    return a == f_.real();
+   return a == f_.real();
 }
 
-template <typename tbase> 
+template <typename tbase>
 inline
 bool operator==(const FDual<tbase>& a, tbase b)
 {
-    return a.real() == b;
+   return a.real() == b;
 }
 
 
@@ -167,379 +166,364 @@ template <typename tbase1, typename tbase2>
 inline
 bool operator<(const FDual<tbase1>& f1, const FDual<tbase2>& f2)
 {
-    return f1.real() < f2.real();
+   return f1.real() < f2.real();
 }
 
-template <typename tbase> 
+template <typename tbase>
 inline
 bool operator<(const FDual<tbase>& f, tbase a)
 {
-    return f.real() < a;
+   return f.real() < a;
 }
-    
-template <typename tbase> 
+
+template <typename tbase>
 inline
 bool operator<(tbase a, const FDual<tbase>& f)
 {
-    return a < f.real();
+   return a < f.real();
 }
 
-template <typename tbase1, typename tbase2> 
+template <typename tbase1, typename tbase2>
 inline
 bool operator>(const FDual<tbase1>& f1, const FDual<tbase2>& f2)
 {
-    return f1.real() > f2.real();
+   return f1.real() > f2.real();
 }
 
-template <typename tbase> 
+template <typename tbase>
 inline
 bool operator>(const FDual<tbase>& f, tbase a)
 {
-    return f.real() > a;
+   return f.real() > a;
 }
-    
-template <typename tbase> 
+
+template <typename tbase>
 inline
 bool operator>(tbase a, const FDual<tbase>& f)
 {
-    return a > f.real();
+   return a > f.real();
 }
 
 template <typename tbase>
 inline
 FDual<tbase> operator-(const FDual<tbase>& f)
 {
-    return FDual<tbase>(-f.real(), -f.dual());
-} 
+   return FDual<tbase>(-f.real(), -f.dual());
+}
 
 template <typename tbase>
 inline
 FDual<tbase> operator-(const FDual<tbase>& f, tbase a)
 {
-    return FDual<tbase>(f.real() - a, f.dual());
+   return FDual<tbase>(f.real() - a, f.dual());
 }
 
 template <typename tbase>
 inline
 FDual<tbase> operator+(const FDual<tbase>& f, tbase a)
 {
-    return FDual<tbase>(f.real() + a, f.dual());
+   return FDual<tbase>(f.real() + a, f.dual());
 }
 
 template <typename tbase>
 inline
 FDual<tbase> operator*(const FDual<tbase>& f, tbase a)
 {
-    return FDual<tbase>(f.real() * a, f.dual() * a);
+   return FDual<tbase>(f.real() * a, f.dual() * a);
 }
 
 template <typename tbase>
 inline
 FDual<tbase> operator/(const FDual<tbase>& f, tbase a)
 {
-    return FDual<tbase>(f.real() / a, f.dual() / a);
+   return FDual<tbase>(f.real() / a, f.dual() / a);
 }
 
 template <typename tbase>
 inline
 FDual<tbase> operator+(tbase a, const FDual<tbase>& f)
 {
-    return FDual<tbase>(a + f.real(), f.dual());
+   return FDual<tbase>(a + f.real(), f.dual());
 }
 
 template <typename tbase>
 inline
 FDual<tbase> operator-(tbase a, const FDual<tbase>& f)
 {
-    return FDual<tbase>(a - f.real(), -f.dual());
+   return FDual<tbase>(a - f.real(), -f.dual());
 }
-     
+
 template <typename tbase>
 inline
 FDual<tbase> operator*(tbase a, const FDual<tbase>& f)
 {
-    return f * a;
+   return f * a;
 }
-     
+
 template <typename tbase>
 inline
 FDual<tbase> operator/(tbase a, const FDual<tbase>& f)
 {
-    a = a / f.real(); 
-    return FDual<tbase>(a, -a * f.dual() / f.real());
+   a = a / f.real();
+   return FDual<tbase>(a, -a * f.dual() / f.real());
 }
 
 template <typename tbase>
 inline
 FDual<tbase> operator+(const FDual<tbase>& f1, const FDual<tbase>& f2)
 {
-    return FDual<tbase>(f1.real() + f2.real(), f1.dual() + f2.dual());
+   return FDual<tbase>(f1.real() + f2.real(), f1.dual() + f2.dual());
 }
 
 template <typename tbase>
 inline
 FDual<tbase> operator-(const FDual<tbase>& f1, const FDual<tbase>& f2)
-{ 
-    return FDual<tbase>(f1.real() - f2.real(), f1.dual() - f2.dual());
+{
+   return FDual<tbase>(f1.real() - f2.real(), f1.dual() - f2.dual());
 }
 
 template <typename tbase>
 inline
 FDual<tbase> operator*(const FDual<tbase>& f1, const FDual<tbase>& f2)
 {
-    return FDual<tbase>(f1.real() * f2.real(),
-                        f1.real() * f2.dual() + f1.dual() * f2.real());
+   return FDual<tbase>(f1.real() * f2.real(),
+                       f1.real() * f2.dual() + f1.dual() * f2.real());
 }
 
 template <typename tbase>
 inline
 FDual<tbase> operator/(const FDual<tbase>& f1, const FDual<tbase>& f2)
-{ 
-    tbase a=tbase(1)/f2.real(); 
-    tbase b=f1.real()*a;
-    return FDual<tbase>(b, (f1.dual() - f2.dual()*b)*a);
+{
+   tbase a=tbase(1)/f2.real();
+   tbase b=f1.real()*a;
+   return FDual<tbase>(b, (f1.dual() - f2.dual()*b)*a);
 }
 
-template <typename tbase> 
+template <typename tbase>
 inline
 FDual<tbase> acos(const FDual<tbase>& f)
 {
-    return FDual<tbase>(acos(f.real()),
-                        -f.dual() / sqrt(tbase(1) - f.real() * f.real()));
+   return FDual<tbase>(acos(f.real()),
+                       -f.dual() / sqrt(tbase(1) - f.real() * f.real()));
 }
 
-template <> 
+template <>
 inline
 FDual<double> acos(const FDual<double>& f)
 {
-    return FDual<double>(std::acos(f.real()),
+   return FDual<double>(std::acos(f.real()),
                         -f.dual() / sqrt(double(1) - f.real() * f.real()));
 }
 
-
-template <typename tbase> 
+template <typename tbase>
 inline
 FDual<tbase> asin(const FDual<tbase>& f)
 {
-    return FDual<tbase>(asin(f.real()),
-                        f.dual() / sqrt(tbase(1) - f.real() * f.real()));
+   return FDual<tbase>(asin(f.real()),
+                       f.dual() / sqrt(tbase(1) - f.real() * f.real()));
 }
 
-template <> 
+template <>
 inline
 FDual<double> asin(const FDual<double>& f)
 {
-    return FDual<double>(std::asin(f.real()),
+   return FDual<double>(std::asin(f.real()),
                         f.dual() / sqrt(double(1) - f.real() * f.real()));
 }
 
-
-
-    
-template <typename tbase> 
+template <typename tbase>
 inline
 FDual<tbase> atan(const FDual<tbase>& f)
 {
-    return FDual<tbase>(atan(f.real()), 
-                        f.dual() / (tbase(1) + f.real() * f.real()));
+   return FDual<tbase>(atan(f.real()),
+                       f.dual() / (tbase(1) + f.real() * f.real()));
 }
 
-template <> 
+template <>
 inline
 FDual<double> atan(const FDual<double>& f)
 {
-    return FDual<double>(std::atan(f.real()), 
+   return FDual<double>(std::atan(f.real()),
                         f.dual() / (double(1) + f.real() * f.real()));
 }
 
-
-template <typename tbase> 
+template <typename tbase>
 inline
 FDual<tbase> cos(const FDual<tbase>& f)
 {
-    return FDual<tbase>(cos(f.real()), -f.dual() * sin(f.real()));
+   return FDual<tbase>(cos(f.real()), -f.dual() * sin(f.real()));
 }
 
-template <> 
+template <>
 inline
 FDual<double> cos(const FDual<double>& f)
 {
-    return FDual<double>(std::cos(f.real()), -f.dual() * std::sin(f.real()));
+   return FDual<double>(std::cos(f.real()), -f.dual() * std::sin(f.real()));
 }
 
-template <typename tbase> 
+template <typename tbase>
 inline
 FDual<tbase> cosh(const FDual<tbase>& f)
 {
-    return FDual<tbase>(cosh(f.real()), f.dual() * sinh(f.real()));
+   return FDual<tbase>(cosh(f.real()), f.dual() * sinh(f.real()));
 }
 
-template <> 
+template <>
 inline
 FDual<double> cosh(const FDual<double>& f)
 {
-    return FDual<double>(std::cosh(f.real()), f.dual() * std::sinh(f.real()));
+   return FDual<double>(std::cosh(f.real()), f.dual() * std::sinh(f.real()));
 }
 
-
-template <typename tbase> 
+template <typename tbase>
 inline
 FDual<tbase> exp(const FDual<tbase>& f)
 {
-    tbase x = exp(f.real());
-    return FDual<tbase>(x, f.dual() * x);
+   tbase x = exp(f.real());
+   return FDual<tbase>(x, f.dual() * x);
 }
 
-template <> 
+template <>
 inline
 FDual<double> exp(const FDual<double>& f)
 {
-    double x = std::exp(f.real());
-    return FDual<double>(x, f.dual() * x);
+   double x = std::exp(f.real());
+   return FDual<double>(x, f.dual() * x);
 }
 
-
-template <typename tbase> 
+template <typename tbase>
 inline
 FDual<tbase> log(const FDual<tbase>& f)
 {
-    return FDual<tbase>(log(f.real()), f.dual() / f.real());
+   return FDual<tbase>(log(f.real()), f.dual() / f.real());
 }
 
-template <> 
+template <>
 inline
 FDual<double> log(const FDual<double>& f)
 {
-    return FDual<double>(std::log(f.real()), f.dual() / f.real());
+   return FDual<double>(std::log(f.real()), f.dual() / f.real());
 }
 
-
-  
-template <typename tbase> 
-inline    
+template <typename tbase>
+inline
 FDual<tbase> log10(const FDual<tbase>& f)
 {
    return log(f) / log(tbase(10));
 }
 
-template <> 
-inline    
+template <>
+inline
 FDual<double> log10(const FDual<double>& f)
 {
    return log(f) / std::log(double(10));
 }
 
-  
-template <typename tbase> 
-inline    
+template <typename tbase>
+inline
 FDual<tbase> pow(const FDual<tbase>& a, const FDual<tbase>& b)
 {
-    return exp(log(a) * b);
+   return exp(log(a) * b);
 }
 
-template <typename tbase> 
-inline    
+template <typename tbase>
+inline
 FDual<tbase> pow(const FDual<tbase>& a, const tbase& b)
 {
-    return exp(log(a) * b);
+   return exp(log(a) * b);
 }
 
-template <typename tbase> 
-inline    
+template <typename tbase>
+inline
 FDual<tbase> pow(const tbase& a, const FDual<tbase>& b)
 {
-    return exp(log(a) * b);
+   return exp(log(a) * b);
 }
 
-template <> 
-inline    
+template <>
+inline
 FDual<double> pow(const double& a, const FDual<double>& b)
 {
-    return exp(std::log(a) * b);
+   return exp(std::log(a) * b);
 }
 
-
-
-
-template <typename tbase> 
+template <typename tbase>
 inline
 FDual<tbase> sin(const FDual<tbase>& f)
 {
-    return FDual<tbase>(sin(f.real()), f.dual() * cos(f.real()));
+   return FDual<tbase>(sin(f.real()), f.dual() * cos(f.real()));
 }
 
-template <> 
+template <>
 inline
 FDual<double> sin(const FDual<double>& f)
 {
-    return FDual<double>(std::sin(f.real()), f.dual() * std::cos(f.real()));
+   return FDual<double>(std::sin(f.real()), f.dual() * std::cos(f.real()));
 }
 
-
-
-template <typename tbase> 
-inline    
+template <typename tbase>
+inline
 FDual<tbase> sinh(const FDual<tbase>& f)
 {
-    return FDual<tbase>(sinh(f.real()), f.dual() * cosh(f.real()));
+   return FDual<tbase>(sinh(f.real()), f.dual() * cosh(f.real()));
 }
 
-template <> 
-inline    
+template <>
+inline
 FDual<double> sinh(const FDual<double>& f)
 {
-    return FDual<double>(std::sinh(f.real()), f.dual() * std::cosh(f.real()));
+   return FDual<double>(std::sinh(f.real()), f.dual() * std::cosh(f.real()));
 }
 
 
-template <typename tbase> 
-inline    
+template <typename tbase>
+inline
 FDual<tbase> sqrt(const FDual<tbase>& f)
 {
-    tbase a = sqrt(f.real());
-    return FDual<tbase>(a, f.dual() / (tbase(2) * a));
+   tbase a = sqrt(f.real());
+   return FDual<tbase>(a, f.dual() / (tbase(2) * a));
 }
 
-template <> 
-inline    
+template <>
+inline
 FDual<double> sqrt(const FDual<double>& f)
 {
-    double a = std::sqrt(f.real());
-    return FDual<double>(a, f.dual() / (double(2) * a));
+   double a = std::sqrt(f.real());
+   return FDual<double>(a, f.dual() / (double(2) * a));
 }
 
 
-template <typename tbase> 
+template <typename tbase>
 inline
 FDual<tbase> tan(const FDual<tbase>& f)
 {
-    tbase a = tan(f.real());
-    return FDual<tbase>(a,f.dual() * (tbase(1) + a * a));
+   tbase a = tan(f.real());
+   return FDual<tbase>(a,f.dual() * (tbase(1) + a * a));
 }
 
-template <> 
+template <>
 inline
 FDual<double> tan(const FDual<double>& f)
 {
-    double a = std::tan(f.real());
-    return FDual<double>(a,f.dual() * (double(1) + a * a));
+   double a = std::tan(f.real());
+   return FDual<double>(a,f.dual() * (double(1) + a * a));
 }
 
 
-template <typename tbase> 
-inline    
+template <typename tbase>
+inline
 FDual<tbase> tanh(const FDual<tbase>& f)
 {
-    tbase a = tanh(f.real());
-    return FDual<tbase>(a, f.dual() * (tbase(1) - a * a));
+   tbase a = tanh(f.real());
+   return FDual<tbase>(a, f.dual() * (tbase(1) - a * a));
 }
 
-template <> 
-inline    
+template <>
+inline
 FDual<double> tanh(const FDual<double>& f)
 {
-    double a = std::tanh(f.real());
-    return FDual<double>(a, f.dual() * (double(1) - a * a));
+   double a = std::tanh(f.real());
+   return FDual<double>(a, f.dual() * (double(1) - a * a));
 }
 
 }

--- a/linalg/fdual.hpp
+++ b/linalg/fdual.hpp
@@ -1,0 +1,552 @@
+// Copyright (c) 2010, Lawrence Livermore National Security, LLC. Produced at
+// the Lawrence Livermore National Laboratory. LLNL-CODE-443211. All Rights
+// reserved. See file COPYRIGHT for details.
+//
+// This file is part of the MFEM library. For more information and source code
+// availability see http://mfem.org.
+//
+// MFEM is free software; you can redistribute it and/or modify it under the
+// terms of the GNU Lesser General Public License (as published by the Free
+// Software Foundation) version 2.1 dated February 1999.
+
+
+
+#ifndef FDUAL_H
+#define FDUAL_H
+
+
+#include <cmath>
+namespace mfem
+{
+    
+namespace ad{
+
+template<typename tbase>
+class FDual
+{
+	private:
+        tbase pr;
+        tbase du;
+    
+	public:
+
+    FDual():pr(tbase()),du(tbase())
+    {
+        
+    }
+        
+	FDual(tbase pr_):pr(pr_),du(tbase(0))
+	{
+
+	}
+
+	FDual(tbase pr_,tbase du_):pr(pr_),du(du_)
+	{
+
+	}
+	
+	template<typename tbase1>
+	FDual(FDual<tbase1>& f)
+    {
+        pr=f.real();
+        du=f.dual();
+    }
+
+	tbase real() const
+	{
+		return pr;
+	}
+
+	tbase dual() const
+	{
+		return du;
+	}
+	
+	FDual<tbase> & operator=(tbase sc_)
+    {
+        pr=sc_;
+        du=tbase(0);
+        return *this;
+    }
+    
+    FDual<tbase> & operator+=(tbase sc_)
+    {
+        pr=pr+sc_;
+        return *this;
+    }
+    
+    FDual<tbase> & operator-=(tbase sc_)
+    {
+        pr=pr-sc_;
+        return *this;
+        
+    }
+    
+    FDual<tbase> & operator*=(tbase sc_)
+    {
+        pr=pr*sc_;
+        du=du*sc_;
+        return *this;
+    }
+    
+    FDual<tbase>& operator/=(tbase sc_)
+    {
+        pr=pr/sc_;
+        du=du/sc_;
+        return *this;
+    }
+    
+    template<typename tbase1>
+    FDual<tbase>& operator=(const FDual<tbase1> & f)
+    {
+        pr = f.real(); 
+        du = f.dual(); 
+        return *this;
+    }
+    
+    template<typename tbase1>
+    FDual<tbase>& operator+=(const FDual<tbase1>& f)
+    {
+        pr += f.real(); 
+        du += f.dual(); 
+        return *this;
+    } 
+    
+    template<typename tbase1>
+    FDual<tbase>& operator-=(const FDual<tbase1>& f)
+    {
+        pr -= f.real(); 
+        du -= f.dual(); 
+        return *this;
+    }
+    
+    template<typename tbase1>
+    FDual<tbase>& operator*=(const FDual<tbase1>& f)
+    {
+        du = du * f.real();
+        du = du+ pr * f.dual();
+        pr = pr * f.real(); 
+        return *this;
+    }
+    
+    template<typename tbase1>
+    FDual<tbase>& operator/=(const FDual<tbase1>& f_)
+    {
+        pr = pr / f_.real(); 
+        du = du - pr * f_.dual();
+        du = du / f_.real();
+        return *this;
+    }
+};
+
+// non-member functions
+// boolean operations
+template <typename tbase1, typename tbase2> 
+inline
+bool operator==(const FDual<tbase1>& a1, const FDual<tbase2>& a2)
+{
+    return a1.real() == a2.real();
+}
+
+template <typename tbase> 
+inline
+bool operator==(tbase a, const FDual<tbase>& f_)
+{
+    return a == f_.real();
+}
+
+template <typename tbase> 
+inline
+bool operator==(const FDual<tbase>& a, tbase b)
+{
+    return a.real() == b;
+}
+
+
+template <typename tbase1, typename tbase2>
+inline
+bool operator<(const FDual<tbase1>& f1, const FDual<tbase2>& f2)
+{
+    return f1.real() < f2.real();
+}
+
+template <typename tbase> 
+inline
+bool operator<(const FDual<tbase>& f, tbase a)
+{
+    return f.real() < a;
+}
+    
+template <typename tbase> 
+inline
+bool operator<(tbase a, const FDual<tbase>& f)
+{
+    return a < f.real();
+}
+
+template <typename tbase1, typename tbase2> 
+inline
+bool operator>(const FDual<tbase1>& f1, const FDual<tbase2>& f2)
+{
+    return f1.real() > f2.real();
+}
+
+template <typename tbase> 
+inline
+bool operator>(const FDual<tbase>& f, tbase a)
+{
+    return f.real() > a;
+}
+    
+template <typename tbase> 
+inline
+bool operator>(tbase a, const FDual<tbase>& f)
+{
+    return a > f.real();
+}
+
+template <typename tbase>
+inline
+FDual<tbase> operator-(const FDual<tbase>& f)
+{
+    return FDual<tbase>(-f.real(), -f.dual());
+} 
+
+template <typename tbase>
+inline
+FDual<tbase> operator-(const FDual<tbase>& f, tbase a)
+{
+    return FDual<tbase>(f.real() - a, f.dual());
+}
+
+template <typename tbase>
+inline
+FDual<tbase> operator+(const FDual<tbase>& f, tbase a)
+{
+    return FDual<tbase>(f.real() + a, f.dual());
+}
+
+template <typename tbase>
+inline
+FDual<tbase> operator*(const FDual<tbase>& f, tbase a)
+{
+    return FDual<tbase>(f.real() * a, f.dual() * a);
+}
+
+template <typename tbase>
+inline
+FDual<tbase> operator/(const FDual<tbase>& f, tbase a)
+{
+    return FDual<tbase>(f.real() / a, f.dual() / a);
+}
+
+template <typename tbase>
+inline
+FDual<tbase> operator+(tbase a, const FDual<tbase>& f)
+{
+    return FDual<tbase>(a + f.real(), f.dual());
+}
+
+template <typename tbase>
+inline
+FDual<tbase> operator-(tbase a, const FDual<tbase>& f)
+{
+    return FDual<tbase>(a - f.real(), -f.dual());
+}
+     
+template <typename tbase>
+inline
+FDual<tbase> operator*(tbase a, const FDual<tbase>& f)
+{
+    return f * a;
+}
+     
+template <typename tbase>
+inline
+FDual<tbase> operator/(tbase a, const FDual<tbase>& f)
+{
+    a = a / f.real(); 
+    return FDual<tbase>(a, -a * f.dual() / f.real());
+}
+
+template <typename tbase>
+inline
+FDual<tbase> operator+(const FDual<tbase>& f1, const FDual<tbase>& f2)
+{
+    return FDual<tbase>(f1.real() + f2.real(), f1.dual() + f2.dual());
+}
+
+template <typename tbase>
+inline
+FDual<tbase> operator-(const FDual<tbase>& f1, const FDual<tbase>& f2)
+{ 
+    return FDual<tbase>(f1.real() - f2.real(), f1.dual() - f2.dual());
+}
+
+template <typename tbase>
+inline
+FDual<tbase> operator*(const FDual<tbase>& f1, const FDual<tbase>& f2)
+{
+    return FDual<tbase>(f1.real() * f2.real(),
+                        f1.real() * f2.dual() + f1.dual() * f2.real());
+}
+
+template <typename tbase>
+inline
+FDual<tbase> operator/(const FDual<tbase>& f1, const FDual<tbase>& f2)
+{ 
+    tbase a=tbase(1)/f2.real(); 
+    tbase b=f1.real()*a;
+    return FDual<tbase>(b, (f1.dual() - f2.dual()*b)*a);
+}
+
+template <typename tbase> 
+inline
+FDual<tbase> acos(const FDual<tbase>& f)
+{
+    return FDual<tbase>(acos(f.real()),
+                        -f.dual() / sqrt(tbase(1) - f.real() * f.real()));
+}
+
+template <> 
+inline
+FDual<double> acos(const FDual<double>& f)
+{
+    return FDual<double>(std::acos(f.real()),
+                        -f.dual() / sqrt(double(1) - f.real() * f.real()));
+}
+
+
+template <typename tbase> 
+inline
+FDual<tbase> asin(const FDual<tbase>& f)
+{
+    return FDual<tbase>(asin(f.real()),
+                        f.dual() / sqrt(tbase(1) - f.real() * f.real()));
+}
+
+template <> 
+inline
+FDual<double> asin(const FDual<double>& f)
+{
+    return FDual<double>(std::asin(f.real()),
+                        f.dual() / sqrt(double(1) - f.real() * f.real()));
+}
+
+
+
+    
+template <typename tbase> 
+inline
+FDual<tbase> atan(const FDual<tbase>& f)
+{
+    return FDual<tbase>(atan(f.real()), 
+                        f.dual() / (tbase(1) + f.real() * f.real()));
+}
+
+template <> 
+inline
+FDual<double> atan(const FDual<double>& f)
+{
+    return FDual<double>(std::atan(f.real()), 
+                        f.dual() / (double(1) + f.real() * f.real()));
+}
+
+
+template <typename tbase> 
+inline
+FDual<tbase> cos(const FDual<tbase>& f)
+{
+    return FDual<tbase>(cos(f.real()), -f.dual() * sin(f.real()));
+}
+
+template <> 
+inline
+FDual<double> cos(const FDual<double>& f)
+{
+    return FDual<double>(std::cos(f.real()), -f.dual() * std::sin(f.real()));
+}
+
+template <typename tbase> 
+inline
+FDual<tbase> cosh(const FDual<tbase>& f)
+{
+    return FDual<tbase>(cosh(f.real()), f.dual() * sinh(f.real()));
+}
+
+template <> 
+inline
+FDual<double> cosh(const FDual<double>& f)
+{
+    return FDual<double>(std::cosh(f.real()), f.dual() * std::sinh(f.real()));
+}
+
+
+template <typename tbase> 
+inline
+FDual<tbase> exp(const FDual<tbase>& f)
+{
+    tbase x = exp(f.real());
+    return FDual<tbase>(x, f.dual() * x);
+}
+
+template <> 
+inline
+FDual<double> exp(const FDual<double>& f)
+{
+    double x = std::exp(f.real());
+    return FDual<double>(x, f.dual() * x);
+}
+
+
+template <typename tbase> 
+inline
+FDual<tbase> log(const FDual<tbase>& f)
+{
+    return FDual<tbase>(log(f.real()), f.dual() / f.real());
+}
+
+template <> 
+inline
+FDual<double> log(const FDual<double>& f)
+{
+    return FDual<double>(std::log(f.real()), f.dual() / f.real());
+}
+
+
+  
+template <typename tbase> 
+inline    
+FDual<tbase> log10(const FDual<tbase>& f)
+{
+   return log(f) / log(tbase(10));
+}
+
+template <> 
+inline    
+FDual<double> log10(const FDual<double>& f)
+{
+   return log(f) / std::log(double(10));
+}
+
+  
+template <typename tbase> 
+inline    
+FDual<tbase> pow(const FDual<tbase>& a, const FDual<tbase>& b)
+{
+    return exp(log(a) * b);
+}
+
+template <typename tbase> 
+inline    
+FDual<tbase> pow(const FDual<tbase>& a, const tbase& b)
+{
+    return exp(log(a) * b);
+}
+
+template <typename tbase> 
+inline    
+FDual<tbase> pow(const tbase& a, const FDual<tbase>& b)
+{
+    return exp(log(a) * b);
+}
+
+template <> 
+inline    
+FDual<double> pow(const double& a, const FDual<double>& b)
+{
+    return exp(std::log(a) * b);
+}
+
+
+
+
+template <typename tbase> 
+inline
+FDual<tbase> sin(const FDual<tbase>& f)
+{
+    return FDual<tbase>(sin(f.real()), f.dual() * cos(f.real()));
+}
+
+template <> 
+inline
+FDual<double> sin(const FDual<double>& f)
+{
+    return FDual<double>(std::sin(f.real()), f.dual() * std::cos(f.real()));
+}
+
+
+
+template <typename tbase> 
+inline    
+FDual<tbase> sinh(const FDual<tbase>& f)
+{
+    return FDual<tbase>(sinh(f.real()), f.dual() * cosh(f.real()));
+}
+
+template <> 
+inline    
+FDual<double> sinh(const FDual<double>& f)
+{
+    return FDual<double>(std::sinh(f.real()), f.dual() * std::cosh(f.real()));
+}
+
+
+template <typename tbase> 
+inline    
+FDual<tbase> sqrt(const FDual<tbase>& f)
+{
+    tbase a = sqrt(f.real());
+    return FDual<tbase>(a, f.dual() / (tbase(2) * a));
+}
+
+template <> 
+inline    
+FDual<double> sqrt(const FDual<double>& f)
+{
+    double a = std::sqrt(f.real());
+    return FDual<double>(a, f.dual() / (double(2) * a));
+}
+
+
+template <typename tbase> 
+inline
+FDual<tbase> tan(const FDual<tbase>& f)
+{
+    tbase a = tan(f.real());
+    return FDual<tbase>(a,f.dual() * (tbase(1) + a * a));
+}
+
+template <> 
+inline
+FDual<double> tan(const FDual<double>& f)
+{
+    double a = std::tan(f.real());
+    return FDual<double>(a,f.dual() * (double(1) + a * a));
+}
+
+
+template <typename tbase> 
+inline    
+FDual<tbase> tanh(const FDual<tbase>& f)
+{
+    tbase a = tanh(f.real());
+    return FDual<tbase>(a, f.dual() * (tbase(1) - a * a));
+}
+
+template <> 
+inline    
+FDual<double> tanh(const FDual<double>& f)
+{
+    double a = std::tanh(f.real());
+    return FDual<double>(a, f.dual() * (double(1) - a * a));
+}
+
+}
+
+}
+
+
+
+
+#endif

--- a/linalg/linalg.hpp
+++ b/linalg/linalg.hpp
@@ -28,6 +28,7 @@
 #include "solvers.hpp"
 #include "handle.hpp"
 #include "invariants.hpp"
+#include "fdual.hpp"
 
 #ifdef MFEM_USE_SUNDIALS
 #include "sundials.hpp"

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -25,6 +25,7 @@ set(UNIT_TESTS_SRCS
   linalg/test_densematrix.cpp
   linalg/test_ilu.cpp
   linalg/test_ode.cpp
+  linalg/test_fdual.cpp
   mesh/test_mesh.cpp
   fem/test_1d_bilininteg.cpp
   fem/test_2d_bilininteg.cpp

--- a/tests/unit/linalg/test_fdual.cpp
+++ b/tests/unit/linalg/test_fdual.cpp
@@ -12,111 +12,180 @@
 #include "mfem.hpp"
 #include "catch.hpp"
 
-#ifdef MFEM_USE_EXCEPTIONS
 
 using namespace mfem;
+
+
+template<typename tbase>
+tbase exprp02(tbase x,tbase y)
+{
+   return sin(x)*cos(y)+tan(x*y);
+}
+
+template<typename tbase>
+tbase exprp02x(tbase x,tbase y)
+{
+   return cos(x)*cos(y)+y*(1.0+pow(tan(x*y),2.0));
+}
+
+template<typename tbase>
+tbase exprp02y(tbase x,tbase y)
+{
+   return -sin(x)*sin(y)+x*(1.0+pow(tan(x*y),2.0));
+}
+
 
 TEST_CASE("Simple AD tests", "[Simple_AD_tests]")
 {
    SECTION("sin")
    {
-   	double x=0.5;
-   	double d;
-	ad::FDual<double> xx(x,1.0);
-	ad::FDual<double> lrez;	
-	lrez=ad::sin(xx);
-    	d=std::cos(x);
-	REQUIRE(std::abs(d-lrez.dual())<std::numeric_limits<double>::epsilon());
+      double x = 0.5;
+      double d;
+      ad::FDual<double> xx(x,1.0);
+      ad::FDual<double> lrez;
+      lrez = ad::sin(xx);
+      d = std::cos(x);
+      REQUIRE(std::abs(d-lrez.dual())<std::numeric_limits<double>::epsilon());
    }
 
    SECTION("cos")
    {
-        double x=0.5;
-        double d;
-        ad::FDual<double> xx(x,1.0);
-        ad::FDual<double> lrez;
-        lrez=ad::cos(xx);
-        d=-std::sin(x);
-        REQUIRE(std::abs(d-lrez.dual())<std::numeric_limits<double>::epsilon());
+      double x = 0.5;
+      double d;
+      ad::FDual<double> xx(x,1.0);
+      ad::FDual<double> lrez;
+      lrez = ad::cos(xx);
+      d = -std::sin(x);
+      REQUIRE(std::abs(d-lrez.dual())<std::numeric_limits<double>::epsilon());
    }
 
    SECTION("tan")
    {
-        double x=0.5;
-        double d;
-        ad::FDual<double> xx(x,1.0);
-        ad::FDual<double> lrez;
-        lrez=ad::tan(xx);
-        d=1.0+std::tan(x)*std::tan(x);
-        REQUIRE(std::abs(d-lrez.dual())<std::numeric_limits<double>::epsilon());
+      double x = 0.5;
+      double d;
+      ad::FDual<double> xx(x,1.0);
+      ad::FDual<double> lrez;
+      lrez = ad::tan(xx);
+      d = 1.0+std::tan(x)*std::tan(x);
+      REQUIRE(std::abs(d-lrez.dual())<std::numeric_limits<double>::epsilon());
    }
 
    SECTION("exp")
    {
-	double x=0.5;
-        double d;
-        ad::FDual<double> xx(x,1.0);
-        ad::FDual<double> lrez;
-        lrez=ad::exp(xx);
-        d=exp(x);
-        REQUIRE(std::abs(d-lrez.dual())<std::numeric_limits<double>::epsilon());   
+      double x = 0.5;
+      double d;
+      ad::FDual<double> xx(x,1.0);
+      ad::FDual<double> lrez;
+      lrez = ad::exp(xx);
+      d = exp(x);
+      REQUIRE(std::abs(d-lrez.dual())<std::numeric_limits<double>::epsilon());
    }
 
    SECTION("log")
    {
-        double x=0.5;
-        double d;
-        ad::FDual<double> xx(x,1.0);
-        ad::FDual<double> lrez;
-        lrez=ad::log(xx);
-        d=1.0/x;
-        REQUIRE(std::abs(d-lrez.dual())<std::numeric_limits<double>::epsilon());
+      double x = 0.5;
+      double d;
+      ad::FDual<double> xx(x,1.0);
+      ad::FDual<double> lrez;
+      lrez = ad::log(xx);
+      d = 1.0/x;
+      REQUIRE(std::abs(d-lrez.dual())<std::numeric_limits<double>::epsilon());
    }
 
    SECTION("pow")
    {
-	double x=0.5;
-        double d;
-        ad::FDual<double> xx(x,1.0);
-        ad::FDual<double> lrez;
-        lrez=ad::pow(xx,1.5);
-        d=1.5*std::pow(x,0.5);
-        REQUIRE(std::abs(d-lrez.dual())<std::numeric_limits<double>::epsilon());
+      double x = 0.5;
+      double d;
+      ad::FDual<double> xx(x,1.0);
+      ad::FDual<double> lrez;
+      lrez = ad::pow(xx,1.5);
+      d = 1.5*std::pow(x,0.5);
+      REQUIRE(std::abs(d-lrez.dual())<std::numeric_limits<double>::epsilon());
 
    }
 
    SECTION("atan")
    {
-        double x=0.5;
-        double d;
-        ad::FDual<double> xx(x,1.0);
-        ad::FDual<double> lrez;
-        lrez=ad::atan(xx);
-        d=1.0/(1.0+x*x);
-        REQUIRE(std::abs(d-lrez.dual())<std::numeric_limits<double>::epsilon());
+      double x = 0.5;
+      double d;
+      ad::FDual<double> xx(x,1.0);
+      ad::FDual<double> lrez;
+      lrez = ad::atan(xx);
+      d = 1.0/(1.0+x*x);
+      REQUIRE(std::abs(d-lrez.dual())<std::numeric_limits<double>::epsilon());
    }
 
    SECTION("asin")
    {
-        double x=0.5;
-        double d;
-        ad::FDual<double> xx(x,1.0);
-        ad::FDual<double> lrez;
-        lrez=ad::asin(xx);
-        d=1.0/std::sqrt(1.0-x*x);
-        REQUIRE(std::abs(d-lrez.dual())<std::numeric_limits<double>::epsilon());
+      double x = 0.5;
+      double d;
+      ad::FDual<double> xx(x,1.0);
+      ad::FDual<double> lrez;
+      lrez = ad::asin(xx);
+      d = 1.0/std::sqrt(1.0-x*x);
+      REQUIRE(std::abs(d-lrez.dual())<std::numeric_limits<double>::epsilon());
    }
 
    SECTION("acos")
    {
-	std::cout<<"Test acos!"<<std::endl;
-        double x=0.5;
-        double d;
-        ad::FDual<double> xx(x,1.0);
-        ad::FDual<double> lrez;
-        lrez=ad::acos(xx);
-        d=-1.0/std::sqrt(1.0-x*x);
-        REQUIRE(std::abs(d-lrez.dual())<std::numeric_limits<double>::epsilon());
+      double x = 0.5;
+      double d;
+      ad::FDual<double> xx(x,1.0);
+      ad::FDual<double> lrez;
+      lrez = ad::acos(xx);
+      d = -1.0/std::sqrt(1.0-x*x);
+      REQUIRE(std::abs(d-lrez.dual())<std::numeric_limits<double>::epsilon());
+   }
+
+   SECTION("general")
+   {
+      double x = 1.0;
+      double y = 1.5;
+
+      double pr = exprp02(x,y);
+      double dx = exprp02x(x,y);
+      double dy = exprp02y(x,y);
+
+      {
+         mfem::ad::FDual<double> xx(x,1.0);
+         mfem::ad::FDual<double> yy(y,0.0);
+         mfem::ad::FDual<double> rr=exprp02(xx,yy);
+         REQUIRE(std::abs(rr.real()-pr)<std::numeric_limits<double>::epsilon());
+         REQUIRE(std::abs(rr.dual()-dx)<std::numeric_limits<double>::epsilon());
+      }
+
+      {
+         mfem::ad::FDual<double> xx(x,0.0);
+         mfem::ad::FDual<double> yy(y,1.0);
+         mfem::ad::FDual<double> rr=exprp02(xx,yy);
+         REQUIRE(std::abs(rr.real()-pr)<std::numeric_limits<double>::epsilon());
+         REQUIRE(std::abs(rr.dual()-dy)<std::numeric_limits<double>::epsilon());
+      }
+   }
+
+   SECTION("second_derivative")
+   {
+
+      double x = 0.5;
+      double d;
+      mfem::ad::FDual<mfem::ad::FDual<double>> xxx(mfem::ad::FDual<double>(x,1.0),
+                                                   mfem::ad::FDual<double>(1.0,0.0));
+      mfem::ad::FDual<mfem::ad::FDual<double>> drez=mfem::ad::exp(xxx);
+      d=exp(x);
+      REQUIRE(std::abs(d-drez.dual().dual())<std::numeric_limits<double>::epsilon());
+
+      drez = mfem::ad::log(xxx);
+      d = -1.0/(x*x);
+      REQUIRE(std::abs(d-drez.dual().dual())<std::numeric_limits<double>::epsilon());
+
+      drez = mfem::ad::sin(xxx);
+      d = -sin(x);
+      REQUIRE(std::abs(d-drez.dual().dual())<std::numeric_limits<double>::epsilon());
+
+      drez = mfem::ad::cos(xxx);
+      d = -cos(x);
+      REQUIRE(std::abs(d-drez.dual().dual())<std::numeric_limits<double>::epsilon());
+
    }
 
 
@@ -124,4 +193,3 @@ TEST_CASE("Simple AD tests", "[Simple_AD_tests]")
 
 }
 
-#endif  // MFEM_USE_EXCEPTIONS

--- a/tests/unit/linalg/test_fdual.cpp
+++ b/tests/unit/linalg/test_fdual.cpp
@@ -1,0 +1,127 @@
+// Copyright (c) 2010, Lawrence Livermore National Security, LLC. Produced at
+// the Lawrence Livermore National Laboratory. LLNL-CODE-443211. All Rights
+// reserved. See file COPYRIGHT for details.
+//
+// This file is part of the MFEM library. For more information and source code
+// availability see http://mfem.org.
+//
+// MFEM is free software; you can redistribute it and/or modify it under the
+// terms of the GNU Lesser General Public License (as published by the Free
+// Software Foundation) version 2.1 dated February 1999.
+
+#include "mfem.hpp"
+#include "catch.hpp"
+
+#ifdef MFEM_USE_EXCEPTIONS
+
+using namespace mfem;
+
+TEST_CASE("Simple AD tests", "[Simple_AD_tests]")
+{
+   SECTION("sin")
+   {
+   	double x=0.5;
+   	double d;
+	ad::FDual<double> xx(x,1.0);
+	ad::FDual<double> lrez;	
+	lrez=ad::sin(xx);
+    	d=std::cos(x);
+	REQUIRE(std::abs(d-lrez.dual())<std::numeric_limits<double>::epsilon());
+   }
+
+   SECTION("cos")
+   {
+        double x=0.5;
+        double d;
+        ad::FDual<double> xx(x,1.0);
+        ad::FDual<double> lrez;
+        lrez=ad::cos(xx);
+        d=-std::sin(x);
+        REQUIRE(std::abs(d-lrez.dual())<std::numeric_limits<double>::epsilon());
+   }
+
+   SECTION("tan")
+   {
+        double x=0.5;
+        double d;
+        ad::FDual<double> xx(x,1.0);
+        ad::FDual<double> lrez;
+        lrez=ad::tan(xx);
+        d=1.0+std::tan(x)*std::tan(x);
+        REQUIRE(std::abs(d-lrez.dual())<std::numeric_limits<double>::epsilon());
+   }
+
+   SECTION("exp")
+   {
+	double x=0.5;
+        double d;
+        ad::FDual<double> xx(x,1.0);
+        ad::FDual<double> lrez;
+        lrez=ad::exp(xx);
+        d=exp(x);
+        REQUIRE(std::abs(d-lrez.dual())<std::numeric_limits<double>::epsilon());   
+   }
+
+   SECTION("log")
+   {
+        double x=0.5;
+        double d;
+        ad::FDual<double> xx(x,1.0);
+        ad::FDual<double> lrez;
+        lrez=ad::log(xx);
+        d=1.0/x;
+        REQUIRE(std::abs(d-lrez.dual())<std::numeric_limits<double>::epsilon());
+   }
+
+   SECTION("pow")
+   {
+	double x=0.5;
+        double d;
+        ad::FDual<double> xx(x,1.0);
+        ad::FDual<double> lrez;
+        lrez=ad::pow(xx,1.5);
+        d=1.5*std::pow(x,0.5);
+        REQUIRE(std::abs(d-lrez.dual())<std::numeric_limits<double>::epsilon());
+
+   }
+
+   SECTION("atan")
+   {
+        double x=0.5;
+        double d;
+        ad::FDual<double> xx(x,1.0);
+        ad::FDual<double> lrez;
+        lrez=ad::atan(xx);
+        d=1.0/(1.0+x*x);
+        REQUIRE(std::abs(d-lrez.dual())<std::numeric_limits<double>::epsilon());
+   }
+
+   SECTION("asin")
+   {
+        double x=0.5;
+        double d;
+        ad::FDual<double> xx(x,1.0);
+        ad::FDual<double> lrez;
+        lrez=ad::asin(xx);
+        d=1.0/std::sqrt(1.0-x*x);
+        REQUIRE(std::abs(d-lrez.dual())<std::numeric_limits<double>::epsilon());
+   }
+
+   SECTION("acos")
+   {
+	std::cout<<"Test acos!"<<std::endl;
+        double x=0.5;
+        double d;
+        ad::FDual<double> xx(x,1.0);
+        ad::FDual<double> lrez;
+        lrez=ad::acos(xx);
+        d=-1.0/std::sqrt(1.0-x*x);
+        REQUIRE(std::abs(d-lrez.dual())<std::numeric_limits<double>::epsilon());
+   }
+
+
+
+
+}
+
+#endif  // MFEM_USE_EXCEPTIONS


### PR DESCRIPTION
This pull request consists of a simple automatic differentiation template class and several unit tests. It is the first of several pull-requests for adding new features to accommodate AD-related implementations in MFEM. The class is templated in fdual.hpp and the unit tests are implemented in tests/unit/linalg/test_fdual.cpp. The implementation is based on dual numbers.  