### PR TITLE
libCEED - prevent duplicate Ceed objects from MFEM FES

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -663,7 +663,7 @@ The specific libraries and their options are:
   URL: https://github.com/CEED/libCEED
        https://ceed.exascaleproject.org/libceed
   Options: CEED_DIR, CEED_OPT, CEED_LIB.
-  Versions: libCEED > 0.6, git-hash 777ff85.
+  Versions: libCEED > 0.6, git-hash bdfed75.
 
 - RAJA (optional), used when MFEM_USE_RAJA = YES.
   Beginning with MFEM v4.1, only RAJA v0.10.0+ is supported.

--- a/INSTALL
+++ b/INSTALL
@@ -663,7 +663,7 @@ The specific libraries and their options are:
   URL: https://github.com/CEED/libCEED
        https://ceed.exascaleproject.org/libceed
   Options: CEED_DIR, CEED_OPT, CEED_LIB.
-  Versions: libCEED > 0.6, git-hash fe5822c.
+  Versions: libCEED > 0.6, git-hash 777ff85.
 
 - RAJA (optional), used when MFEM_USE_RAJA = YES.
   Beginning with MFEM v4.1, only RAJA v0.10.0+ is supported.

--- a/fem/libceed/ceed.cpp
+++ b/fem/libceed/ceed.cpp
@@ -392,7 +392,7 @@ void InitCeedBasisAndRestriction(const FiniteElementSpace &fes,
    }
    else
    {
-      basis = &basis_itr->second;
+      *basis = basis_itr->second;
    }
    if (restr_itr == internal::ceed_restr_map.end())
    {
@@ -409,7 +409,7 @@ void InitCeedBasisAndRestriction(const FiniteElementSpace &fes,
    }
    else
    {
-      restr = &restr_itr->second;
+      *restr = restr_itr->second;
    }
 }
 

