### PR TITLE
Add an option to set or add when using AssembleEA.

### DIFF
--- a/fem/bilinearform_ext.cpp
+++ b/fem/bilinearform_ext.cpp
@@ -307,7 +307,6 @@ void EABilinearFormExtension::Assemble()
 
    ea_data.SetSize(ne*elemDofs*elemDofs, Device::GetMemoryType());
    ea_data.UseDevice(true);
-   ea_data = 0.0;
 
    Array<BilinearFormIntegrator*> &integrators = *a->GetDBFI();
    const int integratorCount = integrators.Size();

--- a/fem/bilinearform_ext.cpp
+++ b/fem/bilinearform_ext.cpp
@@ -326,8 +326,6 @@ void EABilinearFormExtension::Assemble()
       nf_int = trialFes->GetNFbyType(FaceType::Interior);
       ea_data_int.SetSize(2*nf_int*faceDofs*faceDofs, Device::GetMemoryType());
       ea_data_ext.SetSize(2*nf_int*faceDofs*faceDofs, Device::GetMemoryType());
-      ea_data_int = 0.0;
-      ea_data_ext = 0.0;
    }
    for (int i = 0; i < intFaceIntegratorCount; ++i)
    {

--- a/fem/bilinearform_ext.cpp
+++ b/fem/bilinearform_ext.cpp
@@ -313,7 +313,7 @@ void EABilinearFormExtension::Assemble()
    const int integratorCount = integrators.Size();
    for (int i = 0; i < integratorCount; ++i)
    {
-      integrators[i]->AssembleEA(*a->FESpace(), ea_data);
+      integrators[i]->AssembleEA(*a->FESpace(), ea_data, i);
    }
 
    faceDofs = trialFes ->
@@ -334,7 +334,8 @@ void EABilinearFormExtension::Assemble()
    {
       intFaceIntegrators[i]->AssembleEAInteriorFaces(*a->FESpace(),
                                                      ea_data_int,
-                                                     ea_data_ext);
+                                                     ea_data_ext,
+                                                     i);
    }
 
    Array<BilinearFormIntegrator*> &bdrFaceIntegrators = *a->GetBFBFI();
@@ -347,7 +348,7 @@ void EABilinearFormExtension::Assemble()
    }
    for (int i = 0; i < boundFaceIntegratorCount; ++i)
    {
-      bdrFaceIntegrators[i]->AssembleEABoundaryFaces(*a->FESpace(),ea_data_bdr);
+      bdrFaceIntegrators[i]->AssembleEABoundaryFaces(*a->FESpace(),ea_data_bdr,i);
    }
 
    if (factorize_face_terms && int_face_restrict_lex)

--- a/fem/bilininteg.cpp
+++ b/fem/bilininteg.cpp
@@ -52,7 +52,8 @@ void BilinearFormIntegrator::AssembleDiagonalPA(Vector &)
 }
 
 void BilinearFormIntegrator::AssembleEA(const FiniteElementSpace &fes,
-                                        Vector &emat)
+                                        Vector &emat,
+                                        const bool add)
 {
    mfem_error ("BilinearFormIntegrator::AssembleEA(...)\n"
                "   is not implemented for this class.");
@@ -61,7 +62,8 @@ void BilinearFormIntegrator::AssembleEA(const FiniteElementSpace &fes,
 void BilinearFormIntegrator::AssembleEAInteriorFaces(const FiniteElementSpace
                                                      &fes,
                                                      Vector &ea_data_int,
-                                                     Vector &ea_data_ext)
+                                                     Vector &ea_data_ext,
+                                                     const bool add)
 {
    mfem_error ("BilinearFormIntegrator::AssembleEAInteriorFaces(...)\n"
                "   is not implemented for this class.");
@@ -69,7 +71,8 @@ void BilinearFormIntegrator::AssembleEAInteriorFaces(const FiniteElementSpace
 
 void BilinearFormIntegrator::AssembleEABoundaryFaces(const FiniteElementSpace
                                                      &fes,
-                                                     Vector &ea_data_bdr)
+                                                     Vector &ea_data_bdr,
+                                                     const bool add)
 {
    mfem_error ("BilinearFormIntegrator::AssembleEABoundaryFaces(...)\n"
                "   is not implemented for this class.");

--- a/fem/bilininteg.hpp
+++ b/fem/bilininteg.hpp
@@ -80,7 +80,7 @@ public:
 
    /// Method defining element assembly.
    /** The result of the element assembly is added to the @a emat Vector if
-       @a add is true, it sets @a emat if @a add is false. */
+       @a add is true. Otherwise, if @a add is false, we set @a emat. */
    virtual void AssembleEA(const FiniteElementSpace &fes, Vector &emat,
                            const bool add = true);
    /** Used with BilinearFormIntegrators that have different spaces. */

--- a/fem/bilininteg.hpp
+++ b/fem/bilininteg.hpp
@@ -79,9 +79,10 @@ public:
    virtual void AddMultTransposePA(const Vector &x, Vector &y) const;
 
    /// Method defining element assembly.
-   /** The result of the element assembly is added and stored in the @a emat
-       Vector. */
-   virtual void AssembleEA(const FiniteElementSpace &fes, Vector &emat);
+   /** The result of the element assembly is added to the @a emat Vector if
+       @a add is true, it sets @a emat if @a add is false. */
+   virtual void AssembleEA(const FiniteElementSpace &fes, Vector &emat,
+                           const bool add = false);
    /** Used with BilinearFormIntegrators that have different spaces. */
    // virtual void AssembleEA(const FiniteElementSpace &trial_fes,
    //                         const FiniteElementSpace &test_fes,
@@ -89,10 +90,12 @@ public:
 
    virtual void AssembleEAInteriorFaces(const FiniteElementSpace &fes,
                                         Vector &ea_data_int,
-                                        Vector &ea_data_ext);
+                                        Vector &ea_data_ext,
+                                        const bool add = false);
 
    virtual void AssembleEABoundaryFaces(const FiniteElementSpace &fes,
-                                        Vector &ea_data_bdr);
+                                        Vector &ea_data_bdr,
+                                        const bool add = false);
 
    /// Given a particular Finite Element computes the element matrix elmat.
    virtual void AssembleElementMatrix(const FiniteElement &el,
@@ -255,14 +258,17 @@ public:
       bfi->AddMultTransposePA(x, y);
    }
 
-   virtual void AssembleEA(const FiniteElementSpace &fes, Vector &emat);
+   virtual void AssembleEA(const FiniteElementSpace &fes, Vector &emat,
+                           const bool add);
 
    virtual void AssembleEAInteriorFaces(const FiniteElementSpace &fes,
                                         Vector &ea_data_int,
-                                        Vector &ea_data_ext);
+                                        Vector &ea_data_ext,
+                                        const bool add);
 
    virtual void AssembleEABoundaryFaces(const FiniteElementSpace &fes,
-                                        Vector &ea_data_bdr);
+                                        Vector &ea_data_bdr,
+                                        const bool add);
 
    virtual ~TransposeIntegrator() { if (own_bfi) { delete bfi; } }
 };
@@ -1945,7 +1951,8 @@ public:
 
    virtual void AssemblePA(const FiniteElementSpace &fes);
 
-   virtual void AssembleEA(const FiniteElementSpace &fes, Vector &emat);
+   virtual void AssembleEA(const FiniteElementSpace &fes, Vector &emat,
+                           const bool add);
 
    virtual void AssembleDiagonalPA(Vector &diag);
 
@@ -2020,7 +2027,8 @@ public:
 
    virtual void AssemblePA(const FiniteElementSpace &fes);
 
-   virtual void AssembleEA(const FiniteElementSpace &fes, Vector &emat);
+   virtual void AssembleEA(const FiniteElementSpace &fes, Vector &emat,
+                           const bool add);
 
    virtual void AssembleDiagonalPA(Vector &diag);
 
@@ -2076,7 +2084,8 @@ public:
 
    virtual void AssemblePA(const FiniteElementSpace&);
 
-   virtual void AssembleEA(const FiniteElementSpace &fes, Vector &emat);
+   virtual void AssembleEA(const FiniteElementSpace &fes, Vector &emat,
+                           const bool add);
 
    virtual void AddMultPA(const Vector&, Vector&) const;
 
@@ -2641,10 +2650,12 @@ public:
 
    virtual void AssembleEAInteriorFaces(const FiniteElementSpace& fes,
                                         Vector &ea_data_int,
-                                        Vector &ea_data_ext);
+                                        Vector &ea_data_ext,
+                                        const bool add);
 
    virtual void AssembleEABoundaryFaces(const FiniteElementSpace& fes,
-                                        Vector &ea_data_bdr);
+                                        Vector &ea_data_bdr,
+                                        const bool add);
 
    static const IntegrationRule &GetRule(Geometry::Type geom, int order,
                                          FaceElementTransformations &T);

--- a/fem/bilininteg.hpp
+++ b/fem/bilininteg.hpp
@@ -82,7 +82,7 @@ public:
    /** The result of the element assembly is added to the @a emat Vector if
        @a add is true, it sets @a emat if @a add is false. */
    virtual void AssembleEA(const FiniteElementSpace &fes, Vector &emat,
-                           const bool add = false);
+                           const bool add = true);
    /** Used with BilinearFormIntegrators that have different spaces. */
    // virtual void AssembleEA(const FiniteElementSpace &trial_fes,
    //                         const FiniteElementSpace &test_fes,
