### PR TITLE
libCEED - add new qfunction context data object, mild perf improvement

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -663,7 +663,7 @@ The specific libraries and their options are:
   URL: https://github.com/CEED/libCEED
        https://ceed.exascaleproject.org/libceed
   Options: CEED_DIR, CEED_OPT, CEED_LIB.
-  Versions: libCEED > 0.6, git-hash fe5822c.
+  Versions: libCEED > 0.6, git-hash 777ff85.
 
 - RAJA (optional), used when MFEM_USE_RAJA = YES.
   Beginning with MFEM v4.1, only RAJA v0.10.0+ is supported.

--- a/fem/libceed/ceed.hpp
+++ b/fem/libceed/ceed.hpp
@@ -56,7 +56,8 @@ struct CeedData
    CeedVector node_coords, rho;
    CeedCoeff coeff_type;
    void* coeff;
-   BuildContext build_ctx;
+   CeedQFunctionContext build_ctx;
+   BuildContext build_ctx_data;
 
    CeedVector u, v;
 


### PR DESCRIPTION
This new interface is ~~in the [final review in libCEED](https://github.com/CEED/libCEED/pull/596)~~ merged in libCEED. This will prevent extra copies of the context data from host -> device and device -> host on every operator application, which should offer a mild performance improvement.

ToDo:
- [x] Update libCEED git hash
<!--GHEX{"id":1701,"author":"jeremylt","editor":"tzanio","reviewers":["camierjs","YohannDudouit"],"assignment":"2020-08-14T10:50:31-07:00","approval":"2020-08-28T10:50:31-07:00","merge":"2020-09-04T10:50:31-07:00"}XEHG--><!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge| 
 | --- | --- | --- | --- | --- | --- | --- | 
| [#1701](https://github.com/mfem/mfem/pull/1701) | @jeremylt | @tzanio | @camierjs + @YohannDudouit | 08/14/20 | ⌛due 08/28/20 | ⌛due 09/04/20 | |
<!--ELBATXEHG-->