### PR TITLE
Fixing boundary attributes and 1D mesh support [bugfix/mesh-trimmer]

### DIFF
--- a/miniapps/meshing/trimmer.cpp
+++ b/miniapps/meshing/trimmer.cpp
@@ -113,7 +113,7 @@ int main(int argc, char *argv[])
 
    // Count the number of boundary elements in the final mesh
    int num_bdr_elements = 0;
-   for (int f=0; f<mesh.GetNFaces(); f++)
+   for (int f=0; f<mesh.GetNumFaces(); f++)
    {
       int e1 = -1, e2 = -1;
       mesh.GetFaceElements(f, &e1, &e2);
@@ -162,8 +162,22 @@ int main(int argc, char *argv[])
       }
    }
 
-   // Create boundary elements
-   for (int f=0; f<mesh.GetNFaces(); f++)
+   // Copy selected boundary elements
+   for (int be=0; be<mesh.GetNBE(); be++)
+   {
+      int e, info;
+      mesh.GetBdrElementAdjacentElement(be, e, info);
+
+      int elem_attr = mesh.GetElement(e)->GetAttribute();
+      if (!marker[elem_attr-1])
+      {
+         Element * nbel = mesh.GetBdrElement(be)->Duplicate(&trimmed_mesh);
+         trimmed_mesh.AddBdrElement(nbel);
+      }
+   }
+
+   // Create new boundary elements
+   for (int f=0; f<mesh.GetNumFaces(); f++)
    {
       int e1 = -1, e2 = -1;
       mesh.GetFaceElements(f, &e1, &e2);

--- a/miniapps/meshing/trimmer.cpp
+++ b/miniapps/meshing/trimmer.cpp
@@ -189,25 +189,21 @@ int main(int argc, char *argv[])
       if (e1 >= 0) { a1 = mesh.GetElement(e1)->GetAttribute(); }
       if (e2 >= 0) { a2 = mesh.GetElement(e2)->GetAttribute(); }
 
-      if (a1 == 0 || a2 == 0)
-      {
-         if ((a1 == 0 && !marker[a2-1]) || (a2 == 0 && !marker[a1-1]))
-         {
-            Element * bel = mesh.GetFace(f)->Duplicate(&trimmed_mesh);
-            trimmed_mesh.AddBdrElement(bel);
-         }
-      }
-      else
+      if (a1 != 0 && a2 != 0)
       {
          if (marker[a1-1] && !marker[a2-1])
          {
-            Element * bel = mesh.GetFace(f)->Duplicate(&trimmed_mesh);
+            Element * bel = (mesh.Dimension() == 1) ?
+                            (Element*)new Point(&f) :
+                            mesh.GetFace(f)->Duplicate(&trimmed_mesh);
             bel->SetAttribute(bdr_attr[attr_inv[a1-1]]);
             trimmed_mesh.AddBdrElement(bel);
          }
          else if (!marker[a1-1] && marker[a2-1])
          {
-            Element * bel = mesh.GetFace(f)->Duplicate(&trimmed_mesh);
+            Element * bel = (mesh.Dimension() == 1) ?
+                            (Element*)new Point(&f) :
+                            mesh.GetFace(f)->Duplicate(&trimmed_mesh);
             bel->SetAttribute(bdr_attr[attr_inv[a2-1]]);
             trimmed_mesh.AddBdrElement(bel);
          }


### PR DESCRIPTION
The code now loops over boundary faces and interior faces separately so that it can easily copy the pre-existing boundary attributes to the new mesh.

Also added support for 1D meshes by creating new `Point` objects for the new boundary elements rather than duplicating interior face elements which don't exist in 1D.

I briefly looked at adding support for non-conforming meshes but I didn't see a way to build an NCMesh by copying selected elements, etc..  
<!--GHEX{"id":1558,"author":"mlstowell","editor":"tzanio","reviewers":["homijan","delyank"],"assignment":"2020-06-18T18:26:42-07:00","approval":"2020-06-27T00:51:40.242Z","merge":"2020-07-04T20:20:26.230Z"}XEHG--><!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge| 
 | --- | --- | --- | --- | --- | --- | --- | 
| [#1558](https://github.com/mfem/mfem/pull/1558) | @mlstowell | @tzanio | @homijan + @delyank | 06/18/20 | 06/26/20 | 07/04/20 | |
<!--ELBATXEHG-->