### PR TITLE
Add option to derefine elements only if they have the same attribute [nc-attr-dev]

### DIFF
--- a/examples/ex15.cpp
+++ b/examples/ex15.cpp
@@ -63,6 +63,15 @@ double rhs_func(const Vector &pt, double t);
 void UpdateProblem(Mesh &mesh, FiniteElementSpace &fespace,
                    GridFunction &x, BilinearForm &a, LinearForm &b);
 
+void UpdateAttributes(Mesh &mesh)
+{
+   Vector center;
+   for (int i = 0; i < mesh.GetNE(); i++)
+   {
+      mesh.GetElementCenter(i, center);
+      mesh.SetAttribute(i, (center(0) < 0.0) ? 1 : 2);
+   }
+}
 
 int main(int argc, char *argv[])
 {
@@ -210,6 +219,7 @@ int main(int argc, char *argv[])
    ThresholdDerefiner derefiner(estimator);
    derefiner.SetThreshold(hysteresis * max_elem_error);
    derefiner.SetNCLimit(nc_limit);
+   derefiner.SetSameAttributeOnly(true);
 
    // 12. The outer time loop. In each iteration we update the right hand side,
    //     solve the problem on the current mesh, visualize the solution and
@@ -287,6 +297,8 @@ int main(int argc, char *argv[])
          {
             break;
          }
+
+         UpdateAttributes(mesh);
 
          // 20. Update the space and interpolate the solution.
          UpdateProblem(mesh, fespace, x, a, b);

--- a/examples/ex15p.cpp
+++ b/examples/ex15p.cpp
@@ -66,6 +66,16 @@ void UpdateAndRebalance(ParMesh &pmesh, ParFiniteElementSpace &fespace,
                         ParGridFunction &x, ParBilinearForm &a,
                         ParLinearForm &b);
 
+void UpdateAttributes(Mesh &mesh)
+{
+   Vector center;
+   for (int i = 0; i < mesh.GetNE(); i++)
+   {
+      mesh.GetElementCenter(i, center);
+      mesh.SetAttribute(i, (center(0) < 0.0) ? 1 : 2);
+   }
+}
+
 
 int main(int argc, char *argv[])
 {
@@ -236,6 +246,7 @@ int main(int argc, char *argv[])
    ThresholdDerefiner derefiner(estimator);
    derefiner.SetThreshold(hysteresis * max_elem_error);
    derefiner.SetNCLimit(nc_limit);
+   derefiner.SetSameAttributeOnly(true);
 
    // 13. The outer time loop. In each iteration we update the right hand side,
    //     solve the problem on the current mesh, visualize the solution and
@@ -318,6 +329,8 @@ int main(int argc, char *argv[])
          {
             cout << ", total error: " << estimator.GetTotalError() << endl;
          }
+
+         UpdateAttributes(pmesh);
 
          // 21. Quit the AMR loop if the termination criterion has been met
          if (refiner.Stop())

--- a/mesh/mesh.cpp
+++ b/mesh/mesh.cpp
@@ -7579,6 +7579,17 @@ void Mesh::NonconformingRefinement(const Array<Refinement> &refinements,
    }
 }
 
+bool Mesh::CheckSameAttr(const int *elem, int nelem)
+{
+   MFEM_ASSERT(nelem > 0 && ncmesh, "");
+   int attr = ncmesh->GetAttribute(elem[0]);
+   for (int i = 1; i < nelem; i++)
+   {
+      if (ncmesh->GetAttribute(elem[i]) != attr) { return false; }
+   }
+   return true;
+}
+
 double Mesh::AggregateError(const Array<double> &elem_error,
                             const int *fine, int nfine, int op)
 {
@@ -7599,7 +7610,8 @@ double Mesh::AggregateError(const Array<double> &elem_error,
 }
 
 bool Mesh::NonconformingDerefinement(Array<double> &elem_error,
-                                     double threshold, int nc_limit, int op)
+                                     double threshold, int nc_limit, int op,
+                                     bool same_attr_only)
 {
    MFEM_VERIFY(ncmesh, "Only supported for non-conforming meshes.");
    MFEM_VERIFY(!NURBSext, "Derefinement of NURBS meshes is not supported. "
@@ -7620,8 +7632,12 @@ bool Mesh::NonconformingDerefinement(Array<double> &elem_error,
    {
       if (nc_limit > 0 && !level_ok[i]) { continue; }
 
-      double error =
-         AggregateError(elem_error, dt.GetRow(i), dt.RowSize(i), op);
+      const int *fine = dt.GetRow(i);
+      const int nfine = dt.RowSize(i);
+
+      if (same_attr_only && !CheckSameAttr(fine, nfine)) { continue; }
+
+      double error = AggregateError(elem_error, fine, nfine, op);
 
       if (error < threshold) { derefs.Append(i); }
    }
@@ -7647,31 +7663,27 @@ bool Mesh::NonconformingDerefinement(Array<double> &elem_error,
 }
 
 bool Mesh::DerefineByError(Array<double> &elem_error, double threshold,
-                           int nc_limit, int op)
+                           int nc_limit, int op, bool same_attr_only)
 {
    // NOTE: the error array is not const because it will be expanded in parallel
    //       by ghost element errors
-   if (Nonconforming())
-   {
-      return NonconformingDerefinement(elem_error, threshold, nc_limit, op);
-   }
-   else
-   {
-      MFEM_ABORT("Derefinement is currently supported for non-conforming "
-                 "meshes only.");
-      return false;
-   }
+
+   MFEM_VERIFY(Nonconforming(), "Derefinement is currently supported for "
+               "non-conforming meshes only.")
+
+   return NonconformingDerefinement(elem_error, threshold, nc_limit, op,
+                                    same_attr_only);
 }
 
 bool Mesh::DerefineByError(const Vector &elem_error, double threshold,
-                           int nc_limit, int op)
+                           int nc_limit, int op, bool same_attr_only)
 {
    Array<double> tmp(elem_error.Size());
    for (int i = 0; i < tmp.Size(); i++)
    {
       tmp[i] = elem_error(i);
    }
-   return DerefineByError(tmp, threshold, nc_limit, op);
+   return DerefineByError(tmp, threshold, nc_limit, op, same_attr_only);
 }
 
 

--- a/mesh/mesh.hpp
+++ b/mesh/mesh.hpp
@@ -335,8 +335,9 @@ protected:
    /// NC version of GeneralDerefinement.
    virtual bool NonconformingDerefinement(Array<double> &elem_error,
                                           double threshold, int nc_limit = 0,
-                                          int op = 1);
-   /// Derefinement helper.
+                                          int op = 1, bool same_attr_only = false);
+   // Derefinement helpers.
+   bool CheckSameAttr(const int *elem, int nelem);
    double AggregateError(const Array<double> &elem_error,
                          const int *fine, int nfine, int op);
 
@@ -1024,7 +1025,11 @@ public:
    int GetAttribute(int i) const { return elements[i]->GetAttribute(); }
 
    /// Set the attribute of element i.
-   void SetAttribute(int i, int attr) { elements[i]->SetAttribute(attr); }
+   void SetAttribute(int i, int attr)
+   {
+      elements[i]->SetAttribute(attr);
+      if (ncmesh) { ncmesh->SetAttribute(i, attr); }
+   }
 
    /// Return the attribute of boundary element i.
    int GetBdrAttribute(int i) const { return boundary[i]->GetAttribute(); }
@@ -1168,11 +1173,13 @@ public:
        that would increase the maximum level of hanging nodes of the mesh are
        skipped. Returns true if the mesh changed, false otherwise. */
    bool DerefineByError(Array<double> &elem_error, double threshold,
-                        int nc_limit = 0, int op = 1);
+                        int nc_limit = 0, int op = 1,
+                        bool same_attr_only = false);
 
    /// Same as DerefineByError for an error vector.
    bool DerefineByError(const Vector &elem_error, double threshold,
-                        int nc_limit = 0, int op = 1);
+                        int nc_limit = 0, int op = 1,
+                        bool same_attr_only = false);
 
    ///@{ @name NURBS mesh refinement methods
    void KnotInsert(Array<KnotVector *> &kv);

