### PR TITLE
Fix for STRUMPACK with Hypre >= 21600

### DIFF
--- a/linalg/strumpack.cpp
+++ b/linalg/strumpack.cpp
@@ -58,6 +58,13 @@ STRUMPACKRowLocMatrix::STRUMPACKRowLocMatrix(const HypreParMatrix & hypParMat)
    // hypre_CSRMatrix.
    hypre_CSRMatrix * csr_op = hypre_MergeDiagAndOffd(parcsr_op);
    hypre_CSRMatrixSetDataOwner(csr_op,0);
+#if MFEM_HYPRE_VERSION >= 21600
+   // For now, this method assumes that HYPRE_Int is int. Also, csr_op->num_cols
+   // is of type HYPRE_Int, so if we want to check for big indices in
+   // csr_op->big_j, we'll have to check all entries and that check will only be
+   // necessary in HYPRE_MIXEDINT mode which is not supported at the moment.
+   hypre_CSRMatrixBigJtoJ(csr_op);
+#endif
 
    height = csr_op->num_rows;
    width  = csr_op->num_rows;


### PR DESCRIPTION
Make STRUMPACK sparse solver work with Hypre versions 2.16 and beyond.

This fix is similar to the fix for SuperLU_Dist: https://github.com/mfem/mfem/pull/988

Some other comments/questions:
- With this fix, this conflict in the MFEM spack installer can be updated:
`conflicts('+strumpack', when='mfem@4.0.0: ^hypre@2.16.0:')`
https://github.com/spack/spack/blob/develop/var/spack/repos/builtin/packages/mfem/package.py
- I can change all integers used in the STRUMPACK interface to HYPRE_Int ?
- I can add an interface to `strumpack::StrumpackSparseSolver`, which does not rely on MPI. However, since there is also no interface to SuperLU (sequential) or SuperLU_MT (mutithreaded), maybe there is no need for that?
- STRUMPACK's CMake exports the target STRUMPACK::strumpack, which depends on METIS and optionally OpenMP, MPI, CUDA, cuBLAS, cuSOLVER, scalapack, ParMETIS, Scotch, zfp. But MFEM's cmake doesn't seem to support such targets (there is an error message from line 841 in MfemCmakeUtilities.cmake). I think using the target should make it easier to link STRUMPACK's dependencies.

<!--GHEX{"id":1724,"author":"pghysels","editor":"tzanio","reviewers":["tzanio","dylan-copeland"],"assignment":"2020-09-27T13:06:35-07:00","approval":"2020-10-05T17:56:04.916Z","merge":"2020-10-08T19:01:56.856Z"}XEHG--><!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge| 
 | --- | --- | --- | --- | --- | --- | --- | 
| [#1724](https://github.com/mfem/mfem/pull/1724) | @pghysels | @tzanio | @tzanio + @dylan-copeland | 09/27/20 | 10/05/20 | 10/08/20 | |
<!--ELBATXEHG-->