### PR TITLE
GridFunction::AccumulateAndCountZones bug fix

### DIFF
--- a/fem/gridfunc.cpp
+++ b/fem/gridfunc.cpp
@@ -1894,7 +1894,7 @@ void GridFunction::ProjectBdrCoefficient(VectorCoefficient &vcoeff,
 void GridFunction::ProjectBdrCoefficient(Coefficient *coeff[], Array<int> &attr)
 {
    Array<int> values_counter;
-   this->HostReadWrite();
+   // this->HostReadWrite(); // done inside the next call
    AccumulateAndCountBdrValues(coeff, NULL, attr, values_counter);
    ComputeMeans(ARITHMETIC, values_counter);
 #ifdef MFEM_DEBUG

--- a/fem/gridfunc.cpp
+++ b/fem/gridfunc.cpp
@@ -1319,6 +1319,9 @@ void GridFunction::AccumulateAndCountZones(Coefficient &coeff,
    Array<int> vdofs;
    Vector vals;
    *this = 0.0;
+
+   HostReadWrite();
+
    for (int i = 0; i < fes->GetNE(); i++)
    {
       fes->GetElementVDofs(i, vdofs);
@@ -1357,6 +1360,9 @@ void GridFunction::AccumulateAndCountZones(VectorCoefficient &vcoeff,
    Array<int> vdofs;
    Vector vals;
    *this = 0.0;
+
+   HostReadWrite();
+
    for (int i = 0; i < fes->GetNE(); i++)
    {
       fes->GetElementVDofs(i, vdofs);
@@ -1413,6 +1419,9 @@ void GridFunction::AccumulateAndCountBdrValues(
    values_counter = 0;
 
    vdim = fes->GetVDim();
+
+   HostReadWrite();
+
    for (i = 0; i < fes->GetNBE(); i++)
    {
       if (attr[fes->GetBdrAttribute(i) - 1] == 0) { continue; }
@@ -1548,6 +1557,8 @@ void GridFunction::AccumulateAndCountBdrTangentValues(
 
    values_counter.SetSize(Size());
    values_counter = 0;
+
+   HostReadWrite();
 
    for (int i = 0; i < fes->GetNBE(); i++)
    {


### PR DESCRIPTION
This PR closes #1322. Thanks to @v-dobrev  for helping me out on this one. The fixes are fairly minor and make sure within these ```GridFunction::AccumulateAndCount*``` functions that the data is on the host. I've tested these fixes in debug mode with my app without any warnings/asserts being thrown in relation to these parts of code. It also fixed the minimal example shown in #1322 as well.
<!--GHEX{"id":1327,"author":"rcarson3","editor":"tzanio","reviewers":["v-dobrev","camierjs"],"assignment":"2020-02-28T15:14:07-08:00","approval":"2020-03-03T00:55:54.892Z","merge":"2020-03-03T15:07:02.351Z"}XEHG--><!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge| 
 | --- | --- | --- | --- | --- | --- | --- | 
| [#1327](https://github.com/mfem/mfem/pull/1327) | @rcarson3 | @tzanio | @v-dobrev + @camierjs | 02/28/20 | 03/02/20 | 03/03/20 | |
<!--ELBATXEHG-->