@@ -91,11 +91,11 @@ public:
    virtual void AssembleEAInteriorFaces(const FiniteElementSpace &fes,
                                         Vector &ea_data_int,
                                         Vector &ea_data_ext,
-                                        const bool add = false);
+                                        const bool add = true);
 
    virtual void AssembleEABoundaryFaces(const FiniteElementSpace &fes,
                                         Vector &ea_data_bdr,
-                                        const bool add = false);
+                                        const bool add = true);
 
    /// Given a particular Finite Element computes the element matrix elmat.
    virtual void AssembleElementMatrix(const FiniteElement &el,

--- a/fem/bilininteg_convection_ea.cpp
+++ b/fem/bilininteg_convection_ea.cpp
@@ -22,6 +22,7 @@ static void EAConvectionAssemble1D(const int NE,
                                    const Array<double> &g,
                                    const Vector &padata,
                                    Vector &eadata,
+                                   const bool add,
                                    const int d1d = 0,
                                    const int q1d = 0)
 {
@@ -54,7 +55,14 @@ static void EAConvectionAssemble1D(const int NE,
             {
                val += r_Bj[k1] * D(k1, e) * r_Gi[k1];
             }
-            A(i1, j1, e) += val;
+            if (add)
+            {
+               A(i1, j1, e) += val;
+            }
+            else
+            {
+               A(i1, j1, e) = val;
+            }
          }
       }
    });
@@ -66,6 +74,7 @@ static void EAConvectionAssemble2D(const int NE,
                                    const Array<double> &g,
                                    const Vector &padata,
                                    Vector &eadata,
+                                   const bool add,
                                    const int d1d = 0,
                                    const int q1d = 0)
 {
@@ -121,7 +130,14 @@ static void EAConvectionAssemble2D(const int NE,
                                * r_B[k1][j1]* r_B[k2][j2];
                      }
                   }
-                  A(i1, i2, j1, j2, e) += val;
+                  if (add)
+                  {
+                     A(i1, i2, j1, j2, e) += val;
+                  }
+                  else
+                  {
+                     A(i1, i2, j1, j2, e) = val;
+                  }
                }
             }
          }
@@ -135,6 +151,7 @@ static void EAConvectionAssemble3D(const int NE,
                                    const Array<double> &g,
                                    const Vector &padata,
                                    Vector &eadata,
+                                   const bool add,
                                    const int d1d = 0,
                                    const int q1d = 0)
 {
@@ -191,7 +208,14 @@ static void EAConvectionAssemble3D(const int NE,
                               }
                            }
                         }
-                        A(i1, i2, i3, j1, j2, j3, e) += val;
+                        if (add)
+                        {
+                           A(i1, i2, i3, j1, j2, j3, e) += val;
+                        }
+                        else
+                        {
+                           A(i1, i2, i3, j1, j2, j3, e) = val;
+                        }
                      }
                   }
                }
@@ -202,7 +226,8 @@ static void EAConvectionAssemble3D(const int NE,
 }
 
 void ConvectionIntegrator::AssembleEA(const FiniteElementSpace &fes,
-                                      Vector &ea_data)
+                                      Vector &ea_data,
+                                      const bool add)
 {
    AssemblePA(fes);
    const int ne = fes.GetMesh()->GetNE();
@@ -212,44 +237,47 @@ void ConvectionIntegrator::AssembleEA(const FiniteElementSpace &fes,
    {
       switch ((dofs1D << 4 ) | quad1D)
       {
-         case 0x22: return EAConvectionAssemble1D<2,2>(ne,B,G,pa_data,ea_data);
-         case 0x33: return EAConvectionAssemble1D<3,3>(ne,B,G,pa_data,ea_data);
-         case 0x44: return EAConvectionAssemble1D<4,4>(ne,B,G,pa_data,ea_data);
-         case 0x55: return EAConvectionAssemble1D<5,5>(ne,B,G,pa_data,ea_data);
-         case 0x66: return EAConvectionAssemble1D<6,6>(ne,B,G,pa_data,ea_data);
-         case 0x77: return EAConvectionAssemble1D<7,7>(ne,B,G,pa_data,ea_data);
-         case 0x88: return EAConvectionAssemble1D<8,8>(ne,B,G,pa_data,ea_data);
-         case 0x99: return EAConvectionAssemble1D<9,9>(ne,B,G,pa_data,ea_data);
-         default:   return EAConvectionAssemble1D(ne,B,G,pa_data,ea_data,dofs1D,quad1D);
+         case 0x22: return EAConvectionAssemble1D<2,2>(ne,B,G,pa_data,ea_data,add);
+         case 0x33: return EAConvectionAssemble1D<3,3>(ne,B,G,pa_data,ea_data,add);
+         case 0x44: return EAConvectionAssemble1D<4,4>(ne,B,G,pa_data,ea_data,add);
+         case 0x55: return EAConvectionAssemble1D<5,5>(ne,B,G,pa_data,ea_data,add);
+         case 0x66: return EAConvectionAssemble1D<6,6>(ne,B,G,pa_data,ea_data,add);
+         case 0x77: return EAConvectionAssemble1D<7,7>(ne,B,G,pa_data,ea_data,add);
+         case 0x88: return EAConvectionAssemble1D<8,8>(ne,B,G,pa_data,ea_data,add);
+         case 0x99: return EAConvectionAssemble1D<9,9>(ne,B,G,pa_data,ea_data,add);
+         default:   return EAConvectionAssemble1D(ne,B,G,pa_data,ea_data,add,
+                                                  dofs1D,quad1D);
       }
    }
    else if (dim == 2)
    {
       switch ((dofs1D << 4 ) | quad1D)
       {
-         case 0x22: return EAConvectionAssemble2D<2,2>(ne,B,G,pa_data,ea_data);
-         case 0x33: return EAConvectionAssemble2D<3,3>(ne,B,G,pa_data,ea_data);
-         case 0x44: return EAConvectionAssemble2D<4,4>(ne,B,G,pa_data,ea_data);
-         case 0x55: return EAConvectionAssemble2D<5,5>(ne,B,G,pa_data,ea_data);
-         case 0x66: return EAConvectionAssemble2D<6,6>(ne,B,G,pa_data,ea_data);
-         case 0x77: return EAConvectionAssemble2D<7,7>(ne,B,G,pa_data,ea_data);
-         case 0x88: return EAConvectionAssemble2D<8,8>(ne,B,G,pa_data,ea_data);
-         case 0x99: return EAConvectionAssemble2D<9,9>(ne,B,G,pa_data,ea_data);
-         default:   return EAConvectionAssemble2D(ne,B,G,pa_data,ea_data,dofs1D,quad1D);
+         case 0x22: return EAConvectionAssemble2D<2,2>(ne,B,G,pa_data,ea_data,add);
+         case 0x33: return EAConvectionAssemble2D<3,3>(ne,B,G,pa_data,ea_data,add);
+         case 0x44: return EAConvectionAssemble2D<4,4>(ne,B,G,pa_data,ea_data,add);
+         case 0x55: return EAConvectionAssemble2D<5,5>(ne,B,G,pa_data,ea_data,add);
+         case 0x66: return EAConvectionAssemble2D<6,6>(ne,B,G,pa_data,ea_data,add);
+         case 0x77: return EAConvectionAssemble2D<7,7>(ne,B,G,pa_data,ea_data,add);
+         case 0x88: return EAConvectionAssemble2D<8,8>(ne,B,G,pa_data,ea_data,add);
+         case 0x99: return EAConvectionAssemble2D<9,9>(ne,B,G,pa_data,ea_data,add);
+         default:   return EAConvectionAssemble2D(ne,B,G,pa_data,ea_data,add,
+                                                  dofs1D,quad1D);
       }
    }
    else if (dim == 3)
    {
       switch ((dofs1D << 4 ) | quad1D)
       {
-         case 0x23: return EAConvectionAssemble3D<2,3>(ne,B,G,pa_data,ea_data);
-         case 0x34: return EAConvectionAssemble3D<3,4>(ne,B,G,pa_data,ea_data);
-         case 0x45: return EAConvectionAssemble3D<4,5>(ne,B,G,pa_data,ea_data);
-         case 0x56: return EAConvectionAssemble3D<5,6>(ne,B,G,pa_data,ea_data);
-         case 0x67: return EAConvectionAssemble3D<6,7>(ne,B,G,pa_data,ea_data);
-         case 0x78: return EAConvectionAssemble3D<7,8>(ne,B,G,pa_data,ea_data);
-         case 0x89: return EAConvectionAssemble3D<8,9>(ne,B,G,pa_data,ea_data);
-         default:   return EAConvectionAssemble3D(ne,B,G,pa_data,ea_data,dofs1D,quad1D);
+         case 0x23: return EAConvectionAssemble3D<2,3>(ne,B,G,pa_data,ea_data,add);
+         case 0x34: return EAConvectionAssemble3D<3,4>(ne,B,G,pa_data,ea_data,add);
+         case 0x45: return EAConvectionAssemble3D<4,5>(ne,B,G,pa_data,ea_data,add);
+         case 0x56: return EAConvectionAssemble3D<5,6>(ne,B,G,pa_data,ea_data,add);
+         case 0x67: return EAConvectionAssemble3D<6,7>(ne,B,G,pa_data,ea_data,add);
+         case 0x78: return EAConvectionAssemble3D<7,8>(ne,B,G,pa_data,ea_data,add);
+         case 0x89: return EAConvectionAssemble3D<8,9>(ne,B,G,pa_data,ea_data,add);
+         default:   return EAConvectionAssemble3D(ne,B,G,pa_data,ea_data,add,
+                                                  dofs1D,quad1D);
       }
    }
    MFEM_ABORT("Unknown kernel.");

--- a/fem/bilininteg_convection_ea.cpp
+++ b/fem/bilininteg_convection_ea.cpp
@@ -246,7 +246,7 @@ void ConvectionIntegrator::AssembleEA(const FiniteElementSpace &fes,
          case 0x88: return EAConvectionAssemble1D<8,8>(ne,B,G,pa_data,ea_data,add);
          case 0x99: return EAConvectionAssemble1D<9,9>(ne,B,G,pa_data,ea_data,add);
          default:   return EAConvectionAssemble1D(ne,B,G,pa_data,ea_data,add,
-                                                  dofs1D,quad1D);
+                                                     dofs1D,quad1D);
       }
    }
    else if (dim == 2)
