### PR TITLE
[WIP] krylov monitors

### DIFF
--- a/linalg/solvers.cpp
+++ b/linalg/solvers.cpp
@@ -169,6 +169,10 @@ void GMRESLegacyMonitor::IterationInfo(int iteration, double res_norm)
       mfem::out << "   Pass : " << setw(2) << (iteration-1)/restart+1
                 << "   Iteration : " << setw(3) << iteration
                 << "  ||B r|| = " << res_norm << "\n";
+      if (iteration % restart == 0)
+      {
+         mfem::out << "Restarting..." << '\n';
+      }
    }
 }
 
@@ -223,6 +227,10 @@ void FGMRESLegacyMonitor::IterationInfo(int iteration, double res_norm)
       mfem::out << "   Pass : " << setw(2) << (iteration-1)/restart+1
                 << "   Iteration : " << setw(3) << iteration
                 << "  || r || = " << res_norm << endl;
+      if (iteration % restart == 0)
+      {
+         mfem::out << "Restarting..." << endl;
+      }
    }
 }
 
@@ -601,7 +609,7 @@ void CGSolver::Mult(const Vector &b, Vector &x) const
    MFEM_ASSERT(IsFinite(den), "den = " << den);
    if (den <= 0.0)
    {
-      if (Dot(d, d) > 0.0 && print_level >= 0)
+      if (Dot(d, d) > 0.0 && monitor->GetPrintLevel() >= 0)
       {
          mfem::out << "PCG: The operator is not positive definite. (Ad, d) = "
                    << den << '\n';
@@ -664,7 +672,7 @@ void CGSolver::Mult(const Vector &b, Vector &x) const
       MFEM_ASSERT(IsFinite(den), "den = " << den);
       if (den <= 0.0)
       {
-         if (Dot(d, d) > 0.0 && print_level >= 0)
+         if (Dot(d, d) > 0.0 && monitor->GetPrintLevel() >= 0)
          {
             mfem::out << "PCG: The operator is not positive definite. (Ad, d) = "
                       << den << '\n';
@@ -879,11 +887,6 @@ void GMRESSolver::Mult(const Vector &b, Vector &x) const
          monitor->IterationInfo(j, resid);
       }
 
-      if (print_level == 1 && j <= max_iter)
-      {
-         mfem::out << "Restarting..." << '\n';
-      }
-
       Update(x, i-1, H, s, v);
 
       oper->Mult(x, r);
@@ -1034,11 +1037,6 @@ void FGMRESSolver::Mult(const Vector &b, Vector &x) const
             }
             return;
          }
-      }
-
-      if (print_level == 1)
-      {
-         mfem::out << "Restarting..." << endl;
       }
 
       Update(x, i-1, H, s, z);

--- a/linalg/solvers.cpp
+++ b/linalg/solvers.cpp
@@ -87,6 +87,34 @@ void CGLegacyMonitor::NoConvergenceInfo(int iteration, double res_norm,
    }
 }
 
+void GMRESLegacyMonitor::BeginInfo(int iteration, double res_norm)
+{
+}
+
+void GMRESLegacyMonitor::IterationInfo(int iteration, double res_norm)
+{
+}
+
+void GMRESLegacyMonitor::IterationInfo(int pass, int iteration, double res_norm)
+{
+   if (print_level == 1 || print_level == 3)
+   {
+      mfem::out << "   Pass : " << setw(2) << pass
+                << "   Iteration : " << setw(3) << iteration
+                << "  ||B r|| = " << res_norm
+                << (print_level == 3 ? " ...\n" : "\n");
+   }
+}
+
+void GMRESLegacyMonitor::ConvergenceInfo(int iteration, double res_norm,
+                                         double initial_norm)
+{
+}
+
+void GMRESLegacyMonitor::NoConvergenceInfo(int iteration, double res_norm,
+                                           double initial_norm)
+{
+}
 
 IterativeSolver::IterativeSolver()
    : Solver(0, true)
@@ -629,7 +657,7 @@ void GMRESSolver::Mult(const Vector &b, Vector &x) const
 {
    // Generalized Minimum Residual method following the algorithm
    // on p. 20 of the SIAM Templates book.
-
+   monitor->SetPrintLevel(print_level);
    int n = width;
 
    DenseMatrix H(m+1, m);
@@ -685,12 +713,15 @@ void GMRESSolver::Mult(const Vector &b, Vector &x) const
       goto finish;
    }
 