--- a/mesh/mesh_operators.cpp
+++ b/mesh/mesh_operators.cpp
@@ -151,7 +151,8 @@ int ThresholdDerefiner::ApplyImpl(Mesh &mesh)
    if (mesh.Conforming()) { return NONE; }
 
    const Vector &local_err = estimator.GetLocalErrors();
-   bool derefs = mesh.DerefineByError(local_err, threshold, nc_limit, op);
+   bool derefs = mesh.DerefineByError(local_err, threshold, nc_limit, op,
+                                      same_attr_only);
 
    return derefs ? CONTINUE + DEREFINED : NONE;
 }

--- a/mesh/mesh_operators.hpp
+++ b/mesh/mesh_operators.hpp
@@ -272,6 +272,7 @@ protected:
 
    double threshold;
    int nc_limit, op;
+   bool same_attr_only;
 
    /** @brief Apply the operator to the mesh.
        @return DEREFINED + CONTINUE if some elements were de-refined; NONE
@@ -286,6 +287,7 @@ public:
       threshold = 0.0;
       nc_limit = 0;
       op = 1;
+      same_attr_only = false;
    }
 
    // default destructor (virtual)
@@ -301,6 +303,12 @@ public:
    {
       MFEM_ASSERT(nc_limit >= 0, "Invalid NC limit");
       this->nc_limit = nc_limit;
+   }
+
+   /// Only derefine groups of elements with the same attribute.
+   void SetSameAttributeOnly(bool same_attr_only = true)
+   {
+      this->same_attr_only = same_attr_only;
    }
 
    /// Reset the associated estimator.

--- a/mesh/ncmesh.hpp
+++ b/mesh/ncmesh.hpp
@@ -283,6 +283,18 @@ public:
 
    // utility
 
+   /// Set attribute of an element; @a index is the Mesh element index.
+   void SetAttribute(int index, int attr)
+   {
+      elements[leaf_elements[index]].attribute = attr;
+   }
+
+   /// Retrieve attribute of element @index (Mesh numbering).
+   int GetAttribute(int index) const
+   {
+      return elements[leaf_elements[index]].attribute;
+   }
+
    /// Return Mesh vertex indices of an edge identified by 'edge_id'.
    void GetEdgeVertices(const MeshId &edge_id, int vert_index[2],
                         bool oriented = true) const;

--- a/mesh/pmesh.cpp
+++ b/mesh/pmesh.cpp
@@ -3317,7 +3317,8 @@ void ParMesh::NonconformingRefinement(const Array<Refinement> &refinements,
 }
 
 bool ParMesh::NonconformingDerefinement(Array<double> &elem_error,
-                                        double threshold, int nc_limit, int op)
+                                        double threshold, int nc_limit, int op,
+                                        bool same_attr_only)
 {
    MFEM_VERIFY(pncmesh, "Only supported for non-conforming meshes.");
    MFEM_VERIFY(!NURBSext, "Derefinement of NURBS meshes is not supported. "
@@ -3338,8 +3339,12 @@ bool ParMesh::NonconformingDerefinement(Array<double> &elem_error,
    {
       if (nc_limit > 0 && !level_ok[i]) { continue; }
 
-      double error =
-         AggregateError(elem_error, dt.GetRow(i), dt.RowSize(i), op);
+      const int *fine = dt.GetRow(i);
+      const int nfine = dt.RowSize(i);
+
+      if (same_attr_only && !CheckSameAttr(fine, nfine)) { continue; }
+
+      double error = AggregateError(elem_error, fine, nfine, op);
 
       if (error < threshold) { derefs.Append(i); }
    }

--- a/mesh/pmesh.hpp
+++ b/mesh/pmesh.hpp
@@ -146,7 +146,7 @@ protected:
 
    virtual bool NonconformingDerefinement(Array<double> &elem_error,
                                           double threshold, int nc_limit = 0,
-                                          int op = 1);
+                                          int op = 1, bool same_attr_only = false);
 
    void RebalanceImpl(const Array<int> *partition);
 


### PR DESCRIPTION
This tries to address #1572 :

1. Mesh::SetAttribute is propagated into NCMesh elements.
2. ThresholdDerefiner and Mesh::DerefineByError now have the option to only derefine a group of elements only if all of them have the same attribute.

Test code in ex15, ex15p (to be removed):

![derefine_attr](https://user-images.githubusercontent.com/1349371/86930355-37b21080-c137-11ea-82b7-85fec19f811b.png)


TODO:
- [ ] Parallel synchronization of NCMesh::SetAttribute (ghost elements)