@@ -262,7 +262,7 @@ void ConvectionIntegrator::AssembleEA(const FiniteElementSpace &fes,
          case 0x88: return EAConvectionAssemble2D<8,8>(ne,B,G,pa_data,ea_data,add);
          case 0x99: return EAConvectionAssemble2D<9,9>(ne,B,G,pa_data,ea_data,add);
          default:   return EAConvectionAssemble2D(ne,B,G,pa_data,ea_data,add,
-                                                  dofs1D,quad1D);
+                                                     dofs1D,quad1D);
       }
    }
    else if (dim == 3)
@@ -277,7 +277,7 @@ void ConvectionIntegrator::AssembleEA(const FiniteElementSpace &fes,
          case 0x78: return EAConvectionAssemble3D<7,8>(ne,B,G,pa_data,ea_data,add);
          case 0x89: return EAConvectionAssemble3D<8,9>(ne,B,G,pa_data,ea_data,add);
          default:   return EAConvectionAssemble3D(ne,B,G,pa_data,ea_data,add,
-                                                  dofs1D,quad1D);
+                                                     dofs1D,quad1D);
       }
    }
    MFEM_ABORT("Unknown kernel.");

--- a/fem/bilininteg_dgtrace_ea.cpp
+++ b/fem/bilininteg_dgtrace_ea.cpp
@@ -20,7 +20,8 @@ static void EADGTraceAssemble1DInt(const int NF,
                                    const Array<double> &basis,
                                    const Vector &padata,
                                    Vector &eadata_int,
-                                   Vector &eadata_ext)
+                                   Vector &eadata_ext,
+                                   const bool add)
 {
    auto D = Reshape(padata.Read(), 2, 2, NF);
    auto A_int = Reshape(eadata_int.ReadWrite(), 2, NF);
@@ -32,23 +33,41 @@ static void EADGTraceAssemble1DInt(const int NF,
       val_ext10 = D(1, 0, f);
       val_ext01 = D(0, 1, f);
       val_int1  = D(1, 1, f);
-      A_int(0, f) += val_int0;
-      A_int(1, f) += val_int1;
-      A_ext(0, f) += val_ext01;
-      A_ext(1, f) += val_ext10;
+      if (add)
+      {
+         A_int(0, f) += val_int0;
+         A_int(1, f) += val_int1;
+         A_ext(0, f) += val_ext01;
+         A_ext(1, f) += val_ext10;
+      }
+      else
+      {
+         A_int(0, f) = val_int0;
+         A_int(1, f) = val_int1;
+         A_ext(0, f) = val_ext01;
+         A_ext(1, f) = val_ext10;
+      }
    });
 }
 
 static void EADGTraceAssemble1DBdr(const int NF,
                                    const Array<double> &basis,
                                    const Vector &padata,
-                                   Vector &eadata_bdr)
+                                   Vector &eadata_bdr,
+                                   const bool add)
 {
    auto D = Reshape(padata.Read(), 2, 2, NF);
    auto A_bdr = Reshape(eadata_bdr.ReadWrite(), NF);
    MFEM_FORALL(f, NF,
    {
-      A_bdr(f) += D(0, 0, f);
+      if (add)
+      {
+         A_bdr(f) += D(0, 0, f);
+      }
+      else
+      {
+         A_bdr(f) = D(0, 0, f);
+      }
    });
 }
 
@@ -58,6 +77,7 @@ static void EADGTraceAssemble2DInt(const int NF,
                                    const Vector &padata,
                                    Vector &eadata_int,
                                    Vector &eadata_ext,
+                                   const bool add,
                                    const int d1d = 0,
                                    const int q1d = 0)
 {
@@ -88,10 +108,20 @@ static void EADGTraceAssemble2DInt(const int NF,
                val_ext10 += B(k1,i1) * B(k1,j1) * D(k1, 1, 0, f);
                val_int1  += B(k1,i1) * B(k1,j1) * D(k1, 1, 1, f);
             }
-            A_int(i1, j1, 0, f) += val_int0;
-            A_int(i1, j1, 1, f) += val_int1;
-            A_ext(i1, j1, 0, f) += val_ext01;
-            A_ext(i1, j1, 1, f) += val_ext10;
+            if (add)
+            {
+               A_int(i1, j1, 0, f) += val_int0;
+               A_int(i1, j1, 1, f) += val_int1;
+               A_ext(i1, j1, 0, f) += val_ext01;
+               A_ext(i1, j1, 1, f) += val_ext10;
+            }
+            else
+            {   
+               A_int(i1, j1, 0, f) = val_int0;
+               A_int(i1, j1, 1, f) = val_int1;
+               A_ext(i1, j1, 0, f) = val_ext01;
+               A_ext(i1, j1, 1, f) = val_ext10;
+            }
          }
       }
    });
@@ -102,6 +132,7 @@ static void EADGTraceAssemble2DBdr(const int NF,
                                    const Array<double> &basis,
                                    const Vector &padata,
                                    Vector &eadata_bdr,
+                                   const bool add,
                                    const int d1d = 0,
                                    const int q1d = 0)
 {
@@ -125,7 +156,17 @@ static void EADGTraceAssemble2DBdr(const int NF,
             {
                val_bdr  += B(k1,i1) * B(k1,j1) * D(k1, 0, 0, f);
             }
-            A_bdr(i1, j1, f) += val_bdr;
+            if (add)
+            {
+               A_bdr(i1, j1, f) += val_bdr;
+            }
+            else
+            {
+               A_bdr(i1, j1, f) = val_bdr;
+            }
+            
+            
+            
          }
       }
    });
@@ -137,6 +178,7 @@ static void EADGTraceAssemble3DInt(const int NF,
                                    const Vector &padata,
                                    Vector &eadata_int,
                                    Vector &eadata_ext,
+                                   const bool add,
                                    const int d1d = 0,
                                    const int q1d = 0)
 {
@@ -207,10 +249,20 @@ static void EADGTraceAssemble3DInt(const int NF,
                                     * s_D[k1][k2][1][0];
                      }
                   }
-                  A_int(i1, i2, j1, j2, 0, f) += val_int0;
-                  A_int(i1, i2, j1, j2, 1, f) += val_int1;
-                  A_ext(i1, i2, j1, j2, 0, f) += val_ext01;
-                  A_ext(i1, i2, j1, j2, 1, f) += val_ext10;
+                  if (add)
+                  {
+                     A_int(i1, i2, j1, j2, 0, f) += val_int0;
+                     A_int(i1, i2, j1, j2, 1, f) += val_int1;
+                     A_ext(i1, i2, j1, j2, 0, f) += val_ext01;
+                     A_ext(i1, i2, j1, j2, 1, f) += val_ext10;
+                  }
+                  else
+                  {
+                     A_int(i1, i2, j1, j2, 0, f) = val_int0;
+                     A_int(i1, i2, j1, j2, 1, f) = val_int1;
+                     A_ext(i1, i2, j1, j2, 0, f) = val_ext01;
+                     A_ext(i1, i2, j1, j2, 1, f) = val_ext10;
+                  }
                }
             }
          }
@@ -223,6 +275,7 @@ static void EADGTraceAssemble3DBdr(const int NF,
                                    const Array<double> &basis,
                                    const Vector &padata,
                                    Vector &eadata_bdr,
+                                   const bool add,
                                    const int d1d = 0,
                                    const int q1d = 0)
 {
@@ -280,7 +333,14 @@ static void EADGTraceAssemble3DBdr(const int NF,
                                    * s_D[k1][k2][0][0];
                      }
                   }
-                  A_bdr(i1, i2, j1, j2, f) += val_bdr;
+                  if (add)
+                  {
+                     A_bdr(i1, i2, j1, j2, f) += val_bdr;
+                  }
+                  else
+                  {
+                     A_bdr(i1, i2, j1, j2, f) = val_bdr;
+                  }
                }
             }
          }
