### PR TITLE
Fix for doxygen relative path issues with chrome browser

### DIFF
--- a/doc/makefile
+++ b/doc/makefile
@@ -15,8 +15,7 @@ DOXYGEN_CONF = CodeDocumentation.conf
 # doxygen uses: graphviz, latex
 html: $(DOXYGEN_CONF)
 	doxygen $(DOXYGEN_CONF)
-	rm -f CodeDocumentation.html
-	ln -s CodeDocumentation/html/index.html CodeDocumentation.html
+	echo "<meta http-equiv=\"REFRESH\" content=\"0;URL=CodeDocumentation/html/index.html\">" > CodeDocumentation.html
 
 clean:
 	rm -rf $(DOXYGEN_CONF) CodeDocumentation CodeDocumentation.html *~


### PR DESCRIPTION

Should resolve #1480 .

Rather than using a symbolic link, uses html meta refresh to redirect to index.html.
Tested to work in chrome and firefox, both from the command line and opening a file from a running browser.

An alternative would be to just add this file to the repo, rather than generating it from the makefile, but this seems to link the relative path used to the configuration a little more closely.