### PR TITLE
Fix a bug with hybridization on 2D NC meshes

### DIFF
--- a/examples/ex4p.cpp
+++ b/examples/ex4p.cpp
@@ -16,6 +16,7 @@
 //               mpirun -np 4 ex4p -m ../data/periodic-square.mesh -no-bc
 //               mpirun -np 4 ex4p -m ../data/periodic-cube.mesh -no-bc
 //               mpirun -np 4 ex4p -m ../data/amr-quad.mesh
+//               mpirun -np 3 ex4p -m ../data/amr-quad.mesh -o 2 -hb
 //               mpirun -np 4 ex4p -m ../data/amr-hex.mesh -o 2 -sc
 //               mpirun -np 4 ex4p -m ../data/amr-hex.mesh -o 2 -hb
 //               mpirun -np 4 ex4p -m ../data/star-surf.mesh -o 3 -hb

--- a/examples/ex9p.cpp
+++ b/examples/ex9p.cpp
@@ -16,6 +16,7 @@
 //    mpirun -np 4 ex9p -m ../data/disc-nurbs.mesh -p 2 -rp 1 -dt 0.005 -tf 9
 //    mpirun -np 4 ex9p -m ../data/periodic-square.mesh -p 3 -rp 2 -dt 0.0025 -tf 9 -vs 20
 //    mpirun -np 4 ex9p -m ../data/periodic-cube.mesh -p 0 -o 2 -rp 1 -dt 0.01 -tf 8
+//    mpirun -np 3 ex9p -m ../data/amr-hex.mesh -p 1 -rs 1 -rp 0 -dt 0.005 -tf 0.5
 //
 // Device sample runs:
 //    mpirun -np 4 ex9p -pa

--- a/fem/eltrans.cpp
+++ b/fem/eltrans.cpp
@@ -624,4 +624,76 @@ void FaceElementTransformations::Transform(const DenseMatrix &matrix,
    IsoparametricTransformation::Transform(matrix, result);
 }
 
+double FaceElementTransformations::CheckConsistency(int print_level)
+{
+   // Check that the face vertices are mapped to the same physical location
+   // when using the following three transformations:
+   // - the face transformation, *this
+   // - Loc1 + Elem1
+   // - Loc2 + Elem2, if present.
+
+   const bool have_face = (mask & 16);
+   const bool have_el1 = (mask & 1) && (mask & 4);
+   const bool have_el2 = (mask & 2) && (mask & 8) && (Elem2No >= 0);
+   if (int(have_face) + int(have_el1) + int(have_el2) < 2)
+   {
+      // need at least two different transformations to perform a check
+      return 0.0;
+   }
+
+   const IntegrationRule &v_ir = *Geometries.GetVertices(GetGeometryType());
+
+   double max_dist = 0.0;
+   Vector dist(v_ir.GetNPoints());
+   DenseMatrix coords_base, coords_el;
+   IntegrationRule v_eir(v_ir.GetNPoints());
+   if (have_face)
+   {
+      Transform(v_ir, coords_base);
+      if (print_level > 0)
+      {
+         mfem::out << "\nface vertex coordinates (from face transform):\n"
+                   << "----------------------------------------------\n";
+         coords_base.PrintT(mfem::out, coords_base.Height());
+      }
+   }
+   if (have_el1)
+   {
+      Loc1.Transform(v_ir, v_eir);
+      Elem1->Transform(v_eir, coords_el);
+      if (print_level > 0)
+      {
+         mfem::out << "\nface vertex coordinates (from element 1 transform):\n"
+                   << "---------------------------------------------------\n";
+         coords_el.PrintT(mfem::out, coords_el.Height());
+      }
+      if (have_face)
+      {
+         coords_el -= coords_base;
+         coords_el.Norm2(dist);
+         max_dist = std::max(max_dist, dist.Normlinf());
+      }
+      else
+      {
+         coords_base = coords_el;
+      }
+   }
+   if (have_el2)
+   {
+      Loc2.Transform(v_ir, v_eir);
+      Elem2->Transform(v_eir, coords_el);
+      if (print_level > 0)
+      {
+         mfem::out << "\nface vertex coordinates (from element 2 transform):\n"
+                   << "---------------------------------------------------\n";
+         coords_el.PrintT(mfem::out, coords_el.Height());
+      }
+      coords_el -= coords_base;
+      coords_el.Norm2(dist);
+      max_dist = std::max(max_dist, dist.Normlinf());
+   }
+
+   return max_dist;
+}
+
 }

