### PR TITLE
Use LEGACYFULL instead of FULL in the documentation.

### DIFF
--- a/fem/bilinearform.hpp
+++ b/fem/bilinearform.hpp
@@ -416,9 +416,7 @@ public:
        returned in the variable @a A, of type OpType, holding a *reference* to
        the system matrix (created with the method OpType::MakeRef()). The
        reference will be invalidated when SetOperatorType(), Update(), or the
-       destructor is called.
-
-       Currently, this method can be used only with AssemblyLevel::LEGACYFULL. */
+       destructor is called. */
    template <typename OpType>
    void FormLinearSystem(const Array<int> &ess_tdof_list, Vector &x, Vector &b,
                          OpType &A, Vector &X, Vector &B,
@@ -440,9 +438,7 @@ public:
        returned in the variable @a A, of type OpType, holding a *reference* to
        the system matrix (created with the method OpType::MakeRef()). The
        reference will be invalidated when SetOperatorType(), Update(), or the
-       destructor is called.
-
-       Currently, this method can be used only with AssemblyLevel::LEGACYFULL. */
+       destructor is called. */
    template <typename OpType>
    void FormSystemMatrix(const Array<int> &ess_tdof_list, OpType &A)
    {
@@ -862,9 +858,7 @@ public:
        returned in the variable @a A, of type OpType, holding a *reference* to
        the system matrix (created with the method OpType::MakeRef()). The
        reference will be invalidated when SetOperatorType(), Update(), or the
-       destructor is called.
-
-       Currently, this method can be used only with AssemblyLevel::LEGACYFULL. */
+       destructor is called. */
    template <typename OpType>
    void FormRectangularSystemMatrix(const Array<int> &trial_tdof_list,
                                     const Array<int> &test_tdof_list, OpType &A)
@@ -894,9 +888,7 @@ public:
        returned in the variable @a A, of type OpType, holding a *reference* to
        the system matrix (created with the method OpType::MakeRef()). The
        reference will be invalidated when SetOperatorType(), Update(), or the
-       destructor is called.
-
-       Currently, this method can be used only with AssemblyLevel::LEGACYFULL. */
+       destructor is called. */
    template <typename OpType>
    void FormRectangularLinearSystem(const Array<int> &trial_tdof_list,
                                     const Array<int> &test_tdof_list,

--- a/fem/bilinearform.hpp
+++ b/fem/bilinearform.hpp
@@ -157,7 +157,8 @@ public:
    /// Set the desired assembly level.
    /** Valid choices are:
 
-       - AssemblyLevel::FULL  (default)
+       - AssemblyLevel::LEGACYFULL  (default)
+       - AssemblyLevel::FULL
        - AssemblyLevel::PARTIAL
        - AssemblyLevel::ELEMENT
        - AssemblyLevel::NONE
@@ -417,7 +418,7 @@ public:
        reference will be invalidated when SetOperatorType(), Update(), or the
        destructor is called.
 
-       Currently, this method can be used only with AssemblyLevel::FULL. */
+       Currently, this method can be used only with AssemblyLevel::LEGACYFULL. */
    template <typename OpType>
    void FormLinearSystem(const Array<int> &ess_tdof_list, Vector &x, Vector &b,
                          OpType &A, Vector &X, Vector &B,
@@ -441,7 +442,7 @@ public:
        reference will be invalidated when SetOperatorType(), Update(), or the
        destructor is called.
 
-       Currently, this method can be used only with AssemblyLevel::FULL. */
+       Currently, this method can be used only with AssemblyLevel::LEGACYFULL. */
    template <typename OpType>
    void FormSystemMatrix(const Array<int> &ess_tdof_list, OpType &A)
    {
@@ -759,7 +760,7 @@ public:
    /// Sets all sparse values of \f$ M \f$ to @a a.
    void operator=(const double a) { *mat = a; }
 
-   /// Set the desired assembly level. The default is AssemblyLevel::FULL.
+   /// Set the desired assembly level. The default is AssemblyLevel::LEGACYFULL.
    /** This method must be called before assembly. */
    void SetAssemblyLevel(AssemblyLevel assembly_level);
 
@@ -863,7 +864,7 @@ public:
        reference will be invalidated when SetOperatorType(), Update(), or the
        destructor is called.
 
-       Currently, this method can be used only with AssemblyLevel::FULL. */
+       Currently, this method can be used only with AssemblyLevel::LEGACYFULL. */
    template <typename OpType>
    void FormRectangularSystemMatrix(const Array<int> &trial_tdof_list,
                                     const Array<int> &test_tdof_list, OpType &A)
@@ -895,7 +896,7 @@ public:
        reference will be invalidated when SetOperatorType(), Update(), or the
        destructor is called.
 
-       Currently, this method can be used only with AssemblyLevel::FULL. */
+       Currently, this method can be used only with AssemblyLevel::LEGACYFULL. */
    template <typename OpType>
    void FormRectangularLinearSystem(const Array<int> &trial_tdof_list,
                                     const Array<int> &test_tdof_list,

--- a/fem/bilinearform.hpp
+++ b/fem/bilinearform.hpp
@@ -157,7 +157,7 @@ public:
    /// Set the desired assembly level.
    /** Valid choices are:
 
-       - AssemblyLevel::LEGACYFULL  (default)
+       - AssemblyLevel::LEGACYFULL (default)
        - AssemblyLevel::FULL
        - AssemblyLevel::PARTIAL
        - AssemblyLevel::ELEMENT

--- a/fem/complex_fem.hpp
+++ b/fem/complex_fem.hpp
@@ -543,7 +543,7 @@ public:
    /// Set the desired assembly level.
    /** Valid choices are:
 
-       - AssemblyLevel::LEGACYFULL  (default)
+       - AssemblyLevel::LEGACYFULL (default)
        - AssemblyLevel::FULL
        - AssemblyLevel::PARTIAL
        - AssemblyLevel::ELEMENT

--- a/fem/complex_fem.hpp
+++ b/fem/complex_fem.hpp
@@ -222,7 +222,7 @@ public:
    /// Set the desired assembly level.
    /** Valid choices are:
 
-       - AssemblyLevel::LEGACYFULL  (default)
+       - AssemblyLevel::LEGACYFULL (default)
        - AssemblyLevel::FULL
        - AssemblyLevel::PARTIAL
        - AssemblyLevel::ELEMENT

--- a/fem/complex_fem.hpp
+++ b/fem/complex_fem.hpp
@@ -222,7 +222,8 @@ public:
    /// Set the desired assembly level.
    /** Valid choices are:
 
-       - AssemblyLevel::FULL  (default)
+       - AssemblyLevel::LEGACYFULL  (default)
+       - AssemblyLevel::FULL
        - AssemblyLevel::PARTIAL
        - AssemblyLevel::ELEMENT
        - AssemblyLevel::NONE
@@ -542,7 +543,8 @@ public:
    /// Set the desired assembly level.
    /** Valid choices are:
 
-       - AssemblyLevel::FULL  (default)
+       - AssemblyLevel::LEGACYFULL  (default)
+       - AssemblyLevel::FULL
        - AssemblyLevel::PARTIAL
        - AssemblyLevel::ELEMENT
        - AssemblyLevel::NONE

--- a/fem/pbilinearform.hpp
+++ b/fem/pbilinearform.hpp
@@ -76,7 +76,7 @@ public:
    void KeepNbrBlock(bool knb = true) { keep_nbr_block = knb; }
 
    /** @brief Set the operator type id for the parallel matrix/operator when
-       using AssemblyLevel::FULL. */
+       using AssemblyLevel::LEGACYFULL. */
    /** If using static condensation or hybridization, call this method *after*
        enabling it. */
    void SetOperatorType(Operator::Type tid)


### PR DESCRIPTION
I had forgotten some references to `AssemblyLevel::FULL` in the documentation, this PR uses the correct default mode `AssemblyLevel::LEGACYFULL`. I also removed some documentation that seemed outdated to me.
<!--GHEX{"id":1683,"author":"YohannDudouit","editor":"tzanio","reviewers":["tzanio","v-dobrev"],"assignment":"2020-08-13T12:41:42-07:00","approval":"2020-10-05T19:49:58.206Z","merge":"2020-10-08T19:02:43.518Z"}XEHG--><!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge| 
 | --- | --- | --- | --- | --- | --- | --- | 
| [#1683](https://github.com/mfem/mfem/pull/1683) | @YohannDudouit | @tzanio | @tzanio + @v-dobrev | 08/13/20 | 10/05/20 | 10/08/20 | |
<!--ELBATXEHG-->