### PR TITLE
Add const qualifiers to input DeviceTensor used in MFEM_FORALL

### DIFF
--- a/fem/bilininteg_convection_ea.cpp
+++ b/fem/bilininteg_convection_ea.cpp
@@ -29,10 +29,10 @@ static void EAConvectionAssemble1D(const int NE,
    const int Q1D = T_Q1D ? T_Q1D : q1d;
    MFEM_VERIFY(D1D <= MAX_D1D, "");
    MFEM_VERIFY(Q1D <= MAX_Q1D, "");
-   auto B = Reshape(b.Read(), Q1D, D1D);
-   auto G = Reshape(g.Read(), Q1D, D1D);
-   auto D = Reshape(padata.Read(), Q1D, NE);
-   auto A = Reshape(eadata.ReadWrite(), D1D, D1D, NE);
+   auto B = Reshape(b, Q1D, D1D);
+   auto G = Reshape(g, Q1D, D1D);
+   auto D = Reshape(padata, Q1D, NE);
+   auto A = Reshape(eadata, D1D, D1D, NE);
    MFEM_FORALL_3D(e, NE, D1D, D1D, 1,
    {
       const int D1D = T_D1D ? T_D1D : d1d;
@@ -73,10 +73,10 @@ static void EAConvectionAssemble2D(const int NE,
    const int Q1D = T_Q1D ? T_Q1D : q1d;
    MFEM_VERIFY(D1D <= MAX_D1D, "");
    MFEM_VERIFY(Q1D <= MAX_Q1D, "");
-   auto B = Reshape(b.Read(), Q1D, D1D);
-   auto G = Reshape(g.Read(), Q1D, D1D);
-   auto D = Reshape(padata.Read(), Q1D, Q1D, 2, NE);
-   auto A = Reshape(eadata.ReadWrite(), D1D, D1D, D1D, D1D, NE);
+   auto B = Reshape(b, Q1D, D1D);
+   auto G = Reshape(g, Q1D, D1D);
+   auto D = Reshape(padata, Q1D, Q1D, 2, NE);
+   auto A = Reshape(eadata, D1D, D1D, D1D, D1D, NE);
    MFEM_FORALL_3D(e, NE, D1D, D1D, 1,
    {
       const int D1D = T_D1D ? T_D1D : d1d;
@@ -142,10 +142,10 @@ static void EAConvectionAssemble3D(const int NE,
    const int Q1D = T_Q1D ? T_Q1D : q1d;
    MFEM_VERIFY(D1D <= MAX_D1D, "");
    MFEM_VERIFY(Q1D <= MAX_Q1D, "");
-   auto B = Reshape(b.Read(), Q1D, D1D);
-   auto G = Reshape(g.Read(), Q1D, D1D);
-   auto D = Reshape(padata.Read(), Q1D, Q1D, Q1D, 3, NE);
-   auto A = Reshape(eadata.ReadWrite(), D1D, D1D, D1D, D1D, D1D, D1D, NE);
+   auto B = Reshape(b, Q1D, D1D);
+   auto G = Reshape(g, Q1D, D1D);
+   auto D = Reshape(padata, Q1D, Q1D, Q1D, 3, NE);
+   auto A = Reshape(eadata, D1D, D1D, D1D, D1D, D1D, D1D, NE);
    MFEM_FORALL_3D(e, NE, D1D, D1D, D1D,
    {
       const int D1D = T_D1D ? T_D1D : d1d;

--- a/fem/bilininteg_convection_ea.cpp
+++ b/fem/bilininteg_convection_ea.cpp
@@ -29,9 +29,9 @@ static void EAConvectionAssemble1D(const int NE,
    const int Q1D = T_Q1D ? T_Q1D : q1d;
    MFEM_VERIFY(D1D <= MAX_D1D, "");
    MFEM_VERIFY(Q1D <= MAX_Q1D, "");
-   auto B = Reshape(b, Q1D, D1D);
-   auto G = Reshape(g, Q1D, D1D);
-   auto D = Reshape(padata, Q1D, NE);
+   const auto B = Reshape(b, Q1D, D1D);
+   const auto G = Reshape(g, Q1D, D1D);
+   const auto D = Reshape(padata, Q1D, NE);
    auto A = Reshape(eadata, D1D, D1D, NE);
    MFEM_FORALL_3D(e, NE, D1D, D1D, 1,
    {
@@ -73,9 +73,9 @@ static void EAConvectionAssemble2D(const int NE,
    const int Q1D = T_Q1D ? T_Q1D : q1d;
    MFEM_VERIFY(D1D <= MAX_D1D, "");
    MFEM_VERIFY(Q1D <= MAX_Q1D, "");
-   auto B = Reshape(b, Q1D, D1D);
-   auto G = Reshape(g, Q1D, D1D);
-   auto D = Reshape(padata, Q1D, Q1D, 2, NE);
+   const auto B = Reshape(b, Q1D, D1D);
+   const auto G = Reshape(g, Q1D, D1D);
+   const auto D = Reshape(padata, Q1D, Q1D, 2, NE);
    auto A = Reshape(eadata, D1D, D1D, D1D, D1D, NE);
    MFEM_FORALL_3D(e, NE, D1D, D1D, 1,
    {
@@ -142,9 +142,9 @@ static void EAConvectionAssemble3D(const int NE,
    const int Q1D = T_Q1D ? T_Q1D : q1d;
    MFEM_VERIFY(D1D <= MAX_D1D, "");
    MFEM_VERIFY(Q1D <= MAX_Q1D, "");
-   auto B = Reshape(b, Q1D, D1D);
-   auto G = Reshape(g, Q1D, D1D);
-   auto D = Reshape(padata, Q1D, Q1D, Q1D, 3, NE);
+   const auto B = Reshape(b, Q1D, D1D);
+   const auto G = Reshape(g, Q1D, D1D);
+   const auto D = Reshape(padata, Q1D, Q1D, Q1D, 3, NE);
    auto A = Reshape(eadata, D1D, D1D, D1D, D1D, D1D, D1D, NE);
    MFEM_FORALL_3D(e, NE, D1D, D1D, D1D,
    {

--- a/fem/bilininteg_convection_pa.cpp
+++ b/fem/bilininteg_convection_pa.cpp
@@ -33,10 +33,10 @@ static void PAConvectionSetup2D(const int Q1D,
    const int NQ = Q1D*Q1D;
    auto W = w.Read();
 
-   auto J = Reshape(j.Read(), NQ, 2, 2, NE);
+   auto J = Reshape(j, NQ, 2, 2, NE);
    const bool const_v = vel.Size() == 2;
    auto V =
-      const_v ? Reshape(vel.Read(), 2,1,1) : Reshape(vel.Read(), 2,NQ,NE);
+      const_v ? Reshape(vel, 2,1,1) : Reshape(vel, 2,NQ,NE);
    auto y = Reshape(op.Write(), NQ, 2, NE);
 
    MFEM_FORALL(e, NE,
@@ -69,11 +69,11 @@ static void PAConvectionSetup3D(const int Q1D,
                                 Vector &op)
 {
    const int NQ = Q1D*Q1D*Q1D;
-   auto W = w.Read();
-   auto J = Reshape(j.Read(), NQ, 3, 3, NE);
+   auto W = w;
+   auto J = Reshape(j, NQ, 3, 3, NE);
    const bool const_v = vel.Size() == 3;
    auto V =
-      const_v ? Reshape(vel.Read(), 3,1,1) : Reshape(vel.Read(), 3,NQ,NE);
+      const_v ? Reshape(vel, 3,1,1) : Reshape(vel, 3,NQ,NE);
    auto y = Reshape(op.Write(), NQ, 3, NE);
    MFEM_FORALL(e, NE,
    {
@@ -152,12 +152,12 @@ void PAConvectionApply2D(const int ne,
    const int Q1D = T_Q1D ? T_Q1D : q1d;
    MFEM_VERIFY(D1D <= MAX_D1D, "");
    MFEM_VERIFY(Q1D <= MAX_Q1D, "");
-   auto B = Reshape(b.Read(), Q1D, D1D);
-   auto G = Reshape(g.Read(), Q1D, D1D);
-   auto Bt = Reshape(bt.Read(), D1D, Q1D);
-   auto op = Reshape(_op.Read(), Q1D, Q1D, 2, NE);
-   auto x = Reshape(_x.Read(), D1D, D1D, NE);
-   auto y = Reshape(_y.ReadWrite(), D1D, D1D, NE);
+   auto B = Reshape(b, Q1D, D1D);
+   auto G = Reshape(g, Q1D, D1D);
+   auto Bt = Reshape(bt, D1D, Q1D);
+   auto op = Reshape(_op, Q1D, Q1D, 2, NE);
+   auto x = Reshape(_x, D1D, D1D, NE);
+   auto y = Reshape(_y, D1D, D1D, NE);
    MFEM_FORALL(e, NE,
    {
       const int D1D = T_D1D ? T_D1D : d1d;
@@ -272,12 +272,12 @@ void SmemPAConvectionApply2D(const int ne,
    constexpr int NBZ = T_NBZ ? T_NBZ : 1;
    MFEM_VERIFY(D1D <= MAX_D1D, "");
    MFEM_VERIFY(Q1D <= MAX_Q1D, "");
-   auto B = Reshape(b.Read(), Q1D, D1D);
-   auto G = Reshape(g.Read(), Q1D, D1D);
-   auto Bt = Reshape(bt.Read(), D1D, Q1D);
-   auto op = Reshape(_op.Read(), Q1D, Q1D, 2, NE);
-   auto x = Reshape(_x.Read(), D1D, D1D, NE);
-   auto y = Reshape(_y.ReadWrite(), D1D, D1D, NE);
+   auto B = Reshape(b, Q1D, D1D);
+   auto G = Reshape(g, Q1D, D1D);
+   auto Bt = Reshape(bt, D1D, Q1D);
+   auto op = Reshape(_op, Q1D, Q1D, 2, NE);
+   auto x = Reshape(_x, D1D, D1D, NE);
+   auto y = Reshape(_y, D1D, D1D, NE);
    MFEM_FORALL_2D(e, NE, Q1D, Q1D, NBZ,
    {
       const int tidz = MFEM_THREAD_ID(z);
@@ -399,12 +399,12 @@ void PAConvectionApply3D(const int ne,
    const int Q1D = T_Q1D ? T_Q1D : q1d;
    MFEM_VERIFY(D1D <= MAX_D1D, "");
    MFEM_VERIFY(Q1D <= MAX_Q1D, "");
-   auto B = Reshape(b.Read(), Q1D, D1D);
-   auto G = Reshape(g.Read(), Q1D, D1D);
-   auto Bt = Reshape(bt.Read(), D1D, Q1D);
-   auto op = Reshape(_op.Read(), Q1D, Q1D, Q1D, 3, NE);
-   auto x = Reshape(_x.Read(), D1D, D1D, D1D, NE);
-   auto y = Reshape(_y.ReadWrite(), D1D, D1D, D1D, NE);
+   auto B = Reshape(b, Q1D, D1D);
+   auto G = Reshape(g, Q1D, D1D);
+   auto Bt = Reshape(bt, D1D, Q1D);
+   auto op = Reshape(_op, Q1D, Q1D, Q1D, 3, NE);
+   auto x = Reshape(_x, D1D, D1D, D1D, NE);
+   auto y = Reshape(_y, D1D, D1D, D1D, NE);
    MFEM_FORALL(e, NE,
    {
       const int D1D = T_D1D ? T_D1D : d1d;
@@ -580,12 +580,12 @@ void SmemPAConvectionApply3D(const int ne,
    const int Q1D = T_Q1D ? T_Q1D : q1d;
    MFEM_VERIFY(D1D <= MAX_D1D, "");
    MFEM_VERIFY(Q1D <= MAX_Q1D, "");
-   auto B = Reshape(b.Read(), Q1D, D1D);
-   auto G = Reshape(g.Read(), Q1D, D1D);
-   auto Bt = Reshape(bt.Read(), D1D, Q1D);
-   auto op = Reshape(_op.Read(), Q1D, Q1D, Q1D, 3, NE);
-   auto x = Reshape(_x.Read(), D1D, D1D, D1D, NE);
-   auto y = Reshape(_y.ReadWrite(), D1D, D1D, D1D, NE);
+   auto B = Reshape(b, Q1D, D1D);
+   auto G = Reshape(g, Q1D, D1D);
+   auto Bt = Reshape(bt, D1D, Q1D);
+   auto op = Reshape(_op, Q1D, Q1D, Q1D, 3, NE);
+   auto x = Reshape(_x, D1D, D1D, D1D, NE);
+   auto y = Reshape(_y, D1D, D1D, D1D, NE);
    MFEM_FORALL_3D(e, NE, Q1D, Q1D, Q1D,
    {
       const int D1D = T_D1D ? T_D1D : d1d;

--- a/fem/bilininteg_convection_pa.cpp
+++ b/fem/bilininteg_convection_pa.cpp
@@ -31,11 +31,10 @@ static void PAConvectionSetup2D(const int Q1D,
 {
    const int NE = ne;
    const int NQ = Q1D*Q1D;
-   auto W = w.Read();
-
-   auto J = Reshape(j, NQ, 2, 2, NE);
+   const auto W = w.Read();
+   const auto J = Reshape(j, NQ, 2, 2, NE);
    const bool const_v = vel.Size() == 2;
-   auto V =
+   const auto V =
       const_v ? Reshape(vel, 2,1,1) : Reshape(vel, 2,NQ,NE);
    auto y = Reshape(op.Write(), NQ, 2, NE);
 
@@ -69,10 +68,10 @@ static void PAConvectionSetup3D(const int Q1D,
                                 Vector &op)
 {
    const int NQ = Q1D*Q1D*Q1D;
-   auto W = w;
-   auto J = Reshape(j, NQ, 3, 3, NE);
+   const auto W = w;
+   const auto J = Reshape(j, NQ, 3, 3, NE);
    const bool const_v = vel.Size() == 3;
-   auto V =
+   const auto V =
       const_v ? Reshape(vel, 3,1,1) : Reshape(vel, 3,NQ,NE);
    auto y = Reshape(op.Write(), NQ, 3, NE);
    MFEM_FORALL(e, NE,
@@ -152,11 +151,11 @@ void PAConvectionApply2D(const int ne,
    const int Q1D = T_Q1D ? T_Q1D : q1d;
    MFEM_VERIFY(D1D <= MAX_D1D, "");
    MFEM_VERIFY(Q1D <= MAX_Q1D, "");
-   auto B = Reshape(b, Q1D, D1D);
-   auto G = Reshape(g, Q1D, D1D);
-   auto Bt = Reshape(bt, D1D, Q1D);
-   auto op = Reshape(_op, Q1D, Q1D, 2, NE);
-   auto x = Reshape(_x, D1D, D1D, NE);
+   const auto B = Reshape(b, Q1D, D1D);
+   const auto G = Reshape(g, Q1D, D1D);
+   const auto Bt = Reshape(bt, D1D, Q1D);
+   const auto op = Reshape(_op, Q1D, Q1D, 2, NE);
+   const auto x = Reshape(_x, D1D, D1D, NE);
    auto y = Reshape(_y, D1D, D1D, NE);
    MFEM_FORALL(e, NE,
    {
@@ -272,11 +271,11 @@ void SmemPAConvectionApply2D(const int ne,
    constexpr int NBZ = T_NBZ ? T_NBZ : 1;
    MFEM_VERIFY(D1D <= MAX_D1D, "");
    MFEM_VERIFY(Q1D <= MAX_Q1D, "");
-   auto B = Reshape(b, Q1D, D1D);
-   auto G = Reshape(g, Q1D, D1D);
-   auto Bt = Reshape(bt, D1D, Q1D);
-   auto op = Reshape(_op, Q1D, Q1D, 2, NE);
-   auto x = Reshape(_x, D1D, D1D, NE);
+   const auto B = Reshape(b, Q1D, D1D);
+   const auto G = Reshape(g, Q1D, D1D);
+   const auto Bt = Reshape(bt, D1D, Q1D);
+   const auto op = Reshape(_op, Q1D, Q1D, 2, NE);
+   const auto x = Reshape(_x, D1D, D1D, NE);
    auto y = Reshape(_y, D1D, D1D, NE);
    MFEM_FORALL_2D(e, NE, Q1D, Q1D, NBZ,
    {
@@ -399,11 +398,11 @@ void PAConvectionApply3D(const int ne,
    const int Q1D = T_Q1D ? T_Q1D : q1d;
    MFEM_VERIFY(D1D <= MAX_D1D, "");
    MFEM_VERIFY(Q1D <= MAX_Q1D, "");
-   auto B = Reshape(b, Q1D, D1D);
-   auto G = Reshape(g, Q1D, D1D);
-   auto Bt = Reshape(bt, D1D, Q1D);
-   auto op = Reshape(_op, Q1D, Q1D, Q1D, 3, NE);
-   auto x = Reshape(_x, D1D, D1D, D1D, NE);
+   const auto B = Reshape(b, Q1D, D1D);
+   const auto G = Reshape(g, Q1D, D1D);
+   const auto Bt = Reshape(bt, D1D, Q1D);
+   const auto op = Reshape(_op, Q1D, Q1D, Q1D, 3, NE);
+   const auto x = Reshape(_x, D1D, D1D, D1D, NE);
    auto y = Reshape(_y, D1D, D1D, D1D, NE);
    MFEM_FORALL(e, NE,
    {
@@ -580,11 +579,11 @@ void SmemPAConvectionApply3D(const int ne,
    const int Q1D = T_Q1D ? T_Q1D : q1d;
    MFEM_VERIFY(D1D <= MAX_D1D, "");
    MFEM_VERIFY(Q1D <= MAX_Q1D, "");
-   auto B = Reshape(b, Q1D, D1D);
-   auto G = Reshape(g, Q1D, D1D);
-   auto Bt = Reshape(bt, D1D, Q1D);
-   auto op = Reshape(_op, Q1D, Q1D, Q1D, 3, NE);
-   auto x = Reshape(_x, D1D, D1D, D1D, NE);
+   const auto B = Reshape(b, Q1D, D1D);
+   const auto G = Reshape(g, Q1D, D1D);
+   const auto Bt = Reshape(bt, D1D, Q1D);
+   const auto op = Reshape(_op, Q1D, Q1D, Q1D, 3, NE);
+   const auto x = Reshape(_x, D1D, D1D, D1D, NE);
    auto y = Reshape(_y, D1D, D1D, D1D, NE);
    MFEM_FORALL_3D(e, NE, Q1D, Q1D, Q1D,
    {

--- a/fem/bilininteg_dgtrace_ea.cpp
+++ b/fem/bilininteg_dgtrace_ea.cpp
@@ -22,9 +22,9 @@ static void EADGTraceAssemble1DInt(const int NF,
                                    Vector &eadata_int,
                                    Vector &eadata_ext)
 {
-   auto D = Reshape(padata.Read(), 2, 2, NF);
-   auto A_int = Reshape(eadata_int.ReadWrite(), 2, NF);
-   auto A_ext = Reshape(eadata_ext.ReadWrite(), 2, NF);
+   auto D = Reshape(padata, 2, 2, NF);
+   auto A_int = Reshape(eadata_int, 2, NF);
+   auto A_ext = Reshape(eadata_ext, 2, NF);
    MFEM_FORALL(f, NF,
    {
       double val_int0, val_int1, val_ext01, val_ext10;
@@ -44,8 +44,8 @@ static void EADGTraceAssemble1DBdr(const int NF,
                                    const Vector &padata,
                                    Vector &eadata_bdr)
 {
-   auto D = Reshape(padata.Read(), 2, 2, NF);
-   auto A_bdr = Reshape(eadata_bdr.ReadWrite(), NF);
+   auto D = Reshape(padata, 2, 2, NF);
+   auto A_bdr = Reshape(eadata_bdr, NF);
    MFEM_FORALL(f, NF,
    {
       A_bdr(f) += D(0, 0, f);
@@ -65,10 +65,10 @@ static void EADGTraceAssemble2DInt(const int NF,
    const int Q1D = T_Q1D ? T_Q1D : q1d;
    MFEM_VERIFY(D1D <= MAX_D1D, "");
    MFEM_VERIFY(Q1D <= MAX_Q1D, "");
-   auto B = Reshape(basis.Read(), Q1D, D1D);
-   auto D = Reshape(padata.Read(), Q1D, 2, 2, NF);
-   auto A_int = Reshape(eadata_int.ReadWrite(), D1D, D1D, 2, NF);
-   auto A_ext = Reshape(eadata_ext.ReadWrite(), D1D, D1D, 2, NF);
+   auto B = Reshape(basis, Q1D, D1D);
+   auto D = Reshape(padata, Q1D, 2, 2, NF);
+   auto A_int = Reshape(eadata_int, D1D, D1D, 2, NF);
+   auto A_ext = Reshape(eadata_ext, D1D, D1D, 2, NF);
    MFEM_FORALL_3D(f, NF, D1D, D1D, 1,
    {
       const int D1D = T_D1D ? T_D1D : d1d;
@@ -109,9 +109,9 @@ static void EADGTraceAssemble2DBdr(const int NF,
    const int Q1D = T_Q1D ? T_Q1D : q1d;
    MFEM_VERIFY(D1D <= MAX_D1D, "");
    MFEM_VERIFY(Q1D <= MAX_Q1D, "");
-   auto B = Reshape(basis.Read(), Q1D, D1D);
-   auto D = Reshape(padata.Read(), Q1D, 2, 2, NF);
-   auto A_bdr = Reshape(eadata_bdr.ReadWrite(), D1D, D1D, NF);
+   auto B = Reshape(basis, Q1D, D1D);
+   auto D = Reshape(padata, Q1D, 2, 2, NF);
+   auto A_bdr = Reshape(eadata_bdr, D1D, D1D, NF);
    MFEM_FORALL_3D(f, NF, D1D, D1D, 1,
    {
       const int D1D = T_D1D ? T_D1D : d1d;
@@ -144,10 +144,10 @@ static void EADGTraceAssemble3DInt(const int NF,
    const int Q1D = T_Q1D ? T_Q1D : q1d;
    MFEM_VERIFY(D1D <= MAX_D1D, "");
    MFEM_VERIFY(Q1D <= MAX_Q1D, "");
-   auto B = Reshape(basis.Read(), Q1D, D1D);
-   auto D = Reshape(padata.Read(), Q1D, Q1D, 2, 2, NF);
-   auto A_int = Reshape(eadata_int.ReadWrite(), D1D, D1D, D1D, D1D, 2, NF);
-   auto A_ext = Reshape(eadata_ext.ReadWrite(), D1D, D1D, D1D, D1D, 2, NF);
+   auto B = Reshape(basis, Q1D, D1D);
+   auto D = Reshape(padata, Q1D, Q1D, 2, 2, NF);
+   auto A_int = Reshape(eadata_int, D1D, D1D, D1D, D1D, 2, NF);
+   auto A_ext = Reshape(eadata_ext, D1D, D1D, D1D, D1D, 2, NF);
    MFEM_FORALL_3D(f, NF, D1D, D1D, 1,
    {
       const int D1D = T_D1D ? T_D1D : d1d;
@@ -230,9 +230,9 @@ static void EADGTraceAssemble3DBdr(const int NF,
    const int Q1D = T_Q1D ? T_Q1D : q1d;
    MFEM_VERIFY(D1D <= MAX_D1D, "");
    MFEM_VERIFY(Q1D <= MAX_Q1D, "");
-   auto B = Reshape(basis.Read(), Q1D, D1D);
-   auto D = Reshape(padata.Read(), Q1D, Q1D, 2, 2, NF);
-   auto A_bdr = Reshape(eadata_bdr.ReadWrite(), D1D, D1D, D1D, D1D, NF);
+   auto B = Reshape(basis, Q1D, D1D);
+   auto D = Reshape(padata, Q1D, Q1D, 2, 2, NF);
+   auto A_bdr = Reshape(eadata_bdr, D1D, D1D, D1D, D1D, NF);
    MFEM_FORALL_3D(f, NF, D1D, D1D, 1,
    {
       const int D1D = T_D1D ? T_D1D : d1d;

--- a/fem/bilininteg_dgtrace_ea.cpp
+++ b/fem/bilininteg_dgtrace_ea.cpp
@@ -22,7 +22,7 @@ static void EADGTraceAssemble1DInt(const int NF,
                                    Vector &eadata_int,
                                    Vector &eadata_ext)
 {
-   auto D = Reshape(padata, 2, 2, NF);
+   const auto D = Reshape(padata, 2, 2, NF);
    auto A_int = Reshape(eadata_int, 2, NF);
    auto A_ext = Reshape(eadata_ext, 2, NF);
    MFEM_FORALL(f, NF,
@@ -44,7 +44,7 @@ static void EADGTraceAssemble1DBdr(const int NF,
                                    const Vector &padata,
                                    Vector &eadata_bdr)
 {
-   auto D = Reshape(padata, 2, 2, NF);
+   const auto D = Reshape(padata, 2, 2, NF);
    auto A_bdr = Reshape(eadata_bdr, NF);
    MFEM_FORALL(f, NF,
    {
@@ -65,8 +65,8 @@ static void EADGTraceAssemble2DInt(const int NF,
    const int Q1D = T_Q1D ? T_Q1D : q1d;
    MFEM_VERIFY(D1D <= MAX_D1D, "");
    MFEM_VERIFY(Q1D <= MAX_Q1D, "");
-   auto B = Reshape(basis, Q1D, D1D);
-   auto D = Reshape(padata, Q1D, 2, 2, NF);
+   const auto B = Reshape(basis, Q1D, D1D);
+   const auto D = Reshape(padata, Q1D, 2, 2, NF);
    auto A_int = Reshape(eadata_int, D1D, D1D, 2, NF);
    auto A_ext = Reshape(eadata_ext, D1D, D1D, 2, NF);
    MFEM_FORALL_3D(f, NF, D1D, D1D, 1,
@@ -109,8 +109,8 @@ static void EADGTraceAssemble2DBdr(const int NF,
    const int Q1D = T_Q1D ? T_Q1D : q1d;
    MFEM_VERIFY(D1D <= MAX_D1D, "");
    MFEM_VERIFY(Q1D <= MAX_Q1D, "");
-   auto B = Reshape(basis, Q1D, D1D);
-   auto D = Reshape(padata, Q1D, 2, 2, NF);
+   const auto B = Reshape(basis, Q1D, D1D);
+   const auto D = Reshape(padata, Q1D, 2, 2, NF);
    auto A_bdr = Reshape(eadata_bdr, D1D, D1D, NF);
    MFEM_FORALL_3D(f, NF, D1D, D1D, 1,
    {
@@ -144,8 +144,8 @@ static void EADGTraceAssemble3DInt(const int NF,
    const int Q1D = T_Q1D ? T_Q1D : q1d;
    MFEM_VERIFY(D1D <= MAX_D1D, "");
    MFEM_VERIFY(Q1D <= MAX_Q1D, "");
-   auto B = Reshape(basis, Q1D, D1D);
-   auto D = Reshape(padata, Q1D, Q1D, 2, 2, NF);
+   const auto B = Reshape(basis, Q1D, D1D);
+   const auto D = Reshape(padata, Q1D, Q1D, 2, 2, NF);
    auto A_int = Reshape(eadata_int, D1D, D1D, D1D, D1D, 2, NF);
    auto A_ext = Reshape(eadata_ext, D1D, D1D, D1D, D1D, 2, NF);
    MFEM_FORALL_3D(f, NF, D1D, D1D, 1,
@@ -230,8 +230,8 @@ static void EADGTraceAssemble3DBdr(const int NF,
    const int Q1D = T_Q1D ? T_Q1D : q1d;
    MFEM_VERIFY(D1D <= MAX_D1D, "");
    MFEM_VERIFY(Q1D <= MAX_Q1D, "");
-   auto B = Reshape(basis, Q1D, D1D);
-   auto D = Reshape(padata, Q1D, Q1D, 2, 2, NF);
+   const auto B = Reshape(basis, Q1D, D1D);
+   const auto D = Reshape(padata, Q1D, Q1D, 2, 2, NF);
    auto A_bdr = Reshape(eadata_bdr, D1D, D1D, D1D, D1D, NF);
    MFEM_FORALL_3D(f, NF, D1D, D1D, 1,
    {

--- a/fem/bilininteg_dgtrace_pa.cpp
+++ b/fem/bilininteg_dgtrace_pa.cpp
@@ -32,14 +32,14 @@ static void PADGTraceSetup2D(const int Q1D,
 {
    const int VDIM = 2;
 
-   auto d = Reshape(det.Read(), Q1D, NF);
-   auto n = Reshape(nor.Read(), Q1D, VDIM, NF);
+   auto d = Reshape(det, Q1D, NF);
+   auto n = Reshape(nor, Q1D, VDIM, NF);
    const bool const_r = rho.Size() == 1;
    auto R =
-      const_r ? Reshape(rho.Read(), 1,1) : Reshape(rho.Read(), Q1D,NF);
+      const_r ? Reshape(rho, 1,1) : Reshape(rho, Q1D,NF);
    const bool const_v = vel.Size() == 2;
    auto V =
-      const_v ? Reshape(vel.Read(), 2,1,1) : Reshape(vel.Read(), 2,Q1D,NF);
+      const_v ? Reshape(vel, 2,1,1) : Reshape(vel, 2,Q1D,NF);
    auto W = w.Read();
    auto qd = Reshape(op.Write(), Q1D, 2, 2, NF);
 
@@ -74,14 +74,14 @@ static void PADGTraceSetup3D(const int Q1D,
 {
    const int VDIM = 3;
 
-   auto d = Reshape(det.Read(), Q1D, Q1D, NF);
-   auto n = Reshape(nor.Read(), Q1D, Q1D, VDIM, NF);
+   auto d = Reshape(det, Q1D, Q1D, NF);
+   auto n = Reshape(nor, Q1D, Q1D, VDIM, NF);
    const bool const_r = rho.Size() == 1;
    auto R =
-      const_r ? Reshape(rho.Read(), 1,1,1) : Reshape(rho.Read(), Q1D,Q1D,NF);
+      const_r ? Reshape(rho, 1,1,1) : Reshape(rho, Q1D,Q1D,NF);
    const bool const_v = vel.Size() == 3;
    auto V =
-      const_v ? Reshape(vel.Read(), 3,1,1,1) : Reshape(vel.Read(), 3,Q1D,Q1D,NF);
+      const_v ? Reshape(vel, 3,1,1,1) : Reshape(vel, 3,Q1D,Q1D,NF);
    auto W = w.Read();
    auto qd = Reshape(op.Write(), Q1D, Q1D, 2, 2, NF);
 
@@ -263,11 +263,11 @@ void PADGTraceApply2D(const int NF,
    const int Q1D = T_Q1D ? T_Q1D : q1d;
    MFEM_VERIFY(D1D <= MAX_D1D, "");
    MFEM_VERIFY(Q1D <= MAX_Q1D, "");
-   auto B = Reshape(b.Read(), Q1D, D1D);
-   auto Bt = Reshape(bt.Read(), D1D, Q1D);
-   auto op = Reshape(_op.Read(), Q1D, 2, 2, NF);
-   auto x = Reshape(_x.Read(), D1D, VDIM, 2, NF);
-   auto y = Reshape(_y.ReadWrite(), D1D, VDIM, 2, NF);
+   auto B = Reshape(b, Q1D, D1D);
+   auto Bt = Reshape(bt, D1D, Q1D);
+   auto op = Reshape(_op, Q1D, 2, 2, NF);
+   auto x = Reshape(_x, D1D, VDIM, 2, NF);
+   auto y = Reshape(_y, D1D, VDIM, 2, NF);
 
    MFEM_FORALL(f, NF,
    {
@@ -354,11 +354,11 @@ void PADGTraceApply3D(const int NF,
    const int Q1D = T_Q1D ? T_Q1D : q1d;
    MFEM_VERIFY(D1D <= MAX_D1D, "");
    MFEM_VERIFY(Q1D <= MAX_Q1D, "");
-   auto B = Reshape(b.Read(), Q1D, D1D);
-   auto Bt = Reshape(bt.Read(), D1D, Q1D);
-   auto op = Reshape(_op.Read(), Q1D, Q1D, 2, 2, NF);
-   auto x = Reshape(_x.Read(), D1D, D1D, VDIM, 2, NF);
-   auto y = Reshape(_y.ReadWrite(), D1D, D1D, VDIM, 2, NF);
+   auto B = Reshape(b, Q1D, D1D);
+   auto Bt = Reshape(bt, D1D, Q1D);
+   auto op = Reshape(_op, Q1D, Q1D, 2, 2, NF);
+   auto x = Reshape(_x, D1D, D1D, VDIM, 2, NF);
+   auto y = Reshape(_y, D1D, D1D, VDIM, 2, NF);
 
    MFEM_FORALL(f, NF,
    {
@@ -499,11 +499,11 @@ void SmemPADGTraceApply3D(const int NF,
    constexpr int NBZ = T_NBZ ? T_NBZ : 1;
    MFEM_VERIFY(D1D <= MAX_D1D, "");
    MFEM_VERIFY(Q1D <= MAX_Q1D, "");
-   auto B = Reshape(b.Read(), Q1D, D1D);
-   auto Bt = Reshape(bt.Read(), D1D, Q1D);
-   auto op = Reshape(_op.Read(), Q1D, Q1D, 2, 2, NF);
-   auto x = Reshape(_x.Read(), D1D, D1D, 2, NF);
-   auto y = Reshape(_y.ReadWrite(), D1D, D1D, 2, NF);
+   auto B = Reshape(b, Q1D, D1D);
+   auto Bt = Reshape(bt, D1D, Q1D);
+   auto op = Reshape(_op, Q1D, Q1D, 2, 2, NF);
+   auto x = Reshape(_x, D1D, D1D, 2, NF);
+   auto y = Reshape(_y, D1D, D1D, 2, NF);
 
    MFEM_FORALL_2D(f, NF, Q1D, Q1D, NBZ,
    {
@@ -663,11 +663,11 @@ void PADGTraceApplyTranspose2D(const int NF,
    const int Q1D = T_Q1D ? T_Q1D : q1d;
    MFEM_VERIFY(D1D <= MAX_D1D, "");
    MFEM_VERIFY(Q1D <= MAX_Q1D, "");
-   auto B = Reshape(b.Read(), Q1D, D1D);
-   auto Bt = Reshape(bt.Read(), D1D, Q1D);
-   auto op = Reshape(_op.Read(), Q1D, 2, 2, NF);
-   auto x = Reshape(_x.Read(), D1D, VDIM, 2, NF);
-   auto y = Reshape(_y.ReadWrite(), D1D, VDIM, 2, NF);
+   auto B = Reshape(b, Q1D, D1D);
+   auto Bt = Reshape(bt, D1D, Q1D);
+   auto op = Reshape(_op, Q1D, 2, 2, NF);
+   auto x = Reshape(_x, D1D, VDIM, 2, NF);
+   auto y = Reshape(_y, D1D, VDIM, 2, NF);
 
    MFEM_FORALL(f, NF,
    {
@@ -759,11 +759,11 @@ void PADGTraceApplyTranspose3D(const int NF,
    const int Q1D = T_Q1D ? T_Q1D : q1d;
    MFEM_VERIFY(D1D <= MAX_D1D, "");
    MFEM_VERIFY(Q1D <= MAX_Q1D, "");
-   auto B = Reshape(b.Read(), Q1D, D1D);
-   auto Bt = Reshape(bt.Read(), D1D, Q1D);
-   auto op = Reshape(_op.Read(), Q1D, Q1D, 2, 2, NF);
-   auto x = Reshape(_x.Read(), D1D, D1D, VDIM, 2, NF);
-   auto y = Reshape(_y.ReadWrite(), D1D, D1D, VDIM, 2, NF);
+   auto B = Reshape(b, Q1D, D1D);
+   auto Bt = Reshape(bt, D1D, Q1D);
+   auto op = Reshape(_op, Q1D, Q1D, 2, 2, NF);
+   auto x = Reshape(_x, D1D, D1D, VDIM, 2, NF);
+   auto y = Reshape(_y, D1D, D1D, VDIM, 2, NF);
 
    MFEM_FORALL(f, NF,
    {
@@ -915,11 +915,11 @@ void SmemPADGTraceApplyTranspose3D(const int NF,
    constexpr int NBZ = T_NBZ ? T_NBZ : 1;
    MFEM_VERIFY(D1D <= MAX_D1D, "");
    MFEM_VERIFY(Q1D <= MAX_Q1D, "");
-   auto B = Reshape(b.Read(), Q1D, D1D);
-   auto Bt = Reshape(bt.Read(), D1D, Q1D);
-   auto op = Reshape(_op.Read(), Q1D, Q1D, 2, 2, NF);
-   auto x = Reshape(_x.Read(), D1D, D1D, 2, NF);
-   auto y = Reshape(_y.ReadWrite(), D1D, D1D, 2, NF);
+   auto B = Reshape(b, Q1D, D1D);
+   auto Bt = Reshape(bt, D1D, Q1D);
+   auto op = Reshape(_op, Q1D, Q1D, 2, 2, NF);
+   auto x = Reshape(_x, D1D, D1D, 2, NF);
+   auto y = Reshape(_y, D1D, D1D, 2, NF);
 
    MFEM_FORALL_2D(f, NF, Q1D, Q1D, NBZ,
    {

--- a/fem/bilininteg_dgtrace_pa.cpp
+++ b/fem/bilininteg_dgtrace_pa.cpp
@@ -263,10 +263,10 @@ void PADGTraceApply2D(const int NF,
    const int Q1D = T_Q1D ? T_Q1D : q1d;
    MFEM_VERIFY(D1D <= MAX_D1D, "");
    MFEM_VERIFY(Q1D <= MAX_Q1D, "");
-   auto B = Reshape(b, Q1D, D1D);
-   auto Bt = Reshape(bt, D1D, Q1D);
-   auto op = Reshape(_op, Q1D, 2, 2, NF);
-   auto x = Reshape(_x, D1D, VDIM, 2, NF);
+   const auto B = Reshape(b, Q1D, D1D);
+   const auto Bt = Reshape(bt, D1D, Q1D);
+   const auto op = Reshape(_op, Q1D, 2, 2, NF);
+   const auto x = Reshape(_x, D1D, VDIM, 2, NF);
    auto y = Reshape(_y, D1D, VDIM, 2, NF);
 
    MFEM_FORALL(f, NF,
@@ -354,10 +354,10 @@ void PADGTraceApply3D(const int NF,
    const int Q1D = T_Q1D ? T_Q1D : q1d;
    MFEM_VERIFY(D1D <= MAX_D1D, "");
    MFEM_VERIFY(Q1D <= MAX_Q1D, "");
-   auto B = Reshape(b, Q1D, D1D);
-   auto Bt = Reshape(bt, D1D, Q1D);
-   auto op = Reshape(_op, Q1D, Q1D, 2, 2, NF);
-   auto x = Reshape(_x, D1D, D1D, VDIM, 2, NF);
+   const auto B = Reshape(b, Q1D, D1D);
+   const auto Bt = Reshape(bt, D1D, Q1D);
+   const auto op = Reshape(_op, Q1D, Q1D, 2, 2, NF);
+   const auto x = Reshape(_x, D1D, D1D, VDIM, 2, NF);
    auto y = Reshape(_y, D1D, D1D, VDIM, 2, NF);
 
    MFEM_FORALL(f, NF,
@@ -499,10 +499,10 @@ void SmemPADGTraceApply3D(const int NF,
    constexpr int NBZ = T_NBZ ? T_NBZ : 1;
    MFEM_VERIFY(D1D <= MAX_D1D, "");
    MFEM_VERIFY(Q1D <= MAX_Q1D, "");
-   auto B = Reshape(b, Q1D, D1D);
-   auto Bt = Reshape(bt, D1D, Q1D);
-   auto op = Reshape(_op, Q1D, Q1D, 2, 2, NF);
-   auto x = Reshape(_x, D1D, D1D, 2, NF);
+   const auto B = Reshape(b, Q1D, D1D);
+   const auto Bt = Reshape(bt, D1D, Q1D);
+   const auto op = Reshape(_op, Q1D, Q1D, 2, 2, NF);
+   const auto x = Reshape(_x, D1D, D1D, 2, NF);
    auto y = Reshape(_y, D1D, D1D, 2, NF);
 
    MFEM_FORALL_2D(f, NF, Q1D, Q1D, NBZ,
@@ -663,10 +663,10 @@ void PADGTraceApplyTranspose2D(const int NF,
    const int Q1D = T_Q1D ? T_Q1D : q1d;
    MFEM_VERIFY(D1D <= MAX_D1D, "");
    MFEM_VERIFY(Q1D <= MAX_Q1D, "");
-   auto B = Reshape(b, Q1D, D1D);
-   auto Bt = Reshape(bt, D1D, Q1D);
-   auto op = Reshape(_op, Q1D, 2, 2, NF);
-   auto x = Reshape(_x, D1D, VDIM, 2, NF);
+   const auto B = Reshape(b, Q1D, D1D);
+   const auto Bt = Reshape(bt, D1D, Q1D);
+   const auto op = Reshape(_op, Q1D, 2, 2, NF);
+   const auto x = Reshape(_x, D1D, VDIM, 2, NF);
    auto y = Reshape(_y, D1D, VDIM, 2, NF);
 
    MFEM_FORALL(f, NF,
@@ -759,10 +759,10 @@ void PADGTraceApplyTranspose3D(const int NF,
    const int Q1D = T_Q1D ? T_Q1D : q1d;
    MFEM_VERIFY(D1D <= MAX_D1D, "");
    MFEM_VERIFY(Q1D <= MAX_Q1D, "");
-   auto B = Reshape(b, Q1D, D1D);
-   auto Bt = Reshape(bt, D1D, Q1D);
-   auto op = Reshape(_op, Q1D, Q1D, 2, 2, NF);
-   auto x = Reshape(_x, D1D, D1D, VDIM, 2, NF);
+   const auto B = Reshape(b, Q1D, D1D);
+   const auto Bt = Reshape(bt, D1D, Q1D);
+   const auto op = Reshape(_op, Q1D, Q1D, 2, 2, NF);
+   const auto x = Reshape(_x, D1D, D1D, VDIM, 2, NF);
    auto y = Reshape(_y, D1D, D1D, VDIM, 2, NF);
 
    MFEM_FORALL(f, NF,
@@ -915,10 +915,10 @@ void SmemPADGTraceApplyTranspose3D(const int NF,
    constexpr int NBZ = T_NBZ ? T_NBZ : 1;
    MFEM_VERIFY(D1D <= MAX_D1D, "");
    MFEM_VERIFY(Q1D <= MAX_Q1D, "");
-   auto B = Reshape(b, Q1D, D1D);
-   auto Bt = Reshape(bt, D1D, Q1D);
-   auto op = Reshape(_op, Q1D, Q1D, 2, 2, NF);
-   auto x = Reshape(_x, D1D, D1D, 2, NF);
+   const auto B = Reshape(b, Q1D, D1D);
+   const auto Bt = Reshape(bt, D1D, Q1D);
+   const auto op = Reshape(_op, Q1D, Q1D, 2, 2, NF);
+   const auto x = Reshape(_x, D1D, D1D, 2, NF);
    auto y = Reshape(_y, D1D, D1D, 2, NF);
 
    MFEM_FORALL_2D(f, NF, Q1D, Q1D, NBZ,

--- a/fem/bilininteg_diffusion_ea.cpp
+++ b/fem/bilininteg_diffusion_ea.cpp
@@ -29,8 +29,8 @@ static void EADiffusionAssemble1D(const int NE,
    const int Q1D = T_Q1D ? T_Q1D : q1d;
    MFEM_VERIFY(D1D <= MAX_D1D, "");
    MFEM_VERIFY(Q1D <= MAX_Q1D, "");
-   auto G = Reshape(g, Q1D, D1D);
-   auto D = Reshape(padata, Q1D, NE);
+   const auto G = Reshape(g, Q1D, D1D);
+   const auto D = Reshape(padata, Q1D, NE);
    auto A = Reshape(eadata, D1D, D1D, NE);
    MFEM_FORALL_3D(e, NE, D1D, D1D, 1,
    {
@@ -72,9 +72,9 @@ static void EADiffusionAssemble2D(const int NE,
    const int Q1D = T_Q1D ? T_Q1D : q1d;
    MFEM_VERIFY(D1D <= MAX_D1D, "");
    MFEM_VERIFY(Q1D <= MAX_Q1D, "");
-   auto B = Reshape(b, Q1D, D1D);
-   auto G = Reshape(g, Q1D, D1D);
-   auto D = Reshape(padata, Q1D, Q1D, 3, NE);
+   const auto B = Reshape(b, Q1D, D1D);
+   const auto G = Reshape(g, Q1D, D1D);
+   const auto D = Reshape(padata, Q1D, Q1D, 3, NE);
    auto A = Reshape(eadata, D1D, D1D, D1D, D1D, NE);
    MFEM_FORALL_3D(e, NE, D1D, D1D, 1,
    {
@@ -141,9 +141,9 @@ static void EADiffusionAssemble3D(const int NE,
    const int Q1D = T_Q1D ? T_Q1D : q1d;
    MFEM_VERIFY(D1D <= MAX_D1D, "");
    MFEM_VERIFY(Q1D <= MAX_Q1D, "");
-   auto B = Reshape(b, Q1D, D1D);
-   auto G = Reshape(g, Q1D, D1D);
-   auto D = Reshape(padata, Q1D, Q1D, Q1D, 6, NE);
+   const auto B = Reshape(b, Q1D, D1D);
+   const auto G = Reshape(g, Q1D, D1D);
+   const auto D = Reshape(padata, Q1D, Q1D, Q1D, 6, NE);
    auto A = Reshape(eadata, D1D, D1D, D1D, D1D, D1D, D1D, NE);
    MFEM_FORALL_3D(e, NE, D1D, D1D, D1D,
    {

--- a/fem/bilininteg_diffusion_ea.cpp
+++ b/fem/bilininteg_diffusion_ea.cpp
@@ -29,9 +29,9 @@ static void EADiffusionAssemble1D(const int NE,
    const int Q1D = T_Q1D ? T_Q1D : q1d;
    MFEM_VERIFY(D1D <= MAX_D1D, "");
    MFEM_VERIFY(Q1D <= MAX_Q1D, "");
-   auto G = Reshape(g.Read(), Q1D, D1D);
-   auto D = Reshape(padata.Read(), Q1D, NE);
-   auto A = Reshape(eadata.ReadWrite(), D1D, D1D, NE);
+   auto G = Reshape(g, Q1D, D1D);
+   auto D = Reshape(padata, Q1D, NE);
+   auto A = Reshape(eadata, D1D, D1D, NE);
    MFEM_FORALL_3D(e, NE, D1D, D1D, 1,
    {
       const int D1D = T_D1D ? T_D1D : d1d;
@@ -72,10 +72,10 @@ static void EADiffusionAssemble2D(const int NE,
    const int Q1D = T_Q1D ? T_Q1D : q1d;
    MFEM_VERIFY(D1D <= MAX_D1D, "");
    MFEM_VERIFY(Q1D <= MAX_Q1D, "");
-   auto B = Reshape(b.Read(), Q1D, D1D);
-   auto G = Reshape(g.Read(), Q1D, D1D);
-   auto D = Reshape(padata.Read(), Q1D, Q1D, 3, NE);
-   auto A = Reshape(eadata.ReadWrite(), D1D, D1D, D1D, D1D, NE);
+   auto B = Reshape(b, Q1D, D1D);
+   auto G = Reshape(g, Q1D, D1D);
+   auto D = Reshape(padata, Q1D, Q1D, 3, NE);
+   auto A = Reshape(eadata, D1D, D1D, D1D, D1D, NE);
    MFEM_FORALL_3D(e, NE, D1D, D1D, 1,
    {
       const int D1D = T_D1D ? T_D1D : d1d;
@@ -141,10 +141,10 @@ static void EADiffusionAssemble3D(const int NE,
    const int Q1D = T_Q1D ? T_Q1D : q1d;
    MFEM_VERIFY(D1D <= MAX_D1D, "");
    MFEM_VERIFY(Q1D <= MAX_Q1D, "");
-   auto B = Reshape(b.Read(), Q1D, D1D);
-   auto G = Reshape(g.Read(), Q1D, D1D);
-   auto D = Reshape(padata.Read(), Q1D, Q1D, Q1D, 6, NE);
-   auto A = Reshape(eadata.ReadWrite(), D1D, D1D, D1D, D1D, D1D, D1D, NE);
+   auto B = Reshape(b, Q1D, D1D);
+   auto G = Reshape(g, Q1D, D1D);
+   auto D = Reshape(padata, Q1D, Q1D, Q1D, 6, NE);
+   auto A = Reshape(eadata, D1D, D1D, D1D, D1D, D1D, D1D, NE);
    MFEM_FORALL_3D(e, NE, D1D, D1D, D1D,
    {
       const int D1D = T_D1D ? T_D1D : d1d;

--- a/fem/bilininteg_diffusion_pa.cpp
+++ b/fem/bilininteg_diffusion_pa.cpp
@@ -98,9 +98,9 @@ void PADiffusionSetup2D<2>(const int Q1D,
 {
    const int NQ = Q1D*Q1D;
    const bool const_c = c.Size() == 1;
-   auto W = w.Read();
-   auto J = Reshape(j, NQ, 2, 2, NE);
-   auto C = const_c ? Reshape(c, 1, 1) : Reshape(c, NQ, NE);
+   const auto W = w.Read();
+   const auto J = Reshape(j, NQ, 2, 2, NE);
+   const auto C = const_c ? Reshape(c, 1, 1) : Reshape(c, NQ, NE);
    auto D = Reshape(d.Write(), NQ, 3, NE);
 
    MFEM_FORALL(e, NE,
@@ -134,9 +134,9 @@ void PADiffusionSetup2D<3>(const int Q1D,
    const int NQ = Q1D*Q1D;
    const bool const_c = c.Size() == 1;
 
-   auto W = w.Read();
-   auto J = Reshape(j, NQ, SDIM, DIM, NE);
-   auto C = const_c ? Reshape(c, 1, 1) : Reshape(c, NQ, NE);
+   const auto W = w.Read();
+   const auto J = Reshape(j, NQ, SDIM, DIM, NE);
+   const auto C = const_c ? Reshape(c, 1, 1) : Reshape(c, NQ, NE);
    auto D = Reshape(d.Write(), NQ, 3, NE);
    MFEM_FORALL(e, NE,
    {
@@ -172,9 +172,9 @@ static void PADiffusionSetup3D(const int Q1D,
 {
    const int NQ = Q1D*Q1D*Q1D;
    const bool const_c = c.Size() == 1;
-   auto W = w.Read();
-   auto J = Reshape(j, NQ, 3, 3, NE);
-   auto C = const_c ? Reshape(c, 1, 1) : Reshape(c, NQ, NE);
+   const auto W = w.Read();
+   const auto J = Reshape(j, NQ, 3, 3, NE);
+   const auto C = const_c ? Reshape(c, 1, 1) : Reshape(c, NQ, NE);
    auto D = Reshape(d.Write(), NQ, 6, NE);
    MFEM_FORALL(e, NE,
    {
@@ -332,11 +332,11 @@ static void PADiffusionDiagonal2D(const int NE,
    const int Q1D = T_Q1D ? T_Q1D : q1d;
    MFEM_VERIFY(D1D <= MAX_D1D, "");
    MFEM_VERIFY(Q1D <= MAX_Q1D, "");
-   auto B = Reshape(b, Q1D, D1D);
-   auto G = Reshape(g, Q1D, D1D);
+   const auto B = Reshape(b, Q1D, D1D);
+   const auto G = Reshape(g, Q1D, D1D);
    // note the different shape for D, this is a (symmetric) matrix so we only
    // store necessary entries
-   auto D = Reshape(d, Q1D*Q1D, 3, NE);
+   const auto D = Reshape(d, Q1D*Q1D, 3, NE);
    auto Y = Reshape(y, D1D, D1D, NE);
    MFEM_FORALL(e, NE,
    {
@@ -400,9 +400,9 @@ static void SmemPADiffusionDiagonal2D(const int NE,
    constexpr int MD1 = T_D1D ? T_D1D : MAX_D1D;
    MFEM_VERIFY(D1D <= MD1, "");
    MFEM_VERIFY(Q1D <= MQ1, "");
-   auto b = Reshape(b_, Q1D, D1D);
-   auto g = Reshape(g_, Q1D, D1D);
-   auto D = Reshape(d_, Q1D*Q1D, 3, NE);
+   const auto b = Reshape(b_, Q1D, D1D);
+   const auto g = Reshape(g_, Q1D, D1D);
+   const auto D = Reshape(d_, Q1D*Q1D, 3, NE);
    auto Y = Reshape(y_, D1D, D1D, NE);
    MFEM_FORALL_2D(e, NE, Q1D, Q1D, NBZ,
    {
@@ -493,9 +493,9 @@ static void PADiffusionDiagonal3D(const int NE,
    constexpr int MD1 = T_D1D ? T_D1D : MAX_D1D;
    MFEM_VERIFY(D1D <= MD1, "");
    MFEM_VERIFY(Q1D <= MQ1, "");
-   auto B = Reshape(b, Q1D, D1D);
-   auto G = Reshape(g, Q1D, D1D);
-   auto Q = Reshape(d, Q1D*Q1D*Q1D, 6, NE);
+   const auto B = Reshape(b, Q1D, D1D);
+   const auto G = Reshape(g, Q1D, D1D);
+   const auto Q = Reshape(d, Q1D*Q1D*Q1D, 6, NE);
    auto Y = Reshape(y, D1D, D1D, D1D, NE);
    MFEM_FORALL(e, NE,
    {
@@ -592,9 +592,9 @@ static void SmemPADiffusionDiagonal3D(const int NE,
    constexpr int MD1 = T_D1D ? T_D1D : MAX_D1D;
    MFEM_VERIFY(D1D <= MD1, "");
    MFEM_VERIFY(Q1D <= MQ1, "");
-   auto b = Reshape(b_, Q1D, D1D);
-   auto g = Reshape(g_, Q1D, D1D);
-   auto D = Reshape(d_, Q1D*Q1D*Q1D, 6, NE);
+   const auto b = Reshape(b_, Q1D, D1D);
+   const auto g = Reshape(g_, Q1D, D1D);
+   const auto D = Reshape(d_, Q1D*Q1D*Q1D, 6, NE);
    auto Y = Reshape(y_, D1D, D1D, D1D, NE);
    MFEM_FORALL_3D(e, NE, Q1D, Q1D, Q1D,
    {
@@ -859,12 +859,12 @@ static void PADiffusionApply2D(const int NE,
    const int Q1D = T_Q1D ? T_Q1D : q1d;
    MFEM_VERIFY(D1D <= MAX_D1D, "");
    MFEM_VERIFY(Q1D <= MAX_Q1D, "");
-   auto B = Reshape(b_, Q1D, D1D);
-   auto G = Reshape(g_, Q1D, D1D);
-   auto Bt = Reshape(bt_, D1D, Q1D);
-   auto Gt = Reshape(gt_, D1D, Q1D);
-   auto D = Reshape(d_, Q1D*Q1D, 3, NE);
-   auto X = Reshape(x_, D1D, D1D, NE);
+   const auto B = Reshape(b_, Q1D, D1D);
+   const auto G = Reshape(g_, Q1D, D1D);
+   const auto Bt = Reshape(bt_, D1D, Q1D);
+   const auto Gt = Reshape(gt_, D1D, Q1D);
+   const auto D = Reshape(d_, Q1D*Q1D, 3, NE);
+   const auto X = Reshape(x_, D1D, D1D, NE);
    auto Y = Reshape(y_, D1D, D1D, NE);
    MFEM_FORALL(e, NE,
    {
@@ -980,10 +980,10 @@ static void SmemPADiffusionApply2D(const int NE,
    constexpr int MD1 = T_D1D ? T_D1D : MAX_D1D;
    MFEM_VERIFY(D1D <= MD1, "");
    MFEM_VERIFY(Q1D <= MQ1, "");
-   auto b = Reshape(b_, Q1D, D1D);
-   auto g = Reshape(g_, Q1D, D1D);
-   auto D = Reshape(d_, Q1D*Q1D, 3, NE);
-   auto x = Reshape(x_, D1D, D1D, NE);
+   const auto b = Reshape(b_, Q1D, D1D);
+   const auto g = Reshape(g_, Q1D, D1D);
+   const auto D = Reshape(d_, Q1D*Q1D, 3, NE);
+   const auto x = Reshape(x_, D1D, D1D, NE);
    auto Y = Reshape(y_, D1D, D1D, NE);
    MFEM_FORALL_2D(e, NE, Q1D, Q1D, NBZ,
    {
@@ -1134,12 +1134,12 @@ static void PADiffusionApply3D(const int NE,
    const int Q1D = T_Q1D ? T_Q1D : q1d;
    MFEM_VERIFY(D1D <= MAX_D1D, "");
    MFEM_VERIFY(Q1D <= MAX_Q1D, "");
-   auto B = Reshape(b, Q1D, D1D);
-   auto G = Reshape(g, Q1D, D1D);
-   auto Bt = Reshape(bt, D1D, Q1D);
-   auto Gt = Reshape(gt, D1D, Q1D);
-   auto D = Reshape(d_, Q1D*Q1D*Q1D, 6, NE);
-   auto X = Reshape(x_, D1D, D1D, D1D, NE);
+   const auto B = Reshape(b, Q1D, D1D);
+   const auto G = Reshape(g, Q1D, D1D);
+   const auto Bt = Reshape(bt, D1D, Q1D);
+   const auto Gt = Reshape(gt, D1D, Q1D);
+   const auto D = Reshape(d_, Q1D*Q1D*Q1D, 6, NE);
+   const auto X = Reshape(x_, D1D, D1D, D1D, NE);
    auto Y = Reshape(y_, D1D, D1D, D1D, NE);
    MFEM_FORALL(e, NE,
    {
@@ -1350,10 +1350,10 @@ static void SmemPADiffusionApply3D(const int NE,
    constexpr int MD1 = T_D1D ? T_D1D : MAX_D1D;
    MFEM_VERIFY(D1D <= MD1, "");
    MFEM_VERIFY(Q1D <= MQ1, "");
-   auto b = Reshape(b_, Q1D, D1D);
-   auto g = Reshape(g_, Q1D, D1D);
-   auto d = Reshape(d_, Q1D, Q1D, Q1D, 6, NE);
-   auto x = Reshape(x_, D1D, D1D, D1D, NE);
+   const auto b = Reshape(b_, Q1D, D1D);
+   const auto g = Reshape(g_, Q1D, D1D);
+   const auto d = Reshape(d_, Q1D, Q1D, Q1D, 6, NE);
+   const auto x = Reshape(x_, D1D, D1D, D1D, NE);
    auto y = Reshape(y_, D1D, D1D, D1D, NE);
    MFEM_FORALL_3D(e, NE, Q1D, Q1D, 1,
    {

--- a/fem/bilininteg_diffusion_pa.cpp
+++ b/fem/bilininteg_diffusion_pa.cpp
@@ -99,8 +99,8 @@ void PADiffusionSetup2D<2>(const int Q1D,
    const int NQ = Q1D*Q1D;
    const bool const_c = c.Size() == 1;
    auto W = w.Read();
-   auto J = Reshape(j.Read(), NQ, 2, 2, NE);
-   auto C = const_c ? Reshape(c.Read(), 1, 1) : Reshape(c.Read(), NQ, NE);
+   auto J = Reshape(j, NQ, 2, 2, NE);
+   auto C = const_c ? Reshape(c, 1, 1) : Reshape(c, NQ, NE);
    auto D = Reshape(d.Write(), NQ, 3, NE);
 
    MFEM_FORALL(e, NE,
@@ -135,8 +135,8 @@ void PADiffusionSetup2D<3>(const int Q1D,
    const bool const_c = c.Size() == 1;
 
    auto W = w.Read();
-   auto J = Reshape(j.Read(), NQ, SDIM, DIM, NE);
-   auto C = const_c ? Reshape(c.Read(), 1, 1) : Reshape(c.Read(), NQ, NE);
+   auto J = Reshape(j, NQ, SDIM, DIM, NE);
+   auto C = const_c ? Reshape(c, 1, 1) : Reshape(c, NQ, NE);
    auto D = Reshape(d.Write(), NQ, 3, NE);
    MFEM_FORALL(e, NE,
    {
@@ -173,8 +173,8 @@ static void PADiffusionSetup3D(const int Q1D,
    const int NQ = Q1D*Q1D*Q1D;
    const bool const_c = c.Size() == 1;
    auto W = w.Read();
-   auto J = Reshape(j.Read(), NQ, 3, 3, NE);
-   auto C = const_c ? Reshape(c.Read(), 1, 1) : Reshape(c.Read(), NQ, NE);
+   auto J = Reshape(j, NQ, 3, 3, NE);
+   auto C = const_c ? Reshape(c, 1, 1) : Reshape(c, NQ, NE);
    auto D = Reshape(d.Write(), NQ, 6, NE);
    MFEM_FORALL(e, NE,
    {
@@ -332,12 +332,12 @@ static void PADiffusionDiagonal2D(const int NE,
    const int Q1D = T_Q1D ? T_Q1D : q1d;
    MFEM_VERIFY(D1D <= MAX_D1D, "");
    MFEM_VERIFY(Q1D <= MAX_Q1D, "");
-   auto B = Reshape(b.Read(), Q1D, D1D);
-   auto G = Reshape(g.Read(), Q1D, D1D);
+   auto B = Reshape(b, Q1D, D1D);
+   auto G = Reshape(g, Q1D, D1D);
    // note the different shape for D, this is a (symmetric) matrix so we only
    // store necessary entries
-   auto D = Reshape(d.Read(), Q1D*Q1D, 3, NE);
-   auto Y = Reshape(y.ReadWrite(), D1D, D1D, NE);
+   auto D = Reshape(d, Q1D*Q1D, 3, NE);
+   auto Y = Reshape(y, D1D, D1D, NE);
    MFEM_FORALL(e, NE,
    {
       const int D1D = T_D1D ? T_D1D : d1d;
@@ -400,10 +400,10 @@ static void SmemPADiffusionDiagonal2D(const int NE,
    constexpr int MD1 = T_D1D ? T_D1D : MAX_D1D;
    MFEM_VERIFY(D1D <= MD1, "");
    MFEM_VERIFY(Q1D <= MQ1, "");
-   auto b = Reshape(b_.Read(), Q1D, D1D);
-   auto g = Reshape(g_.Read(), Q1D, D1D);
-   auto D = Reshape(d_.Read(), Q1D*Q1D, 3, NE);
-   auto Y = Reshape(y_.ReadWrite(), D1D, D1D, NE);
+   auto b = Reshape(b_, Q1D, D1D);
+   auto g = Reshape(g_, Q1D, D1D);
+   auto D = Reshape(d_, Q1D*Q1D, 3, NE);
+   auto Y = Reshape(y_, D1D, D1D, NE);
    MFEM_FORALL_2D(e, NE, Q1D, Q1D, NBZ,
    {
       const int tidz = MFEM_THREAD_ID(z);
@@ -493,10 +493,10 @@ static void PADiffusionDiagonal3D(const int NE,
    constexpr int MD1 = T_D1D ? T_D1D : MAX_D1D;
    MFEM_VERIFY(D1D <= MD1, "");
    MFEM_VERIFY(Q1D <= MQ1, "");
-   auto B = Reshape(b.Read(), Q1D, D1D);
-   auto G = Reshape(g.Read(), Q1D, D1D);
-   auto Q = Reshape(d.Read(), Q1D*Q1D*Q1D, 6, NE);
-   auto Y = Reshape(y.ReadWrite(), D1D, D1D, D1D, NE);
+   auto B = Reshape(b, Q1D, D1D);
+   auto G = Reshape(g, Q1D, D1D);
+   auto Q = Reshape(d, Q1D*Q1D*Q1D, 6, NE);
+   auto Y = Reshape(y, D1D, D1D, D1D, NE);
    MFEM_FORALL(e, NE,
    {
       const int D1D = T_D1D ? T_D1D : d1d;
@@ -592,10 +592,10 @@ static void SmemPADiffusionDiagonal3D(const int NE,
    constexpr int MD1 = T_D1D ? T_D1D : MAX_D1D;
    MFEM_VERIFY(D1D <= MD1, "");
    MFEM_VERIFY(Q1D <= MQ1, "");
-   auto b = Reshape(b_.Read(), Q1D, D1D);
-   auto g = Reshape(g_.Read(), Q1D, D1D);
-   auto D = Reshape(d_.Read(), Q1D*Q1D*Q1D, 6, NE);
-   auto Y = Reshape(y_.ReadWrite(), D1D, D1D, D1D, NE);
+   auto b = Reshape(b_, Q1D, D1D);
+   auto g = Reshape(g_, Q1D, D1D);
+   auto D = Reshape(d_, Q1D*Q1D*Q1D, 6, NE);
+   auto Y = Reshape(y_, D1D, D1D, D1D, NE);
    MFEM_FORALL_3D(e, NE, Q1D, Q1D, Q1D,
    {
       const int tidz = MFEM_THREAD_ID(z);
@@ -859,13 +859,13 @@ static void PADiffusionApply2D(const int NE,
    const int Q1D = T_Q1D ? T_Q1D : q1d;
    MFEM_VERIFY(D1D <= MAX_D1D, "");
    MFEM_VERIFY(Q1D <= MAX_Q1D, "");
-   auto B = Reshape(b_.Read(), Q1D, D1D);
-   auto G = Reshape(g_.Read(), Q1D, D1D);
-   auto Bt = Reshape(bt_.Read(), D1D, Q1D);
-   auto Gt = Reshape(gt_.Read(), D1D, Q1D);
-   auto D = Reshape(d_.Read(), Q1D*Q1D, 3, NE);
-   auto X = Reshape(x_.Read(), D1D, D1D, NE);
-   auto Y = Reshape(y_.ReadWrite(), D1D, D1D, NE);
+   auto B = Reshape(b_, Q1D, D1D);
+   auto G = Reshape(g_, Q1D, D1D);
+   auto Bt = Reshape(bt_, D1D, Q1D);
+   auto Gt = Reshape(gt_, D1D, Q1D);
+   auto D = Reshape(d_, Q1D*Q1D, 3, NE);
+   auto X = Reshape(x_, D1D, D1D, NE);
+   auto Y = Reshape(y_, D1D, D1D, NE);
    MFEM_FORALL(e, NE,
    {
       const int D1D = T_D1D ? T_D1D : d1d;
@@ -980,11 +980,11 @@ static void SmemPADiffusionApply2D(const int NE,
    constexpr int MD1 = T_D1D ? T_D1D : MAX_D1D;
    MFEM_VERIFY(D1D <= MD1, "");
    MFEM_VERIFY(Q1D <= MQ1, "");
-   auto b = Reshape(b_.Read(), Q1D, D1D);
-   auto g = Reshape(g_.Read(), Q1D, D1D);
-   auto D = Reshape(d_.Read(), Q1D*Q1D, 3, NE);
-   auto x = Reshape(x_.Read(), D1D, D1D, NE);
-   auto Y = Reshape(y_.ReadWrite(), D1D, D1D, NE);
+   auto b = Reshape(b_, Q1D, D1D);
+   auto g = Reshape(g_, Q1D, D1D);
+   auto D = Reshape(d_, Q1D*Q1D, 3, NE);
+   auto x = Reshape(x_, D1D, D1D, NE);
+   auto Y = Reshape(y_, D1D, D1D, NE);
    MFEM_FORALL_2D(e, NE, Q1D, Q1D, NBZ,
    {
       const int tidz = MFEM_THREAD_ID(z);
@@ -1134,13 +1134,13 @@ static void PADiffusionApply3D(const int NE,
    const int Q1D = T_Q1D ? T_Q1D : q1d;
    MFEM_VERIFY(D1D <= MAX_D1D, "");
    MFEM_VERIFY(Q1D <= MAX_Q1D, "");
-   auto B = Reshape(b.Read(), Q1D, D1D);
-   auto G = Reshape(g.Read(), Q1D, D1D);
-   auto Bt = Reshape(bt.Read(), D1D, Q1D);
-   auto Gt = Reshape(gt.Read(), D1D, Q1D);
-   auto D = Reshape(d_.Read(), Q1D*Q1D*Q1D, 6, NE);
-   auto X = Reshape(x_.Read(), D1D, D1D, D1D, NE);
-   auto Y = Reshape(y_.ReadWrite(), D1D, D1D, D1D, NE);
+   auto B = Reshape(b, Q1D, D1D);
+   auto G = Reshape(g, Q1D, D1D);
+   auto Bt = Reshape(bt, D1D, Q1D);
+   auto Gt = Reshape(gt, D1D, Q1D);
+   auto D = Reshape(d_, Q1D*Q1D*Q1D, 6, NE);
+   auto X = Reshape(x_, D1D, D1D, D1D, NE);
+   auto Y = Reshape(y_, D1D, D1D, D1D, NE);
    MFEM_FORALL(e, NE,
    {
       const int D1D = T_D1D ? T_D1D : d1d;
@@ -1324,11 +1324,11 @@ static void SmemPADiffusionApply3D(const int NE,
    constexpr int MD1 = T_D1D ? T_D1D : MAX_D1D;
    MFEM_VERIFY(D1D <= MD1, "");
    MFEM_VERIFY(Q1D <= MQ1, "");
-   auto b = Reshape(b_.Read(), Q1D, D1D);
-   auto g = Reshape(g_.Read(), Q1D, D1D);
-   auto d = Reshape(d_.Read(), Q1D*Q1D*Q1D, 6, NE);
-   auto x = Reshape(x_.Read(), D1D, D1D, D1D, NE);
-   auto y = Reshape(y_.ReadWrite(), D1D, D1D, D1D, NE);
+   auto b = Reshape(b_, Q1D, D1D);
+   auto g = Reshape(g_, Q1D, D1D);
+   auto d = Reshape(d_, Q1D*Q1D*Q1D, 6, NE);
+   auto x = Reshape(x_, D1D, D1D, D1D, NE);
+   auto y = Reshape(y_, D1D, D1D, D1D, NE);
    MFEM_FORALL_3D(e, NE, Q1D, Q1D, Q1D,
    {
       const int tidz = MFEM_THREAD_ID(z);

--- a/fem/bilininteg_divergence.cpp
+++ b/fem/bilininteg_divergence.cpp
@@ -30,7 +30,7 @@ static void PADivergenceSetup2D(const int Q1D,
 {
    const int NQ = Q1D*Q1D;
    auto W = w.Read();
-   auto J = Reshape(j.Read(), NQ, 2, 2, NE);
+   auto J = Reshape(j, NQ, 2, 2, NE);
    auto y = Reshape(op.Write(), NQ, 2, 2, NE);
 
    MFEM_FORALL(e, NE,
@@ -60,7 +60,7 @@ static void PADivergenceSetup3D(const int Q1D,
 {
    const int NQ = Q1D*Q1D*Q1D;
    auto W = w.Read();
-   auto J = Reshape(j.Read(), NQ, 3, 3, NE);
+   auto J = Reshape(j, NQ, 3, 3, NE);
    auto y = Reshape(op.Write(), NQ, 3, 3, NE);
    MFEM_FORALL(e, NE,
    {
@@ -177,12 +177,12 @@ static void PADivergenceApply2D(const int NE,
    MFEM_VERIFY(TR_D1D <= MAX_D1D, "");
    MFEM_VERIFY(TE_D1D <= MAX_D1D, "");
    MFEM_VERIFY(Q1D <= MAX_Q1D, "");
-   auto B = Reshape(b.Read(), Q1D, TR_D1D);
-   auto G = Reshape(g.Read(), Q1D, TR_D1D);
-   auto Bt = Reshape(bt.Read(), TE_D1D, Q1D);
-   auto op = Reshape(_op.Read(), Q1D*Q1D, 2,2, NE);
-   auto x = Reshape(_x.Read(), TR_D1D, TR_D1D, 2, NE);
-   auto y = Reshape(_y.ReadWrite(), TE_D1D, TE_D1D, NE);
+   auto B = Reshape(b, Q1D, TR_D1D);
+   auto G = Reshape(g, Q1D, TR_D1D);
+   auto Bt = Reshape(bt, TE_D1D, Q1D);
+   auto op = Reshape(_op, Q1D*Q1D, 2,2, NE);
+   auto x = Reshape(_x, TR_D1D, TR_D1D, 2, NE);
+   auto y = Reshape(_y, TE_D1D, TE_D1D, NE);
    MFEM_FORALL(e, NE,
    {
       const int TR_D1D = T_TR_D1D ? T_TR_D1D : tr_d1d;
@@ -315,12 +315,12 @@ static void PADivergenceApplyTranspose2D(const int NE,
    MFEM_VERIFY(TR_D1D <= MAX_D1D, "");
    MFEM_VERIFY(TE_D1D <= MAX_D1D, "");
    MFEM_VERIFY(Q1D <= MAX_Q1D, "");
-   auto Bt = Reshape(bt.Read(), TR_D1D, Q1D);
-   auto Gt = Reshape(gt.Read(), TR_D1D, Q1D);
-   auto B  = Reshape(b.Read(), Q1D, TE_D1D);
-   auto op = Reshape(_op.Read(), Q1D*Q1D, 2,2, NE);
-   auto x  = Reshape(_x.Read(), TE_D1D, TE_D1D, NE);
-   auto y  = Reshape(_y.ReadWrite(), TR_D1D, TR_D1D, 2, NE);
+   auto Bt = Reshape(bt, TR_D1D, Q1D);
+   auto Gt = Reshape(gt, TR_D1D, Q1D);
+   auto B  = Reshape(b, Q1D, TE_D1D);
+   auto op = Reshape(_op, Q1D*Q1D, 2,2, NE);
+   auto x  = Reshape(_x, TE_D1D, TE_D1D, NE);
+   auto y  = Reshape(_y, TR_D1D, TR_D1D, 2, NE);
    MFEM_FORALL(e, NE,
    {
       const int TR_D1D = T_TR_D1D ? T_TR_D1D : tr_d1d;
@@ -431,12 +431,12 @@ static void PADivergenceApply3D(const int NE,
    MFEM_VERIFY(TR_D1D <= MAX_D1D, "");
    MFEM_VERIFY(TE_D1D <= MAX_D1D, "");
    MFEM_VERIFY(Q1D <= MAX_Q1D, "");
-   auto B = Reshape(b.Read(), Q1D, TR_D1D);
-   auto G = Reshape(g.Read(), Q1D, TR_D1D);
-   auto Bt = Reshape(bt.Read(), TE_D1D, Q1D);
-   auto op = Reshape(_op.Read(), Q1D*Q1D*Q1D, 3,3, NE);
-   auto x = Reshape(_x.Read(), TR_D1D, TR_D1D, TR_D1D, 3, NE);
-   auto y = Reshape(_y.ReadWrite(), TE_D1D, TE_D1D, TE_D1D, NE);
+   auto B = Reshape(b, Q1D, TR_D1D);
+   auto G = Reshape(g, Q1D, TR_D1D);
+   auto Bt = Reshape(bt, TE_D1D, Q1D);
+   auto op = Reshape(_op, Q1D*Q1D*Q1D, 3,3, NE);
+   auto x = Reshape(_x, TR_D1D, TR_D1D, TR_D1D, 3, NE);
+   auto y = Reshape(_y, TE_D1D, TE_D1D, TE_D1D, NE);
    MFEM_FORALL(e, NE,
    {
       const int TR_D1D = T_TR_D1D ? T_TR_D1D : tr_d1d;
@@ -614,12 +614,12 @@ static void PADivergenceApplyTranspose3D(const int NE,
    MFEM_VERIFY(TR_D1D <= MAX_D1D, "");
    MFEM_VERIFY(TE_D1D <= MAX_D1D, "");
    MFEM_VERIFY(Q1D <= MAX_Q1D, "");
-   auto Bt = Reshape(bt.Read(), TR_D1D, Q1D);
-   auto Gt = Reshape(gt.Read(), TR_D1D, Q1D);
-   auto B  = Reshape(b.Read(), Q1D, TE_D1D);
-   auto op = Reshape(_op.Read(), Q1D*Q1D*Q1D, 3,3, NE);
-   auto x  = Reshape(_x.Read(), TE_D1D, TE_D1D, TE_D1D, NE);
-   auto y  = Reshape(_y.ReadWrite(), TR_D1D, TR_D1D, TR_D1D, 3, NE);
+   auto Bt = Reshape(bt, TR_D1D, Q1D);
+   auto Gt = Reshape(gt, TR_D1D, Q1D);
+   auto B  = Reshape(b, Q1D, TE_D1D);
+   auto op = Reshape(_op, Q1D*Q1D*Q1D, 3,3, NE);
+   auto x  = Reshape(_x, TE_D1D, TE_D1D, TE_D1D, NE);
+   auto y  = Reshape(_y, TR_D1D, TR_D1D, TR_D1D, 3, NE);
    MFEM_FORALL(e, NE,
    {
       const int TR_D1D = T_TR_D1D ? T_TR_D1D : tr_d1d;
@@ -794,12 +794,12 @@ static void SmemPADivergenceApply3D(const int NE,
    MFEM_VERIFY(TE_D1D <= MAX_D1D, "");
    MFEM_VERIFY(Q1D <= MAX_Q1D, "");
 
-   auto b = Reshape(b_.Read(), Q1D, TR_D1D);
-   auto g = Reshape(g_.Read(), Q1D, TR_D1D);
-   auto bt = Reshape(bt_.Read(), TE_D1D, Q1D);
-   auto Q = Reshape(q_.Read(), Q1D*Q1D*Q1D, 3,3, NE);
-   auto x = Reshape(x_.Read(), TR_D1D, TR_D1D, TR_D1D, 3, NE);
-   auto y = Reshape(y_.ReadWrite(), TE_D1D, TE_D1D, TE_D1D, NE);
+   auto b = Reshape(b_, Q1D, TR_D1D);
+   auto g = Reshape(g_, Q1D, TR_D1D);
+   auto bt = Reshape(bt_, TE_D1D, Q1D);
+   auto Q = Reshape(q_, Q1D*Q1D*Q1D, 3,3, NE);
+   auto x = Reshape(x_, TR_D1D, TR_D1D, TR_D1D, 3, NE);
+   auto y = Reshape(y_, TE_D1D, TE_D1D, TE_D1D, NE);
 
    MFEM_FORALL_3D(e, NE, Q1D, Q1D, Q1D,
    {

--- a/fem/bilininteg_divergence.cpp
+++ b/fem/bilininteg_divergence.cpp
@@ -29,8 +29,8 @@ static void PADivergenceSetup2D(const int Q1D,
                                 Vector &op)
 {
    const int NQ = Q1D*Q1D;
-   auto W = w.Read();
-   auto J = Reshape(j, NQ, 2, 2, NE);
+   const auto W = w.Read();
+   const auto J = Reshape(j, NQ, 2, 2, NE);
    auto y = Reshape(op.Write(), NQ, 2, 2, NE);
 
    MFEM_FORALL(e, NE,
@@ -59,8 +59,8 @@ static void PADivergenceSetup3D(const int Q1D,
                                 Vector &op)
 {
    const int NQ = Q1D*Q1D*Q1D;
-   auto W = w.Read();
-   auto J = Reshape(j, NQ, 3, 3, NE);
+   const auto W = w.Read();
+   const auto J = Reshape(j, NQ, 3, 3, NE);
    auto y = Reshape(op.Write(), NQ, 3, 3, NE);
    MFEM_FORALL(e, NE,
    {
@@ -177,11 +177,11 @@ static void PADivergenceApply2D(const int NE,
    MFEM_VERIFY(TR_D1D <= MAX_D1D, "");
    MFEM_VERIFY(TE_D1D <= MAX_D1D, "");
    MFEM_VERIFY(Q1D <= MAX_Q1D, "");
-   auto B = Reshape(b, Q1D, TR_D1D);
-   auto G = Reshape(g, Q1D, TR_D1D);
-   auto Bt = Reshape(bt, TE_D1D, Q1D);
-   auto op = Reshape(_op, Q1D*Q1D, 2,2, NE);
-   auto x = Reshape(_x, TR_D1D, TR_D1D, 2, NE);
+   const auto B = Reshape(b, Q1D, TR_D1D);
+   const auto G = Reshape(g, Q1D, TR_D1D);
+   const auto Bt = Reshape(bt, TE_D1D, Q1D);
+   const auto op = Reshape(_op, Q1D*Q1D, 2,2, NE);
+   const auto x = Reshape(_x, TR_D1D, TR_D1D, 2, NE);
    auto y = Reshape(_y, TE_D1D, TE_D1D, NE);
    MFEM_FORALL(e, NE,
    {
@@ -315,11 +315,11 @@ static void PADivergenceApplyTranspose2D(const int NE,
    MFEM_VERIFY(TR_D1D <= MAX_D1D, "");
    MFEM_VERIFY(TE_D1D <= MAX_D1D, "");
    MFEM_VERIFY(Q1D <= MAX_Q1D, "");
-   auto Bt = Reshape(bt, TR_D1D, Q1D);
-   auto Gt = Reshape(gt, TR_D1D, Q1D);
-   auto B  = Reshape(b, Q1D, TE_D1D);
-   auto op = Reshape(_op, Q1D*Q1D, 2,2, NE);
-   auto x  = Reshape(_x, TE_D1D, TE_D1D, NE);
+   const auto Bt = Reshape(bt, TR_D1D, Q1D);
+   const auto Gt = Reshape(gt, TR_D1D, Q1D);
+   const auto B  = Reshape(b, Q1D, TE_D1D);
+   const auto op = Reshape(_op, Q1D*Q1D, 2,2, NE);
+   const auto x  = Reshape(_x, TE_D1D, TE_D1D, NE);
    auto y  = Reshape(_y, TR_D1D, TR_D1D, 2, NE);
    MFEM_FORALL(e, NE,
    {
@@ -431,11 +431,11 @@ static void PADivergenceApply3D(const int NE,
    MFEM_VERIFY(TR_D1D <= MAX_D1D, "");
    MFEM_VERIFY(TE_D1D <= MAX_D1D, "");
    MFEM_VERIFY(Q1D <= MAX_Q1D, "");
-   auto B = Reshape(b, Q1D, TR_D1D);
-   auto G = Reshape(g, Q1D, TR_D1D);
-   auto Bt = Reshape(bt, TE_D1D, Q1D);
-   auto op = Reshape(_op, Q1D*Q1D*Q1D, 3,3, NE);
-   auto x = Reshape(_x, TR_D1D, TR_D1D, TR_D1D, 3, NE);
+   const auto B = Reshape(b, Q1D, TR_D1D);
+   const auto G = Reshape(g, Q1D, TR_D1D);
+   const auto Bt = Reshape(bt, TE_D1D, Q1D);
+   const auto op = Reshape(_op, Q1D*Q1D*Q1D, 3,3, NE);
+   const auto x = Reshape(_x, TR_D1D, TR_D1D, TR_D1D, 3, NE);
    auto y = Reshape(_y, TE_D1D, TE_D1D, TE_D1D, NE);
    MFEM_FORALL(e, NE,
    {
@@ -614,11 +614,11 @@ static void PADivergenceApplyTranspose3D(const int NE,
    MFEM_VERIFY(TR_D1D <= MAX_D1D, "");
    MFEM_VERIFY(TE_D1D <= MAX_D1D, "");
    MFEM_VERIFY(Q1D <= MAX_Q1D, "");
-   auto Bt = Reshape(bt, TR_D1D, Q1D);
-   auto Gt = Reshape(gt, TR_D1D, Q1D);
-   auto B  = Reshape(b, Q1D, TE_D1D);
-   auto op = Reshape(_op, Q1D*Q1D*Q1D, 3,3, NE);
-   auto x  = Reshape(_x, TE_D1D, TE_D1D, TE_D1D, NE);
+   const auto Bt = Reshape(bt, TR_D1D, Q1D);
+   const auto Gt = Reshape(gt, TR_D1D, Q1D);
+   const auto B  = Reshape(b, Q1D, TE_D1D);
+   const auto op = Reshape(_op, Q1D*Q1D*Q1D, 3,3, NE);
+   const auto x  = Reshape(_x, TE_D1D, TE_D1D, TE_D1D, NE);
    auto y  = Reshape(_y, TR_D1D, TR_D1D, TR_D1D, 3, NE);
    MFEM_FORALL(e, NE,
    {
@@ -794,11 +794,11 @@ static void SmemPADivergenceApply3D(const int NE,
    MFEM_VERIFY(TE_D1D <= MAX_D1D, "");
    MFEM_VERIFY(Q1D <= MAX_Q1D, "");
 
-   auto b = Reshape(b_, Q1D, TR_D1D);
-   auto g = Reshape(g_, Q1D, TR_D1D);
-   auto bt = Reshape(bt_, TE_D1D, Q1D);
-   auto Q = Reshape(q_, Q1D*Q1D*Q1D, 3,3, NE);
-   auto x = Reshape(x_, TR_D1D, TR_D1D, TR_D1D, 3, NE);
+   const auto b = Reshape(b_, Q1D, TR_D1D);
+   const auto g = Reshape(g_, Q1D, TR_D1D);
+   const auto bt = Reshape(bt_, TE_D1D, Q1D);
+   const auto Q = Reshape(q_, Q1D*Q1D*Q1D, 3,3, NE);
+   const auto x = Reshape(x_, TR_D1D, TR_D1D, TR_D1D, 3, NE);
    auto y = Reshape(y_, TE_D1D, TE_D1D, TE_D1D, NE);
 
    MFEM_FORALL_3D(e, NE, Q1D, Q1D, Q1D,

--- a/fem/bilininteg_gradient.cpp
+++ b/fem/bilininteg_gradient.cpp
@@ -78,8 +78,8 @@ static void PAGradientSetup2D(const int Q1D,
                               Vector &op)
 {
    const int NQ = Q1D*Q1D;
-   auto W = w.Read();
-   auto J = Reshape(j, NQ, 2, 2, NE);
+   const auto W = w.Read();
+   const auto J = Reshape(j, NQ, 2, 2, NE);
    auto y = Reshape(op.Write(), NQ, 2, 2, NE);
 
    MFEM_FORALL(e, NE,
@@ -108,8 +108,8 @@ static void PAGradientSetup3D(const int Q1D,
                               Vector &op)
 {
    const int NQ = Q1D*Q1D*Q1D;
-   auto W = w.Read();
-   auto J = Reshape(j, NQ, 3, 3, NE);
+   const auto W = w.Read();
+   const auto J = Reshape(j, NQ, 3, 3, NE);
    auto y = Reshape(op.Write(), NQ, 3, 3, NE);
    MFEM_FORALL(e, NE,
    {
@@ -226,11 +226,11 @@ static void PAGradientApply2D(const int NE,
    MFEM_VERIFY(TR_D1D <= MAX_D1D, "");
    MFEM_VERIFY(TE_D1D <= MAX_D1D, "");
    MFEM_VERIFY(Q1D <= MAX_Q1D, "");
-   auto B = Reshape(b, Q1D, TR_D1D);
-   auto G = Reshape(g, Q1D, TR_D1D);
-   auto Bt = Reshape(bt, TE_D1D, Q1D);
-   auto op = Reshape(_op, Q1D*Q1D, 2,2, NE);
-   auto x = Reshape(_x, TR_D1D, TR_D1D, NE);
+   const auto B = Reshape(b, Q1D, TR_D1D);
+   const auto G = Reshape(g, Q1D, TR_D1D);
+   const auto Bt = Reshape(bt, TE_D1D, Q1D);
+   const auto op = Reshape(_op, Q1D*Q1D, 2,2, NE);
+   const auto x = Reshape(_x, TR_D1D, TR_D1D, NE);
    auto y = Reshape(_y, TE_D1D, TE_D1D, 2, NE);
    MFEM_FORALL(e, NE,
    {
@@ -356,11 +356,11 @@ static void PAGradientApply3D(const int NE,
    MFEM_VERIFY(TR_D1D <= MAX_D1D, "");
    MFEM_VERIFY(TE_D1D <= MAX_D1D, "");
    MFEM_VERIFY(Q1D <= MAX_Q1D, "");
-   auto B = Reshape(b, Q1D, TR_D1D);
-   auto G = Reshape(g, Q1D, TR_D1D);
-   auto Bt = Reshape(bt, TE_D1D, Q1D);
-   auto op = Reshape(_op, Q1D*Q1D*Q1D, 3,3, NE);
-   auto x = Reshape(_x, TR_D1D, TR_D1D, TR_D1D, NE);
+   const auto B = Reshape(b, Q1D, TR_D1D);
+   const auto G = Reshape(g, Q1D, TR_D1D);
+   const auto Bt = Reshape(bt, TE_D1D, Q1D);
+   const auto op = Reshape(_op, Q1D*Q1D*Q1D, 3,3, NE);
+   const auto x = Reshape(_x, TR_D1D, TR_D1D, TR_D1D, NE);
    auto y = Reshape(_y, TE_D1D, TE_D1D, TE_D1D, 3, NE);
    MFEM_FORALL(e, NE,
    {
@@ -555,11 +555,11 @@ static void SmemPAGradientApply3D(const int NE,
    MFEM_VERIFY(TE_D1D <= Q1D, "");
    MFEM_VERIFY(Q1D <= MAX_Q1D, "");
 
-   auto b = Reshape(b_, Q1D, TR_D1D);
-   auto g = Reshape(g_, Q1D, TR_D1D);
-   auto bt = Reshape(bt_, TE_D1D, Q1D);
-   auto D = Reshape(d_, Q1D*Q1D*Q1D, 3, 3, NE);
-   auto x = Reshape(x_, TR_D1D, TR_D1D, TR_D1D, NE);
+   const auto b = Reshape(b_, Q1D, TR_D1D);
+   const auto g = Reshape(g_, Q1D, TR_D1D);
+   const auto bt = Reshape(bt_, TE_D1D, Q1D);
+   const auto D = Reshape(d_, Q1D*Q1D*Q1D, 3, 3, NE);
+   const auto x = Reshape(x_, TR_D1D, TR_D1D, TR_D1D, NE);
    auto y = Reshape(y_, TE_D1D, TE_D1D, TE_D1D, 3, NE);
 
    MFEM_FORALL_3D(e, NE, (Q1D>8)?8:Q1D, (Q1D>8)?8:Q1D, (Q1D>8)?8:Q1D,

--- a/fem/bilininteg_gradient.cpp
+++ b/fem/bilininteg_gradient.cpp
@@ -79,7 +79,7 @@ static void PAGradientSetup2D(const int Q1D,
 {
    const int NQ = Q1D*Q1D;
    auto W = w.Read();
-   auto J = Reshape(j.Read(), NQ, 2, 2, NE);
+   auto J = Reshape(j, NQ, 2, 2, NE);
    auto y = Reshape(op.Write(), NQ, 2, 2, NE);
 
    MFEM_FORALL(e, NE,
@@ -109,7 +109,7 @@ static void PAGradientSetup3D(const int Q1D,
 {
    const int NQ = Q1D*Q1D*Q1D;
    auto W = w.Read();
-   auto J = Reshape(j.Read(), NQ, 3, 3, NE);
+   auto J = Reshape(j, NQ, 3, 3, NE);
    auto y = Reshape(op.Write(), NQ, 3, 3, NE);
    MFEM_FORALL(e, NE,
    {
@@ -226,12 +226,12 @@ static void PAGradientApply2D(const int NE,
    MFEM_VERIFY(TR_D1D <= MAX_D1D, "");
    MFEM_VERIFY(TE_D1D <= MAX_D1D, "");
    MFEM_VERIFY(Q1D <= MAX_Q1D, "");
-   auto B = Reshape(b.Read(), Q1D, TR_D1D);
-   auto G = Reshape(g.Read(), Q1D, TR_D1D);
-   auto Bt = Reshape(bt.Read(), TE_D1D, Q1D);
-   auto op = Reshape(_op.Read(), Q1D*Q1D, 2,2, NE);
-   auto x = Reshape(_x.Read(), TR_D1D, TR_D1D, NE);
-   auto y = Reshape(_y.ReadWrite(), TE_D1D, TE_D1D, 2, NE);
+   auto B = Reshape(b, Q1D, TR_D1D);
+   auto G = Reshape(g, Q1D, TR_D1D);
+   auto Bt = Reshape(bt, TE_D1D, Q1D);
+   auto op = Reshape(_op, Q1D*Q1D, 2,2, NE);
+   auto x = Reshape(_x, TR_D1D, TR_D1D, NE);
+   auto y = Reshape(_y, TE_D1D, TE_D1D, 2, NE);
    MFEM_FORALL(e, NE,
    {
       const int TR_D1D = T_TR_D1D ? T_TR_D1D : tr_d1d;
@@ -356,12 +356,12 @@ static void PAGradientApply3D(const int NE,
    MFEM_VERIFY(TR_D1D <= MAX_D1D, "");
    MFEM_VERIFY(TE_D1D <= MAX_D1D, "");
    MFEM_VERIFY(Q1D <= MAX_Q1D, "");
-   auto B = Reshape(b.Read(), Q1D, TR_D1D);
-   auto G = Reshape(g.Read(), Q1D, TR_D1D);
-   auto Bt = Reshape(bt.Read(), TE_D1D, Q1D);
-   auto op = Reshape(_op.Read(), Q1D*Q1D*Q1D, 3,3, NE);
-   auto x = Reshape(_x.Read(), TR_D1D, TR_D1D, TR_D1D, NE);
-   auto y = Reshape(_y.ReadWrite(), TE_D1D, TE_D1D, TE_D1D, 3, NE);
+   auto B = Reshape(b, Q1D, TR_D1D);
+   auto G = Reshape(g, Q1D, TR_D1D);
+   auto Bt = Reshape(bt, TE_D1D, Q1D);
+   auto op = Reshape(_op, Q1D*Q1D*Q1D, 3,3, NE);
+   auto x = Reshape(_x, TR_D1D, TR_D1D, TR_D1D, NE);
+   auto y = Reshape(_y, TE_D1D, TE_D1D, TE_D1D, 3, NE);
    MFEM_FORALL(e, NE,
    {
       const int TR_D1D = T_TR_D1D ? T_TR_D1D : tr_d1d;
@@ -555,12 +555,12 @@ static void SmemPAGradientApply3D(const int NE,
    MFEM_VERIFY(TE_D1D <= Q1D, "");
    MFEM_VERIFY(Q1D <= MAX_Q1D, "");
 
-   auto b = Reshape(b_.Read(), Q1D, TR_D1D);
-   auto g = Reshape(g_.Read(), Q1D, TR_D1D);
-   auto bt = Reshape(bt_.Read(), TE_D1D, Q1D);
-   auto D = Reshape(d_.Read(), Q1D*Q1D*Q1D, 3, 3, NE);
-   auto x = Reshape(x_.Read(), TR_D1D, TR_D1D, TR_D1D, NE);
-   auto y = Reshape(y_.ReadWrite(), TE_D1D, TE_D1D, TE_D1D, 3, NE);
+   auto b = Reshape(b_, Q1D, TR_D1D);
+   auto g = Reshape(g_, Q1D, TR_D1D);
+   auto bt = Reshape(bt_, TE_D1D, Q1D);
+   auto D = Reshape(d_, Q1D*Q1D*Q1D, 3, 3, NE);
+   auto x = Reshape(x_, TR_D1D, TR_D1D, TR_D1D, NE);
+   auto y = Reshape(y_, TE_D1D, TE_D1D, TE_D1D, 3, NE);
 
    MFEM_FORALL_3D(e, NE, (Q1D>8)?8:Q1D, (Q1D>8)?8:Q1D, (Q1D>8)?8:Q1D,
    {

--- a/fem/bilininteg_hcurl.cpp
+++ b/fem/bilininteg_hcurl.cpp
@@ -33,10 +33,9 @@ void PAHcurlSetup2D(const int Q1D,
                     Vector &op)
 {
    const int NQ = Q1D*Q1D;
-   auto W = w.Read();
-
-   auto J = Reshape(j, NQ, 2, 2, NE);
-   auto coeff = Reshape(_coeff, coeffDim, NQ, NE);
+   const auto W = w.Read();
+   const auto J = Reshape(j, NQ, 2, 2, NE);
+   const auto coeff = Reshape(_coeff, coeffDim, NQ, NE);
    auto y = Reshape(op.Write(), NQ, 3, NE);
 
    MFEM_FORALL(e, NE,
@@ -67,9 +66,9 @@ void PAHcurlSetup3D(const int Q1D,
                     Vector &op)
 {
    const int NQ = Q1D*Q1D*Q1D;
-   auto W = w.Read();
-   auto J = Reshape(j, NQ, 3, 3, NE);
-   auto coeff = Reshape(_coeff, coeffDim, NQ, NE);
+   const auto W = w.Read();
+   const auto J = Reshape(j, NQ, 3, 3, NE);
+   const auto coeff = Reshape(_coeff, coeffDim, NQ, NE);
    auto y = Reshape(op.Write(), NQ, 6, NE);
 
    MFEM_FORALL(e, NE,
@@ -128,12 +127,12 @@ void PAHcurlMassApply2D(const int D1D,
    constexpr static int MAX_D1D = HCURL_MAX_D1D;
    constexpr static int MAX_Q1D = HCURL_MAX_Q1D;
 
-   auto Bo = Reshape(_Bo, Q1D, D1D-1);
-   auto Bc = Reshape(_Bc, Q1D, D1D);
-   auto Bot = Reshape(_Bot, D1D-1, Q1D);
-   auto Bct = Reshape(_Bct, D1D, Q1D);
-   auto op = Reshape(_op, Q1D, Q1D, 3, NE);
-   auto x = Reshape(_x, 2*(D1D-1)*D1D, NE);
+   const auto Bo = Reshape(_Bo, Q1D, D1D-1);
+   const auto Bc = Reshape(_Bc, Q1D, D1D);
+   const auto Bot = Reshape(_Bot, D1D-1, Q1D);
+   const auto Bct = Reshape(_Bct, D1D, Q1D);
+   const auto op = Reshape(_op, Q1D, Q1D, 3, NE);
+   const auto x = Reshape(_x, 2*(D1D-1)*D1D, NE);
    auto y = Reshape(_y, 2*(D1D-1)*D1D, NE);
 
    MFEM_FORALL(e, NE,
@@ -252,9 +251,9 @@ void PAHcurlMassAssembleDiagonal2D(const int D1D,
    constexpr static int VDIM = 2;
    constexpr static int MAX_Q1D = HCURL_MAX_Q1D;
 
-   auto Bo = Reshape(_Bo, Q1D, D1D-1);
-   auto Bc = Reshape(_Bc, Q1D, D1D);
-   auto op = Reshape(_op, Q1D, Q1D, 3, NE);
+   const auto Bo = Reshape(_Bo, Q1D, D1D-1);
+   const auto Bc = Reshape(_Bc, Q1D, D1D);
+   const auto op = Reshape(_op, Q1D, Q1D, 3, NE);
    auto diag = Reshape(_diag, 2*(D1D-1)*D1D, NE);
 
    MFEM_FORALL(e, NE,
@@ -311,9 +310,9 @@ void PAHcurlMassAssembleDiagonal3D(const int D1D,
    MFEM_VERIFY(Q1D <= MAX_Q1D, "Error: Q1D > MAX_Q1D");
    constexpr static int VDIM = 3;
 
-   auto Bo = Reshape(_Bo, Q1D, D1D-1);
-   auto Bc = Reshape(_Bc, Q1D, D1D);
-   auto op = Reshape(_op, Q1D, Q1D, Q1D, 6, NE);
+   const auto Bo = Reshape(_Bo, Q1D, D1D-1);
+   const auto Bc = Reshape(_Bc, Q1D, D1D);
+   const auto op = Reshape(_op, Q1D, Q1D, Q1D, 6, NE);
    auto diag = Reshape(_diag, 3*(D1D-1)*D1D*D1D, NE);
 
    MFEM_FORALL(e, NE,
@@ -384,12 +383,12 @@ void PAHcurlMassApply3D(const int D1D,
    MFEM_VERIFY(Q1D <= MAX_Q1D, "Error: Q1D > MAX_Q1D");
    constexpr static int VDIM = 3;
 
-   auto Bo = Reshape(_Bo, Q1D, D1D-1);
-   auto Bc = Reshape(_Bc, Q1D, D1D);
-   auto Bot = Reshape(_Bot, D1D-1, Q1D);
-   auto Bct = Reshape(_Bct, D1D, Q1D);
-   auto op = Reshape(_op, Q1D, Q1D, Q1D, 6, NE);
-   auto x = Reshape(_x, 3*(D1D-1)*D1D*D1D, NE);
+   const auto Bo = Reshape(_Bo, Q1D, D1D-1);
+   const auto Bc = Reshape(_Bc, Q1D, D1D);
+   const auto Bot = Reshape(_Bot, D1D-1, Q1D);
+   const auto Bct = Reshape(_Bct, D1D, Q1D);
+   const auto op = Reshape(_op, Q1D, Q1D, Q1D, 6, NE);
+   const auto x = Reshape(_x, 3*(D1D-1)*D1D*D1D, NE);
    auto y = Reshape(_y, 3*(D1D-1)*D1D*D1D, NE);
 
    MFEM_FORALL(e, NE,
@@ -566,9 +565,9 @@ static void PACurlCurlSetup2D(const int Q1D,
                               Vector &op)
 {
    const int NQ = Q1D*Q1D;
-   auto W = w.Read();
-   auto J = Reshape(j, NQ, 2, 2, NE);
-   auto coeff = Reshape(_coeff, NQ, NE);
+   const auto W = w.Read();
+   const auto J = Reshape(j, NQ, 2, 2, NE);
+   const auto coeff = Reshape(_coeff, NQ, NE);
    auto y = Reshape(op.Write(), NQ, NE);
    MFEM_FORALL(e, NE,
    {
@@ -594,9 +593,9 @@ static void PACurlCurlSetup3D(const int Q1D,
                               Vector &op)
 {
    const int NQ = Q1D*Q1D*Q1D;
-   auto W = w.Read();
-   auto J = Reshape(j, NQ, 3, 3, NE);
-   auto coeff = Reshape(_coeff, coeffDim, NQ, NE);
+   const auto W = w.Read();
+   const auto J = Reshape(j, NQ, 3, 3, NE);
+   const auto coeff = Reshape(_coeff, coeffDim, NQ, NE);
    auto y = Reshape(op.Write(), NQ, 6, NE);
    MFEM_FORALL(e, NE,
    {
@@ -709,12 +708,12 @@ static void PACurlCurlApply2D(const int D1D,
    constexpr static int MAX_D1D = HCURL_MAX_D1D;
    constexpr static int MAX_Q1D = HCURL_MAX_Q1D;
 
-   auto Bo = Reshape(_Bo, Q1D, D1D-1);
-   auto Bot = Reshape(_Bot, D1D-1, Q1D);
-   auto Gc = Reshape(_Gc, Q1D, D1D);
-   auto Gct = Reshape(_Gct, D1D, Q1D);
-   auto op = Reshape(_op, Q1D, Q1D, NE);
-   auto x = Reshape(_x, 2*(D1D-1)*D1D, NE);
+   const auto Bo = Reshape(_Bo, Q1D, D1D-1);
+   const auto Bot = Reshape(_Bot, D1D-1, Q1D);
+   const auto Gc = Reshape(_Gc, Q1D, D1D);
+   const auto Gct = Reshape(_Gct, D1D, Q1D);
+   const auto op = Reshape(_op, Q1D, Q1D, NE);
+   const auto x = Reshape(_x, 2*(D1D-1)*D1D, NE);
    auto y = Reshape(_y, 2*(D1D-1)*D1D, NE);
 
    MFEM_FORALL(e, NE,
@@ -838,14 +837,14 @@ static void PACurlCurlApply3D(const int D1D,
 
    constexpr static int VDIM = 3;
 
-   auto Bo = Reshape(_Bo, Q1D, D1D-1);
-   auto Bc = Reshape(_Bc, Q1D, D1D);
-   auto Bot = Reshape(_Bot, D1D-1, Q1D);
-   auto Bct = Reshape(_Bct, D1D, Q1D);
-   auto Gc = Reshape(_Gc, Q1D, D1D);
-   auto Gct = Reshape(_Gct, D1D, Q1D);
-   auto op = Reshape(_op, Q1D, Q1D, Q1D, 6, NE);
-   auto x = Reshape(_x, 3*(D1D-1)*D1D*D1D, NE);
+   const auto Bo = Reshape(_Bo, Q1D, D1D-1);
+   const auto Bc = Reshape(_Bc, Q1D, D1D);
+   const auto Bot = Reshape(_Bot, D1D-1, Q1D);
+   const auto Bct = Reshape(_Bct, D1D, Q1D);
+   const auto Gc = Reshape(_Gc, Q1D, D1D);
+   const auto Gct = Reshape(_Gct, D1D, Q1D);
+   const auto op = Reshape(_op, Q1D, Q1D, Q1D, 6, NE);
+   const auto x = Reshape(_x, 3*(D1D-1)*D1D*D1D, NE);
    auto y = Reshape(_y, 3*(D1D-1)*D1D*D1D, NE);
 
    MFEM_FORALL(e, NE,
@@ -1351,9 +1350,9 @@ static void PACurlCurlAssembleDiagonal2D(const int D1D,
    constexpr static int VDIM = 2;
    constexpr static int MAX_Q1D = HCURL_MAX_Q1D;
 
-   auto Bo = Reshape(_Bo, Q1D, D1D-1);
-   auto Gc = Reshape(_Gc, Q1D, D1D);
-   auto op = Reshape(_op, Q1D, Q1D, NE);
+   const auto Bo = Reshape(_Bo, Q1D, D1D-1);
+   const auto Gc = Reshape(_Gc, Q1D, D1D);
+   const auto op = Reshape(_op, Q1D, Q1D, NE);
    auto diag = Reshape(_diag, 2*(D1D-1)*D1D, NE);
 
    MFEM_FORALL(e, NE,
@@ -1409,11 +1408,11 @@ static void PACurlCurlAssembleDiagonal3D(const int D1D,
    MFEM_VERIFY(D1D <= MAX_D1D, "Error: D1D > MAX_D1D");
    MFEM_VERIFY(Q1D <= MAX_Q1D, "Error: Q1D > MAX_Q1D");
 
-   auto Bo = Reshape(_Bo, Q1D, D1D-1);
-   auto Bc = Reshape(_Bc, Q1D, D1D);
-   auto Go = Reshape(_Go, Q1D, D1D-1);
-   auto Gc = Reshape(_Gc, Q1D, D1D);
-   auto op = Reshape(_op, Q1D, Q1D, Q1D, 6, NE);
+   const auto Bo = Reshape(_Bo, Q1D, D1D-1);
+   const auto Bc = Reshape(_Bc, Q1D, D1D);
+   const auto Go = Reshape(_Go, Q1D, D1D-1);
+   const auto Gc = Reshape(_Gc, Q1D, D1D);
+   const auto op = Reshape(_op, Q1D, Q1D, Q1D, 6, NE);
    auto diag = Reshape(_diag, 3*(D1D-1)*D1D*D1D, NE);
 
    MFEM_FORALL(e, NE,
@@ -1633,12 +1632,12 @@ void PAHcurlH1Apply3D(const int D1D,
 
    constexpr static int VDIM = 3;
 
-   auto Bc = Reshape(_Bc, Q1D, D1D);
-   auto Gc = Reshape(_Gc, Q1D, D1D);
-   auto Bot = Reshape(_Bot, D1D-1, Q1D);
-   auto Bct = Reshape(_Bct, D1D, Q1D);
-   auto op = Reshape(_op, Q1D, Q1D, Q1D, 6, NE);
-   auto x = Reshape(_x, D1D, D1D, D1D, NE);
+   const auto Bc = Reshape(_Bc, Q1D, D1D);
+   const auto Gc = Reshape(_Gc, Q1D, D1D);
+   const auto Bot = Reshape(_Bot, D1D-1, Q1D);
+   const auto Bct = Reshape(_Bct, D1D, Q1D);
+   const auto op = Reshape(_op, Q1D, Q1D, Q1D, 6, NE);
+   const auto x = Reshape(_x, D1D, D1D, D1D, NE);
    auto y = Reshape(_y, 3*(D1D-1)*D1D*D1D, NE);
 
    MFEM_FORALL(e, NE,
@@ -1819,12 +1818,12 @@ void PAHcurlH1Apply2D(const int D1D,
    constexpr static int MAX_D1D = HCURL_MAX_D1D;
    constexpr static int MAX_Q1D = HCURL_MAX_Q1D;
 
-   auto Bc = Reshape(_Bc, Q1D, D1D);
-   auto Gc = Reshape(_Gc, Q1D, D1D);
-   auto Bot = Reshape(_Bot, D1D-1, Q1D);
-   auto Bct = Reshape(_Bct, D1D, Q1D);
-   auto op = Reshape(_op, Q1D, Q1D, 3, NE);
-   auto x = Reshape(_x, D1D, D1D, NE);
+   const auto Bc = Reshape(_Bc, Q1D, D1D);
+   const auto Gc = Reshape(_Gc, Q1D, D1D);
+   const auto Bot = Reshape(_Bot, D1D-1, Q1D);
+   const auto Bct = Reshape(_Bct, D1D, Q1D);
+   const auto op = Reshape(_op, Q1D, Q1D, 3, NE);
+   const auto x = Reshape(_x, D1D, D1D, NE);
    auto y = Reshape(_y, 2*(D1D-1)*D1D, NE);
 
    MFEM_FORALL(e, NE,
@@ -1935,8 +1934,8 @@ static void PAHcurlL2Setup3D(const int Q1D,
                              Vector &op)
 {
    const int NQ = Q1D*Q1D*Q1D;
-   auto W = w;
-   auto coeff = Reshape(_coeff, coeffDim, NQ, NE);
+   const auto W = w;
+   const auto coeff = Reshape(_coeff, coeffDim, NQ, NE);
    auto y = Reshape(op.Write(), coeffDim, NQ, NE);
 
    MFEM_FORALL(e, NE,
@@ -2077,13 +2076,13 @@ static void PAHcurlL2Apply3D(const int D1D,
 
    constexpr static int VDIM = 3;
 
-   auto Bo = Reshape(_Bo, Q1D, D1D-1);
-   auto Bc = Reshape(_Bc, Q1D, D1D);
-   auto Bot = Reshape(_Bot, D1D-1, Q1D);
-   auto Bct = Reshape(_Bct, D1D, Q1D);
-   auto Gc = Reshape(_Gc, Q1D, D1D);
-   auto op = Reshape(_op, coeffDim, Q1D, Q1D, Q1D, NE);
-   auto x = Reshape(_x, 3*(D1D-1)*D1D*D1D, NE);
+   const auto Bo = Reshape(_Bo, Q1D, D1D-1);
+   const auto Bc = Reshape(_Bc, Q1D, D1D);
+   const auto Bot = Reshape(_Bot, D1D-1, Q1D);
+   const auto Bct = Reshape(_Bct, D1D, Q1D);
+   const auto Gc = Reshape(_Gc, Q1D, D1D);
+   const auto op = Reshape(_op, coeffDim, Q1D, Q1D, Q1D, NE);
+   const auto x = Reshape(_x, 3*(D1D-1)*D1D*D1D, NE);
    auto y = Reshape(_y, 3*(D1D-1)*D1D*D1D, NE);
 
    MFEM_FORALL(e, NE,
@@ -2418,13 +2417,13 @@ static void PAHcurlHdivApply3D(const int D1D,
 
    constexpr static int VDIM = 3;
 
-   auto Bo = Reshape(_Bo, Q1D, D1D-1);
-   auto Bc = Reshape(_Bc, Q1D, D1D);
-   auto Bot = Reshape(_Bot, D1Dtest-1, Q1D);
-   auto Bct = Reshape(_Bct, D1Dtest, Q1D);
-   auto Gc = Reshape(_Gc, Q1D, D1D);
-   auto op = Reshape(_op, Q1D, Q1D, Q1D, 6, NE);
-   auto x = Reshape(_x, 3*(D1D-1)*D1D*D1D, NE);
+   const auto Bo = Reshape(_Bo, Q1D, D1D-1);
+   const auto Bc = Reshape(_Bc, Q1D, D1D);
+   const auto Bot = Reshape(_Bot, D1Dtest-1, Q1D);
+   const auto Bct = Reshape(_Bct, D1Dtest, Q1D);
+   const auto Gc = Reshape(_Gc, Q1D, D1D);
+   const auto op = Reshape(_op, Q1D, Q1D, Q1D, 6, NE);
+   const auto x = Reshape(_x, 3*(D1D-1)*D1D*D1D, NE);
    auto y = Reshape(_y, 3*(D1Dtest-1)*(D1Dtest-1)*D1D, NE);
 
    MFEM_FORALL(e, NE,
@@ -2875,13 +2874,13 @@ static void PAHcurlL2Apply3DTranspose(const int D1D,
 
    constexpr static int VDIM = 3;
 
-   auto Bo = Reshape(_Bo, Q1D, D1D-1);
-   auto Bc = Reshape(_Bc, Q1D, D1D);
-   auto Bot = Reshape(_Bot, D1D-1, Q1D);
-   auto Bct = Reshape(_Bct, D1D, Q1D);
-   auto Gct = Reshape(_Gct, D1D, Q1D);
-   auto op = Reshape(_op, coeffDim, Q1D, Q1D, Q1D, NE);
-   auto x = Reshape(_x, 3*(D1D-1)*D1D*D1D, NE);
+   const auto Bo = Reshape(_Bo, Q1D, D1D-1);
+   const auto Bc = Reshape(_Bc, Q1D, D1D);
+   const auto Bot = Reshape(_Bot, D1D-1, Q1D);
+   const auto Bct = Reshape(_Bct, D1D, Q1D);
+   const auto Gct = Reshape(_Gct, D1D, Q1D);
+   const auto op = Reshape(_op, coeffDim, Q1D, Q1D, Q1D, NE);
+   const auto x = Reshape(_x, 3*(D1D-1)*D1D*D1D, NE);
    auto y = Reshape(_y, 3*(D1D-1)*D1D*D1D, NE);
 
    MFEM_FORALL(e, NE,

--- a/fem/bilininteg_hcurl.cpp
+++ b/fem/bilininteg_hcurl.cpp
@@ -35,8 +35,8 @@ void PAHcurlSetup2D(const int Q1D,
    const int NQ = Q1D*Q1D;
    auto W = w.Read();
 
-   auto J = Reshape(j.Read(), NQ, 2, 2, NE);
-   auto coeff = Reshape(_coeff.Read(), coeffDim, NQ, NE);
+   auto J = Reshape(j, NQ, 2, 2, NE);
+   auto coeff = Reshape(_coeff, coeffDim, NQ, NE);
    auto y = Reshape(op.Write(), NQ, 3, NE);
 
    MFEM_FORALL(e, NE,
@@ -68,8 +68,8 @@ void PAHcurlSetup3D(const int Q1D,
 {
    const int NQ = Q1D*Q1D*Q1D;
    auto W = w.Read();
-   auto J = Reshape(j.Read(), NQ, 3, 3, NE);
-   auto coeff = Reshape(_coeff.Read(), coeffDim, NQ, NE);
+   auto J = Reshape(j, NQ, 3, 3, NE);
+   auto coeff = Reshape(_coeff, coeffDim, NQ, NE);
    auto y = Reshape(op.Write(), NQ, 6, NE);
 
    MFEM_FORALL(e, NE,
@@ -128,13 +128,13 @@ void PAHcurlMassApply2D(const int D1D,
    constexpr static int MAX_D1D = HCURL_MAX_D1D;
    constexpr static int MAX_Q1D = HCURL_MAX_Q1D;
 
-   auto Bo = Reshape(_Bo.Read(), Q1D, D1D-1);
-   auto Bc = Reshape(_Bc.Read(), Q1D, D1D);
-   auto Bot = Reshape(_Bot.Read(), D1D-1, Q1D);
-   auto Bct = Reshape(_Bct.Read(), D1D, Q1D);
-   auto op = Reshape(_op.Read(), Q1D, Q1D, 3, NE);
-   auto x = Reshape(_x.Read(), 2*(D1D-1)*D1D, NE);
-   auto y = Reshape(_y.ReadWrite(), 2*(D1D-1)*D1D, NE);
+   auto Bo = Reshape(_Bo, Q1D, D1D-1);
+   auto Bc = Reshape(_Bc, Q1D, D1D);
+   auto Bot = Reshape(_Bot, D1D-1, Q1D);
+   auto Bct = Reshape(_Bct, D1D, Q1D);
+   auto op = Reshape(_op, Q1D, Q1D, 3, NE);
+   auto x = Reshape(_x, 2*(D1D-1)*D1D, NE);
+   auto y = Reshape(_y, 2*(D1D-1)*D1D, NE);
 
    MFEM_FORALL(e, NE,
    {
@@ -252,10 +252,10 @@ void PAHcurlMassAssembleDiagonal2D(const int D1D,
    constexpr static int VDIM = 2;
    constexpr static int MAX_Q1D = HCURL_MAX_Q1D;
 
-   auto Bo = Reshape(_Bo.Read(), Q1D, D1D-1);
-   auto Bc = Reshape(_Bc.Read(), Q1D, D1D);
-   auto op = Reshape(_op.Read(), Q1D, Q1D, 3, NE);
-   auto diag = Reshape(_diag.ReadWrite(), 2*(D1D-1)*D1D, NE);
+   auto Bo = Reshape(_Bo, Q1D, D1D-1);
+   auto Bc = Reshape(_Bc, Q1D, D1D);
+   auto op = Reshape(_op, Q1D, Q1D, 3, NE);
+   auto diag = Reshape(_diag, 2*(D1D-1)*D1D, NE);
 
    MFEM_FORALL(e, NE,
    {
@@ -311,10 +311,10 @@ void PAHcurlMassAssembleDiagonal3D(const int D1D,
    MFEM_VERIFY(Q1D <= MAX_Q1D, "Error: Q1D > MAX_Q1D");
    constexpr static int VDIM = 3;
 
-   auto Bo = Reshape(_Bo.Read(), Q1D, D1D-1);
-   auto Bc = Reshape(_Bc.Read(), Q1D, D1D);
-   auto op = Reshape(_op.Read(), Q1D, Q1D, Q1D, 6, NE);
-   auto diag = Reshape(_diag.ReadWrite(), 3*(D1D-1)*D1D*D1D, NE);
+   auto Bo = Reshape(_Bo, Q1D, D1D-1);
+   auto Bc = Reshape(_Bc, Q1D, D1D);
+   auto op = Reshape(_op, Q1D, Q1D, Q1D, 6, NE);
+   auto diag = Reshape(_diag, 3*(D1D-1)*D1D*D1D, NE);
 
    MFEM_FORALL(e, NE,
    {
@@ -384,13 +384,13 @@ void PAHcurlMassApply3D(const int D1D,
    MFEM_VERIFY(Q1D <= MAX_Q1D, "Error: Q1D > MAX_Q1D");
    constexpr static int VDIM = 3;
 
-   auto Bo = Reshape(_Bo.Read(), Q1D, D1D-1);
-   auto Bc = Reshape(_Bc.Read(), Q1D, D1D);
-   auto Bot = Reshape(_Bot.Read(), D1D-1, Q1D);
-   auto Bct = Reshape(_Bct.Read(), D1D, Q1D);
-   auto op = Reshape(_op.Read(), Q1D, Q1D, Q1D, 6, NE);
-   auto x = Reshape(_x.Read(), 3*(D1D-1)*D1D*D1D, NE);
-   auto y = Reshape(_y.ReadWrite(), 3*(D1D-1)*D1D*D1D, NE);
+   auto Bo = Reshape(_Bo, Q1D, D1D-1);
+   auto Bc = Reshape(_Bc, Q1D, D1D);
+   auto Bot = Reshape(_Bot, D1D-1, Q1D);
+   auto Bct = Reshape(_Bct, D1D, Q1D);
+   auto op = Reshape(_op, Q1D, Q1D, Q1D, 6, NE);
+   auto x = Reshape(_x, 3*(D1D-1)*D1D*D1D, NE);
+   auto y = Reshape(_y, 3*(D1D-1)*D1D*D1D, NE);
 
    MFEM_FORALL(e, NE,
    {
@@ -567,8 +567,8 @@ static void PACurlCurlSetup2D(const int Q1D,
 {
    const int NQ = Q1D*Q1D;
    auto W = w.Read();
-   auto J = Reshape(j.Read(), NQ, 2, 2, NE);
-   auto coeff = Reshape(_coeff.Read(), NQ, NE);
+   auto J = Reshape(j, NQ, 2, 2, NE);
+   auto coeff = Reshape(_coeff, NQ, NE);
    auto y = Reshape(op.Write(), NQ, NE);
    MFEM_FORALL(e, NE,
    {
@@ -595,8 +595,8 @@ static void PACurlCurlSetup3D(const int Q1D,
 {
    const int NQ = Q1D*Q1D*Q1D;
    auto W = w.Read();
-   auto J = Reshape(j.Read(), NQ, 3, 3, NE);
-   auto coeff = Reshape(_coeff.Read(), coeffDim, NQ, NE);
+   auto J = Reshape(j, NQ, 3, 3, NE);
+   auto coeff = Reshape(_coeff, coeffDim, NQ, NE);
    auto y = Reshape(op.Write(), NQ, 6, NE);
    MFEM_FORALL(e, NE,
    {
@@ -709,13 +709,13 @@ static void PACurlCurlApply2D(const int D1D,
    constexpr static int MAX_D1D = HCURL_MAX_D1D;
    constexpr static int MAX_Q1D = HCURL_MAX_Q1D;
 
-   auto Bo = Reshape(_Bo.Read(), Q1D, D1D-1);
-   auto Bot = Reshape(_Bot.Read(), D1D-1, Q1D);
-   auto Gc = Reshape(_Gc.Read(), Q1D, D1D);
-   auto Gct = Reshape(_Gct.Read(), D1D, Q1D);
-   auto op = Reshape(_op.Read(), Q1D, Q1D, NE);
-   auto x = Reshape(_x.Read(), 2*(D1D-1)*D1D, NE);
-   auto y = Reshape(_y.ReadWrite(), 2*(D1D-1)*D1D, NE);
+   auto Bo = Reshape(_Bo, Q1D, D1D-1);
+   auto Bot = Reshape(_Bot, D1D-1, Q1D);
+   auto Gc = Reshape(_Gc, Q1D, D1D);
+   auto Gct = Reshape(_Gct, D1D, Q1D);
+   auto op = Reshape(_op, Q1D, Q1D, NE);
+   auto x = Reshape(_x, 2*(D1D-1)*D1D, NE);
+   auto y = Reshape(_y, 2*(D1D-1)*D1D, NE);
 
    MFEM_FORALL(e, NE,
    {
@@ -838,15 +838,15 @@ static void PACurlCurlApply3D(const int D1D,
 
    constexpr static int VDIM = 3;
 
-   auto Bo = Reshape(_Bo.Read(), Q1D, D1D-1);
-   auto Bc = Reshape(_Bc.Read(), Q1D, D1D);
-   auto Bot = Reshape(_Bot.Read(), D1D-1, Q1D);
-   auto Bct = Reshape(_Bct.Read(), D1D, Q1D);
-   auto Gc = Reshape(_Gc.Read(), Q1D, D1D);
-   auto Gct = Reshape(_Gct.Read(), D1D, Q1D);
-   auto op = Reshape(_op.Read(), Q1D, Q1D, Q1D, 6, NE);
-   auto x = Reshape(_x.Read(), 3*(D1D-1)*D1D*D1D, NE);
-   auto y = Reshape(_y.ReadWrite(), 3*(D1D-1)*D1D*D1D, NE);
+   auto Bo = Reshape(_Bo, Q1D, D1D-1);
+   auto Bc = Reshape(_Bc, Q1D, D1D);
+   auto Bot = Reshape(_Bot, D1D-1, Q1D);
+   auto Bct = Reshape(_Bct, D1D, Q1D);
+   auto Gc = Reshape(_Gc, Q1D, D1D);
+   auto Gct = Reshape(_Gct, D1D, Q1D);
+   auto op = Reshape(_op, Q1D, Q1D, Q1D, 6, NE);
+   auto x = Reshape(_x, 3*(D1D-1)*D1D*D1D, NE);
+   auto y = Reshape(_y, 3*(D1D-1)*D1D*D1D, NE);
 
    MFEM_FORALL(e, NE,
    {
@@ -1351,10 +1351,10 @@ static void PACurlCurlAssembleDiagonal2D(const int D1D,
    constexpr static int VDIM = 2;
    constexpr static int MAX_Q1D = HCURL_MAX_Q1D;
 
-   auto Bo = Reshape(_Bo.Read(), Q1D, D1D-1);
-   auto Gc = Reshape(_Gc.Read(), Q1D, D1D);
-   auto op = Reshape(_op.Read(), Q1D, Q1D, NE);
-   auto diag = Reshape(_diag.ReadWrite(), 2*(D1D-1)*D1D, NE);
+   auto Bo = Reshape(_Bo, Q1D, D1D-1);
+   auto Gc = Reshape(_Gc, Q1D, D1D);
+   auto op = Reshape(_op, Q1D, Q1D, NE);
+   auto diag = Reshape(_diag, 2*(D1D-1)*D1D, NE);
 
    MFEM_FORALL(e, NE,
    {
@@ -1409,12 +1409,12 @@ static void PACurlCurlAssembleDiagonal3D(const int D1D,
    MFEM_VERIFY(D1D <= MAX_D1D, "Error: D1D > MAX_D1D");
    MFEM_VERIFY(Q1D <= MAX_Q1D, "Error: Q1D > MAX_Q1D");
 
-   auto Bo = Reshape(_Bo.Read(), Q1D, D1D-1);
-   auto Bc = Reshape(_Bc.Read(), Q1D, D1D);
-   auto Go = Reshape(_Go.Read(), Q1D, D1D-1);
-   auto Gc = Reshape(_Gc.Read(), Q1D, D1D);
-   auto op = Reshape(_op.Read(), Q1D, Q1D, Q1D, 6, NE);
-   auto diag = Reshape(_diag.ReadWrite(), 3*(D1D-1)*D1D*D1D, NE);
+   auto Bo = Reshape(_Bo, Q1D, D1D-1);
+   auto Bc = Reshape(_Bc, Q1D, D1D);
+   auto Go = Reshape(_Go, Q1D, D1D-1);
+   auto Gc = Reshape(_Gc, Q1D, D1D);
+   auto op = Reshape(_op, Q1D, Q1D, Q1D, 6, NE);
+   auto diag = Reshape(_diag, 3*(D1D-1)*D1D*D1D, NE);
 
    MFEM_FORALL(e, NE,
    {
@@ -1633,13 +1633,13 @@ void PAHcurlH1Apply3D(const int D1D,
 
    constexpr static int VDIM = 3;
 
-   auto Bc = Reshape(_Bc.Read(), Q1D, D1D);
-   auto Gc = Reshape(_Gc.Read(), Q1D, D1D);
-   auto Bot = Reshape(_Bot.Read(), D1D-1, Q1D);
-   auto Bct = Reshape(_Bct.Read(), D1D, Q1D);
-   auto op = Reshape(_op.Read(), Q1D, Q1D, Q1D, 6, NE);
-   auto x = Reshape(_x.Read(), D1D, D1D, D1D, NE);
-   auto y = Reshape(_y.ReadWrite(), 3*(D1D-1)*D1D*D1D, NE);
+   auto Bc = Reshape(_Bc, Q1D, D1D);
+   auto Gc = Reshape(_Gc, Q1D, D1D);
+   auto Bot = Reshape(_Bot, D1D-1, Q1D);
+   auto Bct = Reshape(_Bct, D1D, Q1D);
+   auto op = Reshape(_op, Q1D, Q1D, Q1D, 6, NE);
+   auto x = Reshape(_x, D1D, D1D, D1D, NE);
+   auto y = Reshape(_y, 3*(D1D-1)*D1D*D1D, NE);
 
    MFEM_FORALL(e, NE,
    {
@@ -1819,13 +1819,13 @@ void PAHcurlH1Apply2D(const int D1D,
    constexpr static int MAX_D1D = HCURL_MAX_D1D;
    constexpr static int MAX_Q1D = HCURL_MAX_Q1D;
 
-   auto Bc = Reshape(_Bc.Read(), Q1D, D1D);
-   auto Gc = Reshape(_Gc.Read(), Q1D, D1D);
-   auto Bot = Reshape(_Bot.Read(), D1D-1, Q1D);
-   auto Bct = Reshape(_Bct.Read(), D1D, Q1D);
-   auto op = Reshape(_op.Read(), Q1D, Q1D, 3, NE);
-   auto x = Reshape(_x.Read(), D1D, D1D, NE);
-   auto y = Reshape(_y.ReadWrite(), 2*(D1D-1)*D1D, NE);
+   auto Bc = Reshape(_Bc, Q1D, D1D);
+   auto Gc = Reshape(_Gc, Q1D, D1D);
+   auto Bot = Reshape(_Bot, D1D-1, Q1D);
+   auto Bct = Reshape(_Bct, D1D, Q1D);
+   auto op = Reshape(_op, Q1D, Q1D, 3, NE);
+   auto x = Reshape(_x, D1D, D1D, NE);
+   auto y = Reshape(_y, 2*(D1D-1)*D1D, NE);
 
    MFEM_FORALL(e, NE,
    {
@@ -1935,8 +1935,8 @@ static void PAHcurlL2Setup3D(const int Q1D,
                              Vector &op)
 {
    const int NQ = Q1D*Q1D*Q1D;
-   auto W = w.Read();
-   auto coeff = Reshape(_coeff.Read(), coeffDim, NQ, NE);
+   auto W = w;
+   auto coeff = Reshape(_coeff, coeffDim, NQ, NE);
    auto y = Reshape(op.Write(), coeffDim, NQ, NE);
 
    MFEM_FORALL(e, NE,
@@ -2077,14 +2077,14 @@ static void PAHcurlL2Apply3D(const int D1D,
 
    constexpr static int VDIM = 3;
 
-   auto Bo = Reshape(_Bo.Read(), Q1D, D1D-1);
-   auto Bc = Reshape(_Bc.Read(), Q1D, D1D);
-   auto Bot = Reshape(_Bot.Read(), D1D-1, Q1D);
-   auto Bct = Reshape(_Bct.Read(), D1D, Q1D);
-   auto Gc = Reshape(_Gc.Read(), Q1D, D1D);
-   auto op = Reshape(_op.Read(), coeffDim, Q1D, Q1D, Q1D, NE);
-   auto x = Reshape(_x.Read(), 3*(D1D-1)*D1D*D1D, NE);
-   auto y = Reshape(_y.ReadWrite(), 3*(D1D-1)*D1D*D1D, NE);
+   auto Bo = Reshape(_Bo, Q1D, D1D-1);
+   auto Bc = Reshape(_Bc, Q1D, D1D);
+   auto Bot = Reshape(_Bot, D1D-1, Q1D);
+   auto Bct = Reshape(_Bct, D1D, Q1D);
+   auto Gc = Reshape(_Gc, Q1D, D1D);
+   auto op = Reshape(_op, coeffDim, Q1D, Q1D, Q1D, NE);
+   auto x = Reshape(_x, 3*(D1D-1)*D1D*D1D, NE);
+   auto y = Reshape(_y, 3*(D1D-1)*D1D*D1D, NE);
 
    MFEM_FORALL(e, NE,
    {
@@ -2418,14 +2418,14 @@ static void PAHcurlHdivApply3D(const int D1D,
 
    constexpr static int VDIM = 3;
 
-   auto Bo = Reshape(_Bo.Read(), Q1D, D1D-1);
-   auto Bc = Reshape(_Bc.Read(), Q1D, D1D);
-   auto Bot = Reshape(_Bot.Read(), D1Dtest-1, Q1D);
-   auto Bct = Reshape(_Bct.Read(), D1Dtest, Q1D);
-   auto Gc = Reshape(_Gc.Read(), Q1D, D1D);
-   auto op = Reshape(_op.Read(), Q1D, Q1D, Q1D, 6, NE);
-   auto x = Reshape(_x.Read(), 3*(D1D-1)*D1D*D1D, NE);
-   auto y = Reshape(_y.ReadWrite(), 3*(D1Dtest-1)*(D1Dtest-1)*D1D, NE);
+   auto Bo = Reshape(_Bo, Q1D, D1D-1);
+   auto Bc = Reshape(_Bc, Q1D, D1D);
+   auto Bot = Reshape(_Bot, D1Dtest-1, Q1D);
+   auto Bct = Reshape(_Bct, D1Dtest, Q1D);
+   auto Gc = Reshape(_Gc, Q1D, D1D);
+   auto op = Reshape(_op, Q1D, Q1D, Q1D, 6, NE);
+   auto x = Reshape(_x, 3*(D1D-1)*D1D*D1D, NE);
+   auto y = Reshape(_y, 3*(D1Dtest-1)*(D1Dtest-1)*D1D, NE);
 
    MFEM_FORALL(e, NE,
    {
@@ -2875,14 +2875,14 @@ static void PAHcurlL2Apply3DTranspose(const int D1D,
 
    constexpr static int VDIM = 3;
 
-   auto Bo = Reshape(_Bo.Read(), Q1D, D1D-1);
-   auto Bc = Reshape(_Bc.Read(), Q1D, D1D);
-   auto Bot = Reshape(_Bot.Read(), D1D-1, Q1D);
-   auto Bct = Reshape(_Bct.Read(), D1D, Q1D);
-   auto Gct = Reshape(_Gct.Read(), D1D, Q1D);
-   auto op = Reshape(_op.Read(), coeffDim, Q1D, Q1D, Q1D, NE);
-   auto x = Reshape(_x.Read(), 3*(D1D-1)*D1D*D1D, NE);
-   auto y = Reshape(_y.ReadWrite(), 3*(D1D-1)*D1D*D1D, NE);
+   auto Bo = Reshape(_Bo, Q1D, D1D-1);
+   auto Bc = Reshape(_Bc, Q1D, D1D);
+   auto Bot = Reshape(_Bot, D1D-1, Q1D);
+   auto Bct = Reshape(_Bct, D1D, Q1D);
+   auto Gct = Reshape(_Gct, D1D, Q1D);
+   auto op = Reshape(_op, coeffDim, Q1D, Q1D, Q1D, NE);
+   auto x = Reshape(_x, 3*(D1D-1)*D1D*D1D, NE);
+   auto y = Reshape(_y, 3*(D1D-1)*D1D*D1D, NE);
 
    MFEM_FORALL(e, NE,
    {

--- a/fem/bilininteg_hdiv.cpp
+++ b/fem/bilininteg_hdiv.cpp
@@ -37,10 +37,9 @@ void PAHdivSetup2D(const int Q1D,
                    Vector &op)
 {
    const int NQ = Q1D*Q1D;
-   auto W = w.Read();
-
-   auto J = Reshape(j, NQ, 2, 2, NE);
-   auto coeff = Reshape(_coeff, NQ, NE);
+   const auto W = w.Read();
+   const auto J = Reshape(j, NQ, 2, 2, NE);
+   const auto coeff = Reshape(_coeff, NQ, NE);
    auto y = Reshape(op.Write(), NQ, 3, NE);
 
    MFEM_FORALL(e, NE,
@@ -69,9 +68,9 @@ void PAHdivSetup3D(const int Q1D,
                    Vector &op)
 {
    const int NQ = Q1D*Q1D*Q1D;
-   auto W = w.Read();
-   auto J = Reshape(j, NQ, 3, 3, NE);
-   auto coeff = Reshape(_coeff, NQ, NE);
+   const auto W = w.Read();
+   const auto J = Reshape(j, NQ, 3, 3, NE);
+   const auto coeff = Reshape(_coeff, NQ, NE);
    auto y = Reshape(op.Write(), NQ, 6, NE);
 
    MFEM_FORALL(e, NE,
@@ -117,12 +116,12 @@ void PAHdivMassApply2D(const int D1D,
    constexpr static int MAX_D1D = HDIV_MAX_D1D;
    constexpr static int MAX_Q1D = HDIV_MAX_Q1D;
 
-   auto Bo = Reshape(_Bo, Q1D, D1D-1);
-   auto Bc = Reshape(_Bc, Q1D, D1D);
-   auto Bot = Reshape(_Bot, D1D-1, Q1D);
-   auto Bct = Reshape(_Bct, D1D, Q1D);
-   auto op = Reshape(_op, Q1D, Q1D, 3, NE);
-   auto x = Reshape(_x, 2*(D1D-1)*D1D, NE);
+   const auto Bo = Reshape(_Bo, Q1D, D1D-1);
+   const auto Bc = Reshape(_Bc, Q1D, D1D);
+   const auto Bot = Reshape(_Bot, D1D-1, Q1D);
+   const auto Bct = Reshape(_Bct, D1D, Q1D);
+   const auto op = Reshape(_op, Q1D, Q1D, 3, NE);
+   const auto x = Reshape(_x, 2*(D1D-1)*D1D, NE);
    auto y = Reshape(_y, 2*(D1D-1)*D1D, NE);
 
    MFEM_FORALL(e, NE,
@@ -242,9 +241,9 @@ void PAHdivMassAssembleDiagonal2D(const int D1D,
    constexpr static int VDIM = 2;
    constexpr static int MAX_Q1D = HDIV_MAX_Q1D;
 
-   auto Bo = Reshape(_Bo, Q1D, D1D-1);
-   auto Bc = Reshape(_Bc, Q1D, D1D);
-   auto op = Reshape(_op, Q1D, Q1D, 3, NE);
+   const auto Bo = Reshape(_Bo, Q1D, D1D-1);
+   const auto Bc = Reshape(_Bc, Q1D, D1D);
+   const auto op = Reshape(_op, Q1D, Q1D, 3, NE);
    auto diag = Reshape(_diag, 2*(D1D-1)*D1D, NE);
 
    MFEM_FORALL(e, NE,
@@ -298,9 +297,9 @@ void PAHdivMassAssembleDiagonal3D(const int D1D,
    MFEM_VERIFY(Q1D <= HDIV_MAX_Q1D, "Error: Q1D > HDIV_MAX_Q1D");
    constexpr static int VDIM = 3;
 
-   auto Bo = Reshape(_Bo, Q1D, D1D-1);
-   auto Bc = Reshape(_Bc, Q1D, D1D);
-   auto op = Reshape(_op, Q1D, Q1D, Q1D, 6, NE);
+   const auto Bo = Reshape(_Bo, Q1D, D1D-1);
+   const auto Bc = Reshape(_Bc, Q1D, D1D);
+   const auto op = Reshape(_op, Q1D, Q1D, Q1D, 6, NE);
    auto diag = Reshape(_diag, 3*(D1D-1)*(D1D-1)*D1D, NE);
 
    MFEM_FORALL(e, NE,
@@ -368,12 +367,12 @@ void PAHdivMassApply3D(const int D1D,
    MFEM_VERIFY(Q1D <= HDIV_MAX_Q1D, "Error: Q1D > HDIV_MAX_Q1D");
    constexpr static int VDIM = 3;
 
-   auto Bo = Reshape(_Bo, Q1D, D1D-1);
-   auto Bc = Reshape(_Bc, Q1D, D1D);
-   auto Bot = Reshape(_Bot, D1D-1, Q1D);
-   auto Bct = Reshape(_Bct, D1D, Q1D);
-   auto op = Reshape(_op, Q1D, Q1D, Q1D, 6, NE);
-   auto x = Reshape(_x, 3*(D1D-1)*(D1D-1)*D1D, NE);
+   const auto Bo = Reshape(_Bo, Q1D, D1D-1);
+   const auto Bc = Reshape(_Bc, Q1D, D1D);
+   const auto Bot = Reshape(_Bot, D1D-1, Q1D);
+   const auto Bct = Reshape(_Bct, D1D, Q1D);
+   const auto op = Reshape(_op, Q1D, Q1D, Q1D, 6, NE);
+   const auto x = Reshape(_x, 3*(D1D-1)*(D1D-1)*D1D, NE);
    auto y = Reshape(_y, 3*(D1D-1)*(D1D-1)*D1D, NE);
 
    MFEM_FORALL(e, NE,
@@ -553,9 +552,9 @@ static void PADivDivSetup2D(const int Q1D,
                             Vector &op)
 {
    const int NQ = Q1D*Q1D;
-   auto W = w.Read();
-   auto J = Reshape(j, NQ, 2, 2, NE);
-   auto coeff = Reshape(_coeff, NQ, NE);
+   const auto W = w.Read();
+   const auto J = Reshape(j, NQ, 2, 2, NE);
+   const auto coeff = Reshape(_coeff, NQ, NE);
    auto y = Reshape(op.Write(), NQ, NE);
    MFEM_FORALL(e, NE,
    {
@@ -579,9 +578,9 @@ static void PADivDivSetup3D(const int Q1D,
                             Vector &op)
 {
    const int NQ = Q1D*Q1D*Q1D;
-   auto W = w.Read();
-   auto J = Reshape(j, NQ, 3, 3, NE);
-   auto coeff = Reshape(_coeff, NQ, NE);
+   const auto W = w.Read();
+   const auto J = Reshape(j, NQ, 3, 3, NE);
+   const auto coeff = Reshape(_coeff, NQ, NE);
    auto y = Reshape(op.Write(), NQ, NE);
 
    MFEM_FORALL(e, NE,
@@ -620,12 +619,12 @@ static void PADivDivApply2D(const int D1D,
    constexpr static int MAX_D1D = HDIV_MAX_D1D;
    constexpr static int MAX_Q1D = HDIV_MAX_Q1D;
 
-   auto Bo = Reshape(_Bo, Q1D, D1D-1);
-   auto Bot = Reshape(_Bot, D1D-1, Q1D);
-   auto Gc = Reshape(_Gc, Q1D, D1D);
-   auto Gct = Reshape(_Gct, D1D, Q1D);
-   auto op = Reshape(_op, Q1D, Q1D, NE);
-   auto x = Reshape(_x, 2*(D1D-1)*D1D, NE);
+   const auto Bo = Reshape(_Bo, Q1D, D1D-1);
+   const auto Bot = Reshape(_Bot, D1D-1, Q1D);
+   const auto Gc = Reshape(_Gc, Q1D, D1D);
+   const auto Gct = Reshape(_Gct, D1D, Q1D);
+   const auto op = Reshape(_op, Q1D, Q1D, NE);
+   const auto x = Reshape(_x, 2*(D1D-1)*D1D, NE);
    auto y = Reshape(_y, 2*(D1D-1)*D1D, NE);
 
    MFEM_FORALL(e, NE,
@@ -739,12 +738,12 @@ static void PADivDivApply3D(const int D1D,
    MFEM_VERIFY(Q1D <= HDIV_MAX_Q1D, "Error: Q1D > HDIV_MAX_Q1D");
    constexpr static int VDIM = 3;
 
-   auto Bo = Reshape(_Bo, Q1D, D1D-1);
-   auto Gc = Reshape(_Gc, Q1D, D1D);
-   auto Bot = Reshape(_Bot, D1D-1, Q1D);
-   auto Gct = Reshape(_Gct, D1D, Q1D);
-   auto op = Reshape(_op, Q1D, Q1D, Q1D, NE);
-   auto x = Reshape(_x, 3*(D1D-1)*(D1D-1)*D1D, NE);
+   const auto Bo = Reshape(_Bo, Q1D, D1D-1);
+   const auto Gc = Reshape(_Gc, Q1D, D1D);
+   const auto Bot = Reshape(_Bot, D1D-1, Q1D);
+   const auto Gct = Reshape(_Gct, D1D, Q1D);
+   const auto op = Reshape(_op, Q1D, Q1D, Q1D, NE);
+   const auto x = Reshape(_x, 3*(D1D-1)*(D1D-1)*D1D, NE);
    auto y = Reshape(_y, 3*(D1D-1)*(D1D-1)*D1D, NE);
 
    MFEM_FORALL(e, NE,
@@ -984,9 +983,9 @@ static void PADivDivAssembleDiagonal2D(const int D1D,
    constexpr static int VDIM = 2;
    constexpr static int MAX_Q1D = HDIV_MAX_Q1D;
 
-   auto Bo = Reshape(_Bo, Q1D, D1D-1);
-   auto Gc = Reshape(_Gc, Q1D, D1D);
-   auto op = Reshape(_op, Q1D, Q1D, NE);
+   const auto Bo = Reshape(_Bo, Q1D, D1D-1);
+   const auto Gc = Reshape(_Gc, Q1D, D1D);
+   const auto op = Reshape(_op, Q1D, Q1D, NE);
    auto diag = Reshape(_diag, 2*(D1D-1)*D1D, NE);
 
    MFEM_FORALL(e, NE,
@@ -1041,9 +1040,9 @@ static void PADivDivAssembleDiagonal3D(const int D1D,
    MFEM_VERIFY(Q1D <= HDIV_MAX_Q1D, "Error: Q1D > HDIV_MAX_Q1D");
    constexpr static int VDIM = 3;
 
-   auto Bo = Reshape(_Bo, Q1D, D1D-1);
-   auto Gc = Reshape(_Gc, Q1D, D1D);
-   auto op = Reshape(_op, Q1D, Q1D, Q1D, NE);
+   const auto Bo = Reshape(_Bo, Q1D, D1D-1);
+   const auto Gc = Reshape(_Gc, Q1D, D1D);
+   const auto op = Reshape(_op, Q1D, Q1D, Q1D, NE);
    auto diag = Reshape(_diag, 3*(D1D-1)*(D1D-1)*D1D, NE);
 
    MFEM_FORALL(e, NE,
@@ -1117,8 +1116,8 @@ static void PADivL2Setup2D(const int Q1D,
                            Vector &op)
 {
    const int NQ = Q1D*Q1D;
-   auto W = w.Read();
-   auto coeff = Reshape(_coeff, NQ, NE);
+   const auto W = w.Read();
+   const auto coeff = Reshape(_coeff, NQ, NE);
    auto y = Reshape(op.Write(), NQ, NE);
    MFEM_FORALL(e, NE,
    {
@@ -1136,8 +1135,8 @@ static void PADivL2Setup3D(const int Q1D,
                            Vector &op)
 {
    const int NQ = Q1D*Q1D*Q1D;
-   auto W = w.Read();
-   auto coeff = Reshape(_coeff, NQ, NE);
+   const auto W = w.Read();
+   const auto coeff = Reshape(_coeff, NQ, NE);
    auto y = Reshape(op.Write(), NQ, NE);
 
    MFEM_FORALL(e, NE,
@@ -1246,11 +1245,11 @@ static void PAHdivL2Apply3D(const int D1D,
    MFEM_VERIFY(Q1D <= HDIV_MAX_Q1D, "Error: Q1D > HDIV_MAX_Q1D");
    constexpr static int VDIM = 3;
 
-   auto Bo = Reshape(_Bo, Q1D, D1D-1);
-   auto Gc = Reshape(_Gc, Q1D, D1D);
-   auto L2Bot = Reshape(_L2Bot, L2D1D, Q1D);
-   auto op = Reshape(_op, Q1D, Q1D, Q1D, NE);
-   auto x = Reshape(_x, 3*(D1D-1)*(D1D-1)*D1D, NE);
+   const auto Bo = Reshape(_Bo, Q1D, D1D-1);
+   const auto Gc = Reshape(_Gc, Q1D, D1D);
+   const auto L2Bot = Reshape(_L2Bot, L2D1D, Q1D);
+   const auto op = Reshape(_op, Q1D, Q1D, Q1D, NE);
+   const auto x = Reshape(_x, 3*(D1D-1)*(D1D-1)*D1D, NE);
    auto y = Reshape(_y, L2D1D, L2D1D, L2D1D, NE);
 
    MFEM_FORALL(e, NE,
@@ -1409,11 +1408,11 @@ static void PAHdivL2Apply2D(const int D1D,
    constexpr static int MAX_D1D = HDIV_MAX_D1D;
    constexpr static int MAX_Q1D = HDIV_MAX_Q1D;
 
-   auto Bo = Reshape(_Bo, Q1D, D1D-1);
-   auto Gc = Reshape(_Gc, Q1D, D1D);
-   auto L2Bot = Reshape(_L2Bot, L2D1D, Q1D);
-   auto op = Reshape(_op, Q1D, Q1D, NE);
-   auto x = Reshape(_x, 2*(D1D-1)*D1D, NE);
+   const auto Bo = Reshape(_Bo, Q1D, D1D-1);
+   const auto Gc = Reshape(_Gc, Q1D, D1D);
+   const auto L2Bot = Reshape(_L2Bot, L2D1D, Q1D);
+   const auto op = Reshape(_op, Q1D, Q1D, NE);
+   const auto x = Reshape(_x, 2*(D1D-1)*D1D, NE);
    auto y = Reshape(_y, L2D1D, L2D1D, NE);
 
    MFEM_FORALL(e, NE,
@@ -1515,11 +1514,11 @@ static void PAHdivL2ApplyTranspose3D(const int D1D,
    MFEM_VERIFY(Q1D <= HDIV_MAX_Q1D, "Error: Q1D > HDIV_MAX_Q1D");
    constexpr static int VDIM = 3;
 
-   auto L2Bo = Reshape(_L2Bo, Q1D, L2D1D);
-   auto Gct = Reshape(_Gct, D1D, Q1D);
-   auto Bot = Reshape(_Bot, D1D-1, Q1D);
-   auto op = Reshape(_op, Q1D, Q1D, Q1D, NE);
-   auto x = Reshape(_x, L2D1D, L2D1D, L2D1D, NE);
+   const auto L2Bo = Reshape(_L2Bo, Q1D, L2D1D);
+   const auto Gct = Reshape(_Gct, D1D, Q1D);
+   const auto Bot = Reshape(_Bot, D1D-1, Q1D);
+   const auto op = Reshape(_op, Q1D, Q1D, Q1D, NE);
+   const auto x = Reshape(_x, L2D1D, L2D1D, L2D1D, NE);
    auto y = Reshape(_y, 3*(D1D-1)*(D1D-1)*D1D, NE);
 
    MFEM_FORALL(e, NE,
@@ -1677,11 +1676,11 @@ static void PAHdivL2ApplyTranspose2D(const int D1D,
    constexpr static int MAX_D1D = HDIV_MAX_D1D;
    constexpr static int MAX_Q1D = HDIV_MAX_Q1D;
 
-   auto L2Bo = Reshape(_L2Bo, Q1D, L2D1D);
-   auto Gct = Reshape(_Gct, D1D, Q1D);
-   auto Bot = Reshape(_Bot, D1D-1, Q1D);
-   auto op = Reshape(_op, Q1D, Q1D, NE);
-   auto x = Reshape(_x, L2D1D, L2D1D, NE);
+   const auto L2Bo = Reshape(_L2Bo, Q1D, L2D1D);
+   const auto Gct = Reshape(_Gct, D1D, Q1D);
+   const auto Bot = Reshape(_Bot, D1D-1, Q1D);
+   const auto op = Reshape(_op, Q1D, Q1D, NE);
+   const auto x = Reshape(_x, L2D1D, L2D1D, NE);
    auto y = Reshape(_y, 2*(D1D-1)*D1D, NE);
 
    MFEM_FORALL(e, NE,
@@ -1812,11 +1811,11 @@ static void PAHdivL2AssembleDiagonal_ADAt_3D(const int D1D,
    MFEM_VERIFY(Q1D <= HDIV_MAX_Q1D, "Error: Q1D > HDIV_MAX_Q1D");
    constexpr static int VDIM = 3;
 
-   auto L2Bo = Reshape(_L2Bo, Q1D, L2D1D);
-   auto Gct = Reshape(_Gct, D1D, Q1D);
-   auto Bot = Reshape(_Bot, D1D-1, Q1D);
-   auto op = Reshape(_op, Q1D, Q1D, Q1D, NE);
-   auto D = Reshape(_D, 3*(D1D-1)*(D1D-1)*D1D, NE);
+   const auto L2Bo = Reshape(_L2Bo, Q1D, L2D1D);
+   const auto Gct = Reshape(_Gct, D1D, Q1D);
+   const auto Bot = Reshape(_Bot, D1D-1, Q1D);
+   const auto op = Reshape(_op, Q1D, Q1D, Q1D, NE);
+   const auto D = Reshape(_D, 3*(D1D-1)*(D1D-1)*D1D, NE);
    auto diag = Reshape(_diag, L2D1D, L2D1D, L2D1D, NE);
 
    MFEM_FORALL(e, NE,
@@ -1935,11 +1934,11 @@ static void PAHdivL2AssembleDiagonal_ADAt_2D(const int D1D,
 {
    constexpr static int VDIM = 2;
 
-   auto L2Bo = Reshape(_L2Bo, Q1D, L2D1D);
-   auto Gct = Reshape(_Gct, D1D, Q1D);
-   auto Bot = Reshape(_Bot, D1D-1, Q1D);
-   auto op = Reshape(_op, Q1D, Q1D, NE);
-   auto D = Reshape(_D, 2*(D1D-1)*D1D, NE);
+   const auto L2Bo = Reshape(_L2Bo, Q1D, L2D1D);
+   const auto Gct = Reshape(_Gct, D1D, Q1D);
+   const auto Bot = Reshape(_Bot, D1D-1, Q1D);
+   const auto op = Reshape(_op, Q1D, Q1D, NE);
+   const auto D = Reshape(_D, 2*(D1D-1)*D1D, NE);
    auto diag = Reshape(_diag, L2D1D, L2D1D, NE);
 
    MFEM_FORALL(e, NE,

--- a/fem/bilininteg_hdiv.cpp
+++ b/fem/bilininteg_hdiv.cpp
@@ -39,8 +39,8 @@ void PAHdivSetup2D(const int Q1D,
    const int NQ = Q1D*Q1D;
    auto W = w.Read();
 
-   auto J = Reshape(j.Read(), NQ, 2, 2, NE);
-   auto coeff = Reshape(_coeff.Read(), NQ, NE);
+   auto J = Reshape(j, NQ, 2, 2, NE);
+   auto coeff = Reshape(_coeff, NQ, NE);
    auto y = Reshape(op.Write(), NQ, 3, NE);
 
    MFEM_FORALL(e, NE,
@@ -70,8 +70,8 @@ void PAHdivSetup3D(const int Q1D,
 {
    const int NQ = Q1D*Q1D*Q1D;
    auto W = w.Read();
-   auto J = Reshape(j.Read(), NQ, 3, 3, NE);
-   auto coeff = Reshape(_coeff.Read(), NQ, NE);
+   auto J = Reshape(j, NQ, 3, 3, NE);
+   auto coeff = Reshape(_coeff, NQ, NE);
    auto y = Reshape(op.Write(), NQ, 6, NE);
 
    MFEM_FORALL(e, NE,
@@ -117,13 +117,13 @@ void PAHdivMassApply2D(const int D1D,
    constexpr static int MAX_D1D = HDIV_MAX_D1D;
    constexpr static int MAX_Q1D = HDIV_MAX_Q1D;
 
-   auto Bo = Reshape(_Bo.Read(), Q1D, D1D-1);
-   auto Bc = Reshape(_Bc.Read(), Q1D, D1D);
-   auto Bot = Reshape(_Bot.Read(), D1D-1, Q1D);
-   auto Bct = Reshape(_Bct.Read(), D1D, Q1D);
-   auto op = Reshape(_op.Read(), Q1D, Q1D, 3, NE);
-   auto x = Reshape(_x.Read(), 2*(D1D-1)*D1D, NE);
-   auto y = Reshape(_y.ReadWrite(), 2*(D1D-1)*D1D, NE);
+   auto Bo = Reshape(_Bo, Q1D, D1D-1);
+   auto Bc = Reshape(_Bc, Q1D, D1D);
+   auto Bot = Reshape(_Bot, D1D-1, Q1D);
+   auto Bct = Reshape(_Bct, D1D, Q1D);
+   auto op = Reshape(_op, Q1D, Q1D, 3, NE);
+   auto x = Reshape(_x, 2*(D1D-1)*D1D, NE);
+   auto y = Reshape(_y, 2*(D1D-1)*D1D, NE);
 
    MFEM_FORALL(e, NE,
    {
@@ -242,10 +242,10 @@ void PAHdivMassAssembleDiagonal2D(const int D1D,
    constexpr static int VDIM = 2;
    constexpr static int MAX_Q1D = HDIV_MAX_Q1D;
 
-   auto Bo = Reshape(_Bo.Read(), Q1D, D1D-1);
-   auto Bc = Reshape(_Bc.Read(), Q1D, D1D);
-   auto op = Reshape(_op.Read(), Q1D, Q1D, 3, NE);
-   auto diag = Reshape(_diag.ReadWrite(), 2*(D1D-1)*D1D, NE);
+   auto Bo = Reshape(_Bo, Q1D, D1D-1);
+   auto Bc = Reshape(_Bc, Q1D, D1D);
+   auto op = Reshape(_op, Q1D, Q1D, 3, NE);
+   auto diag = Reshape(_diag, 2*(D1D-1)*D1D, NE);
 
    MFEM_FORALL(e, NE,
    {
@@ -298,10 +298,10 @@ void PAHdivMassAssembleDiagonal3D(const int D1D,
    MFEM_VERIFY(Q1D <= HDIV_MAX_Q1D, "Error: Q1D > HDIV_MAX_Q1D");
    constexpr static int VDIM = 3;
 
-   auto Bo = Reshape(_Bo.Read(), Q1D, D1D-1);
-   auto Bc = Reshape(_Bc.Read(), Q1D, D1D);
-   auto op = Reshape(_op.Read(), Q1D, Q1D, Q1D, 6, NE);
-   auto diag = Reshape(_diag.ReadWrite(), 3*(D1D-1)*(D1D-1)*D1D, NE);
+   auto Bo = Reshape(_Bo, Q1D, D1D-1);
+   auto Bc = Reshape(_Bc, Q1D, D1D);
+   auto op = Reshape(_op, Q1D, Q1D, Q1D, 6, NE);
+   auto diag = Reshape(_diag, 3*(D1D-1)*(D1D-1)*D1D, NE);
 
    MFEM_FORALL(e, NE,
    {
@@ -368,13 +368,13 @@ void PAHdivMassApply3D(const int D1D,
    MFEM_VERIFY(Q1D <= HDIV_MAX_Q1D, "Error: Q1D > HDIV_MAX_Q1D");
    constexpr static int VDIM = 3;
 
-   auto Bo = Reshape(_Bo.Read(), Q1D, D1D-1);
-   auto Bc = Reshape(_Bc.Read(), Q1D, D1D);
-   auto Bot = Reshape(_Bot.Read(), D1D-1, Q1D);
-   auto Bct = Reshape(_Bct.Read(), D1D, Q1D);
-   auto op = Reshape(_op.Read(), Q1D, Q1D, Q1D, 6, NE);
-   auto x = Reshape(_x.Read(), 3*(D1D-1)*(D1D-1)*D1D, NE);
-   auto y = Reshape(_y.ReadWrite(), 3*(D1D-1)*(D1D-1)*D1D, NE);
+   auto Bo = Reshape(_Bo, Q1D, D1D-1);
+   auto Bc = Reshape(_Bc, Q1D, D1D);
+   auto Bot = Reshape(_Bot, D1D-1, Q1D);
+   auto Bct = Reshape(_Bct, D1D, Q1D);
+   auto op = Reshape(_op, Q1D, Q1D, Q1D, 6, NE);
+   auto x = Reshape(_x, 3*(D1D-1)*(D1D-1)*D1D, NE);
+   auto y = Reshape(_y, 3*(D1D-1)*(D1D-1)*D1D, NE);
 
    MFEM_FORALL(e, NE,
    {
@@ -554,8 +554,8 @@ static void PADivDivSetup2D(const int Q1D,
 {
    const int NQ = Q1D*Q1D;
    auto W = w.Read();
-   auto J = Reshape(j.Read(), NQ, 2, 2, NE);
-   auto coeff = Reshape(_coeff.Read(), NQ, NE);
+   auto J = Reshape(j, NQ, 2, 2, NE);
+   auto coeff = Reshape(_coeff, NQ, NE);
    auto y = Reshape(op.Write(), NQ, NE);
    MFEM_FORALL(e, NE,
    {
@@ -580,8 +580,8 @@ static void PADivDivSetup3D(const int Q1D,
 {
    const int NQ = Q1D*Q1D*Q1D;
    auto W = w.Read();
-   auto J = Reshape(j.Read(), NQ, 3, 3, NE);
-   auto coeff = Reshape(_coeff.Read(), NQ, NE);
+   auto J = Reshape(j, NQ, 3, 3, NE);
+   auto coeff = Reshape(_coeff, NQ, NE);
    auto y = Reshape(op.Write(), NQ, NE);
 
    MFEM_FORALL(e, NE,
@@ -620,13 +620,13 @@ static void PADivDivApply2D(const int D1D,
    constexpr static int MAX_D1D = HDIV_MAX_D1D;
    constexpr static int MAX_Q1D = HDIV_MAX_Q1D;
 
-   auto Bo = Reshape(_Bo.Read(), Q1D, D1D-1);
-   auto Bot = Reshape(_Bot.Read(), D1D-1, Q1D);
-   auto Gc = Reshape(_Gc.Read(), Q1D, D1D);
-   auto Gct = Reshape(_Gct.Read(), D1D, Q1D);
-   auto op = Reshape(_op.Read(), Q1D, Q1D, NE);
-   auto x = Reshape(_x.Read(), 2*(D1D-1)*D1D, NE);
-   auto y = Reshape(_y.ReadWrite(), 2*(D1D-1)*D1D, NE);
+   auto Bo = Reshape(_Bo, Q1D, D1D-1);
+   auto Bot = Reshape(_Bot, D1D-1, Q1D);
+   auto Gc = Reshape(_Gc, Q1D, D1D);
+   auto Gct = Reshape(_Gct, D1D, Q1D);
+   auto op = Reshape(_op, Q1D, Q1D, NE);
+   auto x = Reshape(_x, 2*(D1D-1)*D1D, NE);
+   auto y = Reshape(_y, 2*(D1D-1)*D1D, NE);
 
    MFEM_FORALL(e, NE,
    {
@@ -739,13 +739,13 @@ static void PADivDivApply3D(const int D1D,
    MFEM_VERIFY(Q1D <= HDIV_MAX_Q1D, "Error: Q1D > HDIV_MAX_Q1D");
    constexpr static int VDIM = 3;
 
-   auto Bo = Reshape(_Bo.Read(), Q1D, D1D-1);
-   auto Gc = Reshape(_Gc.Read(), Q1D, D1D);
-   auto Bot = Reshape(_Bot.Read(), D1D-1, Q1D);
-   auto Gct = Reshape(_Gct.Read(), D1D, Q1D);
-   auto op = Reshape(_op.Read(), Q1D, Q1D, Q1D, NE);
-   auto x = Reshape(_x.Read(), 3*(D1D-1)*(D1D-1)*D1D, NE);
-   auto y = Reshape(_y.ReadWrite(), 3*(D1D-1)*(D1D-1)*D1D, NE);
+   auto Bo = Reshape(_Bo, Q1D, D1D-1);
+   auto Gc = Reshape(_Gc, Q1D, D1D);
+   auto Bot = Reshape(_Bot, D1D-1, Q1D);
+   auto Gct = Reshape(_Gct, D1D, Q1D);
+   auto op = Reshape(_op, Q1D, Q1D, Q1D, NE);
+   auto x = Reshape(_x, 3*(D1D-1)*(D1D-1)*D1D, NE);
+   auto y = Reshape(_y, 3*(D1D-1)*(D1D-1)*D1D, NE);
 
    MFEM_FORALL(e, NE,
    {
@@ -984,10 +984,10 @@ static void PADivDivAssembleDiagonal2D(const int D1D,
    constexpr static int VDIM = 2;
    constexpr static int MAX_Q1D = HDIV_MAX_Q1D;
 
-   auto Bo = Reshape(_Bo.Read(), Q1D, D1D-1);
-   auto Gc = Reshape(_Gc.Read(), Q1D, D1D);
-   auto op = Reshape(_op.Read(), Q1D, Q1D, NE);
-   auto diag = Reshape(_diag.ReadWrite(), 2*(D1D-1)*D1D, NE);
+   auto Bo = Reshape(_Bo, Q1D, D1D-1);
+   auto Gc = Reshape(_Gc, Q1D, D1D);
+   auto op = Reshape(_op, Q1D, Q1D, NE);
+   auto diag = Reshape(_diag, 2*(D1D-1)*D1D, NE);
 
    MFEM_FORALL(e, NE,
    {
@@ -1041,10 +1041,10 @@ static void PADivDivAssembleDiagonal3D(const int D1D,
    MFEM_VERIFY(Q1D <= HDIV_MAX_Q1D, "Error: Q1D > HDIV_MAX_Q1D");
    constexpr static int VDIM = 3;
 
-   auto Bo = Reshape(_Bo.Read(), Q1D, D1D-1);
-   auto Gc = Reshape(_Gc.Read(), Q1D, D1D);
-   auto op = Reshape(_op.Read(), Q1D, Q1D, Q1D, NE);
-   auto diag = Reshape(_diag.ReadWrite(), 3*(D1D-1)*(D1D-1)*D1D, NE);
+   auto Bo = Reshape(_Bo, Q1D, D1D-1);
+   auto Gc = Reshape(_Gc, Q1D, D1D);
+   auto op = Reshape(_op, Q1D, Q1D, Q1D, NE);
+   auto diag = Reshape(_diag, 3*(D1D-1)*(D1D-1)*D1D, NE);
 
    MFEM_FORALL(e, NE,
    {
@@ -1118,7 +1118,7 @@ static void PADivL2Setup2D(const int Q1D,
 {
    const int NQ = Q1D*Q1D;
    auto W = w.Read();
-   auto coeff = Reshape(_coeff.Read(), NQ, NE);
+   auto coeff = Reshape(_coeff, NQ, NE);
    auto y = Reshape(op.Write(), NQ, NE);
    MFEM_FORALL(e, NE,
    {
@@ -1137,7 +1137,7 @@ static void PADivL2Setup3D(const int Q1D,
 {
    const int NQ = Q1D*Q1D*Q1D;
    auto W = w.Read();
-   auto coeff = Reshape(_coeff.Read(), NQ, NE);
+   auto coeff = Reshape(_coeff, NQ, NE);
    auto y = Reshape(op.Write(), NQ, NE);
 
    MFEM_FORALL(e, NE,
@@ -1246,12 +1246,12 @@ static void PAHdivL2Apply3D(const int D1D,
    MFEM_VERIFY(Q1D <= HDIV_MAX_Q1D, "Error: Q1D > HDIV_MAX_Q1D");
    constexpr static int VDIM = 3;
 
-   auto Bo = Reshape(_Bo.Read(), Q1D, D1D-1);
-   auto Gc = Reshape(_Gc.Read(), Q1D, D1D);
-   auto L2Bot = Reshape(_L2Bot.Read(), L2D1D, Q1D);
-   auto op = Reshape(_op.Read(), Q1D, Q1D, Q1D, NE);
-   auto x = Reshape(_x.Read(), 3*(D1D-1)*(D1D-1)*D1D, NE);
-   auto y = Reshape(_y.ReadWrite(), L2D1D, L2D1D, L2D1D, NE);
+   auto Bo = Reshape(_Bo, Q1D, D1D-1);
+   auto Gc = Reshape(_Gc, Q1D, D1D);
+   auto L2Bot = Reshape(_L2Bot, L2D1D, Q1D);
+   auto op = Reshape(_op, Q1D, Q1D, Q1D, NE);
+   auto x = Reshape(_x, 3*(D1D-1)*(D1D-1)*D1D, NE);
+   auto y = Reshape(_y, L2D1D, L2D1D, L2D1D, NE);
 
    MFEM_FORALL(e, NE,
    {
@@ -1409,12 +1409,12 @@ static void PAHdivL2Apply2D(const int D1D,
    constexpr static int MAX_D1D = HDIV_MAX_D1D;
    constexpr static int MAX_Q1D = HDIV_MAX_Q1D;
 
-   auto Bo = Reshape(_Bo.Read(), Q1D, D1D-1);
-   auto Gc = Reshape(_Gc.Read(), Q1D, D1D);
-   auto L2Bot = Reshape(_L2Bot.Read(), L2D1D, Q1D);
-   auto op = Reshape(_op.Read(), Q1D, Q1D, NE);
-   auto x = Reshape(_x.Read(), 2*(D1D-1)*D1D, NE);
-   auto y = Reshape(_y.ReadWrite(), L2D1D, L2D1D, NE);
+   auto Bo = Reshape(_Bo, Q1D, D1D-1);
+   auto Gc = Reshape(_Gc, Q1D, D1D);
+   auto L2Bot = Reshape(_L2Bot, L2D1D, Q1D);
+   auto op = Reshape(_op, Q1D, Q1D, NE);
+   auto x = Reshape(_x, 2*(D1D-1)*D1D, NE);
+   auto y = Reshape(_y, L2D1D, L2D1D, NE);
 
    MFEM_FORALL(e, NE,
    {
@@ -1515,12 +1515,12 @@ static void PAHdivL2ApplyTranspose3D(const int D1D,
    MFEM_VERIFY(Q1D <= HDIV_MAX_Q1D, "Error: Q1D > HDIV_MAX_Q1D");
    constexpr static int VDIM = 3;
 
-   auto L2Bo = Reshape(_L2Bo.Read(), Q1D, L2D1D);
-   auto Gct = Reshape(_Gct.Read(), D1D, Q1D);
-   auto Bot = Reshape(_Bot.Read(), D1D-1, Q1D);
-   auto op = Reshape(_op.Read(), Q1D, Q1D, Q1D, NE);
-   auto x = Reshape(_x.Read(), L2D1D, L2D1D, L2D1D, NE);
-   auto y = Reshape(_y.ReadWrite(), 3*(D1D-1)*(D1D-1)*D1D, NE);
+   auto L2Bo = Reshape(_L2Bo, Q1D, L2D1D);
+   auto Gct = Reshape(_Gct, D1D, Q1D);
+   auto Bot = Reshape(_Bot, D1D-1, Q1D);
+   auto op = Reshape(_op, Q1D, Q1D, Q1D, NE);
+   auto x = Reshape(_x, L2D1D, L2D1D, L2D1D, NE);
+   auto y = Reshape(_y, 3*(D1D-1)*(D1D-1)*D1D, NE);
 
    MFEM_FORALL(e, NE,
    {
@@ -1677,12 +1677,12 @@ static void PAHdivL2ApplyTranspose2D(const int D1D,
    constexpr static int MAX_D1D = HDIV_MAX_D1D;
    constexpr static int MAX_Q1D = HDIV_MAX_Q1D;
 
-   auto L2Bo = Reshape(_L2Bo.Read(), Q1D, L2D1D);
-   auto Gct = Reshape(_Gct.Read(), D1D, Q1D);
-   auto Bot = Reshape(_Bot.Read(), D1D-1, Q1D);
-   auto op = Reshape(_op.Read(), Q1D, Q1D, NE);
-   auto x = Reshape(_x.Read(), L2D1D, L2D1D, NE);
-   auto y = Reshape(_y.ReadWrite(), 2*(D1D-1)*D1D, NE);
+   auto L2Bo = Reshape(_L2Bo, Q1D, L2D1D);
+   auto Gct = Reshape(_Gct, D1D, Q1D);
+   auto Bot = Reshape(_Bot, D1D-1, Q1D);
+   auto op = Reshape(_op, Q1D, Q1D, NE);
+   auto x = Reshape(_x, L2D1D, L2D1D, NE);
+   auto y = Reshape(_y, 2*(D1D-1)*D1D, NE);
 
    MFEM_FORALL(e, NE,
    {
@@ -1812,12 +1812,12 @@ static void PAHdivL2AssembleDiagonal_ADAt_3D(const int D1D,
    MFEM_VERIFY(Q1D <= HDIV_MAX_Q1D, "Error: Q1D > HDIV_MAX_Q1D");
    constexpr static int VDIM = 3;
 
-   auto L2Bo = Reshape(_L2Bo.Read(), Q1D, L2D1D);
-   auto Gct = Reshape(_Gct.Read(), D1D, Q1D);
-   auto Bot = Reshape(_Bot.Read(), D1D-1, Q1D);
-   auto op = Reshape(_op.Read(), Q1D, Q1D, Q1D, NE);
-   auto D = Reshape(_D.Read(), 3*(D1D-1)*(D1D-1)*D1D, NE);
-   auto diag = Reshape(_diag.ReadWrite(), L2D1D, L2D1D, L2D1D, NE);
+   auto L2Bo = Reshape(_L2Bo, Q1D, L2D1D);
+   auto Gct = Reshape(_Gct, D1D, Q1D);
+   auto Bot = Reshape(_Bot, D1D-1, Q1D);
+   auto op = Reshape(_op, Q1D, Q1D, Q1D, NE);
+   auto D = Reshape(_D, 3*(D1D-1)*(D1D-1)*D1D, NE);
+   auto diag = Reshape(_diag, L2D1D, L2D1D, L2D1D, NE);
 
    MFEM_FORALL(e, NE,
    {
@@ -1935,12 +1935,12 @@ static void PAHdivL2AssembleDiagonal_ADAt_2D(const int D1D,
 {
    constexpr static int VDIM = 2;
 
-   auto L2Bo = Reshape(_L2Bo.Read(), Q1D, L2D1D);
-   auto Gct = Reshape(_Gct.Read(), D1D, Q1D);
-   auto Bot = Reshape(_Bot.Read(), D1D-1, Q1D);
-   auto op = Reshape(_op.Read(), Q1D, Q1D, NE);
-   auto D = Reshape(_D.Read(), 2*(D1D-1)*D1D, NE);
-   auto diag = Reshape(_diag.ReadWrite(), L2D1D, L2D1D, NE);
+   auto L2Bo = Reshape(_L2Bo, Q1D, L2D1D);
+   auto Gct = Reshape(_Gct, D1D, Q1D);
+   auto Bot = Reshape(_Bot, D1D-1, Q1D);
+   auto op = Reshape(_op, Q1D, Q1D, NE);
+   auto D = Reshape(_D, 2*(D1D-1)*D1D, NE);
+   auto diag = Reshape(_diag, L2D1D, L2D1D, NE);
 
    MFEM_FORALL(e, NE,
    {

--- a/fem/bilininteg_mass_ea.cpp
+++ b/fem/bilininteg_mass_ea.cpp
@@ -28,8 +28,8 @@ static void EAMassAssemble1D(const int NE,
    const int Q1D = T_Q1D ? T_Q1D : q1d;
    MFEM_VERIFY(D1D <= MAX_D1D, "");
    MFEM_VERIFY(Q1D <= MAX_Q1D, "");
-   auto B = Reshape(basis, Q1D, D1D);
-   auto D = Reshape(padata, Q1D, NE);
+   const auto B = Reshape(basis, Q1D, D1D);
+   const auto D = Reshape(padata, Q1D, NE);
    auto M = Reshape(eadata, D1D, D1D, NE);
    MFEM_FORALL_3D(e, NE, D1D, D1D, 1,
    {
@@ -70,8 +70,8 @@ static void EAMassAssemble2D(const int NE,
    const int Q1D = T_Q1D ? T_Q1D : q1d;
    MFEM_VERIFY(D1D <= MAX_D1D, "");
    MFEM_VERIFY(Q1D <= MAX_Q1D, "");
-   auto B = Reshape(basis, Q1D, D1D);
-   auto D = Reshape(padata, Q1D, Q1D, NE);
+   const auto B = Reshape(basis, Q1D, D1D);
+   const auto D = Reshape(padata, Q1D, Q1D, NE);
    auto M = Reshape(eadata, D1D, D1D, D1D, D1D, NE);
    MFEM_FORALL_3D(e, NE, D1D, D1D, 1,
    {
@@ -134,8 +134,8 @@ static void EAMassAssemble3D(const int NE,
    const int Q1D = T_Q1D ? T_Q1D : q1d;
    MFEM_VERIFY(D1D <= MAX_D1D, "");
    MFEM_VERIFY(Q1D <= MAX_Q1D, "");
-   auto B = Reshape(basis, Q1D, D1D);
-   auto D = Reshape(padata, Q1D, Q1D, Q1D, NE);
+   const auto B = Reshape(basis, Q1D, D1D);
+   const auto D = Reshape(padata, Q1D, Q1D, Q1D, NE);
    auto M = Reshape(eadata, D1D, D1D, D1D, D1D, D1D, D1D, NE);
    MFEM_FORALL_3D(e, NE, D1D, D1D, D1D,
    {

--- a/fem/bilininteg_mass_ea.cpp
+++ b/fem/bilininteg_mass_ea.cpp
@@ -28,9 +28,9 @@ static void EAMassAssemble1D(const int NE,
    const int Q1D = T_Q1D ? T_Q1D : q1d;
    MFEM_VERIFY(D1D <= MAX_D1D, "");
    MFEM_VERIFY(Q1D <= MAX_Q1D, "");
-   auto B = Reshape(basis.Read(), Q1D, D1D);
-   auto D = Reshape(padata.Read(), Q1D, NE);
-   auto M = Reshape(eadata.ReadWrite(), D1D, D1D, NE);
+   auto B = Reshape(basis, Q1D, D1D);
+   auto D = Reshape(padata, Q1D, NE);
+   auto M = Reshape(eadata, D1D, D1D, NE);
    MFEM_FORALL_3D(e, NE, D1D, D1D, 1,
    {
       const int D1D = T_D1D ? T_D1D : d1d;
@@ -70,9 +70,9 @@ static void EAMassAssemble2D(const int NE,
    const int Q1D = T_Q1D ? T_Q1D : q1d;
    MFEM_VERIFY(D1D <= MAX_D1D, "");
    MFEM_VERIFY(Q1D <= MAX_Q1D, "");
-   auto B = Reshape(basis.Read(), Q1D, D1D);
-   auto D = Reshape(padata.Read(), Q1D, Q1D, NE);
-   auto M = Reshape(eadata.ReadWrite(), D1D, D1D, D1D, D1D, NE);
+   auto B = Reshape(basis, Q1D, D1D);
+   auto D = Reshape(padata, Q1D, Q1D, NE);
+   auto M = Reshape(eadata, D1D, D1D, D1D, D1D, NE);
    MFEM_FORALL_3D(e, NE, D1D, D1D, 1,
    {
       const int D1D = T_D1D ? T_D1D : d1d;
@@ -134,9 +134,9 @@ static void EAMassAssemble3D(const int NE,
    const int Q1D = T_Q1D ? T_Q1D : q1d;
    MFEM_VERIFY(D1D <= MAX_D1D, "");
    MFEM_VERIFY(Q1D <= MAX_Q1D, "");
-   auto B = Reshape(basis.Read(), Q1D, D1D);
-   auto D = Reshape(padata.Read(), Q1D, Q1D, Q1D, NE);
-   auto M = Reshape(eadata.ReadWrite(), D1D, D1D, D1D, D1D, D1D, D1D, NE);
+   auto B = Reshape(basis, Q1D, D1D);
+   auto D = Reshape(padata, Q1D, Q1D, Q1D, NE);
+   auto M = Reshape(eadata, D1D, D1D, D1D, D1D, D1D, D1D, NE);
    MFEM_FORALL_3D(e, NE, D1D, D1D, D1D,
    {
       const int D1D = T_D1D ? T_D1D : d1d;

--- a/fem/bilininteg_mass_pa.cpp
+++ b/fem/bilininteg_mass_pa.cpp
@@ -83,9 +83,9 @@ void MassIntegrator::SetupPA(const FiniteElementSpace &fes, const bool force)
       const int NE = ne;
       const int NQ = nq;
       const bool const_c = coeff.Size() == 1;
-      auto w = ir->GetWeights().Read();
-      auto J = Reshape(geom->J.Read(), NQ,2,2,NE);
-      auto C =
+      const auto w = ir->GetWeights().Read();
+      const auto J = Reshape(geom->J.Read(), NQ,2,2,NE);
+      const auto C =
          const_c ? Reshape(coeff.Read(), 1,1) : Reshape(coeff.Read(), NQ,NE);
       auto v = Reshape(pa_data.Write(), NQ, NE);
       MFEM_FORALL(e, NE,
@@ -107,9 +107,9 @@ void MassIntegrator::SetupPA(const FiniteElementSpace &fes, const bool force)
       const int NE = ne;
       const int NQ = nq;
       const bool const_c = coeff.Size() == 1;
-      auto W = ir->GetWeights().Read();
-      auto J = Reshape(geom->J.Read(), NQ,3,3,NE);
-      auto C =
+      const auto W = ir->GetWeights().Read();
+      const auto J = Reshape(geom->J.Read(), NQ,3,3,NE);
+      const auto C =
          const_c ? Reshape(coeff.Read(), 1,1) : Reshape(coeff.Read(), NQ,NE);
       auto v = Reshape(pa_data.Write(), NQ,NE);
       MFEM_FORALL(e, NE,
@@ -147,8 +147,8 @@ static void PAMassAssembleDiagonal2D(const int NE,
    const int Q1D = T_Q1D ? T_Q1D : q1d;
    MFEM_VERIFY(D1D <= MAX_D1D, "");
    MFEM_VERIFY(Q1D <= MAX_Q1D, "");
-   auto B = Reshape(b, Q1D, D1D);
-   auto D = Reshape(d, Q1D, Q1D, NE);
+   const auto B = Reshape(b, Q1D, D1D);
+   const auto D = Reshape(d, Q1D, Q1D, NE);
    auto Y = Reshape(y, D1D, D1D, NE);
    MFEM_FORALL(e, NE,
    {
@@ -196,8 +196,8 @@ static void SmemPAMassAssembleDiagonal2D(const int NE,
    constexpr int MD1 = T_D1D ? T_D1D : MAX_D1D;
    MFEM_VERIFY(D1D <= MD1, "");
    MFEM_VERIFY(Q1D <= MQ1, "");
-   auto b = Reshape(b_, Q1D, D1D);
-   auto D = Reshape(d_, Q1D, Q1D, NE);
+   const auto b = Reshape(b_, Q1D, D1D);
+   const auto D = Reshape(d_, Q1D, Q1D, NE);
    auto Y = Reshape(y_, D1D, D1D, NE);
    MFEM_FORALL_2D(e, NE, Q1D, Q1D, NBZ,
    {
@@ -259,8 +259,8 @@ static void PAMassAssembleDiagonal3D(const int NE,
    const int Q1D = T_Q1D ? T_Q1D : q1d;
    MFEM_VERIFY(D1D <= MAX_D1D, "");
    MFEM_VERIFY(Q1D <= MAX_Q1D, "");
-   auto B = Reshape(b, Q1D, D1D);
-   auto D = Reshape(d, Q1D, Q1D, Q1D, NE);
+   const auto B = Reshape(b, Q1D, D1D);
+   const auto D = Reshape(d, Q1D, Q1D, Q1D, NE);
    auto Y = Reshape(y, D1D, D1D, D1D, NE);
    MFEM_FORALL(e, NE,
    {
@@ -330,8 +330,8 @@ static void SmemPAMassAssembleDiagonal3D(const int NE,
    constexpr int MD1 = T_D1D ? T_D1D : MAX_D1D;
    MFEM_VERIFY(D1D <= MD1, "");
    MFEM_VERIFY(Q1D <= MQ1, "");
-   auto b = Reshape(b_, Q1D, D1D);
-   auto D = Reshape(d_, Q1D, Q1D, Q1D, NE);
+   const auto b = Reshape(b_, Q1D, D1D);
+   const auto D = Reshape(d_, Q1D, Q1D, Q1D, NE);
    auto Y = Reshape(y_, D1D, D1D, D1D, NE);
    MFEM_FORALL_3D(e, NE, Q1D, Q1D, Q1D,
    {
@@ -553,10 +553,10 @@ static void PAMassApply2D(const int NE,
    const int Q1D = T_Q1D ? T_Q1D : q1d;
    MFEM_VERIFY(D1D <= MAX_D1D, "");
    MFEM_VERIFY(Q1D <= MAX_Q1D, "");
-   auto B = Reshape(b_, Q1D, D1D);
-   auto Bt = Reshape(bt_, D1D, Q1D);
-   auto D = Reshape(d_, Q1D, Q1D, NE);
-   auto X = Reshape(x_, D1D, D1D, NE);
+   const auto B = Reshape(b_, Q1D, D1D);
+   const auto Bt = Reshape(bt_, D1D, Q1D);
+   const auto D = Reshape(d_, Q1D, Q1D, NE);
+   const auto X = Reshape(x_, D1D, D1D, NE);
    auto Y = Reshape(y_, D1D, D1D, NE);
    MFEM_FORALL(e, NE,
    {
@@ -649,9 +649,9 @@ static void SmemPAMassApply2D(const int NE,
    constexpr int MD1 = T_D1D ? T_D1D : MAX_D1D;
    MFEM_VERIFY(D1D <= MD1, "");
    MFEM_VERIFY(Q1D <= MQ1, "");
-   auto b = Reshape(b_, Q1D, D1D);
-   auto D = Reshape(d_, Q1D, Q1D, NE);
-   auto x = Reshape(x_, D1D, D1D, NE);
+   const auto b = Reshape(b_, Q1D, D1D);
+   const auto D = Reshape(d_, Q1D, Q1D, NE);
+   const auto x = Reshape(x_, D1D, D1D, NE);
    auto Y = Reshape(y_, D1D, D1D, NE);
    MFEM_FORALL_2D(e, NE, Q1D, Q1D, NBZ,
    {
@@ -768,10 +768,10 @@ static void PAMassApply3D(const int NE,
    const int Q1D = T_Q1D ? T_Q1D : q1d;
    MFEM_VERIFY(D1D <= MAX_D1D, "");
    MFEM_VERIFY(Q1D <= MAX_Q1D, "");
-   auto B = Reshape(b_, Q1D, D1D);
-   auto Bt = Reshape(bt_, D1D, Q1D);
-   auto D = Reshape(d_, Q1D, Q1D, Q1D, NE);
-   auto X = Reshape(x_, D1D, D1D, D1D, NE);
+   const auto B = Reshape(b_, Q1D, D1D);
+   const auto Bt = Reshape(bt_, D1D, Q1D);
+   const auto D = Reshape(d_, Q1D, Q1D, Q1D, NE);
+   const auto X = Reshape(x_, D1D, D1D, D1D, NE);
    auto Y = Reshape(y_, D1D, D1D, D1D, NE);
    MFEM_FORALL(e, NE,
    {
@@ -912,9 +912,9 @@ static void SmemPAMassApply3D(const int NE,
    constexpr int M1D = T_D1D ? T_D1D : MAX_D1D;
    MFEM_VERIFY(D1D <= M1D, "");
    MFEM_VERIFY(Q1D <= M1Q, "");
-   auto b = Reshape(b_, Q1D, D1D);
-   auto d = Reshape(d_, Q1D, Q1D, Q1D, NE);
-   auto x = Reshape(x_, D1D, D1D, D1D, NE);
+   const auto b = Reshape(b_, Q1D, D1D);
+   const auto d = Reshape(d_, Q1D, Q1D, Q1D, NE);
+   const auto x = Reshape(x_, D1D, D1D, D1D, NE);
    auto y = Reshape(y_, D1D, D1D, D1D, NE);
    MFEM_FORALL_3D(e, NE, Q1D, Q1D, 1,
    {

--- a/fem/bilininteg_mass_pa.cpp
+++ b/fem/bilininteg_mass_pa.cpp
@@ -145,9 +145,9 @@ static void PAMassAssembleDiagonal2D(const int NE,
    const int Q1D = T_Q1D ? T_Q1D : q1d;
    MFEM_VERIFY(D1D <= MAX_D1D, "");
    MFEM_VERIFY(Q1D <= MAX_Q1D, "");
-   auto B = Reshape(b.Read(), Q1D, D1D);
-   auto D = Reshape(d.Read(), Q1D, Q1D, NE);
-   auto Y = Reshape(y.ReadWrite(), D1D, D1D, NE);
+   auto B = Reshape(b, Q1D, D1D);
+   auto D = Reshape(d, Q1D, Q1D, NE);
+   auto Y = Reshape(y, D1D, D1D, NE);
    MFEM_FORALL(e, NE,
    {
       const int D1D = T_D1D ? T_D1D : d1d;
@@ -194,9 +194,9 @@ static void SmemPAMassAssembleDiagonal2D(const int NE,
    constexpr int MD1 = T_D1D ? T_D1D : MAX_D1D;
    MFEM_VERIFY(D1D <= MD1, "");
    MFEM_VERIFY(Q1D <= MQ1, "");
-   auto b = Reshape(b_.Read(), Q1D, D1D);
-   auto D = Reshape(d_.Read(), Q1D, Q1D, NE);
-   auto Y = Reshape(y_.ReadWrite(), D1D, D1D, NE);
+   auto b = Reshape(b_, Q1D, D1D);
+   auto D = Reshape(d_, Q1D, Q1D, NE);
+   auto Y = Reshape(y_, D1D, D1D, NE);
    MFEM_FORALL_2D(e, NE, Q1D, Q1D, NBZ,
    {
       const int tidz = MFEM_THREAD_ID(z);
@@ -257,9 +257,9 @@ static void PAMassAssembleDiagonal3D(const int NE,
    const int Q1D = T_Q1D ? T_Q1D : q1d;
    MFEM_VERIFY(D1D <= MAX_D1D, "");
    MFEM_VERIFY(Q1D <= MAX_Q1D, "");
-   auto B = Reshape(b.Read(), Q1D, D1D);
-   auto D = Reshape(d.Read(), Q1D, Q1D, Q1D, NE);
-   auto Y = Reshape(y.ReadWrite(), D1D, D1D, D1D, NE);
+   auto B = Reshape(b, Q1D, D1D);
+   auto D = Reshape(d, Q1D, Q1D, Q1D, NE);
+   auto Y = Reshape(y, D1D, D1D, D1D, NE);
    MFEM_FORALL(e, NE,
    {
       const int D1D = T_D1D ? T_D1D : d1d;
@@ -328,9 +328,9 @@ static void SmemPAMassAssembleDiagonal3D(const int NE,
    constexpr int MD1 = T_D1D ? T_D1D : MAX_D1D;
    MFEM_VERIFY(D1D <= MD1, "");
    MFEM_VERIFY(Q1D <= MQ1, "");
-   auto b = Reshape(b_.Read(), Q1D, D1D);
-   auto D = Reshape(d_.Read(), Q1D, Q1D, Q1D, NE);
-   auto Y = Reshape(y_.ReadWrite(), D1D, D1D, D1D, NE);
+   auto b = Reshape(b_, Q1D, D1D);
+   auto D = Reshape(d_, Q1D, Q1D, Q1D, NE);
+   auto Y = Reshape(y_, D1D, D1D, D1D, NE);
    MFEM_FORALL_3D(e, NE, Q1D, Q1D, Q1D,
    {
       const int tidz = MFEM_THREAD_ID(z);
@@ -551,11 +551,11 @@ static void PAMassApply2D(const int NE,
    const int Q1D = T_Q1D ? T_Q1D : q1d;
    MFEM_VERIFY(D1D <= MAX_D1D, "");
    MFEM_VERIFY(Q1D <= MAX_Q1D, "");
-   auto B = Reshape(b_.Read(), Q1D, D1D);
-   auto Bt = Reshape(bt_.Read(), D1D, Q1D);
-   auto D = Reshape(d_.Read(), Q1D, Q1D, NE);
-   auto X = Reshape(x_.Read(), D1D, D1D, NE);
-   auto Y = Reshape(y_.ReadWrite(), D1D, D1D, NE);
+   auto B = Reshape(b_, Q1D, D1D);
+   auto Bt = Reshape(bt_, D1D, Q1D);
+   auto D = Reshape(d_, Q1D, Q1D, NE);
+   auto X = Reshape(x_, D1D, D1D, NE);
+   auto Y = Reshape(y_, D1D, D1D, NE);
    MFEM_FORALL(e, NE,
    {
       const int D1D = T_D1D ? T_D1D : d1d; // nvcc workaround
@@ -646,10 +646,10 @@ static void SmemPAMassApply2D(const int NE,
    constexpr int MD1 = T_D1D ? T_D1D : MAX_D1D;
    MFEM_VERIFY(D1D <= MD1, "");
    MFEM_VERIFY(Q1D <= MQ1, "");
-   auto b = Reshape(b_.Read(), Q1D, D1D);
-   auto D = Reshape(d_.Read(), Q1D, Q1D, NE);
-   auto x = Reshape(x_.Read(), D1D, D1D, NE);
-   auto Y = Reshape(y_.ReadWrite(), D1D, D1D, NE);
+   auto b = Reshape(b_, Q1D, D1D);
+   auto D = Reshape(d_, Q1D, Q1D, NE);
+   auto x = Reshape(x_, D1D, D1D, NE);
+   auto Y = Reshape(y_, D1D, D1D, NE);
    MFEM_FORALL_2D(e, NE, Q1D, Q1D, NBZ,
    {
       const int tidz = MFEM_THREAD_ID(z);
@@ -765,11 +765,11 @@ static void PAMassApply3D(const int NE,
    const int Q1D = T_Q1D ? T_Q1D : q1d;
    MFEM_VERIFY(D1D <= MAX_D1D, "");
    MFEM_VERIFY(Q1D <= MAX_Q1D, "");
-   auto B = Reshape(b_.Read(), Q1D, D1D);
-   auto Bt = Reshape(bt_.Read(), D1D, Q1D);
-   auto D = Reshape(d_.Read(), Q1D, Q1D, Q1D, NE);
-   auto X = Reshape(x_.Read(), D1D, D1D, D1D, NE);
-   auto Y = Reshape(y_.ReadWrite(), D1D, D1D, D1D, NE);
+   auto B = Reshape(b_, Q1D, D1D);
+   auto Bt = Reshape(bt_, D1D, Q1D);
+   auto D = Reshape(d_, Q1D, Q1D, Q1D, NE);
+   auto X = Reshape(x_, D1D, D1D, D1D, NE);
+   auto Y = Reshape(y_, D1D, D1D, D1D, NE);
    MFEM_FORALL(e, NE,
    {
       const int D1D = T_D1D ? T_D1D : d1d;
@@ -908,10 +908,10 @@ static void SmemPAMassApply3D(const int NE,
    constexpr int M1D = T_D1D ? T_D1D : MAX_D1D;
    MFEM_VERIFY(D1D <= M1D, "");
    MFEM_VERIFY(Q1D <= M1Q, "");
-   auto b = Reshape(b_.Read(), Q1D, D1D);
-   auto d = Reshape(d_.Read(), Q1D, Q1D, Q1D, NE);
-   auto x = Reshape(x_.Read(), D1D, D1D, D1D, NE);
-   auto y = Reshape(y_.ReadWrite(), D1D, D1D, D1D, NE);
+   auto b = Reshape(b_, Q1D, D1D);
+   auto d = Reshape(d_, Q1D, Q1D, Q1D, NE);
+   auto x = Reshape(x_, D1D, D1D, D1D, NE);
+   auto y = Reshape(y_, D1D, D1D, D1D, NE);
    MFEM_FORALL_3D(e, NE, Q1D, Q1D, 1,
    {
       const int D1D = T_D1D ? T_D1D : d1d;

--- a/fem/bilininteg_transpose_ea.cpp
+++ b/fem/bilininteg_transpose_ea.cpp
@@ -24,8 +24,8 @@ void TransposeIntegrator::AssembleEA(const FiniteElementSpace &fes,
    const int ne = fes.GetNE();
    if (ne == 0) { return; }
    const int dofs = fes.GetFE(0)->GetDof();
-   auto A = Reshape(ea_data_tmp.Write(), dofs, dofs, ne);
-   auto AT = Reshape(ea_data.ReadWrite(), dofs, dofs, ne);
+   auto A = Reshape(ea_data_tmp.Read(), dofs, dofs, ne);
+   auto AT = Reshape(ea_data, dofs, dofs, ne);
    MFEM_FORALL(e, ne,
    {
       for (int i = 0; i < dofs; i++)
@@ -54,8 +54,8 @@ void TransposeIntegrator::AssembleEAInteriorFaces(const FiniteElementSpace& fes,
                                             fes.GetMesh()->GetFaceBaseGeometry(0))->GetDof();
    auto A_int = Reshape(ea_data_int_tmp.Read(), faceDofs, faceDofs, 2, nf);
    auto A_ext = Reshape(ea_data_ext_tmp.Read(), faceDofs, faceDofs, 2, nf);
-   auto AT_int = Reshape(ea_data_int.ReadWrite(), faceDofs, faceDofs, 2, nf);
-   auto AT_ext = Reshape(ea_data_ext.ReadWrite(), faceDofs, faceDofs, 2, nf);
+   auto AT_int = Reshape(ea_data_int, faceDofs, faceDofs, 2, nf);
+   auto AT_ext = Reshape(ea_data_ext, faceDofs, faceDofs, 2, nf);
    MFEM_FORALL(f, nf,
    {
       for (int i = 0; i < faceDofs; i++)
@@ -86,7 +86,7 @@ void TransposeIntegrator::AssembleEABoundaryFaces(const FiniteElementSpace& fes,
    const int faceDofs = fes.GetTraceElement(0,
                                             fes.GetMesh()->GetFaceBaseGeometry(0))->GetDof();
    auto A_bdr = Reshape(ea_data_bdr_tmp.Read(), faceDofs, faceDofs, nf);
-   auto AT_bdr = Reshape(ea_data_bdr.ReadWrite(), faceDofs, faceDofs, nf);
+   auto AT_bdr = Reshape(ea_data_bdr, faceDofs, faceDofs, nf);
    MFEM_FORALL(f, nf,
    {
       for (int i = 0; i < faceDofs; i++)

--- a/fem/bilininteg_transpose_ea.cpp
+++ b/fem/bilininteg_transpose_ea.cpp
@@ -24,7 +24,7 @@ void TransposeIntegrator::AssembleEA(const FiniteElementSpace &fes,
    const int ne = fes.GetNE();
    if (ne == 0) { return; }
    const int dofs = fes.GetFE(0)->GetDof();
-   auto A = Reshape(ea_data_tmp.Read(), dofs, dofs, ne);
+   const auto A = Reshape(ea_data_tmp.Read(), dofs, dofs, ne);
    auto AT = Reshape(ea_data, dofs, dofs, ne);
    MFEM_FORALL(e, ne,
    {
@@ -52,8 +52,8 @@ void TransposeIntegrator::AssembleEAInteriorFaces(const FiniteElementSpace& fes,
    bfi->AssembleEAInteriorFaces(fes, ea_data_int_tmp, ea_data_ext_tmp);
    const int faceDofs = fes.GetTraceElement(0,
                                             fes.GetMesh()->GetFaceBaseGeometry(0))->GetDof();
-   auto A_int = Reshape(ea_data_int_tmp.Read(), faceDofs, faceDofs, 2, nf);
-   auto A_ext = Reshape(ea_data_ext_tmp.Read(), faceDofs, faceDofs, 2, nf);
+   const auto A_int = Reshape(ea_data_int_tmp.Read(), faceDofs, faceDofs, 2, nf);
+   const auto A_ext = Reshape(ea_data_ext_tmp.Read(), faceDofs, faceDofs, 2, nf);
    auto AT_int = Reshape(ea_data_int, faceDofs, faceDofs, 2, nf);
    auto AT_ext = Reshape(ea_data_ext, faceDofs, faceDofs, 2, nf);
    MFEM_FORALL(f, nf,
@@ -85,7 +85,7 @@ void TransposeIntegrator::AssembleEABoundaryFaces(const FiniteElementSpace& fes,
    bfi->AssembleEABoundaryFaces(fes, ea_data_bdr_tmp);
    const int faceDofs = fes.GetTraceElement(0,
                                             fes.GetMesh()->GetFaceBaseGeometry(0))->GetDof();
-   auto A_bdr = Reshape(ea_data_bdr_tmp.Read(), faceDofs, faceDofs, nf);
+   const auto A_bdr = Reshape(ea_data_bdr_tmp.Read(), faceDofs, faceDofs, nf);
    auto AT_bdr = Reshape(ea_data_bdr, faceDofs, faceDofs, nf);
    MFEM_FORALL(f, nf,
    {

--- a/fem/bilininteg_vecdiffusion.cpp
+++ b/fem/bilininteg_vecdiffusion.cpp
@@ -29,9 +29,8 @@ static void PAVectorDiffusionSetup2D(const int Q1D,
                                      Vector &op)
 {
    const int NQ = Q1D*Q1D;
-   auto W = w.Read();
-
-   auto J = Reshape(j, NQ, 2, 2, NE);
+   const auto W = w.Read();
+   const auto J = Reshape(j, NQ, 2, 2, NE);
    auto y = Reshape(op.Write(), NQ, 3, NE);
 
    MFEM_FORALL(e, NE,
@@ -59,8 +58,8 @@ static void PAVectorDiffusionSetup3D(const int Q1D,
                                      Vector &op)
 {
    const int NQ = Q1D*Q1D*Q1D;
-   auto W = w.Read();
-   auto J = Reshape(j, NQ, 3, 3, NE);
+   const auto W = w.Read();
+   const auto J = Reshape(j, NQ, 3, 3, NE);
    auto y = Reshape(op.Write(), NQ, 6, NE);
    MFEM_FORALL(e, NE,
    {
@@ -156,8 +155,8 @@ void VectorDiffusionIntegrator::AssemblePA(const FiniteElementSpace &fes)
       constexpr int DIM = 2;
       constexpr int SDIM = 3;
       const int NQ = quad1D*quad1D;
-      auto W = w.Read();
-      auto J = Reshape(j, NQ, SDIM, DIM, ne);
+      const auto W = w.Read();
+      const auto J = Reshape(j, NQ, SDIM, DIM, ne);
       auto D = Reshape(d.Write(), NQ, SDIM, ne);
       MFEM_FORALL(e, ne,
       {
@@ -206,12 +205,12 @@ void PAVectorDiffusionApply2D(const int NE,
    const int VDIM = T_VDIM ? T_VDIM : vdim;
    MFEM_VERIFY(D1D <= MAX_D1D, "");
    MFEM_VERIFY(Q1D <= MAX_Q1D, "");
-   auto B = Reshape(b, Q1D, D1D);
-   auto G = Reshape(g, Q1D, D1D);
-   auto Bt = Reshape(bt, D1D, Q1D);
-   auto Gt = Reshape(gt, D1D, Q1D);
-   auto D = Reshape(d_, Q1D*Q1D, 3, NE);
-   auto x = Reshape(x_, D1D, D1D, VDIM, NE);
+   const auto B = Reshape(b, Q1D, D1D);
+   const auto G = Reshape(g, Q1D, D1D);
+   const auto Bt = Reshape(bt, D1D, Q1D);
+   const auto Gt = Reshape(gt, D1D, Q1D);
+   const auto D = Reshape(d_, Q1D*Q1D, 3, NE);
+   const auto x = Reshape(x_, D1D, D1D, VDIM, NE);
    auto y = Reshape(y_, D1D, D1D, VDIM, NE);
    MFEM_FORALL(e, NE,
    {
@@ -327,12 +326,12 @@ void PAVectorDiffusionApply3D(const int NE,
    constexpr int VDIM = 3;
    MFEM_VERIFY(D1D <= MAX_D1D, "");
    MFEM_VERIFY(Q1D <= MAX_Q1D, "");
-   auto B = Reshape(b, Q1D, D1D);
-   auto G = Reshape(g, Q1D, D1D);
-   auto Bt = Reshape(bt, D1D, Q1D);
-   auto Gt = Reshape(gt, D1D, Q1D);
-   auto op = Reshape(_op, Q1D*Q1D*Q1D, 6, NE);
-   auto x = Reshape(_x, D1D, D1D, D1D, VDIM, NE);
+   const auto B = Reshape(b, Q1D, D1D);
+   const auto G = Reshape(g, Q1D, D1D);
+   const auto Bt = Reshape(bt, D1D, Q1D);
+   const auto Gt = Reshape(gt, D1D, Q1D);
+   const auto op = Reshape(_op, Q1D*Q1D*Q1D, 6, NE);
+   const auto x = Reshape(_x, D1D, D1D, D1D, VDIM, NE);
    auto y = Reshape(_y, D1D, D1D, D1D, VDIM, NE);
    MFEM_FORALL(e, NE,
    {
@@ -618,9 +617,9 @@ static void PAVectorDiffusionDiagonal3D(const int NE,
    constexpr int MD1 = T_D1D ? T_D1D : MAX_D1D;
    MFEM_VERIFY(D1D <= MD1, "");
    MFEM_VERIFY(Q1D <= MQ1, "");
-   auto B = Reshape(b, Q1D, D1D);
-   auto G = Reshape(g, Q1D, D1D);
-   auto Q = Reshape(d, Q1D*Q1D*Q1D, 6, NE);
+   const auto B = Reshape(b, Q1D, D1D);
+   const auto G = Reshape(g, Q1D, D1D);
+   const auto Q = Reshape(d, Q1D*Q1D*Q1D, 6, NE);
    auto Y = Reshape(y, D1D, D1D, D1D, 3, NE);
    MFEM_FORALL(e, NE,
    {

--- a/fem/bilininteg_vecdiffusion.cpp
+++ b/fem/bilininteg_vecdiffusion.cpp
@@ -31,7 +31,7 @@ static void PAVectorDiffusionSetup2D(const int Q1D,
    const int NQ = Q1D*Q1D;
    auto W = w.Read();
 
-   auto J = Reshape(j.Read(), NQ, 2, 2, NE);
+   auto J = Reshape(j, NQ, 2, 2, NE);
    auto y = Reshape(op.Write(), NQ, 3, NE);
 
    MFEM_FORALL(e, NE,
@@ -60,7 +60,7 @@ static void PAVectorDiffusionSetup3D(const int Q1D,
 {
    const int NQ = Q1D*Q1D*Q1D;
    auto W = w.Read();
-   auto J = Reshape(j.Read(), NQ, 3, 3, NE);
+   auto J = Reshape(j, NQ, 3, 3, NE);
    auto y = Reshape(op.Write(), NQ, 6, NE);
    MFEM_FORALL(e, NE,
    {
@@ -157,7 +157,7 @@ void VectorDiffusionIntegrator::AssemblePA(const FiniteElementSpace &fes)
       constexpr int SDIM = 3;
       const int NQ = quad1D*quad1D;
       auto W = w.Read();
-      auto J = Reshape(j.Read(), NQ, SDIM, DIM, ne);
+      auto J = Reshape(j, NQ, SDIM, DIM, ne);
       auto D = Reshape(d.Write(), NQ, SDIM, ne);
       MFEM_FORALL(e, ne,
       {
@@ -206,13 +206,13 @@ void PAVectorDiffusionApply2D(const int NE,
    const int VDIM = T_VDIM ? T_VDIM : vdim;
    MFEM_VERIFY(D1D <= MAX_D1D, "");
    MFEM_VERIFY(Q1D <= MAX_Q1D, "");
-   auto B = Reshape(b.Read(), Q1D, D1D);
-   auto G = Reshape(g.Read(), Q1D, D1D);
-   auto Bt = Reshape(bt.Read(), D1D, Q1D);
-   auto Gt = Reshape(gt.Read(), D1D, Q1D);
-   auto D = Reshape(d_.Read(), Q1D*Q1D, 3, NE);
-   auto x = Reshape(x_.Read(), D1D, D1D, VDIM, NE);
-   auto y = Reshape(y_.ReadWrite(), D1D, D1D, VDIM, NE);
+   auto B = Reshape(b, Q1D, D1D);
+   auto G = Reshape(g, Q1D, D1D);
+   auto Bt = Reshape(bt, D1D, Q1D);
+   auto Gt = Reshape(gt, D1D, Q1D);
+   auto D = Reshape(d_, Q1D*Q1D, 3, NE);
+   auto x = Reshape(x_, D1D, D1D, VDIM, NE);
+   auto y = Reshape(y_, D1D, D1D, VDIM, NE);
    MFEM_FORALL(e, NE,
    {
       const int D1D = T_D1D ? T_D1D : d1d;
@@ -327,13 +327,13 @@ void PAVectorDiffusionApply3D(const int NE,
    constexpr int VDIM = 3;
    MFEM_VERIFY(D1D <= MAX_D1D, "");
    MFEM_VERIFY(Q1D <= MAX_Q1D, "");
-   auto B = Reshape(b.Read(), Q1D, D1D);
-   auto G = Reshape(g.Read(), Q1D, D1D);
-   auto Bt = Reshape(bt.Read(), D1D, Q1D);
-   auto Gt = Reshape(gt.Read(), D1D, Q1D);
-   auto op = Reshape(_op.Read(), Q1D*Q1D*Q1D, 6, NE);
-   auto x = Reshape(_x.Read(), D1D, D1D, D1D, VDIM, NE);
-   auto y = Reshape(_y.ReadWrite(), D1D, D1D, D1D, VDIM, NE);
+   auto B = Reshape(b, Q1D, D1D);
+   auto G = Reshape(g, Q1D, D1D);
+   auto Bt = Reshape(bt, D1D, Q1D);
+   auto Gt = Reshape(gt, D1D, Q1D);
+   auto op = Reshape(_op, Q1D*Q1D*Q1D, 6, NE);
+   auto x = Reshape(_x, D1D, D1D, D1D, VDIM, NE);
+   auto y = Reshape(_y, D1D, D1D, D1D, VDIM, NE);
    MFEM_FORALL(e, NE,
    {
       const int D1D = T_D1D ? T_D1D : d1d;
@@ -548,12 +548,12 @@ static void PAVectorDiffusionDiagonal2D(const int NE,
    const int Q1D = T_Q1D ? T_Q1D : q1d;
    MFEM_VERIFY(D1D <= MAX_D1D, "");
    MFEM_VERIFY(Q1D <= MAX_Q1D, "");
-   auto B = Reshape(b.Read(), Q1D, D1D);
-   auto G = Reshape(g.Read(), Q1D, D1D);
+   auto B = Reshape(b, Q1D, D1D);
+   auto G = Reshape(g, Q1D, D1D);
    // note the different shape for D, this is a (symmetric) matrix so we only
    // store necessary entries
-   auto D = Reshape(d.Read(), Q1D*Q1D, 3, NE);
-   auto Y = Reshape(y.ReadWrite(), D1D, D1D, 2, NE);
+   auto D = Reshape(d, Q1D*Q1D, 3, NE);
+   auto Y = Reshape(y, D1D, D1D, 2, NE);
    MFEM_FORALL(e, NE,
    {
       const int D1D = T_D1D ? T_D1D : d1d;
@@ -618,10 +618,10 @@ static void PAVectorDiffusionDiagonal3D(const int NE,
    constexpr int MD1 = T_D1D ? T_D1D : MAX_D1D;
    MFEM_VERIFY(D1D <= MD1, "");
    MFEM_VERIFY(Q1D <= MQ1, "");
-   auto B = Reshape(b.Read(), Q1D, D1D);
-   auto G = Reshape(g.Read(), Q1D, D1D);
-   auto Q = Reshape(d.Read(), Q1D*Q1D*Q1D, 6, NE);
-   auto Y = Reshape(y.ReadWrite(), D1D, D1D, D1D, 3, NE);
+   auto B = Reshape(b, Q1D, D1D);
+   auto G = Reshape(g, Q1D, D1D);
+   auto Q = Reshape(d, Q1D*Q1D*Q1D, 6, NE);
+   auto Y = Reshape(y, D1D, D1D, D1D, 3, NE);
    MFEM_FORALL(e, NE,
    {
       const int D1D = T_D1D ? T_D1D : d1d;

--- a/fem/bilininteg_vecmass.cpp
+++ b/fem/bilininteg_vecmass.cpp
@@ -111,11 +111,11 @@ static void PAVectorMassApply2D(const int NE,
    constexpr int VDIM = 2;
    MFEM_VERIFY(D1D <= MAX_D1D, "");
    MFEM_VERIFY(Q1D <= MAX_Q1D, "");
-   auto B = Reshape(_B.Read(), Q1D, D1D);
-   auto Bt = Reshape(_Bt.Read(), D1D, Q1D);
-   auto op = Reshape(_op.Read(), Q1D, Q1D, NE);
-   auto x = Reshape(_x.Read(), D1D, D1D, VDIM, NE);
-   auto y = Reshape(_y.ReadWrite(), D1D, D1D, VDIM, NE);
+   auto B = Reshape(_B, Q1D, D1D);
+   auto Bt = Reshape(_Bt, D1D, Q1D);
+   auto op = Reshape(_op, Q1D, Q1D, NE);
+   auto x = Reshape(_x, D1D, D1D, VDIM, NE);
+   auto y = Reshape(_y, D1D, D1D, VDIM, NE);
    MFEM_FORALL(e, NE,
    {
       const int D1D = T_D1D ? T_D1D : d1d; // nvcc workaround
@@ -208,11 +208,11 @@ static void PAVectorMassApply3D(const int NE,
    constexpr int VDIM = 3;
    MFEM_VERIFY(D1D <= MAX_D1D, "");
    MFEM_VERIFY(Q1D <= MAX_Q1D, "");
-   auto B = Reshape(_B.Read(), Q1D, D1D);
-   auto Bt = Reshape(_Bt.Read(), D1D, Q1D);
-   auto op = Reshape(_op.Read(), Q1D, Q1D, Q1D, NE);
-   auto x = Reshape(_x.Read(), D1D, D1D, D1D, VDIM, NE);
-   auto y = Reshape(_y.ReadWrite(), D1D, D1D, D1D, VDIM, NE);
+   auto B = Reshape(_B, Q1D, D1D);
+   auto Bt = Reshape(_Bt, D1D, Q1D);
+   auto op = Reshape(_op, Q1D, Q1D, Q1D, NE);
+   auto x = Reshape(_x, D1D, D1D, D1D, VDIM, NE);
+   auto y = Reshape(_y, D1D, D1D, D1D, VDIM, NE);
    MFEM_FORALL(e, NE,
    {
       const int D1D = T_D1D ? T_D1D : d1d;
@@ -378,9 +378,9 @@ static void PAVectorMassAssembleDiagonal2D(const int NE,
    constexpr int VDIM = 2;
    MFEM_VERIFY(D1D <= MAX_D1D, "");
    MFEM_VERIFY(Q1D <= MAX_Q1D, "");
-   auto B = Reshape(_B.Read(), Q1D, D1D);
-   auto op = Reshape(_op.Read(), Q1D, Q1D, NE);
-   auto y = Reshape(_diag.ReadWrite(), D1D, D1D, VDIM, NE);
+   auto B = Reshape(_B, Q1D, D1D);
+   auto op = Reshape(_op, Q1D, Q1D, NE);
+   auto y = Reshape(_diag, D1D, D1D, VDIM, NE);
    MFEM_FORALL(e, NE,
    {
       const int D1D = T_D1D ? T_D1D : d1d;
@@ -430,9 +430,9 @@ static void PAVectorMassAssembleDiagonal3D(const int NE,
    constexpr int VDIM = 3;
    MFEM_VERIFY(D1D <= MAX_D1D, "");
    MFEM_VERIFY(Q1D <= MAX_Q1D, "");
-   auto B = Reshape(_B.Read(), Q1D, D1D);
-   auto op = Reshape(_op.Read(), Q1D, Q1D, Q1D, NE);
-   auto y = Reshape(_diag.ReadWrite(), D1D, D1D, D1D, VDIM, NE);
+   auto B = Reshape(_B, Q1D, D1D);
+   auto op = Reshape(_op, Q1D, Q1D, Q1D, NE);
+   auto y = Reshape(_diag, D1D, D1D, D1D, VDIM, NE);
    MFEM_FORALL(e, NE,
    {
       const int D1D = T_D1D ? T_D1D : d1d; // nvcc workaround

--- a/fem/bilininteg_vecmass.cpp
+++ b/fem/bilininteg_vecmass.cpp
@@ -55,8 +55,8 @@ void VectorMassIntegrator::AssemblePA(const FiniteElementSpace &fes)
       const double constant = coeff;
       const int NE = ne;
       const int NQ = nq;
-      auto w = ir->GetWeights().Read();
-      auto J = Reshape(geom->J.Read(), NQ,2,2,NE);
+      const auto w = ir->GetWeights().Read();
+      const auto J = Reshape(geom->J.Read(), NQ,2,2,NE);
       auto v = Reshape(pa_data.Write(), NQ, NE);
       MFEM_FORALL(e, NE,
       {
@@ -76,8 +76,8 @@ void VectorMassIntegrator::AssemblePA(const FiniteElementSpace &fes)
       const double constant = coeff;
       const int NE = ne;
       const int NQ = nq;
-      auto W = ir->GetWeights().Read();
-      auto J = Reshape(geom->J.Read(), NQ,3,3,NE);
+      const auto W = ir->GetWeights().Read();
+      const auto J = Reshape(geom->J.Read(), NQ,3,3,NE);
       auto v = Reshape(pa_data.Write(), NQ,NE);
       MFEM_FORALL(e, NE,
       {
@@ -111,10 +111,10 @@ static void PAVectorMassApply2D(const int NE,
    constexpr int VDIM = 2;
    MFEM_VERIFY(D1D <= MAX_D1D, "");
    MFEM_VERIFY(Q1D <= MAX_Q1D, "");
-   auto B = Reshape(_B, Q1D, D1D);
-   auto Bt = Reshape(_Bt, D1D, Q1D);
-   auto op = Reshape(_op, Q1D, Q1D, NE);
-   auto x = Reshape(_x, D1D, D1D, VDIM, NE);
+   const auto B = Reshape(_B, Q1D, D1D);
+   const auto Bt = Reshape(_Bt, D1D, Q1D);
+   const auto op = Reshape(_op, Q1D, Q1D, NE);
+   const auto x = Reshape(_x, D1D, D1D, VDIM, NE);
    auto y = Reshape(_y, D1D, D1D, VDIM, NE);
    MFEM_FORALL(e, NE,
    {
@@ -208,10 +208,10 @@ static void PAVectorMassApply3D(const int NE,
    constexpr int VDIM = 3;
    MFEM_VERIFY(D1D <= MAX_D1D, "");
    MFEM_VERIFY(Q1D <= MAX_Q1D, "");
-   auto B = Reshape(_B, Q1D, D1D);
-   auto Bt = Reshape(_Bt, D1D, Q1D);
-   auto op = Reshape(_op, Q1D, Q1D, Q1D, NE);
-   auto x = Reshape(_x, D1D, D1D, D1D, VDIM, NE);
+   const auto B = Reshape(_B, Q1D, D1D);
+   const auto Bt = Reshape(_Bt, D1D, Q1D);
+   const auto op = Reshape(_op, Q1D, Q1D, Q1D, NE);
+   const auto x = Reshape(_x, D1D, D1D, D1D, VDIM, NE);
    auto y = Reshape(_y, D1D, D1D, D1D, VDIM, NE);
    MFEM_FORALL(e, NE,
    {
@@ -378,8 +378,8 @@ static void PAVectorMassAssembleDiagonal2D(const int NE,
    constexpr int VDIM = 2;
    MFEM_VERIFY(D1D <= MAX_D1D, "");
    MFEM_VERIFY(Q1D <= MAX_Q1D, "");
-   auto B = Reshape(_B, Q1D, D1D);
-   auto op = Reshape(_op, Q1D, Q1D, NE);
+   const auto B = Reshape(_B, Q1D, D1D);
+   const auto op = Reshape(_op, Q1D, Q1D, NE);
    auto y = Reshape(_diag, D1D, D1D, VDIM, NE);
    MFEM_FORALL(e, NE,
    {
@@ -430,8 +430,8 @@ static void PAVectorMassAssembleDiagonal3D(const int NE,
    constexpr int VDIM = 3;
    MFEM_VERIFY(D1D <= MAX_D1D, "");
    MFEM_VERIFY(Q1D <= MAX_Q1D, "");
-   auto B = Reshape(_B, Q1D, D1D);
-   auto op = Reshape(_op, Q1D, Q1D, Q1D, NE);
+   const auto B = Reshape(_B, Q1D, D1D);
+   const auto op = Reshape(_op, Q1D, Q1D, Q1D, NE);
    auto y = Reshape(_diag, D1D, D1D, D1D, VDIM, NE);
    MFEM_FORALL(e, NE,
    {

--- a/general/forall.hpp
+++ b/general/forall.hpp
@@ -51,21 +51,21 @@ const int MAX_Q1D = 14;
 // The MFEM_FORALL wrapper
 #define MFEM_FORALL(i,N,...)                             \
    ForallWrap<1>(true,N,                                 \
-                 [=] MFEM_DEVICE (int i) {__VA_ARGS__},  \
-                 [&]             (int i) {__VA_ARGS__})
+                 [=] MFEM_DEVICE (int i) mutable {__VA_ARGS__},  \
+                 [&]             (int i) mutable {__VA_ARGS__})
 
 // MFEM_FORALL with a 2D CUDA block
 #define MFEM_FORALL_2D(i,N,X,Y,BZ,...)                   \
    ForallWrap<2>(true,N,                                 \
-                 [=] MFEM_DEVICE (int i) {__VA_ARGS__},  \
-                 [&]             (int i) {__VA_ARGS__},  \
+                 [=] MFEM_DEVICE (int i) mutable {__VA_ARGS__},  \
+                 [&]             (int i) mutable {__VA_ARGS__},  \
                  X,Y,BZ)
 
 // MFEM_FORALL with a 3D CUDA block
 #define MFEM_FORALL_3D(i,N,X,Y,Z,...)                    \
    ForallWrap<3>(true,N,                                 \
-                 [=] MFEM_DEVICE (int i) {__VA_ARGS__},  \
-                 [&]             (int i) {__VA_ARGS__},  \
+                 [=] MFEM_DEVICE (int i) mutable {__VA_ARGS__},  \
+                 [&]             (int i) mutable {__VA_ARGS__},  \
                  X,Y,Z)
 
 // MFEM_FORALL that uses the basic CPU backend when use_dev is false. See for
@@ -73,8 +73,8 @@ const int MAX_Q1D = 14;
 // device for operations on small vectors.
 #define MFEM_FORALL_SWITCH(use_dev,i,N,...)              \
    ForallWrap<1>(use_dev,N,                              \
-                 [=] MFEM_DEVICE (int i) {__VA_ARGS__},  \
-                 [&]             (int i) {__VA_ARGS__})
+                 [=] MFEM_DEVICE (int i) mutable {__VA_ARGS__},  \
+                 [&]             (int i) mutable {__VA_ARGS__})
 
 
 /// OpenMP backend

--- a/linalg/dtensor.hpp
+++ b/linalg/dtensor.hpp
@@ -162,26 +162,28 @@ inline const DeviceTensor<sizeof...(Dims),T> Reshape(const T *ptr, Dims... dims)
 template <typename... Dims>
 inline DeviceTensor<sizeof...(Dims),double> Reshape(Vector &v, Dims... dims)
 {
-   return DeviceTensor<sizeof...(Dims),double>(v.ReadWrite(), dims...);
+   return Reshape(v.ReadWrite(), dims...);
 }
 
 template <typename... Dims>
-inline const DeviceTensor<sizeof...(Dims),double> Reshape(const Vector &v, Dims... dims)
+inline const DeviceTensor<sizeof...(Dims),double> Reshape(const Vector &v,
+                                                          Dims... dims)
 {
-   return DeviceTensor<sizeof...(Dims),double>(const_cast<double*>(v.Read()), dims...);
+   return Reshape(const_cast<double*>(v.Read()), dims...);
 }
 
 /** Array interface */
 template <typename T, typename... Dims>
 inline DeviceTensor<sizeof...(Dims),T> Reshape(Array<T> &v, Dims... dims)
 {
-   return DeviceTensor<sizeof...(Dims),T>(v.ReadWrite(), dims...);
+   return Reshape(v.ReadWrite(), dims...);
 }
 
 template <typename T, typename... Dims>
-inline const DeviceTensor<sizeof...(Dims),T> Reshape(const Array<T> &v, Dims... dims)
+inline const DeviceTensor<sizeof...(Dims),T> Reshape(const Array<T> &v,
+                                                     Dims... dims)
 {
-   return DeviceTensor<sizeof...(Dims),T>(const_cast<T*>(v.Read()), dims...);
+   return Reshape(const_cast<T*>(v.Read()), dims...);
 }
 
 typedef DeviceTensor<1,int> DeviceArray;

--- a/linalg/dtensor.hpp
+++ b/linalg/dtensor.hpp
@@ -13,6 +13,8 @@
 #define MFEM_DTENSOR
 
 #include "../general/cuda.hpp"
+#include "vector.hpp"
+#include "../general/array.hpp"
 
 namespace mfem
 {
@@ -154,6 +156,32 @@ template <typename T, typename... Dims>
 inline const DeviceTensor<sizeof...(Dims),T> Reshape(const T *ptr, Dims... dims)
 {
    return DeviceTensor<sizeof...(Dims),T>(const_cast<T*>(ptr), dims...);
+}
+
+/** Vector interface */
+template <typename... Dims>
+inline DeviceTensor<sizeof...(Dims),double> Reshape(Vector &v, Dims... dims)
+{
+   return DeviceTensor<sizeof...(Dims),double>(v.ReadWrite(), dims...);
+}
+
+template <typename... Dims>
+inline const DeviceTensor<sizeof...(Dims),double> Reshape(const Vector &v, Dims... dims)
+{
+   return DeviceTensor<sizeof...(Dims),double>(const_cast<double*>(v.Read()), dims...);
+}
+
+/** Array interface */
+template <typename T, typename... Dims>
+inline DeviceTensor<sizeof...(Dims),T> Reshape(Array<T> &v, Dims... dims)
+{
+   return DeviceTensor<sizeof...(Dims),T>(v.ReadWrite(), dims...);
+}
+
+template <typename T, typename... Dims>
+inline const DeviceTensor<sizeof...(Dims),T> Reshape(const Array<T> &v, Dims... dims)
+{
+   return DeviceTensor<sizeof...(Dims),T>(const_cast<T*>(v.Read()), dims...);
 }
 
 typedef DeviceTensor<1,int> DeviceArray;

--- a/linalg/dtensor.hpp
+++ b/linalg/dtensor.hpp
@@ -114,14 +114,28 @@ public:
 
    /// Const accessor for the data
    template <typename... Args> MFEM_HOST_DEVICE inline
-   Scalar& operator()(Args... args) const
+   const Scalar& operator()(Args... args) const
+   {
+      static_assert(sizeof...(args) == Dim, "Wrong number of arguments");
+      return data[ TensorInd<1, Dim, Args...>::result(sizes, args...) ];
+   }
+
+   /// Accessor for the data
+   template <typename... Args> MFEM_HOST_DEVICE inline
+   Scalar& operator()(Args... args)
    {
       static_assert(sizeof...(args) == Dim, "Wrong number of arguments");
       return data[ TensorInd<1, Dim, Args...>::result(sizes, args...) ];
    }
 
    /// Subscript operator where the tensor is viewed as a 1D array.
-   MFEM_HOST_DEVICE inline Scalar& operator[](int i) const
+   MFEM_HOST_DEVICE inline const Scalar& operator[](int i) const
+   {
+      return data[i];
+   }
+
+   /// Subscript operator where the tensor is viewed as a 1D array.
+   MFEM_HOST_DEVICE inline Scalar& operator[](int i)
    {
       return data[i];
    }
@@ -136,6 +150,11 @@ inline DeviceTensor<sizeof...(Dims),T> Reshape(T *ptr, Dims... dims)
    return DeviceTensor<sizeof...(Dims),T>(ptr, dims...);
 }
 
+template <typename T, typename... Dims>
+inline const DeviceTensor<sizeof...(Dims),T> Reshape(const T *ptr, Dims... dims)
+{
+   return DeviceTensor<sizeof...(Dims),T>(const_cast<T*>(ptr), dims...);
+}
 
 typedef DeviceTensor<1,int> DeviceArray;
 typedef DeviceTensor<1,double> DeviceVector;


### PR DESCRIPTION
```c++
void foo(const double* ptr)
{
  auto t = Reshape(ptr, ... );
}
```
results in `t` having `DeviceTensor` for type instead of `const DeviceTensor`, to be consistent `const` has to be applied to `auto`:
```c++
void foo(const double* ptr)
{
  const auto t = Reshape(ptr, ... );
}
```
It also makes more clear what is an input/output before the `MFEM_FORALL`.