### PR TITLE
Minor bugfix in NURBS miniapps [miniapps-nurbs-fix]

### DIFF
--- a/miniapps/meshing/CMakeLists.txt
+++ b/miniapps/meshing/CMakeLists.txt
@@ -49,7 +49,7 @@ add_mfem_miniapp(twist
 add_test(NAME mesh-optimizer
   COMMAND mesh-optimizer -no-vis -m ${CMAKE_CURRENT_SOURCE_DIR}/icf.mesh)
 
-add_test(NAME minimal-surface COMMAND minimal-surface)
+add_test(NAME minimal-surface COMMAND minimal-surface -no-vis)
 
 # Parallel apps.
 if (MFEM_USE_MPI)
@@ -70,6 +70,6 @@ if (MFEM_USE_MPI)
 
   add_test(NAME pminimal-surface_np=4
     COMMAND ${MPIEXEC} ${MPIEXEC_NUMPROC_FLAG} ${MFEM_MPI_NP}
-    ${MPIEXEC_PREFLAGS} $<TARGET_FILE:pminimal-surface>
+    ${MPIEXEC_PREFLAGS} $<TARGET_FILE:pminimal-surface> -no-vis
     ${MPIEXEC_POSTFLAGS})
 endif()

--- a/miniapps/nurbs/nurbs_ex1.cpp
+++ b/miniapps/nurbs/nurbs_ex1.cpp
@@ -61,7 +61,7 @@ public:
       double w;
 
 #ifdef MFEM_THREAD_SAFE
-      Vector shape[nd];
+      Vector shape(nd);
       Vector laplace(nd);
 #else
       shape.SetSize(nd);

--- a/miniapps/nurbs/nurbs_ex1p.cpp
+++ b/miniapps/nurbs/nurbs_ex1p.cpp
@@ -75,7 +75,7 @@ public:
       double w;
 
 #ifdef MFEM_THREAD_SAFE
-      Vector shape[nd];
+      Vector shape(nd);
       Vector laplace(nd);
 #else
       shape.SetSize(nd);


### PR DESCRIPTION
Fix typos in the `MFEM_THREAD_SAFE` sections of `nurbs_ex1/1p`.

Add `-no-vis` option to the `minimal-surface` tests in CMake.

Resolves #1452.
<!--GHEX{"id":1455,"author":"v-dobrev","editor":"tzanio","reviewers":["tzanio","camierjs"],"assignment":"2020-05-03T13:22:24-07:00","approval":"2020-05-07T23:06:11.067Z","merge":"2020-05-10T23:51:17.299Z"}XEHG--><!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge| 
 | --- | --- | --- | --- | --- | --- | --- | 
| [#1455](https://github.com/mfem/mfem/pull/1455) | @v-dobrev | @tzanio | @tzanio + @camierjs | 05/03/20 | 05/07/20 | 05/10/20 | |
<!--ELBATXEHG-->