### PR TITLE
Boundary integral order bug [bdr-int-order-fix]

### DIFF
--- a/fem/bilinearform.cpp
+++ b/fem/bilinearform.cpp
@@ -467,8 +467,17 @@ void BilinearForm::Assemble(int skip_zeros)
          const FiniteElement &be = *fes->GetBE(i);
          fes -> GetBdrElementVDofs (i, vdofs);
          eltrans = fes -> GetBdrElementTransformation (i);
-         bbfi[0]->AssembleElementMatrix(be, *eltrans, elmat);
-         for (int k = 1; k < bbfi.Size(); k++)
+         int k = 0;
+         for (; k < bbfi.Size(); k++)
+         {
+            if (bbfi_marker[k] &&
+                (*bbfi_marker[k])[bdr_attr-1] == 0) { continue; }
+
+            bbfi[k]->AssembleElementMatrix(be, *eltrans, elmat);
+            k++;
+            break;
+         }
+         for (; k < bbfi.Size(); k++)
          {
             if (bbfi_marker[k] &&
                 (*bbfi_marker[k])[bdr_attr-1] == 0) { continue; }

--- a/tests/unit/fem/test_bilinearform.cpp
+++ b/tests/unit/fem/test_bilinearform.cpp
@@ -17,51 +17,51 @@
 using namespace mfem;
 
 TEST_CASE("Test order of boundary integrators",
-	  "[BilinearForm]")
+          "[BilinearForm]")
 {
-  // Create a simple mesh
-  int dim = 2, nx = 2, ny = 2, order = 2;
-  Element::Type e_type = Element::QUADRILATERAL;
-  Mesh mesh(nx, ny, e_type);
+   // Create a simple mesh
+   int dim = 2, nx = 2, ny = 2, order = 2;
+   Element::Type e_type = Element::QUADRILATERAL;
+   Mesh mesh(nx, ny, e_type);
 
-  H1_FECollection fec(order, dim);
-  FiniteElementSpace fes(&mesh, &fec);
+   H1_FECollection fec(order, dim);
+   FiniteElementSpace fes(&mesh, &fec);
 
-  SECTION("Order of restricted boundary integrators")
-  {
-    ConstantCoefficient one(1.0);
-    ConstantCoefficient two(2.0);
-    ConstantCoefficient three(3.0);
-    ConstantCoefficient four(4.0);
+   SECTION("Order of restricted boundary integrators")
+   {
+      ConstantCoefficient one(1.0);
+      ConstantCoefficient two(2.0);
+      ConstantCoefficient three(3.0);
+      ConstantCoefficient four(4.0);
 
-    Array<int> bdr1(4); bdr1 = 0; bdr1[0] = 1;
-    Array<int> bdr2(4); bdr2 = 0; bdr2[1] = 1;
-    Array<int> bdr3(4); bdr3 = 0; bdr3[2] = 1;
-    Array<int> bdr4(4); bdr4 = 0; bdr4[3] = 1;
-  
-    BilinearForm a1234(&fes);
-    a1234.AddBoundaryIntegrator(new MassIntegrator(one), bdr1);
-    a1234.AddBoundaryIntegrator(new MassIntegrator(two), bdr2);
-    a1234.AddBoundaryIntegrator(new MassIntegrator(three), bdr3);
-    a1234.AddBoundaryIntegrator(new MassIntegrator(four), bdr4);
-    a1234.Assemble(0);
-    a1234.Finalize(0);
-  
-    BilinearForm a4321(&fes);
-    a4321.AddBoundaryIntegrator(new MassIntegrator(four), bdr4);
-    a4321.AddBoundaryIntegrator(new MassIntegrator(three), bdr3);
-    a4321.AddBoundaryIntegrator(new MassIntegrator(two), bdr2);
-    a4321.AddBoundaryIntegrator(new MassIntegrator(one), bdr1);
-    a4321.Assemble(0);
-    a4321.Finalize(0);
+      Array<int> bdr1(4); bdr1 = 0; bdr1[0] = 1;
+      Array<int> bdr2(4); bdr2 = 0; bdr2[1] = 1;
+      Array<int> bdr3(4); bdr3 = 0; bdr3[2] = 1;
+      Array<int> bdr4(4); bdr4 = 0; bdr4[3] = 1;
 
-    const SparseMatrix &A1234 = a1234.SpMat();
-    const SparseMatrix &A4321 = a4321.SpMat();
+      BilinearForm a1234(&fes);
+      a1234.AddBoundaryIntegrator(new MassIntegrator(one), bdr1);
+      a1234.AddBoundaryIntegrator(new MassIntegrator(two), bdr2);
+      a1234.AddBoundaryIntegrator(new MassIntegrator(three), bdr3);
+      a1234.AddBoundaryIntegrator(new MassIntegrator(four), bdr4);
+      a1234.Assemble(0);
+      a1234.Finalize(0);
 
-    SparseMatrix *D = Add(1.0, A1234, -1.0, A4321);
+      BilinearForm a4321(&fes);
+      a4321.AddBoundaryIntegrator(new MassIntegrator(four), bdr4);
+      a4321.AddBoundaryIntegrator(new MassIntegrator(three), bdr3);
+      a4321.AddBoundaryIntegrator(new MassIntegrator(two), bdr2);
+      a4321.AddBoundaryIntegrator(new MassIntegrator(one), bdr1);
+      a4321.Assemble(0);
+      a4321.Finalize(0);
 
-    REQUIRE(D->MaxNorm() == Approx(0.0));
-  
-    delete D;
-  }
+      const SparseMatrix &A1234 = a1234.SpMat();
+      const SparseMatrix &A4321 = a4321.SpMat();
+
+      SparseMatrix *D = Add(1.0, A1234, -1.0, A4321);
+
+      REQUIRE(D->MaxNorm() == Approx(0.0));
+
+      delete D;
+   }
 }