+   monitor->IterationInfo(1, 0, beta);
+   /*
    if (print_level == 1 || print_level == 3)
    {
       mfem::out << "   Pass : " << setw(2) << 1
                 << "   Iteration : " << setw(3) << 0
                 << "  ||B r|| = " << beta << (print_level == 3 ? " ...\n" : "\n");
    }
+   */
 
    v.SetSize(m+1, NULL);
 
@@ -746,9 +777,12 @@ void GMRESSolver::Mult(const Vector &b, Vector &x) const
 
          if (print_level == 1)
          {
+            monitor->IterationInfo((j-1)/m+1, j, resid);
+            /*
             mfem::out << "   Pass : " << setw(2) << (j-1)/m+1
                       << "   Iteration : " << setw(3) << j
                       << "  ||B r|| = " << resid << '\n';
+            */
          }
       }
 

--- a/linalg/solvers.cpp
+++ b/linalg/solvers.cpp
@@ -24,26 +24,26 @@ namespace mfem
 
 using namespace std;
 
-void CGLegacyMonitor::BeginInfo(int iteration, double res_norm_squared)
+void CGLegacyMonitor::BeginInfo(int iteration, double res_norm)
 {
    if (print_level == 1 || print_level == 3)
    {
       mfem::out << "   Iteration : " << setw(3) << iteration << "  (B r, r) = "
-                << res_norm_squared << (print_level == 3 ? " ...\n" : "\n");
+                << res_norm*res_norm << (print_level == 3 ? " ...\n" : "\n");
    }
 }
 
-void CGLegacyMonitor::IterationInfo(int iteration, double res_norm_squared)
+void CGLegacyMonitor::IterationInfo(int iteration, double res_norm)
 {
    if (print_level == 1)
    {
       mfem::out << "   Iteration : " << setw(3) << iteration << "  (B r, r) = "
-                << res_norm_squared << '\n';
+                << res_norm*res_norm << '\n';
    }
 }
 
