### PR TITLE
Resolve deprecation warnings in miniapps [deprecate-warn-dev]

### DIFF
--- a/fem/nonlinearform.hpp
+++ b/fem/nonlinearform.hpp
@@ -111,9 +111,9 @@ public:
        have zero entries at the essential true dofs. */
    void SetEssentialBC(const Array<int> &bdr_attr_is_ess, Vector *rhs = NULL);
 
-   /// (DEPRECATED) Specify essential boundary conditions.
-   /** @deprecated Use either SetEssentialBC() or SetEssentialTrueDofs(). */
-   MFEM_DEPRECATED void SetEssentialVDofs(const Array<int> &ess_vdofs_list);
+   /// Specify essential boundary conditions.
+   /** Use either SetEssentialBC() or SetEssentialTrueDofs() if possible. */
+   void SetEssentialVDofs(const Array<int> &ess_vdofs_list);
 
    /// Specify essential boundary conditions.
    void SetEssentialTrueDofs(const Array<int> &ess_tdof_list)

--- a/miniapps/electromagnetics/joule.cpp
+++ b/miniapps/electromagnetics/joule.cpp
@@ -751,7 +751,7 @@ void b_exact(const Vector &x, double t, Vector &B)
    B[2] = 0.0;
 }
 
-double t_exact(Vector &x)
+double t_exact(const Vector &x)
 {
    double T = 0.0;
    return T;

--- a/miniapps/electromagnetics/joule_solver.hpp
+++ b/miniapps/electromagnetics/joule_solver.hpp
@@ -38,7 +38,7 @@ void edot_bc(const Vector &x, Vector &E);
 void e_exact(const Vector &x, double t, Vector &E);
 void b_exact(const Vector &x, double t, Vector &B);
 double p_bc(const Vector &x, double t);
-double t_exact(Vector &x);
+double t_exact(const Vector &x);
 
 // A Coefficient is an object with a function Eval that returns a double.  A
 // MeshDependentCoefficient returns a different value depending upon the given


### PR DESCRIPTION
The deprecated feature in Joule involved a very simple fix.

The warnings in `[p]mesh-optimizer` required a little more thought. After a quick discussion between @v-dobrev, @vladotomov, @tzanio, and myself we decided to not deprecate the method  `NonlinearForm::SetEssentialVDofs` yet.  Instead, we may move this functionality into `FiniteElementSpace` in the future.
<!--GHEX{"id":1419,"author":"mlstowell","editor":"tzanio","reviewers":["v-dobrev","vladotomov"],"assignment":"2020-04-14T17:33:48-07:00","approval":"2020-04-15T21:34:31.038Z","merge":"2020-04-16T19:05:31.290Z"}XEHG--><!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge| 
 | --- | --- | --- | --- | --- | --- | --- | 
| [#1419](https://github.com/mfem/mfem/pull/1419) | @mlstowell | @tzanio | @v-dobrev + @vladotomov | 04/14/20 | 04/15/20 | 04/16/20 | |
<!--ELBATXEHG-->