### PR TITLE
Fix warnings about sign change when 'char' is 'unsigned char' [signed-char-fix]

### DIFF
--- a/mesh/ncmesh.hpp
+++ b/mesh/ncmesh.hpp
@@ -152,10 +152,12 @@ public:
    {
       int index;   ///< Mesh number
       int element; ///< NCMesh::Element containing this vertex/edge/face
-      char local;  ///< local number within 'element'
-      char geom;   ///< Geometry::Type (faces only) (char storage to save RAM)
+      signed char local; ///< local number within 'element'
+      signed char geom;  /**< Geometry::Type (faces only) (char storage to save
+                              RAM) */
 
-      MeshId(int index = -1, int element = -1, char local = -1, char geom = -1)
+      MeshId(int index = -1, int element = -1, signed char local = -1,
+             signed char geom = -1)
          : index(index), element(element), local(local), geom(geom) {}
 
       Geometry::Type Geom() const { return Geometry::Type(geom); }


### PR DESCRIPTION
Explicitly use a 'signed char' instead of 'char' -- for compilers that use 'char' == 'unsigned char'.
<!--GHEX{"id":1335,"author":"v-dobrev","editor":"tzanio","reviewers":["jakubcerveny","tzanio"],"assignment":"2020-03-04T20:36:50-08:00","approval":"2020-03-05","merge":"2020-03-05T15:57:37.768Z"}XEHG--><!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge| 
 | --- | --- | --- | --- | --- | --- | --- | 
| [#1335](https://github.com/mfem/mfem/pull/1335) | @v-dobrev | @tzanio | @jakubcerveny + @tzanio | 03/04/20 | 03/05/20 | 03/05/20 | |
<!--ELBATXEHG-->