### PR TITLE
MarkerToList: delete and reset the underlying data object

### DIFF
--- a/examples/ex6.cpp
+++ b/examples/ex6.cpp
@@ -157,8 +157,7 @@ int main(int argc, char *argv[])
    // 12. The main AMR loop. In each iteration we solve the problem on the
    //     current mesh, visualize the solution, and refine the mesh.
    const int max_dofs = 50000;
-   Array<int> ess_tdof_list;
-   for (int it = 0; it < 2; it++)
+   for (int it = 0; ; it++)
    {
       int cdofs = fespace.GetTrueVSize();
       cout << "\nAMR iteration " << it << endl;
@@ -169,15 +168,9 @@ int main(int argc, char *argv[])
 
       // 14. Set Dirichlet boundary values in the GridFunction x.
       //     Determine the list of Dirichlet true DOFs in the linear system.
+      Array<int> ess_tdof_list;
       x.ProjectBdrCoefficient(zero, ess_bdr);
       fespace.GetEssentialTrueDofs(ess_bdr, ess_tdof_list);
-
-      cout << "ess_tdof_list.Print():" << endl;
-      ess_tdof_list.Print();
-      cout << "ess_tdof_list.HostRead()" << endl;
-      ess_tdof_list.HostRead();
-      cout << "ess_tdof_list.Print():" << endl;
-      ess_tdof_list.Print();
 
       // 15. Assemble the stiffness matrix.
       a.Assemble();
@@ -208,7 +201,7 @@ int main(int argc, char *argv[])
       }
       else // No preconditioning for now in partial assembly mode.
       {
-         CG(*A, B, X, 1, 2000, 1e-12, 0.0);
+         CG(*A, B, X, 3, 2000, 1e-12, 0.0);
       }
 
       // 18. After solving the linear system, reconstruct the solution as a

--- a/examples/ex6.cpp
+++ b/examples/ex6.cpp
@@ -157,7 +157,8 @@ int main(int argc, char *argv[])
    // 12. The main AMR loop. In each iteration we solve the problem on the
    //     current mesh, visualize the solution, and refine the mesh.
    const int max_dofs = 50000;
-   for (int it = 0; ; it++)
+   Array<int> ess_tdof_list;
+   for (int it = 0; it < 2; it++)
    {
       int cdofs = fespace.GetTrueVSize();
       cout << "\nAMR iteration " << it << endl;
@@ -168,9 +169,15 @@ int main(int argc, char *argv[])
 
       // 14. Set Dirichlet boundary values in the GridFunction x.
       //     Determine the list of Dirichlet true DOFs in the linear system.
-      Array<int> ess_tdof_list;
       x.ProjectBdrCoefficient(zero, ess_bdr);
       fespace.GetEssentialTrueDofs(ess_bdr, ess_tdof_list);
+
+      cout << "ess_tdof_list.Print():" << endl;
+      ess_tdof_list.Print();
+      cout << "ess_tdof_list.HostRead()" << endl;
+      ess_tdof_list.HostRead();
+      cout << "ess_tdof_list.Print():" << endl;
+      ess_tdof_list.Print();
 
       // 15. Assemble the stiffness matrix.
       a.Assemble();
@@ -201,7 +208,7 @@ int main(int argc, char *argv[])
       }
       else // No preconditioning for now in partial assembly mode.
       {
-         CG(*A, B, X, 3, 2000, 1e-12, 0.0);
+         CG(*A, B, X, 1, 2000, 1e-12, 0.0);
       }
 
       // 18. After solving the linear system, reconstruct the solution as a

--- a/fem/fespace.cpp
+++ b/fem/fespace.cpp
@@ -439,7 +439,8 @@ void FiniteElementSpace::MarkerToList(const Array<int> &marker,
    {
       if (marker[i]) { num_marked++; }
    }
-   list.DeleteAll();
+   list.SetSize(0); // original statement
+   //list.DeleteAll(); // fixes the issue
    list.Reserve(num_marked);
    for (int i = 0; i < marker.Size(); i++)
    {

--- a/fem/fespace.cpp
+++ b/fem/fespace.cpp
@@ -439,8 +439,8 @@ void FiniteElementSpace::MarkerToList(const Array<int> &marker,
    {
       if (marker[i]) { num_marked++; }
    }
-   list.SetSize(0); // original statement
-   //list.DeleteAll(); // fixes the issue
+   list.SetSize(0);
+   list.HostWrite();
    list.Reserve(num_marked);
    for (int i = 0; i < marker.Size(); i++)
    {

--- a/fem/fespace.cpp
+++ b/fem/fespace.cpp
@@ -439,7 +439,7 @@ void FiniteElementSpace::MarkerToList(const Array<int> &marker,
    {
       if (marker[i]) { num_marked++; }
    }
-   list.SetSize(0);
+   list.DeleteAll();
    list.Reserve(num_marked);
    for (int i = 0; i < marker.Size(); i++)
    {

--- a/fem/fespace.cpp
+++ b/fem/fespace.cpp
@@ -452,7 +452,9 @@ void FiniteElementSpace::MarkerToList(const Array<int> &marker,
 void FiniteElementSpace::ListToMarker(const Array<int> &list, int marker_size,
                                       Array<int> &marker, int mark_val)
 {
+   list.HostRead(); // make sure we can read the array on host
    marker.SetSize(marker_size);
+   marker.HostWrite();
    marker = 0;
    for (int i = 0; i < list.Size(); i++)
    {


### PR DESCRIPTION
When computing with AMR on GPU, then calling `fespace->GetEssentialTrueDofs(bdr_attr_is_ess, ess_tdof_list)` with the same `Array<int> ess_tdof_list` after mesh refinement caused issues in the computation later (when forming the linear system), where the underlying data of `ess_tdof_list` was not correctly read from device memory (when using `ess_tdof_list.Read()` in `Vector::SetSubVectorComplement`). This appears to have originated from the handling of the data object in `FiniteElementSpace::MarkerToList` which, after the corresponding fespace has been refined via AMR and calling `fespace->GetEssentialTrueDofs`, is resetting the size of `ess_tdof_list` (`list.SetSize(0)`) and reallocating if necessary (`list.Reserve(num_marked)`). By calling `list.DeleteAll()` instead of `list.SetSize(0)` in `MarkerToList`, this particular issue is resolved.

~~I am not certain about the underlying issue here, and if this is somehow connected to the issue of having a dangling pointer to a data object in the memory manager (see #1578).~~ (see @v-dobrev's explanation below)

<!--GHEX{"id":1645,"author":"stefanhenneking","editor":"v-dobrev","reviewers":["v-dobrev","artv3"],"assignment":"2020-07-24T19:22:35-07:00","approval":"2020-08-20T04:20:35.042Z","merge":"2020-08-25T19:36:08.618Z"}XEHG--><!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge| 
 | --- | --- | --- | --- | --- | --- | --- | 
| [#1645](https://github.com/mfem/mfem/pull/1645) | @stefanhenneking | @v-dobrev | @v-dobrev + @artv3 | 07/24/20 | 08/19/20 | 08/25/20 | |
<!--ELBATXEHG-->