### PR TITLE
MFEM_USE_CUDA vs SIMD

### DIFF
--- a/linalg/simd/m128.hpp
+++ b/linalg/simd/m128.hpp
@@ -14,13 +14,6 @@
 
 #ifdef __SSE2__
 
-#include "../../config/tconfig.hpp"
-#if defined(__x86_64__)
-#include <x86intrin.h>
-#else // assuming MSVC with _M_X64 or _M_IX86
-#include <intrin.h>
-#endif
-
 namespace mfem
 {
 

--- a/linalg/simd/m256.hpp
+++ b/linalg/simd/m256.hpp
@@ -14,13 +14,6 @@
 
 #ifdef __AVX__
 
-#include "../../config/tconfig.hpp"
-#if defined(__x86_64__)
-#include <x86intrin.h>
-#else // assuming MSVC with _M_X64 or _M_IX86
-#include <intrin.h>
-#endif
-
 namespace mfem
 {
 

--- a/linalg/simd/m512.hpp
+++ b/linalg/simd/m512.hpp
@@ -14,14 +14,6 @@
 
 #ifdef __AVX512F__
 
-#include "../../config/tconfig.hpp"
-#if defined(__x86_64__)
-#include <x86intrin.h>
-#else // assuming MSVC with _M_X64 or _M_IX86
-#include <intrin.h>
-#endif
-
-
 namespace mfem
 {
 

--- a/linalg/simd/qpx.hpp
+++ b/linalg/simd/qpx.hpp
@@ -12,6 +12,14 @@
 #ifndef MFEM_SIMD_QPX_HPP
 #define MFEM_SIMD_QPX_HPP
 
+#include "../../config/tconfig.hpp"
+
+#ifndef MFEM_USE_CUDA
+
+#include <builtins.h>
+
 #include "qpx256.hpp"
+
+#endif // MFEM_USE_CUDA
 
 #endif // MFEM_SIMD_QPX_HPP

--- a/linalg/simd/qpx256.hpp
+++ b/linalg/simd/qpx256.hpp
@@ -14,9 +14,6 @@
 
 #ifdef __bgq__
 
-#include "../../config/tconfig.hpp"
-#include <builtins.h>
-
 namespace mfem
 {
 

--- a/linalg/simd/vsx.hpp
+++ b/linalg/simd/vsx.hpp
@@ -12,6 +12,14 @@
 #ifndef MFEM_SIMD_VSX_HPP
 #define MFEM_SIMD_VSX_HPP
 
+#include "../../config/tconfig.hpp"
+
+#ifndef __CUDACC__
+
+#include <altivec.h>
+
 #include "vsx128.hpp"
+
+#endif // __CUDACC__
 
 #endif // MFEM_SIMD_VSX_HPP

--- a/linalg/simd/vsx.hpp
+++ b/linalg/simd/vsx.hpp
@@ -14,12 +14,15 @@
 
 #include "../../config/tconfig.hpp"
 
-#ifndef __CUDACC__
+#ifndef MFEM_USE_CUDA
 
 #include <altivec.h>
+#ifdef __GNUC__
+#undef bool
+#endif
 
 #include "vsx128.hpp"
 
-#endif // __CUDACC__
+#endif // MFEM_USE_CUDA
 
 #endif // MFEM_SIMD_VSX_HPP

--- a/linalg/simd/vsx128.hpp
+++ b/linalg/simd/vsx128.hpp
@@ -104,7 +104,11 @@ template <> struct AutoSIMD<double,2,16>
    inline MFEM_ALWAYS_INLINE AutoSIMD operator-() const
    {
       AutoSIMD r;
+#ifndef __GNUC__
       r.vd = vec_neg(vd);
+#else
+      r.vd = 0.0 - vd;
+#endif
       return r;
    }
 

--- a/linalg/simd/vsx128.hpp
+++ b/linalg/simd/vsx128.hpp
@@ -27,7 +27,7 @@ template <> struct AutoSIMD<double,2,16>
 
    union
    {
-      vector double vd;
+      __vector double vd;
       double vec[size];
    };
 

--- a/linalg/simd/vsx128.hpp
+++ b/linalg/simd/vsx128.hpp
@@ -14,9 +14,6 @@
 
 #ifdef __VSX__
 
-#include "../../config/tconfig.hpp"
-#include <altivec.h>
-
 namespace mfem
 {
 

--- a/linalg/simd/vsx128.hpp
+++ b/linalg/simd/vsx128.hpp
@@ -107,7 +107,7 @@ template <> struct AutoSIMD<double,2,16>
 #ifndef __GNUC__
       r.vd = vec_neg(vd);
 #else
-      r.vd = 0.0 - vd;
+      r.vd = vec_splats(0.0) - vd;
 #endif
       return r;
    }

--- a/linalg/simd/x86.hpp
+++ b/linalg/simd/x86.hpp
@@ -12,10 +12,36 @@
 #ifndef MFEM_SIMD_X86_HPP
 #define MFEM_SIMD_X86_HPP
 
+#include "../../config/tconfig.hpp"
+
+#if defined(MFEM_USE_CUDA) && defined(__x86_64__) && \
+    defined(__GNUC__) && (__GNUC__ == 7) && (__GNUC_MINOR__ == 5) && \
+    !defined(__clang__)
+#define MFEM_SIMD_X86_SKIP
+#endif
+
+#if defined(MFEM_SIMD_X86_SKIP) && defined(MFEM_DEBUG)
+#pragma message("warning: Compiler is known to fail with intrinsics: skipping!")
+#endif
+
+#if defined(__x86_64__) && !defined(MFEM_SIMD_X86_SKIP)
+#warning x86intrin
+#include <x86intrin.h>
+// Assuming MSVC with _M_X64 or _M_IX86
+#elif defined(_MSC_VER)
+#include <intrin.h>
+#else
+#pragma message("warning: Unknown intrinsic header")
+#endif
+
+#if !defined(MFEM_SIMD_X86_SKIP)
+
 #include "m128.hpp"
 
 #include "m256.hpp"
 
 #include "m512.hpp"
+
+#endif // !MFEM_SIMD_SKIP
 
 #endif // MFEM_SIMD_X86_HPP

--- a/linalg/simd/x86.hpp
+++ b/linalg/simd/x86.hpp
@@ -14,27 +14,13 @@
 
 #include "../../config/tconfig.hpp"
 
-#if defined(MFEM_USE_CUDA) && defined(__x86_64__) && \
-    defined(__GNUC__) && (__GNUC__ == 7) && (__GNUC_MINOR__ == 5) && \
-    !defined(__clang__)
-#define MFEM_SIMD_X86_SKIP
-#endif
+#ifndef MFEM_USE_CUDA
 
-#if defined(MFEM_SIMD_X86_SKIP) && defined(MFEM_DEBUG)
-#pragma message("warning: Compiler is known to fail with intrinsics: skipping!")
-#endif
-
-#if defined(__x86_64__) && !defined(MFEM_SIMD_X86_SKIP)
-#warning x86intrin
+#if defined(__x86_64__)
 #include <x86intrin.h>
-// Assuming MSVC with _M_X64 or _M_IX86
-#elif defined(_MSC_VER)
+#else // assuming MSVC with _M_X64 or _M_IX86
 #include <intrin.h>
-#else
-#pragma message("warning: Unknown intrinsic header")
 #endif
-
-#if !defined(MFEM_SIMD_X86_SKIP)
 
 #include "m128.hpp"
 
@@ -42,6 +28,6 @@
 
 #include "m512.hpp"
 
-#endif // !MFEM_SIMD_SKIP
+#endif // MFEM_USE_CUDA
 
 #endif // MFEM_SIMD_X86_HPP


### PR DESCRIPTION
Simplify `nvcc` + `host` compiler: if `MFEM_USE_CUDA` is enabled, don't try to use `SIMD` on the host; otherwise do.

- [x] `x86` @ `tux429`, `pascal`: `intel/19.0.4`, `intel/19.1.0`, `gcc/4.9.3`, `gcc/7.1.0`, `gcc/7.3.0`, `gcc/7.5.0`, `gcc/8.1.0`, `gcc/8.4.0`,`clang/6.0.0` 
- [x] `vsx` @ `lassen`: `gcc/7.2.1-redhat`, `gcc/8.3.1`, `xl/2020.06.25`
- [x] `qpx`
<!--GHEX{"id":1642,"author":"camierjs","editor":"v-dobrev","reviewers":["v-dobrev","YohannDudouit"],"assignment":"2020-07-24T19:31:16-07:00","approval":"2020-08-07T19:31:16-07:00","merge":"2020-08-14T19:31:16-07:00"}XEHG--><!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge| 
 | --- | --- | --- | --- | --- | --- | --- | 
| [#1642](https://github.com/mfem/mfem/pull/1642) | @camierjs | @v-dobrev | @v-dobrev + @YohannDudouit | 07/24/20 | ⌛due 08/07/20 | ⌛due 08/14/20 | |
<!--ELBATXEHG-->