### PR TITLE
Bug in TMOP's AdvectorCG.

### DIFF
--- a/fem/tmop_tools.hpp
+++ b/fem/tmop_tools.hpp
@@ -28,8 +28,12 @@ private:
    Vector nodes0;
    Vector field0;
 
+   const double dt_scale;
+
 public:
-   AdvectorCG() : AdaptivityEvaluator(), ode_solver(), nodes0(), field0() { }
+   AdvectorCG(double timestep_scale = 0.5)
+      : AdaptivityEvaluator(),
+        ode_solver(), nodes0(), field0(), dt_scale(timestep_scale) { }
 
    virtual void SetInitialField(const Vector &init_nodes,
                                 const Vector &init_field);


### PR DESCRIPTION
Fixed a parallel communication bug in tmop's AdvectorCG.
Some autotests might differ as this improves slightly the computation.
<!--GHEX{"id":1387,"author":"vladotomov","editor":"tzanio","reviewers":["tzanio","kmittal2"],"assignment":"2020-03-30T16:52:24-07:00","approval":"2020-03-31T00:19:12.261Z","merge":"2020-03-31T19:17:47.022Z"}XEHG--><!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge| 
 | --- | --- | --- | --- | --- | --- | --- | 
| [#1387](https://github.com/mfem/mfem/pull/1387) | @vladotomov | @tzanio | @tzanio + @kmittal2 | 03/30/20 | 03/30/20 | 03/31/20 | |
<!--ELBATXEHG-->