### PR TITLE
[WIP] Discuss: Improve face neighbor documentation and functionality

### DIFF
--- a/fem/pfespace.hpp
+++ b/fem/pfespace.hpp
@@ -341,12 +341,20 @@ public:
 
    // Face-neighbor functions
    void ExchangeFaceNbrData();
+   /// Return the number of face-neighbor dofs
    int GetFaceNbrVSize() const { return num_face_nbr_dofs; }
+   /** Get the vdofs associated with the @a ith face neighbor element. These are
+       vdof indices that can be used to index into the Vector returned by
+       ParGridFunction::FaceNbrData(). */
    void GetFaceNbrElementVDofs(int i, Array<int> &vdofs) const;
    void GetFaceNbrFaceVDofs(int i, Array<int> &vdofs) const;
+   /// Get the FiniteElement object for the @a ith face neighbor element
    const FiniteElement *GetFaceNbrFE(int i) const;
    const FiniteElement *GetFaceNbrFaceFE(int i) const;
+   /// Return an array of global L-dofs corresponding to face neigbor dofs
    const HYPRE_Int *GetFaceNbrGlobalDofMap() { return face_nbr_glob_dof_map; }
+   /// Get the ElementTransformation associated with the @a ith face neighbor
+   /// element
    ElementTransformation *GetFaceNbrElementTransformation(int i) const
    { return pmesh->GetFaceNbrElementTransformation(i); }
 

--- a/mesh/mesh.hpp
+++ b/mesh/mesh.hpp
@@ -406,13 +406,6 @@ protected:
 
    void AddQuadFaceElement (int lf, int gf, int el,
                             int v0, int v1, int v2, int v3);
-   /** For a serial Mesh, return true if the face is interior. For a parallel
-       ParMesh return true if the face is interior or shared. In parallel, this
-       method only works if the face neighbor data is exchanged. */
-   bool FaceIsTrueInterior(int FaceNo) const
-   {
-      return FaceIsInterior(FaceNo) || (faces_info[FaceNo].Elem2Inf >= 0);
-   }
 
    void FreeElement(Element *E);
 
@@ -1009,6 +1002,29 @@ public:
    {
       return (faces_info[FaceNo].Elem2No >= 0);
    }
+
+   /** For a serial Mesh, return true if the face is interior. For a parallel
+       ParMesh return true if the face is interior or shared. In parallel, this
+       method only works if the face neighbor data is exchanged. */
+   bool FaceIsTrueInterior(int FaceNo) const
+   {
+      return FaceIsInterior(FaceNo) || (faces_info[FaceNo].Elem2Inf >= 0);
+   }
+
+   /// Returns true if the face is shared (i.e. lies in the interior of the
+   /// domain, and one neighboring element belongs to a different MPI rank)
+   bool FaceIsShared(int FaceNo) const
+   {
+       return !FaceIsInterior(FaceNo) && FaceIsTrueInterior(FaceNo);
+   }
+
+   /** Get the indices of the elements containing the given face. @a *Elem1 will
+       always be the index of a valid element. @a *Elem2 will be negative if the
+       given face either lies on the domain boundary or is a shared face of a
+       parallel mesh, or if the face is a master face in a nonconforming mesh.
+       The case of boundary or shared faces can be distinguished using
+       Mesh::FaceIsTrueInterior. If the face is a shared face, the shared face
+       index is given by -1 - *Elem2. */
    void GetFaceElements (int Face, int *Elem1, int *Elem2) const;
    void GetFaceInfos (int Face, int *Inf1, int *Inf2) const;
 

--- a/mesh/mesh.hpp
+++ b/mesh/mesh.hpp
@@ -1002,7 +1002,9 @@ public:
 
    FaceElementTransformations *GetBdrFaceTransformations (int BdrElemNo);
 
-   /// Return true if the given face is interior. @sa FaceIsTrueInterior().
+   /// Return true if the given face is interior. Returns false if the face
+   /// is on the domain boundary or is a shared face of a parallel mesh.
+   /// @sa FaceIsTrueInterior().
    bool FaceIsInterior(int FaceNo) const
    {
       return (faces_info[FaceNo].Elem2No >= 0);

--- a/mesh/pmesh.cpp
+++ b/mesh/pmesh.cpp
@@ -2505,6 +2505,32 @@ GetSharedFaceTransformations(int sf, bool fill2)
    return &FaceElemTr;
 }
 
