### PR TITLE
Add element attribute to adios2 bp dataset

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -177,7 +177,7 @@ Miscellaneous
 - Added support for ADIOS2 for parallel I/O with ParaView visualization. The
   classes adios2stream and ADIOS2DataCollection are introduced in mfem as the
   interfaces to generate ADIOS2 Binary Pack (BP4) directory datasets for the
-  entire spatial and temporal node data. Cell centered data accessible by ADIOS2
+  entire spatial and temporal node data. Cell centered data is accessible by ADIOS2
   data readers (e.g. Python), but currently not yet implement as of ParaView 
   v5.8.1. In addition, ADIOS2 allows for setting a user-defined number of data 
   substreams/subfiles at scale. See examples 5, 9, 12, 16.

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -177,10 +177,10 @@ Miscellaneous
 - Added support for ADIOS2 for parallel I/O with ParaView visualization. The
   classes adios2stream and ADIOS2DataCollection are introduced in mfem as the
   interfaces to generate ADIOS2 Binary Pack (BP4) directory datasets for the
-  entire spatial and temporal node data. Cell centered data is accessible by ADIOS2
-  data readers (e.g. Python), but currently not yet implement as of ParaView 
-  v5.8.1. In addition, ADIOS2 allows for setting a user-defined number of data 
-  substreams/subfiles at scale. See examples 5, 9, 12, 16.
+  entire spatial and temporal node data. Cell centered data is accessible by
+  ADIOS2 data readers (e.g. Python), but currently not yet implement as of
+  ParaView v5.8.1. In addition, ADIOS2 allows for setting a user-defined number
+  of data substreams/subfiles at scale. See examples 5, 9, 12, 16.
 
 - The integration order used in the ComputeLpError and ComputeElementLpError
   methods of class GridFunction has been increased.

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -177,8 +177,10 @@ Miscellaneous
 - Added support for ADIOS2 for parallel I/O with ParaView visualization. The
   classes adios2stream and ADIOS2DataCollection are introduced in mfem as the
   interfaces to generate ADIOS2 Binary Pack (BP4) directory datasets for the
-  entire spatial and temporal data. In addition, ADIOS2 allows for setting a
-  user-defined number of data substreams/subfiles. See examples 5, 9, 12, 16.
+  entire spatial and temporal node data. Cell centered data accessible by ADIOS2
+  data readers (e.g. Python), but currently not yet implement as of ParaView 
+  v5.8.1. In addition, ADIOS2 allows for setting a user-defined number of data 
+  substreams/subfiles at scale. See examples 5, 9, 12, 16.
 
 - The integration order used in the ComputeLpError and ComputeElementLpError
   methods of class GridFunction has been increased.

--- a/config/cmake/modules/FindADIOS2.cmake
+++ b/config/cmake/modules/FindADIOS2.cmake
@@ -38,7 +38,19 @@ if(NOT ADIOS2_FOUND)
   endif()
 
   find_path(ADIOS2_INCLUDE_DIR adios2.h ${ADIOS2_INCLUDE_OPTS})
-  find_library(ADIOS2_LIBRARY NAMES adios2 ${ADIOS2_LIBRARY_OPTS}) 
+  
+  # adios2 version 2.5.0 
+  find_library(ADIOS2_LIBRARY NAMES adios2 ${ADIOS2_LIBRARY_OPTS})
+  
+  # adios2 version 2.6.0 and onwards
+  if(NOT ADIOS2_LIBRARY)
+  	find_library(ADIOS2_CXX11_MPI_LIBRARY NAMES adios2_cxx11_mpi ${ADIOS2_LIBRARY_OPTS})
+  	find_library(ADIOS2_CXX11_LIBRARY NAMES adios2_cxx11 ${ADIOS2_LIBRARY_OPTS})
+  	set(ADIOS2_LIBRARY ${ADIOS2_CXX11_MPI_LIBRARY} ${ADIOS2_CXX11_LIBRARY})
+  	if(MFEM_USE_MPI)
+  	  add_definitions(-DADIOS2_USE_MPI)
+  	endif()
+  endif() 
 
   include(FindPackageHandleStandardArgs)
   find_package_handle_standard_args(ADIOS2


### PR DESCRIPTION
Update dataset format version
Save element attribute as "material" local array variable
Add material as CellData in xml schema
Update FindADIOS2.cmake for adios2 v2.6.0.

Partially addresses #1616 (needs visualization support in VTK). 
<!--GHEX{"id":1704,"author":"williamfgc","editor":"tzanio","reviewers":["rcarson3","tzanio"],"assignment":"2020-08-25T14:14:10-07:00","approval":"2020-09-11T19:26:49.353Z","merge":"2020-09-18T00:40:11.865Z"}XEHG--><!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge| 
 | --- | --- | --- | --- | --- | --- | --- | 
| [#1704](https://github.com/mfem/mfem/pull/1704) | @williamfgc | @tzanio | @rcarson3 + @tzanio | 08/25/20 | 09/11/20 | 09/17/20 | |
<!--ELBATXEHG-->