### PR TITLE
Fix memory leak with nonconforming tet meshes [nc-tet-alloc-fix]

### DIFF
--- a/fem/bilinearform.hpp
+++ b/fem/bilinearform.hpp
@@ -783,7 +783,7 @@ public:
 
    virtual void EliminateTestDofs(const Array<int> &bdr_attr_is_ess);
 
-   /** @brief Return in @a A a parallel (on truedofs) version of this operator.
+   /** @brief Return in @a A that is column-constrained.
 
       This returns the same operator as FormRectangularLinearSystem(), but does
       without the transformations of the right-hand side. */

--- a/fem/bilininteg.cpp
+++ b/fem/bilininteg.cpp
@@ -626,7 +626,7 @@ void DiffusionIntegrator::AssembleElementVector(
 
 void DiffusionIntegrator::ComputeElementFlux
 ( const FiniteElement &el, ElementTransformation &Trans,
-  Vector &u, const FiniteElement &fluxelem, Vector &flux, int with_coef )
+  Vector &u, const FiniteElement &fluxelem, Vector &flux, bool with_coef )
 {
    int i, j, nd, dim, spaceDim, fnd;
 
@@ -1539,7 +1539,7 @@ void CurlCurlIntegrator::AssembleElementMatrix
 void CurlCurlIntegrator
 ::ComputeElementFlux(const FiniteElement &el, ElementTransformation &Trans,
                      Vector &u, const FiniteElement &fluxelem, Vector &flux,
-                     int with_coef)
+                     bool with_coef)
 {
 #ifdef MFEM_THREAD_SAFE
    DenseMatrix projcurl;
@@ -2317,7 +2317,7 @@ void ElasticityIntegrator::AssembleElementMatrix(
 void ElasticityIntegrator::ComputeElementFlux(
    const mfem::FiniteElement &el, ElementTransformation &Trans,
    Vector &u, const mfem::FiniteElement &fluxelem, Vector &flux,
-   int with_coef)
+   bool with_coef)
 {
    const int dof = el.GetDof();
    const int dim = el.GetDim();

--- a/fem/bilininteg.hpp
+++ b/fem/bilininteg.hpp
@@ -147,7 +147,7 @@ public:
                                    ElementTransformation &Trans,
                                    Vector &u,
                                    const FiniteElement &fluxelem,
-                                   Vector &flux, int with_coef = 1) { }
+                                   Vector &flux, bool with_coef = true) { }
 
    /** @brief Virtual method required for Zienkiewicz-Zhu type error estimators.
 
@@ -1807,7 +1807,7 @@ public:
    virtual void ComputeElementFlux(const FiniteElement &el,
                                    ElementTransformation &Trans,
                                    Vector &u, const FiniteElement &fluxelem,
-                                   Vector &flux, int with_coef = 1);
+                                   Vector &flux, bool with_coef = true);
 
    virtual double ComputeFluxEnergy(const FiniteElement &fluxelem,
                                     ElementTransformation &Trans,
@@ -2164,7 +2164,7 @@ public:
    virtual void ComputeElementFlux(const FiniteElement &el,
                                    ElementTransformation &Trans,
                                    Vector &u, const FiniteElement &fluxelem,
-                                   Vector &flux, int with_coef);
+                                   Vector &flux, bool with_coef);
 
    virtual double ComputeFluxEnergy(const FiniteElement &fluxelem,
                                     ElementTransformation &Trans,
@@ -2388,7 +2388,7 @@ public:
                                    ElementTransformation &Trans,
                                    Vector &u,
                                    const FiniteElement &fluxelem,
-                                   Vector &flux, int with_coef = 1);
+                                   Vector &flux, bool with_coef = true);
 
    /** Compute the element energy (integral of the strain energy density)
        corresponding to the stress represented by @a flux which is a vector of

--- a/fem/bilininteg.hpp
+++ b/fem/bilininteg.hpp
@@ -2025,6 +2025,7 @@ public:
                                        DenseMatrix &elmat);
    using BilinearFormIntegrator::AssemblePA;
    virtual void AssemblePA(const FiniteElementSpace &fes);
+   virtual void AssembleDiagonalPA(Vector &diag);
    virtual void AddMultPA(const Vector &x, Vector &y) const;
 };
 
@@ -2343,6 +2344,7 @@ public:
                                       const Vector &elfun, Vector &elvect);
    using BilinearFormIntegrator::AssemblePA;
    virtual void AssemblePA(const FiniteElementSpace &fes);
+   virtual void AssembleDiagonalPA(Vector &diag);
    virtual void AddMultPA(const Vector &x, Vector &y) const;
 };
 

--- a/fem/bilininteg_diffusion.cpp
+++ b/fem/bilininteg_diffusion.cpp
@@ -1543,7 +1543,9 @@ static void PADiffusionApply(const int dim,
          case 0x23: return SmemPADiffusionApply3D<2,3>(NE,B,G,Bt,Gt,D,X,Y);
          case 0x34: return SmemPADiffusionApply3D<3,4>(NE,B,G,Bt,Gt,D,X,Y);
          case 0x45: return SmemPADiffusionApply3D<4,5>(NE,B,G,Bt,Gt,D,X,Y);
+         case 0x46: return SmemPADiffusionApply3D<4,6>(NE,B,G,Bt,Gt,D,X,Y);
          case 0x56: return SmemPADiffusionApply3D<5,6>(NE,B,G,Bt,Gt,D,X,Y);
+         case 0x58: return SmemPADiffusionApply3D<5,8>(NE,B,G,Bt,Gt,D,X,Y);
          case 0x67: return SmemPADiffusionApply3D<6,7>(NE,B,G,Bt,Gt,D,X,Y);
          case 0x78: return SmemPADiffusionApply3D<7,8>(NE,B,G,Bt,Gt,D,X,Y);
          case 0x89: return SmemPADiffusionApply3D<8,9>(NE,B,G,Bt,Gt,D,X,Y);

--- a/fem/bilininteg_vecmass.cpp
+++ b/fem/bilininteg_vecmass.cpp
@@ -364,4 +364,164 @@ void VectorMassIntegrator::AddMultPA(const Vector &x, Vector &y) const
    PAVectorMassApply(dim, dofs1D, quad1D, ne, maps->B, maps->Bt, pa_data, x, y);
 }
 
+template<const int T_D1D = 0, const int T_Q1D = 0>
+static void PAVectorMassAssembleDiagonal2D(const int NE,
+                                           const Array<double> &_B,
+                                           const Array<double> &_Bt,
+                                           const Vector &_op,
+                                           Vector &_diag,
+                                           const int d1d = 0,
+                                           const int q1d = 0)
+{
+   const int D1D = T_D1D ? T_D1D : d1d;
+   const int Q1D = T_Q1D ? T_Q1D : q1d;
+   constexpr int VDIM = 2;
+   MFEM_VERIFY(D1D <= MAX_D1D, "");
+   MFEM_VERIFY(Q1D <= MAX_Q1D, "");
+   auto B = Reshape(_B.Read(), Q1D, D1D);
+   auto op = Reshape(_op.Read(), Q1D, Q1D, NE);
+   auto y = Reshape(_diag.ReadWrite(), D1D, D1D, VDIM, NE);
+   MFEM_FORALL(e, NE,
+   {
+      const int D1D = T_D1D ? T_D1D : d1d;
+      const int Q1D = T_Q1D ? T_Q1D : q1d;
+      constexpr int max_D1D = T_D1D ? T_D1D : MAX_D1D;
+      constexpr int max_Q1D = T_Q1D ? T_Q1D : MAX_Q1D;
+
+      double temp[max_Q1D][max_D1D];
+      for (int qx = 0; qx < Q1D; ++qx)
+      {
+         for (int dy = 0; dy < D1D; ++dy)
+         {
+            temp[qx][dy] = 0.0;
+            for (int qy = 0; qy < Q1D; ++qy)
+            {
+               temp[qx][dy] += B(qy, dy) * B(qy, dy) * op(qx, qy, e);
+            }
+         }
+      }
+      for (int dy = 0; dy < D1D; ++dy)
+      {
+         for (int dx = 0; dx < D1D; ++dx)
+         {
+            double temp1 = 0.0;
+            for (int qx = 0; qx < Q1D; ++qx)
+            {
+               temp1 += B(qx, dx) * B(qx, dx) * temp[qx][dy];
+            }
+            y(dx, dy, 0, e) = temp1;
+            y(dx, dy, 1, e) = temp1;
+         }
+      }
+   });
+}
+
+template<const int T_D1D = 0, const int T_Q1D = 0>
+static void PAVectorMassAssembleDiagonal3D(const int NE,
+                                           const Array<double> &_B,
+                                           const Array<double> &_Bt,
+                                           const Vector &_op,
+                                           Vector &_diag,
+                                           const int d1d = 0,
+                                           const int q1d = 0)
+{
+   const int D1D = T_D1D ? T_D1D : d1d;
+   const int Q1D = T_Q1D ? T_Q1D : q1d;
+   constexpr int VDIM = 3;
+   MFEM_VERIFY(D1D <= MAX_D1D, "");
+   MFEM_VERIFY(Q1D <= MAX_Q1D, "");
+   auto B = Reshape(_B.Read(), Q1D, D1D);
+   auto op = Reshape(_op.Read(), Q1D, Q1D, Q1D, NE);
+   auto y = Reshape(_diag.ReadWrite(), D1D, D1D, D1D, VDIM, NE);
+   MFEM_FORALL(e, NE,
+   {
+      const int D1D = T_D1D ? T_D1D : d1d; // nvcc workaround
+      const int Q1D = T_Q1D ? T_Q1D : q1d;
+      // the following variables are evaluated at compile time
+      constexpr int max_D1D = T_D1D ? T_D1D : MAX_D1D;
+      constexpr int max_Q1D = T_Q1D ? T_Q1D : MAX_Q1D;
+
+      double temp[max_Q1D][max_Q1D][max_D1D];
+      for (int qx = 0; qx < Q1D; ++qx)
+      {
+         for (int qy = 0; qy < Q1D; ++qy)
+         {
+            for (int dz = 0; dz < D1D; ++dz)
+            {
+               temp[qx][qy][dz] = 0.0;
+               for (int qz = 0; qz < Q1D; ++qz)
+               {
+                  temp[qx][qy][dz] += B(qz, dz) * B(qz, dz) * op(qx, qy, qz, e);
+               }
+            }
+         }
+      }
+      double temp2[max_Q1D][max_D1D][max_D1D];
+      for (int qx = 0; qx < Q1D; ++qx)
+      {
+         for (int dz = 0; dz < D1D; ++dz)
+         {
+            for (int dy = 0; dy < D1D; ++dy)
+            {
+               temp2[qx][dy][dz] = 0.0;
+               for (int qy = 0; qy < Q1D; ++qy)
+               {
+                  temp2[qx][dy][dz] += B(qy, dy) * B(qy, dy) * temp[qx][qy][dz];
+               }
+            }
+         }
+      }
+      for (int dz = 0; dz < D1D; ++dz)
+      {
+         for (int dy = 0; dy < D1D; ++dy)
+         {
+            for (int dx = 0; dx < D1D; ++dx)
+            {
+               double temp3 = 0.0;
+               for (int qx = 0; qx < Q1D; ++qx)
+               {
+                  temp3 += B(qx, dx) * B(qx, dx)
+                           * temp2[qx][dy][dz];
+               }
+               y(dx, dy, dz, 0, e) = temp3;
+               y(dx, dy, dz, 1, e) = temp3;
+               y(dx, dy, dz, 2, e) = temp3;
+            }
+         }
+      }
+   });
+}
+
+static void PAVectorMassAssembleDiagonal(const int dim,
+                                         const int D1D,
+                                         const int Q1D,
+                                         const int NE,
+                                         const Array<double> &B,
+                                         const Array<double> &Bt,
+                                         const Vector &op,
+                                         Vector &y)
+{
+   if (dim == 2)
+   {
+      return PAVectorMassAssembleDiagonal2D(NE, B, Bt, op, y, D1D, Q1D);
+   }
+   else if (dim == 3)
+   {
+      return PAVectorMassAssembleDiagonal3D(NE, B, Bt, op, y, D1D, Q1D);
+   }
+   MFEM_ABORT("Dimension not implemented.");
+}
+
+void VectorMassIntegrator::AssembleDiagonalPA(Vector &diag)
+{
+   PAVectorMassAssembleDiagonal(dim,
+                                dofs1D,
+                                quad1D,
+                                ne,
+                                maps->B,
+                                maps->Bt,
+                                pa_data,
+                                diag);
+}
+
 } // namespace mfem

--- a/fem/estimators.cpp
+++ b/fem/estimators.cpp
@@ -24,7 +24,8 @@ void ZienkiewiczZhuEstimator::ComputeEstimates()
    if (!anisotropic) { aniso_flags.SetSize(0); }
    total_error = ZZErrorEstimator(*integ, *solution, flux, error_estimates,
                                   anisotropic ? &aniso_flags : NULL,
-                                  flux_averaging);
+                                  flux_averaging,
+                                  with_coeff);
 
    current_sequence = solution->FESpace()->GetMesh()->GetSequence();
 }

--- a/fem/estimators.hpp
+++ b/fem/estimators.hpp
@@ -84,6 +84,7 @@ protected:
 
    FiniteElementSpace *flux_space; /**< @brief Ownership based on own_flux_fes.
       Its Update() method is called automatically by this class when needed. */
