### PR TITLE
[barker29/cg-converged-bugfix] add checks for indefinite preconditioner in CGSolver

### DIFF
--- a/linalg/solvers.cpp
+++ b/linalg/solvers.cpp
@@ -388,7 +388,6 @@ void CGSolver::Mult(const Vector &b, Vector &x) const
                 << nom << (print_level == 3 ? " ...\n" : "\n");
    }
 
-   r0 = std::max(nom*rel_tol*rel_tol, abs_tol*abs_tol);
    if (nom < 0.0)
    {
       if (print_level >= 0)
@@ -401,6 +400,7 @@ void CGSolver::Mult(const Vector &b, Vector &x) const
       final_norm = nom;
       return;
    }
+   r0 = std::max(nom*rel_tol*rel_tol, abs_tol*abs_tol);
    if (nom <= r0)
    {
       converged = 1;

--- a/linalg/solvers.cpp
+++ b/linalg/solvers.cpp
@@ -382,7 +382,6 @@ void CGSolver::Mult(const Vector &b, Vector &x) const
    }
    nom0 = nom = Dot(d, r);
    MFEM_ASSERT(IsFinite(nom), "nom = " << nom);
-
    if (print_level == 1 || print_level == 3)
    {
       mfem::out << "   Iteration : " << setw(3) << 0 << "  (B r, r) = "
@@ -390,6 +389,18 @@ void CGSolver::Mult(const Vector &b, Vector &x) const
    }
 
    r0 = std::max(nom*rel_tol*rel_tol, abs_tol*abs_tol);
+   if (nom < 0.0)
+   {
+      if (print_level >= 0)
+      {
+         mfem::out << "PCG: The preconditioner is not positive definite. (Br, r) = "
+                   << nom << '\n';
+      }
+      converged = 0;
+      final_iter = 0;
+      final_norm = nom;
+      return;
+   }
    if (nom <= r0)
    {
       converged = 1;
@@ -436,6 +447,17 @@ void CGSolver::Mult(const Vector &b, Vector &x) const
          betanom = Dot(r, r);
       }
       MFEM_ASSERT(IsFinite(betanom), "betanom = " << betanom);
