### PR TITLE
Address leaks in SlepcEigenSolver

### DIFF
--- a/examples/petsc/ex11p.cpp
+++ b/examples/petsc/ex11p.cpp
@@ -423,7 +423,7 @@ int main(int argc, char *argv[])
    delete fespace;
    if (order > 0)
    {
-     delete fec;
+      delete fec;
    }
    delete pmesh;
 

--- a/examples/petsc/ex11p.cpp
+++ b/examples/petsc/ex11p.cpp
@@ -421,7 +421,10 @@ int main(int argc, char *argv[])
    delete Arow;
 #endif
    delete fespace;
-   delete fec;
+   if (order > 0)
+   {
+     delete fec;
+   }
    delete pmesh;
 
    // We finalize SLEPc

--- a/examples/petsc/ex11p.cpp
+++ b/examples/petsc/ex11p.cpp
@@ -410,26 +410,18 @@ int main(int argc, char *argv[])
    }
 
    // 12. Free the used memory.
-   if (!use_slepc)
-   {
-      delete lobpcg;
-   }
-   else
-   {
-      delete slepc;
-   }
+   delete lobpcg;
+   delete slepc;
    delete precond;
    delete M;
    delete A;
+   delete pA;
+   delete pM;
 #if defined(MFEM_USE_SUPERLU) || defined(MFEM_USE_STRUMPACK)
    delete Arow;
 #endif
-
    delete fespace;
-   if (order > 0)
-   {
-      delete fec;
-   }
+   delete fec;
    delete pmesh;
 
    // We finalize SLEPc

--- a/linalg/slepc.cpp
+++ b/linalg/slepc.cpp
@@ -62,6 +62,8 @@ SlepcEigenSolver::SlepcEigenSolver(MPI_Comm comm, const std::string &prefix)
 
 SlepcEigenSolver::~SlepcEigenSolver()
 {
+   if (VR) { delete VR; }
+   if (VC) { delete VC; }
    MPI_Comm comm;
    ierr = PetscObjectGetComm((PetscObject)eps,&comm); PCHKERRQ(eps,ierr);
    ierr = EPSDestroy(&eps); CCHKERRQ(comm,ierr);

--- a/linalg/slepc.cpp
+++ b/linalg/slepc.cpp
@@ -64,7 +64,6 @@ SlepcEigenSolver::~SlepcEigenSolver()
 {
    delete VR;
    delete VC;
-   VR = VC = NULL;
 
    MPI_Comm comm;
    ierr = PetscObjectGetComm((PetscObject)eps,&comm); PCHKERRQ(eps,ierr);

--- a/linalg/slepc.cpp
+++ b/linalg/slepc.cpp
@@ -62,8 +62,10 @@ SlepcEigenSolver::SlepcEigenSolver(MPI_Comm comm, const std::string &prefix)
 
 SlepcEigenSolver::~SlepcEigenSolver()
 {
-   if (VR) { delete VR; }
-   if (VC) { delete VC; }
+   delete VR;
+   delete VC;
+   VR = VC = NULL;
+
    MPI_Comm comm;
    ierr = PetscObjectGetComm((PetscObject)eps,&comm); PCHKERRQ(eps,ierr);
    ierr = EPSDestroy(&eps); CCHKERRQ(comm,ierr);


### PR DESCRIPTION
Currently, the `SlepcEigenSolver` leaks as it allocates two `PetscParVector` that are never deleted.
I added deletes to the destructor. I can put them somewhere else if it would be preferred.

Note that the `SlepcEigenSolver` still leaks with these fixes. The leaks are small (236 bytes definitely lost, 1408 bytes indirectly lost) and appear to come from PETSc and SLEPc. Fortunately, the remaining unfixed leaks are not a function of the dimension of the system and appear to simply be overhead.
<!--GHEX{"id":1673,"author":"wcdawn","editor":"tzanio","reviewers":["stefanozampini","jandrej","mlstowell"],"assignment":"2020-08-30T17:51:41-07:00","approval":"2020-10-13T19:57:57.265Z","merge":"2020-10-18T04:42:53.361Z"}XEHG--><!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge| 
 | --- | --- | --- | --- | --- | --- | --- | 
| [#1673](https://github.com/mfem/mfem/pull/1673) | @wcdawn | @tzanio | @stefanozampini + @jandrej + @mlstowell | 08/30/20 | 10/13/20 | 10/17/20 | |
<!--ELBATXEHG-->