@@ -290,7 +350,8 @@ static void EADGTraceAssemble3DBdr(const int NF,
 
 void DGTraceIntegrator::AssembleEAInteriorFaces(const FiniteElementSpace& fes,
                                                 Vector &ea_data_int,
-                                                Vector &ea_data_ext)
+                                                Vector &ea_data_ext,
+                                                const bool add)
 {
    SetupPA(fes, FaceType::Interior);
    nf = fes.GetNFbyType(FaceType::Interior);
@@ -298,7 +359,7 @@ void DGTraceIntegrator::AssembleEAInteriorFaces(const FiniteElementSpace& fes,
    const Array<double> &B = maps->B;
    if (dim == 1)
    {
-      return EADGTraceAssemble1DInt(nf,B,pa_data,ea_data_int,ea_data_ext);
+      return EADGTraceAssemble1DInt(nf,B,pa_data,ea_data_int,ea_data_ext,add);
    }
    else if (dim == 2)
    {
@@ -306,31 +367,31 @@ void DGTraceIntegrator::AssembleEAInteriorFaces(const FiniteElementSpace& fes,
       {
          case 0x22:
             return EADGTraceAssemble2DInt<2,2>(nf,B,pa_data,ea_data_int,
-                                               ea_data_ext);
+                                               ea_data_ext,add);
          case 0x33:
             return EADGTraceAssemble2DInt<3,3>(nf,B,pa_data,ea_data_int,
-                                               ea_data_ext);
+                                               ea_data_ext,add);
          case 0x44:
             return EADGTraceAssemble2DInt<4,4>(nf,B,pa_data,ea_data_int,
-                                               ea_data_ext);
+                                               ea_data_ext,add);
          case 0x55:
             return EADGTraceAssemble2DInt<5,5>(nf,B,pa_data,ea_data_int,
-                                               ea_data_ext);
+                                               ea_data_ext,add);
          case 0x66:
             return EADGTraceAssemble2DInt<6,6>(nf,B,pa_data,ea_data_int,
-                                               ea_data_ext);
+                                               ea_data_ext,add);
          case 0x77:
             return EADGTraceAssemble2DInt<7,7>(nf,B,pa_data,ea_data_int,
-                                               ea_data_ext);
+                                               ea_data_ext,add);
          case 0x88:
             return EADGTraceAssemble2DInt<8,8>(nf,B,pa_data,ea_data_int,
-                                               ea_data_ext);
+                                               ea_data_ext,add);
          case 0x99:
             return EADGTraceAssemble2DInt<9,9>(nf,B,pa_data,ea_data_int,
-                                               ea_data_ext);
+                                               ea_data_ext,add);
          default:
             return EADGTraceAssemble2DInt(nf,B,pa_data,ea_data_int,
-                                          ea_data_ext,dofs1D,quad1D);
+                                          ea_data_ext,add,dofs1D,quad1D);
       }
    }
    else if (dim == 3)
@@ -339,35 +400,36 @@ void DGTraceIntegrator::AssembleEAInteriorFaces(const FiniteElementSpace& fes,
       {
          case 0x23:
             return EADGTraceAssemble3DInt<2,3>(nf,B,pa_data,ea_data_int,
-                                               ea_data_ext);
+                                               ea_data_ext,add);
          case 0x34:
             return EADGTraceAssemble3DInt<3,4>(nf,B,pa_data,ea_data_int,
-                                               ea_data_ext);
+                                               ea_data_ext,add);
          case 0x45:
             return EADGTraceAssemble3DInt<4,5>(nf,B,pa_data,ea_data_int,
-                                               ea_data_ext);
+                                               ea_data_ext,add);
          case 0x56:
             return EADGTraceAssemble3DInt<5,6>(nf,B,pa_data,ea_data_int,
-                                               ea_data_ext);
+                                               ea_data_ext,add);
          case 0x67:
             return EADGTraceAssemble3DInt<6,7>(nf,B,pa_data,ea_data_int,
-                                               ea_data_ext);
+                                               ea_data_ext,add);
          case 0x78:
             return EADGTraceAssemble3DInt<7,8>(nf,B,pa_data,ea_data_int,
-                                               ea_data_ext);
+                                               ea_data_ext,add);
          case 0x89:
             return EADGTraceAssemble3DInt<8,9>(nf,B,pa_data,ea_data_int,
-                                               ea_data_ext);
+                                               ea_data_ext,add);
          default:
             return EADGTraceAssemble3DInt(nf,B,pa_data,ea_data_int,
-                                          ea_data_ext,dofs1D,quad1D);
+                                          ea_data_ext,add,dofs1D,quad1D);
       }
    }
    MFEM_ABORT("Unknown kernel.");
 }
 
 void DGTraceIntegrator::AssembleEABoundaryFaces(const FiniteElementSpace& fes,
-                                                Vector &ea_data_bdr)
+                                                Vector &ea_data_bdr,
+                                                const bool add)
 {
    SetupPA(fes, FaceType::Boundary);
    nf = fes.GetNFbyType(FaceType::Boundary);
@@ -375,37 +437,37 @@ void DGTraceIntegrator::AssembleEABoundaryFaces(const FiniteElementSpace& fes,
    const Array<double> &B = maps->B;
    if (dim == 1)
    {
-      return EADGTraceAssemble1DBdr(nf,B,pa_data,ea_data_bdr);
+      return EADGTraceAssemble1DBdr(nf,B,pa_data,ea_data_bdr,add);
    }
    else if (dim == 2)
    {
       switch ((dofs1D << 4 ) | quad1D)
       {
-         case 0x22: return EADGTraceAssemble2DBdr<2,2>(nf,B,pa_data,ea_data_bdr);
-         case 0x33: return EADGTraceAssemble2DBdr<3,3>(nf,B,pa_data,ea_data_bdr);
-         case 0x44: return EADGTraceAssemble2DBdr<4,4>(nf,B,pa_data,ea_data_bdr);
-         case 0x55: return EADGTraceAssemble2DBdr<5,5>(nf,B,pa_data,ea_data_bdr);
-         case 0x66: return EADGTraceAssemble2DBdr<6,6>(nf,B,pa_data,ea_data_bdr);
-         case 0x77: return EADGTraceAssemble2DBdr<7,7>(nf,B,pa_data,ea_data_bdr);
-         case 0x88: return EADGTraceAssemble2DBdr<8,8>(nf,B,pa_data,ea_data_bdr);
-         case 0x99: return EADGTraceAssemble2DBdr<9,9>(nf,B,pa_data,ea_data_bdr);
+         case 0x22: return EADGTraceAssemble2DBdr<2,2>(nf,B,pa_data,ea_data_bdr,add);
+         case 0x33: return EADGTraceAssemble2DBdr<3,3>(nf,B,pa_data,ea_data_bdr,add);
+         case 0x44: return EADGTraceAssemble2DBdr<4,4>(nf,B,pa_data,ea_data_bdr,add);
+         case 0x55: return EADGTraceAssemble2DBdr<5,5>(nf,B,pa_data,ea_data_bdr,add);
+         case 0x66: return EADGTraceAssemble2DBdr<6,6>(nf,B,pa_data,ea_data_bdr,add);
+         case 0x77: return EADGTraceAssemble2DBdr<7,7>(nf,B,pa_data,ea_data_bdr,add);
+         case 0x88: return EADGTraceAssemble2DBdr<8,8>(nf,B,pa_data,ea_data_bdr,add);
+         case 0x99: return EADGTraceAssemble2DBdr<9,9>(nf,B,pa_data,ea_data_bdr,add);
          default:
-            return EADGTraceAssemble2DBdr(nf,B,pa_data,ea_data_bdr,dofs1D,quad1D);
+            return EADGTraceAssemble2DBdr(nf,B,pa_data,ea_data_bdr,add,dofs1D,quad1D);
       }
    }
    else if (dim == 3)
    {
       switch ((dofs1D << 4 ) | quad1D)
       {
-         case 0x23: return EADGTraceAssemble3DBdr<2,3>(nf,B,pa_data,ea_data_bdr);
-         case 0x34: return EADGTraceAssemble3DBdr<3,4>(nf,B,pa_data,ea_data_bdr);
-         case 0x45: return EADGTraceAssemble3DBdr<4,5>(nf,B,pa_data,ea_data_bdr);
-         case 0x56: return EADGTraceAssemble3DBdr<5,6>(nf,B,pa_data,ea_data_bdr);
-         case 0x67: return EADGTraceAssemble3DBdr<6,7>(nf,B,pa_data,ea_data_bdr);
-         case 0x78: return EADGTraceAssemble3DBdr<7,8>(nf,B,pa_data,ea_data_bdr);
-         case 0x89: return EADGTraceAssemble3DBdr<8,9>(nf,B,pa_data,ea_data_bdr);
+         case 0x23: return EADGTraceAssemble3DBdr<2,3>(nf,B,pa_data,ea_data_bdr,add);
+         case 0x34: return EADGTraceAssemble3DBdr<3,4>(nf,B,pa_data,ea_data_bdr,add);
+         case 0x45: return EADGTraceAssemble3DBdr<4,5>(nf,B,pa_data,ea_data_bdr,add);
+         case 0x56: return EADGTraceAssemble3DBdr<5,6>(nf,B,pa_data,ea_data_bdr,add);
+         case 0x67: return EADGTraceAssemble3DBdr<6,7>(nf,B,pa_data,ea_data_bdr,add);
+         case 0x78: return EADGTraceAssemble3DBdr<7,8>(nf,B,pa_data,ea_data_bdr,add);
+         case 0x89: return EADGTraceAssemble3DBdr<8,9>(nf,B,pa_data,ea_data_bdr,add);
          default:
-            return EADGTraceAssemble3DBdr(nf,B,pa_data,ea_data_bdr,dofs1D,quad1D);
+            return EADGTraceAssemble3DBdr(nf,B,pa_data,ea_data_bdr,add,dofs1D,quad1D);
       }
    }
    MFEM_ABORT("Unknown kernel.");

--- a/fem/bilininteg_dgtrace_ea.cpp
+++ b/fem/bilininteg_dgtrace_ea.cpp
@@ -116,7 +116,7 @@ static void EADGTraceAssemble2DInt(const int NF,
                A_ext(i1, j1, 1, f) += val_ext10;
             }
             else
-            {   
+            {
                A_int(i1, j1, 0, f) = val_int0;
                A_int(i1, j1, 1, f) = val_int1;
                A_ext(i1, j1, 0, f) = val_ext01;
@@ -164,9 +164,6 @@ static void EADGTraceAssemble2DBdr(const int NF,
             {
                A_bdr(i1, j1, f) = val_bdr;
             }
-            
-            
-            
          }
       }
    });

--- a/fem/bilininteg_diffusion_ea.cpp
+++ b/fem/bilininteg_diffusion_ea.cpp
@@ -263,7 +263,7 @@ void DiffusionIntegrator::AssembleEA(const FiniteElementSpace &fes,
          case 0x88: return EADiffusionAssemble1D<8,8>(ne,B,G,pa_data,ea_data,add);
          case 0x99: return EADiffusionAssemble1D<9,9>(ne,B,G,pa_data,ea_data,add);
          default:   return EADiffusionAssemble1D(ne,B,G,pa_data,ea_data,add,
-                                                 dofs1D,quad1D);
+                                                    dofs1D,quad1D);
       }
    }
    else if (dim == 2)
