### PR TITLE
Introduction of basic CUDA builds and tests on lassen

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -99,8 +99,10 @@ setup:
   script:
     - srun -p mi60 -t 15 -N 1 tests/gitlab/build_and_test
 
-# Lassen and Butte use a different job scheduler (spectrum lsf) that does not
+# Lassen uses a different job scheduler (spectrum lsf) that does not
 # allow pre-allocation the same way slurm does.
+# We use pdebug queue on lassen to speed-up the allocation.
+# However this would not be scalable to multiple builds.
 .build_blueos_3_ppc64le_ib_script:
   script:
     - lalloc 1 -W 30 -q pdebug tests/gitlab/build_and_test

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -103,7 +103,7 @@ setup:
 # allow pre-allocation the same way slurm does.
 .build_blueos_3_ppc64le_ib_script:
   script:
-    - lalloc 1 -W 15 tests/gitlab/build_and_test
+    - lalloc 1 -W 30 -q pdebug tests/gitlab/build_and_test
 
 # Shared script for baseline and sample-run-baseline, the value of BASELINE_TEST
 # differentiates between the two tests.

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -228,4 +228,4 @@ setup:
 # The list on jobs is defined in machine-specific files.
 include:
   - local: .gitlab/quartz.yml
-    #  - local: .gitlab/lassen.yml
+  - local: .gitlab/lassen.yml

--- a/.gitlab/lassen.yml
+++ b/.gitlab/lassen.yml
@@ -33,20 +33,20 @@
 #    SPEC: "%clang@9.0.0 +debug~cuda"
 #  extends: .build_and_test_on_lassen
 
-debug_xl_16_1_1_8:
-  variables:
-    SPEC: "%xl@16.1.1.8 +debug~cuda"
-  extends: .build_and_test_on_lassen
+#debug_xl_16_1_1_8:
+#  variables:
+#    SPEC: "%xl@16.1.1.8 +debug~cuda"
+#  extends: .build_and_test_on_lassen
 
 #debug_cuda_clang_9_0_0:
 #  variables:
 #    SPEC: "%clang@9.0.0 +debug+cuda"
 #  extends: .build_and_test_on_lassen
 
-debug_cuda_xl_16_1_1_8:
-  variables:
-    SPEC: "%xl@16.1.1.8 +debug+cuda cuda_arch=sm_70"
-  extends: .build_and_test_on_lassen
+#debug_cuda_xl_16_1_1_8:
+#  variables:
+#    SPEC: "%xl@16.1.1.8 +debug+cuda cuda_arch=sm_70"
+#  extends: .build_and_test_on_lassen
 
 #opt_cuda_clang_9_0_0:
 #  variables:
@@ -56,4 +56,4 @@ debug_cuda_xl_16_1_1_8:
 opt_cuda_xl_16_1_1_8:
   variables:
     SPEC: "%xl@16.1.1.8 +cuda cuda_arch=sm_70"
-cuda_arch  extends: .build_and_test_on_lassen
+  extends: .build_and_test_on_lassen

--- a/.gitlab/lassen.yml
+++ b/.gitlab/lassen.yml
@@ -28,32 +28,32 @@
   needs: []
 
 # Build MFEM
-debug_clang_9_0_0_ibm:
+debug_clang_9_0_0:
   variables:
-    SPEC: "%clang@9.0.0ibm +debug~cuda"
+    SPEC: "%clang@9.0.0 +debug~cuda"
   extends: .build_and_test_on_lassen
 
-debug_xl_16_1_1_7:
+debug_xl_16_1_1_8:
   variables:
-    SPEC: "%xl@16.1.1.7 +debug~cuda"
+    SPEC: "%xl@16.1.1.8 +debug~cuda"
   extends: .build_and_test_on_lassen
 
-debug_cuda_clang_9_0_0_ibm:
+debug_cuda_clang_9_0_0:
   variables:
-    SPEC: "%clang@9.0.0ibm +debug+cuda"
+    SPEC: "%clang@9.0.0 +debug+cuda"
   extends: .build_and_test_on_lassen
 
-debug_cuda_xl_16_1_1_7:
+debug_cuda_xl_16_1_1_8:
   variables:
-    SPEC: "%xl@16.1.1.7 +debug+cuda"
+    SPEC: "%xl@16.1.1.8 +debug+cuda"
   extends: .build_and_test_on_lassen
 
-opt_cuda_clang_9_0_0_ibm:
+opt_cuda_clang_9_0_0:
   variables:
