### PR TITLE
Fix a bug in Diffusion Element Assembly in 3D.

### DIFF
--- a/fem/bilininteg_diffusion_ea.cpp
+++ b/fem/bilininteg_diffusion_ea.cpp
@@ -130,8 +130,8 @@ static void EADiffusionAssemble2D(const int NE,
 
 template<int T_D1D = 0, int T_Q1D = 0>
 static void EADiffusionAssemble3D(const int NE,
-                                  const Array<double> &g,
                                   const Array<double> &b,
+                                  const Array<double> &g,
                                   const Vector &padata,
                                   Vector &eadata,
                                   const int d1d = 0,

--- a/tests/unit/fem/test_assembly_levels.cpp
+++ b/tests/unit/fem/test_assembly_levels.cpp
@@ -48,8 +48,6 @@ void test_assembly_level(Mesh &&mesh, int order, bool dg, const int pb,
                          const AssemblyLevel assembly)
 {
    mesh.EnsureNodes();
-   mesh.SetCurvature(mesh.GetNodalFESpace()->GetOrder(0),
-                     mesh.GetNodalFESpace()->IsDGSpace());
    int dim = mesh.Dimension();
 
    FiniteElementCollection *fec;

--- a/tests/unit/fem/test_assembly_levels.cpp
+++ b/tests/unit/fem/test_assembly_levels.cpp
@@ -176,7 +176,7 @@ TEST_CASE("Assembly Levels", "[AssemblyLevel]")
       {
          for (AssemblyLevel assembly : {AssemblyLevel::PARTIAL,AssemblyLevel::ELEMENT,AssemblyLevel::FULL})
          {
-            for (int pb : {0, 1})
+            for (int pb : {0, 1, 2})
             {
                for (int order : {2, 3, 4})
                {
@@ -194,7 +194,7 @@ TEST_CASE("Assembly Levels", "[AssemblyLevel]")
       {
          for (AssemblyLevel assembly : {AssemblyLevel::PARTIAL,AssemblyLevel::ELEMENT,AssemblyLevel::FULL})
          {
-            for (int pb : {0, 1})
+            for (int pb : {0, 1, 2})
             {
                for (bool dg : {true, false})
                {

--- a/tests/unit/fem/test_assembly_levels.cpp
+++ b/tests/unit/fem/test_assembly_levels.cpp
@@ -48,7 +48,8 @@ void test_assembly_level(Mesh &&mesh, int order, bool dg, const int pb,
                          const AssemblyLevel assembly)
 {
    mesh.EnsureNodes();
-   mesh.SetCurvature(mesh.GetNodalFESpace()->GetOrder(0));
+   mesh.SetCurvature(mesh.GetNodalFESpace()->GetOrder(0),
+                     mesh.GetNodalFESpace()->IsDGSpace());
    int dim = mesh.Dimension();
 
    FiniteElementCollection *fec;
@@ -107,49 +108,105 @@ void test_assembly_level(Mesh &&mesh, int order, bool dg, const int pb,
 
 TEST_CASE("Assembly Levels", "[AssemblyLevel]")
 {
-   for (AssemblyLevel assembly : {AssemblyLevel::PARTIAL,AssemblyLevel::ELEMENT,AssemblyLevel::FULL})
+   SECTION("Continuous Galerkin")
    {
-      for (int pb : {0, 1, 2})
+      const bool dg = false;
+      SECTION("2D")
       {
-         for (bool dg : {true, false})
+         for (AssemblyLevel assembly : {AssemblyLevel::PARTIAL,AssemblyLevel::ELEMENT,AssemblyLevel::FULL})
          {
-            SECTION("2D")
+            for (int pb : {0, 1, 2})
+            {
+               for (int order : {2, 3, 4})
+               {
+                  test_assembly_level(Mesh("../../data/inline-quad.mesh", 1, 1),
+                                       order, dg, pb, assembly);
+                  test_assembly_level(Mesh("../../data/periodic-hexagon.mesh", 1, 1),
+                                       order, dg, pb, assembly);
+                  test_assembly_level(Mesh("../../data/star-q3.mesh", 1, 1),
+                                       order, dg, pb, assembly);
+               }
+            }
+         }
+      }
+      SECTION("3D")
+      {
+         for (AssemblyLevel assembly : {AssemblyLevel::PARTIAL,AssemblyLevel::ELEMENT,AssemblyLevel::FULL})
+         {
+            for (int pb : {0, 1, 2})
+            {
+               int order = 2;
+               test_assembly_level(Mesh("../../data/inline-hex.mesh", 1, 1),
+                                    order, dg, pb, assembly);
+               test_assembly_level(Mesh("../../data/fichera-q3.mesh", 1, 1),
+                                    order, dg, pb, assembly);
+            }
+         }
+      }
+      SECTION("AMR 2D")
+      {
+         for (AssemblyLevel assembly : {AssemblyLevel::PARTIAL,AssemblyLevel::ELEMENT,AssemblyLevel::FULL})
+         {
+            for (int pb : {0, 1, 2})
+            {
+               for (int order : {2, 3, 4})
+               {
+                  test_assembly_level(Mesh("../../data/amr-quad.mesh", 1, 1),
+                                       order, false, 0, assembly);
+               }
+            }
+         }
+      }
+      SECTION("AMR 3D")
+      {
+         for (AssemblyLevel assembly : {AssemblyLevel::PARTIAL,AssemblyLevel::ELEMENT,AssemblyLevel::FULL})
+         {
+            for (int pb : {0, 1, 2})
+            {
+               int order = 2;
+               test_assembly_level(Mesh("../../data/fichera-amr.mesh", 1, 1),
+                                    order, false, 0, assembly);
+            }
+         }
+      }
+   }
+
+   SECTION("Discontinuous Galerkin")
+   {
+      const bool dg = true;
+      SECTION("2D")
+      {
+         for (AssemblyLevel assembly : {AssemblyLevel::PARTIAL,AssemblyLevel::ELEMENT,AssemblyLevel::FULL})
+         {
+            for (int pb : {0, 1})
             {
                for (int order : {2, 3, 4})
                {
                   test_assembly_level(Mesh("../../data/periodic-square.mesh", 1, 1),
-                                      order, dg, pb, assembly);
+                                       order, dg, pb, assembly);
                   test_assembly_level(Mesh("../../data/periodic-hexagon.mesh", 1, 1),
-                                      order, dg, pb, assembly);
+                                       order, dg, pb, assembly);
                   test_assembly_level(Mesh("../../data/star-q3.mesh", 1, 1),
-                                      order, dg, pb, assembly);
+                                       order, dg, pb, assembly);
                }
             }
-
-            SECTION("3D")
-            {
-               int order = 2;
-               test_assembly_level(Mesh("../../data/periodic-cube.mesh", 1, 1),
-                                   order, dg, pb, assembly);
-               test_assembly_level(Mesh("../../data/fichera-q3.mesh", 1, 1),
-                                   order, dg, pb, assembly);
-            }
          }
-
-         // Test AMR cases (DG not implemented)
-         SECTION("AMR 2D")
+      }
+      SECTION("3D")
+      {
+         for (AssemblyLevel assembly : {AssemblyLevel::PARTIAL,AssemblyLevel::ELEMENT,AssemblyLevel::FULL})
          {
-            for (int order : {2, 3, 4})
+            for (int pb : {0, 1})
             {
-               test_assembly_level(Mesh("../../data/amr-quad.mesh", 1, 1),
-                                   order, false, 0, assembly);
+               for (bool dg : {true, false})
+               {
+                  int order = 2;
+                  test_assembly_level(Mesh("../../data/periodic-cube.mesh", 1, 1),
+                                       order, dg, pb, assembly);
+                  test_assembly_level(Mesh("../../data/fichera-q3.mesh", 1, 1),
+                                       order, dg, pb, assembly);
+               }
             }
-         }
-         SECTION("AMR 3D")
-         {
-            int order = 2;
-            test_assembly_level(Mesh("../../data/fichera-amr.mesh", 1, 1),
-                                order, false, 0, assembly);
          }
       }
    }

--- a/tests/unit/fem/test_assembly_levels.cpp
+++ b/tests/unit/fem/test_assembly_levels.cpp
@@ -118,11 +118,11 @@ TEST_CASE("Assembly Levels", "[AssemblyLevel]")
                for (int order : {2, 3, 4})
                {
                   test_assembly_level(Mesh("../../data/inline-quad.mesh", 1, 1),
-                                       order, dg, pb, assembly);
+                                      order, dg, pb, assembly);
                   test_assembly_level(Mesh("../../data/periodic-hexagon.mesh", 1, 1),
-                                       order, dg, pb, assembly);
+                                      order, dg, pb, assembly);
                   test_assembly_level(Mesh("../../data/star-q3.mesh", 1, 1),
-                                       order, dg, pb, assembly);
+                                      order, dg, pb, assembly);
                }
             }
          }
@@ -135,9 +135,9 @@ TEST_CASE("Assembly Levels", "[AssemblyLevel]")
             {
                int order = 2;
                test_assembly_level(Mesh("../../data/inline-hex.mesh", 1, 1),
-                                    order, dg, pb, assembly);
+                                   order, dg, pb, assembly);
                test_assembly_level(Mesh("../../data/fichera-q3.mesh", 1, 1),
-                                    order, dg, pb, assembly);
+                                   order, dg, pb, assembly);
             }
          }
       }
@@ -150,7 +150,7 @@ TEST_CASE("Assembly Levels", "[AssemblyLevel]")
                for (int order : {2, 3, 4})
                {
                   test_assembly_level(Mesh("../../data/amr-quad.mesh", 1, 1),
-                                       order, false, 0, assembly);
+                                      order, false, 0, assembly);
                }
             }
          }
