### PR TITLE
Add tests on Lassen in Gitlab CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -71,6 +71,8 @@ stages:
   - build
   - test
   - deallocate
+  - lassen_build
+  - lassen_test
   - baseline_check
   - baseline_publish
 
@@ -79,7 +81,11 @@ stages:
 # TODO: updating tests and tpls is not necessary anymore since pipelines are
 # now using unique directories so repo are never shared with another pipeline.
 # This is not memory efficient (we keep a lot of data), hence this reminder.
-.setup:
+# Setup
+setup:
+  tags:
+    - shell
+    - quartz
   stage: setup
   variables:
     GIT_STRATEGY: none
@@ -290,3 +296,4 @@ stages:
 # The list on jobs is defined in machine-specific files.
 include:
   - local: .gitlab/quartz.yml
+  - local: .gitlab/lassen.yml

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -106,6 +106,15 @@ setup:
   before_script:
     - module load gcc/6.1.0
 
+# On lassen
+.with_gcc_8_3_1:
+  variables:
+    TOOLCHAIN: gcc_8_3_1
+    CXX: g++
+    CC: gcc
+  before_script:
+    - module load gcc/8.3.1
+
 .with_gcc_4_9_3:
   variables:
     TOOLCHAIN: gcc_4_9_3

--- a/.gitlab/lassen.yml
+++ b/.gitlab/lassen.yml
@@ -1,0 +1,65 @@
+# Copyright (c) 2010-2020, Lawrence Livermore National Security, LLC. Produced
+# at the Lawrence Livermore National Laboratory. All Rights reserved. See files
+# LICENSE and NOTICE for details. LLNL-CODE-806117.
+#
+# This file is part of the MFEM library. For more information and source code
+# availability visit https://mfem.org.
+#
+# MFEM is free software; you can redistribute it and/or modify it under the
+# terms of the BSD-3 license. We welcome feedback and contributions, see file
+# CONTRIBUTING.md for details.
+
+# GitLab pipelines configurations for the Lassen machine at LLNL
+
+.on_lassen:
+  tags:
+    - shell
+    - lassen
+  variables:
+    PLAT: lassen
+
+# Build MFEM
+build_mfem_ser_lassen:
+  extends: [.on_lassen]
+  needs: [setup]
+  stage: lassen_build
+  script:
+    - mkdir -p ${BUILD_PATH}
+    - cp -r ${CI_PROJECT_DIR} ${BUILD_PATH}/${CI_PROJECT_NAME}_lassen_ser
+    - cd ${BUILD_PATH}/${CI_PROJECT_NAME}_lassen_ser
+    - lalloc 1 -W 5 -q pdebug make -j cuda
+
+build_mfem_debug_ser_lassen:
+  extends: [.on_lassen]
+  needs: [setup]
+  stage: lassen_build
+  script:
+    - mkdir -p ${BUILD_PATH}
+    - cp -r ${CI_PROJECT_DIR} ${BUILD_PATH}/${CI_PROJECT_NAME}_lassen_ser_debug
+    - cd ${BUILD_PATH}/${CI_PROJECT_NAME}_lassen_ser_debug
+    - lalloc 1 -W 5 -q pdebug make -j cuda MFEM_DEBUG="YES"
+
+# Sanity check
+sanitycheck_mfem_ser_lassen:
+  extends: [.on_lassen]
+  stage: lassen_test
+  needs: [build_mfem_ser_lassen]
+  script:
+    - cd ${BUILD_PATH}/${CI_PROJECT_NAME}_lassen_ser
+    - lalloc 1 -W 15 -q pdebug make -j test
+
+sanitycheck_mfem_debug_ser_lassen:
+  extends: [.on_lassen]
+  stage: lassen_test
+  needs: [build_mfem_debug_ser_lassen]
+  script:
+    - cd ${BUILD_PATH}/${CI_PROJECT_NAME}_lassen_ser_debug
+    - lalloc 1 -W 30 -q pdebug make -j test
+
+  ## Baseline
+  #baselinecheck_mfem_intel_lassen:
+  #  extends: [.baselinecheck_mfem, .on_lassen]
+  #
+  #baselinepublish_mfem_lassen:
+  #  extends: [.rebaseline_mfem, .on_lassen]
+  #  needs: [baselinecheck_mfem_intel_lassen]

--- a/.gitlab/lassen.yml
+++ b/.gitlab/lassen.yml
@@ -55,11 +55,3 @@ sanitycheck_mfem_debug_ser_lassen:
   script:
     - cd ${BUILD_PATH}/${CI_PROJECT_NAME}_lassen_ser_debug
     - lalloc 1 -W 30 -q pdebug make -j test
-
-  ## Baseline
-  #baselinecheck_mfem_intel_lassen:
-  #  extends: [.baselinecheck_mfem, .on_lassen]
-  #
-  #baselinepublish_mfem_lassen:
-  #  extends: [.rebaseline_mfem, .on_lassen]
-  #  needs: [baselinecheck_mfem_intel_lassen]