@@ -279,7 +279,7 @@ void DiffusionIntegrator::AssembleEA(const FiniteElementSpace &fes,
          case 0x88: return EADiffusionAssemble2D<8,8>(ne,B,G,pa_data,ea_data,add);
          case 0x99: return EADiffusionAssemble2D<9,9>(ne,B,G,pa_data,ea_data,add);
          default:   return EADiffusionAssemble2D(ne,B,G,pa_data,ea_data,add,
-                                                 dofs1D,quad1D);
+                                                    dofs1D,quad1D);
       }
    }
    else if (dim == 3)
@@ -294,7 +294,7 @@ void DiffusionIntegrator::AssembleEA(const FiniteElementSpace &fes,
          case 0x78: return EADiffusionAssemble3D<7,8>(ne,B,G,pa_data,ea_data,add);
          case 0x89: return EADiffusionAssemble3D<8,9>(ne,B,G,pa_data,ea_data,add);
          default:   return EADiffusionAssemble3D(ne,B,G,pa_data,ea_data,add,
-                                                 dofs1D,quad1D);
+                                                    dofs1D,quad1D);
       }
    }
    MFEM_ABORT("Unknown kernel.");

--- a/fem/bilininteg_diffusion_ea.cpp
+++ b/fem/bilininteg_diffusion_ea.cpp
@@ -22,6 +22,7 @@ static void EADiffusionAssemble1D(const int NE,
                                   const Array<double> &g,
                                   const Vector &padata,
                                   Vector &eadata,
+                                  const bool add,
                                   const int d1d = 0,
                                   const int q1d = 0)
 {
@@ -53,7 +54,14 @@ static void EADiffusionAssemble1D(const int NE,
             {
                val += r_Gj[k1] * D(k1, e) * r_Gi[k1];
             }
-            A(i1, j1, e) += val;
+            if (add)
+            {
+               A(i1, j1, e) += val;
+            }
+            else
+            {
+               A(i1, j1, e) = val;
+            }
          }
       }
    });
@@ -65,6 +73,7 @@ static void EADiffusionAssemble2D(const int NE,
                                   const Array<double> &g,
                                   const Vector &padata,
                                   Vector &eadata,
+                                  const bool add,
                                   const int d1d = 0,
                                   const int q1d = 0)
 {
@@ -120,7 +129,14 @@ static void EADiffusionAssemble2D(const int NE,
                                + gbi * D11 * gbj;
                      }
                   }
-                  A(i1, i2, j1, j2, e) += val;
+                  if (add)
+                  {
+                     A(i1, i2, j1, j2, e) += val;
+                  }
+                  else
+                  {
+                     A(i1, i2, j1, j2, e) = val;
+                  }
                }
             }
          }
@@ -134,6 +150,7 @@ static void EADiffusionAssemble3D(const int NE,
                                   const Array<double> &b,
                                   const Vector &padata,
                                   Vector &eadata,
+                                  const bool add,
                                   const int d1d = 0,
                                   const int q1d = 0)
 {
@@ -208,7 +225,14 @@ static void EADiffusionAssemble3D(const int NE,
                               }
                            }
                         }
-                        A(i1, i2, i3, j1, j2, j3, e) += val;
+                        if (add)
+                        {
+                           A(i1, i2, i3, j1, j2, j3, e) += val;
+                        }
+                        else
+                        {
+                           A(i1, i2, i3, j1, j2, j3, e) = val;
+                        }
                      }
                   }
                }
@@ -219,7 +243,8 @@ static void EADiffusionAssemble3D(const int NE,
 }
 
 void DiffusionIntegrator::AssembleEA(const FiniteElementSpace &fes,
-                                     Vector &ea_data)
+                                     Vector &ea_data,
+                                     const bool add)
 {
    AssemblePA(fes);
    const int ne = fes.GetMesh()->GetNE();
@@ -229,44 +254,47 @@ void DiffusionIntegrator::AssembleEA(const FiniteElementSpace &fes,
    {
       switch ((dofs1D << 4 ) | quad1D)
       {
-         case 0x22: return EADiffusionAssemble1D<2,2>(ne,B,G,pa_data,ea_data);
-         case 0x33: return EADiffusionAssemble1D<3,3>(ne,B,G,pa_data,ea_data);
-         case 0x44: return EADiffusionAssemble1D<4,4>(ne,B,G,pa_data,ea_data);
-         case 0x55: return EADiffusionAssemble1D<5,5>(ne,B,G,pa_data,ea_data);
-         case 0x66: return EADiffusionAssemble1D<6,6>(ne,B,G,pa_data,ea_data);
-         case 0x77: return EADiffusionAssemble1D<7,7>(ne,B,G,pa_data,ea_data);
-         case 0x88: return EADiffusionAssemble1D<8,8>(ne,B,G,pa_data,ea_data);
-         case 0x99: return EADiffusionAssemble1D<9,9>(ne,B,G,pa_data,ea_data);
-         default:   return EADiffusionAssemble1D(ne,B,G,pa_data,ea_data,dofs1D,quad1D);
+         case 0x22: return EADiffusionAssemble1D<2,2>(ne,B,G,pa_data,ea_data,add);
+         case 0x33: return EADiffusionAssemble1D<3,3>(ne,B,G,pa_data,ea_data,add);
+         case 0x44: return EADiffusionAssemble1D<4,4>(ne,B,G,pa_data,ea_data,add);
+         case 0x55: return EADiffusionAssemble1D<5,5>(ne,B,G,pa_data,ea_data,add);
+         case 0x66: return EADiffusionAssemble1D<6,6>(ne,B,G,pa_data,ea_data,add);
+         case 0x77: return EADiffusionAssemble1D<7,7>(ne,B,G,pa_data,ea_data,add);
+         case 0x88: return EADiffusionAssemble1D<8,8>(ne,B,G,pa_data,ea_data,add);
+         case 0x99: return EADiffusionAssemble1D<9,9>(ne,B,G,pa_data,ea_data,add);
+         default:   return EADiffusionAssemble1D(ne,B,G,pa_data,ea_data,add,
+                                                 dofs1D,quad1D);
       }
    }
    else if (dim == 2)
    {
       switch ((dofs1D << 4 ) | quad1D)
       {
-         case 0x22: return EADiffusionAssemble2D<2,2>(ne,B,G,pa_data,ea_data);
-         case 0x33: return EADiffusionAssemble2D<3,3>(ne,B,G,pa_data,ea_data);
-         case 0x44: return EADiffusionAssemble2D<4,4>(ne,B,G,pa_data,ea_data);
-         case 0x55: return EADiffusionAssemble2D<5,5>(ne,B,G,pa_data,ea_data);
-         case 0x66: return EADiffusionAssemble2D<6,6>(ne,B,G,pa_data,ea_data);
-         case 0x77: return EADiffusionAssemble2D<7,7>(ne,B,G,pa_data,ea_data);
-         case 0x88: return EADiffusionAssemble2D<8,8>(ne,B,G,pa_data,ea_data);
-         case 0x99: return EADiffusionAssemble2D<9,9>(ne,B,G,pa_data,ea_data);
-         default:   return EADiffusionAssemble2D(ne,B,G,pa_data,ea_data,dofs1D,quad1D);
+         case 0x22: return EADiffusionAssemble2D<2,2>(ne,B,G,pa_data,ea_data,add);
+         case 0x33: return EADiffusionAssemble2D<3,3>(ne,B,G,pa_data,ea_data,add);
+         case 0x44: return EADiffusionAssemble2D<4,4>(ne,B,G,pa_data,ea_data,add);
+         case 0x55: return EADiffusionAssemble2D<5,5>(ne,B,G,pa_data,ea_data,add);
+         case 0x66: return EADiffusionAssemble2D<6,6>(ne,B,G,pa_data,ea_data,add);
+         case 0x77: return EADiffusionAssemble2D<7,7>(ne,B,G,pa_data,ea_data,add);
+         case 0x88: return EADiffusionAssemble2D<8,8>(ne,B,G,pa_data,ea_data,add);
+         case 0x99: return EADiffusionAssemble2D<9,9>(ne,B,G,pa_data,ea_data,add);
+         default:   return EADiffusionAssemble2D(ne,B,G,pa_data,ea_data,add,
+                                                 dofs1D,quad1D);
       }
    }
    else if (dim == 3)
    {
       switch ((dofs1D << 4 ) | quad1D)
       {
-         case 0x23: return EADiffusionAssemble3D<2,3>(ne,B,G,pa_data,ea_data);
-         case 0x34: return EADiffusionAssemble3D<3,4>(ne,B,G,pa_data,ea_data);
-         case 0x45: return EADiffusionAssemble3D<4,5>(ne,B,G,pa_data,ea_data);
-         case 0x56: return EADiffusionAssemble3D<5,6>(ne,B,G,pa_data,ea_data);
-         case 0x67: return EADiffusionAssemble3D<6,7>(ne,B,G,pa_data,ea_data);
-         case 0x78: return EADiffusionAssemble3D<7,8>(ne,B,G,pa_data,ea_data);
-         case 0x89: return EADiffusionAssemble3D<8,9>(ne,B,G,pa_data,ea_data);
-         default:   return EADiffusionAssemble3D(ne,B,G,pa_data,ea_data,dofs1D,quad1D);
+         case 0x23: return EADiffusionAssemble3D<2,3>(ne,B,G,pa_data,ea_data,add);
+         case 0x34: return EADiffusionAssemble3D<3,4>(ne,B,G,pa_data,ea_data,add);
+         case 0x45: return EADiffusionAssemble3D<4,5>(ne,B,G,pa_data,ea_data,add);
+         case 0x56: return EADiffusionAssemble3D<5,6>(ne,B,G,pa_data,ea_data,add);
+         case 0x67: return EADiffusionAssemble3D<6,7>(ne,B,G,pa_data,ea_data,add);
+         case 0x78: return EADiffusionAssemble3D<7,8>(ne,B,G,pa_data,ea_data,add);
+         case 0x89: return EADiffusionAssemble3D<8,9>(ne,B,G,pa_data,ea_data,add);
+         default:   return EADiffusionAssemble3D(ne,B,G,pa_data,ea_data,add,
+                                                 dofs1D,quad1D);
       }
    }
    MFEM_ABORT("Unknown kernel.");

--- a/fem/bilininteg_mass_ea.cpp
+++ b/fem/bilininteg_mass_ea.cpp
@@ -21,6 +21,7 @@ static void EAMassAssemble1D(const int NE,
                              const Array<double> &basis,
                              const Vector &padata,
                              Vector &eadata,
+                             const bool add,
                              const int d1d = 0,
                              const int q1d = 0)
 {
@@ -52,7 +53,14 @@ static void EAMassAssemble1D(const int NE,
             {
                val += r_Bi[k1] * r_Bj[k1] * D(k1, e);
             }
-            M(i1, j1, e) += val;
+            if (add)
+            {
+               M(i1, j1, e) += val;
+            }
+            else
+            {
+               M(i1, j1, e) = val;
+            }
          }
       }
    });