@@ -163,7 +163,7 @@ TEST_CASE("Assembly Levels", "[AssemblyLevel]")
             {
                int order = 2;
                test_assembly_level(Mesh("../../data/fichera-amr.mesh", 1, 1),
-                                    order, false, 0, assembly);
+                                   order, false, 0, assembly);
             }
          }
       }
@@ -181,11 +181,11 @@ TEST_CASE("Assembly Levels", "[AssemblyLevel]")
                for (int order : {2, 3, 4})
                {
                   test_assembly_level(Mesh("../../data/periodic-square.mesh", 1, 1),
-                                       order, dg, pb, assembly);
+                                      order, dg, pb, assembly);
                   test_assembly_level(Mesh("../../data/periodic-hexagon.mesh", 1, 1),
-                                       order, dg, pb, assembly);
+                                      order, dg, pb, assembly);
                   test_assembly_level(Mesh("../../data/star-q3.mesh", 1, 1),
-                                       order, dg, pb, assembly);
+                                      order, dg, pb, assembly);
                }
             }
          }
@@ -200,9 +200,9 @@ TEST_CASE("Assembly Levels", "[AssemblyLevel]")
                {
                   int order = 2;
                   test_assembly_level(Mesh("../../data/periodic-cube.mesh", 1, 1),
-                                       order, dg, pb, assembly);
+                                      order, dg, pb, assembly);
                   test_assembly_level(Mesh("../../data/fichera-q3.mesh", 1, 1),
-                                       order, dg, pb, assembly);
+                                      order, dg, pb, assembly);
                }
             }
          }

