### PR TITLE
Fix for superlu_dist 6.3.

### DIFF
--- a/linalg/superlu.cpp
+++ b/linalg/superlu.cpp
@@ -24,6 +24,18 @@
 #error "SuperLUDist has been built with 64bit integers. This is not supported"
 #endif
 
+#if SUPERLU_DIST_MAJOR_VERSION > 6 ||                                   \
+  (SUPERLU_DIST_MAJOR_VERSION == 6 && SUPERLU_DIST_MINOR_VERSION > 2)
+#define ScalePermstruct_t dScalePermstruct_t
+#define LUstruct_t dLUstruct_t
+#define SOLVEstruct_t dSOLVEstruct_t
+#define ScalePermstructFree dScalePermstructFree
+#define Destroy_LU dDestroy_LU
+#define LUstructFree dLUstructFree
+#define LUstructInit dLUstructInit
+#endif
+
+
 using namespace std;
 
 namespace mfem


### PR DESCRIPTION
Some SuperLU_Dist structures are now prefixed with 'd' (real double) or 'z' (complex double), etc. so that codes can link both real and complex versions of the SuperLU_Dist library.

See https://portal.nersc.gov/project/sparse/superlu/changes.html#slu_dist_change