@@ -63,6 +71,7 @@ static void EAMassAssemble2D(const int NE,
                              const Array<double> &basis,
                              const Vector &padata,
                              Vector &eadata,
+                             const bool add,
                              const int d1d = 0,
                              const int q1d = 0)
 {
@@ -114,7 +123,15 @@ static void EAMassAssemble2D(const int NE,
                                * s_D[k1][k2];
                      }
                   }
-                  M(i1, i2, j1, j2, e) += val;
+                  if (add)
+                  {
+                     M(i1, i2, j1, j2, e) += val;
+                  }
+                  else
+                  {
+                     M(i1, i2, j1, j2, e) = val;
+                  }
+                  
                }
             }
          }
@@ -127,6 +144,7 @@ static void EAMassAssemble3D(const int NE,
                              const Array<double> &basis,
                              const Vector &padata,
                              Vector &eadata,
+                             const bool add,
                              const int d1d = 0,
                              const int q1d = 0)
 {
@@ -189,7 +207,14 @@ static void EAMassAssemble3D(const int NE,
                               }
                            }
                         }
-                        M(i1, i2, i3, j1, j2, j3, e) += val;
+                        if (add)
+                        {
+                           M(i1, i2, i3, j1, j2, j3, e) += val;
+                        }
+                        else
+                        {
+                           M(i1, i2, i3, j1, j2, j3, e) = val;
+                        }
                      }
                   }
                }
@@ -200,7 +225,8 @@ static void EAMassAssemble3D(const int NE,
 }
 
 void MassIntegrator::AssembleEA(const FiniteElementSpace &fes,
-                                Vector &ea_data)
+                                Vector &ea_data,
+                                const bool add)
 {
    AssemblePA(fes);
    const int ne = fes.GetMesh()->GetNE();
@@ -209,44 +235,47 @@ void MassIntegrator::AssembleEA(const FiniteElementSpace &fes,
    {
       switch ((dofs1D << 4 ) | quad1D)
       {
-         case 0x22: return EAMassAssemble1D<2,2>(ne,B,pa_data,ea_data);
-         case 0x33: return EAMassAssemble1D<3,3>(ne,B,pa_data,ea_data);
-         case 0x44: return EAMassAssemble1D<4,4>(ne,B,pa_data,ea_data);
-         case 0x55: return EAMassAssemble1D<5,5>(ne,B,pa_data,ea_data);
-         case 0x66: return EAMassAssemble1D<6,6>(ne,B,pa_data,ea_data);
-         case 0x77: return EAMassAssemble1D<7,7>(ne,B,pa_data,ea_data);
-         case 0x88: return EAMassAssemble1D<8,8>(ne,B,pa_data,ea_data);
-         case 0x99: return EAMassAssemble1D<9,9>(ne,B,pa_data,ea_data);
-         default:   return EAMassAssemble1D(ne,B,pa_data,ea_data,dofs1D,quad1D);
+         case 0x22: return EAMassAssemble1D<2,2>(ne,B,pa_data,ea_data,add);
+         case 0x33: return EAMassAssemble1D<3,3>(ne,B,pa_data,ea_data,add);
+         case 0x44: return EAMassAssemble1D<4,4>(ne,B,pa_data,ea_data,add);
+         case 0x55: return EAMassAssemble1D<5,5>(ne,B,pa_data,ea_data,add);
+         case 0x66: return EAMassAssemble1D<6,6>(ne,B,pa_data,ea_data,add);
+         case 0x77: return EAMassAssemble1D<7,7>(ne,B,pa_data,ea_data,add);
+         case 0x88: return EAMassAssemble1D<8,8>(ne,B,pa_data,ea_data,add);
+         case 0x99: return EAMassAssemble1D<9,9>(ne,B,pa_data,ea_data,add);
+         default:   return EAMassAssemble1D(ne,B,pa_data,ea_data,add,
+                                            dofs1D,quad1D);
       }
    }
    else if (dim == 2)
    {
       switch ((dofs1D << 4 ) | quad1D)
       {
-         case 0x22: return EAMassAssemble2D<2,2>(ne,B,pa_data,ea_data);
-         case 0x33: return EAMassAssemble2D<3,3>(ne,B,pa_data,ea_data);
-         case 0x44: return EAMassAssemble2D<4,4>(ne,B,pa_data,ea_data);
-         case 0x55: return EAMassAssemble2D<5,5>(ne,B,pa_data,ea_data);
-         case 0x66: return EAMassAssemble2D<6,6>(ne,B,pa_data,ea_data);
-         case 0x77: return EAMassAssemble2D<7,7>(ne,B,pa_data,ea_data);
-         case 0x88: return EAMassAssemble2D<8,8>(ne,B,pa_data,ea_data);
-         case 0x99: return EAMassAssemble2D<9,9>(ne,B,pa_data,ea_data);
-         default:   return EAMassAssemble2D(ne,B,pa_data,ea_data,dofs1D,quad1D);
+         case 0x22: return EAMassAssemble2D<2,2>(ne,B,pa_data,ea_data,add);
+         case 0x33: return EAMassAssemble2D<3,3>(ne,B,pa_data,ea_data,add);
+         case 0x44: return EAMassAssemble2D<4,4>(ne,B,pa_data,ea_data,add);
+         case 0x55: return EAMassAssemble2D<5,5>(ne,B,pa_data,ea_data,add);
+         case 0x66: return EAMassAssemble2D<6,6>(ne,B,pa_data,ea_data,add);
+         case 0x77: return EAMassAssemble2D<7,7>(ne,B,pa_data,ea_data,add);
+         case 0x88: return EAMassAssemble2D<8,8>(ne,B,pa_data,ea_data,add);
+         case 0x99: return EAMassAssemble2D<9,9>(ne,B,pa_data,ea_data,add);
+         default:   return EAMassAssemble2D(ne,B,pa_data,ea_data,add,
+                                            dofs1D,quad1D);
       }
    }
    else if (dim == 3)
    {
       switch ((dofs1D << 4 ) | quad1D)
       {
-         case 0x23: return EAMassAssemble3D<2,3>(ne,B,pa_data,ea_data);
-         case 0x34: return EAMassAssemble3D<3,4>(ne,B,pa_data,ea_data);
-         case 0x45: return EAMassAssemble3D<4,5>(ne,B,pa_data,ea_data);
-         case 0x56: return EAMassAssemble3D<5,6>(ne,B,pa_data,ea_data);
-         case 0x67: return EAMassAssemble3D<6,7>(ne,B,pa_data,ea_data);
-         case 0x78: return EAMassAssemble3D<7,8>(ne,B,pa_data,ea_data);
-         case 0x89: return EAMassAssemble3D<8,9>(ne,B,pa_data,ea_data);
-         default:   return EAMassAssemble3D(ne,B,pa_data,ea_data,dofs1D,quad1D);
+         case 0x23: return EAMassAssemble3D<2,3>(ne,B,pa_data,ea_data,add);
+         case 0x34: return EAMassAssemble3D<3,4>(ne,B,pa_data,ea_data,add);
+         case 0x45: return EAMassAssemble3D<4,5>(ne,B,pa_data,ea_data,add);
+         case 0x56: return EAMassAssemble3D<5,6>(ne,B,pa_data,ea_data,add);
+         case 0x67: return EAMassAssemble3D<6,7>(ne,B,pa_data,ea_data,add);
+         case 0x78: return EAMassAssemble3D<7,8>(ne,B,pa_data,ea_data,add);
+         case 0x89: return EAMassAssemble3D<8,9>(ne,B,pa_data,ea_data,add);
+         default:   return EAMassAssemble3D(ne,B,pa_data,ea_data,add,
+                                            dofs1D,quad1D);
       }
    }
    MFEM_ABORT("Unknown kernel.");

--- a/fem/bilininteg_mass_ea.cpp
+++ b/fem/bilininteg_mass_ea.cpp
@@ -131,7 +131,6 @@ static void EAMassAssemble2D(const int NE,
                   {
                      M(i1, i2, j1, j2, e) = val;
                   }
-                  
                }
             }
          }
