### PR TITLE
Adding prototype for Sheath Potential calculation [sheath-potential-dev]

### DIFF
--- a/fem/gridfunc.hpp
+++ b/fem/gridfunc.hpp
@@ -162,7 +162,8 @@ public:
                            int vdim = 1) const;
 
    /** Return a vector value from within the given element. */
-   virtual void GetVectorValue(int i, const IntegrationPoint &ip, Vector &val) const;
+   virtual void GetVectorValue(int i, const IntegrationPoint &ip,
+                               Vector &val) const;
    ///@}
 
    /** @name Element Index Get Values Methods

--- a/fem/pgridfunc.hpp
+++ b/fem/pgridfunc.hpp
@@ -213,8 +213,8 @@ public:
    virtual double GetValue(ElementTransformation &T, const IntegrationPoint &ip,
                            int comp = 0, Vector *tr = NULL) const;
 
-  using GridFunction::GetVectorValue;
-  
+   using GridFunction::GetVectorValue;
+
    // Redefine to handle the case when T describes a face-neighbor element
    virtual void GetVectorValue(ElementTransformation &T,
                                const IntegrationPoint &ip,

--- a/miniapps/plasma/cold_plasma_dielectric_solver.cpp
+++ b/miniapps/plasma/cold_plasma_dielectric_solver.cpp
@@ -379,8 +379,11 @@ CPDSolver::CPDSolver(ParMesh & pmesh, int order, double omega,
       e_t_ = new ParGridFunction(L2VFESpace_);
       e_v_ = new ParComplexGridFunction(L2VFESpace_);
       d_v_ = new ParComplexGridFunction(L2VFESpace_);
-      phi_v_ = new ParComplexGridFunction(L2FESpace_);
       j_v_ = new ParComplexGridFunction(L2VFESpace_);
+      if (sbcs_->Size() > 0)
+      {
+         phi_v_ = new ParComplexGridFunction(L2FESpace_);
+      }
 
       sinkx_ = new PhaseCoefficient(*kCoef_, &sin);
       coskx_ = new PhaseCoefficient(*kCoef_, &cos);
@@ -944,7 +947,6 @@ CPDSolver::Update()
    // Inform the grid functions that the space has changed.
    e_->Update();
    d_->Update();
-   phi_->Update();
    if (u_) { u_->Update(); }
    if (uE_) { uE_->Update(); }
    if (uB_) { uB_->Update(); }
@@ -954,6 +956,8 @@ CPDSolver::Update()
    if (e_v_) { e_v_->Update(); }
    if (d_v_) { d_v_->Update(); }
    if (j_v_) { j_v_->Update(); }
+   if (phi_) {phi_->Update(); }
+   if (phi_v_) {phi_v_->Update(); }
    // e_r_->Update();
    // e_i_->Update();
    // h_->Update();

--- a/miniapps/plasma/cold_plasma_dielectric_solver.hpp
+++ b/miniapps/plasma/cold_plasma_dielectric_solver.hpp
@@ -45,6 +45,14 @@ struct SolverOptions
    int euLvl;
 };
 
+struct ComplexCoefficientByAttr
+{
+   Array<int> attr;
+   Array<int> attr_marker;
+   Coefficient * real;
+   Coefficient * imag;
+};
+
 struct ComplexVectorCoefficientByAttr
 {
    Array<int> attr;
@@ -56,16 +64,13 @@ struct ComplexVectorCoefficientByAttr
 class ElectricEnergyDensityCoef : public Coefficient
 {
 public:
-   ElectricEnergyDensityCoef(double omega,
-                             VectorCoefficient &Er, VectorCoefficient &Ei,
+   ElectricEnergyDensityCoef(VectorCoefficient &Er, VectorCoefficient &Ei,
                              MatrixCoefficient &epsr, MatrixCoefficient &epsi);
 
    double Eval(ElementTransformation &T,
                const IntegrationPoint &ip);
 
 private:
-   double omega_;
-
    VectorCoefficient &ErCoef_;
    VectorCoefficient &EiCoef_;
    MatrixCoefficient &epsrCoef_;
@@ -219,14 +224,12 @@ public:
              MatrixCoefficient & epsAbsCoef,
              Coefficient & muInvCoef,
              Coefficient * etaInvCoef,
-             Coefficient * etaInvReCoef,
-             Coefficient * etaInvImCoef,
              VectorCoefficient * kCoef,
              Array<int> & abcs,
-             Array<int> & sbcs,
              // Array<int> & dbcs,
              Array<ComplexVectorCoefficientByAttr> & dbcs,
              Array<ComplexVectorCoefficientByAttr> & nbcs,
+             Array<ComplexCoefficientByAttr> & sbcs,
              void (*j_r_src)(const Vector&, Vector&),
              void (*j_i_src)(const Vector&, Vector&),
              bool vis_u = false);
@@ -283,7 +286,7 @@ private:
 
    L2_ParFESpace * L2FESpace_;
    L2_ParFESpace * L2VFESpace_;
-   // H1_ParFESpace * H1FESpace_;
+   H1_ParFESpace * H1FESpace_;
    ND_ParFESpace * HCurlFESpace_;
    RT_ParFESpace * HDivFESpace_;
    RT_ParFESpace * HDivFESpace2p_;
@@ -298,14 +301,20 @@ private:
    ParMixedBilinearForm * m12EpsRe_;
    ParMixedBilinearForm * m12EpsIm_;
 
+   ParBilinearForm * m0_;
+   ParMixedBilinearForm * n20ZRe_;
+   ParMixedBilinearForm * n20ZIm_;
+
    ParComplexGridFunction * e_;   // Complex electric field (HCurl)
    ParComplexGridFunction * d_;   // Complex electric flux (HDiv)
+   ParComplexGridFunction * phi_; // Complex sheath potential (H1)
    ParComplexGridFunction * j_;   // Complex current density (HCurl)
    ParComplexLinearForm   * rhs_; // Dual of complex current density (HCurl)
    ParGridFunction        * e_t_; // Time dependent Electric field
    ParComplexGridFunction * e_b_; // Complex parallel electric field (L2)
    ParComplexGridFunction * e_v_; // Complex electric field (L2^d)
    ParComplexGridFunction * d_v_; // Complex electric flux (L2^d)
+   ParComplexGridFunction * phi_v_; // Complex sheath potential (L2)
    ParComplexGridFunction * j_v_; // Complex current density (L2^d)
    ParGridFunction        * u_;   // Energy density (L2)
    ParGridFunction        * uE_;  // Electric Energy density (L2)
@@ -318,8 +327,6 @@ private:
    MatrixCoefficient * epsAbsCoef_;   // Dielectric Material Coefficient
    Coefficient       * muInvCoef_;    // Dia/Paramagnetic Material Coefficient
    Coefficient       * etaInvCoef_;   // Admittance Coefficient
-   Coefficient       * etaInvReCoef_; // Real Admittance Coefficient
-   Coefficient       * etaInvImCoef_; // Imaginary Admittance Coefficient
    VectorCoefficient * kCoef_;        // Wave Vector
 
    Coefficient * omegaCoef_;     // omega expressed as a Coefficient
@@ -327,8 +334,8 @@ private:
    Coefficient * omega2Coef_;    // omega^2 expressed as a Coefficient
    Coefficient * negOmega2Coef_; // -omega^2 expressed as a Coefficient
    Coefficient * abcCoef_;       // -omega eta^{-1}
-   Coefficient * sbcReCoef_;     //  omega Im(eta^{-1})
-   Coefficient * sbcImCoef_;     // -omega Re(eta^{-1})
+   // Coefficient * sbcReCoef_;     //  omega Im(eta^{-1})
+   // Coefficient * sbcImCoef_;     // -omega Re(eta^{-1})
    Coefficient * sinkx_;         // sin(ky * y + kz * z)
    Coefficient * coskx_;         // cos(ky * y + kz * z)
    Coefficient * negsinkx_;      // -sin(ky * y + kz * z)
@@ -367,7 +374,7 @@ private:
    Array<int> abc_marker_;
 
    // Array of 0's and 1's marking the location of sheath surfaces
-   Array<int> sbc_marker_;
+   // Array<int> sbc_marker_;
 
    // Array of 0's and 1's marking the location of Dirichlet boundaries
    Array<int> dbc_marker_;
@@ -382,6 +389,8 @@ private:
 
    Array<ComplexVectorCoefficientByAttr> * nbcs_; // Surface current BCs
    Array<ComplexVectorCoefficientByAttr> * nkbcs_; // Neumann BCs (-i*omega*K)
+
+   Array<ComplexCoefficientByAttr> * sbcs_; // Sheath BCs
 
    VisItDataCollection * visit_dc_;
 

--- a/miniapps/plasma/stix1d.cpp
+++ b/miniapps/plasma/stix1d.cpp
@@ -103,11 +103,6 @@ using namespace mfem::plasma;
 Coefficient * SetupRealAdmittanceCoefficient(const Mesh & mesh,
                                              const Array<int> & abcs);
 
-// Admittance for Complex-Valued Sheath Boundary Condition
-void SetupComplexAdmittanceCoefs(const Mesh & mesh, const Array<int> & sbcs,
-                                 Coefficient *& etaInvReCoef,
-                                 Coefficient *& etaInvImCoef);
-
 // Storage for user-supplied, real-valued impedance
 static Vector pw_eta_(0);      // Piecewise impedance values
 static Vector pw_eta_inv_(0);  // Piecewise inverse impedance values
@@ -289,7 +284,7 @@ int main(int argc, char *argv[])
    Vector tpp;
 
    Array<int> abcs; // Absorbing BC attributes
-   Array<int> sbcs; // Sheath BC attributes
+   Array<int> sbca; // Sheath BC attributes
    Array<int> dbca; // Dirichlet BC attributes
    int num_elements = 10;
 
@@ -382,7 +377,7 @@ int main(int argc, char *argv[])
                   "Amplitude");
    args.AddOption(&abcs, "-abcs", "--absorbing-bc-surf",
                   "Absorbing Boundary Condition Surfaces");
-   args.AddOption(&sbcs, "-sbcs", "--sheath-bc-surf",
+   args.AddOption(&sbca, "-sbcs", "--sheath-bc-surf",
                   "Sheath Boundary Condition Surfaces");
    args.AddOption(&dbca, "-dbcs", "--dirichlet-bc-surf",
                   "Dirichlet Boundary Condition Surfaces");
@@ -823,10 +818,6 @@ int main(int argc, char *argv[])
    // Create a coefficient describing the surface admittance
    Coefficient * etaInvCoef = SetupRealAdmittanceCoefficient(pmesh, abcs);
 
-   Coefficient * etaInvReCoef = NULL;
-   Coefficient * etaInvImCoef = NULL;
-   SetupComplexAdmittanceCoefs(pmesh, sbcs, etaInvReCoef, etaInvImCoef);
-
    // Create tensor coefficients describing the dielectric permittivity
    DielectricTensor epsilon_real(BField, density, temperature,
                                  L2FESpace, H1FESpace,
@@ -912,6 +903,20 @@ int main(int argc, char *argv[])
 
    Array<ComplexVectorCoefficientByAttr> nbcs(0);
 
+   // These are placeholder coefficients awaiting CM's sheath impedance coefs
+   ConstantCoefficient z_r(1.0);
+   ConstantCoefficient z_i(0.0);
+
+   Array<ComplexCoefficientByAttr> sbcs((sbca.Size() > 0)? 1 : 0);
+   if (sbca.Size() > 0)
+   {
+      sbcs[0].real = &z_r;
+      sbcs[0].imag = &z_i;
+      sbcs[0].attr = sbca;
+      AttrToMarker(pmesh.bdr_attributes.Max(), sbcs[0].attr,
+                   sbcs[0].attr_marker);
+   }
+
    // Create the Magnetostatic solver
    if (mpi.Root() && logging > 0)
    {
@@ -921,9 +926,9 @@ int main(int argc, char *argv[])
                  (CPDSolver::SolverType)sol, solOpts,
                  (CPDSolver::PrecondType)prec,
                  conv, *BCoef, epsilon_real, epsilon_imag, epsilon_abs,
-                 muInvCoef, etaInvCoef, etaInvReCoef, etaInvImCoef,
+                 muInvCoef, etaInvCoef,
                  (phase_shift) ? &kCoef : NULL,
-                 abcs, sbcs, dbcs, nbcs,
+                 abcs, dbcs, nbcs, sbcs,
                  // e_bc_r, e_bc_i,
                  // EReCoef, EImCoef,
                  (slab_params_.Size() > 0) ? j_src : NULL, NULL, vis_u);
@@ -1192,50 +1197,6 @@ SetupRealAdmittanceCoefficient(const Mesh & mesh, const Array<int> & abcs)
    }
 
    return coef;
-}
-
-// Complex Admittance is an optional pair of coefficients, defined on boundary
-// surfaces, which can be used to approximate a sheath boundary condition.
-void
-SetupComplexAdmittanceCoefs(const Mesh & mesh, const Array<int> & sbcs,
-                            Coefficient *& etaInvReCoef,
-                            Coefficient *& etaInvImCoef )
-{
-   MFEM_VERIFY(pw_eta_re_.Size() == sbcs.Size() &&
-               pw_eta_im_.Size() == sbcs.Size(),
-               "Each impedance value must be associated with exactly one "
-               "sheath boundary surface.");
-
-   if (pw_eta_re_.Size() > 0)
-   {
-
-      pw_eta_inv_re_.SetSize(mesh.bdr_attributes.Size());
-      pw_eta_inv_im_.SetSize(mesh.bdr_attributes.Size());
-
-      if ( sbcs[0] == -1 )
-      {
-         double zmag2 = pow(pw_eta_re_[0], 2) + pow(pw_eta_im_[0], 2);
-         pw_eta_inv_re_ =  pw_eta_re_[0] / zmag2;
-         pw_eta_inv_im_ = -pw_eta_im_[0] / zmag2;
-      }
-      else
-      {
-         pw_eta_inv_re_ = 0.0;
-         pw_eta_inv_im_ = 0.0;
-
-         for (int i=0; i<pw_eta_re_.Size(); i++)
-         {
-            double zmag2 = pow(pw_eta_re_[i], 2) + pow(pw_eta_im_[i], 2);
-            if ( zmag2 > 0.0 )
-            {
-               pw_eta_inv_re_[sbcs[i]-1] =  pw_eta_re_[i] / zmag2;
-               pw_eta_inv_im_[sbcs[i]-1] = -pw_eta_im_[i] / zmag2;
-            }
-         }
-      }
-      etaInvReCoef = new PWConstCoefficient(pw_eta_inv_re_);
-      etaInvImCoef = new PWConstCoefficient(pw_eta_inv_im_);
-   }
 }
 
 void slab_current_source(const Vector &x, Vector &j)

--- a/miniapps/plasma/stix2d.cpp
+++ b/miniapps/plasma/stix2d.cpp
@@ -125,11 +125,6 @@ using namespace mfem::plasma;
 Coefficient * SetupRealAdmittanceCoefficient(const Mesh & mesh,
                                              const Array<int> & abcs);
 
-// Admittance for Complex-Valued Sheath Boundary Condition
-void SetupComplexAdmittanceCoefs(const Mesh & mesh, const Array<int> & sbcs,
-                                 Coefficient *& etaInvReCoef,
-                                 Coefficient *& etaInvImCoef);
-
 // Storage for user-supplied, real-valued impedance
 static Vector pw_eta_(0);      // Piecewise impedance values
 static Vector pw_eta_inv_(0);  // Piecewise inverse impedance values
@@ -361,7 +356,7 @@ int main(int argc, char *argv[])
    Vector tpp;
 
    Array<int> abcs; // Absorbing BC attributes
-   Array<int> sbcs; // Sheath BC attributes
+   Array<int> sbca; // Sheath BC attributes
    Array<int> peca; // Perfect Electric Conductor BC attributes
    Array<int> dbca1; // Dirichlet BC attributes
    Array<int> dbca2; // Dirichlet BC attributes
@@ -465,6 +460,8 @@ int main(int argc, char *argv[])
                   "3D Vector Amplitude, 2D Position, Radius");
    args.AddOption(&abcs, "-abcs", "--absorbing-bc-surf",
                   "Absorbing Boundary Condition Surfaces");
+   args.AddOption(&sbca, "-sbcs", "--sheath-bc-surf",
+                  "Sheath Boundary Condition Surfaces");
    args.AddOption(&peca, "-pecs", "--pec-bc-surf",
                   "Perfect Electrical Conductor Boundary Condition Surfaces");
    args.AddOption(&dbca1, "-dbcs1", "--dirichlet-bc-1-surf",
@@ -874,10 +871,6 @@ int main(int argc, char *argv[])
    // Create a coefficient describing the surface admittance
    Coefficient * etaInvCoef = SetupRealAdmittanceCoefficient(pmesh, abcs);
 
-   Coefficient * etaInvReCoef = NULL;
-   Coefficient * etaInvImCoef = NULL;
-   SetupComplexAdmittanceCoefs(pmesh, sbcs, etaInvReCoef, etaInvImCoef);
-
    // Create tensor coefficients describing the dielectric permittivity
    DielectricTensor epsilon_real(BField, density, temperature,
                                  L2FESpace, H1FESpace,
@@ -1055,6 +1048,20 @@ int main(int argc, char *argv[])
 
    Array<ComplexVectorCoefficientByAttr> nbcs(0);
 
+   // These are placeholder coefficients awaiting CM's sheath impedance coefs
+   ConstantCoefficient z_r(1.0);
+   ConstantCoefficient z_i(0.0);
+
+   Array<ComplexCoefficientByAttr> sbcs((sbca.Size() > 0)? 1 : 0);
+   if (sbca.Size() > 0)
+   {
+      sbcs[0].real = &z_r;
+      sbcs[0].imag = &z_i;
+      sbcs[0].attr = sbca;
+      AttrToMarker(pmesh.bdr_attributes.Max(), sbcs[0].attr,
+                   sbcs[0].attr_marker);
+   }
+
    if (mpi.Root())
    {
       cout << "Creating Cold Plasma Dielectric solver." << endl;
@@ -1065,9 +1072,9 @@ int main(int argc, char *argv[])
                  (CPDSolver::SolverType)sol, solOpts,
                  (CPDSolver::PrecondType)prec,
                  conv, BCoef, epsilon_real, epsilon_imag, epsilon_abs,
-                 muInvCoef, etaInvCoef, etaInvReCoef, etaInvImCoef,
+                 muInvCoef, etaInvCoef,
                  (phase_shift) ? &kCoef : NULL,
-                 abcs, sbcs, dbcs, nbcs,
+                 abcs, dbcs, nbcs, sbcs,
                  // e_bc_r, e_bc_i,
                  // EReCoef, EImCoef,
                  (rod_params_.Size() > 0) ? j_src : NULL, NULL, vis_u);
@@ -1336,49 +1343,6 @@ SetupRealAdmittanceCoefficient(const Mesh & mesh, const Array<int> & abcs)
    }
 
    return coef;
-}
-
-// Complex Admittance is an optional pair of coefficients, defined on boundary
-// surfaces, which can be used to approximate a sheath boundary condition.
-void
-SetupComplexAdmittanceCoefs(const Mesh & mesh, const Array<int> & sbcs,
-                            Coefficient *& etaInvReCoef,
-                            Coefficient *& etaInvImCoef )
-{
-   if (pw_eta_re_.Size() > 0)
-   {
-      MFEM_VERIFY(pw_eta_re_.Size() == sbcs.Size() &&
-                  pw_eta_im_.Size() == sbcs.Size(),
-                  "Each impedance value must be associated with exactly one "
-                  "sheath boundary surface.");
-
-      pw_eta_inv_re_.SetSize(mesh.bdr_attributes.Size());
-      pw_eta_inv_im_.SetSize(mesh.bdr_attributes.Size());
-
-      if ( sbcs[0] == -1 )
-      {
-         double zmag2 = pow(pw_eta_re_[0], 2) + pow(pw_eta_im_[0], 2);
-         pw_eta_inv_re_ =  pw_eta_re_[0] / zmag2;
-         pw_eta_inv_im_ = -pw_eta_im_[0] / zmag2;
-      }
-      else
-      {
-         pw_eta_inv_re_ = 0.0;
-         pw_eta_inv_im_ = 0.0;
-
-         for (int i=0; i<pw_eta_re_.Size(); i++)
-         {
-            double zmag2 = pow(pw_eta_re_[i], 2) + pow(pw_eta_im_[i], 2);
-            if ( zmag2 > 0.0 )
-            {
-               pw_eta_inv_re_[sbcs[i]-1] =  pw_eta_re_[i] / zmag2;
-               pw_eta_inv_im_[sbcs[i]-1] = -pw_eta_im_[i] / zmag2;
-            }
-         }
-      }
-      etaInvReCoef = new PWConstCoefficient(pw_eta_inv_re_);
-      etaInvImCoef = new PWConstCoefficient(pw_eta_inv_im_);
-   }
 }
 
 void rod_current_source(const Vector &x, Vector &j)


### PR DESCRIPTION
This PR demonstrates the type of solve that needs to be performed to compute the sheath potential on the surface of a mesh.

Once the sheath impedance is incorporated into the code we can compute the actual sheath potential.  This prototype uses a sheath impedance of 1.  The plan is to compute the electric field using a nested iteration:

0: Assume sheath potential is zero.
1: Compute E using -GradPhi as a Dirichlet BC
2: Compute D = epsilon E (solve an H(Div) mass matrix)
3. phi = z(phi, z_previous) n.D, repeat until z converges (solve an H1 mass matrix in each iteration) 
4. Go back to 1 unless the change in GradPhi is below some tolerance.
