### PR TITLE
Combinations of TMOPIntegrators

### DIFF
--- a/fem/tmop.cpp
+++ b/fem/tmop.cpp
@@ -991,7 +991,6 @@ void DiscreteAdaptTC::SetSerialDiscreteTargetSpec(GridFunction &tspec_)
    (*tspec_.FESpace()->GetMesh()->GetNodes(), tspec);
 
    tspec_sav = tspec;
-   good_tspec = true;
 }
 
 void DiscreteAdaptTC::UpdateTargetSpecification(const Vector &new_x,

--- a/fem/tmop.hpp
+++ b/fem/tmop.hpp
@@ -793,7 +793,6 @@ public:
 };
 
 class TMOPNewtonSolver;
-class TMOPDescentNewtonSolver;
 
 /** @brief A TMOP integrator class based on any given TMOP_QualityMetric and
     TargetConstructor.
@@ -806,7 +805,6 @@ class TMOP_Integrator : public NonlinearFormIntegrator
 {
 protected:
    friend class TMOPNewtonSolver;
-   friend class TMOPDescentNewtonSolver;
    friend class TMOPComboIntegrator;
 
    TMOP_QualityMetric *metric;        // not owned

--- a/fem/tmop_tools.cpp
+++ b/fem/tmop_tools.cpp
@@ -411,28 +411,55 @@ double TMOPNewtonSolver::ComputeScalingFactor(const Vector &x,
 
 void TMOPNewtonSolver::ProcessNewState(const Vector &x) const
 {
+   const NonlinearForm *nlf = dynamic_cast<const NonlinearForm *>(oper);
+   const Array<NonlinearFormIntegrator*> &integs = *nlf->GetDNFI();
+
+   // Reset the update flags of all TargetConstructors.
+   // This is done to avoid repeated updates of shared TargetConstructors.
+   TMOP_Integrator *ti  = NULL;
+   TMOPComboIntegrator *co = NULL;
+   DiscreteAdaptTC *dtc = NULL;
+   for (int i = 0; i<integs.Size(); i++)
+   {
+      ti = dynamic_cast<TMOP_Integrator *>(integs[i]);
+      if (ti)  { dtc = ti->GetDiscreteAdaptTC(); }
+      if (dtc) { dtc->ResetUpdateFlags(); }
+      co = dynamic_cast<TMOPComboIntegrator *>(integs[i]);
+      if (co)
+      {
+         Array<TMOP_Integrator *> ati = co->GetTMOPIntegrators();
+         for (int j = 0; j < ati.Size(); j++)
+         {
+            dtc = ati[j]->GetDiscreteAdaptTC();
+            if (dtc) { dtc->ResetUpdateFlags(); }
+         }
+      }
+   }
+
    if (parallel)
    {
 #ifdef MFEM_USE_MPI
       const ParNonlinearForm *nlf =
          dynamic_cast<const ParNonlinearForm *>(oper);
-      const Array<NonlinearFormIntegrator*> &integs = *nlf->GetDNFI();
       const ParFiniteElementSpace *pfesc = nlf->ParFESpace();
       Vector x_loc(pfesc->GetVSize());
       pfesc->GetProlongationMatrix()->Mult(x, x_loc);
       for (int i=0; i<integs.Size(); i++)
       {
-         TMOP_Integrator *tmopi = dynamic_cast<TMOP_Integrator *>(integs[i]);
-         DiscreteAdaptTC *discrtc = tmopi->GetDiscreteAdaptTC();
-         tmopi->ComputeFDh(x_loc, *pfesc);
-         if (discrtc)
+         ti = dynamic_cast<TMOP_Integrator *>(integs[i]);
+         if (ti)
          {
-            discrtc->UpdateTargetSpecification(x_loc);
-            double dx = tmopi->GetFDh();
-            if (tmopi->GetFDFlag())
+            ti->ComputeFDh(x_loc, *pfesc);
+            UpdateDiscreteTC(*ti, x_loc);
+         }
+         co = dynamic_cast<TMOPComboIntegrator *>(integs[i]);
+         if (co)
+         {
+            Array<TMOP_Integrator *> ati = co->GetTMOPIntegrators();
+            for (int j = 0; j < ati.Size(); j++)
             {
-               discrtc->UpdateGradientTargetSpecification(x_loc, dx);
-               discrtc->UpdateHessianTargetSpecification(x_loc, dx);
+               ati[j]->ComputeFDh(x_loc, *pfesc);
+               UpdateDiscreteTC(*ati[j], x_loc);
             }
          }
       }
@@ -440,9 +467,6 @@ void TMOPNewtonSolver::ProcessNewState(const Vector &x) const
    }
    else
    {
-      const NonlinearForm *nlf =
-         dynamic_cast<const NonlinearForm *>(oper);
-      const Array<NonlinearFormIntegrator*> &integs = *nlf->GetDNFI();
       const FiniteElementSpace *fesc = nlf->FESpace();
       const Operator *P = nlf->GetProlongation();
       Vector x_loc;
@@ -457,19 +481,39 @@ void TMOPNewtonSolver::ProcessNewState(const Vector &x) const
       }
       for (int i=0; i<integs.Size(); i++)
       {
-         TMOP_Integrator *tmopi = dynamic_cast<TMOP_Integrator *>(integs[i]);
-         DiscreteAdaptTC *discrtc = tmopi->GetDiscreteAdaptTC();
-         tmopi->ComputeFDh(x_loc, *fesc);
-         if (discrtc)
+         ti = dynamic_cast<TMOP_Integrator *>(integs[i]);
+         if (ti)
          {
-            discrtc->UpdateTargetSpecification(x);
-            double dx = tmopi->GetFDh();
-            if (tmopi->GetFDFlag())
+            ti->ComputeFDh(x_loc, *fesc);
+            UpdateDiscreteTC(*ti, x_loc);
+         }
+         co = dynamic_cast<TMOPComboIntegrator *>(integs[i]);
+         if (co)
+         {
+            Array<TMOP_Integrator *> ati = co->GetTMOPIntegrators();
+            for (int j = 0; j < ati.Size(); j++)
             {
-               discrtc->UpdateGradientTargetSpecification(x_loc, dx);
-               discrtc->UpdateHessianTargetSpecification(x_loc, dx);
+               ati[j]->ComputeFDh(x_loc, *fesc);
+               UpdateDiscreteTC(*ati[j], x_loc);
             }
          }
+      }
+   }
+}
+
+void TMOPNewtonSolver::UpdateDiscreteTC(const TMOP_Integrator &ti,
+                                        const Vector &x_new) const
+{
+   const bool update_flag = true;
+   DiscreteAdaptTC *discrtc = ti.GetDiscreteAdaptTC();
+   if (discrtc)
+   {
+      discrtc->UpdateTargetSpecification(x_new, update_flag);
+      if (ti.GetFDFlag())
+      {
+         double dx = ti.GetFDh();
+         discrtc->UpdateGradientTargetSpecification(x_new, dx, update_flag);
+         discrtc->UpdateHessianTargetSpecification(x_new, dx, update_flag);
       }
    }
 }
@@ -571,71 +615,6 @@ double TMOPDescentNewtonSolver::ComputeScalingFactor(const Vector &x,
    if (x_out_ok == false) { return 0.0; }
 
    return scale;
-}
-
-void TMOPDescentNewtonSolver::ProcessNewState(const Vector &x) const
-{
-   if (parallel)
-   {
-#ifdef MFEM_USE_MPI
-      const ParNonlinearForm *nlf =
-         dynamic_cast<const ParNonlinearForm *>(oper);
-      const Array<NonlinearFormIntegrator*> &integs = *nlf->GetDNFI();
-      const ParFiniteElementSpace *pfesc = nlf->ParFESpace();
-      Vector x_loc(pfesc->GetVSize());
-      pfesc->GetProlongationMatrix()->Mult(x, x_loc);
-      for (int i=0; i<integs.Size(); i++)
-      {
-         TMOP_Integrator *tmopi = dynamic_cast<TMOP_Integrator *>(integs[i]);
-         DiscreteAdaptTC *discrtc = tmopi->GetDiscreteAdaptTC();
-         tmopi->ComputeFDh(x_loc, *pfesc);
-         if (discrtc)
-         {
-            discrtc->UpdateTargetSpecification(x_loc);
-            double dx = tmopi->GetFDh();
-            if (tmopi->GetFDFlag())
-            {
-               discrtc->UpdateGradientTargetSpecification(x_loc, dx);
-               discrtc->UpdateHessianTargetSpecification(x_loc, dx);
-            }
-         }
-      }
-#endif
-   }
-   else
-   {
-      const NonlinearForm *nlf =
-         dynamic_cast<const NonlinearForm *>(oper);
-      const Array<NonlinearFormIntegrator*> &integs = *nlf->GetDNFI();
-      const FiniteElementSpace *fesc = nlf->FESpace();
-      const Operator *P = nlf->GetProlongation();
-      Vector x_loc;
-      if (P)
-      {
-         x_loc.SetSize(P->Height());
-         P->Mult(x,x_loc);
-      }
-      else
-      {
-         x_loc = x;
-      }
-      for (int i=0; i<integs.Size(); i++)
-      {
-         TMOP_Integrator *tmopi = dynamic_cast<TMOP_Integrator *>(integs[i]);
-         DiscreteAdaptTC *discrtc = tmopi->GetDiscreteAdaptTC();
-         tmopi->ComputeFDh(x_loc, *fesc);
-         if (discrtc)
-         {
-            discrtc->UpdateTargetSpecification(x);
-            double dx = tmopi->GetFDh();
-            if (tmopi->GetFDFlag())
-            {
-               discrtc->UpdateGradientTargetSpecification(x_loc, dx);
-               discrtc->UpdateHessianTargetSpecification(x_loc, dx);
-            }
-         }
-      }
-   }
 }
 
 #ifdef MFEM_USE_MPI

--- a/fem/tmop_tools.cpp
+++ b/fem/tmop_tools.cpp
@@ -422,8 +422,11 @@ void TMOPNewtonSolver::ProcessNewState(const Vector &x) const
    for (int i = 0; i<integs.Size(); i++)
    {
       ti = dynamic_cast<TMOP_Integrator *>(integs[i]);
-      if (ti)  { dtc = ti->GetDiscreteAdaptTC(); }
-      if (dtc) { dtc->ResetUpdateFlags(); }
+      if (ti)
+      {
+         dtc = ti->GetDiscreteAdaptTC();
+         if (dtc) { dtc->ResetUpdateFlags(); }
+      }
       co = dynamic_cast<TMOPComboIntegrator *>(integs[i]);
       if (co)
       {

--- a/fem/tmop_tools.cpp
+++ b/fem/tmop_tools.cpp
@@ -420,7 +420,7 @@ void TMOPNewtonSolver::ProcessNewState(const Vector &x) const
    TMOP_Integrator *ti  = NULL;
    TMOPComboIntegrator *co = NULL;
    DiscreteAdaptTC *dtc = NULL;
-   for (int i = 0; i<integs.Size(); i++)
+   for (int i = 0; i < integs.Size(); i++)
    {
       ti = dynamic_cast<TMOP_Integrator *>(integs[i]);
       if (ti)
@@ -448,7 +448,7 @@ void TMOPNewtonSolver::ProcessNewState(const Vector &x) const
       const ParFiniteElementSpace *pfesc = nlf->ParFESpace();
       Vector x_loc(pfesc->GetVSize());
       pfesc->GetProlongationMatrix()->Mult(x, x_loc);
-      for (int i=0; i<integs.Size(); i++)
+      for (int i = 0; i < integs.Size(); i++)
       {
          ti = dynamic_cast<TMOP_Integrator *>(integs[i]);
          if (ti)
@@ -483,7 +483,7 @@ void TMOPNewtonSolver::ProcessNewState(const Vector &x) const
       {
          x_loc = x;
       }
-      for (int i=0; i<integs.Size(); i++)
+      for (int i = 0; i < integs.Size(); i++)
       {
          ti = dynamic_cast<TMOP_Integrator *>(integs[i]);
          if (ti)

--- a/fem/tmop_tools.cpp
+++ b/fem/tmop_tools.cpp
@@ -84,6 +84,7 @@ void AdvectorCG::ComputeAtNewPosition(const Vector &new_nodes,
    if (v_max == 0.0)
    {
       // No mesh motion --> no need to change the field.
+      delete oper;
       return;
    }
    v_max = std::sqrt(v_max);

--- a/fem/tmop_tools.hpp
+++ b/fem/tmop_tools.hpp
@@ -109,11 +109,13 @@ public:
 
 class TMOPNewtonSolver : public NewtonSolver
 {
-private:
+protected:
    bool parallel;
 
    // Quadrature points that are checked for negative Jacobians etc.
    const IntegrationRule &ir;
+
+   void UpdateDiscreteTC(const TMOP_Integrator &ti, const Vector &x_new) const;
 
 public:
 #ifdef MFEM_USE_MPI
@@ -129,25 +131,17 @@ public:
 };
 
 /// Allows negative Jacobians. Used for untangling.
-class TMOPDescentNewtonSolver : public NewtonSolver
+class TMOPDescentNewtonSolver : public TMOPNewtonSolver
 {
-private:
-   bool parallel;
-
-   // Quadrature points that are checked for negative Jacobians etc.
-   const IntegrationRule &ir;
-
 public:
 #ifdef MFEM_USE_MPI
    TMOPDescentNewtonSolver(MPI_Comm comm, const IntegrationRule &irule)
-      : NewtonSolver(comm), parallel(true), ir(irule) { }
+      : TMOPNewtonSolver(comm, irule) { }
 #endif
    TMOPDescentNewtonSolver(const IntegrationRule &irule)
-      : NewtonSolver(), parallel(false), ir(irule) { }
+      : TMOPNewtonSolver(irule) { }
 
    virtual double ComputeScalingFactor(const Vector &x, const Vector &b) const;
-
-   virtual void ProcessNewState(const Vector &x) const;
 };
 
 void vis_tmop_metric_s(int order, TMOP_QualityMetric &qm,

--- a/miniapps/meshing/mesh-optimizer.cpp
+++ b/miniapps/meshing/mesh-optimizer.cpp
@@ -56,7 +56,7 @@
 //   ICF limited shape:
 //     mesh-optimizer -o 3 -rs 0 -mid 1 -tid 1 -ni 100 -ls 2 -li 100 -bnd -qt 1 -qo 8 -lc 10
 //   ICF combo shape + size (rings, slow convergence):
-//     mesh-optimizer -o 3 -rs 0 -mid 1 -tid 1 -ni 1000 -ls 2 -li 100 -bnd -qt 1 -qo 8 -cmb
+//     mesh-optimizer -o 3 -rs 0 -mid 1 -tid 1 -ni 1000 -ls 2 -li 100 -bnd -qt 1 -qo 8 -cmb 1
 //   3D pinched sphere shape (the mesh is in the mfem/data GitHub repository):
 //   * mesh-optimizer -m ../../../mfem_data/ball-pert.mesh -o 4 -rs 0 -mid 303 -tid 1 -ni 20 -ls 2 -li 500 -fix-bnd
 //   2D non-conforming shape and equal size:

--- a/miniapps/meshing/mesh-optimizer.cpp
+++ b/miniapps/meshing/mesh-optimizer.cpp
@@ -40,7 +40,7 @@
 //     mesh-optimizer -m square01.mesh -o 2 -rs 2 -mid 87 -tid 4 -ni 100 -ls 2 -li 100 -bnd -qt 1 -qo 8 -fd 1
 //   Adapted discrete size:
 //     mesh-optimizer -m square01.mesh -o 2 -rs 2 -mid 7 -tid 5 -ni 200 -ls 2 -li 100 -bnd -qt 1 -qo 8
-//
+//     mesh-optimizer -m square01.mesh -o 2 -rs 2 -mid 2 -tid 5 -ni 200 -ls 2 -li 100 -bnd -qt 1 -qo 8 -cmb 2 -nor
 //   Blade shape:
 //     mesh-optimizer -m blade.mesh -o 4 -rs 0 -mid 2 -tid 1 -ni 200 -ls 2 -li 100 -bnd -qt 1 -qo 8
 //   Blade shape with FD-based solver:
@@ -266,7 +266,7 @@ int main(int argc, char *argv[])
    int lin_solver        = 2;
    int max_lin_iter      = 100;
    bool move_bnd         = true;
-   bool combomet         = 0;
+   int combomet          = 0;
    bool normalization    = false;
    bool visualization    = true;
    int verbosity_level   = 0;
@@ -330,8 +330,11 @@ int main(int argc, char *argv[])
    args.AddOption(&move_bnd, "-bnd", "--move-boundary", "-fix-bnd",
                   "--fix-boundary",
                   "Enable motion along horizontal and vertical boundaries.");
-   args.AddOption(&combomet, "-cmb", "--combo-met", "-no-cmb", "--no-combo-met",
-                  "Combination of metrics.");
+   args.AddOption(&combomet, "-cmb", "--combo-type",
+                  "Combination of metrics options:"
+                  "0: Use single metric\n\t"
+                  "1: Shape + space-dependent size given analytically\n\t"
+                  "2: Shape + adapted size given discretely; shared target");
    args.AddOption(&normalization, "-nor", "--normalization", "-no-nor",
                   "--no-normalization",
                   "Make all terms in the optimization functional unitless.");
@@ -560,29 +563,35 @@ int main(int argc, char *argv[])
    TargetConstructor *target_c2 = NULL;
    FunctionCoefficient coeff2(weight_fun);
 
-   if (combomet == 1)
+   if (combomet > 0)
    {
-      // TODO normalization of combinations.
-      // We will probably drop this example and replace it with adaptivity.
-      if (normalization) { MFEM_ABORT("Not implemented."); }
-
-      // Weight of the original metric.
+      // First metric.
       coeff1 = new ConstantCoefficient(1.0);
       he_nlf_integ->SetCoefficient(*coeff1);
-      a.AddDomainIntegrator(he_nlf_integ);
 
+      // Second metric.
       metric2 = new TMOP_Metric_077;
-      target_c2 = new TargetConstructor(
-         TargetConstructor::IDEAL_SHAPE_EQUAL_SIZE);
-      target_c2->SetVolumeScale(0.01);
-      target_c2->SetNodes(x0);
-      TMOP_Integrator *he_nlf_integ2 = new TMOP_Integrator(metric2, target_c2);
+      TMOP_Integrator *he_nlf_integ2 = NULL;
+      if (combomet == 1)
+      {
+         target_c2 = new TargetConstructor(
+            TargetConstructor::IDEAL_SHAPE_EQUAL_SIZE);
+         target_c2->SetVolumeScale(0.01);
+         target_c2->SetNodes(x0);
+         he_nlf_integ2 = new TMOP_Integrator(metric2, target_c2);
+         he_nlf_integ2->SetCoefficient(coeff2);
+      }
+      else { he_nlf_integ2 = new TMOP_Integrator(metric2, target_c); }
       he_nlf_integ2->SetIntegrationRule(*ir);
       if (fdscheme) { he_nlf_integ2->EnableFiniteDifferences(x); }
 
-      // Weight of metric2.
-      he_nlf_integ2->SetCoefficient(coeff2);
-      a.AddDomainIntegrator(he_nlf_integ2);
+      TMOPComboIntegrator *combo = new TMOPComboIntegrator;
+      combo->AddTMOPIntegrator(he_nlf_integ);
+      combo->AddTMOPIntegrator(he_nlf_integ2);
+      if (normalization) { combo->EnableNormalization(x0); }
+      if (lim_const != 0.0) { combo->EnableLimiting(x0, dist, lim_coeff); }
+
+      a.AddDomainIntegrator(combo);
    }
    else { a.AddDomainIntegrator(he_nlf_integ); }
 

--- a/miniapps/meshing/pmesh-optimizer.cpp
+++ b/miniapps/meshing/pmesh-optimizer.cpp
@@ -40,6 +40,7 @@
 //     mpirun -np 4 pmesh-optimizer -m square01.mesh -o 2 -rs 2 -mid 87 -tid 4 -ni 100 -ls 2 -li 100 -bnd -qt 1 -qo 8 -fd 1
 //   Adapted discrete size:
 //     mpirun -np 4 pmesh-optimizer -m square01.mesh -o 2 -rs 2 -mid 7 -tid 5 -ni 200 -ls 2 -li 100 -bnd -qt 1 -qo 8
+//     mpirun -np 4 pmesh-optimizer -m square01.mesh -o 2 -rs 2 -mid 2 -tid 5 -ni 200 -ls 2 -li 100 -bnd -qt 1 -qo 8 -cmb 2 -nor
 //   Blade shape:
 //     mpirun -np 4 pmesh-optimizer -m blade.mesh -o 4 -rs 0 -mid 2 -tid 1 -ni 200 -ls 2 -li 100 -bnd -qt 1 -qo 8
 //   Blade shape with FD-based solver:
@@ -55,7 +56,7 @@
 //   ICF limited shape:
 //     mpirun -np 4 pmesh-optimizer -o 3 -rs 0 -mid 1 -tid 1 -ni 100 -ls 2 -li 100 -bnd -qt 1 -qo 8 -lc 10
 //   ICF combo shape + size (rings, slow convergence):
-//     mpirun -np 4 pmesh-optimizer -o 3 -rs 0 -mid 1 -tid 1 -ni 1000 -ls 2 -li 100 -bnd -qt 1 -qo 8 -cmb
+//     mpirun -np 4 pmesh-optimizer -o 3 -rs 0 -mid 1 -tid 1 -ni 1000 -ls 2 -li 100 -bnd -qt 1 -qo 8 -cmb 1
 //   3D pinched sphere shape (the mesh is in the mfem/data GitHub repository):
 //   * mpirun -np 4 pmesh-optimizer -m ../../../mfem_data/ball-pert.mesh -o 4 -rs 0 -mid 303 -tid 1 -ni 20 -ls 2 -li 500 -fix-bnd
 //   2D non-conforming shape and equal size:
@@ -271,7 +272,7 @@ int main (int argc, char *argv[])
    int lin_solver        = 2;
    int max_lin_iter      = 100;
    bool move_bnd         = true;
-   bool combomet         = 0;
+   int combomet          = 0;
    bool normalization    = false;
    bool visualization    = true;
    int verbosity_level   = 0;
@@ -336,8 +337,11 @@ int main (int argc, char *argv[])
    args.AddOption(&move_bnd, "-bnd", "--move-boundary", "-fix-bnd",
                   "--fix-boundary",
                   "Enable motion along horizontal and vertical boundaries.");
-   args.AddOption(&combomet, "-cmb", "--combo-met", "-no-cmb", "--no-combo-met",
-                  "Combination of metrics.");
+   args.AddOption(&combomet, "-cmb", "--combo-type",
+                  "Combination of metrics options:"
+                  "0: Use single metric\n\t"
+                  "1: Shape + space-dependent size given analytically\n\t"
+                  "2: Shape + adapted size given discretely; shared target");
    args.AddOption(&normalization, "-nor", "--normalization", "-no-nor",
                   "--no-normalization",
                   "Make all terms in the optimization functional unitless.");
@@ -593,31 +597,35 @@ int main (int argc, char *argv[])
    TargetConstructor *target_c2 = NULL;
    FunctionCoefficient coeff2(weight_fun);
 
-   if (combomet == 1)
+   if (combomet > 0)
    {
-      // TODO normalization of combinations.
-      // We will probably drop this example and replace it with adaptivity.
-      if (normalization) { MFEM_ABORT("Not implemented."); }
-
       // First metric.
       coeff1 = new ConstantCoefficient(1.0);
       he_nlf_integ->SetCoefficient(*coeff1);
-      a.AddDomainIntegrator(he_nlf_integ);
 
       // Second metric.
       metric2 = new TMOP_Metric_077;
-      target_c2 = new TargetConstructor(
-         TargetConstructor::IDEAL_SHAPE_EQUAL_SIZE, MPI_COMM_WORLD);
-      target_c2->SetVolumeScale(0.01);
-      target_c2->SetNodes(x0);
-      TMOP_Integrator *he_nlf_integ2;
-      he_nlf_integ2 = new TMOP_Integrator(metric2, target_c2);
+      TMOP_Integrator *he_nlf_integ2 = NULL;
+      if (combomet == 1)
+      {
+         target_c2 = new TargetConstructor(
+            TargetConstructor::IDEAL_SHAPE_EQUAL_SIZE, MPI_COMM_WORLD);
+         target_c2->SetVolumeScale(0.01);
+         target_c2->SetNodes(x0);
+         he_nlf_integ2 = new TMOP_Integrator(metric2, target_c2);
+         he_nlf_integ2->SetCoefficient(coeff2);
+      }
+      else { he_nlf_integ2 = new TMOP_Integrator(metric2, target_c); }
       he_nlf_integ2->SetIntegrationRule(*ir);
       if (fdscheme) { he_nlf_integ2->EnableFiniteDifferences(x); }
 
-      // Weight of metric2.
-      he_nlf_integ2->SetCoefficient(coeff2);
-      a.AddDomainIntegrator(he_nlf_integ2);
+      TMOPComboIntegrator *combo = new TMOPComboIntegrator;
+      combo->AddTMOPIntegrator(he_nlf_integ);
+      combo->AddTMOPIntegrator(he_nlf_integ2);
+      if (normalization) { combo->ParEnableNormalization(x0); }
+      if (lim_const != 0.0) { combo->EnableLimiting(x0, dist, lim_coeff); }
+
+      a.AddDomainIntegrator(combo);
    }
    else { a.AddDomainIntegrator(he_nlf_integ); }
 


### PR DESCRIPTION
This defines a better interface for doing combinations of `TMOP_Integrators`. It is an alternative to adding many of them in a `NonlinearForm`, which does not allow to perform TMOP-specific interactions between the `TMOPIntegrators` in the combination.
New features:
- Interface for limiting of combinations.
- Correct normalization of combinations (fixing a issue that showed up in BLAST).
- In a combination, shared `DiscreteAdaptTCs` are updated only once (per mesh update).

<!--GHEX{"id":1394,"author":"vladotomov","editor":"tzanio","reviewers":["tzanio","kmittal2"],"assignment":"2020-04-05T16:35:33-07:00","approval":"2020-04-15T21:49:10.093Z","merge":"2020-04-21T17:09:09.667Z"}XEHG--><!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge| 
 | --- | --- | --- | --- | --- | --- | --- | 
| [#1394](https://github.com/mfem/mfem/pull/1394) | @vladotomov | @tzanio | @tzanio + @kmittal2 | 04/05/20 | 04/15/20 | 04/21/20 | |
<!--ELBATXEHG-->