### PR TITLE
Fix mem leak in BlockNonlinearForm

### DIFF
--- a/fem/nonlinearform.cpp
+++ b/fem/nonlinearform.cpp
@@ -581,8 +581,8 @@ double BlockNonlinearForm::GetEnergyBlocked(const BlockVector &bx) const
          }
       }
 
-   //free the allocated memory
-   for (int i=0; i<fes.Size(); ++i)
+   // free the allocated memory
+   for (int i = 0; i < fes.Size(); ++i)
    {
       delete el_x[i];
       delete vdofs[i];

--- a/fem/nonlinearform.cpp
+++ b/fem/nonlinearform.cpp
@@ -581,6 +581,13 @@ double BlockNonlinearForm::GetEnergyBlocked(const BlockVector &bx) const
          }
       }
 
+   //free the allocated memory
+   for (int i=0; i<fes.Size(); ++i)
+   {
+	   delete el_x[i];
+	   delete vdofs[i];
+   }
+
    if (fnfi.Size())
    {
       MFEM_ABORT("TODO: add energy contribution from interior face terms");
@@ -590,6 +597,8 @@ double BlockNonlinearForm::GetEnergyBlocked(const BlockVector &bx) const
    {
       MFEM_ABORT("TODO: add energy contribution from boundary face terms");
    }
+
+
 
    return energy;
 }

--- a/fem/nonlinearform.cpp
+++ b/fem/nonlinearform.cpp
@@ -598,8 +598,6 @@ double BlockNonlinearForm::GetEnergyBlocked(const BlockVector &bx) const
       MFEM_ABORT("TODO: add energy contribution from boundary face terms");
    }
 
-
-
    return energy;
 }
 

--- a/fem/nonlinearform.cpp
+++ b/fem/nonlinearform.cpp
@@ -584,8 +584,8 @@ double BlockNonlinearForm::GetEnergyBlocked(const BlockVector &bx) const
    //free the allocated memory
    for (int i=0; i<fes.Size(); ++i)
    {
-	   delete el_x[i];
-	   delete vdofs[i];
+      delete el_x[i];
+      delete vdofs[i];
    }
 
    if (fnfi.Size())


### PR DESCRIPTION
The pull request adds a small change in BlockNonlinearForm to delete the allocated memory. 
<!--GHEX{"id":1647,"author":"bslazarov","editor":"v-dobrev","reviewers":["v-dobrev","kmittal2"],"assignment":"2020-08-20T15:53:52-07:00","approval":"2020-09-08T19:15:34.680Z","merge":"2020-09-27T19:01:45.148Z"}XEHG--><!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge| 
 | --- | --- | --- | --- | --- | --- | --- | 
| [#1647](https://github.com/mfem/mfem/pull/1647) | @bslazarov | @v-dobrev | @v-dobrev + @kmittal2 | 08/20/20 | 09/08/20 | 09/27/20 | |
<!--ELBATXEHG-->