--- a/tests/unit/fem/test_bilinearform.cpp
+++ b/tests/unit/fem/test_bilinearform.cpp
@@ -1,0 +1,67 @@
+// Copyright (c) 2010-2020, Lawrence Livermore National Security, LLC. Produced
+// at the Lawrence Livermore National Laboratory. All Rights reserved. See files
+// LICENSE and NOTICE for details. LLNL-CODE-806117.
+//
+// This file is part of the MFEM library. For more information and source code
+// availability visit https://mfem.org.
+//
+// MFEM is free software; you can redistribute it and/or modify it under the
+// terms of the BSD-3 license. We welcome feedback and contributions, see file
+// CONTRIBUTING.md for details.
+
+#include "mfem.hpp"
+#include "catch.hpp"
+
+#include <iostream>
+
+using namespace mfem;
+
+TEST_CASE("Test order of boundary integrators",
+	  "[BilinearForm]")
+{
+  // Create a simple mesh
+  int dim = 2, nx = 2, ny = 2, order = 2;
+  Element::Type e_type = Element::QUADRILATERAL;
+  Mesh mesh(nx, ny, e_type);
+
+  H1_FECollection fec(order, dim);
+  FiniteElementSpace fes(&mesh, &fec);
+
+  SECTION("Order of restricted boundary integrators")
+  {
+    ConstantCoefficient one(1.0);
+    ConstantCoefficient two(2.0);
+    ConstantCoefficient three(3.0);
+    ConstantCoefficient four(4.0);
+
+    Array<int> bdr1(4); bdr1 = 0; bdr1[0] = 1;
+    Array<int> bdr2(4); bdr2 = 0; bdr2[1] = 1;
+    Array<int> bdr3(4); bdr3 = 0; bdr3[2] = 1;
+    Array<int> bdr4(4); bdr4 = 0; bdr4[3] = 1;
+  
+    BilinearForm a1234(&fes);
+    a1234.AddBoundaryIntegrator(new MassIntegrator(one), bdr1);
+    a1234.AddBoundaryIntegrator(new MassIntegrator(two), bdr2);
+    a1234.AddBoundaryIntegrator(new MassIntegrator(three), bdr3);
+    a1234.AddBoundaryIntegrator(new MassIntegrator(four), bdr4);
+    a1234.Assemble(0);
+    a1234.Finalize(0);
+  
+    BilinearForm a4321(&fes);
+    a4321.AddBoundaryIntegrator(new MassIntegrator(four), bdr4);
+    a4321.AddBoundaryIntegrator(new MassIntegrator(three), bdr3);
+    a4321.AddBoundaryIntegrator(new MassIntegrator(two), bdr2);
+    a4321.AddBoundaryIntegrator(new MassIntegrator(one), bdr1);
+    a4321.Assemble(0);
+    a4321.Finalize(0);
+
+    const SparseMatrix &A1234 = a1234.SpMat();
+    const SparseMatrix &A4321 = a4321.SpMat();
+
+    SparseMatrix *D = Add(1.0, A1234, -1.0, A4321);
+
+    REQUIRE(D->MaxNorm() == Approx(0.0));
+  
+    delete D;
+  }
+}


### PR DESCRIPTION
When adding boundary integrators to a `BilinearForm` we can optionally supply arrays of boundary attributes on which to apply each integrator.  If multiple integrators were added on different portions of the boundary, the first integrator was being applied on each of the boundaries provided for the other integrators in addition to its own.

The new unit test simply verifies that `BilinearForm` produces the same matrix when boundary integrators are added in two different orders. 
<!--GHEX{"id":1395,"author":"mlstowell","editor":"tzanio","reviewers":["acfisher","cjvogl"],"assignment":"2020-04-05T16:34:42-07:00","approval":"2020-04-22T04:09:58.297Z","merge":"2020-04-26T17:16:54.451Z"}XEHG--><!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge| 
 | --- | --- | --- | --- | --- | --- | --- | 
| [#1395](https://github.com/mfem/mfem/pull/1395) | @mlstowell | @tzanio | @acfisher + @cjvogl | 04/05/20 | 04/21/20 | 04/26/20 | |
<!--ELBATXEHG-->