--- a/.gitlab/lassen.yml
+++ b/.gitlab/lassen.yml
@@ -20,38 +20,38 @@
 
 # Build MFEM
 build_mfem_ser_lassen:
-  extends: [.on_lassen]
+  extends: [.with_gcc_8_3_1, .on_lassen]
   needs: [setup]
   stage: lassen_build
   script:
     - mkdir -p ${BUILD_PATH}
     - cp -r ${CI_PROJECT_DIR} ${BUILD_PATH}/${CI_PROJECT_NAME}_lassen_ser
     - cd ${BUILD_PATH}/${CI_PROJECT_NAME}_lassen_ser
-    - lalloc 1 -W 5 -q pdebug make -j cuda
+    - lalloc 1 -W 5 -q pdebug make -j cuda CUDA_ARCH=sm_70
 
 build_mfem_debug_ser_lassen:
-  extends: [.on_lassen]
+  extends: [.with_gcc_8_3_1, .on_lassen]
   needs: [setup]
   stage: lassen_build
   script:
     - mkdir -p ${BUILD_PATH}
     - cp -r ${CI_PROJECT_DIR} ${BUILD_PATH}/${CI_PROJECT_NAME}_lassen_ser_debug
     - cd ${BUILD_PATH}/${CI_PROJECT_NAME}_lassen_ser_debug
-    - lalloc 1 -W 5 -q pdebug make -j cuda MFEM_DEBUG="YES"
+    - lalloc 1 -W 5 -q pdebug make -j cuda MFEM_DEBUG="YES" CUDA_ARCH=sm_70
 
 # Sanity check
 sanitycheck_mfem_ser_lassen:
-  extends: [.on_lassen]
+  extends: [.with_gcc_8_3_1, .on_lassen]
   stage: lassen_test
   needs: [build_mfem_ser_lassen]
   script:
     - cd ${BUILD_PATH}/${CI_PROJECT_NAME}_lassen_ser
-    - lalloc 1 -W 15 -q pdebug make -j test
+    - lalloc 1 -W 15 -q pdebug make -j test CUDA_ARCH=sm_70
 
 sanitycheck_mfem_debug_ser_lassen:
-  extends: [.on_lassen]
+  extends: [.with_gcc_8_3_1, .on_lassen]
   stage: lassen_test
   needs: [build_mfem_debug_ser_lassen]
   script:
     - cd ${BUILD_PATH}/${CI_PROJECT_NAME}_lassen_ser_debug
-    - lalloc 1 -W 30 -q pdebug make -j test
+    - lalloc 1 -W 30 -q pdebug make -j test CUDA_ARCH=sm_70

--- a/.gitlab/lassen.yml
+++ b/.gitlab/lassen.yml
@@ -46,7 +46,7 @@ sanitycheck_mfem_ser_lassen:
   needs: [build_mfem_ser_lassen]
   script:
     - cd ${BUILD_PATH}/${CI_PROJECT_NAME}_lassen_ser
-    - lalloc 1 -W 15 -q pdebug make -j test CUDA_ARCH=sm_70
+    - lalloc 1 -W 15 -q pdebug make -j test
 
 sanitycheck_mfem_debug_ser_lassen:
   extends: [.with_gcc_8_3_1, .on_lassen]
@@ -54,4 +54,4 @@ sanitycheck_mfem_debug_ser_lassen:
   needs: [build_mfem_debug_ser_lassen]
   script:
     - cd ${BUILD_PATH}/${CI_PROJECT_NAME}_lassen_ser_debug
-    - lalloc 1 -W 30 -q pdebug make -j test CUDA_ARCH=sm_70
+    - lalloc 1 -W 30 -q pdebug make -j test

--- a/.gitlab/quartz.yml
+++ b/.gitlab/quartz.yml
@@ -22,10 +22,6 @@
     MAKE_PAR: 6
     BASELINE_PAR: 18
 
-# Setup
-setup_quartz:
-  extends: [.setup, .on_quartz]
-
 # Allocate
 allocate_quartz:
   variables:


### PR DESCRIPTION
This PR adds the capability to test MFEM on lassen in Gitlab CI.

Current stage:
- Adds basic cuda builds of MFEM (with no dependencies).
- Adds sanity checks.
- Tests on Lassen are triggered at the same time as tests on quartz and baseline tests (not sequentially).

TODO:
- [x] Fix minor failure in test builds (arch option power9 not recognized).
- [ ] Add some sort of baseline test on lassen if any.

<!--GHEX{"id":1688,"author":"adrienbernede","editor":"tzanio","reviewers":["v-dobrev","YohannDudouit","camierjs","jandrej"],"assignment":"2020-08-13T12:24:31-07:00","approval":"2020-09-01T17:27:11.194Z","merge":"2020-09-08T19:46:21.882Z"}XEHG--><!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge| 
 | --- | --- | --- | --- | --- | --- | --- | 
| [#1688](https://github.com/mfem/mfem/pull/1688) | @adrienbernede | @tzanio | @v-dobrev + @YohannDudouit + @camierjs + @jandrej | 08/13/20 | 09/01/20 | 09/08/20 | |
<!--ELBATXEHG-->