--- a/fem/eltrans.cpp
+++ b/fem/eltrans.cpp
@@ -624,7 +624,8 @@ void FaceElementTransformations::Transform(const DenseMatrix &matrix,
    IsoparametricTransformation::Transform(matrix, result);
 }
 
-double FaceElementTransformations::CheckConsistency(int print_level)
+double FaceElementTransformations::CheckConsistency(int print_level,
+                                                    std::ostream &out)
 {
    // Check that the face vertices are mapped to the same physical location
    // when using the following three transformations:
@@ -652,9 +653,9 @@ double FaceElementTransformations::CheckConsistency(int print_level)
       Transform(v_ir, coords_base);
       if (print_level > 0)
       {
-         mfem::out << "\nface vertex coordinates (from face transform):\n"
-                   << "----------------------------------------------\n";
-         coords_base.PrintT(mfem::out, coords_base.Height());
+         out << "\nface vertex coordinates (from face transform):\n"
+             << "----------------------------------------------\n";
+         coords_base.PrintT(out, coords_base.Height());
       }
    }
    if (have_el1)
@@ -663,9 +664,9 @@ double FaceElementTransformations::CheckConsistency(int print_level)
       Elem1->Transform(v_eir, coords_el);
       if (print_level > 0)
       {
-         mfem::out << "\nface vertex coordinates (from element 1 transform):\n"
-                   << "---------------------------------------------------\n";
-         coords_el.PrintT(mfem::out, coords_el.Height());
+         out << "\nface vertex coordinates (from element 1 transform):\n"
+             << "---------------------------------------------------\n";
+         coords_el.PrintT(out, coords_el.Height());
       }
       if (have_face)
       {
@@ -684,9 +685,9 @@ double FaceElementTransformations::CheckConsistency(int print_level)
       Elem2->Transform(v_eir, coords_el);
       if (print_level > 0)
       {
-         mfem::out << "\nface vertex coordinates (from element 2 transform):\n"
-                   << "---------------------------------------------------\n";
-         coords_el.PrintT(mfem::out, coords_el.Height());
+         out << "\nface vertex coordinates (from element 2 transform):\n"
+             << "---------------------------------------------------\n";
+         coords_el.PrintT(out, coords_el.Height());
       }
       coords_el -= coords_base;
       coords_el.Norm2(dist);

--- a/fem/eltrans.hpp
+++ b/fem/eltrans.hpp
@@ -493,11 +493,25 @@ public:
    IntegrationPointTransformation & GetIntPoint1Transformation();
    IntegrationPointTransformation & GetIntPoint2Transformation();
 
-   /** @brief Check for self-consistency. Returns a maximal distance between
-       physical points that should coincide. A successful check should return
-       a small number relative to the mesh extents. */
-   /** @note This check will generally fail on periodic boundary faces. */
-   double CheckConsistency(int print_level = 0);
+   /** @brief Check for self-consistency: compares the result of mapping the
+       reference face vertices to physical coordinates using the three
+       transformations: face, element 1, and element 2.
+
+       @param[in] print_level  If set to a positive number, print the physical
+                               coordinates of the face vertices computed through
+                               all available transformations: face, element 1,
+                               and/or element 2.
+       @param[in,out] out      The output stream to use for printing.
+
+       @returns A maximal distance between physical coordinates of face vertices
+                that should coincide. A successful check should return a small
+                number relative to the mesh extents. If less than 2 of the three
+                transformations are set, returns 0.
+
+       @warning This check will generally fail on periodic boundary faces.
+   */
+   double CheckConsistency(int print_level = 0,
+                           std::ostream &out = mfem::out);
 };
 
 /**                Elem1(Loc1(x)) = Face(x) = Elem2(Loc2(x))

--- a/fem/eltrans.hpp
+++ b/fem/eltrans.hpp
@@ -492,6 +492,12 @@ public:
    ElementTransformation & GetElement2Transformation();
    IntegrationPointTransformation & GetIntPoint1Transformation();
    IntegrationPointTransformation & GetIntPoint2Transformation();
+
+   /** @brief Check for self-consistency. Returns a maximal distance between
+       physical points that should coincide. A successful check should return
+       a small number relative to the mesh extents. */
+   /** @note This check will generally fail on periodic boundary faces. */
+   double CheckConsistency(int print_level = 0);
 };
 
 /**                Elem1(Loc1(x)) = Face(x) = Elem2(Loc2(x))

--- a/fem/gridfunc.cpp
+++ b/fem/gridfunc.cpp
@@ -1031,13 +1031,13 @@ int GridFunction::GetFaceVectorValues(
    }
    if (di == 0)
    {
-      Transf = fes->GetMesh()->GetFaceElementTransformations(i, 4);
+      Transf = fes->GetMesh()->GetFaceElementTransformations(i, 5);
       Transf->Loc1.Transform(ir, eir);
       GetVectorValues(*Transf->Elem1, eir, vals, &tr);
    }
    else
    {
-      Transf = fes->GetMesh()->GetFaceElementTransformations(i, 8);
+      Transf = fes->GetMesh()->GetFaceElementTransformations(i, 10);
       Transf->Loc2.Transform(ir, eir);
       GetVectorValues(*Transf->Elem2, eir, vals, &tr);
    }

--- a/fem/pfespace.cpp
+++ b/fem/pfespace.cpp
@@ -1172,7 +1172,7 @@ void ParFiniteElementSpace::GetFaceNbrFaceVDofs(int i, Array<int> &vdofs) const
 {
    // Works for NC mesh where 'i' is an index returned by
    // ParMesh::GetSharedFace() such that i >= Mesh::GetNumFaces(), i.e. 'i' is
-   // the index of a ghost.
+   // the index of a ghost face.
    MFEM_ASSERT(Nonconforming() && i >= pmesh->GetNumFaces(), "");
    int el1, el2, inf1, inf2;
    pmesh->GetFaceElements(i, &el1, &el2);
@@ -1212,13 +1212,14 @@ const FiniteElement *ParFiniteElementSpace::GetFaceNbrFE(int i) const
 
 const FiniteElement *ParFiniteElementSpace::GetFaceNbrFaceFE(int i) const
 {
-   // FIXME: triangle faces
-
+   // Works for NC mesh where 'i' is an index returned by
+   // ParMesh::GetSharedFace() such that i >= Mesh::GetNumFaces(), i.e. 'i' is
+   // the index of a ghost face.
    // Works in tandem with GetFaceNbrFaceVDofs() defined above.
+
    MFEM_ASSERT(Nonconforming() && !NURBSext, "");
-   Geometry::Type geom = (pmesh->Dimension() == 2) ?
-                         Geometry::SEGMENT : Geometry::SQUARE;
-   return fec->FiniteElementForGeometry(geom);
+   Geometry::Type face_geom = pmesh->GetFaceGeometryType(i);
+   return fec->FiniteElementForGeometry(face_geom);
 }
 
 void ParFiniteElementSpace::Lose_Dof_TrueDof_Matrix()

--- a/fem/pfespace.cpp
+++ b/fem/pfespace.cpp
@@ -1212,6 +1212,8 @@ const FiniteElement *ParFiniteElementSpace::GetFaceNbrFE(int i) const
 
 const FiniteElement *ParFiniteElementSpace::GetFaceNbrFaceFE(int i) const
 {
+   // FIXME: triangle faces
+
    // Works in tandem with GetFaceNbrFaceVDofs() defined above.
    MFEM_ASSERT(Nonconforming() && !NURBSext, "");
    Geometry::Type geom = (pmesh->Dimension() == 2) ?

--- a/mesh/mesh.cpp
+++ b/mesh/mesh.cpp
@@ -911,34 +911,22 @@ FaceElementTransformations *Mesh::GetFaceElementTransformations(int FaceNo,
       // NC meshes: prepend slave edge/face transformation to Loc2
       if (Nonconforming() && IsSlaveFace(face_info))
       {
-#if 0
-         ApplyLocalSlaveTransformation(FaceElemTr.Loc2.Transf, face_info);
-
-         if (face_type == Element::SEGMENT)
-         {
-            // flip Loc2 to match Loc1 and Face
-            DenseMatrix &pm = FaceElemTr.Loc2.Transf.GetPointMat();
-            std::swap(pm(0,0), pm(0,1));
-            std::swap(pm(1,0), pm(1,1));
-         }
-#else
          ApplyLocalSlaveTransformation(FaceElemTr, face_info, false);
-#endif
       }
    }
 
    FaceElemTr.SetConfigurationMask(mask);
 
    // This check can be useful for internal debugging, however it will fail on
-   // periodic boundary faces.
-#if 1
+   // periodic boundary faces, so we keep it disabled in general.
+#if 0
 #ifdef MFEM_DEBUG
    double dist = FaceElemTr.CheckConsistency();
    if (dist >= 1e-12)
    {
       mfem::out << "\nInternal error: face id = " << FaceNo
                 << ", dist = " << dist << '\n';
-      FaceElemTr.CheckConsistency(1);
+      FaceElemTr.CheckConsistency(1); // print coordinates
       MFEM_ABORT("internal error");
    }
 #endif
@@ -950,19 +938,6 @@ FaceElementTransformations *Mesh::GetFaceElementTransformations(int FaceNo,
 bool Mesh::IsSlaveFace(const FaceInfo &fi) const
 {
    return fi.NCFace >= 0 && nc_faces_info[fi.NCFace].Slave;
-}
-
-void Mesh::ApplyLocalSlaveTransformation(IsoparametricTransformation &transf,
-                                         const FaceInfo &fi)
-{
-#ifdef MFEM_THREAD_SAFE
-   DenseMatrix composition;
-#else
-   static DenseMatrix composition;
-#endif
-   MFEM_ASSERT(fi.NCFace >= 0, "");
-   transf.Transform(*nc_faces_info[fi.NCFace].PointMatrix, composition);
-   transf.SetPointMat(composition);
 }
 
 void Mesh::ApplyLocalSlaveTransformation(FaceElementTransformations &FT,
@@ -1046,7 +1021,21 @@ void Mesh::GetFaceInfos(int Face, int *Inf1, int *Inf2) const
 
 Geometry::Type Mesh::GetFaceGeometryType(int Face) const
 {
-   return (Dim == 1) ? Geometry::POINT : faces[Face]->GetGeometryType();
+   switch (Dim)
+   {
+      case 1: return Geometry::POINT;
+      case 2: return Geometry::SEGMENT;
+      case 3:
+         if (Face < NumOfFaces) // local (non-ghost) face
+         {
+            return faces[Face]->GetGeometryType();
+         }
+         // ghost face
+         const int nc_face_id = faces_info[Face].NCFace;
+         MFEM_ASSERT(nc_face_id >= 0, "parent ghost faces are not supported");
+         return faces[nc_faces_info[nc_face_id].MasterFace]->GetGeometryType();
+   }
+   return Geometry::INVALID;
 }
 
 Element::Type Mesh::GetFaceElementType(int Face) const
@@ -5319,8 +5308,10 @@ void Mesh::GenerateNCFaceInfo()
 
       slave_fi.Elem2No = master_fi.Elem1No;
       slave_fi.Elem2Inf = 64 * master_nc.MasterFace; // get lf no. stored above
-      // NOTE: orientation part of Elem2Inf is encoded in the point matrix;
-      //       the above is not true in 2D.
+      // NOTE: In 3D, the orientation part of Elem2Inf is encoded in the point
+      //       matrix. In 2D, the point matrix has the orientation of the parent
+      //       edge, so its columns need to be flipped when applying it, see
+      //       ApplyLocalSlaveTransformation.
    }
 }
 

--- a/mesh/mesh.hpp
+++ b/mesh/mesh.hpp
@@ -368,11 +368,9 @@ protected:
 
    /** Used in GetFaceElementTransformations to account for the fact that a
        slave face occupies only a portion of its master face. */
