### PR TITLE
HypreBoomerAMG: allow Ordering::byNODES in systems version

### DIFF
--- a/examples/ex2p.cpp
+++ b/examples/ex2p.cpp
@@ -60,6 +60,7 @@ int main(int argc, char *argv[])
    bool static_cond = false;
    bool visualization = 1;
    bool amg_elast = 0;
+   bool reorder_space = false;
 
    OptionsParser args(argc, argv);
    args.AddOption(&mesh_file, "-m", "--mesh",
@@ -75,6 +76,9 @@ int main(int argc, char *argv[])
    args.AddOption(&visualization, "-vis", "--visualization", "-no-vis",
                   "--no-visualization",
                   "Enable or disable GLVis visualization.");
+   args.AddOption(&reorder_space, "-nodes", "--by-nodes", "-vdim",
+                  "--by-vdim",
+                  "Use byNODES ordering of vector space instead of byVDIM");
    args.Parse();
    if (!args.Good())
    {
@@ -156,7 +160,14 @@ int main(int argc, char *argv[])
    else
    {
       fec = new H1_FECollection(order, dim);
-      fespace = new ParFiniteElementSpace(pmesh, fec, dim, Ordering::byVDIM);
+      if (reorder_space)
+      {
+         fespace = new ParFiniteElementSpace(pmesh, fec, dim, Ordering::byNODES);
+      }
+      else
+      {
+         fespace = new ParFiniteElementSpace(pmesh, fec, dim, Ordering::byVDIM);
+      }
    }
    HYPRE_Int size = fespace->GlobalTrueVSize();
    if (myid == 0)
@@ -249,7 +260,7 @@ int main(int argc, char *argv[])
    }
    else
    {
-      amg->SetSystemsOptions(dim);
+      amg->SetSystemsOptions(dim, reorder_space);
    }
    HyprePCG *pcg = new HyprePCG(A);
    pcg->SetTol(1e-8);

--- a/examples/ex2p.cpp
+++ b/examples/ex2p.cpp
@@ -76,8 +76,7 @@ int main(int argc, char *argv[])
    args.AddOption(&visualization, "-vis", "--visualization", "-no-vis",
                   "--no-visualization",
                   "Enable or disable GLVis visualization.");
-   args.AddOption(&reorder_space, "-nodes", "--by-nodes", "-vdim",
-                  "--by-vdim",
+   args.AddOption(&reorder_space, "-nodes", "--by-nodes", "-vdim", "--by-vdim",
                   "Use byNODES ordering of vector space instead of byVDIM");
    args.Parse();
    if (!args.Good())

--- a/linalg/hypre.cpp
+++ b/linalg/hypre.cpp
@@ -3191,11 +3191,15 @@ void HypreBoomerAMG::SetOperator(const Operator &op)
 void HypreBoomerAMG::SetSystemsOptions(int dim, bool order_bynodes)
 {
    HYPRE_BoomerAMGSetNumFunctions(amg_precond, dim);
-   if (order_bynodes) // ordering == Ordering::byNODES
+
+   // The default "system" ordering in hypre is Ordering::byVDIM. When we are
+   // using Ordering::byNODES, we have to specify the ordering explicitly with
+   // HYPRE_BoomerAMGSetDofFunc as in the following code.
+   if (order_bynodes)
    {
-      // hypre actually deletes the following pointer in
-      // HYPRE_BoomerAMGDestroy, so we don't need to track it
-      HYPRE_Int * mapping = mfem_hypre_CTAlloc(HYPRE_Int, height);
+      // hypre actually deletes the following pointer in HYPRE_BoomerAMGDestroy,
+      // so we don't need to track it
+      HYPRE_Int *mapping = mfem_hypre_CTAlloc(HYPRE_Int, height);
       int h_nnodes = height / dim; // nodes owned in linear algebra (not fem)
       MFEM_VERIFY(height % dim == 0, "Ordering does not work as claimed!");
       int k = 0;

--- a/linalg/hypre.hpp
+++ b/linalg/hypre.hpp
@@ -993,16 +993,15 @@ public:
 
    virtual void SetOperator(const Operator &op);
 
-   /** More robust options for systems, such as elasticity. Note that BoomerAMG
-       assumes Ordering::byVDIM in the finite element space used to generate the
-       matrix A. */
-   void SetSystemsOptions(int dim);
+   /** More robust options for systems, such as elasticity. */
+   void SetSystemsOptions(int dim, bool order_bynodes=false);
 
    /** A special elasticity version of BoomerAMG that takes advantage of
        geometric rigid body modes and could perform better on some problems, see
        "Improving algebraic multigrid interpolation operators for linear
        elasticity problems", Baker, Kolev, Yang, NLAA 2009, DOI:10.1002/nla.688.
-       As with SetSystemsOptions(), this solver assumes Ordering::byVDIM. */
+       This solver assumes Ordering::byVDIM in the FiniteElementSpace used to
+       construct A. */
    void SetElasticityOptions(ParFiniteElementSpace *fespace);
 
    void SetPrintLevel(int print_level)


### PR DESCRIPTION
In some of my constraint / contact work, collaborators want to use `Ordering::byNODES` for an elasticity problem, and getting `HypreBooomerAMG` to work well in that setting is not entirely trivial, so I thought it might be a reasonable addition to the library.

The changes to `ex2p` perhaps do not need to actually be merged but may be helpful for reviewers to see what these changes actually do.
<!--GHEX{"id":1623,"author":"barker29","editor":"tzanio","reviewers":["jamiebramwell","tzanio"],"assignment":"2020-07-25T18:56:28-07:00","approval":"2020-08-16T22:40:36.487Z","merge":"2020-08-23T21:03:26.204Z"}XEHG--><!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge| 
 | --- | --- | --- | --- | --- | --- | --- | 
| [#1623](https://github.com/mfem/mfem/pull/1623) | @barker29 | @tzanio | @jamiebramwell + @tzanio | 07/25/20 | 08/16/20 | 08/23/20 | |
<!--ELBATXEHG-->