### PR TITLE
SparseMatrix Copy Constructor MemoryType

### DIFF
--- a/linalg/sparsemat.cpp
+++ b/linalg/sparsemat.cpp
@@ -175,21 +175,9 @@ SparseMatrix::SparseMatrix(const SparseMatrix &mat, bool copy_graph,
       }
 
       // We probably do not need to set the ownership flags here.
-      if (mt != MemoryType::SIZE)
-      {
-         I.Reset(mt);
-         J.Reset(mt);
-         A.Reset(mt);
-      }
-      else
-      {
-         I.Reset();
-         J.Reset();
-         A.Reset();
-      }
-      I.SetHostPtrOwner(true);
-      J.SetHostPtrOwner(true);
-      A.SetHostPtrOwner(true);
+      I.Reset(); I.SetHostPtrOwner(true);
+      J.Reset(); J.SetHostPtrOwner(true);
+      A.Reset(); A.SetHostPtrOwner(true);
    }
 
    current_row = -1;

--- a/linalg/sparsemat.cpp
+++ b/linalg/sparsemat.cpp
@@ -121,7 +121,8 @@ SparseMatrix::SparseMatrix(int nrows, int ncols, int rowsize)
    }
 }
 
-SparseMatrix::SparseMatrix(const SparseMatrix &mat, bool copy_graph)
+SparseMatrix::SparseMatrix(const SparseMatrix &mat, bool copy_graph,
+                           MemoryType mt)
    : AbstractSparseMatrix(mat.Height(), mat.Width())
 {
    if (mat.Finalized())
@@ -129,8 +130,8 @@ SparseMatrix::SparseMatrix(const SparseMatrix &mat, bool copy_graph)
       const int nnz = mat.I[height];
       if (copy_graph)
       {
-         I.New(height+1, mat.I.GetMemoryType());
-         J.New(nnz, mat.J.GetMemoryType());
+         I.New(height+1, mt == MemoryType::SIZE ? mat.I.GetMemoryType() : mt);
+         J.New(nnz, mt == MemoryType::SIZE ? mat.J.GetMemoryType() : mt);
          I.CopyFrom(mat.I, height+1);
          J.CopyFrom(mat.J, nnz);
       }
@@ -141,7 +142,7 @@ SparseMatrix::SparseMatrix(const SparseMatrix &mat, bool copy_graph)
          I.ClearOwnerFlags();
          J.ClearOwnerFlags();
       }
-      A.New(nnz, mat.A.GetMemoryType());
+      A.New(nnz, mt == MemoryType::SIZE ? mat.A.GetMemoryType() : mt);
       A.CopyFrom(mat.A, nnz);
 
       Rows = NULL;
@@ -174,9 +175,12 @@ SparseMatrix::SparseMatrix(const SparseMatrix &mat, bool copy_graph)
       }
 
       // We probably do not need to set the ownership flags here.
-      I.Reset(); I.SetHostPtrOwner(true);
-      J.Reset(); J.SetHostPtrOwner(true);
-      A.Reset(); A.SetHostPtrOwner(true);
+      I.Reset(mt == MemoryType::SIZE ? I.GetMemoryType() : mt);
+      I.SetHostPtrOwner(true);
+      J.Reset(mt == MemoryType::SIZE ? J.GetMemoryType() : mt);
+      J.SetHostPtrOwner(true);
+      A.Reset(mt == MemoryType::SIZE ? A.GetMemoryType() : mt);
+      A.SetHostPtrOwner(true);
    }
 
    current_row = -1;

--- a/linalg/sparsemat.cpp
+++ b/linalg/sparsemat.cpp
@@ -175,11 +175,20 @@ SparseMatrix::SparseMatrix(const SparseMatrix &mat, bool copy_graph,
       }
 
       // We probably do not need to set the ownership flags here.
-      I.Reset(mt == MemoryType::SIZE ? I.GetMemoryType() : mt);
+      if (mt != MemoryType::SIZE)
+      {
+         I.Reset(mt);
+         J.Reset(mt);
+         A.Reset(mt);
+      }
+      else
+      {
+         I.Reset();
+         J.Reset();
+         A.Reset();
+      }
       I.SetHostPtrOwner(true);
-      J.Reset(mt == MemoryType::SIZE ? J.GetMemoryType() : mt);
       J.SetHostPtrOwner(true);
-      A.Reset(mt == MemoryType::SIZE ? A.GetMemoryType() : mt);
       A.SetHostPtrOwner(true);
    }
 

--- a/linalg/sparsemat.hpp
+++ b/linalg/sparsemat.hpp
@@ -113,7 +113,8 @@ public:
    /** If @a mat is finalized and @a copy_graph is false, the #I and #J arrays
        will use a shallow copy (copy the pointers only) without transferring
        ownership. */
-   SparseMatrix(const SparseMatrix &mat, bool copy_graph = true);
+   SparseMatrix(const SparseMatrix &mat, bool copy_graph = true,
+                MemoryType mt = MemoryType::SIZE);
 
    /// Create a SparseMatrix with diagonal @a v, i.e. A = Diag(v)
    SparseMatrix(const Vector & v);

--- a/linalg/sparsemat.hpp
+++ b/linalg/sparsemat.hpp
@@ -115,7 +115,7 @@ public:
        ownership.
        If @a mt is MemoryType::SIZE the memory type of the resulting
        SparseMatrix's #I, #J, and #A arrays will be the same as @a mat,
-       otherwise the type with be @a mt for those arrays that are deep
+       otherwise the type will be @a mt for those arrays that are deep
        copied. */
    SparseMatrix(const SparseMatrix &mat, bool copy_graph = true,
                 MemoryType mt = MemoryType::SIZE);

--- a/linalg/sparsemat.hpp
+++ b/linalg/sparsemat.hpp
@@ -112,7 +112,11 @@ public:
    /// Copy constructor (deep copy).
    /** If @a mat is finalized and @a copy_graph is false, the #I and #J arrays
        will use a shallow copy (copy the pointers only) without transferring
-       ownership. */
+       ownership.
+       If @a mt is MemoryType::SIZE the memory type of the resulting
+       SparseMatrix's #I, #J, and #A arrays will be the same as @a mat,
+       otherwise the type with be @a mt for those arrays that are deep
+       copied. */
    SparseMatrix(const SparseMatrix &mat, bool copy_graph = true,
                 MemoryType mt = MemoryType::SIZE);
 


### PR DESCRIPTION
Adds optional `MemoryType` parameter for the `SparseMatrix` Copy Constructor.

I've only tested the `if (mat.Finalized())` case since that's the only one we're using.

<!--GHEX{"id":1669,"author":"tomstitt","editor":"tzanio","reviewers":["artv3","v-dobrev","YohannDudouit"],"assignment":"2020-08-13T12:42:05-07:00","approval":"2020-08-27T12:42:05-07:00","merge":"2020-09-03T12:42:05-07:00"}XEHG--><!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge| 
 | --- | --- | --- | --- | --- | --- | --- | 
| [#1669](https://github.com/mfem/mfem/pull/1669) | @tomstitt | @tzanio | @artv3 + @v-dobrev + @YohannDudouit | 08/13/20 | ⌛due 08/27/20 | ⌛due 09/03/20 | |
<!--ELBATXEHG-->