-   void ApplyLocalSlaveTransformation(IsoparametricTransformation &transf,
-                                      const FaceInfo &fi);
-   /// TODO: Add documentation.
    void ApplyLocalSlaveTransformation(FaceElementTransformations &FT,
                                       const FaceInfo &fi, bool is_ghost);
+
    bool IsSlaveFace(const FaceInfo &fi) const;
 
    /// Returns the orientation of "test" relative to "base"

--- a/mesh/mesh.hpp
+++ b/mesh/mesh.hpp
@@ -131,11 +131,16 @@ protected:
    //   face. Elem2No is < 0 and -1-Elem2No is the index of the ghost
    //   face-neighbor element that generated this slave ghost face. In this
    //   case, Elem2Inf >= 0.
+   // Relevant methods: GenerateFaces(), GenerateNCFaceInfo(),
+   //                   ParNCMesh::GetFaceNeighbors(),
+   //                   ParMesh::ExchangeFaceNbrData()
 
    struct NCFaceInfo
    {
       bool Slave; // true if this is a slave face, false if master face
       int MasterFace; // if Slave, this is the index of the master face
+      // If not Slave, 'MasterFace' is the local face index of this master face
+      // as a face in the unique adjacent element.
       const DenseMatrix* PointMatrix; // if Slave, position within master face
       // (NOTE: PointMatrix points to a matrix owned by NCMesh.)
 
@@ -365,6 +370,9 @@ protected:
        slave face occupies only a portion of its master face. */
    void ApplyLocalSlaveTransformation(IsoparametricTransformation &transf,
                                       const FaceInfo &fi);
+   /// TODO: Add documentation.
+   void ApplyLocalSlaveTransformation(FaceElementTransformations &FT,
+                                      const FaceInfo &fi, bool is_ghost);
    bool IsSlaveFace(const FaceInfo &fi) const;
 
    /// Returns the orientation of "test" relative to "base"

--- a/mesh/pmesh.cpp
+++ b/mesh/pmesh.cpp
@@ -2452,58 +2452,31 @@ GetSharedFaceTransformations(int sf, bool fill2)
    // adjust Loc1 or Loc2 of the master face if this is a slave face
    if (is_slave)
    {
-#if 0
-      // is a ghost slave? -> master not a ghost -> choose Elem1 local transf
-      // not a ghost slave? -> master is a ghost -> choose Elem2 local transf
-      IsoparametricTransformation &loctr =
-         is_ghost ? FaceElemTr.Loc1.Transf : FaceElemTr.Loc2.Transf;
-
-      if (is_ghost || fill2)
-      {
-         ApplyLocalSlaveTransformation(loctr, face_info);
-      }
-
-      if (face_type == Element::SEGMENT && fill2)
-      {
-         // fix slave orientation in 2D: flip Loc2 to match Loc1 and Face
-         DenseMatrix &pm = FaceElemTr.Loc2.Transf.GetPointMat();
-         std::swap(pm(0,0), pm(0,1));
-         std::swap(pm(1,0), pm(1,1));
-      }
-#else
       if (is_ghost || fill2)
       {
          // is_ghost -> modify side 1, otherwise -> modify side 2:
          ApplyLocalSlaveTransformation(FaceElemTr, face_info, is_ghost);
       }
-#endif
    }
 
    // for ghost faces we need a special version of GetFaceTransformation
    if (is_ghost)
    {
       GetGhostFaceTransformation(&FaceElemTr, face_type, face_geom);
-
-#if 1
-      MFEM_ASSERT(is_slave, "internal error");
-      mfem::out << "\n[rank " << MyRank << "]: processed child ghost face"
-                << ", face id = " << FaceNo
-                << MFEM_LOCATION << std::flush;
-#endif
    }
 
    FaceElemTr.SetConfigurationMask(fill2 ? 31 : 21);
 
    // This check can be useful for internal debugging, however it will fail on
-   // periodic boundary faces.
-#if 1
+   // periodic boundary faces, so we keep it disabled in general.
+#if 0
 #ifdef MFEM_DEBUG
    double dist = FaceElemTr.CheckConsistency();
    if (dist >= 1e-12)
    {
       mfem::out << "\nInternal error: face id = " << FaceNo
                 << ", dist = " << dist << ", rank = " << MyRank << '\n';
-      FaceElemTr.CheckConsistency(1);
+      FaceElemTr.CheckConsistency(1); // print coordinates
       MFEM_ABORT("internal error");
    }
 #endif

--- a/mesh/pmesh.cpp
+++ b/mesh/pmesh.cpp
@@ -2363,16 +2363,16 @@ Table *ParMesh::GetFaceToAllElementTable() const
    return face_elem;
 }
 
