### PR TITLE
Support for hypre mixedint

### DIFF
--- a/fem/hybridization.cpp
+++ b/fem/hybridization.cpp
@@ -174,8 +174,9 @@ void Hybridization::ConstructC()
          {
             // Convert Ct to parallel and then transpose it:
             Ct->Finalize(skip_zeros);
-            HYPRE_Int Ct_num_rows = Ct->Height();
-            Array<HYPRE_Int> Ct_rows, *offsets[1] = { &Ct_rows };
+            HYPRE_BigInt Ct_num_rows = Ct->Height();
+            Array<HYPRE_BigInt> Ct_rows;
+            Array<HYPRE_BigInt> *offsets[1] = { &Ct_rows };
             pmesh->GenerateOffsets(1, &Ct_num_rows, offsets);
             Array<HYPRE_Int> Ct_J(Ct->NumNonZeroElems());
             HYPRE_Int c_ldof_offset = c_pfes->GetMyDofOffset();

--- a/fem/pfespace.cpp
+++ b/fem/pfespace.cpp
@@ -603,8 +603,8 @@ void ParFiniteElementSpace::GenerateGlobalOffsets() const
 {
    MFEM_ASSERT(Conforming(), "wrong code path");
 
-   HYPRE_Int ldof[2];
-   Array<HYPRE_Int> *offsets[2] = { &dof_offsets, &tdof_offsets };
+   HYPRE_BigInt ldof[2];
+   Array<HYPRE_BigInt> *offsets[2] = { &dof_offsets, &tdof_offsets };
 
    ldof[0] = GetVSize();
    ldof[1] = TrueVSize();
@@ -659,10 +659,10 @@ void ParFiniteElementSpace::Build_Dof_TrueDof_Matrix() const // matrix P
    HYPRE_Int *j_offd = Memory<HYPRE_Int>(ldof-ltdof);
    int offd_counter;
 
-   HYPRE_Int *cmap   = Memory<HYPRE_Int>(ldof-ltdof);
+   HYPRE_BigInt *cmap   = Memory<HYPRE_BigInt>(ldof-ltdof);
 
-   HYPRE_Int *col_starts = GetTrueDofOffsets();
-   HYPRE_Int *row_starts = GetDofOffsets();
+   HYPRE_BigInt *col_starts = GetTrueDofOffsets();
+   HYPRE_BigInt *row_starts = GetDofOffsets();
 
    Array<Pair<HYPRE_Int, int> > cmap_j_offd(ldof-ltdof);
 
@@ -704,7 +704,7 @@ void ParFiniteElementSpace::Build_Dof_TrueDof_Matrix() const // matrix P
 HypreParMatrix *ParFiniteElementSpace::GetPartialConformingInterpolation()
 {
    HypreParMatrix *P_pc;
-   Array<HYPRE_Int> P_pc_row_starts, P_pc_col_starts;
+   Array<HYPRE_BigInt> P_pc_row_starts, P_pc_col_starts;
    BuildParallelConformingInterpolation(&P_pc, NULL, P_pc_row_starts,
                                         P_pc_col_starts, NULL, true);
    P_pc->CopyRowStarts();
@@ -1974,8 +1974,8 @@ void ParFiniteElementSpace
 
 int ParFiniteElementSpace
 ::BuildParallelConformingInterpolation(HypreParMatrix **P, SparseMatrix **R,
-                                       Array<HYPRE_Int> &dof_offs,
-                                       Array<HYPRE_Int> &tdof_offs,
+                                       Array<HYPRE_BigInt> &dof_offs,
+                                       Array<HYPRE_BigInt> &tdof_offs,
                                        Array<int> *dof_tdof,
                                        bool partial) const
 {
@@ -2111,8 +2111,8 @@ int ParFiniteElementSpace
    }
 
    // calculate global offsets
-   HYPRE_Int loc_sizes[2] = { ndofs*vdim, num_true_dofs*vdim };
-   Array<HYPRE_Int>* offsets[2] = { &dof_offs, &tdof_offs };
+   HYPRE_BigInt loc_sizes[2] = { ndofs*vdim, num_true_dofs*vdim };
+   Array<HYPRE_BigInt>* offsets[2] = { &dof_offs, &tdof_offs };
    pmesh->GenerateOffsets(2, loc_sizes, offsets); // calls MPI_Scan, MPI_Bcast
 
    HYPRE_Int my_tdof_offset =
@@ -2334,8 +2334,8 @@ int ParFiniteElementSpace
 HypreParMatrix* ParFiniteElementSpace
 ::MakeVDimHypreMatrix(const std::vector<PMatrixRow> &rows,
                       int local_rows, int local_cols,
-                      Array<HYPRE_Int> &row_starts,
-                      Array<HYPRE_Int> &col_starts) const
+                      Array<HYPRE_BigInt> &row_starts,
+                      Array<HYPRE_BigInt> &col_starts) const
 {
    bool assumed = HYPRE_AssumedPartitionCheck();
    bool bynodes = (ordering == Ordering::byNODES);
@@ -2369,7 +2369,7 @@ HypreParMatrix* ParFiniteElementSpace
    }
 
    // create offd column mapping
-   HYPRE_Int *cmap = Memory<HYPRE_Int>(col_map.size());
+   HYPRE_BigInt *cmap = Memory<HYPRE_BigInt>(col_map.size());
    int offd_col = 0;
    for (std::map<HYPRE_Int, int>::iterator
         it = col_map.begin(); it != col_map.end(); ++it)
@@ -2548,7 +2548,7 @@ ParFiniteElementSpace::RebalanceMatrix(int old_ndofs,
    }
    SortPairs<HYPRE_Int, int>(cmap_offd, offd_cols);
 
-   HYPRE_Int* cmap = Memory<HYPRE_Int>(offd_cols);
+   HYPRE_BigInt* cmap = Memory<HYPRE_BigInt>(offd_cols);
    for (int i = 0; i < offd_cols; i++)
    {
       cmap[i] = cmap_offd[i].one;
@@ -2768,7 +2768,7 @@ ParFiniteElementSpace::ParallelDerefinementMatrix(int old_ndofs,
    offd->SetWidth(col_map.size());
 
    // create offd column mapping for use by hypre
-   HYPRE_Int *cmap = Memory<HYPRE_Int>(offd->Width());
+   HYPRE_BigInt *cmap = Memory<HYPRE_BigInt>(offd->Width());
    for (std::map<HYPRE_Int, int>::iterator
         it = col_map.begin(); it != col_map.end(); ++it)
    {

--- a/fem/pfespace.hpp
+++ b/fem/pfespace.hpp
@@ -54,16 +54,16 @@ private:
    mutable Array<int> ldof_ltdof;
 
    /// Offsets for the dofs in each processor in global numbering.
-   mutable Array<HYPRE_Int> dof_offsets;
+   mutable Array<HYPRE_BigInt> dof_offsets;
 
    /// Offsets for the true dofs in each processor in global numbering.
-   mutable Array<HYPRE_Int> tdof_offsets;
+   mutable Array<HYPRE_BigInt> tdof_offsets;
 
    /// Offsets for the true dofs in neighbor processor in global numbering.
-   mutable Array<HYPRE_Int> tdof_nb_offsets;
+   mutable Array<HYPRE_BigInt> tdof_nb_offsets;
 
    /// Previous 'dof_offsets' (before Update()), column partition of T.
-   Array<HYPRE_Int> old_dof_offsets;
+   Array<HYPRE_BigInt> old_dof_offsets;
 
    /// The sign of the basis functions at the scalar local dofs.
    Array<int> ldof_sign;
@@ -143,8 +143,8 @@ private:
    HypreParMatrix*
    MakeVDimHypreMatrix(const std::vector<struct PMatrixRow> &rows,
                        int local_rows, int local_cols,
-                       Array<HYPRE_Int> &row_starts,
-                       Array<HYPRE_Int> &col_starts) const;
+                       Array<HYPRE_BigInt> &row_starts,
+                       Array<HYPRE_BigInt> &col_starts) const;
 
    /// Build the P and R matrices.
    void Build_Dof_TrueDof_Matrix() const;
@@ -154,8 +154,8 @@ private:
        and the DOF -> true DOF map ('dof_tdof'). Returns the number of
        vector true DOFs. All pointer arguments are optional and can be NULL. */
    int BuildParallelConformingInterpolation(HypreParMatrix **P, SparseMatrix **R,
-                                            Array<HYPRE_Int> &dof_offs,
-                                            Array<HYPRE_Int> &tdof_offs,
+                                            Array<HYPRE_BigInt> &dof_offs,
+                                            Array<HYPRE_BigInt> &tdof_offs,
                                             Array<int> *dof_tdof,
                                             bool partial = false) const;
 
@@ -244,11 +244,11 @@ public:
 
    int GetDofSign(int i)
    { return NURBSext || Nonconforming() ? 1 : ldof_sign[VDofToDof(i)]; }
-   HYPRE_Int *GetDofOffsets()     const { return dof_offsets; }
-   HYPRE_Int *GetTrueDofOffsets() const { return tdof_offsets; }
-   HYPRE_Int GlobalVSize() const
+   HYPRE_BigInt *GetDofOffsets()     const { return dof_offsets; }
+   HYPRE_BigInt *GetTrueDofOffsets() const { return tdof_offsets; }
+   HYPRE_BigInt GlobalVSize() const
    { return Dof_TrueDof_Matrix()->GetGlobalNumRows(); }
-   HYPRE_Int GlobalTrueVSize() const
+   HYPRE_BigInt GlobalTrueVSize() const
    { return Dof_TrueDof_Matrix()->GetGlobalNumCols(); }
 
    /// Return the number of local vector true dofs.

--- a/linalg/handle.cpp
+++ b/linalg/handle.cpp
@@ -57,8 +57,8 @@ Operator::Type OperatorHandle::CheckType(Operator::Type tid)
 }
 
 #ifdef MFEM_USE_MPI
-void OperatorHandle::MakeSquareBlockDiag(MPI_Comm comm, HYPRE_Int glob_size,
-                                         HYPRE_Int *row_starts,
+void OperatorHandle::MakeSquareBlockDiag(MPI_Comm comm, HYPRE_BigInt glob_size,
+                                         HYPRE_BigInt *row_starts,
                                          SparseMatrix *diag)
 {
    if (own_oper) { delete oper; }
@@ -88,9 +88,9 @@ void OperatorHandle::MakeSquareBlockDiag(MPI_Comm comm, HYPRE_Int glob_size,
 }
 
 void OperatorHandle::
-MakeRectangularBlockDiag(MPI_Comm comm, HYPRE_Int glob_num_rows,
-                         HYPRE_Int glob_num_cols, HYPRE_Int *row_starts,
-                         HYPRE_Int *col_starts, SparseMatrix *diag)
+MakeRectangularBlockDiag(MPI_Comm comm, HYPRE_BigInt glob_num_rows,
+                         HYPRE_BigInt glob_num_cols, HYPRE_BigInt *row_starts,
+                         HYPRE_BigInt *col_starts, SparseMatrix *diag)
 {
    if (own_oper) { delete oper; }
 

--- a/linalg/handle.hpp
+++ b/linalg/handle.hpp
@@ -144,15 +144,15 @@ public:
    /** @brief Reset the OperatorHandle to hold a parallel square block-diagonal
        matrix using the currently set type id. */
    /** The operator ownership flag is set to true. */
-   void MakeSquareBlockDiag(MPI_Comm comm, HYPRE_Int glob_size,
-                            HYPRE_Int *row_starts, SparseMatrix *diag);
+   void MakeSquareBlockDiag(MPI_Comm comm, HYPRE_BigInt glob_size,
+                            HYPRE_BigInt *row_starts, SparseMatrix *diag);
 
    /** @brief Reset the OperatorHandle to hold a parallel rectangular
        block-diagonal matrix using the currently set type id. */
    /** The operator ownership flag is set to true. */
-   void MakeRectangularBlockDiag(MPI_Comm comm, HYPRE_Int glob_num_rows,
-                                 HYPRE_Int glob_num_cols, HYPRE_Int *row_starts,
-                                 HYPRE_Int *col_starts, SparseMatrix *diag);
+   void MakeRectangularBlockDiag(MPI_Comm comm, HYPRE_BigInt glob_num_rows,
+                                 HYPRE_BigInt glob_num_cols, HYPRE_BigInt *row_starts,
+                                 HYPRE_BigInt *col_starts, SparseMatrix *diag);
 #endif // MFEM_USE_MPI
 
    /// Reset the OperatorHandle to hold the product @a P^t @a A @a P.

--- a/linalg/hypre.cpp
+++ b/linalg/hypre.cpp
@@ -46,8 +46,8 @@ inline void HypreParVector::_SetDataAndSize_()
                      hypre_VectorSize(hypre_ParVectorLocalVector(x))));
 }
 
-HypreParVector::HypreParVector(MPI_Comm comm, HYPRE_Int glob_size,
-                               HYPRE_Int *col) : Vector()
+HypreParVector::HypreParVector(MPI_Comm comm, HYPRE_BigInt glob_size,
+                               HYPRE_BigInt *col) : Vector()
 {
    x = hypre_ParVectorCreate(comm,glob_size,col);
    hypre_ParVectorInitialize(x);
@@ -59,8 +59,8 @@ HypreParVector::HypreParVector(MPI_Comm comm, HYPRE_Int glob_size,
    own_ParVector = 1;
 }
 
-HypreParVector::HypreParVector(MPI_Comm comm, HYPRE_Int glob_size,
-                               double *_data, HYPRE_Int *col) : Vector()
+HypreParVector::HypreParVector(MPI_Comm comm, HYPRE_BigInt glob_size,
+                               double *_data, HYPRE_BigInt *col) : Vector()
 {
    x = hypre_ParVectorCreate(comm,glob_size,col);
    hypre_ParVectorSetDataOwner(x,1); // owns the seq vector
@@ -304,8 +304,8 @@ void HypreParMatrix::CopyCSR_J(hypre_CSRMatrix *hypre_csr, int *J)
 }
 
 // Square block-diagonal constructor (4 arguments, v1)
-HypreParMatrix::HypreParMatrix(MPI_Comm comm, HYPRE_Int glob_size,
-                               HYPRE_Int *row_starts, SparseMatrix *diag)
+HypreParMatrix::HypreParMatrix(MPI_Comm comm, HYPRE_BigInt glob_size,
+                               HYPRE_BigInt *row_starts, SparseMatrix *diag)
    : Operator(diag->Height(), diag->Width())
 {
    Init();
@@ -340,9 +340,9 @@ HypreParMatrix::HypreParMatrix(MPI_Comm comm, HYPRE_Int glob_size,
 
 // Rectangular block-diagonal constructor (6 arguments, v1)
 HypreParMatrix::HypreParMatrix(MPI_Comm comm,
-                               HYPRE_Int global_num_rows,
-                               HYPRE_Int global_num_cols,
-                               HYPRE_Int *row_starts, HYPRE_Int *col_starts,
+                               HYPRE_BigInt global_num_rows,
+                               HYPRE_BigInt global_num_cols,
+                               HYPRE_BigInt *row_starts, HYPRE_BigInt *col_starts,
                                SparseMatrix *diag)
    : Operator(diag->Height(), diag->Width())
 {
@@ -377,11 +377,11 @@ HypreParMatrix::HypreParMatrix(MPI_Comm comm,
 
 // General rectangular constructor with diagonal and off-diagonal (8 arguments)
 HypreParMatrix::HypreParMatrix(MPI_Comm comm,
-                               HYPRE_Int global_num_rows,
-                               HYPRE_Int global_num_cols,
-                               HYPRE_Int *row_starts, HYPRE_Int *col_starts,
+                               HYPRE_BigInt global_num_rows,
+                               HYPRE_BigInt global_num_cols,
+                               HYPRE_BigInt *row_starts, HYPRE_BigInt *col_starts,
                                SparseMatrix *diag, SparseMatrix *offd,
-                               HYPRE_Int *cmap)
+                               HYPRE_BigInt *cmap)
    : Operator(diag->Height(), diag->Width())
 {
    Init();
@@ -422,11 +422,11 @@ HypreParMatrix::HypreParMatrix(MPI_Comm comm,
 // General rectangular constructor with diagonal and off-diagonal (13 arguments)
 HypreParMatrix::HypreParMatrix(
    MPI_Comm comm,
-   HYPRE_Int global_num_rows, HYPRE_Int global_num_cols,
-   HYPRE_Int *row_starts, HYPRE_Int *col_starts,
+   HYPRE_BigInt global_num_rows, HYPRE_BigInt global_num_cols,
+   HYPRE_BigInt *row_starts, HYPRE_BigInt *col_starts,
    HYPRE_Int *diag_i, HYPRE_Int *diag_j, double *diag_data,
    HYPRE_Int *offd_i, HYPRE_Int *offd_j, double *offd_data,
-   HYPRE_Int offd_num_cols, HYPRE_Int *offd_col_map)
+   HYPRE_Int offd_num_cols, HYPRE_BigInt *offd_col_map)
 {
    Init();
    A = hypre_ParCSRMatrixCreate(comm, global_num_rows, global_num_cols,
@@ -475,7 +475,7 @@ HypreParMatrix::HypreParMatrix(
 
 // Constructor from a CSR matrix on rank 0 (4 arguments, v2)
 HypreParMatrix::HypreParMatrix(MPI_Comm comm,
-                               HYPRE_Int *row_starts, HYPRE_Int *col_starts,
+                               HYPRE_BigInt *row_starts, HYPRE_BigInt *col_starts,
                                SparseMatrix *sm_a)
 {
    MFEM_ASSERT(sm_a != NULL, "invalid input");
@@ -515,9 +515,9 @@ HypreParMatrix::HypreParMatrix(MPI_Comm comm,
 
 // Boolean, rectangular, block-diagonal constructor (6 arguments, v2)
 HypreParMatrix::HypreParMatrix(MPI_Comm comm,
-                               HYPRE_Int global_num_rows,
-                               HYPRE_Int global_num_cols,
-                               HYPRE_Int *row_starts, HYPRE_Int *col_starts,
+                               HYPRE_BigInt global_num_rows,
+                               HYPRE_BigInt global_num_cols,
+                               HYPRE_BigInt *row_starts, HYPRE_BigInt *col_starts,
                                Table *diag)
 {
    Init();
@@ -555,10 +555,10 @@ HypreParMatrix::HypreParMatrix(MPI_Comm comm,
 // Boolean, general rectangular constructor with diagonal and off-diagonal
 // (11 arguments)
 HypreParMatrix::HypreParMatrix(MPI_Comm comm, int id, int np,
-                               HYPRE_Int *row, HYPRE_Int *col,
+                               HYPRE_BigInt *row, HYPRE_BigInt *col,
                                HYPRE_Int *i_diag, HYPRE_Int *j_diag,
                                HYPRE_Int *i_offd, HYPRE_Int *j_offd,
-                               HYPRE_Int *cmap, HYPRE_Int cmap_size)
+                               HYPRE_BigInt *cmap, HYPRE_BigInt cmap_size)
 {
    HYPRE_Int diag_nnz, offd_nnz;
 
@@ -635,9 +635,10 @@ HypreParMatrix::HypreParMatrix(MPI_Comm comm, int id, int np,
 // General rectangular constructor with diagonal and off-diagonal constructed
 // from a CSR matrix that contains both diagonal and off-diagonal blocks
 // (9 arguments)
-HypreParMatrix::HypreParMatrix(MPI_Comm comm, int nrows, HYPRE_Int glob_nrows,
-                               HYPRE_Int glob_ncols, int *I, HYPRE_Int *J,
-                               double *data, HYPRE_Int *rows, HYPRE_Int *cols)
+HypreParMatrix::HypreParMatrix(MPI_Comm comm, int nrows,
+                               HYPRE_BigInt glob_nrows,
+                               HYPRE_BigInt glob_ncols, int *I, HYPRE_Int *J,
+                               double *data, HYPRE_BigInt *rows, HYPRE_BigInt *cols)
 {
    Init();
 
@@ -661,10 +662,10 @@ HypreParMatrix::HypreParMatrix(MPI_Comm comm, int nrows, HYPRE_Int glob_nrows,
    }
 
    // Copy in the row and column partitionings
-   HYPRE_Int *row_starts, *col_starts;
+   HYPRE_BigInt *row_starts, *col_starts;
    if (rows == cols)
    {
-      row_starts = col_starts = mfem_hypre_TAlloc(HYPRE_Int, part_size);
+      row_starts = col_starts = mfem_hypre_TAlloc(HYPRE_BigInt, part_size);
       for (int i = 0; i < part_size; i++)
       {
          row_starts[i] = rows[i];
@@ -672,8 +673,8 @@ HypreParMatrix::HypreParMatrix(MPI_Comm comm, int nrows, HYPRE_Int glob_nrows,
    }
    else
    {
-      row_starts = mfem_hypre_TAlloc(HYPRE_Int, part_size);
-      col_starts = mfem_hypre_TAlloc(HYPRE_Int, part_size);
+      row_starts = mfem_hypre_TAlloc(HYPRE_BigInt, part_size);
+      col_starts = mfem_hypre_TAlloc(HYPRE_BigInt, part_size);
       for (int i = 0; i < part_size; i++)
       {
          row_starts[i] = rows[i];
@@ -711,7 +712,8 @@ HypreParMatrix::HypreParMatrix(MPI_Comm comm, int nrows, HYPRE_Int glob_nrows,
                                 diag_nnz, offd_nnz);
    hypre_ParCSRMatrixInitialize(A);
 
-   HYPRE_Int *diag_i, *diag_j, *offd_i, *offd_j, *offd_col_map;
+   HYPRE_Int *diag_i, *diag_j, *offd_i, *offd_j;
+   HYPRE_BigInt *offd_col_map;
    double *diag_data, *offd_data;
    diag_i = A->diag->i;
    diag_j = A->diag->j;
@@ -829,8 +831,9 @@ void HypreParMatrix::CopyRowStarts()
       row_starts_size++; // num_proc + 1
    }
 
-   HYPRE_Int *old_row_starts = hypre_ParCSRMatrixRowStarts(A);
-   HYPRE_Int *new_row_starts = mfem_hypre_CTAlloc(HYPRE_Int, row_starts_size);
+   HYPRE_BigInt *old_row_starts = hypre_ParCSRMatrixRowStarts(A);
+   HYPRE_BigInt *new_row_starts = mfem_hypre_CTAlloc(HYPRE_BigInt,
+                                                     row_starts_size);
    for (int i = 0; i < row_starts_size; i++)
    {
       new_row_starts[i] = old_row_starts[i];
@@ -866,8 +869,9 @@ void HypreParMatrix::CopyColStarts()
       col_starts_size++; // num_proc + 1
    }
 
-   HYPRE_Int *old_col_starts = hypre_ParCSRMatrixColStarts(A);
-   HYPRE_Int *new_col_starts = mfem_hypre_CTAlloc(HYPRE_Int, col_starts_size);
+   HYPRE_BigInt *old_col_starts = hypre_ParCSRMatrixColStarts(A);
+   HYPRE_BigInt *new_col_starts = mfem_hypre_CTAlloc(HYPRE_BigInt,
+                                                     col_starts_size);
    for (int i = 0; i < col_starts_size; i++)
    {
       new_col_starts[i] = old_col_starts[i];
@@ -923,7 +927,7 @@ void HypreParMatrix::GetDiag(SparseMatrix &diag) const
    MakeWrapper(A->diag, diag);
 }
 
-void HypreParMatrix::GetOffd(SparseMatrix &offd, HYPRE_Int* &cmap) const
+void HypreParMatrix::GetOffd(SparseMatrix &offd, HYPRE_BigInt* &cmap) const
 {
    MakeWrapper(A->offd, offd);
    cmap = A->col_map_offd;
@@ -1052,7 +1056,7 @@ HYPRE_Int HypreParMatrix::MultTranspose(HypreParVector & x, HypreParVector & y,
 }
 
 HypreParMatrix* HypreParMatrix::LeftDiagMult(const SparseMatrix &D,
-                                             HYPRE_Int* row_starts) const
+                                             HYPRE_BigInt* row_starts) const
 {
    const bool assumed_partition = HYPRE_AssumedPartitionCheck();
    const bool row_starts_given = (row_starts != NULL);
@@ -1082,7 +1086,7 @@ HypreParMatrix* HypreParMatrix::LeftDiagMult(const SparseMatrix &D,
    // multiplication function, mfem::Mult(), called below.
 
    int part_size;
-   HYPRE_Int global_num_rows;
+   HYPRE_BigInt global_num_rows;
    if (assumed_partition)
    {
       part_size = 2;
@@ -1105,8 +1109,8 @@ HypreParMatrix* HypreParMatrix::LeftDiagMult(const SparseMatrix &D,
       part_size++;
    }
 
-   HYPRE_Int *col_starts = hypre_ParCSRMatrixColStarts(A);
-   HYPRE_Int *col_map_offd;
+   HYPRE_BigInt *col_starts = hypre_ParCSRMatrixColStarts(A);
+   HYPRE_BigInt *col_map_offd;
 
    // get the diag and offd blocks as SparseMatrix wrappers
    SparseMatrix A_diag, A_offd;
@@ -1120,10 +1124,10 @@ HypreParMatrix* HypreParMatrix::LeftDiagMult(const SparseMatrix &D,
    HypreParMatrix* DA =
       new HypreParMatrix(GetComm(),
                          global_num_rows, hypre_ParCSRMatrixGlobalNumCols(A),
-                         DuplicateAs<HYPRE_Int>(row_starts, part_size, false),
-                         DuplicateAs<HYPRE_Int>(col_starts, part_size, false),
+                         DuplicateAs<HYPRE_BigInt>(row_starts, part_size, false),
+                         DuplicateAs<HYPRE_BigInt>(col_starts, part_size, false),
                          DA_diag, DA_offd,
-                         DuplicateAs<HYPRE_Int>(col_map_offd, A_offd.Width()));
+                         DuplicateAs<HYPRE_BigInt>(col_map_offd, A_offd.Width()));
 
    // When HYPRE_BIGINT is defined, we want DA_{diag,offd} to delete their I and
    // J arrays but not their data arrays; when HYPRE_BIGINT is not defined, we
@@ -1270,9 +1274,9 @@ void HypreParMatrix::Threshold(double threshold)
    hypre_CSRMatrix * csr_A;
    hypre_CSRMatrix * csr_A_wo_z;
    hypre_ParCSRMatrix * parcsr_A_ptr;
-   HYPRE_Int * row_starts = NULL; HYPRE_Int * col_starts = NULL;
-   HYPRE_Int row_start = -1;   HYPRE_Int row_end = -1;
-   HYPRE_Int col_start = -1;   HYPRE_Int col_end = -1;
+   HYPRE_BigInt * row_starts = NULL; HYPRE_BigInt * col_starts = NULL;
+   HYPRE_BigInt row_start = -1;   HYPRE_BigInt row_end = -1;
+   HYPRE_BigInt col_start = -1;   HYPRE_BigInt col_end = -1;
 
    comm = hypre_ParCSRMatrixComm(A);
 
@@ -1470,9 +1474,9 @@ inline void delete_hypre_CSRMatrixData(hypre_CSRMatrix *M)
 
 inline void delete_hypre_ParCSRMatrixColMapOffd(hypre_ParCSRMatrix *A)
 {
-   HYPRE_Int  *A_col_map_offd = hypre_ParCSRMatrixColMapOffd(A);
+   HYPRE_BigInt  *A_col_map_offd = hypre_ParCSRMatrixColMapOffd(A);
    int size = hypre_CSRMatrixNumCols(hypre_ParCSRMatrixOffd(A));
-   Memory<HYPRE_Int>(A_col_map_offd, size, true).Delete();
+   Memory<HYPRE_BigInt>(A_col_map_offd, size, true).Delete();
 }
 
 inline void delete_hypre_CSRMatrixI(hypre_CSRMatrix *M)
@@ -1936,19 +1940,19 @@ HypreParMatrix * HypreParMatrixFromBlocks(Array2D<HypreParMatrix*> &blocks,
       }
    }
 
-   std::vector<HYPRE_Int> rowStarts2(2);
+   std::vector<HYPRE_BigInt> rowStarts2(2);
    rowStarts2[0] = first_loc_row;
    rowStarts2[1] = first_loc_row + all_num_loc_rows[rank];
 
-   std::vector<HYPRE_Int> colStarts2(2);
+   std::vector<HYPRE_BigInt> colStarts2(2);
    colStarts2[0] = first_loc_col;
    colStarts2[1] = first_loc_col + all_num_loc_cols[rank];
 
    return new HypreParMatrix(comm, num_loc_rows, glob_nrows, glob_ncols,
                              (int *)opI.data(), (HYPRE_Int *)opJ.data(),
                              (double *)data.data(),
-                             (HYPRE_Int *)rowStarts2.data(),
-                             (HYPRE_Int *)colStarts2.data());
+                             (HYPRE_BigInt *)rowStarts2.data(),
+                             (HYPRE_BigInt *)colStarts2.data());
 }
 
 void EliminateBC(HypreParMatrix &A, HypreParMatrix &Ae,
@@ -3982,20 +3986,20 @@ HypreLOBPCG::SetOperator(Operator & A)
 
    if (HYPRE_AssumedPartitionCheck())
    {
-      part = new HYPRE_Int[2];
+      part = new HYPRE_BigInt[2];
 
-      MPI_Scan(&locSize, &part[1], 1, HYPRE_MPI_INT, MPI_SUM, comm);
+      MPI_Scan(&locSize, &part[1], 1, HYPRE_MPI_BIG_INT, MPI_SUM, comm);
 
       part[0] = part[1] - locSize;
 
-      MPI_Allreduce(&locSize, &glbSize, 1, HYPRE_MPI_INT, MPI_SUM, comm);
+      MPI_Allreduce(&locSize, &glbSize, 1, HYPRE_MPI_BIG_INT, MPI_SUM, comm);
    }
    else
    {
-      part = new HYPRE_Int[numProcs+1];
+      part = new HYPRE_BigInt[numProcs+1];
 
-      MPI_Allgather(&locSize, 1, HYPRE_MPI_INT,
-                    &part[1], 1, HYPRE_MPI_INT, comm);
+      MPI_Allgather(&locSize, 1, HYPRE_MPI_BIG_INT,
+                    &part[1], 1, HYPRE_MPI_BIG_INT, comm);
 
       part[0] = 0;
       for (int i=0; i<numProcs; i++)

--- a/linalg/hypre.hpp
+++ b/linalg/hypre.hpp
@@ -96,14 +96,14 @@ public:
           length (number of processors + 1) and processor P owns columns
           [col[P],col[P+1]) i.e. each processor has a copy of the same col
           array. */
-   HypreParVector(MPI_Comm comm, HYPRE_Int glob_size, HYPRE_Int *col);
+   HypreParVector(MPI_Comm comm, HYPRE_BigInt glob_size, HYPRE_BigInt *col);
    /** @brief Creates vector with given global size, partitioning of the
        columns, and data. */
    /** The data must be allocated and destroyed outside. If @a _data is NULL, a
        dummy vector without a valid data array will be created. See @ref
        hypre_partitioning_descr "here" for a description of the @a col array. */
-   HypreParVector(MPI_Comm comm, HYPRE_Int glob_size, double *_data,
-                  HYPRE_Int *col);
+   HypreParVector(MPI_Comm comm, HYPRE_BigInt glob_size, double *_data,
+                  HYPRE_BigInt *col);
    /// Creates vector compatible with y
    HypreParVector(const HypreParVector &y);
    /// Creates vector compatible with (i.e. in the domain of) A or A^T
@@ -119,10 +119,10 @@ public:
    /// Returns the parallel row/column partitioning
    /** See @ref hypre_partitioning_descr "here" for a description of the
        partitioning array. */
-   inline HYPRE_Int *Partitioning() { return x->partitioning; }
+   inline HYPRE_BigInt *Partitioning() { return x->partitioning; }
 
    /// Returns the global number of rows
-   inline HYPRE_Int GlobalSize() { return x->global_size; }
+   inline HYPRE_BigInt GlobalSize() { return x->global_size; }
 
    /// Typecasting to hypre's hypre_ParVector*
    operator hypre_ParVector*() const { return x; }
@@ -254,7 +254,7 @@ public:
        @warning The ordering of the columns in each row in @a *diag may be
        changed by this constructor to ensure that the first entry in each row is
        the diagonal one. This is expected by most hypre functions. */
-   HypreParMatrix(MPI_Comm comm, HYPRE_Int glob_size, HYPRE_Int *row_starts,
+   HypreParMatrix(MPI_Comm comm, HYPRE_BigInt glob_size, HYPRE_BigInt *row_starts,
                   SparseMatrix *diag); // constructor with 4 arguments, v1
 
    /// Creates block-diagonal rectangular parallel matrix.
@@ -262,19 +262,19 @@ public:
        new HypreParMatrix does not take ownership of any of the input arrays.
        See @ref hypre_partitioning_descr "here" for a description of the
        partitioning arrays @a row_starts and @a col_starts. */
-   HypreParMatrix(MPI_Comm comm, HYPRE_Int global_num_rows,
-                  HYPRE_Int global_num_cols, HYPRE_Int *row_starts,
-                  HYPRE_Int *col_starts,
+   HypreParMatrix(MPI_Comm comm, HYPRE_BigInt global_num_rows,
+                  HYPRE_BigInt global_num_cols, HYPRE_BigInt *row_starts,
+                  HYPRE_BigInt *col_starts,
                   SparseMatrix *diag); // constructor with 6 arguments, v1
 
    /// Creates general (rectangular) parallel matrix.
    /** The new HypreParMatrix does not take ownership of any of the input
        arrays. See @ref hypre_partitioning_descr "here" for a description of the
        partitioning arrays @a row_starts and @a col_starts. */
-   HypreParMatrix(MPI_Comm comm, HYPRE_Int global_num_rows,
-                  HYPRE_Int global_num_cols, HYPRE_Int *row_starts,
-                  HYPRE_Int *col_starts, SparseMatrix *diag, SparseMatrix *offd,
-                  HYPRE_Int *cmap); // constructor with 8 arguments
+   HypreParMatrix(MPI_Comm comm, HYPRE_BigInt global_num_rows,
+                  HYPRE_BigInt global_num_cols, HYPRE_BigInt *row_starts,
+                  HYPRE_BigInt *col_starts, SparseMatrix *diag, SparseMatrix *offd,
+                  HYPRE_BigInt *cmap); // constructor with 8 arguments
 
    /// Creates general (rectangular) parallel matrix.
    /** The new HypreParMatrix takes ownership of all input arrays, except
@@ -282,26 +282,27 @@ public:
        for a description of the partitioning arrays @a row_starts and @a
        col_starts. */
    HypreParMatrix(MPI_Comm comm,
-                  HYPRE_Int global_num_rows, HYPRE_Int global_num_cols,
-                  HYPRE_Int *row_starts, HYPRE_Int *col_starts,
+                  HYPRE_BigInt global_num_rows, HYPRE_BigInt global_num_cols,
+                  HYPRE_BigInt *row_starts, HYPRE_BigInt *col_starts,
                   HYPRE_Int *diag_i, HYPRE_Int *diag_j, double *diag_data,
                   HYPRE_Int *offd_i, HYPRE_Int *offd_j, double *offd_data,
                   HYPRE_Int offd_num_cols,
-                  HYPRE_Int *offd_col_map); // constructor with 13 arguments
+                  HYPRE_BigInt *offd_col_map); // constructor with 13 arguments
 
    /// Creates a parallel matrix from SparseMatrix on processor 0.
    /** See @ref hypre_partitioning_descr "here" for a description of the
        partitioning arrays @a row_starts and @a col_starts. */
-   HypreParMatrix(MPI_Comm comm, HYPRE_Int *row_starts, HYPRE_Int *col_starts,
+   HypreParMatrix(MPI_Comm comm, HYPRE_BigInt *row_starts,
+                  HYPRE_BigInt *col_starts,
                   SparseMatrix *a); // constructor with 4 arguments, v2
 
    /// Creates boolean block-diagonal rectangular parallel matrix.
    /** The new HypreParMatrix does not take ownership of any of the input
        arrays. See @ref hypre_partitioning_descr "here" for a description of the
        partitioning arrays @a row_starts and @a col_starts. */
-   HypreParMatrix(MPI_Comm comm, HYPRE_Int global_num_rows,
-                  HYPRE_Int global_num_cols, HYPRE_Int *row_starts,
-                  HYPRE_Int *col_starts,
+   HypreParMatrix(MPI_Comm comm, HYPRE_BigInt global_num_rows,
+                  HYPRE_BigInt global_num_cols, HYPRE_BigInt *row_starts,
+                  HYPRE_BigInt *col_starts,
                   Table *diag); // constructor with 6 arguments, v2
 
    /// Creates boolean rectangular parallel matrix.
@@ -309,10 +310,11 @@ public:
        @a j_diag, @a i_offd, @a j_offd, and @a cmap; does not take ownership of
        the arrays @a row and @a col. See @ref hypre_partitioning_descr "here"
        for a description of the partitioning arrays @a row and @a col. */
-   HypreParMatrix(MPI_Comm comm, int id, int np, HYPRE_Int *row, HYPRE_Int *col,
+   HypreParMatrix(MPI_Comm comm, int id, int np, HYPRE_BigInt *row,
+                  HYPRE_BigInt *col,
                   HYPRE_Int *i_diag, HYPRE_Int *j_diag, HYPRE_Int *i_offd,
-                  HYPRE_Int *j_offd, HYPRE_Int *cmap,
-                  HYPRE_Int cmap_size); // constructor with 11 arguments
+                  HYPRE_Int *j_offd, HYPRE_BigInt *cmap,
+                  HYPRE_BigInt cmap_size); // constructor with 11 arguments
 
    /** @brief Creates a general parallel matrix from a local CSR matrix on each
        processor described by the @a I, @a J and @a data arrays. */
@@ -320,10 +322,10 @@ public:
        @a glob_ncols. The new parallel matrix contains copies of all input
        arrays (so they can be deleted). See @ref hypre_partitioning_descr "here"
        for a description of the partitioning arrays @a rows and @a cols. */
-   HypreParMatrix(MPI_Comm comm, int nrows, HYPRE_Int glob_nrows,
-                  HYPRE_Int glob_ncols, int *I, HYPRE_Int *J,
-                  double *data, HYPRE_Int *rows,
-                  HYPRE_Int *cols); // constructor with 9 arguments
+   HypreParMatrix(MPI_Comm comm, int nrows, HYPRE_BigInt glob_nrows,
+                  HYPRE_BigInt glob_ncols, int *I, HYPRE_Int *J,
+                  double *data, HYPRE_BigInt *rows,
+                  HYPRE_BigInt *cols); // constructor with 9 arguments
 
    /** @brief Copy constructor for a ParCSR matrix which creates a deep copy of
        structure and data from @a P. */
@@ -369,30 +371,30 @@ public:
    /// Returns the row partitioning
    /** See @ref hypre_partitioning_descr "here" for a description of the
        partitioning array. */
-   inline HYPRE_Int *RowPart() { return A->row_starts; }
+   inline HYPRE_BigInt *RowPart() { return A->row_starts; }
    /// Returns the column partitioning
    /** See @ref hypre_partitioning_descr "here" for a description of the
        partitioning array. */
-   inline HYPRE_Int *ColPart() { return A->col_starts; }
+   inline HYPRE_BigInt *ColPart() { return A->col_starts; }
    /// Returns the row partitioning (const version)
    /** See @ref hypre_partitioning_descr "here" for a description of the
        partitioning array. */
-   inline const HYPRE_Int *RowPart() const { return A->row_starts; }
+   inline const HYPRE_BigInt *RowPart() const { return A->row_starts; }
    /// Returns the column partitioning (const version)
    /** See @ref hypre_partitioning_descr "here" for a description of the
        partitioning array. */
-   inline const HYPRE_Int *ColPart() const { return A->col_starts; }
+   inline const HYPRE_BigInt *ColPart() const { return A->col_starts; }
    /// Returns the global number of rows
-   inline HYPRE_Int M() const { return A->global_num_rows; }
+   inline HYPRE_BigInt M() const { return A->global_num_rows; }
    /// Returns the global number of columns
-   inline HYPRE_Int N() const { return A->global_num_cols; }
+   inline HYPRE_BigInt N() const { return A->global_num_cols; }
 
    /// Get the local diagonal of the matrix.
    void GetDiag(Vector &diag) const;
    /// Get the local diagonal block. NOTE: 'diag' will not own any data.
    void GetDiag(SparseMatrix &diag) const;
    /// Get the local off-diagonal block. NOTE: 'offd' will not own any data.
-   void GetOffd(SparseMatrix &offd, HYPRE_Int* &cmap) const;
+   void GetOffd(SparseMatrix &offd, HYPRE_BigInt* &cmap) const;
 
    /** Split the matrix into M x N equally sized blocks of parallel matrices.
        The size of 'blocks' must already be set to M x N. */
@@ -418,22 +420,22 @@ public:
    }
 
    /// Return the global number of rows
-   HYPRE_Int GetGlobalNumRows() const
+   HYPRE_BigInt GetGlobalNumRows() const
    { return hypre_ParCSRMatrixGlobalNumRows(A); }
 
    /// Return the global number of columns
-   HYPRE_Int GetGlobalNumCols() const
+   HYPRE_BigInt GetGlobalNumCols() const
    { return hypre_ParCSRMatrixGlobalNumCols(A); }
 
    /// Return the parallel row partitioning array.
    /** See @ref hypre_partitioning_descr "here" for a description of the
        partitioning array. */
-   HYPRE_Int *GetRowStarts() const { return hypre_ParCSRMatrixRowStarts(A); }
+   HYPRE_BigInt *GetRowStarts() const { return hypre_ParCSRMatrixRowStarts(A); }
 
    /// Return the parallel column partitioning array.
    /** See @ref hypre_partitioning_descr "here" for a description of the
        partitioning array. */
-   HYPRE_Int *GetColStarts() const { return hypre_ParCSRMatrixColStarts(A); }
+   HYPRE_BigInt *GetColStarts() const { return hypre_ParCSRMatrixColStarts(A); }
 
    /// Computes y = alpha * A * x + beta * y
    HYPRE_Int Mult(HypreParVector &x, HypreParVector &y,
@@ -500,7 +502,7 @@ public:
        matrix and @a row_starts can be deleted.
        @note This operation is local and does not require communication. */
    HypreParMatrix* LeftDiagMult(const SparseMatrix &D,
-                                HYPRE_Int* row_starts = NULL) const;
+                                HYPRE_BigInt* row_starts = NULL) const;
 
    /// Scale the local row i by s(i).
    void ScaleRows(const Vector & s);
@@ -1136,8 +1138,8 @@ private:
    int nev;   // Number of desired eigenmodes
    int seed;  // Random seed used for initial vectors
 
-   HYPRE_Int glbSize; // Global number of DoFs in the linear system
-   HYPRE_Int * part;  // Row partitioning of the linear system
+   HYPRE_BigInt glbSize; // Global number of DoFs in the linear system
+   HYPRE_BigInt * part;  // Row partitioning of the linear system
 
    // Pointer to HYPRE's solver struct
    HYPRE_Solver lobpcg_solver;

--- a/linalg/hypre_parcsr.cpp
+++ b/linalg/hypre_parcsr.cpp
@@ -510,8 +510,8 @@ void hypre_ParCSRMatrixEliminateAAe(hypre_ParCSRMatrix *A,
    HYPRE_Int  num_offd_cols_to_elim;
    HYPRE_Int  *offd_cols_to_elim;
 
-   HYPRE_Int  *A_col_map_offd = hypre_ParCSRMatrixColMapOffd(A);
-   HYPRE_Int  *Ae_col_map_offd;
+   HYPRE_BigInt  *A_col_map_offd = hypre_ParCSRMatrixColMapOffd(A);
+   HYPRE_BigInt  *Ae_col_map_offd;
 
    HYPRE_Int  *col_mark;
    HYPRE_Int  *col_remap;
@@ -664,7 +664,7 @@ void hypre_ParCSRMatrixEliminateAAe(hypre_ParCSRMatrix *A,
       if (col_mark[i]) { Ae_offd_ncols++; }
    }
 
-   Ae_col_map_offd  = mfem_hypre_CTAlloc(HYPRE_Int, Ae_offd_ncols);
+   Ae_col_map_offd  = mfem_hypre_CTAlloc(HYPRE_BigInt, Ae_offd_ncols);
 
    Ae_offd_ncols = 0;
    for (i = 0; i < A_offd_ncols; i++)
@@ -886,8 +886,8 @@ void hypre_ParCSRMatrixSplit(hypre_ParCSRMatrix *A,
       hypre_MPI_Comm_size(comm, &num_procs);
    }
 
-   HYPRE_Int *row_starts = mfem_hypre_TAlloc(HYPRE_Int, num_procs+1);
-   HYPRE_Int *col_starts = mfem_hypre_TAlloc(HYPRE_Int, num_procs+1);
+   HYPRE_BigInt *row_starts = mfem_hypre_TAlloc(HYPRE_BigInt, num_procs+1);
+   HYPRE_BigInt *col_starts = mfem_hypre_TAlloc(HYPRE_BigInt, num_procs+1);
    for (i = 0; i <= num_procs; i++)
    {
       row_starts[i] = hypre_ParCSRMatrixRowStarts(A)[i] / nr;
@@ -947,8 +947,8 @@ void hypre_ParCSRMatrixSplit(hypre_ParCSRMatrix *A,
          hypre_CSRMatrix *block_offd = hypre_ParCSRMatrixOffd(block);
          HYPRE_Int block_offd_cols = hypre_CSRMatrixNumCols(block_offd);
 
-         HYPRE_Int *block_col_map = mfem_hypre_TAlloc(HYPRE_Int,
-                                                      block_offd_cols);
+         HYPRE_BigInt *block_col_map = mfem_hypre_TAlloc(HYPRE_BigInt,
+                                                         block_offd_cols);
          for (i = j = 0; i < offd_cols; i++)
          {
             HYPRE_Int bn = offd_col_block_num[i];
@@ -1432,17 +1432,17 @@ hypre_ParCSRMatrixAdd(hypre_ParCSRMatrix *A,
    MPI_Comm            comm   = hypre_ParCSRMatrixComm(A);
    hypre_CSRMatrix    *A_diag = hypre_ParCSRMatrixDiag(A);
    hypre_CSRMatrix    *A_offd = hypre_ParCSRMatrixOffd(A);
-   HYPRE_Int          *A_cmap = hypre_ParCSRMatrixColMapOffd(A);
-   HYPRE_Int           A_cmap_size = hypre_CSRMatrixNumCols(A_offd);
+   HYPRE_BigInt       *A_cmap = hypre_ParCSRMatrixColMapOffd(A);
+   HYPRE_BigInt        A_cmap_size = hypre_CSRMatrixNumCols(A_offd);
    hypre_CSRMatrix    *B_diag = hypre_ParCSRMatrixDiag(B);
    hypre_CSRMatrix    *B_offd = hypre_ParCSRMatrixOffd(B);
-   HYPRE_Int          *B_cmap = hypre_ParCSRMatrixColMapOffd(B);
-   HYPRE_Int           B_cmap_size = hypre_CSRMatrixNumCols(B_offd);
+   HYPRE_BigInt       *B_cmap = hypre_ParCSRMatrixColMapOffd(B);
+   HYPRE_BigInt        B_cmap_size = hypre_CSRMatrixNumCols(B_offd);
    hypre_ParCSRMatrix *C;
    hypre_CSRMatrix    *C_diag;
    hypre_CSRMatrix    *C_offd;
-   HYPRE_Int          *C_cmap;
-   HYPRE_Int           im;
+   HYPRE_BigInt       *C_cmap;
+   HYPRE_BigInt        im;
    HYPRE_Int           cmap_differ;
 
    /* Check if A_cmap and B_cmap are the same. */
@@ -1482,7 +1482,7 @@ hypre_ParCSRMatrixAdd(hypre_ParCSRMatrix *A,
          return NULL; /* error: A_offd and B_offd have different dimensions */
       }
       /* copy A_cmap -> C_cmap */
-      C_cmap = mfem_hypre_TAlloc(HYPRE_Int, A_cmap_size);
+      C_cmap = mfem_hypre_TAlloc(HYPRE_BigInt, A_cmap_size);
       for (im = 0; im < A_cmap_size; im++)
       {
          C_cmap[im] = A_cmap[im];

--- a/mesh/pmesh.cpp
+++ b/mesh/pmesh.cpp
@@ -1639,20 +1639,20 @@ bool ParMesh::DecodeFaceSplittings(HashTable<Hashed2> &v_to_v, const int *v,
    return need_refinement;
 }
 
-void ParMesh::GenerateOffsets(int N, HYPRE_Int loc_sizes[],
-                              Array<HYPRE_Int> *offsets[]) const
+void ParMesh::GenerateOffsets(int N, HYPRE_BigInt loc_sizes[],
+                              Array<HYPRE_BigInt> *offsets[]) const
 {
    if (HYPRE_AssumedPartitionCheck())
    {
-      Array<HYPRE_Int> temp(N);
-      MPI_Scan(loc_sizes, temp.GetData(), N, HYPRE_MPI_INT, MPI_SUM, MyComm);
+      Array<HYPRE_BigInt> temp(N);
+      MPI_Scan(loc_sizes, temp.GetData(), N, HYPRE_MPI_BIG_INT, MPI_SUM, MyComm);
       for (int i = 0; i < N; i++)
       {
          offsets[i]->SetSize(3);
          (*offsets[i])[0] = temp[i] - loc_sizes[i];
          (*offsets[i])[1] = temp[i];
       }
-      MPI_Bcast(temp.GetData(), N, HYPRE_MPI_INT, NRanks-1, MyComm);
+      MPI_Bcast(temp.GetData(), N, HYPRE_MPI_BIG_INT, NRanks-1, MyComm);
       for (int i = 0; i < N; i++)
       {
          (*offsets[i])[2] = temp[i];
@@ -1668,7 +1668,7 @@ void ParMesh::GenerateOffsets(int N, HYPRE_Int loc_sizes[],
                     HYPRE_MPI_INT, MyComm);
       for (int i = 0; i < N; i++)
       {
-         Array<HYPRE_Int> &offs = *offsets[i];
+         Array<HYPRE_BigInt> &offs = *offsets[i];
          offs.SetSize(NRanks+1);
          offs[0] = 0;
          for (int j = 0; j < NRanks; j++)

--- a/mesh/pmesh.hpp
+++ b/mesh/pmesh.hpp
@@ -272,8 +272,8 @@ public:
    void GroupQuadrilateral(int group, int i, int &face, int &o);
    ///@}
 
-   void GenerateOffsets(int N, HYPRE_Int loc_sizes[],
-                        Array<HYPRE_Int> *offsets[]) const;
+   void GenerateOffsets(int N, HYPRE_BigInt loc_sizes[],
+                        Array<HYPRE_BigInt> *offsets[]) const;
 
    void ExchangeFaceNbrData();
    void ExchangeFaceNbrNodes();


### PR DESCRIPTION
This PR should add support for hypre built with the option `--enable-mixedint`, e.g. allow local sizes to use 32bit integers and global sizes to use 64bit integers.

I added an initial guess of changes and I hope that we get a group of contributors that go through a group of files and check for errors or add changes.

Right now the code branch does not compile without changes. What I did locally was commenting out the complex operator files. With that `ex1p` runs fine in serial and parallel.

If you participate and want to compile individual files, I recommend using the makefile build system and specifying the file you are working on with
```
make fem/pfespace.o
```
this way you only get the errors from the file you are looking at.

I'd especially like to see someone help with the complex stuff, since I'm not comfortable just churning through the files. @dylan-copeland @mlstowell @psocratis 