### PR TITLE
Reset ElementTransformation::EvalState in new situations [eval-state-dev]

### DIFF
--- a/fem/eltrans.hpp
+++ b/fem/eltrans.hpp
@@ -77,6 +77,9 @@ public:
 
    ElementTransformation();
 
+   /** @brief Force the reevaluation of the Jacobian in the next call. */
+   void Reset() { EvalState = 0; }
+
    /** @brief Set the integration point @a ip that weights and Jacobians will
        be evaluated at. */
    void SetIntPoint(const IntegrationPoint *ip)

--- a/fem/eltrans.hpp
+++ b/fem/eltrans.hpp
@@ -362,7 +362,11 @@ private:
    virtual const DenseMatrix &EvalHessian();
 public:
    /// Set the element that will be used to compute the transformations
-   void SetFE(const FiniteElement *FE) { FElem = FE; geom = FE->GetGeomType(); }
+   void SetFE(const FiniteElement *FE)
+   {
+      EvalState = (FE != FElem) ? 0 : EvalState;
+      FElem = FE; geom = FE->GetGeomType();
+   }
 
    /// Get the current element used to compute the transformations
    const FiniteElement* GetFE() const { return FElem; }
@@ -377,7 +381,7 @@ public:
        the column-vector of all basis functions evaluated at \f$ \hat x \f$ .
        The columns of @a P represent the control points in physical space
        defining the transformation. */
-   void SetPointMat(const DenseMatrix &pm) { PointMat = pm; }
+   void SetPointMat(const DenseMatrix &pm) { PointMat = pm; EvalState = 0; }
 
    /// Return the stored point matrix.
    const DenseMatrix &GetPointMat() const { return PointMat; }

--- a/fem/eltrans.hpp
+++ b/fem/eltrans.hpp
@@ -360,7 +360,10 @@ private:
    // Evaluate the Hessian of the transformation at the IntPoint and store it
    // in d2Fdx2.
    virtual const DenseMatrix &EvalHessian();
+
 public:
