### PR TITLE
Improve handling of nodes in LOR meshes [lor-pargridfunction]

### DIFF
--- a/fem/fespace.cpp
+++ b/fem/fespace.cpp
@@ -834,8 +834,7 @@ const Operator *FiniteElementSpace::GetElementRestriction(
    ElementDofOrdering e_ordering) const
 {
    // Check if we have a discontinuous space using the FE collection:
-   const L2_FECollection *dg_space = dynamic_cast<const L2_FECollection*>(fec);
-   if (dg_space)
+   if (IsDGSpace())
    {
       if (L2E_nat.Ptr() == NULL)
       {
@@ -862,7 +861,7 @@ const Operator *FiniteElementSpace::GetElementRestriction(
 const Operator *FiniteElementSpace::GetFaceRestriction(
    ElementDofOrdering e_ordering, FaceType type, L2FaceValues mul) const
 {
-   const bool is_dg_space = dynamic_cast<const L2_FECollection*>(fec)!=nullptr;
+   const bool is_dg_space = IsDGSpace();
    const L2FaceValues m = (is_dg_space && mul==L2FaceValues::DoubleValued) ?
                           L2FaceValues::DoubleValued : L2FaceValues::SingleValued;
    key_face key = std::make_tuple(is_dg_space, e_ordering, type, m);

--- a/fem/fespace.hpp
+++ b/fem/fespace.hpp
@@ -656,6 +656,9 @@ public:
    /// Return update counter (see Mesh::sequence)
    long GetSequence() const { return sequence; }
 
+   /// Return whether or not the space is discontinuous (L2)
+   bool IsDGSpace() const { return dynamic_cast<const L2_FECollection*>(fec); }
+
    void Save(std::ostream &out) const;
 
    /** @brief Read a FiniteElementSpace from a stream. The returned

--- a/fem/fespace.hpp
+++ b/fem/fespace.hpp
@@ -657,7 +657,10 @@ public:
    long GetSequence() const { return sequence; }
 
    /// Return whether or not the space is discontinuous (L2)
-   bool IsDGSpace() const { return dynamic_cast<const L2_FECollection*>(fec); }
+   bool IsDGSpace() const
+   {
+      return dynamic_cast<const L2_FECollection*>(fec) != NULL;
+   }
 
    void Save(std::ostream &out) const;
 

--- a/fem/pfespace.cpp
+++ b/fem/pfespace.cpp
@@ -498,7 +498,7 @@ void ParFiniteElementSpace::GetFaceDofs(int i, Array<int> &dofs) const
 const Operator *ParFiniteElementSpace::GetFaceRestriction(
    ElementDofOrdering e_ordering, FaceType type, L2FaceValues mul) const
 {
-   const bool is_dg_space = dynamic_cast<const L2_FECollection*>(fec)!=nullptr;
+   const bool is_dg_space = IsDGSpace();
    const L2FaceValues m = (is_dg_space && mul==L2FaceValues::DoubleValued) ?
                           L2FaceValues::DoubleValued : L2FaceValues::SingleValued;
    auto key = std::make_tuple(is_dg_space, e_ordering, type, m);

--- a/mesh/mesh.cpp
+++ b/mesh/mesh.cpp
@@ -3595,11 +3595,15 @@ Mesh::Mesh(Mesh *orig_mesh, int ref_factor, int ref_type)
       }
    }
 
-   SetCurvature(1, true, spaceDim);
-   Vector node_coordinates_vec(
-      node_coordinates.Data(),
-      node_coordinates.Width()*node_coordinates.Height());
-   SetNodes(node_coordinates_vec);
+   if (orig_mesh->GetNodes())
+   {
+      bool discont = orig_mesh->GetNodalFESpace()->IsDGSpace();
+      SetCurvature(1, discont, spaceDim);
+      Vector node_coordinates_vec(
+         node_coordinates.Data(),
+         node_coordinates.Width()*node_coordinates.Height());
+      SetNodes(node_coordinates_vec);
+   }
 
    // Add refined boundary elements
    for (int el = 0; el < orig_mesh->GetNBE(); el++)

--- a/mesh/mesh.cpp
+++ b/mesh/mesh.cpp
@@ -3597,14 +3597,9 @@ Mesh::Mesh(Mesh *orig_mesh, int ref_factor, int ref_type)
 
    if (orig_mesh->GetNodes())
    {
-      Vector node_coordinates_vec(
-         node_coordinates.Data(),
-         node_coordinates.Width()*node_coordinates.Height());
       L2_FECollection fec_dg(1, Dim, BasisType::GaussLobatto);
       FiniteElementSpace fes_dg(this, &fec_dg, spaceDim, 1);
-      GridFunction nodes_dg(&fes_dg);
-      nodes_dg = node_coordinates_vec;
-
+      GridFunction nodes_dg(&fes_dg, node_coordinates.Data());
       bool discont = orig_mesh->GetNodalFESpace()->IsDGSpace();
       SetCurvature(1, discont, spaceDim);
       Nodes->ProjectGridFunction(nodes_dg);

--- a/mesh/mesh.cpp
+++ b/mesh/mesh.cpp
@@ -3597,12 +3597,17 @@ Mesh::Mesh(Mesh *orig_mesh, int ref_factor, int ref_type)
 
    if (orig_mesh->GetNodes())
    {
-      bool discont = orig_mesh->GetNodalFESpace()->IsDGSpace();
-      SetCurvature(1, discont, spaceDim);
       Vector node_coordinates_vec(
          node_coordinates.Data(),
          node_coordinates.Width()*node_coordinates.Height());
-      SetNodes(node_coordinates_vec);
+      L2_FECollection fec_dg(1, Dim, BasisType::GaussLobatto);
+      FiniteElementSpace fes_dg(this, &fec_dg, spaceDim, 1);
+      GridFunction nodes_dg(&fes_dg);
+      nodes_dg = node_coordinates_vec;
+
+      bool discont = orig_mesh->GetNodalFESpace()->IsDGSpace();
+      SetCurvature(1, discont, spaceDim);
+      Nodes->ProjectGridFunction(nodes_dg);
    }
 
    // Add refined boundary elements

--- a/mesh/mesh.cpp
+++ b/mesh/mesh.cpp
@@ -3601,7 +3601,8 @@ Mesh::Mesh(Mesh *orig_mesh, int ref_factor, int ref_type)
       FiniteElementSpace fes_dg(this, &fec_dg, spaceDim, 1);
       GridFunction nodes_dg(&fes_dg, node_coordinates.Data());
       bool discont = orig_mesh->GetNodalFESpace()->IsDGSpace();
-      SetCurvature(1, discont, spaceDim);
+      Ordering::Type dof_ordering = orig_mesh->GetNodalFESpace()->GetOrdering();
+      SetCurvature(1, discont, spaceDim, dof_ordering);
       Nodes->ProjectGridFunction(nodes_dg);
    }
 

--- a/mesh/pmesh.cpp
+++ b/mesh/pmesh.cpp
@@ -1066,12 +1066,6 @@ ParMesh::ParMesh(ParMesh *orig_mesh, int ref_factor, int ref_type)
      have_face_nbr_data(false),
      pncmesh(NULL)
 {
-   if (Nodes != NULL)
-   {
-      // This call will turn the Nodes into a ParGridFunction
-      SetCurvature(1, GetNodalFESpace()->IsDGSpace(), spaceDim);
-   }
-
    // Need to initialize:
    // - shared_edges, shared_{trias,quads}
    // - group_svert, group_sedge, group_{stria,squad}
@@ -1282,6 +1276,12 @@ ParMesh::ParMesh(ParMesh *orig_mesh, int ref_factor, int ref_type)
    group_squad.ShiftUpI();
 
    FinalizeParTopo();
+
+   if (Nodes != NULL)
+   {
+      // This call will turn the Nodes into a ParGridFunction
+      SetCurvature(1, GetNodalFESpace()->IsDGSpace(), spaceDim);
+   }
 }
 
 void ParMesh::Finalize(bool refine, bool fix_orientation)

--- a/mesh/pmesh.cpp
+++ b/mesh/pmesh.cpp
@@ -1280,7 +1280,8 @@ ParMesh::ParMesh(ParMesh *orig_mesh, int ref_factor, int ref_type)
    if (Nodes != NULL)
    {
       // This call will turn the Nodes into a ParGridFunction
-      SetCurvature(1, GetNodalFESpace()->IsDGSpace(), spaceDim);
+      SetCurvature(1, GetNodalFESpace()->IsDGSpace(), spaceDim,
+                   GetNodalFESpace()->GetOrdering());
    }
 }
 

--- a/mesh/pmesh.cpp
+++ b/mesh/pmesh.cpp
@@ -1066,7 +1066,11 @@ ParMesh::ParMesh(ParMesh *orig_mesh, int ref_factor, int ref_type)
      have_face_nbr_data(false),
      pncmesh(NULL)
 {
-   SetCurvature(1, true, spaceDim);
+   if (Nodes != NULL)
+   {
+      // This call will turn the Nodes into a ParGridFunction
+      SetCurvature(1, GetNodalFESpace()->IsDGSpace(), spaceDim);
+   }
 
    // Need to initialize:
    // - shared_edges, shared_{trias,quads}

--- a/mesh/pmesh.cpp
+++ b/mesh/pmesh.cpp
@@ -1066,6 +1066,8 @@ ParMesh::ParMesh(ParMesh *orig_mesh, int ref_factor, int ref_type)
      have_face_nbr_data(false),
      pncmesh(NULL)
 {
+   SetCurvature(1, true, spaceDim);
+
    // Need to initialize:
    // - shared_edges, shared_{trias,quads}
    // - group_svert, group_sedge, group_{stria,squad}


### PR DESCRIPTION
This small PR improves the handling and creation of nodes in LOR meshes.

In particular:
- Only create nodes if the original mesh has nodes
- Only use a discontinuous space if the original nodal space is DG
- Make sure the nodes of the ParMesh are a ParGridFunction

Also adds a convenience function `FiniteElementSpace::IsDGSpace` to check if a space has an L2 finite element collection or not (and refactors the few existing places where this check was done using `dynamic_cast`).

Fixes #1361.
<!--GHEX{"id":1362,"author":"pazner","editor":"tzanio","reviewers":["tzanio","v-dobrev"],"assignment":"2020-03-18T06:48:35-07:00","approval":"2020-03-18T18:19:07.642Z","merge":"2020-03-20T15:13:10.850Z"}XEHG--><!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge| 
 | --- | --- | --- | --- | --- | --- | --- | 
| [#1362](https://github.com/mfem/mfem/pull/1362) | @pazner | @tzanio | @tzanio + @v-dobrev | 03/18/20 | 03/18/20 | 03/20/20 | |
<!--ELBATXEHG-->