### PR TITLE
Add a DeviceVector class that executes on Device by default.

### DIFF
--- a/linalg/vector.hpp
+++ b/linalg/vector.hpp
@@ -377,6 +377,44 @@ public:
 #endif
 };
 
+/// This class is nothing more than a Vector that executes on Device by default.
+class DeviceVector : public Vector
+{
+public:
+   /// Default constructor for DeviceVector. Sets size = 0 and data = NULL.
+   DeviceVector() : Vector()
+   {
+      this->UseDevice(true);
+   }
+
+   /// Copy constructor. Allocates a new data array and copies the data.
+   DeviceVector(const Vector &v) : Vector(v)
+   {
+      this->UseDevice(true);
+   }
+
+   /// @brief Creates vector of size s.
+   /// @warning Entries are not initialized to zero!
+   explicit DeviceVector(int s) : Vector(s)
+   {
+      this->UseDevice(true);
+   }
+
+   /// Creates a vector referencing an array of doubles, owned by someone else.
+   /** The pointer @a _data can be NULL. The data array can be replaced later
+       with SetData(). */
+   DeviceVector(double *_data, int _size) : Vector(_data,_size)
+   {
+      this->UseDevice(true);
+   }
+
+   /// Create a DeviceVector of size @a size_ using MemoryType @a mt.
+   DeviceVector(int size_, MemoryType mt) : Vector(size_,mt)
+   {
+      this->UseDevice(true);
+   }
+};
+
 // Inline methods
 
 inline bool IsFinite(const double &val)


### PR DESCRIPTION
For backward compatibility and performance reasons it was decided that the `Vector` class executes on CPU by default even when MFEM is ran on Device, it is required to use `UseDevice(true)` on the Vector to have it run on GPU.
In practice `UseDevice(true)` is often omitted/forgotten, and developers that were not part of the core team during the GPU port are unaware of the importance to call this method, resulting in __unsafe__ and __slow__ code because the `Vector` code unexpectedly execute partially or fully on CPU.
This PR proposes to add a very simple class `DeviceVector` which is nothing more than a `Vector` that executes on Device by default.
Since `DeviceVector` simply inherit from `Vector` they can be used wherever `Vector` is used, without the need to change anything in MFEM.
I believe it is much more natural and less bug prone for a developper to specify the intent for a `Vector` in the type, rather than using the `UseDevice(true)` method call.
The logic for this `DeviceVector` class could also be extended to the `Array` class into a `DeviceArray` class.