### PR TITLE
[barker29/doftoquad-bugfix] minor bug in VectorTensorFiniteElement::GetTensorDofToQuadm

### DIFF
--- a/fem/fe.cpp
+++ b/fem/fe.cpp
@@ -11537,7 +11537,8 @@ const DofToQuad &VectorTensorFiniteElement::GetTensorDofToQuad(
 {
    MFEM_VERIFY(mode == DofToQuad::TENSOR, "invalid mode requested");
 
-   for (int i = 0; i < closed ? dof2quad_array.Size() : dof2quad_array_open.Size();
+   for (int i = 0;
+        i < (closed ? dof2quad_array.Size() : dof2quad_array_open.Size());
         i++)
    {
       const DofToQuad &d2q = closed ? *dof2quad_array[i] : *dof2quad_array_open[i];


### PR DESCRIPTION
For the line of code changed, the loop condition was incorrect and would in fact always evaluate to true. If given a non-standard integration rule, this method would previously give an Array out of bounds error.
<!--GHEX{"id":1448,"author":"barker29","editor":"v-dobrev","reviewers":["dylan-copeland","v-dobrev"],"assignment":"2020-04-29T10:26:21-07:00","approval":"2020-05-05T04:09:42.840Z","merge":"2020-05-13T16:28:39.873Z"}XEHG--><!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge| 
 | --- | --- | --- | --- | --- | --- | --- | 
| [#1448](https://github.com/mfem/mfem/pull/1448) | @barker29 | @v-dobrev | @dylan-copeland + @v-dobrev | 04/29/20 | 05/04/20 | 05/13/20 | |
<!--ELBATXEHG-->