+   bool with_coeff;
    bool own_flux_fes; ///< Ownership flag for flux_space.
 
    /// Check if the mesh of the solution was modified.
@@ -104,7 +105,7 @@ public:
        @param sol      The solution field whose error is to be estimated.
        @param flux_fes The ZienkiewiczZhuEstimator assumes ownership of this
                        FiniteElementSpace and will call its Update() method when
-                       needed. */
+                       needed.*/
    ZienkiewiczZhuEstimator(BilinearFormIntegrator &integ, GridFunction &sol,
                            FiniteElementSpace *flux_fes)
       : current_sequence(-1),
@@ -114,6 +115,7 @@ public:
         integ(&integ),
         solution(&sol),
         flux_space(flux_fes),
+        with_coeff(false),
         own_flux_fes(true)
    { }
 
@@ -133,8 +135,13 @@ public:
         integ(&integ),
         solution(&sol),
         flux_space(&flux_fes),
+        with_coeff(false),
         own_flux_fes(false)
    { }
+
+   /** @brief Consider the coefficient in BilinearFormIntegrator to calculate the
+       fluxes for the error estimator.*/
+   void SetWithCoeff(bool w_coeff = true) { with_coeff = w_coeff; }
 
    /** @brief Enable/disable anisotropic estimates. To enable this option, the
        BilinearFormIntegrator must support the 'd_energy' parameter in its

--- a/fem/gridfunc.cpp
+++ b/fem/gridfunc.cpp
@@ -240,7 +240,7 @@ void GridFunction::MakeTRef(FiniteElementSpace *f, Vector &tv, int tv_offset)
 void GridFunction::SumFluxAndCount(BilinearFormIntegrator &blfi,
                                    GridFunction &flux,
                                    Array<int>& count,
-                                   int wcoef,
+                                   bool wcoef,
                                    int subdomain)
 {
    GridFunction &u = *this;
@@ -285,7 +285,7 @@ void GridFunction::SumFluxAndCount(BilinearFormIntegrator &blfi,
 }
 
 void GridFunction::ComputeFlux(BilinearFormIntegrator &blfi,
-                               GridFunction &flux, int wcoef,
+                               GridFunction &flux, bool wcoef,
                                int subdomain)
 {
    Array<int> count(flux.Size());
@@ -2995,9 +2995,9 @@ double ZZErrorEstimator(BilinearFormIntegrator &blfi,
                         GridFunction &u,
                         GridFunction &flux, Vector &error_estimates,
                         Array<int>* aniso_flags,
-                        int with_subdomains)
+                        int with_subdomains,
+                        bool with_coeff)
 {
-   const int with_coeff = 0;
    FiniteElementSpace *ufes = u.FESpace();
    FiniteElementSpace *ffes = flux.FESpace();
    ElementTransformation *Transf;

--- a/fem/gridfunc.hpp
+++ b/fem/gridfunc.hpp
@@ -56,7 +56,7 @@ protected:
    void SumFluxAndCount(BilinearFormIntegrator &blfi,
                         GridFunction &flux,
                         Array<int>& counts,
-                        int wcoef,
+                        bool wcoef,
                         int subdomain);
 
    /** Project a discontinuous vector coefficient in a continuous space and
@@ -426,7 +426,7 @@ public:
 
    virtual void ComputeFlux(BilinearFormIntegrator &blfi,
                             GridFunction &flux,
-                            int wcoef = 1, int subdomain = -1);
+                            bool wcoef = true, int subdomain = -1);
 
    /// Redefine '=' for GridFunction = constant.
    GridFunction &operator=(double value);
@@ -654,7 +654,8 @@ double ZZErrorEstimator(BilinearFormIntegrator &blfi,
                         GridFunction &flux,
                         Vector &error_estimates,
                         Array<int> *aniso_flags = NULL,
-                        int with_subdomains = 1);
+                        int with_subdomains = 1,
+                        bool with_coeff = false);
 
 /// Compute the Lp distance between two grid functions on the given element.
 double ComputeElementLpDistance(double p, int i,

--- a/fem/pbilinearform.hpp
+++ b/fem/pbilinearform.hpp
@@ -195,6 +195,9 @@ protected:
    /// Auxiliary objects used in TrueAddMult().
    mutable ParGridFunction X, Y;
 
+   /// Matrix and eliminated matrix
+   OperatorHandle p_mat, p_mat_e;
+
 private:
    /// Copy construction is not supported; body is undefined.
    ParMixedBilinearForm(const ParMixedBilinearForm &);
@@ -209,7 +212,8 @@ public:
        constructed object. */
    ParMixedBilinearForm(ParFiniteElementSpace *trial_fes,
                         ParFiniteElementSpace *test_fes)