-    SPEC: "%clang@9.0.0ibm +cuda"
+    SPEC: "%clang@9.0.0 +cuda"
   extends: .build_and_test_on_lassen
 
-opt_cuda_xl_16_1_1_7:
+opt_cuda_xl_16_1_1_8:
   variables:
-    SPEC: "%xl@16.1.1.7 +cuda"
+    SPEC: "%xl@16.1.1.8 +cuda"
   extends: .build_and_test_on_lassen

--- a/.gitlab/lassen.yml
+++ b/.gitlab/lassen.yml
@@ -15,43 +15,44 @@
   tags:
     - shell
     - lassen
-  variables:
-    PLAT: lassen
+  rules:
+    - if: '$CI_COMMIT_BRANCH =~ /_lnone/ || $ON_LASSEN == "OFF"' #run except if ...
+      when: never
+    - when: on_success
+
+# Spack helped builds
+# Generic lassen build job, extending build script
+.build_and_test_on_lassen:
+  extends: [.build_blueos_3_ppc64le_ib_script, .on_lassen]
+  stage: l_build_and_test
 
 # Build MFEM
-build_mfem_ser_lassen:
-  extends: [.with_gcc_8_3_1, .on_lassen]
-  needs: [setup]
-  stage: lassen_build
-  script:
-    - mkdir -p ${BUILD_PATH}
-    - cp -r ${CI_PROJECT_DIR} ${BUILD_PATH}/${CI_PROJECT_NAME}_lassen_ser
-    - cd ${BUILD_PATH}/${CI_PROJECT_NAME}_lassen_ser
-    - lalloc 1 -W 5 -q pdebug make -j cuda CUDA_ARCH=sm_70
+debug_clang_9_0_0_ibm:
+  variables:
+    SPEC: "%clang@9.0.0ibm +debug~cuda"
+  extends: .build_and_test_on_lassen
 
-build_mfem_debug_ser_lassen:
-  extends: [.with_gcc_8_3_1, .on_lassen]
-  needs: [setup]
-  stage: lassen_build
-  script:
-    - mkdir -p ${BUILD_PATH}
-    - cp -r ${CI_PROJECT_DIR} ${BUILD_PATH}/${CI_PROJECT_NAME}_lassen_ser_debug
-    - cd ${BUILD_PATH}/${CI_PROJECT_NAME}_lassen_ser_debug
-    - lalloc 1 -W 5 -q pdebug make -j cuda MFEM_DEBUG="YES" CPPFLAGS=-O2 CUDA_ARCH=sm_70
+debug_xl_16_1_1_7:
+  variables:
+    SPEC: "%xl@16.1.1.7 +debug~cuda"
+  extends: .build_and_test_on_lassen
 
-# Sanity check
-sanitycheck_mfem_ser_lassen:
-  extends: [.with_gcc_8_3_1, .on_lassen]
-  stage: lassen_test
-  needs: [build_mfem_ser_lassen]
-  script:
-    - cd ${BUILD_PATH}/${CI_PROJECT_NAME}_lassen_ser
-    - lalloc 1 -W 15 -q pdebug make -j test
+debug_cuda_clang_9_0_0_ibm:
+  variables:
+    SPEC: "%clang@9.0.0ibm +debug+cuda"
+  extends: .build_and_test_on_lassen
 
-sanitycheck_mfem_debug_ser_lassen:
-  extends: [.with_gcc_8_3_1, .on_lassen]
-  stage: lassen_test
-  needs: [build_mfem_debug_ser_lassen]
-  script:
-    - cd ${BUILD_PATH}/${CI_PROJECT_NAME}_lassen_ser_debug
-    - lalloc 1 -W 30 -q pdebug make -j test
+debug_cuda_xl_16_1_1_7:
+  variables:
+    SPEC: "%xl@16.1.1.7 +debug+cuda"
+  extends: .build_and_test_on_lassen
+
+opt_cuda_clang_9_0_0_ibm:
+  variables:
+    SPEC: "%clang@9.0.0ibm +cuda"
+  extends: .build_and_test_on_lassen
+
+opt_cuda_xl_16_1_1_7:
+  variables:
+    SPEC: "%xl@16.1.1.7 +cuda"
+  extends: .build_and_test_on_lassen

--- a/.gitlab/lassen.yml
+++ b/.gitlab/lassen.yml
@@ -27,33 +27,7 @@
   stage: l_build_and_test
   needs: []
 