@@ -244,7 +243,7 @@ void MassIntegrator::AssembleEA(const FiniteElementSpace &fes,
          case 0x88: return EAMassAssemble1D<8,8>(ne,B,pa_data,ea_data,add);
          case 0x99: return EAMassAssemble1D<9,9>(ne,B,pa_data,ea_data,add);
          default:   return EAMassAssemble1D(ne,B,pa_data,ea_data,add,
-                                            dofs1D,quad1D);
+                                               dofs1D,quad1D);
       }
    }
    else if (dim == 2)
@@ -260,7 +259,7 @@ void MassIntegrator::AssembleEA(const FiniteElementSpace &fes,
          case 0x88: return EAMassAssemble2D<8,8>(ne,B,pa_data,ea_data,add);
          case 0x99: return EAMassAssemble2D<9,9>(ne,B,pa_data,ea_data,add);
          default:   return EAMassAssemble2D(ne,B,pa_data,ea_data,add,
-                                            dofs1D,quad1D);
+                                               dofs1D,quad1D);
       }
    }
    else if (dim == 3)
@@ -275,7 +274,7 @@ void MassIntegrator::AssembleEA(const FiniteElementSpace &fes,
          case 0x78: return EAMassAssemble3D<7,8>(ne,B,pa_data,ea_data,add);
          case 0x89: return EAMassAssemble3D<8,9>(ne,B,pa_data,ea_data,add);
          default:   return EAMassAssemble3D(ne,B,pa_data,ea_data,add,
-                                            dofs1D,quad1D);
+                                               dofs1D,quad1D);
       }
    }
    MFEM_ABORT("Unknown kernel.");

--- a/fem/bilininteg_transpose_ea.cpp
+++ b/fem/bilininteg_transpose_ea.cpp
@@ -113,20 +113,22 @@ void TransposeIntegrator::AssembleEAInteriorFaces(const FiniteElementSpace& fes,
             {
                const double aij_int0 = A_int(i, j, 0, f);
                const double aij_int1 = A_int(i, j, 1, f);
-               const double aij_ext0 = A_ext(i, j, 0, f);
-               const double aij_ext1 = A_ext(i, j, 1, f);
                const double aji_int0 = A_int(j, i, 0, f);
                const double aji_int1 = A_int(j, i, 1, f);
-               const double aji_ext0 = A_ext(j, i, 0, f);
-               const double aji_ext1 = A_ext(j, i, 1, f);
                A_int(j, i, 0, f) = aij_int0;
                A_int(j, i, 1, f) = aij_int1;
-               A_ext(j, i, 0, f) = aij_ext1;
-               A_ext(j, i, 1, f) = aij_ext0;
                A_int(i, j, 0, f) = aji_int0;
                A_int(i, j, 1, f) = aji_int1;
+            }
+         }
+         for (int i = 0; i < faceDofs; i++)
+         {
+            for (int j = 0; j < faceDofs; j++)
+            {
+               const double aij_ext0 = A_ext(i, j, 0, f);
+               const double aji_ext1 = A_ext(j, i, 1, f);
+               A_ext(j, i, 1, f) = aij_ext0;
                A_ext(i, j, 0, f) = aji_ext1;
-               A_ext(i, j, 1, f) = aji_ext0;
             }
          }
       });