-void CGLegacyMonitor::ConvergenceInfo(int iteration, double res_norm_squared,
-                                      double initial_norm_squared)
+void CGLegacyMonitor::ConvergenceInfo(int iteration, double res_norm,
+                                      double initial_norm)
 {
    if (print_level == 2)
    {
@@ -52,18 +52,18 @@ void CGLegacyMonitor::ConvergenceInfo(int iteration, double res_norm_squared,
    else if (print_level == 3)
    {
       mfem::out << "   Iteration : " << setw(3) << iteration << "  (B r, r) = "
-                << res_norm_squared << '\n';
+                << res_norm*res_norm << '\n';
    }
    if (print_level >= 1)
    {
       mfem::out << "Average reduction factor = "
-                << pow(res_norm_squared/initial_norm_squared,
+                << pow(res_norm*res_norm/(initial_norm*initial_norm),
                        0.5/iteration) << '\n';
    }
 }
 
-void CGLegacyMonitor::NoConvergenceInfo(int iteration, double res_norm_squared,
-                                        double initial_norm_squared)
+void CGLegacyMonitor::NoConvergenceInfo(int iteration, double res_norm,
+                                        double initial_norm)
 {
    if (print_level >= 0)
    {
@@ -72,17 +72,17 @@ void CGLegacyMonitor::NoConvergenceInfo(int iteration, double res_norm_squared,
          if (print_level != 3)
          {
             mfem::out << "   Iteration : " << setw(3) << 0 << "  (B r, r) = "
-                      << initial_norm_squared << " ...\n";
+                      << initial_norm*initial_norm << " ...\n";
          }
          mfem::out << "   Iteration : " << setw(3) << iteration << "  (B r, r) = "
-                   << res_norm_squared << '\n';
+                   << res_norm*res_norm << '\n';
       }
       mfem::out << "PCG: No convergence!" << '\n';
    }
    if (print_level >= 0)
    {
       mfem::out << "Average reduction factor = "
-                << pow(res_norm_squared/initial_norm_squared,
+                << pow(res_norm*res_norm/(initial_norm*initial_norm),
                        0.5/iteration) << '\n';
    }
 }
@@ -448,7 +448,7 @@ void CGSolver::Mult(const Vector &b, Vector &x) const
    MFEM_ASSERT(IsFinite(nom), "nom = " << nom);
 
    monitor->SetPrintLevel(print_level);
-   monitor->BeginInfo(0, nom);
+   monitor->BeginInfo(0, sqrt(nom));
 
    r0 = std::max(nom*rel_tol*rel_tol, abs_tol*abs_tol);
    if (nom <= r0)
@@ -498,11 +498,11 @@ void CGSolver::Mult(const Vector &b, Vector &x) const
       }
       MFEM_ASSERT(IsFinite(betanom), "betanom = " << betanom);
 
-      monitor->IterationInfo(i, betanom);
+      monitor->IterationInfo(i, sqrt(betanom));
 
       if (betanom < r0)
       {
-         monitor->ConvergenceInfo(i, betanom, nom0);
+         monitor->ConvergenceInfo(i, sqrt(betanom), sqrt(nom0));
          converged = 1;
          final_iter = i;
          break;
@@ -542,7 +542,7 @@ void CGSolver::Mult(const Vector &b, Vector &x) const
    }
    if (!converged)
    {
-      monitor->NoConvergenceInfo(final_iter, betanom, nom0);
+      monitor->NoConvergenceInfo(final_iter, sqrt(betanom), sqrt(nom0));
    }
    final_norm = sqrt(betanom);
 }

--- a/linalg/solvers.cpp
+++ b/linalg/solvers.cpp
@@ -24,6 +24,24 @@ namespace mfem
 
 using namespace std;
 
+void CGLegacyMonitor::BeginInfo(int iteration, double res_norm_squared)
+{
+   if (print_level == 1 || print_level == 3)
+   {
+      mfem::out << "   Iteration : " << setw(3) << iteration << "  (B r, r) = "
+                << res_norm_squared << (print_level == 3 ? " ...\n" : "\n");
+   }
+}
+
+void CGLegacyMonitor::IterationInfo(int iteration, double res_norm_squared)
+{
+   if (print_level == 1)
+   {
+      mfem::out << "   Iteration : " << setw(3) << iteration << "  (B r, r) = "
+                << res_norm_squared << '\n';
+   }
+}
+
 IterativeSolver::IterativeSolver()
    : Solver(0, true)
 {
@@ -383,11 +401,8 @@ void CGSolver::Mult(const Vector &b, Vector &x) const
    nom0 = nom = Dot(d, r);
    MFEM_ASSERT(IsFinite(nom), "nom = " << nom);
 
-   if (print_level == 1 || print_level == 3)
-   {
-      mfem::out << "   Iteration : " << setw(3) << 0 << "  (B r, r) = "
-                << nom << (print_level == 3 ? " ...\n" : "\n");
-   }
+   monitor->SetPrintLevel(print_level);
+   monitor->BeginInfo(0, nom);
 
    r0 = std::max(nom*rel_tol*rel_tol, abs_tol*abs_tol);
    if (nom <= r0)
@@ -437,11 +452,7 @@ void CGSolver::Mult(const Vector &b, Vector &x) const
       }
       MFEM_ASSERT(IsFinite(betanom), "betanom = " << betanom);
 
-      if (print_level == 1)
-      {
-         mfem::out << "   Iteration : " << setw(3) << i << "  (B r, r) = "
-                   << betanom << '\n';
-      }
+      monitor->IterationInfo(i, betanom);
 
       if (betanom < r0)
       {

--- a/linalg/solvers.hpp
+++ b/linalg/solvers.hpp
@@ -43,7 +43,6 @@ public:
 
    virtual ~IterativeSolverMonitor() { }
 
-   /// outputs for pl 1 or 3
    virtual void BeginInfo(int iteration, double res_norm) = 0;
 
    virtual void IterationInfo(int iteration, double res_norm) = 0;
@@ -80,12 +79,13 @@ public:
 
 /// todo: this one needs to somehow get "pass"
 /// does that go in the interface, or specialized to this one?
-/// (FGMRES too)
+/// (FGMRES too) (check with ./ex14p -s 1)
 class GMRESLegacyMonitor : public IterativeSolverMonitor
 {
 public:
    void BeginInfo(int iteration, double res_norm);
    void IterationInfo(int iteration, double res_norm);
+   void IterationInfo(int pass, int iteration, double res_norm);
    void ConvergenceInfo(int iteration, double res_norm,
                         double initial_norm);
    void NoConvergenceInfo(int iteration, double res_norm,
@@ -232,7 +232,9 @@ public:
    CGSolver() : monitor(new CGLegacyMonitor) { }
 
 #ifdef MFEM_USE_MPI
-   CGSolver(MPI_Comm _comm) : IterativeSolver(_comm) { }
+   CGSolver(MPI_Comm _comm) : IterativeSolver(_comm),
+                              monitor(new CGLegacyMonitor)
+   { }
 #endif
 
    ~CGSolver() { delete monitor; }
@@ -260,11 +262,15 @@ class GMRESSolver : public IterativeSolver
 protected:
    int m; // see SetKDim()
 
+   IterativeSolverMonitor * monitor;
+
 public:
-   GMRESSolver() { m = 50; }
+   GMRESSolver() : monitor(new GMRESLegacyMonitor) { m = 50; }
 
 #ifdef MFEM_USE_MPI
-   GMRESSolver(MPI_Comm _comm) : IterativeSolver(_comm) { m = 50; }
+   GMRESSolver(MPI_Comm _comm) : IterativeSolver(_comm),
+                                 monitor(new GMRESLegacyMonitor)
+   { m = 50; }
 #endif
 
    /// Set the number of iteration to perform between restarts, default is 50.

--- a/linalg/solvers.hpp
+++ b/linalg/solvers.hpp
@@ -44,34 +44,61 @@ public:
    virtual ~IterativeSolverMonitor() { }
 
    /// outputs for pl 1 or 3
-   virtual void BeginInfo(int iteration, double res_norm_squared) = 0;
+   virtual void BeginInfo(int iteration, double res_norm) = 0;
 
-   virtual void IterationInfo(int iteration, double res_norm_squared) = 0;
+   virtual void IterationInfo(int iteration, double res_norm) = 0;
+   virtual void IterationInfo(int pass, int iteration, double res_norm)
+   {
+      IterationInfo(iteration, res_norm);
+   }
 
-   virtual void ConvergenceInfo(int iteration, double res_norm_squared,
-                                double initial_norm_square) = 0;
+   virtual void ConvergenceInfo(int iteration, double res_norm,
+                                double initial_norm) = 0;
 
-   virtual void NoConvergenceInfo(int iteration, double res_norm_squared,
-                                  double initial_norm_square) = 0;
+   virtual void NoConvergenceInfo(int iteration, double res_norm,
+                                  double initial_norm) = 0;
 
    /// outputs for pl >= 0
    virtual void Alert(std::string& message) = 0;
 };
 
+/// SLI will be very similar to this
 class CGLegacyMonitor : public IterativeSolverMonitor
 {
 public:
-   void BeginInfo(int iteration, double res_norm_squared);
-   void IterationInfo(int iteration, double res_norm_squared);
-   void ConvergenceInfo(int iteration, double res_norm_squared,
-                        double initial_norm_square);
-   void NoConvergenceInfo(int iteration, double res_norm_squared,
-                          double initial_norm_square);
+   void BeginInfo(int iteration, double res_norm);
+   void IterationInfo(int iteration, double res_norm);
+   void ConvergenceInfo(int iteration, double res_norm,
+                        double initial_norm);
+   void NoConvergenceInfo(int iteration, double res_norm,
+                          double initial_norm);
    
    void Alert(std::string& message)
    {
    }
 };
+
+/// todo: this one needs to somehow get "pass"
+/// does that go in the interface, or specialized to this one?
+/// (FGMRES too)
+class GMRESLegacyMonitor : public IterativeSolverMonitor
+{
+public:
+   void BeginInfo(int iteration, double res_norm);
+   void IterationInfo(int iteration, double res_norm);
+   void ConvergenceInfo(int iteration, double res_norm,
+                        double initial_norm);
+   void NoConvergenceInfo(int iteration, double res_norm,
+                          double initial_norm);
+   
+   void Alert(std::string& message)
+   {
+   }
+};
+
+/// Minres, bicgstab are fine...
+/// Newton will be just a bit different (but quite doable)
+/// and SLBQP probably does not fit in this framework
 
 /// Abstract base class for iterative solver
 class IterativeSolver : public Solver

--- a/linalg/solvers.hpp
+++ b/linalg/solvers.hpp
@@ -33,6 +33,9 @@ class BilinearForm;
 /// TODO:
 /// - name instead of leading_spaces?
 /// - have the base IterativeSolver class own this
+/// - alerts etc?
+/// (BICGStab, MINRES, Newton remain)
+/// (also OptimizationSolver, but that seems different?)
 class IterativeSolverMonitor
 {
 protected:
@@ -41,6 +44,7 @@ protected:
    int leading_spaces;
 
 public:
+   int GetPrintLevel() const { return print_level; }
    void SetPrintLevel(int pl) { print_level = pl; }
 
    virtual ~IterativeSolverMonitor() { }
@@ -112,7 +116,7 @@ public:
    }
 };
 
-/// FGMRES check with ./ex22p
+/// FGMRES check with ./ex22p --no-visualization
 class FGMRESLegacyMonitor : public IterativeSolverMonitor
 {
 private:

--- a/linalg/solvers.hpp
+++ b/linalg/solvers.hpp
@@ -71,8 +71,24 @@ public:
    }
 };
 
-/// todo: this one needs to somehow get "pass"
-/// does that go in the interface, or specialized to this one?
+class SLILegacyMonitor : public IterativeSolverMonitor
+{
+private:
+   double nomold;
+
+public:
+   void BeginInfo(int iteration, double res_norm);
+   void IterationInfo(int iteration, double res_norm);
+   void ConvergenceInfo(int iteration, double res_norm,
+                        double initial_norm);
+   void NoConvergenceInfo(int iteration, double res_norm,
+                          double initial_norm);
+   
+   void Alert(std::string& message)
+   {
+   }
+};
+
 /// (FGMRES too) (check with ./ex14p -s 1)
 class GMRESLegacyMonitor : public IterativeSolverMonitor
 {
@@ -192,12 +208,18 @@ protected:
 
    void UpdateVectors();
 
+   IterativeSolverMonitor * monitor;
+
 public:
-   SLISolver() { }
+   SLISolver() : monitor(new SLILegacyMonitor) { }
 
 #ifdef MFEM_USE_MPI
-   SLISolver(MPI_Comm _comm) : IterativeSolver(_comm) { }
+   SLISolver(MPI_Comm _comm) : IterativeSolver(_comm),
+                               monitor(new SLILegacyMonitor)
+   { }
 #endif
+
+   ~SLISolver() { delete monitor; }
 
    virtual void SetOperator(const Operator &op)
    { IterativeSolver::SetOperator(op); UpdateVectors(); }

--- a/linalg/solvers.hpp
+++ b/linalg/solvers.hpp
@@ -137,6 +137,30 @@ public:
    }
 };
 
+/**
+   this one has two different norms potentially outputted, ||s|| and ||r||,
+   not easy to unify interface
+ */
+class BiCGSTABLegacyMonitor : public IterativeSolverMonitor
+{
+private:
+   int restart;
+
+public:
+   BiCGSTABLegacyMonitor(int m_) : restart(m_) { }
+
+   void BeginInfo(int iteration, double res_norm);
+   void IterationInfo(int iteration, double res_norm);
+   void ConvergenceInfo(int iteration, double res_norm,
+                        double initial_norm);
+   void NoConvergenceInfo(int iteration, double res_norm,
+                          double initial_norm);
+   
+   void Alert(std::string& message)
+   {
+   }
+};
+
 /// Minres, bicgstab are fine...
 /// Newton will be just a bit different (but quite doable)
 /// and SLBQP probably does not fit in this framework
@@ -379,12 +403,16 @@ protected:
 
    void UpdateVectors();
 
+   IterativeSolverMonitor * monitor;
+
 public:
-   BiCGSTABSolver() { }
+   BiCGSTABSolver() : monitor(new BiCGSTABLegacyMonitor) { }
 
 #ifdef MFEM_USE_MPI
-   BiCGSTABSolver(MPI_Comm _comm) : IterativeSolver(_comm) { }
+   BiCGSTABSolver(MPI_Comm _comm) : IterativeSolver(_comm),
+                                    monitor(new BiCGSTABLegacyMonitor) { }
 #endif
+   ~BiCGSTABSolver() { delete monitor; }
 
    virtual void SetOperator(const Operator &op)
    { IterativeSolver::SetOperator(op); UpdateVectors(); }

--- a/linalg/solvers.hpp
+++ b/linalg/solvers.hpp
@@ -63,16 +63,10 @@ class CGLegacyMonitor : public IterativeSolverMonitor
 public:
    void BeginInfo(int iteration, double res_norm_squared);
    void IterationInfo(int iteration, double res_norm_squared);
-
    void ConvergenceInfo(int iteration, double res_norm_squared,
-                        double initial_norm_square)
-   {
-   }
-
+                        double initial_norm_square);
    void NoConvergenceInfo(int iteration, double res_norm_squared,
-                          double initial_norm_square)
-   {
-   }
+                          double initial_norm_square);
    
    void Alert(std::string& message)
    {


### PR DESCRIPTION
The main idea here is an abstract `IterativeSolverMonitor` class that allows for more flexibility in how residuals etc. are reported in various `IterativeSolver`s.

The dream was to implement several `Legacy` monitors that would duplicate exactly the output from the current solvers, and then over the next couple versions of MFEM to mark those as deprecated and move to a more unified interface, and also one where users could write and use their own monitors.

After a little work, I decided this interface / framework was not workable. In particular, I could not figure out a unified interface for different *kinds* of residual information, for example in `BiCGSTAB` which prints two different kinds of residuals at each iteration. But perhaps someone can learn from my mistakes now that something like this is being considered.