-      : MixedBilinearForm(trial_fes, test_fes)
+      : MixedBilinearForm(trial_fes, test_fes),
+        p_mat(Operator::Hypre_ParCSR), p_mat_e(Operator::Hypre_ParCSR)
    {
       trial_pfes = trial_fes;
       test_pfes  = test_fes;
@@ -227,7 +231,8 @@ public:
    ParMixedBilinearForm(ParFiniteElementSpace *trial_fes,
                         ParFiniteElementSpace *test_fes,
                         ParMixedBilinearForm * mbf)
-      : MixedBilinearForm(trial_fes, test_fes, mbf)
+      : MixedBilinearForm(trial_fes, test_fes, mbf),
+        p_mat(Operator::Hypre_ParCSR), p_mat_e(Operator::Hypre_ParCSR)
    {
       trial_pfes = trial_fes;
       test_pfes  = test_fes;
@@ -240,6 +245,25 @@ public:
        @a A = P_test^t A_local P_trial, in the format (type id) specified by
        @a A. */
    void ParallelAssemble(OperatorHandle &A);
+
+   /** @brief Return in @a A a parallel (on truedofs) version of this operator.
+
+       This returns the same operator as FormRectangularLinearSystem(), but does
+       without the transformations of the right-hand side. */
+   virtual void FormRectangularSystemMatrix(const Array<int> &trial_tdof_list,
+                                            const Array<int> &test_tdof_list,
+                                            OperatorHandle &A);
+
+   /** @brief Form the parallel linear system A X = B, corresponding to this mixed
+       bilinear form and the linear form @a b(.).
+
+       Return in @a A a *reference* to the system matrix that is column-constrained.
+       The reference will be invalidated when SetOperatorType(), Update(), or the
+       destructor is called. */
+   virtual void FormRectangularLinearSystem(const Array<int> &trial_tdof_list,
+                                            const Array<int> &test_tdof_list, Vector &x,
+                                            Vector &b, OperatorHandle &A, Vector &X,
+                                            Vector &B);
 
    /// Compute y += a (P^t A P) x, where x and y are vectors on the true dofs
    void TrueAddMult(const Vector &x, Vector &y, const double a = 1.0) const;

--- a/fem/pgridfunc.cpp
+++ b/fem/pgridfunc.cpp
@@ -661,7 +661,7 @@ double GlobalLpNorm(const double p, double loc_norm, MPI_Comm comm)
 
 void ParGridFunction::ComputeFlux(
    BilinearFormIntegrator &blfi,
-   GridFunction &flux, int wcoef, int subdomain)
+   GridFunction &flux, bool wcoef, int subdomain)
 {
    ParFiniteElementSpace *ffes =
       dynamic_cast<ParFiniteElementSpace*>(flux.FESpace());

--- a/fem/pgridfunc.hpp
+++ b/fem/pgridfunc.hpp
@@ -308,7 +308,7 @@ public:
 
    virtual void ComputeFlux(BilinearFormIntegrator &blfi,
                             GridFunction &flux,
-                            int wcoef = 1, int subdomain = -1);
+                            bool wcoef = true, int subdomain = -1);
 
    /** Save the local portion of the ParGridFunction. It differs from the
        serial GridFunction::Save in that it takes into account the signs of

--- a/general/forall.hpp
+++ b/general/forall.hpp
@@ -32,8 +32,8 @@ namespace mfem
 {
 
 // Maximum size of dofs and quads in 1D.
-const int MAX_D1D = 16;
-const int MAX_Q1D = 16;
+const int MAX_D1D = 14;
+const int MAX_Q1D = 14;
 
 // Implementation of MFEM's "parallel for" (forall) device/host kernel
 // interfaces supporting RAJA, CUDA, OpenMP, and sequential backends.

--- a/general/mem_alloc.hpp
+++ b/general/mem_alloc.hpp
@@ -13,7 +13,7 @@
 #define MFEM_MEM_ALLOC
 
 #include "../config/config.hpp"
-#include <cstddef>
+#include "array.hpp" // mfem::Swap
 
 namespace mfem
 {
@@ -38,6 +38,7 @@ public:
    void Push (Elem E);
    Elem Pop();
    void Clear();
+   void Swap(Stack<Elem, Num> &other);
    size_t MemoryUsage() const;
    ~Stack() { Clear(); }
 };
@@ -98,6 +99,15 @@ void Stack <Elem, Num>::Clear()
 }
 
 template <class Elem, int Num>
+void Stack<Elem, Num>::Swap(Stack<Elem, Num> &other)
+{
+   mfem::Swap(TopPart, other.TopPart);
+   mfem::Swap(TopFreePart, other.TopFreePart);
+   mfem::Swap(UsedInTop, other.UsedInTop);
+   mfem::Swap(SSize, other.SSize);
+}
+
+template <class Elem, int Num>
 size_t Stack <Elem, Num>::MemoryUsage() const
 {
    size_t used_mem = 0;
@@ -138,6 +148,7 @@ public:
    Elem *Alloc();
    void Free (Elem *);
    void Clear();
+   void Swap(MemAlloc<Elem, Num> &other);
    size_t MemoryUsage() const;
    ~MemAlloc() { Clear(); }
 };
@@ -178,6 +189,14 @@ void MemAlloc <Elem, Num>::Clear()
    }
    AllocatedInLast = Num;
    UsedMem.Clear();
+}
+
+template <class Elem, int Num>
+void MemAlloc<Elem, Num>::Swap(MemAlloc<Elem, Num> &other)
+{
+   mfem::Swap(Last, other.Last);
+   mfem::Swap(AllocatedInLast, other.AllocatedInLast);
+   UsedMem.Swap(other.UsedMem);
 }
 
 template <class Elem, int Num>

--- a/linalg/hypre.cpp
+++ b/linalg/hypre.cpp
@@ -2713,7 +2713,7 @@ void HypreEuclid::SetOperator(const Operator &op)
    if (A)
    {
       MPI_Comm comm;
-      HYPRE_ParCSRMatrixGetComm(*A, &comm);
+      HYPRE_ParCSRMatrixGetComm(*new_A, &comm);
       ResetEuclidPrecond(comm);
    }
 

--- a/linalg/petsc.cpp
+++ b/linalg/petsc.cpp
@@ -84,6 +84,7 @@ static PetscErrorCode __mfem_pc_shell_view(PC,PetscViewer);
 static PetscErrorCode __mfem_mat_shell_apply(Mat,Vec,Vec);
 static PetscErrorCode __mfem_mat_shell_apply_transpose(Mat,Vec,Vec);
 static PetscErrorCode __mfem_mat_shell_destroy(Mat);
+static PetscErrorCode __mfem_mat_shell_copy(Mat,Mat,MatStructure);
 static PetscErrorCode __mfem_array_container_destroy(void*);
 static PetscErrorCode __mfem_matarray_container_destroy(void*);
 static PetscErrorCode __mfem_monitor_ctx_destroy(void**);
@@ -106,11 +107,6 @@ static PetscErrorCode MatConvert_hypreParCSR_IS(hypre_ParCSRMatrix*,Mat*);
 #endif
 
 // structs used by PETSc code
-typedef struct
-{
-   mfem::Operator *op;
-} __mfem_mat_shell_ctx;
-
 typedef struct
 {
    mfem::Solver                     *op;
@@ -839,23 +835,24 @@ MPI_Comm PetscParMatrix::GetComm() const
 // TODO This should take a reference on op but how?
 void PetscParMatrix::MakeWrapper(MPI_Comm comm, const Operator* op, Mat *A)
 {
-   __mfem_mat_shell_ctx *ctx = new __mfem_mat_shell_ctx;
    ierr = MatCreate(comm,A); CCHKERRQ(comm,ierr);
    ierr = MatSetSizes(*A,op->Height(),op->Width(),
                       PETSC_DECIDE,PETSC_DECIDE); PCHKERRQ(A,ierr);
    ierr = MatSetType(*A,MATSHELL); PCHKERRQ(A,ierr);
-   ierr = MatShellSetContext(*A,(void *)ctx); PCHKERRQ(A,ierr);
+   ierr = MatShellSetContext(*A,(void *)op); PCHKERRQ(A,ierr);
    ierr = MatShellSetOperation(*A,MATOP_MULT,
                                (void (*)())__mfem_mat_shell_apply);
    PCHKERRQ(A,ierr);
    ierr = MatShellSetOperation(*A,MATOP_MULT_TRANSPOSE,
                                (void (*)())__mfem_mat_shell_apply_transpose);
    PCHKERRQ(A,ierr);
+   ierr = MatShellSetOperation(*A,MATOP_COPY,
+                               (void (*)())__mfem_mat_shell_copy);
+   PCHKERRQ(A,ierr);
    ierr = MatShellSetOperation(*A,MATOP_DESTROY,
                                (void (*)())__mfem_mat_shell_destroy);
    PCHKERRQ(A,ierr);
    ierr = MatSetUp(*A); PCHKERRQ(*A,ierr);
-   ctx->op = const_cast<Operator *>(op);
 }
 
 void PetscParMatrix::ConvertOperator(MPI_Comm comm, const Operator &op, Mat* A,
@@ -3846,6 +3843,14 @@ static PetscErrorCode __mfem_ts_ijacobian(TS ts, PetscReal t, Vec x,
    // Jacobian reusage
    ierr = PetscObjectStateGet((PetscObject)P,&ts_ctx->cached_ijacstate);
    CHKERRQ(ierr);
+
+   // Fool DM
+   DM dm;
+   MatType mtype;
+   ierr = MatGetType(P,&mtype); CHKERRQ(ierr);
+   ierr = TSGetDM(ts,&dm); CHKERRQ(ierr);
+   ierr = DMSetMatType(dm,mtype); CHKERRQ(ierr);
+   ierr = DMShellSetMatrix(dm,P); CHKERRQ(ierr);
    PetscFunctionReturn(0);
 }
 
@@ -3872,7 +3877,6 @@ static PetscErrorCode __mfem_ts_computesplits(TS ts,PetscReal t,Vec x,Vec xp,
    ierr = PetscObjectStateGet((PetscObject)Jxp,&state); CHKERRQ(ierr);
    if (ts_ctx->type == mfem::PetscODESolver::ODE_SOLVER_LINEAR &&
        state == ts_ctx->cached_splits_xdotstate) { rxp = PETSC_FALSE; }
-
    if (!rx && !rxp) { PetscFunctionReturn(0); }
 
    // update time
@@ -4124,6 +4128,14 @@ static PetscErrorCode __mfem_ts_rhsjacobian(TS ts, PetscReal t, Vec x,
    }
    ierr = PetscObjectStateGet((PetscObject)A,&ts_ctx->cached_rhsjacstate);
    CHKERRQ(ierr);
+
+   // Fool DM
+   DM dm;
+   MatType mtype;
+   ierr = MatGetType(P,&mtype); CHKERRQ(ierr);
+   ierr = TSGetDM(ts,&dm); CHKERRQ(ierr);
+   ierr = DMSetMatType(dm,mtype); CHKERRQ(ierr);
+   ierr = DMShellSetMatrix(dm,P); CHKERRQ(ierr);
    PetscFunctionReturn(0);
 }
 
@@ -4243,6 +4255,14 @@ static PetscErrorCode __mfem_snes_jacobian(SNES snes, Vec x, Mat A, Mat P,
       ierr = MatAssemblyBegin(A,MAT_FINAL_ASSEMBLY); CHKERRQ(ierr);
       ierr = MatAssemblyEnd(A,MAT_FINAL_ASSEMBLY); CHKERRQ(ierr);
    }
+
+   // Fool DM
+   DM dm;
+   MatType mtype;
+   ierr = MatGetType(P,&mtype); CHKERRQ(ierr);
+   ierr = SNESGetDM(snes,&dm); CHKERRQ(ierr);
+   ierr = DMSetMatType(dm,mtype); CHKERRQ(ierr);
+   ierr = DMShellSetMatrix(dm,P); CHKERRQ(ierr);
    PetscFunctionReturn(0);
 }
 
@@ -4376,14 +4396,15 @@ static PetscErrorCode __mfem_ksp_monitor(KSP ksp, PetscInt it, PetscReal res,
 
 static PetscErrorCode __mfem_mat_shell_apply(Mat A, Vec x, Vec y)
 {
-   __mfem_mat_shell_ctx *ctx;
-   PetscErrorCode       ierr;
+   mfem::Operator *op;
+   PetscErrorCode ierr;
 
    PetscFunctionBeginUser;
-   ierr = MatShellGetContext(A,(void **)&ctx); CHKERRQ(ierr);
+   ierr = MatShellGetContext(A,(void **)&op); CHKERRQ(ierr);
+   if (!op) { SETERRQ(PetscObjectComm((PetscObject)A),PETSC_ERR_LIB,"Missing operator"); }
    mfem::PetscParVector xx(x,true);
    mfem::PetscParVector yy(y,true);
-   ctx->op->Mult(xx,yy);
+   op->Mult(xx,yy);
    // need to tell PETSc the Vec has been updated
    ierr = PetscObjectStateIncrease((PetscObject)y); CHKERRQ(ierr);
    PetscFunctionReturn(0);
@@ -4391,27 +4412,35 @@ static PetscErrorCode __mfem_mat_shell_apply(Mat A, Vec x, Vec y)
 
 static PetscErrorCode __mfem_mat_shell_apply_transpose(Mat A, Vec x, Vec y)
 {
-   __mfem_mat_shell_ctx *ctx;
-   PetscErrorCode       ierr;
+   mfem::Operator *op;
+   PetscErrorCode ierr;
 
    PetscFunctionBeginUser;
-   ierr = MatShellGetContext(A,(void **)&ctx); CHKERRQ(ierr);
+   ierr = MatShellGetContext(A,(void **)&op); CHKERRQ(ierr);
+   if (!op) { SETERRQ(PetscObjectComm((PetscObject)A),PETSC_ERR_LIB,"Missing operator"); }
    mfem::PetscParVector xx(x,true);
    mfem::PetscParVector yy(y,true);
-   ctx->op->MultTranspose(xx,yy);
+   op->MultTranspose(xx,yy);
    // need to tell PETSc the Vec has been updated
    ierr = PetscObjectStateIncrease((PetscObject)y); CHKERRQ(ierr);
    PetscFunctionReturn(0);
 }
 
-static PetscErrorCode __mfem_mat_shell_destroy(Mat A)
+static PetscErrorCode __mfem_mat_shell_copy(Mat A, Mat B, MatStructure str)
 {
-   __mfem_mat_shell_ctx *ctx;
-   PetscErrorCode       ierr;
+   mfem::Operator *op;
+   PetscErrorCode ierr;
 
    PetscFunctionBeginUser;
-   ierr = MatShellGetContext(A,(void **)&ctx); CHKERRQ(ierr);
-   delete ctx;
+   ierr = MatShellGetContext(A,(void **)&op); CHKERRQ(ierr);
+   if (!op) { SETERRQ(PetscObjectComm((PetscObject)A),PETSC_ERR_LIB,"Missing operator"); }
+   ierr = MatShellSetContext(B,(void *)op); CHKERRQ(ierr);
+   PetscFunctionReturn(0);
+}
+
+static PetscErrorCode __mfem_mat_shell_destroy(Mat A)
+{
+   PetscFunctionBeginUser;
    PetscFunctionReturn(0);
 }
 

--- a/mesh/mesh.cpp
+++ b/mesh/mesh.cpp
@@ -7349,7 +7349,7 @@ void Mesh::InitFromNCMesh(const NCMesh &ncmesh)
 
    DeleteTables();
 
-   ncmesh.GetMeshComponents(vertices, elements, boundary);
+   ncmesh.GetMeshComponents(*this);
 
    NumOfVertices = vertices.Size();
    NumOfElements = elements.Size();
@@ -7419,6 +7419,10 @@ void Mesh::Swap(Mesh& other, bool non_geometry)
    mfem::Swap(bdr_attributes, other.bdr_attributes);
 
    mfem::Swap(geom_factors, other.geom_factors);
+
+#ifdef MFEM_USE_MEMALLOC
+   TetMemory.Swap(other.TetMemory);
+#endif
 
    if (non_geometry)
    {

--- a/mesh/mesh.hpp
+++ b/mesh/mesh.hpp
@@ -48,6 +48,7 @@ class Mesh
    friend class ParMesh;
    friend class ParNCMesh;
 #endif
+   friend class NCMesh;
    friend class NURBSExtension;
 
 protected:

--- a/mesh/ncmesh.cpp
+++ b/mesh/ncmesh.cpp
@@ -2030,29 +2030,27 @@ const double* NCMesh::CalcVertexPos(int node) const
    return tv.pos;
 }
 
-void NCMesh::GetMeshComponents(Array<mfem::Vertex> &mvertices,
-                               Array<mfem::Element*> &melements,
-                               Array<mfem::Element*> &mboundary) const
+void NCMesh::GetMeshComponents(Mesh &mesh) const
 {
-   mvertices.SetSize(vertex_nodeId.Size());
+   mesh.vertices.SetSize(vertex_nodeId.Size());
    if (top_vertex_pos.Size())
    {
       // calculate vertex positions from stored top-level vertex coordinates
       tmp_vertex = new TmpVertex[nodes.NumIds()];
-      for (int i = 0; i < mvertices.Size(); i++)
+      for (int i = 0; i < mesh.vertices.Size(); i++)
       {
-         mvertices[i].SetCoords(spaceDim, CalcVertexPos(vertex_nodeId[i]));
+         mesh.vertices[i].SetCoords(spaceDim, CalcVertexPos(vertex_nodeId[i]));
       }
       delete [] tmp_vertex;
    }
-   // NOTE: if the mesh is curved (top_vertex_pos is empty), mvertices are left
-   // uninitialized here; they will be initialized later by the Mesh from Nodes
-   // - here we just make sure mvertices has the correct size.
+   // NOTE: if the mesh is curved (top_vertex_pos is empty), mesh.vertices are
+   // left uninitialized here; they will be initialized later by the Mesh from
+   // Nodes -- here we just make sure mesh.vertices has the correct size.
 
-   melements.SetSize(leaf_elements.Size() - GetNumGhostElements());
-   melements.SetSize(0);
+   mesh.elements.SetSize(leaf_elements.Size() - GetNumGhostElements());
+   mesh.elements.SetSize(0);
 
-   mboundary.SetSize(0);
+   mesh.boundary.SetSize(0);
 
    // create an mfem::Element for each leaf Element
    for (int i = 0; i < leaf_elements.Size(); i++)
@@ -2063,8 +2061,8 @@ void NCMesh::GetMeshComponents(Array<mfem::Vertex> &mvertices,
       const int* node = nc_elem.node;
       GeomInfo& gi = GI[(int) nc_elem.geom];
 
-      mfem::Element* elem = NewMeshElement(nc_elem.geom);
-      melements.Append(elem);
+      mfem::Element* elem = mesh.NewElement(nc_elem.geom);
+      mesh.elements.Append(elem);
 
       elem->SetAttribute(nc_elem.attribute);
       for (int j = 0; j < gi.nv; j++)
@@ -2084,35 +2082,35 @@ void NCMesh::GetMeshComponents(Array<mfem::Vertex> &mvertices,
             if ((nc_elem.geom == Geometry::CUBE) ||
                 (nc_elem.geom == Geometry::PRISM && nfv == 4))
             {
-               Quadrilateral* quad = new Quadrilateral;
+               auto* quad = (Quadrilateral*) mesh.NewElement(Geometry::SQUARE);
                quad->SetAttribute(face->attribute);
                for (int j = 0; j < 4; j++)
                {
                   quad->GetVertices()[j] = nodes[node[fv[j]]].vert_index;
                }
-               mboundary.Append(quad);
+               mesh.boundary.Append(quad);
             }
             else if (nc_elem.geom == Geometry::PRISM ||
                      nc_elem.geom == Geometry::TETRAHEDRON)
             {
                MFEM_ASSERT(nfv == 3, "");
-               Triangle* tri = new Triangle;
+               auto* tri = (Triangle*) mesh.NewElement(Geometry::TRIANGLE);
                tri->SetAttribute(face->attribute);
                for (int j = 0; j < 3; j++)
                {
                   tri->GetVertices()[j] = nodes[node[fv[j]]].vert_index;
                }
-               mboundary.Append(tri);
+               mesh.boundary.Append(tri);
             }
             else
             {
-               Segment* segment = new Segment;
+               auto* segment = (Segment*) mesh.NewElement(Geometry::SEGMENT);
                segment->SetAttribute(face->attribute);
                for (int j = 0; j < 2; j++)
                {
                   segment->GetVertices()[j] = nodes[node[fv[2*j]]].vert_index;
                }
-               mboundary.Append(segment);
+               mesh.boundary.Append(segment);
             }
          }
       }

--- a/mesh/ncmesh.hpp
+++ b/mesh/ncmesh.hpp
@@ -367,10 +367,8 @@ protected: // interface for Mesh to be able to construct itself from NCMesh
 
    friend class Mesh;
 
-   /// Return the basic Mesh arrays for the current finest level.
-   void GetMeshComponents(Array<mfem::Vertex> &mvertices,
-                          Array<mfem::Element*> &melements,
-                          Array<mfem::Element*> &mboundary) const;
+   /// Fill Mesh::{vertices,elements,boundary} for the current finest level.
+   void GetMeshComponents(Mesh &mesh) const;
 
    /** Get edge and face numbering from 'mesh' (i.e., set all Edge::index and
        Face::index) after a new mesh was created from us. */

--- a/tests/unit/linalg/test_rectangularmatrix.cpp
+++ b/tests/unit/linalg/test_rectangularmatrix.cpp
@@ -1,0 +1,164 @@
+// Copyright (c) 2010, Lawrence Livermore National Security, LLC. Produced at
+// the Lawrence Livermore National Laboratory. LLNL-CODE-443211. All Rights
+// reserved. See file COPYRIGHT for details.
+//
+// This file is part of the MFEM library. For more information and source code
+// availability see http://mfem.org.
+//
+// MFEM is free software; you can redistribute it and/or modify it under the
+// terms of the GNU Lesser General Public License (as published by the Free
+// Software Foundation) version 2.1 dated February 1999.
+
+#include "catch.hpp"
+#include "mfem.hpp"
+
+namespace mfem
+{
+
+double f1(const Vector &x)
+{
+   double r = cos(x(0)) + sin(x(1));
+   if (x.Size() == 3)
+   {
+      r += cos(x(2));
+   }
+   return r;
+}
+
+void gradf1(const Vector &x, Vector &u)
+{
+   u(0) = -sin(x(0));
+   u(1) = cos(x(1));
+   if (x.Size() == 3)
+   {
+      u(2) = -sin(x(2));
+   }
+}
+
+TEST_CASE("FormRectangular", "[FormRectangularSystemMatrix]")
+{
+   SECTION("MixedBilinearForm::FormRectangularSystemMatrix")
+   {
+      Mesh mesh(10, 10, Element::QUADRILATERAL, 0, 1.0, 1.0);
+      int dim = mesh.Dimension();
+      int order = 2;
+
+      int nattr = mesh.bdr_attributes.Max();
+      Array<int> ess_trial_tdof_list, ess_test_tdof_list;
+
+      Array<int> ess_bdr(nattr);
+      ess_bdr = 0;
+      ess_bdr[0] = 1;
+
+      // Scalar
+      H1_FECollection fec1(order, dim);
+      FiniteElementSpace fes1(&mesh, &fec1);
+
+      // Vector valued
+      H1_FECollection fec2(order, dim);
+      FiniteElementSpace fes2(&mesh, &fec2, dim);
+
+      fes1.GetEssentialTrueDofs(ess_bdr, ess_trial_tdof_list);
+      fes2.GetEssentialTrueDofs(ess_bdr, ess_test_tdof_list);
+
+      GridFunction field(&fes1), field2(&fes2);
+
+      MixedBilinearForm gform(&fes1, &fes2);
+      gform.AddDomainIntegrator(new GradientIntegrator);
+      gform.Assemble();
+
+      // Project u = f1
+      FunctionCoefficient fcoeff1(f1);
+      field.ProjectCoefficient(fcoeff1);
+
+      VectorFunctionCoefficient fcoeff2(dim, gradf1);
+      LinearForm lf(&fes2);
+      lf.AddDomainIntegrator(new VectorDomainLFIntegrator(fcoeff2));
+      lf.Assemble();
+
+      OperatorHandle G;
+      Vector X, B;
+      gform.FormRectangularLinearSystem(ess_trial_tdof_list,
+                                        ess_test_tdof_list,
+                                        field,
+                                        lf,
+                                        G,
+                                        X,
+                                        B);
+
+      G->Mult(field, field2);
+
+      subtract(B, field2, field2);
+      REQUIRE(field2.Norml2() == Approx(0.0));
+   }
+}
+
+#ifdef MFEM_USE_MPI
+
+TEST_CASE("ParallelFormRectangular",
+          "[Parallel], [FormRectangularSystemMatrix]")
+{
+   SECTION("ParMixedBilinearForm::FormRectangularSystemMatrix")
+   {
+      Mesh mesh(10, 10, Element::QUADRILATERAL, 0, 1.0, 1.0);
+      int dim = mesh.Dimension();
+      int order = 2;
+
+      int nattr = mesh.bdr_attributes.Max();
+      Array<int> ess_trial_tdof_list, ess_test_tdof_list;
+
+      Array<int> ess_bdr(nattr);
+      ess_bdr = 0;
+      ess_bdr[0] = 1;
+
+      ParMesh pmesh(MPI_COMM_WORLD, mesh);
+
+      // Scalar
+      H1_FECollection fec1(order, dim);
+      ParFiniteElementSpace fes1(&pmesh, &fec1);
+
+      // Vector valued
+      H1_FECollection fec2(order, dim);
+      ParFiniteElementSpace fes2(&pmesh, &fec2, dim);
+
+      fes1.GetEssentialTrueDofs(ess_bdr, ess_trial_tdof_list);
+      fes2.GetEssentialTrueDofs(ess_bdr, ess_test_tdof_list);
+
+      ParGridFunction field(&fes1), field2(&fes2);
+
+      ParMixedBilinearForm gform(&fes1, &fes2);
+      gform.AddDomainIntegrator(new GradientIntegrator);
+      gform.Assemble();
+
+      // Project u = f1
+      FunctionCoefficient fcoeff1(f1);
+      field.ProjectCoefficient(fcoeff1);
+
+      VectorFunctionCoefficient fcoeff2(dim, gradf1);
+      ParLinearForm lf(&fes2);
+      lf.AddDomainIntegrator(new VectorDomainLFIntegrator(fcoeff2));
+      lf.Assemble();
+
+      OperatorHandle G;
+      Vector X, B;
+      gform.FormRectangularLinearSystem(ess_trial_tdof_list,
+                                        ess_test_tdof_list,
+                                        field,
+                                        lf,
+                                        G,
+                                        X,
+                                        B);
+
+      Vector *field_tdof = field.ParallelProject();
+      Vector *field2_tdof = field2.ParallelProject();
+
+      G->Mult(*field_tdof, *field2_tdof);
+
+      subtract(B, *field2_tdof, *field2_tdof);
+      REQUIRE(field2_tdof->Norml2() == Approx(0.0));
+   }
+}
+
+#endif
+
+} // namespace mfem


### PR DESCRIPTION
This a fix of #1307 
<!--GHEX{"id":1310,"author":"jakubcerveny","editor":"tzanio","reviewers":["tzanio","v-dobrev"],"assignment":"2020-02-22T16:20:01-08:00","approval":"2020-02-24T20:04:52.327Z","merge":"2020-02-27T17:06:44.738Z"}XEHG--><!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge| 
 | --- | --- | --- | --- | --- | --- | --- | 
| [#1310](https://github.com/mfem/mfem/pull/1310) | @jakubcerveny | @tzanio | @tzanio + @v-dobrev | 02/22/20 | 02/24/20 | 02/27/20 | |
<!--ELBATXEHG-->