### PR TITLE
Document that Array<T> operates correctly only with POD types

### DIFF
--- a/general/array.hpp
+++ b/general/array.hpp
@@ -35,11 +35,10 @@ void Swap(Array<T> &, Array<T> &);
 /**
    Abstract data type Array.
 
-   Array<T> is an automatically increasing array containing elements
-   of the generic type T, which must be a POD (plain old data)
-   type. The allocated size may be larger then the logical size of the
-   array.  The elements can be accessed by the [] operator, the range
-   is 0 to size-1.
+   Array<T> is an automatically increasing array containing elements of the
+   generic type T, which must be a POD (plain old data) type. The allocated size
+   may be larger then the logical size of the array. The elements can be
+   accessed by the [] operator, the range is 0 to size-1.
 */
 template <class T>
 class Array

--- a/general/array.hpp
+++ b/general/array.hpp
@@ -35,10 +35,11 @@ void Swap(Array<T> &, Array<T> &);
 /**
    Abstract data type Array.
 
-   Array<T> is an automatically increasing array containing elements of the
-   generic type T. The allocated size may be larger then the logical size
-   of the array.
-   The elements can be accessed by the [] operator, the range is 0 to size-1.
+   Array<T> is an automatically increasing array containing elements
+   of the generic type T, which must be a POD (plain old data)
+   type. The allocated size may be larger then the logical size of the
+   array.  The elements can be accessed by the [] operator, the range
+   is 0 to size-1.
 */
 template <class T>
 class Array


### PR DESCRIPTION

Update to documentation to specify that Array<T> requires T to be a POD type.

<!--GHEX{"id":1615,"author":"rw-anderson","editor":"tzanio","reviewers":["stefanhenneking","cjvogl"],"assignment":"2020-07-14T09:26:14-07:00","approval":"2020-07-14T23:21:48.504Z","merge":"2020-07-15T21:05:52.771Z"}XEHG--><!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge| 
 | --- | --- | --- | --- | --- | --- | --- | 
| [#1615](https://github.com/mfem/mfem/pull/1615) | @rw-anderson | @tzanio | @stefanhenneking + @cjvogl | 07/14/20 | 07/14/20 | 07/15/20 | |
<!--ELBATXEHG-->