-# Build MFEM
-#debug_clang_9_0_0:
-#  variables:
-#    SPEC: "%clang@9.0.0 +debug~cuda"
-#  extends: .build_and_test_on_lassen
-
-#debug_xl_16_1_1_8:
-#  variables:
-#    SPEC: "%xl@16.1.1.8 +debug~cuda"
-#  extends: .build_and_test_on_lassen
-
-#debug_cuda_clang_9_0_0:
-#  variables:
-#    SPEC: "%clang@9.0.0 +debug+cuda"
-#  extends: .build_and_test_on_lassen
-
-#debug_cuda_xl_16_1_1_8:
-#  variables:
-#    SPEC: "%xl@16.1.1.8 +debug+cuda cuda_arch=sm_70"
-#  extends: .build_and_test_on_lassen
-
-#opt_cuda_clang_9_0_0:
-#  variables:
-#    SPEC: "%clang@9.0.0 +cuda"
-#  extends: .build_and_test_on_lassen
-
-opt_cuda_xl_16_1_1_8:
+opt_mpi_cuda_xl_16_1_1_8:
   variables:
-    SPEC: "%xl@16.1.1.8 +cuda cuda_arch=sm_70"
+    SPEC: "%xl@16.1.1.8 +mpi +cuda cuda_arch=sm_70"
   extends: .build_and_test_on_lassen

--- a/.gitlab/lassen.yml
+++ b/.gitlab/lassen.yml
@@ -28,32 +28,32 @@
   needs: []
 
 # Build MFEM
-debug_clang_9_0_0:
-  variables:
-    SPEC: "%clang@9.0.0 +debug~cuda"
-  extends: .build_and_test_on_lassen
+#debug_clang_9_0_0:
+#  variables:
+#    SPEC: "%clang@9.0.0 +debug~cuda"
+#  extends: .build_and_test_on_lassen
 
 debug_xl_16_1_1_8:
   variables:
     SPEC: "%xl@16.1.1.8 +debug~cuda"
   extends: .build_and_test_on_lassen
 
-debug_cuda_clang_9_0_0:
-  variables:
-    SPEC: "%clang@9.0.0 +debug+cuda"
-  extends: .build_and_test_on_lassen
+#debug_cuda_clang_9_0_0:
+#  variables:
+#    SPEC: "%clang@9.0.0 +debug+cuda"
+#  extends: .build_and_test_on_lassen
 
 debug_cuda_xl_16_1_1_8:
   variables:
-    SPEC: "%xl@16.1.1.8 +debug+cuda"
+    SPEC: "%xl@16.1.1.8 +debug+cuda cuda_arch=sm_70"
   extends: .build_and_test_on_lassen
 
-opt_cuda_clang_9_0_0:
-  variables:
-    SPEC: "%clang@9.0.0 +cuda"
-  extends: .build_and_test_on_lassen
+#opt_cuda_clang_9_0_0:
+#  variables:
+#    SPEC: "%clang@9.0.0 +cuda"
+#  extends: .build_and_test_on_lassen
 
 opt_cuda_xl_16_1_1_8:
   variables:
-    SPEC: "%xl@16.1.1.8 +cuda"
-  extends: .build_and_test_on_lassen
+    SPEC: "%xl@16.1.1.8 +cuda cuda_arch=sm_70"
+cuda_arch  extends: .build_and_test_on_lassen

--- a/.gitlab/lassen.yml
+++ b/.gitlab/lassen.yml
@@ -25,6 +25,7 @@
 .build_and_test_on_lassen:
   extends: [.build_blueos_3_ppc64le_ib_script, .on_lassen]
   stage: l_build_and_test
+  needs: []
 
 # Build MFEM
 debug_clang_9_0_0_ibm:

--- a/tests/gitlab/get_mfem_uberenv
+++ b/tests/gitlab/get_mfem_uberenv
@@ -18,7 +18,7 @@ set -o errexit
 set -o nounset
 
 uberenv_url="https://github.com/mfem/mfem-uberenv.git"
-uberenv_ref="c604270cf106513c0d3c3cc813e694fa40d621df"
+uberenv_ref="dbe35eb4dbeaabc7184ad110fcb98377092baeb0"
 
 [[ ! -d tests/uberenv ]] && git clone ${uberenv_url} tests/uberenv
 cd tests/uberenv

--- a/tests/gitlab/get_mfem_uberenv
+++ b/tests/gitlab/get_mfem_uberenv
@@ -18,7 +18,7 @@ set -o errexit
 set -o nounset
 
 uberenv_url="https://github.com/mfem/mfem-uberenv.git"
