### PR TITLE
Minor fix in unit test

### DIFF
--- a/tests/unit/linalg/test_matrix_dense.cpp
+++ b/tests/unit/linalg/test_matrix_dense.cpp
@@ -289,7 +289,7 @@ TEST_CASE("DenseTensor LinearSolve methods",
    {
       for (int r=0; r<N; ++r)
       {
-         REQUIRE(xans_batch(r,e) == X[r]);
+         REQUIRE(xans_batch(r,e) == Approx(X[r]));
       }
    }
 }


### PR DESCRIPTION
`make unittest` fails on my machine because of the check `REQUIRE(xans_batch(r,e) == X[r]);` in `test_matrix_dense.cpp`.

<details>
<summary>See output:</summary>

```
make unittest
/Applications/Xcode.app/Contents/Developer/usr/bin/make -C tests/unit test
    Parallel unit tests [ mpirun -np 1 punit_tests ... ]: OK  (1.07s 45292kB)
    Parallel unit tests [ mpirun -np 4 punit_tests ... ]: OK  (0.97s 22924kB)
    Parallel unit tests [ mpirun -np 1 psedov_tests_cpu ... ]: OK  (1.12s 10640kB)
    Parallel unit tests [ mpirun -np 4 psedov_tests_cpu ... ]: OK  (0.64s 9060kB)
    Parallel unit tests [ mpirun -np 1 psedov_tests_debug ... ]: OK  (3.78s 11260kB)
    Parallel unit tests [ mpirun -np 4 psedov_tests_debug ... ]: OK  (7.99s 10096kB)
    Unit tests [ unit_tests ... ]: FAILED  (12.68s 85420kB)
.
.
.
-------------------------------------------------------------------------------
DenseTensor LinearSolve methods
-------------------------------------------------------------------------------
/Users/stefan/LLNL/LIBS/mfem/tests/unit/linalg/test_matrix_dense.cpp:251
...............................................................................

/Users/stefan/LLNL/LIBS/mfem/tests/unit/linalg/test_matrix_dense.cpp:292: FAILED:
  REQUIRE( xans_batch(r,e) == X[r] )
with expansion:
  5.0 == 5.0
.
.
.
===============================================================================
test cases:    143 |    142 passed | 1 failed
assertions: 232288 | 232287 passed | 1 failed

make[1]: *** [unit_tests-test-seq] Error 1
    Unit tests [ sedov_tests_cpu ... ]: OK  (0.89s 6476kB)
    Unit tests [ sedov_tests_debug ... ]: OK  (3.34s 6776kB)
```

</details>

It is going through when using `REQUIRE(xans_batch(r,e) == Approx(X[r]));` instead.

<details>
<summary>See output:</summary>

```
make unittest
/Applications/Xcode.app/Contents/Developer/usr/bin/make -C tests/unit test
    Parallel unit tests [ mpirun -np 1 punit_tests ... ]: OK  (1.04s 45324kB)
    Parallel unit tests [ mpirun -np 4 punit_tests ... ]: OK  (0.78s 23672kB)
    Parallel unit tests [ mpirun -np 1 psedov_tests_cpu ... ]: OK  (0.99s 10364kB)
    Parallel unit tests [ mpirun -np 4 psedov_tests_cpu ... ]: OK  (0.55s 9016kB)
    Parallel unit tests [ mpirun -np 1 psedov_tests_debug ... ]: OK  (3.48s 11172kB)
    Parallel unit tests [ mpirun -np 4 psedov_tests_debug ... ]: OK  (7.23s 10160kB)
    Unit tests [ unit_tests ... ]: OK  (12.01s 93516kB)
    Unit tests [ sedov_tests_cpu ... ]: OK  (0.89s 6416kB)
    Unit tests [ sedov_tests_debug ... ]: OK  (3.18s 6708kB)
```

</details>

<!--GHEX{"id":1658,"author":"stefanhenneking","editor":"tzanio","reviewers":["pazner","artv3"],"assignment":"2020-07-25T18:24:28-07:00","approval":"2020-07-29T20:35:20.576Z","merge":"2020-08-05T02:41:48.711Z"}XEHG--><!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge| 
 | --- | --- | --- | --- | --- | --- | --- | 
| [#1658](https://github.com/mfem/mfem/pull/1658) | @stefanhenneking | @tzanio | @pazner + @artv3 | 07/25/20 | 07/29/20 | 08/04/20 | |
<!--ELBATXEHG-->