### PR TITLE
Change CuKernel to use a for loop instead of an if statement.

### DIFF
--- a/general/forall.hpp
+++ b/general/forall.hpp
@@ -187,25 +187,34 @@ void RajaSeqWrap(const int N, HBODY &&h_body)
 template <typename BODY> __global__ static
 void CuKernel1D(const int N, BODY body)
 {
-   const int k = blockDim.x*blockIdx.x + threadIdx.x;
-   if (k >= N) { return; }
-   body(k);
+   for (int k = blockIdx.x * blockDim.x + threadIdx.x; 
+        k < N; 
+        k += blockDim.x * gridDim.x)
+   {
+      body(k);
+   }
 }
 
 template <typename BODY> __global__ static
 void CuKernel2D(const int N, BODY body, const int BZ)
 {
-   const int k = blockIdx.x*BZ + threadIdx.z;
-   if (k >= N) { return; }
-   body(k);
+   for (int k = blockIdx.x * BZ + threadIdx.z; 
+        k < N; 
+        k += blockDim.x * blockDim.y * blockDim.z * gridDim.x)
+   {
+      body(k);
+   }
 }
 
 template <typename BODY> __global__ static
 void CuKernel3D(const int N, BODY body)
 {
-   const int k = blockIdx.x;
-   if (k >= N) { return; }
-   body(k);
+   for (int k = blockIdx.x; 
+        k < N; 
+        k += blockDim.x * blockDim.y * blockDim.z * gridDim.x)
+   {
+      body(k);
+   }
 }
 
 template <const int BLCK = MFEM_CUDA_BLOCKS, typename DBODY>


### PR DESCRIPTION
Following a conversation with @dylan-copeland I realized there was a better and more standard way to transform a CPU `for` loop into a GPU kernel.

This would allow @dylan-copeland to use `continue` inside the body of an `MFEM_FORALL` similarly to a `for` loop.

You can read this link to understand why it might be better:
https://devblogs.nvidia.com/cuda-pro-tip-write-flexible-kernels-grid-stride-loops/