+      if (betanom < 0.0)
+      {
+         if (print_level >= 0)
+         {
+            mfem::out << "PCG: The preconditioner is not positive definite. (Br, r) = "
+                      << betanom << '\n';
+         }
+         converged = 0;
+         final_iter = i;
+         break;
+      }
 
       if (print_level == 1)
       {

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -30,6 +30,7 @@ set(UNIT_TESTS_SRCS
   linalg/test_ode.cpp
   linalg/test_ode2.cpp
   linalg/test_operator.cpp
+  linalg/test_cg_indefinite.cpp
   mesh/test_mesh.cpp
   fem/test_1d_bilininteg.cpp
   fem/test_2d_bilininteg.cpp

--- a/tests/unit/linalg/test_cg_indefinite.cpp
+++ b/tests/unit/linalg/test_cg_indefinite.cpp
@@ -39,17 +39,16 @@ TEST_CASE("CGSolver", "[Indefinite]")
    Vector x(2);
    x = 0.0;
 
-   // check indefinite operator - this particular example
-   // does not make sense with CG and should not converge
+   // Check indefinite operator - this particular example does not make sense
+   // with CG and should not converge
    CGSolver cg;
    cg.SetOperator(indefinite);
    cg.SetPrintLevel(1);
    cg.Mult(v, x);
    REQUIRE(!cg.GetConverged());
 
-   // check indefinite preconditioner - this particular
-   // example does not make sense with CG and should not
-   // converge
+   // Check indefinite preconditioner - this particular example does not make
+   // sense with CG and should not converge
    IdentityOperator identity(2);
    FakeSolver indefprec(indefinite);
    CGSolver cg2;

--- a/tests/unit/linalg/test_cg_indefinite.cpp
+++ b/tests/unit/linalg/test_cg_indefinite.cpp
@@ -1,0 +1,59 @@
+// Copyright (c) 2010-2020, Lawrence Livermore National Security, LLC. Produced
+// at the Lawrence Livermore National Laboratory. All Rights reserved. See files
+// LICENSE and NOTICE for details. LLNL-CODE-806117.
+//
+// This file is part of the MFEM library. For more information and source code
+// availability visit https://mfem.org.
+//
+// MFEM is free software; you can redistribute it and/or modify it under the
+// terms of the BSD-3 license. We welcome feedback and contributions, see file
+// CONTRIBUTING.md for details.
+
+#include "mfem.hpp"
+#include "catch.hpp"
+
+using namespace mfem;
+
+class FakeSolver : public Solver
+{
+private:
+   Operator& op;
+
+public:
+   FakeSolver(Operator& op_) : Solver(op_.Height()), op(op_) { }
+   void SetOperator(const Operator &op) { }
+   void Mult(const Vector& x, Vector& y) const { op.Mult(x, y); }
+};
+
+TEST_CASE("CGSolver", "[Indefinite]")
+{
+   // Define indefinite SparseMatrix
+   SparseMatrix indefinite(2, 2);
+   indefinite.Add(0, 1, 1.0);
+   indefinite.Add(1, 0, 1.0);
+   indefinite.Finalize();
+
+   Vector v(2);
+   v(0) = 1.0;
+   v(1) = -1.0;
+   Vector x(2);
+   x = 0.0;
+
+   // check indefinite operator
+   CGSolver cg;
+   cg.SetOperator(indefinite);
+   cg.SetPrintLevel(1);
+   cg.Mult(v, x);
+   REQUIRE(!cg.GetConverged());
+
+   // check indefinite preconditioner
+   IdentityOperator identity(2);
+   FakeSolver indefprec(indefinite);
+   CGSolver cg2;
+   cg2.SetOperator(identity);
+   cg2.SetPreconditioner(indefprec);
+   cg2.SetPrintLevel(1);
+   x = 0.0;
+   cg2.Mult(v, x);
+   REQUIRE(!cg2.GetConverged());
+}

--- a/tests/unit/linalg/test_cg_indefinite.cpp
+++ b/tests/unit/linalg/test_cg_indefinite.cpp
@@ -39,14 +39,17 @@ TEST_CASE("CGSolver", "[Indefinite]")
    Vector x(2);
    x = 0.0;
 
-   // check indefinite operator
+   // check indefinite operator - this particular example
+   // does not make sense with CG and should not converge
    CGSolver cg;
    cg.SetOperator(indefinite);
    cg.SetPrintLevel(1);
    cg.Mult(v, x);
    REQUIRE(!cg.GetConverged());
 
-   // check indefinite preconditioner
+   // check indefinite preconditioner - this particular
+   // example does not make sense with CG and should not
+   // converge
    IdentityOperator identity(2);
    FakeSolver indefprec(indefinite);
    CGSolver cg2;


### PR DESCRIPTION
Current if `CGSolver` has an indefinite preconditioner, it may get a negative `(Br, r)` inner product, compare that to desired tolerance, and conclude that the iteration has converged. This PR adds a check to catch that and correctly report `GetConverged() == 0`.
<!--GHEX{"id":1391,"author":"barker29","editor":"tzanio","reviewers":["delyank","dylan-copeland"],"assignment":"2020-04-01T13:09:01-07:00","approval":"2020-04-07T16:23:05.449Z","merge":"2020-04-10T00:10:45.300Z"}XEHG--><!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge| 
 | --- | --- | --- | --- | --- | --- | --- | 
| [#1391](https://github.com/mfem/mfem/pull/1391) | @barker29 | @tzanio | @delyank + @dylan-copeland | 04/01/20 | 04/07/20 | 04/09/20 | |
<!--ELBATXEHG-->