### PR TITLE
[Fix] SetFromTrueDofs & uninitialized X in ex24p [tdof-fix]

### DIFF
--- a/examples/ex24p.cpp
+++ b/examples/ex24p.cpp
@@ -222,7 +222,7 @@ int main(int argc, char *argv[])
       cg.SetPrintLevel(1);
       cg.SetOperator(*A);
       cg.SetPreconditioner(Jacobi);
-
+      X = 0.0;
       cg.Mult(B, X);
    }
    else

--- a/fem/gridfunc.cpp
+++ b/fem/gridfunc.cpp
@@ -341,7 +341,7 @@ void GridFunction::SetFromTrueDofs(const Vector &tv)
    const SparseMatrix *cP = fes->GetConformingProlongation();
    if (!cP)
    {
-      if (tv.GetData() != data)
+      if (tv.HostRead() != data)
       {
          *this = tv;
       }

--- a/fem/gridfunc.cpp
+++ b/fem/gridfunc.cpp
@@ -341,7 +341,7 @@ void GridFunction::SetFromTrueDofs(const Vector &tv)
    const SparseMatrix *cP = fes->GetConformingProlongation();
    if (!cP)
    {
-      if (tv.HostRead() != data)
+      if (tv.Read() != data)
       {
          *this = tv;
       }

--- a/fem/gridfunc.cpp
+++ b/fem/gridfunc.cpp
@@ -326,7 +326,7 @@ void GridFunction::GetTrueDofs(Vector &tv) const
    if (!R)
    {
       // R is identity -> make tv a reference to *this
-      tv = *this;
+      tv.MakeRef(const_cast<GridFunction &>(*this), 0, size);
    }
    else
    {
@@ -341,10 +341,7 @@ void GridFunction::SetFromTrueDofs(const Vector &tv)
    const SparseMatrix *cP = fes->GetConformingProlongation();
    if (!cP)
    {
-      if (tv.Read() != data)
-      {
-         *this = tv;
-      }
+      *this = tv; // no real copy if 'tv' and '*this' use the same data
    }
    else
    {


### PR DESCRIPTION
- Initializes `X` vector before `CG` solve in `ex24p`
- `Read` instead of `GetData` in `SetFromTrueDofs`
<!--GHEX{"id":1329,"author":"camierjs","editor":"tzanio","reviewers":["tzanio","dylan-copeland","v-dobrev"],"assignment":"2020-03-02T13:55:11-08:00","approval":"2020-03-03T01:45:46.081Z","merge":"2020-03-03T15:03:00.161Z"}XEHG--><!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge| 
 | --- | --- | --- | --- | --- | --- | --- | 
| [#1329](https://github.com/mfem/mfem/pull/1329) | @camierjs | @tzanio | @tzanio + @dylan-copeland + @v-dobrev | 03/02/20 | 03/02/20 | 03/03/20 | |
<!--ELBATXEHG-->