### PR TITLE
Additional interface for FindPointsGSLIB methods and bug fix

### DIFF
--- a/fem/gslib.cpp
+++ b/fem/gslib.cpp
@@ -67,7 +67,7 @@ void FindPointsGSLIB::Setup(Mesh &m, const double bb_t, const double newt_tol,
    MFEM_VERIFY(m.GetNumGeometries(m.Dimension()) == 1,
                "Mixed meshes are not currently supported in FindPointsGSLIB.");
 
-   //FreeData if FindPointsGSLIB::Setup has been called already
+   // call FreeData if FindPointsGSLIB::Setup has been called already
    if (setupflag) { FreeData(); }
 
    mesh = &m;

--- a/fem/gslib.cpp
+++ b/fem/gslib.cpp
@@ -29,8 +29,8 @@ namespace mfem
 {
 
 FindPointsGSLIB::FindPointsGSLIB()
-   : mesh(NULL), ir_simplex(NULL), gsl_mesh(), fdata2D(NULL), fdata3D(NULL),
-     dim(-1)
+   : mesh(NULL), ir_simplex(NULL), fdata2D(NULL), fdata3D(NULL),
+     dim(-1), gsl_mesh(), gsl_ref(), gsl_dist(), setupflag(false)
 {
    gsl_comm = new comm;
 #ifdef MFEM_USE_MPI
@@ -52,8 +52,8 @@ FindPointsGSLIB::~FindPointsGSLIB()
 
 #ifdef MFEM_USE_MPI
 FindPointsGSLIB::FindPointsGSLIB(MPI_Comm _comm)
-   : mesh(NULL), ir_simplex(NULL), gsl_mesh(), fdata2D(NULL), fdata3D(NULL),
-     dim(-1)
+   : mesh(NULL), ir_simplex(NULL), fdata2D(NULL), fdata3D(NULL),
+     dim(-1), gsl_mesh(), gsl_ref(), gsl_dist(), setupflag(false)
 {
    gsl_comm = new comm;
    comm_init(gsl_comm, _comm);
@@ -65,6 +65,9 @@ void FindPointsGSLIB::Setup(Mesh &m, double bb_t, double newt_tol, int npt_max)
    MFEM_VERIFY(m.GetNodes() != NULL, "Mesh nodes are required.");
    MFEM_VERIFY(m.GetNumGeometries(m.Dimension()) == 1,
                "Mixed meshes are not currently supported in FindPointsGSLIB.");
+
+   //FreeData if FindPointsGSLIB::Setup has been called already
+   if (setupflag) { FreeData(); }
 
    mesh = &m;
    dim  = mesh->Dimension();
@@ -109,6 +112,7 @@ void FindPointsGSLIB::Setup(Mesh &m, double bb_t, double newt_tol, int npt_max)
       fdata3D = findpts_setup_3(gsl_comm, elx, nr, NEtot, mr, bb_t,
                                 pts_cnt, pts_cnt, npt_max, newt_tol);
    }
+   setupflag = true;
 }
 
 void FindPointsGSLIB::FindPoints(const Vector &point_pos,
@@ -117,6 +121,7 @@ void FindPointsGSLIB::FindPoints(const Vector &point_pos,
                                  Array<unsigned int> &elem_ids,
                                  Vector &ref_pos, Vector &dist)
 {
+   MFEM_VERIFY(setupflag, "Use FindPointsGSLIB::Setup before finding points.");
    const int points_cnt = point_pos.Size() / dim;
    if (dim == 2)
    {
@@ -152,6 +157,18 @@ void FindPointsGSLIB::FindPoints(const Vector &point_pos,
    }
 }
 
+void FindPointsGSLIB::FindPoints(const Vector &point_pos)
+{
+   const int points_cnt = point_pos.Size() / dim;
+   gsl_code.SetSize(points_cnt);
+   gsl_proc.SetSize(points_cnt);
+   gsl_elem.SetSize(points_cnt);
+   gsl_ref.SetSize(points_cnt * dim);
+   gsl_dist.SetSize(points_cnt);
+
+   FindPoints(point_pos, gsl_code, gsl_proc, gsl_elem, gsl_ref, gsl_dist);
+}
+
 void FindPointsGSLIB::Interpolate(Array<unsigned int> &codes,
                                   Array<unsigned int> &proc_ids,
                                   Array<unsigned int> &elem_ids,
@@ -162,6 +179,8 @@ void FindPointsGSLIB::Interpolate(Array<unsigned int> &codes,
    GetNodeValues(field_in, node_vals);
 
    const int points_cnt = ref_pos.Size() / dim;
+   MFEM_VERIFY(field_out.Size() >= points_cnt,
+               " Increase size of field_out in FindPointsGSLIB::Interpolate.");
    if (dim==2)
    {
       findpts_eval_2(field_out.GetData(), sizeof(double),
@@ -182,6 +201,19 @@ void FindPointsGSLIB::Interpolate(Array<unsigned int> &codes,
    }
 }
 
+void FindPointsGSLIB::Interpolate(const GridFunction &field_in,
+                                  Vector &field_out)
+{
+   Interpolate(gsl_code, gsl_proc, gsl_elem, gsl_ref, field_in, field_out);
+}
+
+void FindPointsGSLIB::Interpolate(const Vector &point_pos,
+                                  const GridFunction &field_in, Vector &field_out)
+{
+   FindPoints(point_pos);
+   Interpolate(gsl_code, gsl_proc, gsl_elem, gsl_ref, field_in, field_out);
+}
+
 void FindPointsGSLIB::FreeData()
 {
    if (dim == 2)
@@ -192,7 +224,13 @@ void FindPointsGSLIB::FreeData()
    {
       findpts_free_3(fdata3D);
    }
+   setupflag = false;
+   gsl_code.DeleteAll();
+   gsl_proc.DeleteAll();
+   gsl_elem.DeleteAll();
    gsl_mesh.Destroy();
+   gsl_ref.Destroy();
+   gsl_dist.Destroy();
 }
 
 void FindPointsGSLIB::GetNodeValues(const GridFunction &gf_in,

--- a/fem/gslib.cpp
+++ b/fem/gslib.cpp
@@ -60,7 +60,8 @@ FindPointsGSLIB::FindPointsGSLIB(MPI_Comm _comm)
 }
 #endif
 
-void FindPointsGSLIB::Setup(Mesh &m, double bb_t, double newt_tol, int npt_max)
+void FindPointsGSLIB::Setup(Mesh &m, const double bb_t, const double newt_tol,
+                            const int npt_max)
 {
    MFEM_VERIFY(m.GetNodes() != NULL, "Mesh nodes are required.");
    MFEM_VERIFY(m.GetNumGeometries(m.Dimension()) == 1,
@@ -169,14 +170,13 @@ void FindPointsGSLIB::FindPoints(const Vector &point_pos)
    FindPoints(point_pos, gsl_code, gsl_proc, gsl_elem, gsl_ref, gsl_dist);
 }
 
-void FindPointsGSLIB::FindPoints(Mesh &m, const Vector &point_pos)
+void FindPointsGSLIB::FindPoints(Mesh &m, const Vector &point_pos,
+                                 const double bb_t, const double newt_tol,
+                                 const int npt_max)
 {
    if (!setupflag || (mesh != &m) )
    {
-      const double rel_bbox_el = 0.05;
-      const double newton_tol  = 1.0e-12;
-      const int npts_at_once   = 256;
-      Setup(m, rel_bbox_el, newton_tol, npts_at_once);
+      Setup(m, bb_t, newt_tol, npt_max);
    }
    FindPoints(point_pos);
 }

--- a/fem/gslib.cpp
+++ b/fem/gslib.cpp
@@ -34,7 +34,9 @@ FindPointsGSLIB::FindPointsGSLIB()
 {
    gsl_comm = new comm;
 #ifdef MFEM_USE_MPI
-   MPI_Init(NULL, NULL);
+   int initialized;
+   MPI_Initialized(&initialized);
+   if (!initialized) { MPI_Init(NULL, NULL); }
    MPI_Comm comm = MPI_COMM_WORLD;;
    comm_init(gsl_comm, comm);
 #else

--- a/fem/gslib.cpp
+++ b/fem/gslib.cpp
@@ -169,6 +169,18 @@ void FindPointsGSLIB::FindPoints(const Vector &point_pos)
    FindPoints(point_pos, gsl_code, gsl_proc, gsl_elem, gsl_ref, gsl_dist);
 }
 
+void FindPointsGSLIB::FindPoints(Mesh &m, const Vector &point_pos)
+{
+   if (!setupflag || (mesh != &m) )
+   {
+      const double rel_bbox_el = 0.05;
+      const double newton_tol  = 1.0e-12;
+      const int npts_at_once   = 256;
+      Setup(m, rel_bbox_el, newton_tol, npts_at_once);
+   }
+   FindPoints(point_pos);
+}
+
 void FindPointsGSLIB::Interpolate(Array<unsigned int> &codes,
                                   Array<unsigned int> &proc_ids,
                                   Array<unsigned int> &elem_ids,
@@ -211,6 +223,13 @@ void FindPointsGSLIB::Interpolate(const Vector &point_pos,
                                   const GridFunction &field_in, Vector &field_out)
 {
    FindPoints(point_pos);
+   Interpolate(gsl_code, gsl_proc, gsl_elem, gsl_ref, field_in, field_out);
+}
+
+void FindPointsGSLIB::Interpolate(Mesh &m, const Vector &point_pos,
+                                  const GridFunction &field_in, Vector &field_out)
+{
+   FindPoints(m, point_pos);
    Interpolate(gsl_code, gsl_proc, gsl_elem, gsl_ref, field_in, field_out);
 }
 

--- a/fem/gslib.hpp
+++ b/fem/gslib.hpp
@@ -29,10 +29,12 @@ class FindPointsGSLIB
 protected:
    Mesh *mesh;
    IntegrationRule *ir_simplex;
-   Vector gsl_mesh;
    struct findpts_data_2 *fdata2D;
    struct findpts_data_3 *fdata3D;
    int dim;
+   Array<unsigned int> gsl_code, gsl_proc, gsl_elem;
+   Vector gsl_mesh, gsl_ref, gsl_dist;
+   bool setupflag;
 
    struct comm *gsl_comm;
 
@@ -78,6 +80,7 @@ public:
    void FindPoints(const Vector &point_pos, Array<unsigned int> &codes,
                    Array<unsigned int> &proc_ids, Array<unsigned int> &elem_ids,
                    Vector &ref_pos, Vector &dist);
+   void FindPoints(const Vector &point_pos);
 
    /** Interpolation of field values at prescribed reference space positions.
 
@@ -96,11 +99,21 @@ public:
    void Interpolate(Array<unsigned int> &codes, Array<unsigned int> &proc_ids,
                     Array<unsigned int> &elem_ids, Vector &ref_pos,
                     const GridFunction &field_in, Vector &field_out);
+   void Interpolate(const GridFunction &field_in, Vector &field_out);
+   /** Search positions and Interpolate */
+   void Interpolate(const Vector &point_pos, const GridFunction &field_in,
+                    Vector &field_out);
 
    /** Cleans up memory allocated internally by gslib.
        Note that in parallel, this must be called before MPI_Finalize(), as
        it calls MPI_Comm_free() for internal gslib communicators. */
    void FreeData();
+
+   const Array<unsigned int> &GetCode()   { return gsl_code; }
+   const Array<unsigned int> &GetElem()   { return gsl_elem; }
+   const Array<unsigned int> &GetProc()   { return gsl_proc; }
+   const Vector &GetReferencePosition()   { return gsl_ref;  }
+   const Vector &GetDist2()               { return gsl_dist; }
 };
 
 } // namespace mfem

--- a/fem/gslib.hpp
+++ b/fem/gslib.hpp
@@ -61,7 +61,8 @@ public:
        @param[in] newt_tol  Newton tolerance for the gslib search methods.
        @param[in] npt_max   Number of points for simultaneous iteration. This
                             alters performance and memory footprint. */
-   void Setup(Mesh &m, double bb_t, double newt_tol, int npt_max);
+   void Setup(Mesh &m, const double bb_t = 0.1, const double newt_tol = 1.0e-12,
+              const int npt_max = 256);
 
    /** Searches positions given in physical space by @a point_pos. All output
        Arrays and Vectors are expected to have the correct size.
@@ -75,14 +76,15 @@ public:
        @param[out] ref_pos    Reference coordinates of the found point. Ordered
                               by vdim (XYZ,XYZ,XYZ...).
                               Note: the gslib reference frame is [-1,1].
-       @param[out] dist       Distance between the seeked and the found point
+       @param[out] dist       Distance between the sought and the found point
                               in physical space. */
    void FindPoints(const Vector &point_pos, Array<unsigned int> &codes,
                    Array<unsigned int> &proc_ids, Array<unsigned int> &elem_ids,
                    Vector &ref_pos, Vector &dist);
    void FindPoints(const Vector &point_pos);
    /** Setup FindPoints and search positions*/
-   void FindPoints(Mesh &m, const Vector &point_pos);
+   void FindPoints(Mesh &m, const Vector &point_pos, const double bb_t = 0.1,
+                   const double newt_tol = 1.0e-12,  const int npt_max = 256);
 
    /** Interpolation of field values at prescribed reference space positions.
 
@@ -114,11 +116,18 @@ public:
        it calls MPI_Comm_free() for internal gslib communicators. */
    void FreeData();
 
-   const Array<unsigned int> &GetCode()   { return gsl_code; }
-   const Array<unsigned int> &GetElem()   { return gsl_elem; }
-   const Array<unsigned int> &GetProc()   { return gsl_proc; }
-   const Vector &GetReferencePosition()   { return gsl_ref;  }
-   const Vector &GetDist2()               { return gsl_dist; }
+   /// Return code for each point searched by FindPoints: inside element (0),
+   /// element boundary (1), not found (2).
+   const Array<unsigned int> &GetCode() const { return gsl_code; }
+   /// Return element number for each point found by FindPoints.
+   const Array<unsigned int> &GetElem() const { return gsl_elem; }
+   /// Return MPI rank on which each point was found by FindPoints.
+   const Array<unsigned int> &GetProc() const { return gsl_proc; }
+   /// Return reference coordinates for each point found by FindPoints.
+   const Vector &GetReferencePosition() const { return gsl_ref;  }
+   /// Return distance Distance between the sought and the found point
+   /// in physical space, for each point found by FindPoints.
+   const Vector &GetDist()              const { return gsl_dist; }
 };
 
 } // namespace mfem

--- a/fem/gslib.hpp
+++ b/fem/gslib.hpp
@@ -82,7 +82,7 @@ public:
                    Array<unsigned int> &proc_ids, Array<unsigned int> &elem_ids,
                    Vector &ref_pos, Vector &dist);
    void FindPoints(const Vector &point_pos);
-   /** Setup FindPoints and search positions*/
+   /// Setup FindPoints and search positions
    void FindPoints(Mesh &m, const Vector &point_pos, const double bb_t = 0.1,
                    const double newt_tol = 1.0e-12,  const int npt_max = 256);
 
@@ -116,8 +116,8 @@ public:
        it calls MPI_Comm_free() for internal gslib communicators. */
    void FreeData();
 
-   /// Return code for each point searched by FindPoints: inside element (0),
-   /// element boundary (1), not found (2).
+   /// Return code for each point searched by FindPoints: inside element (0), on
+   /// element boundary (1), or not found (2).
    const Array<unsigned int> &GetCode() const { return gsl_code; }
    /// Return element number for each point found by FindPoints.
    const Array<unsigned int> &GetElem() const { return gsl_elem; }

--- a/fem/gslib.hpp
+++ b/fem/gslib.hpp
@@ -81,6 +81,8 @@ public:
                    Array<unsigned int> &proc_ids, Array<unsigned int> &elem_ids,
                    Vector &ref_pos, Vector &dist);
    void FindPoints(const Vector &point_pos);
+   /** Setup FindPoints and search positions*/
+   void FindPoints(Mesh &m, const Vector &point_pos);
 
    /** Interpolation of field values at prescribed reference space positions.
 
@@ -100,9 +102,12 @@ public:
                     Array<unsigned int> &elem_ids, Vector &ref_pos,
                     const GridFunction &field_in, Vector &field_out);
    void Interpolate(const GridFunction &field_in, Vector &field_out);
-   /** Search positions and Interpolate */
+   /** Search positions and interpolate */
    void Interpolate(const Vector &point_pos, const GridFunction &field_in,
                     Vector &field_out);
+   /** Setup FindPoints, search positions and interpolate */
+   void Interpolate(Mesh &m, const Vector &point_pos,
+                    const GridFunction &field_in, Vector &field_out);
 
    /** Cleans up memory allocated internally by gslib.
        Note that in parallel, this must be called before MPI_Finalize(), as

--- a/miniapps/gslib/CMakeLists.txt
+++ b/miniapps/gslib/CMakeLists.txt
@@ -22,7 +22,7 @@ if (MFEM_USE_GSLIB)
   # Parallel apps.
   if (MFEM_USE_MPI)
     add_mfem_miniapp(pfindpts
-      MAIN findpts.cpp
+      MAIN pfindpts.cpp
       LIBRARIES mfem)
   endif()
 

--- a/miniapps/gslib/field-diff.cpp
+++ b/miniapps/gslib/field-diff.cpp
@@ -160,23 +160,15 @@ int main (int argc, char *argv[])
    const double rel_bbox_el = 0.05;
    const double newton_tol  = 1.0e-12;
    const int npts_at_once   = 256;
-   Array<unsigned int> el_id_out(pts_cnt), code_out(pts_cnt), task_id_out(pts_cnt);
-   Vector pos_r_out(pts_cnt * dim), dist_p_out(pts_cnt);
    Vector interp_vals_1(pts_cnt), interp_vals_2(pts_cnt);
 
    // First solution.
    finder.Setup(mesh_1, rel_bbox_el, newton_tol, npts_at_once);
-   finder.FindPoints(vxyz, code_out, task_id_out,
-                     el_id_out, pos_r_out, dist_p_out);
-   finder.Interpolate(code_out, task_id_out, el_id_out,
-                      pos_r_out, func_1, interp_vals_1);
+   finder.Interpolate(vxyz, func_1, interp_vals_1);
 
    // Second solution.
    finder.Setup(mesh_2, rel_bbox_el, newton_tol, npts_at_once);
-   finder.FindPoints(vxyz, code_out, task_id_out,
-                     el_id_out, pos_r_out, dist_p_out);
-   finder.Interpolate(code_out, task_id_out, el_id_out,
-                      pos_r_out, func_2, interp_vals_2);
+   finder.Interpolate(vxyz, func_2, interp_vals_2);
 
    // Compute differences between the two sets of values.
    double avg_diff = 0.0, max_diff = 0.0, diff_p;
@@ -220,15 +212,8 @@ int main (int argc, char *argv[])
    const int nodes_cnt = vxyz.Size() / dim;
 
    // Difference at the nodes of mesh 1.
-   el_id_out.SetSize(nodes_cnt); code_out.SetSize(nodes_cnt);
-   task_id_out.SetSize(nodes_cnt);
-   pos_r_out.SetSize(nodes_cnt * dim); dist_p_out.SetSize(nodes_cnt * dim);
    interp_vals_2.SetSize(nodes_cnt);
-   finder.Setup(mesh_2, rel_bbox_el, newton_tol, npts_at_once);
-   finder.FindPoints(vxyz, code_out, task_id_out,
-                     el_id_out, pos_r_out, dist_p_out);
-   finder.Interpolate(code_out, task_id_out, el_id_out,
-                      pos_r_out, func_2, interp_vals_2);
+   finder.Interpolate(vxyz, func_2, interp_vals_2);
    for (int n = 0; n < nodes_cnt; n++)
    {
       diff(n) = fabs(func_1(n) - interp_vals_2(n));

--- a/miniapps/gslib/field-diff.cpp
+++ b/miniapps/gslib/field-diff.cpp
@@ -156,14 +156,14 @@ int main (int argc, char *argv[])
       }
    }
 
-   FindPointsGSLIB finder;
+   FindPointsGSLIB finder1, finder2;
    Vector interp_vals_1(pts_cnt), interp_vals_2(pts_cnt);
 
    // First solution.
-   finder.Interpolate(mesh_1, vxyz, func_1, interp_vals_1);
+   finder1.Interpolate(mesh_1, vxyz, func_1, interp_vals_1);
 
    // Second solution.
-   finder.Interpolate(mesh_2, vxyz, func_2, interp_vals_2);
+   finder2.Interpolate(mesh_2, vxyz, func_2, interp_vals_2);
 
    // Compute differences between the two sets of values.
    double avg_diff = 0.0, max_diff = 0.0, diff_p;
@@ -208,7 +208,7 @@ int main (int argc, char *argv[])
 
    // Difference at the nodes of mesh 1.
    interp_vals_2.SetSize(nodes_cnt);
-   finder.Interpolate(vxyz, func_2, interp_vals_2);
+   finder2.Interpolate(vxyz, func_2, interp_vals_2);
    for (int n = 0; n < nodes_cnt; n++)
    {
       diff(n) = fabs(func_1(n) - interp_vals_2(n));
@@ -238,7 +238,8 @@ int main (int argc, char *argv[])
    std::cout << "Vol diff: " << vol_diff << std::endl;
 
    // Free the internal gslib data.
-   finder.FreeData();
+   finder1.FreeData();
+   finder2.FreeData();
 
    return 0;
 }

--- a/miniapps/gslib/field-diff.cpp
+++ b/miniapps/gslib/field-diff.cpp
@@ -157,18 +157,13 @@ int main (int argc, char *argv[])
    }
 
    FindPointsGSLIB finder;
-   const double rel_bbox_el = 0.05;
-   const double newton_tol  = 1.0e-12;
-   const int npts_at_once   = 256;
    Vector interp_vals_1(pts_cnt), interp_vals_2(pts_cnt);
 
    // First solution.
-   finder.Setup(mesh_1, rel_bbox_el, newton_tol, npts_at_once);
-   finder.Interpolate(vxyz, func_1, interp_vals_1);
+   finder.Interpolate(mesh_1, vxyz, func_1, interp_vals_1);
 
    // Second solution.
-   finder.Setup(mesh_2, rel_bbox_el, newton_tol, npts_at_once);
-   finder.Interpolate(vxyz, func_2, interp_vals_2);
+   finder.Interpolate(mesh_2, vxyz, func_2, interp_vals_2);
 
    // Compute differences between the two sets of values.
    double avg_diff = 0.0, max_diff = 0.0, diff_p;

--- a/miniapps/gslib/findpts.cpp
+++ b/miniapps/gslib/findpts.cpp
@@ -169,18 +169,11 @@ int main (int argc, char *argv[])
       }
    }
 
-   Array<unsigned int> el_id_out(pts_cnt), code_out(pts_cnt),
-         task_id_out(pts_cnt);
-   Vector pos_r_out(pts_cnt * dim), dist_p_out(pts_cnt);
-
-   // Finds points stored in vxyz.
-   finder.FindPoints(vxyz, code_out, task_id_out,
-                     el_id_out, pos_r_out, dist_p_out);
-
-   // Interpolate FE function values on the found points.
+   // Find and Interpolate FE function values on the desired points.
    Vector interp_vals(pts_cnt);
-   finder.Interpolate(code_out, task_id_out, el_id_out,
-                      pos_r_out, field_vals, interp_vals);
+   finder.Interpolate(vxyz, field_vals, interp_vals);
+   Array<unsigned int> code_out = finder.GetCode();
+   Vector dist_p_out = finder.GetDist2();
 
    // Free the internal gslib data.
    finder.FreeData();

--- a/miniapps/gslib/findpts.cpp
+++ b/miniapps/gslib/findpts.cpp
@@ -168,7 +168,7 @@ int main (int argc, char *argv[])
    FindPointsGSLIB finder;
    finder.Interpolate(mesh, vxyz, field_vals, interp_vals);
    Array<unsigned int> code_out = finder.GetCode();
-   Vector dist_p_out = finder.GetDist2();
+   Vector dist_p_out = finder.GetDist();
 
    // Free the internal gslib data.
    finder.FreeData();

--- a/miniapps/gslib/findpts.cpp
+++ b/miniapps/gslib/findpts.cpp
@@ -132,13 +132,6 @@ int main (int argc, char *argv[])
       }
    }
 
-   // Setup the gslib mesh.
-   FindPointsGSLIB finder;
-   const double rel_bbox_el = 0.05;
-   const double newton_tol  = 1.0e-12;
-   const int npts_at_once   = 256;
-   finder.Setup(mesh, rel_bbox_el, newton_tol, npts_at_once);
-
    // Generate equidistant points in physical coordinates over the whole mesh.
    // Note that some points might be outside, if the mesh is not a box. Note
    // also that all tasks search the same points (not mandatory).
@@ -171,7 +164,9 @@ int main (int argc, char *argv[])
 
    // Find and Interpolate FE function values on the desired points.
    Vector interp_vals(pts_cnt);
-   finder.Interpolate(vxyz, field_vals, interp_vals);
+   // FindPoints using GSLIB and interpolate
+   FindPointsGSLIB finder;
+   finder.Interpolate(mesh, vxyz, field_vals, interp_vals);
    Array<unsigned int> code_out = finder.GetCode();
    Vector dist_p_out = finder.GetDist2();
 

--- a/miniapps/gslib/pfindpts.cpp
+++ b/miniapps/gslib/pfindpts.cpp
@@ -160,13 +160,6 @@ int main (int argc, char *argv[])
       }
    }
 
-   // Setup the gslib mesh.
-   FindPointsGSLIB finder(MPI_COMM_WORLD);
-   const double rel_bbox_el = 0.05;
-   const double newton_tol  = 1.0e-12;
-   const int npts_at_once   = 256;
-   finder.Setup(pmesh, rel_bbox_el, newton_tol, npts_at_once);
-
    // Generate equidistant points in physical coordinates over the whole mesh.
    // Note that some points might be outside, if the mesh is not a box. Note
    // also that all tasks search the same points (not mandatory).
@@ -199,7 +192,9 @@ int main (int argc, char *argv[])
 
    // Find and Interpolate FE function values on the desired points.
    Vector interp_vals(pts_cnt);
-   finder.Interpolate(vxyz, field_vals, interp_vals);
+   // FindPoints using GSLIB and interpolate
+   FindPointsGSLIB finder(MPI_COMM_WORLD);
+   finder.Interpolate(pmesh, vxyz, field_vals, interp_vals);
    Array<unsigned int> code_out    = finder.GetCode();
    Array<unsigned int> task_id_out = finder.GetProc();
    Vector dist_p_out = finder.GetDist2();

--- a/miniapps/gslib/pfindpts.cpp
+++ b/miniapps/gslib/pfindpts.cpp
@@ -197,21 +197,12 @@ int main (int argc, char *argv[])
       }
    }
 
-   Array<unsigned int> el_id_out(pts_cnt), code_out(pts_cnt),
-         task_id_out(pts_cnt);
-   Vector pos_r_out(pts_cnt * dim), dist_p_out(pts_cnt);
-
-   // Finds points stored in vxyz.
-   finder.FindPoints(vxyz, code_out, task_id_out,
-                     el_id_out, pos_r_out, dist_p_out);
-
-   // Interpolate FE function values on the found points.
+   // Find and Interpolate FE function values on the desired points.
    Vector interp_vals(pts_cnt);
-   finder.Interpolate(code_out, task_id_out, el_id_out,
-                      pos_r_out, field_vals, interp_vals);
-
-   // Free the internal gslib data.
-   finder.FreeData();
+   finder.Interpolate(vxyz, field_vals, interp_vals);
+   Array<unsigned int> code_out    = finder.GetCode();
+   Array<unsigned int> task_id_out = finder.GetProc();
+   Vector dist_p_out = finder.GetDist2();
 
    int face_pts = 0, not_found = 0, found_loc = 0, found_away = 0;
    double max_err = 0.0, max_dist = 0.0;
@@ -246,6 +237,8 @@ int main (int argc, char *argv[])
            << "\nPoints on faces:      " << face_pts << endl;
    }
 
+   // Free the internal gslib data.
+   finder.FreeData();
    MPI_Finalize();
    return 0;
 }

--- a/miniapps/gslib/pfindpts.cpp
+++ b/miniapps/gslib/pfindpts.cpp
@@ -197,7 +197,7 @@ int main (int argc, char *argv[])
    finder.Interpolate(pmesh, vxyz, field_vals, interp_vals);
    Array<unsigned int> code_out    = finder.GetCode();
    Array<unsigned int> task_id_out = finder.GetProc();
-   Vector dist_p_out = finder.GetDist2();
+   Vector dist_p_out = finder.GetDist();
 
    int face_pts = 0, not_found = 0, found_loc = 0, found_away = 0;
    double max_err = 0.0, max_dist = 0.0;


### PR DESCRIPTION
There is a minor bug in the serial constructor of FindPointsGSLIB where MPI_Init is called every time. This has been fixed now such that MPI_Init is called only if MPI is not already initialized.
<!--GHEX{"id":1415,"author":"kmittal2","editor":"tzanio","reviewers":["aschaf","drzisga"],"assignment":"2020-04-18T18:21:49-07:00","approval":"2020-05-03T21:12:26.127Z","merge":"2020-05-11T00:02:45.698Z"}XEHG--><!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge| 
 | --- | --- | --- | --- | --- | --- | --- | 
| [#1415](https://github.com/mfem/mfem/pull/1415) | @kmittal2 | @tzanio | @aschaf + @drzisga | 04/18/20 | 05/03/20 | 05/10/20 | |
<!--ELBATXEHG-->