### PR TITLE
Navier miniapp compilation with nvcc

### DIFF
--- a/miniapps/navier/makefile
+++ b/miniapps/navier/makefile
@@ -41,7 +41,7 @@ endif
 %.o: %.cpp
 
 %: %.cpp $(NAVIER_COMMON_OBJ)
-	$(MFEM_CXX) $(MFEM_FLAGS) $< -o $@ $(NAVIER_COMMON_OBJ) $(MFEM_LIBS)
+	$(MFEM_CXX) $(MFEM_LINK_FLAGS) $< -o $@ $(NAVIER_COMMON_OBJ) $(MFEM_LIBS)
 
 %.o: %.cpp $(MFEM_LIB_FILE) $(CONFIG_MK)
 	$(MFEM_CXX) $(MFEM_FLAGS) -c $< -o $@

--- a/miniapps/navier/navier_solver.cpp
+++ b/miniapps/navier/navier_solver.cpp
@@ -381,7 +381,7 @@ void NavierSolver::Step(double &time, double dt, int cur_step)
       const auto d_un = un.Read();
       const auto d_unm1 = unm1.Read();
       const auto d_unm2 = unm2.Read();
-      auto d_Fext = Fext.Write();
+      auto d_Fext = Fext.ReadWrite();
       MFEM_FORALL(i, Fext.Size(),
                   d_Fext[i] += bd1idt * d_un[i] +
                                bd2idt * d_unm1[i] +

--- a/miniapps/navier/navier_solver.cpp
+++ b/miniapps/navier/navier_solver.cpp
@@ -352,9 +352,16 @@ void NavierSolver::Step(double &time, double dt, int cur_step)
    N->Mult(un, Nun);
    Nun.Add(1.0, fn);
 
-   MFEM_FORALL(i,
-               Fext.Size(),
-               Fext[i] = ab1 * Nun[i] + ab2 * Nunm1[i] + ab3 * Nunm2[i];);
+   {
+      const auto d_Nun = Nun.Read();
+      const auto d_Nunm1 = Nunm1.Read();
+      const auto d_Nunm2 = Nunm2.Read();
+      auto d_Fext = Fext.Write();
+      MFEM_FORALL(i, Fext.Size(),
+                  d_Fext[i] = ab1 * d_Nun[i] +
+                              ab2 * d_Nunm1[i] +
+                              ab3 * d_Nunm2[i];);
+   }
 
    // Rotate the solutions from previous time steps.
    Nunm2 = Nunm1;
@@ -367,12 +374,19 @@ void NavierSolver::Step(double &time, double dt, int cur_step)
    Fext.Set(1.0, tmp1);
 
    // Compute BDF terms.
-   double bd1idt = -bd1 / dt;
-   double bd2idt = -bd2 / dt;
-   double bd3idt = -bd3 / dt;
-   MFEM_FORALL(i,
-               Fext.Size(),
-               Fext[i] += bd1idt * un[i] + bd2idt * unm1[i] + bd3idt * unm2[i];);
+   {
+      const double bd1idt = -bd1 / dt;
+      const double bd2idt = -bd2 / dt;
+      const double bd3idt = -bd3 / dt;
+      const auto d_un = un.Read();
+      const auto d_unm1 = unm1.Read();
+      const auto d_unm2 = unm2.Read();
+      auto d_Fext = Fext.Write();
+      MFEM_FORALL(i, Fext.Size(),
+                  d_Fext[i] += bd1idt * d_un[i] +
+                               bd2idt * d_unm1[i] +
+                               bd3idt * d_unm2[i];);
+   }
 
    sw_extrap.Stop();
 
@@ -380,10 +394,16 @@ void NavierSolver::Step(double &time, double dt, int cur_step)
    // Pressure poisson.
    //
    sw_curlcurl.Start();
-
-   MFEM_FORALL(i,
-               Lext.Size(),
-               Lext[i] = ab1 * un[i] + ab2 * unm1[i] + ab3 * unm2[i];);
+   {
+      const auto d_un = un.Read();
+      const auto d_unm1 = unm1.Read();
+      const auto d_unm2 = unm2.Read();
+      auto d_Lext = Lext.Write();
+      MFEM_FORALL(i, Lext.Size(),
+                  d_Lext[i] = ab1 * d_un[i] +
+                              ab2 * d_unm1[i] +
+                              ab3 * d_unm2[i];);
+   }
 
    Lext_gf.SetFromTrueDofs(Lext);
    if (pmesh->Dimension() == 2)


### PR DESCRIPTION
Allow the compilation with `nvcc` and the `pcuda` make target.

- [x] tux429
- [x] Lassen
```
lalloc 1 -q pdebug -G ceed
module load gcc/7.3.1 && module load spectrum-mpi/rolling-release && module load cuda/10.1.243
make distclean && make pcuda -j CUDA_ARCH=sm_70
```
- [x] Pascal
```
salloc -N 1 -p pvis
make distclean && make pcuda -j MFEM_MPIEXEC=srun MFEM_MPIEXEC_NP=-n
```