### PR TITLE
Hotfix for sample runs

### DIFF
--- a/examples/ex6.cpp
+++ b/examples/ex6.cpp
@@ -20,7 +20,7 @@
 //               ex6 -pa -d occa-cuda
 //               ex6 -pa -d raja-omp
 //               ex6 -pa -d ceed-cpu
-//               *ex6 -pa -d ceed-cuda
+//               * ex6 -pa -d ceed-cuda
 //               ex6 -pa -d ceed-cuda:/gpu/cuda/ref
 //
 // Description:  This is a version of Example 1 with a simple adaptive mesh

--- a/examples/ex6.cpp
+++ b/examples/ex6.cpp
@@ -21,7 +21,7 @@
 //               ex6 -pa -d raja-omp
 //               ex6 -pa -d ceed-cpu
 //               * ex6 -pa -d ceed-cuda
-//               ex6 -pa -d ceed-cuda:/gpu/cuda/ref
+//               ex6 -pa -d ceed-cuda:/gpu/cuda/shared
 //
 // Description:  This is a version of Example 1 with a simple adaptive mesh
 //               refinement loop. The problem being solved is again the Laplace

--- a/examples/ex6.cpp
+++ b/examples/ex6.cpp
@@ -20,7 +20,8 @@
 //               ex6 -pa -d occa-cuda
 //               ex6 -pa -d raja-omp
 //               ex6 -pa -d ceed-cpu
-//               ex6 -pa -d ceed-cuda
+//               *ex6 -pa -d ceed-cuda
+//               ex6 -pa -d ceed-cuda:/gpu/cuda/ref
 //
 // Description:  This is a version of Example 1 with a simple adaptive mesh
 //               refinement loop. The problem being solved is again the Laplace

--- a/examples/ex6p.cpp
+++ b/examples/ex6p.cpp
@@ -20,7 +20,7 @@
 //               mpirun -np 4 ex6p -pa -d occa-cuda
 //               mpirun -np 4 ex6p -pa -d raja-omp
 //               mpirun -np 4 ex6p -pa -d ceed-cpu
-//               *mpirun -np 4 ex6p -pa -d ceed-cuda
+//               * mpirun -np 4 ex6p -pa -d ceed-cuda
 //               mpirun -np 4 ex6p -pa -d ceed-cuda:/gpu/cuda/ref
 //
 // Description:  This is a version of Example 1 with a simple adaptive mesh

--- a/examples/ex6p.cpp
+++ b/examples/ex6p.cpp
@@ -21,7 +21,7 @@
 //               mpirun -np 4 ex6p -pa -d raja-omp
 //               mpirun -np 4 ex6p -pa -d ceed-cpu
 //               * mpirun -np 4 ex6p -pa -d ceed-cuda
-//               mpirun -np 4 ex6p -pa -d ceed-cuda:/gpu/cuda/ref
+//               mpirun -np 4 ex6p -pa -d ceed-cuda:/gpu/cuda/shared
 //
 // Description:  This is a version of Example 1 with a simple adaptive mesh
 //               refinement loop. The problem being solved is again the Laplace

--- a/examples/ex6p.cpp
+++ b/examples/ex6p.cpp
@@ -20,7 +20,8 @@
 //               mpirun -np 4 ex6p -pa -d occa-cuda
 //               mpirun -np 4 ex6p -pa -d raja-omp
 //               mpirun -np 4 ex6p -pa -d ceed-cpu
-//               mpirun -np 4 ex6p -pa -d ceed-cuda
+//               *mpirun -np 4 ex6p -pa -d ceed-cuda
+//               mpirun -np 4 ex6p -pa -d ceed-cuda:/gpu/cuda/ref
 //
 // Description:  This is a version of Example 1 with a simple adaptive mesh
 //               refinement loop. The problem being solved is again the Laplace

--- a/miniapps/nurbs/nurbs_ex11p.cpp
+++ b/miniapps/nurbs/nurbs_ex11p.cpp
@@ -157,12 +157,16 @@ int main(int argc, char *argv[])
          fec = pmesh->GetNodes()->OwnFEC();
          own_fec = 0;
          if (myid == 0)
+         {
             cout << "Using isoparametric FEs: " << fec->Name() << endl;
+         }
       }
       else
       {
          if (myid == 0)
+         {
             cout <<"Mesh does not have FEs --> Assume order 1.\n";
+         }
          fec = new H1_FECollection(1, dim);
          own_fec = 1;
       }

--- a/miniapps/nurbs/nurbs_ex11p.cpp
+++ b/miniapps/nurbs/nurbs_ex11p.cpp
@@ -156,11 +156,13 @@ int main(int argc, char *argv[])
       {
          fec = pmesh->GetNodes()->OwnFEC();
          own_fec = 0;
-         cout << "Using isoparametric FEs: " << fec->Name() << endl;
+         if (myid == 0)
+            cout << "Using isoparametric FEs: " << fec->Name() << endl;
       }
       else
       {
-         cout <<"Mesh does not have FEs --> Assume order 1.\n";
+         if (myid == 0)
+            cout <<"Mesh does not have FEs --> Assume order 1.\n";
          fec = new H1_FECollection(1, dim);
          own_fec = 1;
       }


### PR DESCRIPTION
This PR fixes `ex6` and `ex6p` to use deterministic backends of libCEED in the sample runs, and fixes `nurbs_ex11p` to print messages only once.
<!--GHEX{"id":1360,"author":"YohannDudouit","editor":"tzanio","reviewers":["tzanio","camierjs"],"assignment":"2020-03-18T06:46:50-07:00","approval":"2020-03-18T18:16:54.602Z","merge":"2020-03-19T15:18:08.438Z"}XEHG--><!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge| 
 | --- | --- | --- | --- | --- | --- | --- | 
| [#1360](https://github.com/mfem/mfem/pull/1360) | @YohannDudouit | @tzanio | @tzanio + @camierjs | 03/18/20 | 03/18/20 | 03/19/20 | |
<!--ELBATXEHG-->