-uberenv_ref="dcd0b861ea7ab692a18a0e5af6b7bf3c22e79286
+uberenv_ref="dcd0b861ea7ab692a18a0e5af6b7bf3c22e79286"
 
 [[ ! -d tests/uberenv ]] && git clone ${uberenv_url} tests/uberenv
 cd tests/uberenv

--- a/tests/gitlab/get_mfem_uberenv
+++ b/tests/gitlab/get_mfem_uberenv
@@ -18,7 +18,7 @@ set -o errexit
 set -o nounset
 
 uberenv_url="https://github.com/mfem/mfem-uberenv.git"
-uberenv_ref="01641bd2aa04ce09af020a055aefa9c60d821c58"
+uberenv_ref="082aa82cb268b72d297d44d3981f6e2c111cb4b8"
 
 [[ ! -d tests/uberenv ]] && git clone ${uberenv_url} tests/uberenv
 cd tests/uberenv

--- a/tests/gitlab/get_mfem_uberenv
+++ b/tests/gitlab/get_mfem_uberenv
@@ -18,7 +18,7 @@ set -o errexit
 set -o nounset
 
 uberenv_url="https://github.com/mfem/mfem-uberenv.git"
-uberenv_ref="af5f7f9ef3fbdc70d441a605e2b2f84be245682e"
+uberenv_ref="01641bd2aa04ce09af020a055aefa9c60d821c58"
 
 [[ ! -d tests/uberenv ]] && git clone ${uberenv_url} tests/uberenv
 cd tests/uberenv

--- a/tests/gitlab/get_mfem_uberenv
+++ b/tests/gitlab/get_mfem_uberenv
@@ -18,7 +18,7 @@ set -o errexit
 set -o nounset
 
 uberenv_url="https://github.com/mfem/mfem-uberenv.git"
-uberenv_ref="dcd0b861ea7ab692a18a0e5af6b7bf3c22e79286"
+uberenv_ref="c604270cf106513c0d3c3cc813e694fa40d621df"
 
 [[ ! -d tests/uberenv ]] && git clone ${uberenv_url} tests/uberenv
 cd tests/uberenv

--- a/tests/gitlab/get_mfem_uberenv
+++ b/tests/gitlab/get_mfem_uberenv
@@ -18,7 +18,7 @@ set -o errexit
 set -o nounset
 
 uberenv_url="https://github.com/mfem/mfem-uberenv.git"
-uberenv_ref="ed51345fd96588c02b912a0f54e76a20882b7e5d"
+uberenv_ref="dcd0b861ea7ab692a18a0e5af6b7bf3c22e79286
 
 [[ ! -d tests/uberenv ]] && git clone ${uberenv_url} tests/uberenv
 cd tests/uberenv

--- a/tests/gitlab/get_mfem_uberenv
+++ b/tests/gitlab/get_mfem_uberenv
@@ -18,7 +18,7 @@ set -o errexit
 set -o nounset
 
 uberenv_url="https://github.com/mfem/mfem-uberenv.git"
-uberenv_ref="082aa82cb268b72d297d44d3981f6e2c111cb4b8"
+uberenv_ref="ed51345fd96588c02b912a0f54e76a20882b7e5d"
 
 [[ ! -d tests/uberenv ]] && git clone ${uberenv_url} tests/uberenv
 cd tests/uberenv


### PR DESCRIPTION
This branch adds testing of a cuda build on lassen. Dependencies are installed with Spack through uberenv.
A .mk config file is generated to point to the dependencies and apply the correct options to a subsequent build on MFEM outside of Spack.

This PR relates to https://github.com/mfem/mfem-uberenv/pull/1

- [x] The change in mfem-uberenv should be merged first.
- [x] Then the commit hash of the merge should be updated in tests/gitlab/get_mfem_uberenv
<!--GHEX{"id":1367,"author":"adrienbernede","editor":"tzanio","reviewers":["tzanio","v-dobrev"],"assignment":"2021-04-29T12:48:53-07:00","approval":"2021-05-04T22:34:14.034Z","merge":"2021-05-05T16:48:35.753Z"}XEHG--><!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge| 
 | --- | --- | --- | --- | --- | --- | --- | 
| [#1367](https://github.com/mfem/mfem/pull/1367) | @adrienbernede | @tzanio | @tzanio + @v-dobrev | 04/29/21 | 05/04/21 | 05/05/21 | |
<!--ELBATXEHG-->