+   IsoparametricTransformation() : FElem(NULL) {}
+
    /// Set the element that will be used to compute the transformations
    void SetFE(const FiniteElement *FE)
    {

--- a/fem/eltrans.hpp
+++ b/fem/eltrans.hpp
@@ -367,6 +367,7 @@ public:
    /// Set the element that will be used to compute the transformations
    void SetFE(const FiniteElement *FE)
    {
+      MFEM_ASSERT(FE != NULL, "Must provide a valid FiniteElement object!");
       EvalState = (FE != FElem) ? 0 : EvalState;
       FElem = FE; geom = FE->GetGeomType();
    }

--- a/fem/eltrans.hpp
+++ b/fem/eltrans.hpp
@@ -386,7 +386,10 @@ public:
    /// Return the stored point matrix.
    const DenseMatrix &GetPointMat() const { return PointMat; }
 
-   /// Write access to the stored point matrix. Use with caution.
+   /// @brief Write access to the stored point matrix. Use with caution.
+   /** If the point matrix is altered using this member function the Reset
+       function should also be called to force the reevaluation of the
+       Jacobian, etc.. */
    DenseMatrix &GetPointMat() { return PointMat; }
 
    /// Set the FiniteElement Geometry for the reference elements being used.

--- a/mesh/mesh.cpp
+++ b/mesh/mesh.cpp
@@ -338,6 +338,7 @@ void Mesh::GetElementTransformation(int i, IsoparametricTransformation *ElTr)
    ElTr->Attribute = GetAttribute(i);
    ElTr->ElementNo = i;
    ElTr->ElementType = ElementTransformation::ELEMENT;
+   ElTr->Reset();
    if (Nodes == NULL)
    {
       GetPointMatrix(i, ElTr->GetPointMat());
@@ -370,6 +371,7 @@ void Mesh::GetElementTransformation(int i, const Vector &nodes,
    ElTr->ElementNo = i;
    ElTr->ElementType = ElementTransformation::ELEMENT;
    DenseMatrix &pm = ElTr->GetPointMat();
+   ElTr->Reset();
    nodes.HostRead();
    if (Nodes == NULL)
    {
@@ -424,6 +426,7 @@ void Mesh::GetBdrElementTransformation(int i, IsoparametricTransformation* ElTr)
    ElTr->ElementNo = i; // boundary element number
    ElTr->ElementType = ElementTransformation::BDR_ELEMENT;
    DenseMatrix &pm = ElTr->GetPointMat();
+   ElTr->Reset();
    if (Nodes == NULL)
    {
       GetBdrPointMatrix(i, pm);
@@ -480,6 +483,7 @@ void Mesh::GetFaceTransformation(int FaceNo, IsoparametricTransformation *FTr)
    FTr->ElementNo = FaceNo;
    FTr->ElementType = ElementTransformation::FACE;
    DenseMatrix &pm = FTr->GetPointMat();
+   FTr->Reset();
    if (Nodes == NULL)
    {
       const int *v = (Dim == 1) ? &FaceNo : faces[FaceNo]->GetVertices();
@@ -562,6 +566,7 @@ void Mesh::GetEdgeTransformation(int EdgeNo, IsoparametricTransformation *EdTr)
    EdTr->ElementNo = EdgeNo;
    EdTr->ElementType = ElementTransformation::EDGE;
    DenseMatrix &pm = EdTr->GetPointMat();
+   EdTr->Reset();
    if (Nodes == NULL)
    {
       Array<int> v;
@@ -614,6 +619,7 @@ void Mesh::GetLocalPtToSegTransformation(
 {
    const IntegrationRule *SegVert;
    DenseMatrix &locpm = Transf.GetPointMat();
+   Transf.Reset();
 
    Transf.SetFE(&PointFE);
    SegVert = Geometries.GetVertices(Geometry::SEGMENT);
@@ -629,6 +635,7 @@ void Mesh::GetLocalSegToTriTransformation(
    const int *tv, *so;
    const IntegrationRule *TriVert;
    DenseMatrix &locpm = Transf.GetPointMat();
+   Transf.Reset();
 
    Transf.SetFE(&SegmentFE);
    tv = tri_t::Edges[i/64];  //  (i/64) is the local face no. in the triangle
@@ -648,6 +655,7 @@ void Mesh::GetLocalSegToQuadTransformation(
    const int *qv, *so;
    const IntegrationRule *QuadVert;
    DenseMatrix &locpm = Transf.GetPointMat();
+   Transf.Reset();
 
    Transf.SetFE(&SegmentFE);
    qv = quad_t::Edges[i/64]; //  (i/64) is the local face no. in the quad
@@ -665,6 +673,7 @@ void Mesh::GetLocalTriToTetTransformation(
    IsoparametricTransformation &Transf, int i)
 {
    DenseMatrix &locpm = Transf.GetPointMat();
+   Transf.Reset();
 
    Transf.SetFE(&TriangleFE);
    //  (i/64) is the local face no. in the tet
@@ -688,6 +697,7 @@ void Mesh::GetLocalTriToWdgTransformation(
    IsoparametricTransformation &Transf, int i)
 {
    DenseMatrix &locpm = Transf.GetPointMat();
+   Transf.Reset();
 
    Transf.SetFE(&TriangleFE);
    //  (i/64) is the local face no. in the pri
@@ -713,6 +723,7 @@ void Mesh::GetLocalQuadToHexTransformation(
    IsoparametricTransformation &Transf, int i)
 {
    DenseMatrix &locpm = Transf.GetPointMat();
+   Transf.Reset();
 
    Transf.SetFE(&QuadrilateralFE);
    //  (i/64) is the local face no. in the hex
@@ -734,6 +745,7 @@ void Mesh::GetLocalQuadToWdgTransformation(
    IsoparametricTransformation &Transf, int i)
 {
    DenseMatrix &locpm = Transf.GetPointMat();
+   Transf.Reset();
 
    Transf.SetFE(&QuadrilateralFE);
    //  (i/64) is the local face no. in the pri

--- a/mesh/pmesh.cpp
+++ b/mesh/pmesh.cpp
@@ -1691,6 +1691,7 @@ void ParMesh::GetFaceNbrElementTransformation(
    ElTr->Attribute = elem->GetAttribute();
    ElTr->ElementNo = NumOfElements + i;
    ElTr->ElementType = ElementTransformation::ELEMENT;
+   ElTr->Reset();
 
    if (Nodes == NULL)
    {
@@ -2370,6 +2371,7 @@ void ParMesh::GetGhostFaceTransformation(
 {
    // calculate composition of FETr->Loc1 and FETr->Elem1
    DenseMatrix &face_pm = FETr->GetPointMat();
+   FETr->Reset();
    if (Nodes == NULL)
    {
       FETr->Elem1->Transform(FETr->Loc1.Transf.GetPointMat(), face_pm);


### PR DESCRIPTION
The `ElementTransformation` currently only sets its `EvalState` to zero during construction and in calls to `SetIntPoint`.  This is fine for most cases but there are exceptions.  For example, if a user wants to compute the Jacobian at each element's center and they know the elements are all of the same type they could be tempted to call `SetIntPoint` once before looping over their elements.

To make the `ElementTransformation` and its derived classes more user friendly (mainly the `IsoparametricTransformation`) we can reset the `EvalState` whenever the `FiniteElement` is set to a new type (changing the basis functions), whenever the point matrix changes (changing the geometry), or whenever the integration point changes (changing the evaluation location).

The point matrix introduces a slight complication because we typically alter this by obtaining a reference to the `DenseMatrix` stored within `IsoparametricTransformation` and modify it externally.  This requires that we reset the `EvalState` using a separate function call unless we want to assume that all calls to `DenseMatrix &GetPointMat()` will result in a new point matrix.
<!--GHEX{"id":1641,"author":"mlstowell","editor":"v-dobrev","reviewers":["psocratis","kmittal2"],"assignment":"2020-07-24T19:01:58-07:00","approval":"2020-08-07T22:43:04.135Z","merge":"2020-08-19T00:22:17.114Z"}XEHG--><!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge| 
 | --- | --- | --- | --- | --- | --- | --- | 
| [#1641](https://github.com/mfem/mfem/pull/1641) | @mlstowell | @v-dobrev | @psocratis + @kmittal2 | 07/24/20 | 08/07/20 | 08/18/20 | |
<!--ELBATXEHG-->