--- a/fem/bilininteg_transpose_ea.cpp
+++ b/fem/bilininteg_transpose_ea.cpp
@@ -169,7 +169,7 @@ void TransposeIntegrator::AssembleEABoundaryFaces(const FiniteElementSpace& fes,
       {
          for (int i = 0; i < faceDofs; i++)
          {
-            for (int j = 0; j < faceDofs; j++)
+            for (int j = i+1; j < faceDofs; j++)
             {
                const double aij_bdr = A_bdr(i, j, f);
                const double aji_bdr = A_bdr(j, i, f);

--- a/fem/bilininteg_transpose_ea.cpp
+++ b/fem/bilininteg_transpose_ea.cpp
@@ -75,7 +75,7 @@ void TransposeIntegrator::AssembleEAInteriorFaces(const FiniteElementSpace& fes,
       Vector ea_data_ext_tmp(ea_data_ext.Size());
       bfi->AssembleEAInteriorFaces(fes, ea_data_int_tmp, ea_data_ext_tmp, false);
       const int faceDofs = fes.GetTraceElement(0,
-                                             fes.GetMesh()->GetFaceBaseGeometry(0))->GetDof();
+                                               fes.GetMesh()->GetFaceBaseGeometry(0))->GetDof();
       auto A_int = Reshape(ea_data_int_tmp.Read(), faceDofs, faceDofs, 2, nf);
       auto A_ext = Reshape(ea_data_ext_tmp.Read(), faceDofs, faceDofs, 2, nf);
       auto AT_int = Reshape(ea_data_int.ReadWrite(), faceDofs, faceDofs, 2, nf);
@@ -102,7 +102,7 @@ void TransposeIntegrator::AssembleEAInteriorFaces(const FiniteElementSpace& fes,
    {
       bfi->AssembleEAInteriorFaces(fes, ea_data_int, ea_data_ext, false);
       const int faceDofs = fes.GetTraceElement(0,
-                                             fes.GetMesh()->GetFaceBaseGeometry(0))->GetDof();
+                                               fes.GetMesh()->GetFaceBaseGeometry(0))->GetDof();
       auto A_int = Reshape(ea_data_int.ReadWrite(), faceDofs, faceDofs, 2, nf);
       auto A_ext = Reshape(ea_data_ext.ReadWrite(), faceDofs, faceDofs, 2, nf);
       MFEM_FORALL(f, nf,
@@ -144,7 +144,7 @@ void TransposeIntegrator::AssembleEABoundaryFaces(const FiniteElementSpace& fes,
       Vector ea_data_bdr_tmp(ea_data_bdr.Size());
       bfi->AssembleEABoundaryFaces(fes, ea_data_bdr_tmp, false);
       const int faceDofs = fes.GetTraceElement(0,
-                                             fes.GetMesh()->GetFaceBaseGeometry(0))->GetDof();
+                                               fes.GetMesh()->GetFaceBaseGeometry(0))->GetDof();
       auto A_bdr = Reshape(ea_data_bdr_tmp.Read(), faceDofs, faceDofs, nf);
       auto AT_bdr = Reshape(ea_data_bdr.ReadWrite(), faceDofs, faceDofs, nf);
       MFEM_FORALL(f, nf,
@@ -163,7 +163,7 @@ void TransposeIntegrator::AssembleEABoundaryFaces(const FiniteElementSpace& fes,
    {
       bfi->AssembleEABoundaryFaces(fes, ea_data_bdr, false);
       const int faceDofs = fes.GetTraceElement(0,
-                                             fes.GetMesh()->GetFaceBaseGeometry(0))->GetDof();
+                                               fes.GetMesh()->GetFaceBaseGeometry(0))->GetDof();
       auto A_bdr = Reshape(ea_data_bdr.ReadWrite(), faceDofs, faceDofs, nf);
       MFEM_FORALL(f, nf,
       {

--- a/fem/bilininteg_transpose_ea.cpp
+++ b/fem/bilininteg_transpose_ea.cpp
@@ -16,88 +16,169 @@ namespace mfem
 {
 
 void TransposeIntegrator::AssembleEA(const FiniteElementSpace &fes,
-                                     Vector &ea_data)
+                                     Vector &ea_data, const bool add)
 {
-   Vector ea_data_tmp(ea_data.Size());
-   ea_data_tmp = 0.0;
-   bfi->AssembleEA(fes, ea_data_tmp);
-   const int ne = fes.GetNE();
-   if (ne == 0) { return; }
-   const int dofs = fes.GetFE(0)->GetDof();
-   auto A = Reshape(ea_data_tmp.Write(), dofs, dofs, ne);
-   auto AT = Reshape(ea_data.ReadWrite(), dofs, dofs, ne);
-   MFEM_FORALL(e, ne,
+   if (add)
    {
-      for (int i = 0; i < dofs; i++)
+      Vector ea_data_tmp(ea_data.Size());
+      bfi->AssembleEA(fes, ea_data_tmp, false);
+      const int ne = fes.GetNE();
+      if (ne == 0) { return; }
+      const int dofs = fes.GetFE(0)->GetDof();
+      auto A = Reshape(ea_data_tmp.Read(), dofs, dofs, ne);
+      auto AT = Reshape(ea_data.ReadWrite(), dofs, dofs, ne);
+      MFEM_FORALL(e, ne,
       {
-         for (int j = 0; j < dofs; j++)
+         for (int i = 0; i < dofs; i++)
          {
-            const double a = A(i, j, e);
-            AT(j, i, e) += a;
+            for (int j = 0; j < dofs; j++)
+            {
+               const double a = A(i, j, e);
+               AT(j, i, e) += a;
+            }
          }
-      }
-   });
+      });
+   }
+   else
+   {
+      bfi->AssembleEA(fes, ea_data, false);
+      const int ne = fes.GetNE();
+      if (ne == 0) { return; }
+      const int dofs = fes.GetFE(0)->GetDof();
+      auto A = Reshape(ea_data.ReadWrite(), dofs, dofs, ne);
+      MFEM_FORALL(e, ne,
+      {
+         for (int i = 0; i < dofs; i++)
+         {
+            for (int j = i+1; j < dofs; j++)
+            {
+               const double aij = A(i, j, e);
+               const double aji = A(j, i, e);
+               A(j, i, e) = aij;
+               A(i, j, e) = aji;
+            }
+         }
+      });
+   }
 }
 
 void TransposeIntegrator::AssembleEAInteriorFaces(const FiniteElementSpace& fes,
                                                   Vector &ea_data_int,
-                                                  Vector &ea_data_ext)
+                                                  Vector &ea_data_ext,
+                                                  const bool add)
 {
    const int nf = fes.GetNFbyType(FaceType::Interior);
    if (nf == 0) { return; }
-   Vector ea_data_int_tmp(ea_data_int.Size());
-   Vector ea_data_ext_tmp(ea_data_ext.Size());
-   ea_data_int_tmp = 0.0;
-   ea_data_ext_tmp = 0.0;
-   bfi->AssembleEAInteriorFaces(fes, ea_data_int_tmp, ea_data_ext_tmp);
-   const int faceDofs = fes.GetTraceElement(0,
-                                            fes.GetMesh()->GetFaceBaseGeometry(0))->GetDof();
-   auto A_int = Reshape(ea_data_int_tmp.Read(), faceDofs, faceDofs, 2, nf);
-   auto A_ext = Reshape(ea_data_ext_tmp.Read(), faceDofs, faceDofs, 2, nf);
-   auto AT_int = Reshape(ea_data_int.ReadWrite(), faceDofs, faceDofs, 2, nf);
-   auto AT_ext = Reshape(ea_data_ext.ReadWrite(), faceDofs, faceDofs, 2, nf);
-   MFEM_FORALL(f, nf,
+   if (add)
    {
-      for (int i = 0; i < faceDofs; i++)
+      Vector ea_data_int_tmp(ea_data_int.Size());
+      Vector ea_data_ext_tmp(ea_data_ext.Size());
+      bfi->AssembleEAInteriorFaces(fes, ea_data_int_tmp, ea_data_ext_tmp, false);
+      const int faceDofs = fes.GetTraceElement(0,
+                                             fes.GetMesh()->GetFaceBaseGeometry(0))->GetDof();
+      auto A_int = Reshape(ea_data_int_tmp.Read(), faceDofs, faceDofs, 2, nf);
+      auto A_ext = Reshape(ea_data_ext_tmp.Read(), faceDofs, faceDofs, 2, nf);
+      auto AT_int = Reshape(ea_data_int.ReadWrite(), faceDofs, faceDofs, 2, nf);
+      auto AT_ext = Reshape(ea_data_ext.ReadWrite(), faceDofs, faceDofs, 2, nf);
+      MFEM_FORALL(f, nf,
       {
-         for (int j = 0; j < faceDofs; j++)
+         for (int i = 0; i < faceDofs; i++)
          {
-            const double a_int0 = A_int(i, j, 0, f);
-            const double a_int1 = A_int(i, j, 1, f);
-            const double a_ext0 = A_ext(i, j, 0, f);
-            const double a_ext1 = A_ext(i, j, 1, f);
-            AT_int(j, i, 0, f) += a_int0;
-            AT_int(j, i, 1, f) += a_int1;
-            AT_ext(j, i, 0, f) += a_ext1;
-            AT_ext(j, i, 1, f) += a_ext0;
+            for (int j = 0; j < faceDofs; j++)
+            {
+               const double a_int0 = A_int(i, j, 0, f);
+               const double a_int1 = A_int(i, j, 1, f);
+               const double a_ext0 = A_ext(i, j, 0, f);
+               const double a_ext1 = A_ext(i, j, 1, f);
+               AT_int(j, i, 0, f) += a_int0;
+               AT_int(j, i, 1, f) += a_int1;
+               AT_ext(j, i, 0, f) += a_ext1;
+               AT_ext(j, i, 1, f) += a_ext0;
+            }
          }
-      }
-   });
+      });
+   }
+   else
+   {
+      bfi->AssembleEAInteriorFaces(fes, ea_data_int, ea_data_ext, false);
+      const int faceDofs = fes.GetTraceElement(0,
+                                             fes.GetMesh()->GetFaceBaseGeometry(0))->GetDof();
+      auto A_int = Reshape(ea_data_int.ReadWrite(), faceDofs, faceDofs, 2, nf);
+      auto A_ext = Reshape(ea_data_ext.ReadWrite(), faceDofs, faceDofs, 2, nf);
+      MFEM_FORALL(f, nf,
+      {
+         for (int i = 0; i < faceDofs; i++)
+         {
+            for (int j = i+1; j < faceDofs; j++)
+            {
+               const double aij_int0 = A_int(i, j, 0, f);
+               const double aij_int1 = A_int(i, j, 1, f);
+               const double aij_ext0 = A_ext(i, j, 0, f);
+               const double aij_ext1 = A_ext(i, j, 1, f);
+               const double aji_int0 = A_int(j, i, 0, f);
+               const double aji_int1 = A_int(j, i, 1, f);
+               const double aji_ext0 = A_ext(j, i, 0, f);
+               const double aji_ext1 = A_ext(j, i, 1, f);
+               A_int(j, i, 0, f) = aij_int0;
+               A_int(j, i, 1, f) = aij_int1;
+               A_ext(j, i, 0, f) = aij_ext1;
+               A_ext(j, i, 1, f) = aij_ext0;
+               A_int(i, j, 0, f) = aji_int0;
+               A_int(i, j, 1, f) = aji_int1;
+               A_ext(i, j, 0, f) = aji_ext1;
+               A_ext(i, j, 1, f) = aji_ext0;
+            }
+         }
+      });
+   }
 }
 
 void TransposeIntegrator::AssembleEABoundaryFaces(const FiniteElementSpace& fes,
-                                                  Vector &ea_data_bdr)
+                                                  Vector &ea_data_bdr,
+                                                  const bool add)
 {
    const int nf = fes.GetNFbyType(FaceType::Boundary);
    if (nf == 0) { return; }
-   Vector ea_data_bdr_tmp(ea_data_bdr.Size());
-   ea_data_bdr_tmp = 0.0;
-   bfi->AssembleEABoundaryFaces(fes, ea_data_bdr_tmp);
-   const int faceDofs = fes.GetTraceElement(0,
-                                            fes.GetMesh()->GetFaceBaseGeometry(0))->GetDof();
-   auto A_bdr = Reshape(ea_data_bdr_tmp.Read(), faceDofs, faceDofs, nf);
-   auto AT_bdr = Reshape(ea_data_bdr.ReadWrite(), faceDofs, faceDofs, nf);
-   MFEM_FORALL(f, nf,
+   if (add)
    {
-      for (int i = 0; i < faceDofs; i++)
+      Vector ea_data_bdr_tmp(ea_data_bdr.Size());
+      bfi->AssembleEABoundaryFaces(fes, ea_data_bdr_tmp, false);
+      const int faceDofs = fes.GetTraceElement(0,
+                                             fes.GetMesh()->GetFaceBaseGeometry(0))->GetDof();
+      auto A_bdr = Reshape(ea_data_bdr_tmp.Read(), faceDofs, faceDofs, nf);
+      auto AT_bdr = Reshape(ea_data_bdr.ReadWrite(), faceDofs, faceDofs, nf);
+      MFEM_FORALL(f, nf,
       {
-         for (int j = 0; j < faceDofs; j++)
+         for (int i = 0; i < faceDofs; i++)
          {
-            const double a_bdr = A_bdr(i, j, f);
-            AT_bdr(j, i, f) += a_bdr;
+            for (int j = 0; j < faceDofs; j++)
+            {
+               const double a_bdr = A_bdr(i, j, f);
+               AT_bdr(j, i, f) += a_bdr;
+            }
          }
-      }
-   });
+      });
+   }
+   else
+   {
+      bfi->AssembleEABoundaryFaces(fes, ea_data_bdr, false);
+      const int faceDofs = fes.GetTraceElement(0,
+                                             fes.GetMesh()->GetFaceBaseGeometry(0))->GetDof();
+      auto A_bdr = Reshape(ea_data_bdr.ReadWrite(), faceDofs, faceDofs, nf);
+      MFEM_FORALL(f, nf,
+      {
+         for (int i = 0; i < faceDofs; i++)
+         {
+            for (int j = 0; j < faceDofs; j++)
+            {
+               const double aij_bdr = A_bdr(i, j, f);
+               const double aji_bdr = A_bdr(j, i, f);
+               A_bdr(j, i, f) = aij_bdr;
+               A_bdr(i, j, f) = aji_bdr;
+            }
+         }
+      });
+   }
 }
 
 }


### PR DESCRIPTION
This PR adds a `const bool add` to the bilininteg `AssembleEA` method. This allows to set the element matrices instead of always adding to them, therefore preventing some unnecessary data movements if there is only one `Integrator`.
<!--GHEX{"id":1691,"author":"YohannDudouit","editor":"tzanio","reviewers":["v-dobrev","tzanio"],"assignment":"2020-08-13T12:41:19-07:00","approval":"2020-08-20T13:17:37.503Z","merge":"2020-08-25T21:19:07.154Z"}XEHG--><!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge| 
 | --- | --- | --- | --- | --- | --- | --- | 
| [#1691](https://github.com/mfem/mfem/pull/1691) | @YohannDudouit | @tzanio | @v-dobrev + @tzanio | 08/13/20 | 08/20/20 | 08/25/20 | |
<!--ELBATXEHG-->