### PR TITLE
Add an interface to coefficients to be evaluated at quadrature points.

### DIFF
--- a/fem/bilininteg_divergence.cpp
+++ b/fem/bilininteg_divergence.cpp
@@ -25,11 +25,14 @@ static void PADivergenceSetup2D(const int Q1D,
                                 const int NE,
                                 const Array<double> &w,
                                 const Vector &j,
-                                const double COEFF,
+                                const Vector &coeff,
                                 Vector &op)
 {
    const int NQ = Q1D*Q1D;
    auto W = w.Read();
+   const bool const_c = coeff.Size() == 1;
+   auto C = const_c ?
+               Reshape(coeff.Read(), 1, 1) : Reshape(coeff.Read(), NQ, NE);
    auto J = Reshape(j.Read(), NQ, 2, 2, NE);
    auto y = Reshape(op.Write(), NQ, 2, 2, NE);
 
@@ -42,6 +45,7 @@ static void PADivergenceSetup2D(const int Q1D,
          const double J21 = J(q,1,0,e);
          const double J22 = J(q,1,1,e);
          // Store wq * Q * adj(J)
+         const double COEFF = const_c ? C(0,0) : C(q,e);
          y(q,0,0,e) = W[q] * COEFF *  J22; // 1,1
          y(q,0,1,e) = W[q] * COEFF * -J12; // 1,2
          y(q,1,0,e) = W[q] * COEFF * -J21; // 2,1
@@ -55,11 +59,14 @@ static void PADivergenceSetup3D(const int Q1D,
                                 const int NE,
                                 const Array<double> &w,
                                 const Vector &j,
-                                const double COEFF,
+                                const Vector &coeff,
                                 Vector &op)
 {
    const int NQ = Q1D*Q1D*Q1D;
    auto W = w.Read();
+   const bool const_c = coeff.Size() == 1;
+   auto C = const_c ?
+               Reshape(coeff.Read(), 1, 1) : Reshape(coeff.Read(), NQ, NE);
    auto J = Reshape(j.Read(), NQ, 3, 3, NE);
    auto y = Reshape(op.Write(), NQ, 3, 3, NE);
    MFEM_FORALL(e, NE,
@@ -75,6 +82,7 @@ static void PADivergenceSetup3D(const int Q1D,
          const double J13 = J(q,0,2,e);
          const double J23 = J(q,1,2,e);
          const double J33 = J(q,2,2,e);
+         const double COEFF = const_c ? C(0,0) : C(q,e);
          const double cw  = W[q] * COEFF;
          // adj(J)
          const double A11 = (J22 * J33) - (J23 * J32);
@@ -107,17 +115,17 @@ static void PADivergenceSetup(const int dim,
                               const int NE,
                               const Array<double> &W,
                               const Vector &J,
-                              const double COEFF,
+                              const Vector &coeff,
                               Vector &op)
 {
    if (dim == 1) { MFEM_ABORT("dim==1 not supported in PADivergenceSetup"); }
    if (dim == 2)
    {
-      PADivergenceSetup2D(Q1D, NE, W, J, COEFF, op);
+      PADivergenceSetup2D(Q1D, NE, W, J, coeff, op);
    }
    if (dim == 3)
    {
-      PADivergenceSetup3D(Q1D, NE, W, J, COEFF, op);
+      PADivergenceSetup3D(Q1D, NE, W, J, coeff, op);
    }
 }
 
@@ -147,13 +155,16 @@ void VectorDivergenceIntegrator::AssemblePA(const FiniteElementSpace &trial_fes,
    MFEM_ASSERT(quad1D == test_maps->nqpt,
                "PA requires test and trial space to have same number of quadrature points!");
    pa_data.SetSize(nq * dimsToStore * ne, Device::GetMemoryType());
-   double coeff = 1.0;
+   Vector coeff;
    if (Q)
    {
-      ConstantCoefficient *cQ = dynamic_cast<ConstantCoefficient*>(Q);
-      MFEM_VERIFY(cQ != NULL, "only ConstantCoefficient is supported!");
-      coeff = cQ->constant;
+      Q->Eval(trial_fes,*ir,coeff);
    }
+   else
+   {
+      coeff.SetSize(1);
+      coeff(0) = 1.0;      
+   }   
    PADivergenceSetup(dim, trial_dofs1D, test_dofs1D, quad1D,
                      ne, ir->GetWeights(), geom->J, coeff, pa_data);
 }

--- a/fem/bilininteg_hcurl.cpp
+++ b/fem/bilininteg_hcurl.cpp
@@ -692,7 +692,6 @@ void CurlCurlIntegrator::AssemblePA(const FiniteElementSpace &fes)
       mfem_error("Not yet supported");
       MQ->Eval(fes,*ir,coeff);
    }
-   
    else
    {
       coeff.SetSize(1);
@@ -2031,11 +2030,11 @@ void MixedVectorCurlIntegrator::AssemblePA(const FiniteElementSpace &trial_fes,
    }
    else if (VQ)
    {
+      mfem_error("Not yet supported.");
       VQ->Eval(trial_fes,*ir,coeff);
    }
    else if (DQ)
    {
-      mfem_error("Not yet supported.");
       DQ->Eval(trial_fes,*ir,coeff);
    }
    else if (MQ)

--- a/fem/coefficient.hpp
+++ b/fem/coefficient.hpp
@@ -21,6 +21,7 @@ namespace mfem
 {
 
 class Mesh;
+class FiniteElementSpace;
 
 #ifdef MFEM_USE_MPI
 class ParMesh;
@@ -68,6 +69,11 @@ public:
       return Eval(T, ip);
    }
 
+   /** @brief Evaluate the coefficient at all the quadrature points given by the
+       IntegrationRule @a ir on the FiniteElementSpace @a fes. */
+   virtual void Eval(const FiniteElementSpace &fes, const IntegrationRule &ir,
+                     Vector &qcoeff);
+
    virtual ~Coefficient() { }
 };
 
@@ -85,6 +91,9 @@ public:
    virtual double Eval(ElementTransformation &T,
                        const IntegrationPoint &ip)
    { return (constant); }
+
+   void Eval(const FiniteElementSpace &fes, const IntegrationRule &ir,
+             Vector &qcoeff);
 };
 
 /** @brief A piecewise constant coefficient with the constants keyed
@@ -382,6 +391,11 @@ public:
    virtual void Eval(DenseMatrix &M, ElementTransformation &T,
                      const IntegrationRule &ir);
 
+   /** @brief Evaluate the coefficient at all the quadrature points given by the
+       IntegrationRule @a ir on the FiniteElementSpace @a fes. */
+   virtual void Eval(const FiniteElementSpace &fes, const IntegrationRule &ir,
+                     Vector &qcoeff);
+
    virtual ~VectorCoefficient() { }
 };
 
@@ -400,6 +414,9 @@ public:
    ///  Evaluate the vector coefficient at @a ip.
    virtual void Eval(Vector &V, ElementTransformation &T,
                      const IntegrationPoint &ip) { V = vec; }
+
+   void Eval(const FiniteElementSpace &fes, const IntegrationRule &ir,
+             Vector &qcoeff);
 
    /// Return a reference to the constant vector in this class.
    const Vector& GetVec() { return vec; }
@@ -726,6 +743,11 @@ public:
    virtual void Eval(DenseMatrix &K, ElementTransformation &T,
                      const IntegrationPoint &ip) = 0;
 
+   /** @brief Evaluate the coefficient at all the quadrature points given by the
+       IntegrationRule @a ir on the FiniteElementSpace @a fes. */
+   virtual void Eval(const FiniteElementSpace &fes, const IntegrationRule &ir,
+                     Vector &qcoeff);
+
    virtual ~MatrixCoefficient() { }
 };
 
@@ -743,6 +765,9 @@ public:
    /// Evaluate the matrix coefficient at @a ip.
    virtual void Eval(DenseMatrix &M, ElementTransformation &T,
                      const IntegrationPoint &ip) { M = mat; }
+
+   void Eval(const FiniteElementSpace &fes, const IntegrationRule &ir,
+             Vector &qcoeff);
 };
 
 


### PR DESCRIPTION
This PR adds an interface to `Coefficient`, `VectorCoefficient`, and `MatrixCoefficient` to be evaluated at quadrature points in order to simplify the partial assembly kernel codes.