-ElementTransformation* ParMesh::GetGhostFaceTransformation(
+void ParMesh::GetGhostFaceTransformation(
    FaceElementTransformations* FETr, Element::Type face_type,
    Geometry::Type face_geom)
 {
    // calculate composition of FETr->Loc1 and FETr->Elem1
-   DenseMatrix &face_pm = FaceTransformation.GetPointMat();
+   DenseMatrix &face_pm = FETr->GetPointMat();
    if (Nodes == NULL)
    {
       FETr->Elem1->Transform(FETr->Loc1.Transf.GetPointMat(), face_pm);
-      FaceTransformation.SetFE(GetTransformationFEforElementType(face_type));
+      FETr->SetFE(GetTransformationFEforElementType(face_type));
    }
    else
    {
@@ -2388,9 +2388,8 @@ ElementTransformation* ParMesh::GetGhostFaceTransformation(
       FETr->Loc1.Transform(face_el->GetNodes(), eir);
       Nodes->GetVectorValues(*FETr->Elem1, eir, face_pm);
 #endif
-      FaceTransformation.SetFE(face_el);
+      FETr->SetFE(face_el);
    }
-   return &FaceTransformation;
 }
 
 FaceElementTransformations *ParMesh::
@@ -2453,6 +2452,7 @@ GetSharedFaceTransformations(int sf, bool fill2)
    // adjust Loc1 or Loc2 of the master face if this is a slave face
    if (is_slave)
    {
+#if 0
       // is a ghost slave? -> master not a ghost -> choose Elem1 local transf
       // not a ghost slave? -> master is a ghost -> choose Elem2 local transf
       IsoparametricTransformation &loctr =
@@ -2470,13 +2470,44 @@ GetSharedFaceTransformations(int sf, bool fill2)
          std::swap(pm(0,0), pm(0,1));
          std::swap(pm(1,0), pm(1,1));
       }
+#else
+      if (is_ghost || fill2)
+      {
+         // is_ghost -> modify side 1, otherwise -> modify side 2:
+         ApplyLocalSlaveTransformation(FaceElemTr, face_info, is_ghost);
+      }
+#endif
    }
 
    // for ghost faces we need a special version of GetFaceTransformation
    if (is_ghost)
    {
       GetGhostFaceTransformation(&FaceElemTr, face_type, face_geom);
+
+#if 1
+      MFEM_ASSERT(is_slave, "internal error");
+      mfem::out << "\n[rank " << MyRank << "]: processed child ghost face"
+                << ", face id = " << FaceNo
+                << MFEM_LOCATION << std::flush;
+#endif
    }
+
+   FaceElemTr.SetConfigurationMask(fill2 ? 31 : 21);
+
+   // This check can be useful for internal debugging, however it will fail on
+   // periodic boundary faces.
+#if 1
+#ifdef MFEM_DEBUG
+   double dist = FaceElemTr.CheckConsistency();
+   if (dist >= 1e-12)
+   {
+      mfem::out << "\nInternal error: face id = " << FaceNo
+                << ", dist = " << dist << ", rank = " << MyRank << '\n';
+      FaceElemTr.CheckConsistency(1);
+      MFEM_ABORT("internal error");
+   }
+#endif
+#endif
 
    return &FaceElemTr;
 }

