### PR TITLE
Add residual monitor for checking for correct handling of essential boundary conditions

### DIFF
--- a/linalg/solvers.cpp
+++ b/linalg/solvers.cpp
@@ -2696,7 +2696,7 @@ void ResidualBCMonitor::MonitorResidual(
    if ((it == 0 || final || bc_norm_squared > 0.0) && print)
    {
       mfem::out << "      ResidualBCMonitor : b.c. residual norm = "
-                << sqrt(bc_norm_squared) << std::endl;
+                << sqrt(bc_norm_squared) << endl;
    }
 }
 

--- a/linalg/solvers.cpp
+++ b/linalg/solvers.cpp
@@ -2665,6 +2665,42 @@ void BlockILU::Mult(const Vector &b, Vector &x) const
    }
 }
 
+
+void ResidualBCMonitor::MonitorResidual(
+   int it, double norm, const Vector &r, bool final)
+{
+   if (!ess_dofs_list) { return; }
+
+   double bc_norm_squared = 0.0;
+   r.HostRead();
+   ess_dofs_list->HostRead();
+   for (int i = 0; i < ess_dofs_list->Size(); i++)
+   {
+      const double r_entry = r((*ess_dofs_list)[i]);
+      bc_norm_squared += r_entry*r_entry;
+   }
+   bool print = true;
+#ifdef MFEM_USE_MPI
+   MPI_Comm comm = iter_solver->GetComm();
+   if (comm != MPI_COMM_NULL)
+   {
+      double glob_bc_norm_squared = 0.0;
+      MPI_Reduce(&bc_norm_squared, &glob_bc_norm_squared, 1, MPI_DOUBLE,
+                 MPI_SUM, 0, comm);
+      bc_norm_squared = glob_bc_norm_squared;
+      int rank;
+      MPI_Comm_rank(comm, &rank);
+      print = (rank == 0);
+   }
+#endif
+   if ((it == 0 || final || bc_norm_squared > 0.0) && print)
+   {
+      mfem::out << "      ResidualBCMonitor : b.c. residual norm = "
+                << sqrt(bc_norm_squared) << std::endl;
+   }
+}
+
+
 #ifdef MFEM_USE_SUITESPARSE
 
 void UMFPackSolver::Init()

--- a/linalg/solvers.hpp
+++ b/linalg/solvers.hpp
@@ -33,8 +33,12 @@ class BilinearForm;
 /// Abstract base class for an iterative solver monitor
 class IterativeSolverMonitor
 {
+protected:
+   /// The last IterativeSolver to which this monitor was attached.
+   const class IterativeSolver *iter_solver;
+
 public:
-   IterativeSolverMonitor() {}
+   IterativeSolverMonitor() : iter_solver(nullptr) {}
 
    virtual ~IterativeSolverMonitor() {}
 
@@ -49,6 +53,11 @@ public:
                                 bool final)
    {
    }
+
+   /** @brief This method is invoked by ItertiveSolver::SetMonitor, informing
+       the monitor which IterativeSolver is using it. */
+   void SetIterativeSolver(const IterativeSolver &solver)
+   { iter_solver = &solver; }
 };
 
 /// Abstract base class for iterative solver
@@ -100,7 +109,15 @@ public:
    virtual void SetOperator(const Operator &op);
 
    /// Set the iterative solver monitor
-   void SetMonitor(IterativeSolverMonitor &m) { monitor = &m; }
+   void SetMonitor(IterativeSolverMonitor &m)
+   { monitor = &m; m.SetIterativeSolver(*this); }
+
+#ifdef MFEM_USE_MPI
+   /** @brief Return the associated MPI communicator, or MPI_COMM_NULL if no
+       communicator is set. */
+   MPI_Comm GetComm() const
+   { return dot_prod_type == 0 ? MPI_COMM_NULL : comm; }
+#endif
 };
 
 
@@ -685,6 +702,25 @@ private:
    /// Pivot arrays for the LU factorizations given by #DB
    mutable Array<int> ipiv;
 };
+
+
+/// Monitor that checks whether the residual is zero at a given set of dofs.
+/** This monitor is useful for checking if the initial guess, rhs, operator, and
+    preconditioner are properly setup for solving in the subspace with imposed
+    essential boundary conditions. */
+class ResidualBCMonitor : public IterativeSolverMonitor
+{
+protected:
+   const Array<int> *ess_dofs_list; ///< Not owned
+
+public:
+   ResidualBCMonitor(const Array<int> &ess_dofs_list_)
+      : ess_dofs_list(&ess_dofs_list_) { }
+
+   void MonitorResidual(int it, double norm, const Vector &r,
+                        bool final) override;
+};
+
 
 #ifdef MFEM_USE_SUITESPARSE
 


### PR DESCRIPTION
This branch adds a simple `ResidualBCMonitor` that can be used to check if essential b.c. are properly imposed on the initial guess, rhs, operator, and preconditioner.

To use this class simply add  something like
```c++
   ResidualBCMonitor bc_mon(ess_tdof_list);
   iter_solver.SetMonitor(bc_mon);
```
before the call to `iter_solver.Mult`.
<!--GHEX{"id":1633,"author":"v-dobrev","editor":"tzanio","reviewers":["barker29","jandrej"],"assignment":"2020-07-19T21:52:46-07:00","approval":"2020-08-05T02:47:14.403Z","merge":"2020-08-14T01:35:21.549Z"}XEHG--><!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge| 
 | --- | --- | --- | --- | --- | --- | --- | 
| [#1633](https://github.com/mfem/mfem/pull/1633) | @v-dobrev | @tzanio | @barker29 + @jandrej | 07/19/20 | 08/04/20 | 08/13/20 | |
<!--ELBATXEHG-->