### PR TITLE
Fixing compiling with C++17

### DIFF
--- a/general/mem_manager.hpp
+++ b/general/mem_manager.hpp
@@ -450,7 +450,7 @@ private:
 
    template <std::size_t align_bytes, bool dummy = true> struct Alloc
    {
-      static inline T *New(std::size_t)
+      static inline T *New(std::size_t size)
       {
 #if __cplusplus < 201703L
          // Generate an error in debug mode


### PR DESCRIPTION
Compiling the MFEM header using C++17 results in a compiler error:
```
error: use of undeclared identifier 'size'
```

This is fixed by adding a parameter declaration to the function.