### PR TITLE
Assert that added bilinear form integrators are supported by PA/EA

### DIFF
--- a/fem/bilinearform_ext.cpp
+++ b/fem/bilinearform_ext.cpp
@@ -800,9 +800,12 @@ void PAMixedBilinearFormExtension::Assemble()
    {
       integrators[i]->AssemblePA(*trialFes, *testFes);
    }
-
    MFEM_ASSERT(a->GetBBFI()->Size() == 0,
                "Partial assembly does not support AddBoundaryIntegrator yet.");
+   MFEM_ASSERT(a->TFBFI()->Size() == 0,
+               "Partial assembly does not support AddTraceFaceIntegrator yet.");
+   MFEM_ASSERT(a->BTFBFI()->Size() == 0,
+               "Partial assembly does not support AddBdrTraceFaceIntegrator yet.");
 }
 
 void PAMixedBilinearFormExtension::Update()

--- a/fem/bilinearform_ext.cpp
+++ b/fem/bilinearform_ext.cpp
@@ -802,9 +802,9 @@ void PAMixedBilinearFormExtension::Assemble()
    }
    MFEM_ASSERT(a->GetBBFI()->Size() == 0,
                "Partial assembly does not support AddBoundaryIntegrator yet.");
-   MFEM_ASSERT(a->TFBFI()->Size() == 0,
+   MFEM_ASSERT(a->GetTFBFI()->Size() == 0,
                "Partial assembly does not support AddTraceFaceIntegrator yet.");
-   MFEM_ASSERT(a->BTFBFI()->Size() == 0,
+   MFEM_ASSERT(a->GetBTFBFI()->Size() == 0,
                "Partial assembly does not support AddBdrTraceFaceIntegrator yet.");
 }
 

--- a/fem/bilinearform_ext.cpp
+++ b/fem/bilinearform_ext.cpp
@@ -96,7 +96,7 @@ void PABilinearFormExtension::Assemble()
       integrators[i]->AssemblePA(*a->FESpace());
    }
 
-   MFEM_ASSERT(a->GetBBFI()->Size() == 0,
+   MFEM_VERIFY(a->GetBBFI()->Size() == 0,
                "Partial assembly does not support AddBoundaryIntegrator yet.");
 
    Array<BilinearFormIntegrator*> &intFaceIntegrators = *a->GetFBFI();
@@ -323,7 +323,7 @@ void EABilinearFormExtension::Assemble()
               GetTraceElement(0, trialFes->GetMesh()->GetFaceBaseGeometry(0)) ->
               GetDof();
 
-   MFEM_ASSERT(a->GetBBFI()->Size() == 0,
+   MFEM_VERIFY(a->GetBBFI()->Size() == 0,
                "Element assembly does not support AddBoundaryIntegrator yet.");
 
    Array<BilinearFormIntegrator*> &intFaceIntegrators = *a->GetFBFI();
@@ -800,11 +800,11 @@ void PAMixedBilinearFormExtension::Assemble()
    {
       integrators[i]->AssemblePA(*trialFes, *testFes);
    }
-   MFEM_ASSERT(a->GetBBFI()->Size() == 0,
+   MFEM_VERIFY(a->GetBBFI()->Size() == 0,
                "Partial assembly does not support AddBoundaryIntegrator yet.");
-   MFEM_ASSERT(a->GetTFBFI()->Size() == 0,
+   MFEM_VERIFY(a->GetTFBFI()->Size() == 0,
                "Partial assembly does not support AddTraceFaceIntegrator yet.");
-   MFEM_ASSERT(a->GetBTFBFI()->Size() == 0,
+   MFEM_VERIFY(a->GetBTFBFI()->Size() == 0,
                "Partial assembly does not support AddBdrTraceFaceIntegrator yet.");
 }
 

--- a/fem/bilinearform_ext.cpp
+++ b/fem/bilinearform_ext.cpp
@@ -96,6 +96,9 @@ void PABilinearFormExtension::Assemble()
       integrators[i]->AssemblePA(*a->FESpace());
    }
 
+   MFEM_ASSERT(a->GetBBFI()->Size() == 0,
+               "Partial assembly does not support AddBoundaryIntegrator yet.");
+
    Array<BilinearFormIntegrator*> &intFaceIntegrators = *a->GetFBFI();
    const int intFaceIntegratorCount = intFaceIntegrators.Size();
    for (int i = 0; i < intFaceIntegratorCount; ++i)
@@ -319,6 +322,9 @@ void EABilinearFormExtension::Assemble()
    faceDofs = trialFes ->
               GetTraceElement(0, trialFes->GetMesh()->GetFaceBaseGeometry(0)) ->
               GetDof();
+
+   MFEM_ASSERT(a->GetBBFI()->Size() == 0,
+               "Element assembly does not support AddBoundaryIntegrator yet.");
 
    Array<BilinearFormIntegrator*> &intFaceIntegrators = *a->GetFBFI();
    const int intFaceIntegratorCount = intFaceIntegrators.Size();
@@ -794,6 +800,9 @@ void PAMixedBilinearFormExtension::Assemble()
    {
       integrators[i]->AssemblePA(*trialFes, *testFes);
    }
+
+   MFEM_ASSERT(a->GetBBFI()->Size() == 0,
+               "Partial assembly does not support AddBoundaryIntegrator yet.");
 }
 
 void PAMixedBilinearFormExtension::Update()


### PR DESCRIPTION
@YohannDudouit @dylan-copeland Currently, bilinear form integrators added via `AddBoundaryIntegrator` are simply ignored in PA and EA assembly. Similarly, mixed bilinear form integrators added via `AddTraceFaceIntegrator` and `AddBdrTraceFaceIntegrator` are ignored in PA assembly. Until these are supported, it would be good to have assertions to inform the user if they are trying to use PA or EA for such integrators. 
<!--GHEX{"id":1694,"author":"stefanhenneking","editor":"tzanio","reviewers":["YohannDudouit","tzanio"],"assignment":"2020-08-13T12:40:17-07:00","approval":"2020-08-14T01:17:51.490Z","merge":"2020-08-19T21:38:36.431Z"}XEHG--><!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge| 
 | --- | --- | --- | --- | --- | --- | --- | 
| [#1694](https://github.com/mfem/mfem/pull/1694) | @stefanhenneking | @tzanio | @YohannDudouit + @tzanio | 08/13/20 | 08/13/20 | 08/19/20 | |
<!--ELBATXEHG-->