--- a/tests/unit/fem/test_pa_kernels.cpp
+++ b/tests/unit/fem/test_pa_kernels.cpp
@@ -422,9 +422,9 @@ void test_pa_convection(Mesh &&mesh, int order, bool dg)
 //Basic unit test for convection
 TEST_CASE("PA Convection", "[PartialAssembly]")
 {
-   for (bool dg : {true, false})
+   SECTION("2D")
    {
-      SECTION("2D")
+      for (bool dg : {true, false})
       {
          for (int order : {2, 3, 4})
          {
@@ -433,8 +433,10 @@ TEST_CASE("PA Convection", "[PartialAssembly]")
             test_pa_convection(Mesh("../../data/star-q3.mesh", 1, 1), order, dg);
          }
       }
-
-      SECTION("3D")
+   }
+   SECTION("3D")
+   {
+      for (bool dg : {true, false})
       {
          int order = 2;
          test_pa_convection(Mesh("../../data/periodic-cube.mesh", 1, 1), order, dg);
@@ -442,9 +444,9 @@ TEST_CASE("PA Convection", "[PartialAssembly]")
       }
    }
    // Test AMR cases (DG not implemented)
-   for (int order : {2, 3, 4})
+   SECTION("AMR 2D")
    {
-      SECTION("AMR 2D")
+      for (int order : {2, 3, 4})
       {
          test_pa_convection(Mesh("../../data/amr-quad.mesh", 1, 1), order, false);
       }


### PR DESCRIPTION
Thanks to @nbeams for finding a bug in the `DiffusionIntegrator` Element Assembly in 3D, it also impacts Full Assembly. This PR fixes the bug.
<!--GHEX{"id":1660,"author":"YohannDudouit","editor":"tzanio","reviewers":["camierjs","artv3","barker29"],"assignment":"2020-08-01T23:33:13-07:00","approval":"2020-08-05T03:03:03.346Z","merge":"2020-08-13T19:23:14.907Z"}XEHG--><!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge| 
 | --- | --- | --- | --- | --- | --- | --- | 
| [#1660](https://github.com/mfem/mfem/pull/1660) | @YohannDudouit | @tzanio | @camierjs + @artv3 + @barker29 | 08/01/20 | 08/04/20 | 08/13/20 | |
<!--ELBATXEHG-->