### PR TITLE
Kernel attributes for CalcEigenvalues and CalcSingularvalue

### DIFF
--- a/linalg/kernels.hpp
+++ b/linalg/kernels.hpp
@@ -203,11 +203,11 @@ void MultABt(const int Aheight, const int Awidth, const int Bheight,
 /// Compute the spectrum of the matrix of size dim with given @a data, returning
 /// the eigenvalues in the array @a lambda and the eigenvectors in the array @a
 /// vec (listed consecutively).
-template<int dim>
+template<int dim> MFEM_HOST_DEVICE
 void CalcEigenvalues(const double *data, double *lambda, double *vec);
 
 /// Return the i'th singular value of the matrix of size dim with given @a data.
-template<int dim>
+template<int dim> MFEM_HOST_DEVICE
 double CalcSingularvalue(const double *data, const int i);
 
 


### PR DESCRIPTION
Allow to compile with `hipcc`
<!--GHEX{"id":1377,"author":"camierjs","editor":"tzanio","reviewers":["tzanio","v-dobrev"],"assignment":"2020-03-26T16:38:33-07:00","approval":"2020-03-26T23:46:05.702Z","merge":"2020-03-27T16:50:59.216Z"}XEHG--><!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge| 
 | --- | --- | --- | --- | --- | --- | --- | 
| [#1377](https://github.com/mfem/mfem/pull/1377) | @camierjs | @tzanio | @tzanio + @v-dobrev | 03/26/20 | 03/26/20 | 03/27/20 | |
<!--ELBATXEHG-->