--- a/fem/libceed/ceed.cpp
+++ b/fem/libceed/ceed.cpp
@@ -99,7 +99,6 @@ static void InitCeedNonTensorBasis(const FiniteElementSpace &fes,
    Vector qweight(Q);
    Vector shape_i(P);
    DenseMatrix grad_i(P, dim);
-   CeedInt compstride = fes.GetOrdering()==Ordering::byVDIM ? 1 : fes.GetNDofs();
    const Table &el_dof = fes.GetElementToDofTable();
    Array<int> tp_el_dof(el_dof.Size_of_connections());
    const TensorBasisElement * tfe =
@@ -261,7 +260,6 @@ static void InitCeedTensorBasis(const FiniteElementSpace &fes,
    const TensorBasisElement * tfe =
       dynamic_cast<const TensorBasisElement *>(fe);
    MFEM_VERIFY(tfe, "invalid FE");
-   const Array<int>& dof_map = tfe->GetDofMap();
    const FiniteElement *fe1d =
       fes.FEColl()->FiniteElementForGeometry(Geometry::SEGMENT);
    DenseMatrix shape1d(fe1d->GetDof(), ir.GetNPoints());
@@ -298,7 +296,6 @@ static void InitCeedTensorRestriction(const FiniteElementSpace &fes,
 {
    Mesh *mesh = fes.GetMesh();
    const FiniteElement *fe = fes.GetFE(0);
-   const int order = fes.GetOrder(0);
    const TensorBasisElement * tfe =
       dynamic_cast<const TensorBasisElement *>(fe);
    MFEM_VERIFY(tfe, "invalid FE");

--- a/fem/libceed/ceed.cpp
+++ b/fem/libceed/ceed.cpp
@@ -251,15 +251,6 @@ static void InitCeedNonTensorRestriction(const FiniteElementSpace &fes,
                              tp_el_dof.GetData(), restr);
 }
 
-static void InitCeedNonTensorBasisAndRestriction(const FiniteElementSpace &fes,
-                                                 const IntegrationRule &ir,
-                                                 Ceed ceed, CeedBasis *basis,
-                                                 CeedElemRestriction *restr)
-{
-   InitCeedNonTensorBasis(fes, ir, ceed, basis);
-   InitCeedNonTensorRestriction(fes, ir, ceed, restr);
-}
-
 static void InitCeedTensorBasis(const FiniteElementSpace &fes,
                                 const IntegrationRule &ir,
                                 Ceed ceed, CeedBasis *basis)
@@ -346,15 +337,6 @@ static void InitCeedTensorRestriction(const FiniteElementSpace &fes,
                              compstride, (fes.GetVDim())*(fes.GetNDofs()),
                              CEED_MEM_HOST, CEED_COPY_VALUES,
                              tp_el_dof.GetData(), restr);
-}
-
-static void InitCeedTensorBasisAndRestriction(const FiniteElementSpace &fes,
-                                              const IntegrationRule &ir,
-                                              Ceed ceed, CeedBasis *basis,
-                                              CeedElemRestriction *restr)
-{
-   InitCeedTensorBasis(fes, ir, ceed, basis);
-   InitCeedTensorRestriction(fes, ir, ceed, restr);
 }
 
 void InitCeedBasisAndRestriction(const FiniteElementSpace &fes,

--- a/fem/libceed/ceed.cpp
+++ b/fem/libceed/ceed.cpp
@@ -301,20 +301,20 @@ void InitCeedBasisAndRestriction(const FiniteElementSpace &fes,
    }
 
    // Set or retreive key values
-   if (new_basis)
+   if (new_basis && basis)
    {
       kh_value(internal::ceed_basis_from_fes, k_basis) = *basis;
    }
-   else
+   else if (basis)
    {
       khint_t k_basis = kh_get(basis, internal::ceed_basis_from_fes, basis_key);
       CeedHashGetValue(internal::ceed_basis_from_fes, k_basis, *basis);
    }
-   if (new_restr)
+   if (new_restr && restr)
    {
       kh_value(internal::ceed_restr_from_fes, k_restr) = *restr;
    }
-   else
+   else if (restr)
    {
       khint_t k_restr = kh_get(restr, internal::ceed_restr_from_fes, restr_key);
       CeedHashGetValue(internal::ceed_restr_from_fes, k_restr, *restr);

--- a/fem/libceed/ceed.cpp
+++ b/fem/libceed/ceed.cpp
@@ -368,9 +368,9 @@ void InitCeedBasisAndRestriction(const FiniteElementSpace &fes,
    const int P = fe->GetDof();
    const int Q = irm.GetNPoints();
    const int nelem = mesh->GetNE();
-   CeedBasisKey basis_key (&fes, &irm, P, Q);
+   CeedBasisKey basis_key(&fes, &irm, P, Q);
    auto basis_itr = internal::ceed_basis_map.find(basis_key);
-   CeedRestrKey restr_key (&fes, P, nelem);
+   CeedRestrKey restr_key(&fes, P, nelem);
    auto restr_itr = internal::ceed_restr_map.find(restr_key);
 
    // Init or retreive key values

--- a/fem/libceed/ceed.cpp
+++ b/fem/libceed/ceed.cpp
@@ -369,10 +369,11 @@ void InitCeedBasisAndRestriction(const FiniteElementSpace &fes,
    const int Q = irm.GetNPoints();
    const int nelem = mesh->GetNE();
    std::string basis_key = std::to_string(reinterpret_cast<intptr_t>(&fes)) +
-      std::to_string(reinterpret_cast<intptr_t>(&irm)) + std::to_string(P) + std::to_string(Q);
+                           std::to_string(reinterpret_cast<intptr_t>(&irm)) +
+                           std::to_string(P) + std::to_string(Q);
    auto basis_itr = internal::ceed_basis_table.find(basis_key);
-   std::string restr_key = std::to_string(reinterpret_cast<intptr_t>(&fes)) + std::to_string(P) +
-      std::to_string(nelem);
+   std::string restr_key = std::to_string(reinterpret_cast<intptr_t>(&fes)) +
+                           std::to_string(P) + std::to_string(nelem);
    auto restr_itr = internal::ceed_restr_table.find(restr_key);
 
    // Init or retreive key values

--- a/fem/libceed/ceed.cpp
+++ b/fem/libceed/ceed.cpp
@@ -368,12 +368,9 @@ void InitCeedBasisAndRestriction(const FiniteElementSpace &fes,
    const int P = fe->GetDof();
    const int Q = irm.GetNPoints();
    const int nelem = mesh->GetNE();
-   CeedBasisKey basis_key (const_cast<FiniteElementSpace *>(&fes),
-                           const_cast<IntegrationRule *>(&irm),
-                           P, Q);
+   CeedBasisKey basis_key (&fes, &irm, P, Q);
    auto basis_itr = internal::ceed_basis_map.find(basis_key);
-   CeedRestrKey restr_key (const_cast<FiniteElementSpace *>(&fes),
-                           P, nelem);
+   CeedRestrKey restr_key (&fes, P, nelem);
    auto restr_itr = internal::ceed_restr_map.find(restr_key);
 
    // Init or retreive key values

--- a/fem/libceed/ceed.cpp
+++ b/fem/libceed/ceed.cpp
@@ -347,9 +347,10 @@ void InitCeedBasisAndRestriction(const FiniteElementSpace &fes,
    const int P = fe->GetDof();
    const int Q = irm.GetNPoints();
    const int nelem = mesh->GetNE();
-   CeedBasisKey basis_key(&fes, &irm, P, Q);
+   const int ncomp = fes.GetVDim();
+   CeedBasisKey basis_key(&fes, &irm, ncomp, P, Q);
    auto basis_itr = internal::ceed_basis_map.find(basis_key);
-   CeedRestrKey restr_key(&fes, P, nelem);
+   CeedRestrKey restr_key(&fes, nelem, P, ncomp);
    auto restr_itr = internal::ceed_restr_map.find(restr_key);
 
    // Init or retreive key values

--- a/fem/libceed/ceed.hpp
+++ b/fem/libceed/ceed.hpp
@@ -56,7 +56,8 @@ struct CeedData
    CeedVector node_coords, rho;
    CeedCoeff coeff_type;
    void* coeff;
-   BuildContext build_ctx;
+   CeedQFunctionContext build_ctx;
+   BuildContext build_ctx_data;
 
    CeedVector u, v;
 

--- a/fem/libceed/ceed.hpp
+++ b/fem/libceed/ceed.hpp
@@ -31,18 +31,22 @@ class IntegrationRule;
 class Coefficient;
 
 // Hash table for CeedBasis
-using CeedBasisKey = std::tuple<FiniteElementSpace*, IntegrationRule*, int, int>;
+using CeedBasisKey =
+   std::tuple<FiniteElementSpace*, IntegrationRule*, int, int>;
 struct CeedBasisHash
 {
    std::size_t operator()(const CeedBasisKey& k) const
    {
-      return CeedHashCombine(CeedHashCombine(CeedHashInt(reinterpret_cast<CeedHash64_t>(std::get<0>(k))),
-                                             CeedHashInt(reinterpret_cast<CeedHash64_t>(std::get<1>(k)))),
+      return CeedHashCombine(CeedHashCombine(CeedHashInt(
+                                                reinterpret_cast<CeedHash64_t>(std::get<0>(k))),
+                                             CeedHashInt(
+                                                reinterpret_cast<CeedHash64_t>(std::get<1>(k)))),
                              CeedHashCombine(CeedHashInt(std::get<2>(k)),
                                              CeedHashInt(std::get<3>(k))));
    }
 };
-using CeedBasisMap = std::unordered_map<const CeedBasisKey, CeedBasis, CeedBasisHash>;
+using CeedBasisMap =
+   std::unordered_map<const CeedBasisKey, CeedBasis, CeedBasisHash>;
 
 // Hash table for CeedElemRestriction
 using CeedRestrKey = std::tuple<FiniteElementSpace*, int, int>;
@@ -50,17 +54,20 @@ struct CeedRestrHash
 {
    std::size_t operator()(const CeedRestrKey& k) const
    {
-      return CeedHashCombine(CeedHashCombine(CeedHashInt(reinterpret_cast<CeedHash64_t>(std::get<0>(k))),
+      return CeedHashCombine(CeedHashCombine(CeedHashInt(
+                                                reinterpret_cast<CeedHash64_t>(std::get<0>(k))),
                                              CeedHashInt(std::get<1>(k))),
                              CeedHashInt(std::get<2>(k)));
    }
 };
-using CeedRestrMap = std::unordered_map<const CeedRestrKey, CeedElemRestriction, CeedRestrHash>;
+using CeedRestrMap =
+   std::unordered_map<const CeedRestrKey, CeedElemRestriction, CeedRestrHash>;
 
-namespace internal {
-   extern Ceed ceed; // defined in device.cpp
-   extern CeedBasisMap basis_map;
-   extern CeedRestrMap restr_map;
+namespace internal
+{
+extern Ceed ceed; // defined in device.cpp
+extern CeedBasisMap basis_map;
+extern CeedRestrMap restr_map;
 }
 
 /// A structure used to pass additional data to f_build_diff and f_apply_diff

--- a/fem/libceed/ceed.hpp
+++ b/fem/libceed/ceed.hpp
@@ -32,7 +32,7 @@ class Coefficient;
 
 // Hash table for CeedBasis
 using CeedBasisKey =
-   std::tuple<const FiniteElementSpace*, const IntegrationRule*, int, int>;
+   std::tuple<const FiniteElementSpace*, const IntegrationRule*, int, int, int>;
 struct CeedBasisHash
 {
    std::size_t operator()(const CeedBasisKey& k) const
@@ -41,15 +41,16 @@ struct CeedBasisHash
                                                 reinterpret_cast<CeedHash64_t>(std::get<0>(k))),
                                              CeedHashInt(
                                                 reinterpret_cast<CeedHash64_t>(std::get<1>(k)))),
-                             CeedHashCombine(CeedHashInt(std::get<2>(k)),
-                                             CeedHashInt(std::get<3>(k))));
+                             CeedHashCombine(CeedHashCombine(CeedHashInt(std::get<2>(k)),
+                                                             CeedHashInt(std::get<3>(k))),
+                                             CeedHashInt(std::get<4>(k))));
    }
 };
 using CeedBasisMap =
    std::unordered_map<const CeedBasisKey, CeedBasis, CeedBasisHash>;
 
 // Hash table for CeedElemRestriction
-using CeedRestrKey = std::tuple<const FiniteElementSpace*, int, int>;
+using CeedRestrKey = std::tuple<const FiniteElementSpace*, int, int, int>;
 struct CeedRestrHash
 {
    std::size_t operator()(const CeedRestrKey& k) const
@@ -57,7 +58,8 @@ struct CeedRestrHash
       return CeedHashCombine(CeedHashCombine(CeedHashInt(
                                                 reinterpret_cast<CeedHash64_t>(std::get<0>(k))),
                                              CeedHashInt(std::get<1>(k))),
-                             CeedHashInt(std::get<2>(k)));
+                             CeedHashCombine(CeedHashInt(std::get<2>(k)),
+                                             CeedHashInt(std::get<3>(k))));
    }
 };
 using CeedRestrMap =

--- a/fem/libceed/ceed.hpp
+++ b/fem/libceed/ceed.hpp
@@ -65,10 +65,6 @@ struct CeedData
    {
       CeedOperatorDestroy(&build_oper);
       CeedOperatorDestroy(&oper);
-      CeedBasisDestroy(&basis);
-      CeedBasisDestroy(&mesh_basis);
-      CeedElemRestrictionDestroy(&restr);
-      CeedElemRestrictionDestroy(&mesh_restr);
       CeedElemRestrictionDestroy(&restr_i);
       CeedElemRestrictionDestroy(&mesh_restr_i);
       CeedQFunctionDestroy(&apply_qfunc);

--- a/fem/libceed/ceed.hpp
+++ b/fem/libceed/ceed.hpp
@@ -117,8 +117,6 @@ struct CeedData
       if (coeff_type==CeedCoeff::Grid)
       {
          CeedGridCoeff* c = (CeedGridCoeff*)coeff;
-         CeedBasisDestroy(&c->basis);
-         CeedElemRestrictionDestroy(&c->restr);
          CeedVectorDestroy(&c->coeffVector);
          delete c;
       }

--- a/fem/libceed/ceed.hpp
+++ b/fem/libceed/ceed.hpp
@@ -32,7 +32,7 @@ class Coefficient;
 
 // Hash table for CeedBasis
 using CeedBasisKey =
-   std::tuple<FiniteElementSpace*, IntegrationRule*, int, int>;
+   std::tuple<const FiniteElementSpace*, const IntegrationRule*, int, int>;
 struct CeedBasisHash
 {
    std::size_t operator()(const CeedBasisKey& k) const
@@ -49,7 +49,7 @@ using CeedBasisMap =
    std::unordered_map<const CeedBasisKey, CeedBasis, CeedBasisHash>;
 
 // Hash table for CeedElemRestriction
-using CeedRestrKey = std::tuple<FiniteElementSpace*, int, int>;
+using CeedRestrKey = std::tuple<const FiniteElementSpace*, int, int>;
 struct CeedRestrHash
 {
    std::size_t operator()(const CeedRestrKey& k) const

--- a/fem/libceed/ceed.hpp
+++ b/fem/libceed/ceed.hpp
@@ -18,6 +18,9 @@
 #include "../../general/device.hpp"
 #include "../../linalg/vector.hpp"
 #include <ceed.h>
+#include <ceed-hash.h>
+#include <tuple>
+#include <unordered_map>
 
 namespace mfem
 {
@@ -27,7 +30,38 @@ class GridFunction;
 class IntegrationRule;
 class Coefficient;
 
-namespace internal { extern Ceed ceed; } // defined in device.cpp
+// Hash table for CeedBasis
+using CeedBasisKey = std::tuple<FiniteElementSpace*, IntegrationRule*, int, int>;
+struct CeedBasisHash
+{
+   std::size_t operator()(const CeedBasisKey& k) const
+   {
+      return CeedHashCombine(CeedHashCombine(CeedHashInt(reinterpret_cast<CeedHash64_t>(std::get<0>(k))),
+                                             CeedHashInt(reinterpret_cast<CeedHash64_t>(std::get<1>(k)))),
+                             CeedHashCombine(CeedHashInt(std::get<2>(k)),
+                                             CeedHashInt(std::get<3>(k))));
+   }
+};
+using CeedBasisMap = std::unordered_map<const CeedBasisKey, CeedBasis, CeedBasisHash>;
+
+// Hash table for CeedElemRestriction
+using CeedRestrKey = std::tuple<FiniteElementSpace*, int, int>;
+struct CeedRestrHash
+{
+   std::size_t operator()(const CeedRestrKey& k) const
+   {
+      return CeedHashCombine(CeedHashCombine(CeedHashInt(reinterpret_cast<CeedHash64_t>(std::get<0>(k))),
+                                             CeedHashInt(std::get<1>(k))),
+                             CeedHashInt(std::get<2>(k)));
+   }
+};
+using CeedRestrMap = std::unordered_map<const CeedRestrKey, CeedElemRestriction, CeedRestrHash>;
+
+namespace internal {
+   extern Ceed ceed; // defined in device.cpp
+   extern CeedBasisMap basis_map;
+   extern CeedRestrMap restr_map;
+}
 
 /// A structure used to pass additional data to f_build_diff and f_apply_diff
 struct BuildContext { CeedInt dim, space_dim; CeedScalar coeff; };

--- a/general/device.cpp
+++ b/general/device.cpp
@@ -33,6 +33,10 @@ occa::device occaDevice;
 
 #ifdef MFEM_USE_CEED
 Ceed ceed = NULL;
+
+// Initalize FES -> CeedBasis, CeedElemRestriction hash tables
+khash_t(basis) *ceed_basis_from_fes = kh_init(basis);
+khash_t(restr) *ceed_restr_from_fes = kh_init(restr);
 #endif
 
 // Backends listed by priority, high to low:
@@ -154,6 +158,17 @@ Device::~Device()
    {
       free(device_option);
 #ifdef MFEM_USE_CEED
+      // Destroy FES -> CeedBasis, CeedElemRestriction hash table contents
+      CeedBasis basis;
+      kh_foreach_value(internal::ceed_basis_from_fes,
+                       basis, CeedBasisDestroy(&basis));
+      kh_destroy(basis, internal::ceed_basis_from_fes);
+      CeedElemRestriction restr;
+      kh_foreach_value(internal::ceed_restr_from_fes,
+                       restr, CeedElemRestrictionDestroy(&restr));
+      kh_destroy(restr, internal::ceed_restr_from_fes);
+
+      // Destroy Ceed context
       CeedDestroy(&internal::ceed);
 #endif
       mm.Destroy();

--- a/general/device.cpp
+++ b/general/device.cpp
@@ -183,7 +183,7 @@ Device::~Device()
 
 void Device::Configure(const std::string &device, const int dev)
 {
-   // If device a was configured via the environment, skip the configuration,
+   // If a device was configured via the environment, skip the configuration,
    // and avoid the 'singleton_device' to destroy the mm.
    if (device_env)
    {

--- a/general/device.cpp
+++ b/general/device.cpp
@@ -35,8 +35,8 @@ occa::device occaDevice;
 Ceed ceed = NULL;
 
 // Initalize FES -> CeedBasis, CeedElemRestriction hash tables
-khash_t(basis) *ceed_basis_from_fes = kh_init(basis);
-khash_t(restr) *ceed_restr_from_fes = kh_init(restr);
+std::unordered_map<std::string, CeedBasis> ceed_basis_table;
+std::unordered_map<std::string, CeedElemRestriction> ceed_restr_table;
 #endif
 
 // Backends listed by priority, high to low:
@@ -159,15 +159,12 @@ Device::~Device()
       free(device_option);
 #ifdef MFEM_USE_CEED
       // Destroy FES -> CeedBasis, CeedElemRestriction hash table contents
-      CeedBasis basis;
-      kh_foreach_value(internal::ceed_basis_from_fes,
-                       basis, CeedBasisDestroy(&basis));
-      kh_destroy(basis, internal::ceed_basis_from_fes);
-      CeedElemRestriction restr;
-      kh_foreach_value(internal::ceed_restr_from_fes,
-                       restr, CeedElemRestrictionDestroy(&restr));
-      kh_destroy(restr, internal::ceed_restr_from_fes);
-
+      for (auto entry : internal::ceed_basis_table) {
+         CeedBasisDestroy(&entry.second);
+      }
+      for (auto entry : internal::ceed_restr_table) {
+         CeedElemRestrictionDestroy(&entry.second);
+      }
       // Destroy Ceed context
       CeedDestroy(&internal::ceed);
 #endif

--- a/general/device.cpp
+++ b/general/device.cpp
@@ -159,10 +159,12 @@ Device::~Device()
       free(device_option);
 #ifdef MFEM_USE_CEED
       // Destroy FES -> CeedBasis, CeedElemRestriction hash table contents
-      for (auto entry : internal::ceed_basis_table) {
+      for (auto entry : internal::ceed_basis_table)
+      {
          CeedBasisDestroy(&entry.second);
       }
-      for (auto entry : internal::ceed_restr_table) {
+      for (auto entry : internal::ceed_restr_table)
+      {
          CeedElemRestrictionDestroy(&entry.second);
       }
       // Destroy Ceed context

--- a/general/device.hpp
+++ b/general/device.hpp
@@ -15,12 +15,6 @@
 #include "globals.hpp"
 #include "mem_manager.hpp"
 
-
-#ifdef MFEM_USE_CEED
-// FES -> CeedBasis, CeedElemRestriction hash tables
-#include <unordered_map>
-#endif
-
 namespace mfem
 {
 

--- a/general/device.hpp
+++ b/general/device.hpp
@@ -15,11 +15,10 @@
 #include "globals.hpp"
 #include "mem_manager.hpp"
 
+
 #ifdef MFEM_USE_CEED
-// Setup FES -> CeedBasis, CeedElemRestriction hash tables
-#include <ceed-hash.h>
-CeedHashIJKLInit(basis, CeedBasis)
-CeedHashIJKInit(restr, CeedElemRestriction)
+// FES -> CeedBasis, CeedElemRestriction hash tables
+#include <unordered_map>
 #endif
 
 namespace mfem

--- a/general/device.hpp
+++ b/general/device.hpp
@@ -15,6 +15,13 @@
 #include "globals.hpp"
 #include "mem_manager.hpp"
 
+#ifdef MFEM_USE_CEED
+// Setup FES -> CeedBasis, CeedElemRestriction hash tables
+#include <ceed-hash.h>
+CeedHashIJKLInit(basis, CeedBasis)
+CeedHashIJKInit(restr, CeedElemRestriction)
+#endif
+
 namespace mfem
 {
 


### PR DESCRIPTION
This PR slightly factors the libCEED integration, using a hash table to look up libCEED Basis and ElemRestriction objects corresponding to a particular MFEM FES.

This prevents excessive copies of identical data on the GPU from repeated libCEED objects associated with a single FES across multiple integrators (mass and diffusion). This will also improve the future libCEED grid transfer operators.

Note, this PR must be merged after #1701 
<!--GHEX{"id":1705,"author":"jeremylt","editor":"tzanio","reviewers":["YohannDudouit","tzanio"],"assignment":"2020-08-16T12:33:58-07:00","approval":"2020-08-23T21:10:30.942Z","merge":"2020-08-31T00:41:54.855Z"}XEHG--><!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge| 
 | --- | --- | --- | --- | --- | --- | --- | 
| [#1705](https://github.com/mfem/mfem/pull/1705) | @jeremylt | @tzanio | @YohannDudouit + @tzanio | 08/16/20 | 08/23/20 | 08/30/20 | |
<!--ELBATXEHG-->