### PR TITLE
Fix the const correctness of casting operators and make them explicit.

### DIFF
--- a/linalg/dtensor.hpp
+++ b/linalg/dtensor.hpp
@@ -110,7 +110,8 @@ public:
    }
 
    /// Conversion to `Scalar *`.
-   inline operator Scalar *() const { return data; }
+   explicit inline operator const Scalar *() const { return data; }
+   explicit inline operator Scalar *() { return data; }
 
    /// Const accessor for the data
    template <typename... Args> MFEM_HOST_DEVICE inline


### PR DESCRIPTION
This PR forces explicit casting from `DeviceTensor<T>` to `T*`, it also enforces a stronger const-correctness.