### PR TITLE
Set MFEM_USE_SIMD=NO by default

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -41,7 +41,7 @@ Performance improvements
     - x86 (SSE/AVX/AVX2/AVX512),
     - Power8 & Power9 (VSX),
     - BG/Q (QPX).
-  These are now enabled by default, and can be disabled with MFEM_USE_SIMD=NO.
+  These are disabled by default, and can be enabled with MFEM_USE_SIMD=YES.
   See the new file linalg/simd.hpp and the new directory linalg/simd.
 
 Improved GPU capabilities

--- a/config/defaults.cmake
+++ b/config/defaults.cmake
@@ -50,7 +50,7 @@ option(MFEM_USE_OCCA "Enable OCCA" OFF)
 option(MFEM_USE_RAJA "Enable RAJA" OFF)
 option(MFEM_USE_CEED "Enable CEED" OFF)
 option(MFEM_USE_UMPIRE "Enable Umpire" OFF)
-option(MFEM_USE_SIMD "Enable use of SIMD intrinsics" ON)
+option(MFEM_USE_SIMD "Enable use of SIMD intrinsics" OFF)
 option(MFEM_USE_ADIOS2 "Enable ADIOS2" OFF)
 
 set(MFEM_MPI_NP 4 CACHE STRING "Number of processes used for MPI tests")

--- a/config/defaults.mk
+++ b/config/defaults.mk
@@ -138,7 +138,7 @@ MFEM_USE_RAJA          = NO
 MFEM_USE_OCCA          = NO
 MFEM_USE_CEED          = NO
 MFEM_USE_UMPIRE        = NO
-MFEM_USE_SIMD          = YES
+MFEM_USE_SIMD          = NO
 MFEM_USE_ADIOS2        = NO
 
 # Compile and link options for zlib.


### PR DESCRIPTION
`MFEM_USE_SIMD=YES` results in compilation errors on IBM machines (Lassen, Ray,...), I suggests that we change the default value of this option because the compilation bugs are very confusing, and I think MFEM master should compile on Lassen with its default configuration.
<!--GHEX{"id":1627,"author":"YohannDudouit","editor":"tzanio","reviewers":["camierjs","v-dobrev"],"assignment":"2020-07-19T21:53:19-07:00","approval":"2020-07-27T18:51:37.010Z","merge":"2020-08-02T06:28:30.336Z"}XEHG--><!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge| 
 | --- | --- | --- | --- | --- | --- | --- | 
| [#1627](https://github.com/mfem/mfem/pull/1627) | @YohannDudouit | @tzanio | @camierjs + @v-dobrev | 07/19/20 | 07/27/20 | 08/01/20 | |
<!--ELBATXEHG-->