### PR TITLE
Recycle memory when recomputing geo-factors/ add user option for nodes. 

### DIFF
--- a/mesh/mesh.cpp
+++ b/mesh/mesh.cpp
@@ -10520,9 +10520,13 @@ GeometricFactors::GeometricFactors(const GridFunction *nodes,
    }
 }
 
-void GeometricFactors::Assemble(const int flags)
+void GeometricFactors::Assemble(const GridFunction *nodes,
+                                const IntegrationRule &ir,
+                                int flags)
 {
-
+   this->mesh = NULL;
+   this->nodes = nodes;
+   IntRule = &ir;
    computed_factors = flags;
 
    const FiniteElementSpace *fespace = nodes->FESpace();

--- a/mesh/mesh.cpp
+++ b/mesh/mesh.cpp
@@ -10436,14 +10436,14 @@ GeometricFactors::GeometricFactors(const Mesh *mesh, const IntegrationRule &ir,
                                    int flags)
 {
    MFEM_VERIFY(mesh->GetNodes() != NULL, "Mesh nodes are null");
-   Assemble(mesh->GetNodes(), *IntRule, flags);
+   Assemble(mesh->GetNodes(), ir, flags);
 }
 
 GeometricFactors::GeometricFactors(const GridFunction *nodes,
                                    const IntegrationRule &ir,
                                    int flags)
 {
-   Assemble(this->nodes, *IntRule, flags);
+   Assemble(this->nodes, ir, flags);
 }
 
 void GeometricFactors::Assemble(const GridFunction *nodes,

--- a/mesh/mesh.cpp
+++ b/mesh/mesh.cpp
@@ -10431,6 +10431,7 @@ int Mesh::FindPoints(DenseMatrix &point_mat, Array<int>& elem_ids,
    return pts_found;
 }
 
+
 GeometricFactors::GeometricFactors(const Mesh *mesh, const IntegrationRule &ir,
                                    int flags)
 {

--- a/mesh/mesh.cpp
+++ b/mesh/mesh.cpp
@@ -10439,49 +10439,7 @@ GeometricFactors::GeometricFactors(const Mesh *mesh, const IntegrationRule &ir,
    computed_factors = flags;
 
    this->nodes = mesh->GetNodes();
-   const FiniteElementSpace *fespace = nodes->FESpace();
-   const FiniteElement *fe = fespace->GetFE(0);
-   const int dim  = fe->GetDim();
-   const int vdim = fespace->GetVDim();
-   const int NE   = fespace->GetNE();
-   const int ND   = fe->GetDof();
-   const int NQ   = IntRule->GetNPoints();
-
-   // For now, we are not using tensor product evaluation
-   const Operator *elem_restr = fespace->GetElementRestriction(
-                                   ElementDofOrdering::NATIVE);
-
-   unsigned eval_flags = 0;
-   if (flags & GeometricFactors::COORDINATES)
-   {
-      X.SetSize(vdim*NQ*NE);
-      eval_flags |= QuadratureInterpolator::VALUES;
-   }
-   if (flags & GeometricFactors::JACOBIANS)
-   {
-      J.SetSize(dim*vdim*NQ*NE);
-      eval_flags |= QuadratureInterpolator::DERIVATIVES;
-   }
-   if (flags & GeometricFactors::DETERMINANTS)
-   {
-      detJ.SetSize(NQ*NE);
-      eval_flags |= QuadratureInterpolator::DETERMINANTS;
-   }
-
-   const QuadratureInterpolator *qi = fespace->GetQuadratureInterpolator(*IntRule);
-   // For now, we are not using tensor product evaluation (not implemented)
-   qi->DisableTensorProducts();
-   qi->SetOutputLayout(QVectorLayout::byNODES);
-   if (elem_restr)
-   {
-      Enodes.SetSize(vdim*ND*NE);
-      elem_restr->Mult(*nodes, Enodes);
-      qi->Mult(Enodes, eval_flags, X, J, detJ);
-   }
-   else
-   {
-      qi->Mult(*nodes, eval_flags, X, J, detJ);
-   }
+   Assemble(this->nodes, *IntRule, flags);
 }
 
 GeometricFactors::GeometricFactors(const GridFunction *nodes,
@@ -10492,49 +10450,7 @@ GeometricFactors::GeometricFactors(const GridFunction *nodes,
    IntRule = &ir;
    computed_factors = flags;
 
-   const FiniteElementSpace *fespace = nodes->FESpace();
-   const FiniteElement *fe = fespace->GetFE(0);
-   const int dim  = fe->GetDim();
-   const int vdim = fespace->GetVDim();
-   const int NE   = fespace->GetNE();
-   const int ND   = fe->GetDof();
-   const int NQ   = IntRule->GetNPoints();
-
-   // For now, we are not using tensor product evaluation
-   const Operator *elem_restr = fespace->GetElementRestriction(
-                                   ElementDofOrdering::NATIVE);
-
-   unsigned eval_flags = 0;
-   if (flags & GeometricFactors::COORDINATES)
-   {
-      X.SetSize(vdim*NQ*NE);
-      eval_flags |= QuadratureInterpolator::VALUES;
-   }
-   if (flags & GeometricFactors::JACOBIANS)
-   {
-      J.SetSize(dim*vdim*NQ*NE);
-      eval_flags |= QuadratureInterpolator::DERIVATIVES;
-   }
-   if (flags & GeometricFactors::DETERMINANTS)
-   {
-      detJ.SetSize(NQ*NE);
-      eval_flags |= QuadratureInterpolator::DETERMINANTS;
-   }
-
-   const QuadratureInterpolator *qi = fespace->GetQuadratureInterpolator(*IntRule);
-   // For now, we are not using tensor product evaluation (not implemented)
-   qi->DisableTensorProducts();
-   qi->SetOutputLayout(QVectorLayout::byNODES);
-   if (elem_restr)
-   {
-      Enodes.SetSize(vdim*ND*NE);
-      elem_restr->Mult(*nodes, Enodes);
-      qi->Mult(Enodes, eval_flags, X, J, detJ);
-   }
-   else
-   {
-      qi->Mult(*nodes, eval_flags, X, J, detJ);
-   }
+   Assemble(this->nodes, *IntRule, flags);
 }
 
 void GeometricFactors::Assemble(const GridFunction *nodes,

--- a/mesh/mesh.cpp
+++ b/mesh/mesh.cpp
@@ -337,7 +337,6 @@ void Mesh::GetElementTransformation(int i, IsoparametricTransformation *ElTr)
 {
    ElTr->Attribute = GetAttribute(i);
    ElTr->ElementNo = i;
-   ElTr->ElementType = ElementTransformation::ELEMENT;
    if (Nodes == NULL)
    {
       GetPointMatrix(i, ElTr->GetPointMat());
@@ -368,7 +367,6 @@ void Mesh::GetElementTransformation(int i, const Vector &nodes,
 {
    ElTr->Attribute = GetAttribute(i);
    ElTr->ElementNo = i;
-   ElTr->ElementType = ElementTransformation::ELEMENT;
    DenseMatrix &pm = ElTr->GetPointMat();
    nodes.HostRead();
    if (Nodes == NULL)
@@ -422,7 +420,6 @@ void Mesh::GetBdrElementTransformation(int i, IsoparametricTransformation* ElTr)
 {
    ElTr->Attribute = GetBdrAttribute(i);
    ElTr->ElementNo = i; // boundary element number
-   ElTr->ElementType = ElementTransformation::BDR_ELEMENT;
    DenseMatrix &pm = ElTr->GetPointMat();
    if (Nodes == NULL)
    {
@@ -465,7 +462,6 @@ void Mesh::GetBdrElementTransformation(int i, IsoparametricTransformation* ElTr)
 
          IntegrationRule eir(face_el->GetDof());
          FaceElemTr.Loc1.Transf.ElementNo = elem_id;
-         FaceElemTr.Loc1.Transf.ElementType = ElementTransformation::ELEMENT;
          FaceElemTr.Loc1.Transform(face_el->GetNodes(), eir);
          Nodes->GetVectorValues(FaceElemTr.Loc1.Transf, eir, pm);
 
@@ -478,7 +474,6 @@ void Mesh::GetFaceTransformation(int FaceNo, IsoparametricTransformation *FTr)
 {
    FTr->Attribute = (Dim == 1) ? 1 : faces[FaceNo]->GetAttribute();
    FTr->ElementNo = FaceNo;
-   FTr->ElementType = ElementTransformation::FACE;
    DenseMatrix &pm = FTr->GetPointMat();
    if (Nodes == NULL)
    {
@@ -531,7 +526,6 @@ void Mesh::GetFaceTransformation(int FaceNo, IsoparametricTransformation *FTr)
 
          IntegrationRule eir(face_el->GetDof());
          FaceElemTr.Loc1.Transf.ElementNo = face_info.Elem1No;
-         FaceElemTr.Loc1.Transf.ElementType = ElementTransformation::ELEMENT;
          FaceElemTr.Loc1.Transform(face_el->GetNodes(), eir);
          Nodes->GetVectorValues(FaceElemTr.Loc1.Transf, eir, pm);
 
@@ -560,7 +554,6 @@ void Mesh::GetEdgeTransformation(int EdgeNo, IsoparametricTransformation *EdTr)
 
    EdTr->Attribute = 1;
    EdTr->ElementNo = EdgeNo;
-   EdTr->ElementType = ElementTransformation::EDGE;
    DenseMatrix &pm = EdTr->GetPointMat();
    if (Nodes == NULL)
    {
@@ -859,7 +852,6 @@ FaceElementTransformations *Mesh::GetFaceElementTransformations(int FaceNo,
 {
    FaceInfo &face_info = faces_info[FaceNo];
 
-   FaceElemTr.SetConfigurationMask(0);
    FaceElemTr.Elem1 = NULL;
    FaceElemTr.Elem2 = NULL;
 
@@ -885,14 +877,8 @@ FaceElementTransformations *Mesh::GetFaceElementTransformations(int FaceNo,
    }
 
    // setup the face transformation
-   if (mask & 16)
-   {
-      GetFaceTransformation(FaceNo, &FaceElemTr);
-   }
-   else
-   {
-      FaceElemTr.SetGeometryType(GetFaceGeometryType(FaceNo));
-   }
+   FaceElemTr.FaceGeom = GetFaceGeometryType(FaceNo);
+   FaceElemTr.Face = (mask & 16) ? GetFaceTransformation(FaceNo) : NULL;
 
    // setup Loc1 & Loc2
    int face_type = GetFaceElementType(FaceNo);
@@ -922,8 +908,6 @@ FaceElementTransformations *Mesh::GetFaceElementTransformations(int FaceNo,
          }
       }
    }
-
-   FaceElemTr.SetConfigurationMask(mask);
 
    return &FaceElemTr;
 }
@@ -968,9 +952,7 @@ FaceElementTransformations *Mesh::GetBdrFaceTransformations(int BdrElemNo)
       return NULL;
    }
    tr = GetFaceElementTransformations(fn);
-   tr->Attribute = boundary[BdrElemNo]->GetAttribute();
-   tr->ElementNo = BdrElemNo;
-   tr->ElementType = ElementTransformation::BDR_FACE;
+   tr->Face->Attribute = boundary[BdrElemNo]->GetAttribute();
    return tr;
 }
 
@@ -10439,14 +10421,14 @@ GeometricFactors::GeometricFactors(const Mesh *mesh, const IntegrationRule &ir,
    IntRule = &ir;
    computed_factors = flags;
 
-   const GridFunction *nodes = mesh->GetNodes();
+   this->nodes = mesh->GetNodes();
    const FiniteElementSpace *fespace = nodes->FESpace();
    const FiniteElement *fe = fespace->GetFE(0);
    const int dim  = fe->GetDim();
    const int vdim = fespace->GetVDim();
    const int NE   = fespace->GetNE();
    const int ND   = fe->GetDof();
-   const int NQ   = ir.GetNPoints();
+   const int NQ   = IntRule->GetNPoints();
 
    // For now, we are not using tensor product evaluation
    const Operator *elem_restr = fespace->GetElementRestriction(
@@ -10469,13 +10451,13 @@ GeometricFactors::GeometricFactors(const Mesh *mesh, const IntegrationRule &ir,
       eval_flags |= QuadratureInterpolator::DETERMINANTS;
    }
 
-   const QuadratureInterpolator *qi = fespace->GetQuadratureInterpolator(ir);
+   const QuadratureInterpolator *qi = fespace->GetQuadratureInterpolator(*IntRule);
    // For now, we are not using tensor product evaluation (not implemented)
    qi->DisableTensorProducts();
    qi->SetOutputLayout(QVectorLayout::byNODES);
    if (elem_restr)
    {
-      Vector Enodes(vdim*ND*NE);
+      Enodes.SetSize(vdim*ND*NE);
       elem_restr->Mult(*nodes, Enodes);
       qi->Mult(Enodes, eval_flags, X, J, detJ);
    }
@@ -10483,6 +10465,110 @@ GeometricFactors::GeometricFactors(const Mesh *mesh, const IntegrationRule &ir,
    {
       qi->Mult(*nodes, eval_flags, X, J, detJ);
    }
+}
+
+GeometricFactors::GeometricFactors(const GridFunction *nodes,
+                                   const IntegrationRule &ir,
+                                   int flags)
+{
+   this->nodes = nodes;
+   IntRule = &ir;
+   computed_factors = flags;
+
+   const FiniteElementSpace *fespace = nodes->FESpace();
+   const FiniteElement *fe = fespace->GetFE(0);
+   const int dim  = fe->GetDim();
+   const int vdim = fespace->GetVDim();
+   const int NE   = fespace->GetNE();
+   const int ND   = fe->GetDof();
+   const int NQ   = IntRule->GetNPoints();
+
+   // For now, we are not using tensor product evaluation
+   const Operator *elem_restr = fespace->GetElementRestriction(
+                                   ElementDofOrdering::NATIVE);
+
+   unsigned eval_flags = 0;
+   if (flags & GeometricFactors::COORDINATES)
+   {
+      X.SetSize(vdim*NQ*NE);
+      eval_flags |= QuadratureInterpolator::VALUES;
+   }
+   if (flags & GeometricFactors::JACOBIANS)
+   {
+      J.SetSize(dim*vdim*NQ*NE);
+      eval_flags |= QuadratureInterpolator::DERIVATIVES;
+   }
+   if (flags & GeometricFactors::DETERMINANTS)
+   {
+      detJ.SetSize(NQ*NE);
+      eval_flags |= QuadratureInterpolator::DETERMINANTS;
+   }
+
+   const QuadratureInterpolator *qi = fespace->GetQuadratureInterpolator(*IntRule);
+   // For now, we are not using tensor product evaluation (not implemented)
+   qi->DisableTensorProducts();
+   qi->SetOutputLayout(QVectorLayout::byNODES);
+   if (elem_restr)
+   {
+      Enodes.SetSize(vdim*ND*NE);
+      elem_restr->Mult(*nodes, Enodes);
+      qi->Mult(Enodes, eval_flags, X, J, detJ);
+   }
+   else
+   {
+      qi->Mult(*nodes, eval_flags, X, J, detJ);
+   }
+}
+
+void GeometricFactors::Assemble(const int flags)
+{
+
+   computed_factors = flags;
+
+   const FiniteElementSpace *fespace = nodes->FESpace();
+   const FiniteElement *fe = fespace->GetFE(0);
+   const int dim  = fe->GetDim();
+   const int vdim = fespace->GetVDim();
+   const int NE   = fespace->GetNE();
+   const int ND   = fe->GetDof();
+   const int NQ   = IntRule->GetNPoints();
+
+   // For now, we are not using tensor product evaluation
+   const Operator *elem_restr = fespace->GetElementRestriction(
+                                   ElementDofOrdering::NATIVE);
+
+   unsigned eval_flags = 0;
+   if (flags & GeometricFactors::COORDINATES)
+   {
+      X.SetSize(vdim*NQ*NE);
+      eval_flags |= QuadratureInterpolator::VALUES;
+   }
+   if (flags & GeometricFactors::JACOBIANS)
+   {
+      J.SetSize(dim*vdim*NQ*NE);
+      eval_flags |= QuadratureInterpolator::DERIVATIVES;
+   }
+   if (flags & GeometricFactors::DETERMINANTS)
+   {
+      detJ.SetSize(NQ*NE);
+      eval_flags |= QuadratureInterpolator::DETERMINANTS;
+   }
+
+   const QuadratureInterpolator *qi = fespace->GetQuadratureInterpolator(*IntRule);
+   // For now, we are not using tensor product evaluation (not implemented)
+   qi->DisableTensorProducts();
+   qi->SetOutputLayout(QVectorLayout::byNODES);
+   if (elem_restr)
+   {
+      Enodes.SetSize(vdim*ND*NE);
+      elem_restr->Mult(*nodes, Enodes);
+      qi->Mult(Enodes, eval_flags, X, J, detJ);
+   }
+   else
+   {
+      qi->Mult(*nodes, eval_flags, X, J, detJ);
+   }
+
 }
 
 FaceGeometricFactors::FaceGeometricFactors(const Mesh *mesh,

--- a/mesh/mesh.cpp
+++ b/mesh/mesh.cpp
@@ -10434,22 +10434,14 @@ int Mesh::FindPoints(DenseMatrix &point_mat, Array<int>& elem_ids,
 GeometricFactors::GeometricFactors(const Mesh *mesh, const IntegrationRule &ir,
                                    int flags)
 {
-   this->mesh = mesh;
-   IntRule = &ir;
-   computed_factors = flags;
-
-   this->nodes = mesh->GetNodes();
-   Assemble(this->nodes, *IntRule, flags);
+   MFEM_VERIFY(mesh->GetNodes() != NULL, "Mesh nodes are null");
+   Assemble(mesh->GetNodes(), *IntRule, flags);
 }
 
 GeometricFactors::GeometricFactors(const GridFunction *nodes,
                                    const IntegrationRule &ir,
                                    int flags)
 {
-   this->nodes = nodes;
-   IntRule = &ir;
-   computed_factors = flags;
-
    Assemble(this->nodes, *IntRule, flags);
 }
 
@@ -10457,7 +10449,7 @@ void GeometricFactors::Assemble(const GridFunction *nodes,
                                 const IntegrationRule &ir,
                                 int flags)
 {
-   this->mesh = NULL;
+   this->mesh = nodes->FESpace()->GetMesh();
    this->nodes = nodes;
    IntRule = &ir;
    computed_factors = flags;
@@ -10505,7 +10497,6 @@ void GeometricFactors::Assemble(const GridFunction *nodes,
    {
       qi->Mult(*nodes, eval_flags, X, J, detJ);
    }
-
 }
 
 FaceGeometricFactors::FaceGeometricFactors(const Mesh *mesh,

--- a/mesh/mesh.cpp
+++ b/mesh/mesh.cpp
@@ -337,6 +337,7 @@ void Mesh::GetElementTransformation(int i, IsoparametricTransformation *ElTr)
 {
    ElTr->Attribute = GetAttribute(i);
    ElTr->ElementNo = i;
+   ElTr->ElementType = ElementTransformation::ELEMENT;
    if (Nodes == NULL)
    {
       GetPointMatrix(i, ElTr->GetPointMat());
@@ -367,6 +368,7 @@ void Mesh::GetElementTransformation(int i, const Vector &nodes,
 {
    ElTr->Attribute = GetAttribute(i);
    ElTr->ElementNo = i;
+   ElTr->ElementType = ElementTransformation::ELEMENT;
    DenseMatrix &pm = ElTr->GetPointMat();
    nodes.HostRead();
    if (Nodes == NULL)
@@ -420,6 +422,7 @@ void Mesh::GetBdrElementTransformation(int i, IsoparametricTransformation* ElTr)
 {
    ElTr->Attribute = GetBdrAttribute(i);
    ElTr->ElementNo = i; // boundary element number
+   ElTr->ElementType = ElementTransformation::BDR_ELEMENT;
    DenseMatrix &pm = ElTr->GetPointMat();
    if (Nodes == NULL)
    {
@@ -462,6 +465,7 @@ void Mesh::GetBdrElementTransformation(int i, IsoparametricTransformation* ElTr)
 
          IntegrationRule eir(face_el->GetDof());
          FaceElemTr.Loc1.Transf.ElementNo = elem_id;
+         FaceElemTr.Loc1.Transf.ElementType = ElementTransformation::ELEMENT;
          FaceElemTr.Loc1.Transform(face_el->GetNodes(), eir);
          Nodes->GetVectorValues(FaceElemTr.Loc1.Transf, eir, pm);
 
@@ -474,6 +478,7 @@ void Mesh::GetFaceTransformation(int FaceNo, IsoparametricTransformation *FTr)
 {
    FTr->Attribute = (Dim == 1) ? 1 : faces[FaceNo]->GetAttribute();
    FTr->ElementNo = FaceNo;
+   FTr->ElementType = ElementTransformation::FACE;
    DenseMatrix &pm = FTr->GetPointMat();
    if (Nodes == NULL)
    {
@@ -526,6 +531,7 @@ void Mesh::GetFaceTransformation(int FaceNo, IsoparametricTransformation *FTr)
 
          IntegrationRule eir(face_el->GetDof());
          FaceElemTr.Loc1.Transf.ElementNo = face_info.Elem1No;
+         FaceElemTr.Loc1.Transf.ElementType = ElementTransformation::ELEMENT;
          FaceElemTr.Loc1.Transform(face_el->GetNodes(), eir);
          Nodes->GetVectorValues(FaceElemTr.Loc1.Transf, eir, pm);
 
@@ -554,6 +560,7 @@ void Mesh::GetEdgeTransformation(int EdgeNo, IsoparametricTransformation *EdTr)
 
    EdTr->Attribute = 1;
    EdTr->ElementNo = EdgeNo;
+   EdTr->ElementType = ElementTransformation::EDGE;
    DenseMatrix &pm = EdTr->GetPointMat();
    if (Nodes == NULL)
    {
@@ -852,6 +859,7 @@ FaceElementTransformations *Mesh::GetFaceElementTransformations(int FaceNo,
 {
    FaceInfo &face_info = faces_info[FaceNo];
 
+   FaceElemTr.SetConfigurationMask(0);
    FaceElemTr.Elem1 = NULL;
    FaceElemTr.Elem2 = NULL;
 
@@ -877,8 +885,14 @@ FaceElementTransformations *Mesh::GetFaceElementTransformations(int FaceNo,
    }
 
    // setup the face transformation
-   FaceElemTr.FaceGeom = GetFaceGeometryType(FaceNo);
-   FaceElemTr.Face = (mask & 16) ? GetFaceTransformation(FaceNo) : NULL;
+   if (mask & 16)
+   {
+      GetFaceTransformation(FaceNo, &FaceElemTr);
+   }
+   else
+   {
+      FaceElemTr.SetGeometryType(GetFaceGeometryType(FaceNo));
+   }
 
    // setup Loc1 & Loc2
    int face_type = GetFaceElementType(FaceNo);
@@ -908,6 +922,8 @@ FaceElementTransformations *Mesh::GetFaceElementTransformations(int FaceNo,
          }
       }
    }
+
+   FaceElemTr.SetConfigurationMask(mask);
 
    return &FaceElemTr;
 }
@@ -952,7 +968,9 @@ FaceElementTransformations *Mesh::GetBdrFaceTransformations(int BdrElemNo)
       return NULL;
    }
    tr = GetFaceElementTransformations(fn);
-   tr->Face->Attribute = boundary[BdrElemNo]->GetAttribute();
+   tr->Attribute = boundary[BdrElemNo]->GetAttribute();
+   tr->ElementNo = BdrElemNo;
+   tr->ElementType = ElementTransformation::BDR_FACE;
    return tr;
 }
 
@@ -10412,7 +10430,6 @@ int Mesh::FindPoints(DenseMatrix &point_mat, Array<int>& elem_ids,
    }
    return pts_found;
 }
-
 
 GeometricFactors::GeometricFactors(const Mesh *mesh, const IntegrationRule &ir,
                                    int flags)

--- a/mesh/mesh.cpp
+++ b/mesh/mesh.cpp
@@ -10466,7 +10466,7 @@ GeometricFactors::GeometricFactors(const GridFunction *nodes,
                                    const IntegrationRule &ir,
                                    int flags) : recompute_factors(false)
 {
-   AssembleWithNodes(this->nodes, ir, flags);
+   AssembleWithNodes(nodes, ir, flags);
 }
 
 void GeometricFactors::AssembleWithNodes(const GridFunction *nodes,

--- a/mesh/mesh.cpp
+++ b/mesh/mesh.cpp
@@ -10483,7 +10483,6 @@ void GeometricFactors::AssembleWithNodes(const GridFunction *nodes,
 
 void GeometricFactors::Recompute()
 {
-
    const FiniteElementSpace *fespace = nodes->FESpace();
    const FiniteElement *fe = fespace->GetFE(0);
    const int dim  = fe->GetDim();

--- a/mesh/mesh.cpp
+++ b/mesh/mesh.cpp
@@ -801,11 +801,11 @@ const FaceGeometricFactors* Mesh::GetFaceGeometricFactors(
    return gf;
 }
 
-void Mesh::DeleteGeometricFactors(bool recompute)
+void Mesh::DeleteGeometricFactors(bool set_for_recompute)
 {
    for (int i = 0; i < geom_factors.Size(); i++)
    {
-      if (recompute)
+      if (set_for_recompute)
       {
          geom_factors[i]->SetForRecompute();
       }
@@ -814,20 +814,20 @@ void Mesh::DeleteGeometricFactors(bool recompute)
          delete geom_factors[i];
       }
    }
-   if (!recompute) {geom_factors.SetSize(0);}
+   if (!set_for_recompute) {geom_factors.SetSize(0);}
 
    for (int i = 0; i < face_geom_factors.Size(); i++)
    {
-      if (recompute)
+      if (set_for_recompute)
       {
-         face_geom_factors[i]->Recompute();
+         face_geom_factors[i]->SetForRecompute();
       }
       else
       {
          delete face_geom_factors[i];
       }
    }
-   if (!recompute) {face_geom_factors.SetSize(0);}
+   if (!set_for_recompute) {face_geom_factors.SetSize(0);}
 }
 
 void Mesh::GetLocalFaceTransformation(

--- a/mesh/mesh.hpp
+++ b/mesh/mesh.hpp
@@ -1353,7 +1353,7 @@ std::ostream &operator<<(std::ostream &out, const Mesh &mesh);
 class GeometricFactors
 {
 public:
-   const Mesh *mesh{nullptr};
+   const Mesh *mesh {nullptr};
    const GridFunction *nodes{nullptr};
    const IntegrationRule *IntRule{nullptr};
    int computed_factors;
@@ -1367,9 +1367,10 @@ public:
 
    GeometricFactors(const Mesh *mesh, const IntegrationRule &ir,const int flags);
 
-   GeometricFactors(const GridFunction *nodes, const IntegrationRule &ir, const int flags);
+   GeometricFactors(const GridFunction *nodes, const IntegrationRule &ir,
+                    const int flags);
 
-   void Assemble(const int flags); 
+   void Assemble(const int flags);
 
    /// Mapped (physical) coordinates of all quadrature points.
    /** This array uses a column-major layout with dimensions (NQ x SDIM x NE)

--- a/mesh/mesh.hpp
+++ b/mesh/mesh.hpp
@@ -1367,7 +1367,7 @@ public:
 
    GeometricFactors() = default;
 
-   GeometricFactors(const Mesh *mesh, const IntegrationRule &ir,const int flags);
+   GeometricFactors(const Mesh *mesh, const IntegrationRule &ir, int flags);
 
    GeometricFactors(const GridFunction *nodes, const IntegrationRule &ir,
                     const int flags);
@@ -1399,6 +1399,11 @@ public:
        - NE = number of elements in the mesh. */
    Vector detJ;
 
+   /// Element restricted nodes
+   /** This array uses a column-major layout with dimensions (SDIM x NQ x NE) where
+       - SDIM = space dimension of the mesh = mesh.SpaceDimension(), and
+       - NQ   = number of quadrature points per element, and
+       - NE   = number of elements in the mesh. */
    Vector Enodes;
 };
 

--- a/mesh/mesh.hpp
+++ b/mesh/mesh.hpp
@@ -1353,8 +1353,9 @@ std::ostream &operator<<(std::ostream &out, const Mesh &mesh);
 class GeometricFactors
 {
 public:
-   const Mesh *mesh;
-   const IntegrationRule *IntRule;
+   const Mesh *mesh{nullptr};
+   const GridFunction *nodes{nullptr};
+   const IntegrationRule *IntRule{nullptr};
    int computed_factors;
 
    enum FactorFlags
@@ -1364,7 +1365,11 @@ public:
       DETERMINANTS = 1 << 2,
    };
 
-   GeometricFactors(const Mesh *mesh, const IntegrationRule &ir, int flags);
+   GeometricFactors(const Mesh *mesh, const IntegrationRule &ir,const int flags);
+
+   GeometricFactors(const GridFunction *nodes, const IntegrationRule &ir, const int flags);
+
+   void Assemble(const int flags); 
 
    /// Mapped (physical) coordinates of all quadrature points.
    /** This array uses a column-major layout with dimensions (NQ x SDIM x NE)
@@ -1388,6 +1393,8 @@ public:
        - NQ = number of quadrature points per element, and
        - NE = number of elements in the mesh. */
    Vector detJ;
+
+   Vector Enodes;
 };
 
 /** @brief Structure for storing face geometric factors: coordinates, Jacobians,

--- a/mesh/mesh.hpp
+++ b/mesh/mesh.hpp
@@ -1353,7 +1353,7 @@ std::ostream &operator<<(std::ostream &out, const Mesh &mesh);
 class GeometricFactors
 {
 public:
-   const Mesh *mesh {nullptr};
+   const Mesh *mesh{nullptr};
    const GridFunction *nodes{nullptr};
    const IntegrationRule *IntRule{nullptr};
    int computed_factors;
@@ -1365,12 +1365,14 @@ public:
       DETERMINANTS = 1 << 2,
    };
 
+   GeometricFactors() = default;
+
    GeometricFactors(const Mesh *mesh, const IntegrationRule &ir,const int flags);
 
-   GeometricFactors(const GridFunction *nodes, const IntegrationRule &ir,
-                    const int flags);
+   GeometricFactors(const GridFunction *nodes, const IntegrationRule &ir, const int flags);
 
-   void Assemble(const int flags);
+   //Overrides calcuating geometric factors with mesh nodes and uses user defined nodes
+   void Assemble(const GridFunction *nodes, const IntegrationRule &ir, const int flags);
 
    /// Mapped (physical) coordinates of all quadrature points.
    /** This array uses a column-major layout with dimensions (NQ x SDIM x NE)

--- a/mesh/mesh.hpp
+++ b/mesh/mesh.hpp
@@ -1428,8 +1428,8 @@ protected:
    Vector Fnodes;
 
 public:
-   const Mesh *mesh;
-   const IntegrationRule *IntRule;
+   const Mesh *mesh{nullptr};
+   const IntegrationRule *IntRule{nullptr};
    int computed_factors;
    bool recompute_factors{false};
    FaceType type;

--- a/mesh/mesh.hpp
+++ b/mesh/mesh.hpp
@@ -1352,6 +1352,16 @@ std::ostream &operator<<(std::ostream &out, const Mesh &mesh);
     Mesh. See Mesh::GetGeometricFactors(). */
 class GeometricFactors
 {
+
+protected:
+   /// Element restricted nodes
+   /// [TODO move to stack when pools are available]
+   /** This array uses a column-major layout with dimensions (ND x SDIM x NE) where
+        - ND   = number of degrees of freedom per element,
+        - SDIM = space dimension of the mesh = mesh.SpaceDimension(), and
+        - NE   = number of elements in the mesh. */
+   Vector Enodes;
+
 public:
    const Mesh *mesh {nullptr};
    const GridFunction *nodes{nullptr};
@@ -1398,13 +1408,6 @@ public:
        - NQ = number of quadrature points per element, and
        - NE = number of elements in the mesh. */
    Vector detJ;
-
-   /// Element restricted nodes
-   /** This array uses a column-major layout with dimensions (ND x SDIM x NE) where
-       - ND   = number of degrees of freedom per element,
-       - SDIM = space dimension of the mesh = mesh.SpaceDimension(), and
-       - NE   = number of elements in the mesh. */
-   Vector Enodes;
 };
 
 /** @brief Structure for storing face geometric factors: coordinates, Jacobians,
@@ -1413,16 +1416,6 @@ public:
     Mesh. See Mesh::GetFaceGeometricFactors(). */
 class FaceGeometricFactors
 {
-
-protected:
-   /// Element restricted nodes
-   /// [TODO move to stack when pools are available]
-   /** This array uses a column-major layout with dimensions (ND x SDIM x NE) where
-        - ND   = number of degrees of freedom per element,
-        - SDIM = space dimension of the mesh = mesh.SpaceDimension(), and
-        - NE   = number of elements in the mesh. */
-   Vector Enodes;
-
 public:
    const Mesh *mesh;
    const IntegrationRule *IntRule;

--- a/mesh/mesh.hpp
+++ b/mesh/mesh.hpp
@@ -1400,9 +1400,9 @@ public:
    Vector detJ;
 
    /// Element restricted nodes
-   /** This array uses a column-major layout with dimensions (SDIM x NQ x NE) where
+   /** This array uses a column-major layout with dimensions (ND x SDIM x NE) where
+       - ND   = number of degrees of freedom per element,
        - SDIM = space dimension of the mesh = mesh.SpaceDimension(), and
-       - NQ   = number of quadrature points per element, and
        - NE   = number of elements in the mesh. */
    Vector Enodes;
 };

--- a/mesh/mesh.hpp
+++ b/mesh/mesh.hpp
@@ -747,7 +747,7 @@ public:
    /// Destroy all GeometricFactors stored by the Mesh.
    /** This method can be used to force recomputation of the GeometricFactors,
        for example, after the mesh nodes are modified externally. */
-   void DeleteGeometricFactors();
+   void DeleteGeometricFactors(bool recompute=false);
 
    /// Equals 1 + num_holes - num_loops
    inline int EulerNumber() const
@@ -1367,6 +1367,7 @@ public:
    const GridFunction *nodes{nullptr};
    const IntegrationRule *IntRule{nullptr};
    int computed_factors;
+   bool recompute_factors{false};
 
    enum FactorFlags
    {
@@ -1383,8 +1384,14 @@ public:
                     const int flags);
 
    //Overrides calcuating geometric factors with mesh nodes and uses user defined nodes
-   void Assemble(const GridFunction *nodes, const IntegrationRule &ir,
-                 const int flags);
+   void AssembleWithNodes(const GridFunction *nodes, const IntegrationRule &ir,
+                          const int flags);
+
+   void Recompute();
+
+   void SetForRecompute(bool recompute=false) {recompute_factors = recompute; };
+
+   bool RecomputeStatus() {return recompute_factors; };
 
    /// Mapped (physical) coordinates of all quadrature points.
    /** This array uses a column-major layout with dimensions (NQ x SDIM x NE)
@@ -1416,10 +1423,15 @@ public:
     Mesh. See Mesh::GetFaceGeometricFactors(). */
 class FaceGeometricFactors
 {
+protected:
+   //Temporary used computing face geometric factors
+   Vector Fnodes;
+
 public:
    const Mesh *mesh;
    const IntegrationRule *IntRule;
    int computed_factors;
+   bool recompute_factors{false};
    FaceType type;
 
    enum FactorFlags
@@ -1432,6 +1444,12 @@ public:
 
    FaceGeometricFactors(const Mesh *mesh, const IntegrationRule &ir, int flags,
                         FaceType type);
+
+   void Recompute();
+
+   void SetForRecompute(bool recompute=false) {recompute_factors = recompute; };
+
+   bool RecomputeStatus() {return recompute_factors; };
 
    /// Mapped (physical) coordinates of all quadrature points.
    /** This array uses a column-major layout with dimensions (NQ x SDIM x NF)

--- a/mesh/mesh.hpp
+++ b/mesh/mesh.hpp
@@ -1353,7 +1353,7 @@ std::ostream &operator<<(std::ostream &out, const Mesh &mesh);
 class GeometricFactors
 {
 public:
-   const Mesh *mesh{nullptr};
+   const Mesh *mesh {nullptr};
    const GridFunction *nodes{nullptr};
    const IntegrationRule *IntRule{nullptr};
    int computed_factors;
@@ -1369,10 +1369,12 @@ public:
 
    GeometricFactors(const Mesh *mesh, const IntegrationRule &ir,const int flags);
 
-   GeometricFactors(const GridFunction *nodes, const IntegrationRule &ir, const int flags);
+   GeometricFactors(const GridFunction *nodes, const IntegrationRule &ir,
+                    const int flags);
 
    //Overrides calcuating geometric factors with mesh nodes and uses user defined nodes
-   void Assemble(const GridFunction *nodes, const IntegrationRule &ir, const int flags);
+   void Assemble(const GridFunction *nodes, const IntegrationRule &ir,
+                 const int flags);
 
    /// Mapped (physical) coordinates of all quadrature points.
    /** This array uses a column-major layout with dimensions (NQ x SDIM x NE)

--- a/mesh/mesh.hpp
+++ b/mesh/mesh.hpp
@@ -1413,6 +1413,16 @@ public:
     Mesh. See Mesh::GetFaceGeometricFactors(). */
 class FaceGeometricFactors
 {
+
+protected:
+   /// Element restricted nodes
+   /// [TODO move to stack when pools are available]
+   /** This array uses a column-major layout with dimensions (ND x SDIM x NE) where
+        - ND   = number of degrees of freedom per element,
+        - SDIM = space dimension of the mesh = mesh.SpaceDimension(), and
+        - NE   = number of elements in the mesh. */
+   Vector Enodes;
+
 public:
    const Mesh *mesh;
    const IntegrationRule *IntRule;

--- a/mesh/mesh.hpp
+++ b/mesh/mesh.hpp
@@ -1428,7 +1428,7 @@ protected:
    Vector Fnodes;
 
 public:
-   const Mesh *mesh{nullptr};
+   const Mesh *mesh {nullptr};
    const IntegrationRule *IntRule{nullptr};
    int computed_factors;
    bool recompute_factors{false};

--- a/mesh/mesh.hpp
+++ b/mesh/mesh.hpp
@@ -1383,7 +1383,8 @@ public:
    GeometricFactors(const GridFunction *nodes, const IntegrationRule &ir,
                     const int flags);
 
-   // Overrides calcuating geometric factors with mesh nodes and uses user defined nodes
+   /** Overrides calculating geometric factors with mesh nodes and uses user
+       defined nodes. */
    void AssembleWithNodes(const GridFunction *nodes, const IntegrationRule &ir,
                           const int flags);
 

--- a/mesh/mesh.hpp
+++ b/mesh/mesh.hpp
@@ -1389,7 +1389,7 @@ public:
 
    void Recompute();
 
-   void SetForRecompute(bool recompute = false) {recompute_factors = recompute; };
+   void SetForRecompute(bool recompute = true) {recompute_factors = recompute; };
 
    bool RecomputeStatus() {return recompute_factors; };
 
@@ -1447,7 +1447,7 @@ public:
 
    void Recompute();
 
-   void SetForRecompute(bool recompute = false) {recompute_factors = recompute; };
+   void SetForRecompute(bool recompute = true) {recompute_factors = recompute; };
 
    bool RecomputeStatus() {return recompute_factors; };
 

--- a/mesh/mesh.hpp
+++ b/mesh/mesh.hpp
@@ -747,7 +747,7 @@ public:
    /// Destroy all GeometricFactors stored by the Mesh.
    /** This method can be used to force recomputation of the GeometricFactors,
        for example, after the mesh nodes are modified externally. */
-   void DeleteGeometricFactors(bool recompute=false);
+   void DeleteGeometricFactors(bool recompute = false);
 
    /// Equals 1 + num_holes - num_loops
    inline int EulerNumber() const
@@ -1447,7 +1447,7 @@ public:
 
    void Recompute();
 
-   void SetForRecompute(bool recompute=false) {recompute_factors = recompute; };
+   void SetForRecompute(bool recompute = false) {recompute_factors = recompute; };
 
    bool RecomputeStatus() {return recompute_factors; };
 

--- a/mesh/mesh.hpp
+++ b/mesh/mesh.hpp
@@ -1355,7 +1355,7 @@ class GeometricFactors
 
 protected:
    /// Element restricted nodes
-   /// [TODO move to stack when pools are available]
+   /// [TODO move to temp when pools are available]
    /** This array uses a column-major layout with dimensions (ND x SDIM x NE) where
         - ND   = number of degrees of freedom per element,
         - SDIM = space dimension of the mesh = mesh.SpaceDimension(), and
@@ -1363,11 +1363,11 @@ protected:
    Vector Enodes;
 
 public:
-   const Mesh *mesh {nullptr};
-   const GridFunction *nodes{nullptr};
-   const IntegrationRule *IntRule{nullptr};
+   const Mesh *mesh;
+   const GridFunction *nodes;
+   const IntegrationRule *IntRule;
    int computed_factors;
-   bool recompute_factors{false};
+   bool recompute_factors;
 
    enum FactorFlags
    {
@@ -1383,13 +1383,13 @@ public:
    GeometricFactors(const GridFunction *nodes, const IntegrationRule &ir,
                     const int flags);
 
-   //Overrides calcuating geometric factors with mesh nodes and uses user defined nodes
+   // Overrides calcuating geometric factors with mesh nodes and uses user defined nodes
    void AssembleWithNodes(const GridFunction *nodes, const IntegrationRule &ir,
                           const int flags);
 
    void Recompute();
 
-   void SetForRecompute(bool recompute=false) {recompute_factors = recompute; };
+   void SetForRecompute(bool recompute = false) {recompute_factors = recompute; };
 
    bool RecomputeStatus() {return recompute_factors; };
 
@@ -1428,10 +1428,10 @@ protected:
    Vector Fnodes;
 
 public:
-   const Mesh *mesh {nullptr};
-   const IntegrationRule *IntRule{nullptr};
+   const Mesh *mesh;
+   const IntegrationRule *IntRule;
    int computed_factors;
-   bool recompute_factors{false};
+   bool recompute_factors;
    FaceType type;
 
    enum FactorFlags


### PR DESCRIPTION
This PR enables the GeometricFactors class to calculate geometric factors based on user provided nodes. I also did a minor clean up on the class. 

Resolves #1500.

<!--GHEX{"id":1517,"author":"artv3","editor":"tzanio","reviewers":["camierjs","v-dobrev"],"assignment":"2020-06-07T10:03:07-07:00","approval":"2020-07-28","merge":"2020-08-04T07:00:00.000Z"}XEHG--><!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge| 
 | --- | --- | --- | --- | --- | --- | --- | 
| [#1517](https://github.com/mfem/mfem/pull/1517) | @artv3 | @tzanio | @camierjs + @v-dobrev | 06/07/20 | 07/28/20 | ⌛due 08/04/20 | |
<!--ELBATXEHG-->