### PR TITLE
Fix crash in ParNCMesh::GetFaceNeighbors [nc-face-neighbors-fix]

### DIFF
--- a/mesh/pncmesh.cpp
+++ b/mesh/pncmesh.cpp
@@ -1066,9 +1066,9 @@ void ParNCMesh::GetFaceNeighbors(ParMesh &pmesh)
       for (int j = mf.slaves_begin; j < mf.slaves_end; j++)
       {
          const Slave &sf = full_list.slaves[j];
-         if (sf.index < 0) { continue; }
+         if (sf.element < 0) { continue; }
 
-         MFEM_ASSERT(mf.element >= 0 && sf.element >= 0, "");
+         MFEM_ASSERT(mf.element >= 0, "");
          Element* e[2] = { &elements[mf.element], &elements[sf.element] };
 
          bool loc0 = (e[0]->rank == MyRank);
@@ -1224,9 +1224,9 @@ void ParNCMesh::GetFaceNeighbors(ParMesh &pmesh)
          for (int j = mf.slaves_begin; j < mf.slaves_end; j++)
          {
             const Slave &sf = full_list.slaves[j];
-            if (sf.index < 0) { continue; }
+            if (sf.element < 0) { continue; }
 
-            MFEM_ASSERT(sf.element >= 0 && mf.element >= 0, "");
+            MFEM_ASSERT(mf.element >= 0, "");
             Element &sfe = elements[sf.element];
             Element &mfe = elements[mf.element];
 


### PR DESCRIPTION
This fixes a problem in `ParNCMesh::GetFaceNeigbors` where a condition to skip slave faces was incorrect. Ghost master faces may have slaves that extend beyond the ghost layer. We want to skip these, but the right way to recognize them is to use `sf.element < 0` instead of `sf.index < 0`.

Thanks @mlstowell for helping me debug this.

<!--GHEX{"id":1697,"author":"jakubcerveny","editor":"tzanio","reviewers":["mlstowell","rw-anderson"],"assignment":"2020-08-13T12:14:03-07:00","approval":"2020-08-23T21:46:52.287Z","merge":"2020-08-31T00:39:40.346Z"}XEHG--><!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge| 
 | --- | --- | --- | --- | --- | --- | --- | 
| [#1697](https://github.com/mfem/mfem/pull/1697) | @jakubcerveny | @tzanio | @mlstowell + @rw-anderson | 08/13/20 | 08/23/20 | 08/30/20 | |
<!--ELBATXEHG-->