--- a/mesh/pmesh.hpp
+++ b/mesh/pmesh.hpp
@@ -107,7 +107,7 @@ protected:
    void GetFaceNbrElementTransformation(
       int i, IsoparametricTransformation *ElTr);
 
-   ElementTransformation* GetGhostFaceTransformation(
+   void GetGhostFaceTransformation(
       FaceElementTransformations* FETr, Element::Type face_type,
       Geometry::Type face_geom);
 

--- a/mesh/pncmesh.cpp
+++ b/mesh/pncmesh.cpp
@@ -1263,6 +1263,8 @@ void ParNCMesh::GetFaceNeighbors(ParMesh &pmesh)
             const DenseMatrix* pm = &sf.point_matrix;
             if (!sloc && Dim == 3)
             {
+               // TODO: does this handle triangle faces correctly?
+
                // ghost slave in 3D needs flipping orientation
                DenseMatrix* pm2 = new DenseMatrix(*pm);
                std::swap((*pm2)(0,1), (*pm2)(0,3));
@@ -1281,6 +1283,14 @@ void ParNCMesh::GetFaceNeighbors(ParMesh &pmesh)
                // 1, which is the element containing the slave face on one
                // processor, but on the other it is the element containing the
                // master face. In the latter case we need to flip the pm.
+            }
+            else if (!sloc && Dim == 2)
+            {
+               fi.Elem2Inf ^= 1; // set orientation to 1
+               // The point matrix (used to define "side 1" which is the same as
+               // "parent side" in this case) does not require a flip since it
+               // is aligned with the parent side, so NO flip is performed in
+               // Mesh::ApplyLocalSlaveTransformation.
             }
 
             MFEM_ASSERT(fi.NCFace < 0, "");


### PR DESCRIPTION
This bug affected 2D NC meshes that are partitioned so that NC faces lie between processors.

I also added a sample run in ex4p that tests such a case.

Resolves #1105.

<!--GHEX{"id":1564,"author":"v-dobrev","editor":"tzanio","reviewers":["tzanio","vladotomov"],"assignment":"2020-06-19T21:51:35-07:00","approval":"2020-06-20T19:03:55.045Z","merge":"2020-06-22T19:47:00.798Z"}XEHG--><!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge| 
 | --- | --- | --- | --- | --- | --- | --- | 
| [#1564](https://github.com/mfem/mfem/pull/1564) | @v-dobrev | @tzanio | @tzanio + @vladotomov | 06/19/20 | 06/20/20 | 06/22/20 | |
<!--ELBATXEHG-->