+int ParMesh::GetFaceNbrElementOfSharedFace(int sf) const
+{
+   int face_idx = GetSharedFace(sf);
+   const FaceInfo &face_info = faces_info[face_idx];
+   int shifted_index = -1 - face_info.Elem2No;
+   // Return the face-neighbor element index
+   return shifted_index - GetNE();
+}
+
+int ParMesh::GetSharedFaceIndexOfLocalFace(int face_idx) const
+{
+   if (lface_sface.empty())
+   {
+      const Array<int> *mapping;
+      if (Dim == 1) { mapping = &svert_lvert; }
+      else if (Dim == 2) { mapping = &sedge_ledge; }
+      else { mapping = &sface_lface; }
+
+      for (int i=0; i<mapping->Size(); ++i)
+      {
+         lface_sface[(*mapping)[i]] = i;
+      }
+   }
+   return lface_sface[face_idx];
+}
+
 int ParMesh::GetNSharedFaces() const
 {
    if (Conforming())

--- a/mesh/pmesh.cpp
+++ b/mesh/pmesh.cpp
@@ -2509,9 +2509,7 @@ int ParMesh::GetFaceNbrElementOfSharedFace(int sf) const
 {
    int face_idx = GetSharedFace(sf);
    const FaceInfo &face_info = faces_info[face_idx];
-   int shifted_index = -1 - face_info.Elem2No;
-   // Return the face-neighbor element index
-   return shifted_index - GetNE();
+   return -1 - face_info.Elem2No;
 }
 
 int ParMesh::GetSharedFaceIndexOfLocalFace(int face_idx) const

--- a/mesh/pmesh.hpp
+++ b/mesh/pmesh.hpp
@@ -277,14 +277,22 @@ public:
    void GenerateOffsets(int N, HYPRE_Int loc_sizes[],
                         Array<HYPRE_Int> *offsets[]) const;
 
+   /** Communicate face-neighbor mesh information. Also calls
+       ExchangeFaceNbrNodes. */
    void ExchangeFaceNbrData();
+   /** Communicate the nodal gridfunction associated with face-neighbor
+       elements. Calls ExchangeFaceNbrData if it has not been called before. */
    void ExchangeFaceNbrNodes();
 
    virtual void SetCurvature(int order, bool discont = false, int space_dim = -1,
                              int ordering = 1);
 
+   /** Returns the number of MPI ranks that are face-neighbors of the current
+       rank. */
    int GetNFaceNeighbors() const { return face_nbr_group.Size(); }
+   /// Get the group index of the face-neighbor @a fn
    int GetFaceNbrGroup(int fn) const { return face_nbr_group[fn]; }
+   /// Get the MPI rank of the face-neighbor @a fn
    int GetFaceNbrRank(int fn) const;
 
    /** Similar to Mesh::GetFaceToElementTable with added face-neighbor elements
@@ -297,6 +305,7 @@ public:
    FaceElementTransformations *
    GetSharedFaceTransformations(int sf, bool fill2 = true);
 
+   /// Get the ElementTransformation of the @a ith face-neighbor element
    ElementTransformation *
    GetFaceNbrElementTransformation(int i)
    {

--- a/mesh/pmesh.hpp
+++ b/mesh/pmesh.hpp
@@ -78,6 +78,10 @@ protected:
    // sface ids: all triangles first, then all quads
    Array<int> sface_lface;
 
+   /// Local to shared face mapping (vertex in 1D, edge in 2D, face in 3D).
+   /// Generated on first call to GetSharedFaceIndexOfLocalFace.
+   mutable std::map<int,int> lface_sface;
+
    IsoparametricTransformation FaceNbrTransformation;
 
    // glob_elem_offset + local element number defines a global element numbering
@@ -313,6 +317,16 @@ public:
 
       return &FaceNbrTransformation;
    }
+
+   /// Return the shared face index of a given local face
+   int GetSharedFaceIndexOfLocalFace(int face_idx) const;
+
+   /// Return the shared face index of a given local face
+   int GetLocalFaceIndexOfSharedFace(int s) const { return GetSharedFace(s); }
+
+   /// Return the index of the face-neighbor element containing the given
+   /// shared face.
+   int GetFaceNbrElementOfSharedFace(int sf) const;
 
    /// Return the number of shared faces (3D), edges (2D), vertices (1D)
    int GetNSharedFaces() const;

--- a/mesh/pmesh.hpp
+++ b/mesh/pmesh.hpp
@@ -321,8 +321,12 @@ public:
    /// Return the shared face index of a given local face
    int GetSharedFaceIndexOfLocalFace(int face_idx) const;
 
-   /// Return the shared face index of a given local face
+   /// Return the local face index for the given shared face.
    int GetLocalFaceIndexOfSharedFace(int s) const { return GetSharedFace(s); }
+
+   /// Return the local face index for the given shared face. This performs the
+   /// same function as GetLocalFaceIndexOfSharedFace.
+   int GetSharedFace(int sface) const;
 
    /// Return the index of the face-neighbor element containing the given
    /// shared face.
@@ -331,8 +335,6 @@ public:
    /// Return the number of shared faces (3D), edges (2D), vertices (1D)
    int GetNSharedFaces() const;
 
-   /// Return the local face index for the given shared face.
-   int GetSharedFace(int sface) const;
 
    /// See the remarks for the serial version in mesh.hpp
    virtual void ReorientTetMesh();


### PR DESCRIPTION
This WIP PR is intended to improve the documentation and functionality associated with face-neighbor functionality often used in DG methods.

The PR has two parts:

1. Improve documentation, in the form of Doxygen comments and inline comments to make clear e.g. how face-neighbor indexing works.
2. Add some convenience functions that make common operations more user-friendly, so that users don't have to do "low-level" manipulation of negative or shifted indices.

### Sources of Confusion

It can be difficult for users to work with the "low-level" face neighbor interface. For example, `Mesh::GetFaceElements` returns a negative index for the second element whenever the face is boundary, shared, or master in the nonconforming case. The user must distinguish these cases and provide the appropriate transformations to get the shared face index from the returned negative index. On the other hand, given the `FaceElementTransformations` object for a shared face, the `Elem2` index is a _shifted_ index, which has to be transformed by subtracting the number of (local) mesh elements to obtain the face neighbor index.

If we can provide convenience functions that wrap the most commonly performed operations with descriptive names, then users could avoid performing these low-level operations themselves (and hopefully also avoid some pitfalls/corner cases that may arise).

#### Common operations we may want to support:

- Unified loops over all faces (including shared faces), rather than duplicated loops over interior and shared faces
- Looping over all elements that share a face with a given element (including those that belong to a different MPI rank)
- Easily getting the face neighbor index corresponding to a shared face, and getting the shared face index given a local face index.

### Proposed Changes

- Provide a more descriptive name `ParMesh::GetLocalFaceIndexOfSharedFace` instead of `ParMesh::GetSharedFace`. Retain the old interface for backwards compatibility. Should we add a deprecation warning?
- Add `ParMesh::GetSharedFaceIndexOfLocalFace`, which is the inverse mapping of `ParMesh::GetLocalFaceIndexOfSharedFace`. This allows the user to have one unified loop over all faces, rather than separate (duplicated) loops over shared and non-shared faces. I know of several cases where the user actually ended up building this inverse mapping, so it seems useful for MFEM to provide.
- Add `ParMesh::GetFaceNbrElementOfSharedFace`, which returns the face neighbor index of a given shared face, instead of the user having to manually transform negative/shifted indices. I'm not sure if this handles the AMR case properly.
- Change `GetFaceNbrGlobalDofMap` to return an `Array` reference instead of a raw pointer (is there a reason I am missing why this isn't the current interface?)

### Questions

Some questions that arose while working on this:

- The "local to shared" face mapping is generated on first call to `ParMesh::GetSharedFaceIndexOfLocalFace`. When should it be invalidated?
- `GetFaceNbrFaceVDofs` and `GetFaceNbrFaceFE`: Do these work only for nonconforming meshes? Some documentation/explanation here would be useful. I have never used these.
- What is the proper way to handle all cases of a negative `Elem2` index in `Mesh::GetFaceElements`? Does the case of a master shared face in a nonconforming mesh require special treatment?
- `Mesh::FaceIsTrueInterior` returns `FaceIsInterior(FaceNo) || (faces_info[FaceNo].Elem2Inf >= 0)`. Is the check to `FaceIsInterior` superfluous? Or does this handle an edge case involving AMR/ghost elements?

Feedback, suggestions, or answers to the above questions would greatly be appreciated! Tagging some potentially interested people, feel free to ignore (or tag others!): @v-dobrev @mlstowell @YohannDudouit @psocratis