### PR TITLE
Support non-conforming meshes with BlockNonlinearForm and ParBlockNonlinearForm

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -90,6 +90,9 @@ Discretization improvements
   Additionally, new LinearForm integrators were also added which make use of
   these new QuadratureFunction coefficient classes.
 
+- Non-conforming meshes are now supported with block nonlinear forms. See the
+  updated Example 19/19p.
+
 - Added support face integrals on the boundaries of NURBS meshes.
 
 Linear and nonlinear solvers

--- a/examples/ex19.cpp
+++ b/examples/ex19.cpp
@@ -8,6 +8,7 @@
 //    ex19 -m ../data/beam-hex.mesh
 //    ex19 -m ../data/beam-tet.mesh
 //    ex19 -m ../data/beam-wedge.mesh
+//    ex19 -m ../data/beam-quad-amr.mesh
 //
 // Description:  This examples solves a quasi-static incompressible nonlinear
 //               elasticity problem of the form 0 = H(x), where H is an
@@ -96,7 +97,7 @@ protected:
    Array<FiniteElementSpace *> spaces;
 
    // Offsets for extracting block vector segments
-   Array<int> &block_offsets;
+   Array<int> &block_trueOffsets;
 
    // Jacobian for block access
    BlockOperator *jacobian;
@@ -152,7 +153,7 @@ protected:
    Coefficient &mu;
 
    // Block offsets for variable access
-   Array<int> &block_offsets;
+   Array<int> &block_trueOffsets;
 
 public:
    RubberOperator(Array<FiniteElementSpace *> &fes, Array<Array<int> *>&ess_bdr,
@@ -246,8 +247,8 @@ int main(int argc, char *argv[])
    spaces[0] = &R_space;
    spaces[1] = &W_space;
 
-   int R_size = R_space.GetVSize();
-   int W_size = W_space.GetVSize();
+   int R_size = R_space.GetTrueVSize();
+   int W_size = W_space.GetTrueVSize();
 
    // 6. Define the Dirichlet conditions (set to boundary attribute 1 and 2)
    Array<Array<int> *> ess_bdr(2);
@@ -271,13 +272,13 @@ int main(int argc, char *argv[])
    std::cout << "***********************************************************\n";
 
    // 8. Define the block structure of the solution vector (u then p)
-   Array<int> block_offsets(3);
-   block_offsets[0] = 0;
-   block_offsets[1] = R_space.GetVSize();
-   block_offsets[2] = W_space.GetVSize();
-   block_offsets.PartialSum();
+   Array<int> block_trueOffsets(3);
+   block_trueOffsets[0] = 0;
+   block_trueOffsets[1] = R_space.GetTrueVSize();
+   block_trueOffsets[2] = W_space.GetTrueVSize();
+   block_trueOffsets.PartialSum();
 
-   BlockVector xp(block_offsets);
+   BlockVector xp(block_trueOffsets);
 
    // 9. Define grid functions for the current configuration, reference
    //    configuration, final deformation, and pressure
@@ -286,8 +287,8 @@ int main(int argc, char *argv[])
    GridFunction x_def(&R_space);
    GridFunction p_gf(&W_space);
 
-   x_gf.MakeRef(&R_space, xp.GetBlock(0), 0);
-   p_gf.MakeRef(&W_space, xp.GetBlock(1), 0);
+   x_gf.MakeTRef(&R_space, xp.GetBlock(0), 0);
+   p_gf.MakeTRef(&W_space, xp.GetBlock(1), 0);
 
    VectorFunctionCoefficient deform(dim, InitialDeformation);
    VectorFunctionCoefficient refconfig(dim, ReferenceConfiguration);
@@ -296,14 +297,19 @@ int main(int argc, char *argv[])
    x_ref.ProjectCoefficient(refconfig);
    p_gf = 0.0;
 
+   x_gf.SetTrueVector();
+   p_gf.SetTrueVector();
+
    // 10. Initialize the incompressible neo-Hookean operator
-   RubberOperator oper(spaces, ess_bdr, block_offsets,
+   RubberOperator oper(spaces, ess_bdr, block_trueOffsets,
                        newton_rel_tol, newton_abs_tol, newton_iter, c_mu);
 
    // 11. Solve the Newton system
    oper.Solve(xp);
 
    // 12. Compute the final deformation
+   x_gf.SetFromTrueVector();
+   p_gf.SetFromTrueVector();
    subtract(x_gf, x_ref, x_def);
 
    // 13. Visualize the results if requested
@@ -349,7 +355,7 @@ int main(int argc, char *argv[])
 JacobianPreconditioner::JacobianPreconditioner(Array<FiniteElementSpace *> &fes,
                                                SparseMatrix &mass,
                                                Array<int> &offsets)
-   : Solver(offsets[2]), block_offsets(offsets), pressure_mass(&mass)
+   : Solver(offsets[2]), block_trueOffsets(offsets), pressure_mass(&mass)
 {
    fes.Copy(spaces);
 
@@ -381,18 +387,18 @@ JacobianPreconditioner::JacobianPreconditioner(Array<FiniteElementSpace *> &fes,
 void JacobianPreconditioner::Mult(const Vector &k, Vector &y) const
 {
    // Extract the blocks from the input and output vectors
-   Vector disp_in(k.GetData() + block_offsets[0],
-                  block_offsets[1]-block_offsets[0]);
-   Vector pres_in(k.GetData() + block_offsets[1],
-                  block_offsets[2]-block_offsets[1]);
+   Vector disp_in(k.GetData() + block_trueOffsets[0],
+                  block_trueOffsets[1]-block_trueOffsets[0]);
+   Vector pres_in(k.GetData() + block_trueOffsets[1],
+                  block_trueOffsets[2]-block_trueOffsets[1]);
 
-   Vector disp_out(y.GetData() + block_offsets[0],
-                   block_offsets[1]-block_offsets[0]);
-   Vector pres_out(y.GetData() + block_offsets[1],
-                   block_offsets[2]-block_offsets[1]);
+   Vector disp_out(y.GetData() + block_trueOffsets[0],
+                   block_trueOffsets[1]-block_trueOffsets[0]);
+   Vector pres_out(y.GetData() + block_trueOffsets[1],
+                   block_trueOffsets[2]-block_trueOffsets[1]);
 
-   Vector temp(block_offsets[1]-block_offsets[0]);
-   Vector temp2(block_offsets[1]-block_offsets[0]);
+   Vector temp(block_trueOffsets[1]-block_trueOffsets[0]);
+   Vector temp2(block_trueOffsets[1]-block_trueOffsets[0]);
 
    // Perform the block elimination for the preconditioner
    mass_pcg->Mult(pres_in, pres_out);
@@ -447,9 +453,9 @@ RubberOperator::RubberOperator(Array<FiniteElementSpace *> &fes,
                                double abs_tol,
                                int iter,
                                Coefficient &c_mu)
-   : Operator(fes[0]->GetVSize() + fes[1]->GetVSize()),
+   : Operator(fes[0]->GetTrueVSize() + fes[1]->GetTrueVSize()),
      newton_solver(), newton_monitor("Newton", 1),
-     j_monitor("  GMRES", 3), mu(c_mu), block_offsets(offsets)
+     j_monitor("  GMRES", 3), mu(c_mu), block_trueOffsets(offsets)
 {
    Array<Vector *> rhs(2);
    rhs = NULL; // Set all entries in the array
@@ -471,12 +477,16 @@ RubberOperator::RubberOperator(Array<FiniteElementSpace *> &fes,
    a->AddDomainIntegrator(new MassIntegrator(one));
    a->Assemble();
    a->Finalize();
+
+   OperatorPtr op;
+   Array<int> p_ess_tdofs;
+   a->FormSystemMatrix(p_ess_tdofs, op);
    pressure_mass = a->LoseMat();
    delete a;
 
    // Initialize the Jacobian preconditioner
    JacobianPreconditioner *jac_prec =
-      new JacobianPreconditioner(fes, *pressure_mass, block_offsets);
+      new JacobianPreconditioner(fes, *pressure_mass, block_trueOffsets);
    j_prec = jac_prec;
 
    // Set up the Jacobian solver

--- a/examples/ex19p.cpp
+++ b/examples/ex19p.cpp
@@ -238,7 +238,6 @@ int main(int argc, char *argv[])
       {
          args.PrintUsage(cout);
       }
-      MPI_Finalize();
       return 1;
    }
    if (myid == 0)

--- a/examples/ex19p.cpp
+++ b/examples/ex19p.cpp
@@ -8,6 +8,7 @@
 //    mpirun -np 2 ex19p -m ../data/beam-hex.mesh
 //    mpirun -np 2 ex19p -m ../data/beam-tet.mesh
 //    mpirun -np 2 ex19p -m ../data/beam-wedge.mesh
+//    mpirun -np 2 ex19p -m ../data/beam-quad-amr.mesh
 //
 // Description:  This examples solves a quasi-static incompressible nonlinear
 //               elasticity problem of the form 0 = H(x), where H is an
@@ -474,7 +475,11 @@ void JacobianPreconditioner::SetOperator(const Operator &op)
    {
       HypreBoomerAMG *stiff_prec_amg = new HypreBoomerAMG();
       stiff_prec_amg->SetPrintLevel(0);
-      stiff_prec_amg->SetElasticityOptions(spaces[0]);
+
+      if (!spaces[0]->GetParMesh()->Nonconforming())
+      {
+         stiff_prec_amg->SetElasticityOptions(spaces[0]);
+      }
 
       stiff_prec = stiff_prec_amg;
 

--- a/examples/ex19p.cpp
+++ b/examples/ex19p.cpp
@@ -197,10 +197,8 @@ void InitialDeformation(const Vector &x, Vector &y);
 int main(int argc, char *argv[])
 {
    // 1. Initialize MPI
-   int num_procs, myid;
-   MPI_Init(&argc, &argv);
-   MPI_Comm_size(MPI_COMM_WORLD, &num_procs);
-   MPI_Comm_rank(MPI_COMM_WORLD, &myid);
+   MPI_Session mpi;
+   const int myid = mpi.WorldRank();
 
    // 2. Parse command-line options
    const char *mesh_file = "../data/beam-tet.mesh";
@@ -399,8 +397,6 @@ int main(int argc, char *argv[])
 
    // 19. Free the used memory
    delete pmesh;
-
-   MPI_Finalize();
 
    return 0;
 }

--- a/fem/nonlinearform.hpp
+++ b/fem/nonlinearform.hpp
@@ -206,8 +206,9 @@ protected:
    Array<int> block_offsets;
    Array<int> block_trueOffsets;
 
-   // Essential vdofs: one list of vdofs for each space in 'fes'
-   Array<Array<int> *> ess_vdofs;
+   // Array of Arrays of tdofs for each space in 'fes'
+   Array<Array<int> *> ess_tdofs;
+
 
    /// Specialized version of GetEnergy() for BlockVectors
    double GetEnergyBlocked(const BlockVector &bx) const;

--- a/fem/nonlinearform.hpp
+++ b/fem/nonlinearform.hpp
@@ -199,7 +199,7 @@ protected:
        GridFunction-like block-vector data (e.g. in parallel). */
    mutable BlockVector xs, ys;
 
-   mutable Array2D<SparseMatrix*> Grads;
+   mutable Array2D<SparseMatrix*> Grads, cGrads;
    mutable BlockOperator *BlockGrad;
 
    // A list of the offsets
@@ -209,15 +209,31 @@ protected:
    // Array of Arrays of tdofs for each space in 'fes'
    Array<Array<int> *> ess_tdofs;
 
+   /// Array of pointers to the prolongation matrix of fes, may be NULL
+   Array<const Operator *> P;
+
+   /// Array of results of dynamic-casting P to SparseMatrix pointer
+   Array<const SparseMatrix *> cP;
+
+   /// Indicator if the Operator is part of a parallel run
+   bool is_serial = true;
+
+   /// Indicator if the Operator needs prolongation on assembly
+   bool needs_prolongation = false;
+
+   mutable BlockVector aux1, aux2;
+
+   const BlockVector &Prolongate(const BlockVector &bx) const;
 
    /// Specialized version of GetEnergy() for BlockVectors
    double GetEnergyBlocked(const BlockVector &bx) const;
 
    /// Specialized version of Mult() for BlockVector%s
+   /// Block L-Vector to Block L-Vector
    void MultBlocked(const BlockVector &bx, BlockVector &by) const;
 
    /// Specialized version of GetGradient() for BlockVector
-   Operator &GetGradientBlocked(const BlockVector &bx) const;
+   void ComputeGradientBlocked(const BlockVector &bx) const;
 
 public:
    /// Construct an empty BlockNonlinearForm. Initialize with SetSpaces().
@@ -262,8 +278,12 @@ public:
 
    virtual double GetEnergy(const Vector &x) const;
 
+   /// Method is only called in serial, the parallel version calls MultBlocked
+   /// directly.
    virtual void Mult(const Vector &x, Vector &y) const;
 
+   /// Method is only called in serial, the parallel version calls
+   /// GetGradientBlocked directly.
    virtual Operator &GetGradient(const Vector &x) const;
 
    /// Destructor.

--- a/fem/pnonlinearform.cpp
+++ b/fem/pnonlinearform.cpp
@@ -200,19 +200,11 @@ void ParBlockNonlinearForm::SetEssentialBC(const
 
    BlockNonlinearForm::SetEssentialBC(bdr_attr_is_ess, nullarray);
 
-   for (int s=0; s<fes.Size(); ++s)
+   for (int s = 0; s < fes.Size(); ++s)
    {
       if (rhs[s])
       {
-         ParFiniteElementSpace *pfes = ParFESpace(s);
-         for (int i=0; i < ess_vdofs[s]->Size(); ++i)
-         {
-            int tdof = pfes->GetLocalTDofNumber((*(ess_vdofs[s]))[i]);
-            if (tdof >= 0)
-            {
-               (*rhs[s])(tdof) = 0.0;
-            }
-         }
+         rhs[s]->SetSubVector(*ess_tdofs[s], 0.0);
       }
    }
 }
@@ -241,6 +233,8 @@ void ParBlockNonlinearForm::Mult(const Vector &x, Vector &y) const
    {
       fes[s]->GetProlongationMatrix()->MultTranspose(
          ys.GetBlock(s), ys_true.GetBlock(s));
+
+      ys_true.GetBlock(s).SetSubVector(*ess_tdofs[s], 0.0);
    }
 }
 
@@ -314,6 +308,9 @@ BlockOperator & ParBlockNonlinearForm::GetGradient(const Vector &x) const
                                    pfes[s1]->GetDofOffsets(), Grads(s1,s1));
             Ph.ConvertFrom(pfes[s1]->Dof_TrueDof_Matrix());
             phBlockGrad(s1,s1)->MakePtAP(dA, Ph);
+
+            OperatorHandle Ae;
+            Ae.EliminateRowsCols(*phBlockGrad(s1,s1), *ess_tdofs[s1]);
          }
          else
          {
@@ -327,6 +324,9 @@ BlockOperator & ParBlockNonlinearForm::GetGradient(const Vector &x) const
             Ph.ConvertFrom(pfes[s2]->Dof_TrueDof_Matrix());
 
             phBlockGrad(s1,s2)->MakeRAP(Rh, dA, Ph);
+
+            phBlockGrad(s1,s2)->EliminateRows(*ess_tdofs[s1]);
+            phBlockGrad(s1,s2)->EliminateCols(*ess_tdofs[s2]);
          }
 
          pBlockGrad->SetBlock(s1, s2, phBlockGrad(s1,s2)->Ptr());

--- a/fem/pnonlinearform.cpp
+++ b/fem/pnonlinearform.cpp
@@ -251,8 +251,18 @@ const BlockOperator & ParBlockNonlinearForm::GetLocalGradient(
          xs_true.GetBlock(s), xs.GetBlock(s));
    }
 
-   BlockNonlinearForm::GetGradientBlocked(xs); // (re)assemble Grad with b.c.
+   BlockNonlinearForm::ComputeGradientBlocked(xs); // (re)assemble Grad with b.c.
 
+   delete BlockGrad;
+   BlockGrad = new BlockOperator(block_offsets);
+
+   for (int i = 0; i < fes.Size(); ++i)
+   {
+      for (int j = 0; j < fes.Size(); ++j)
+      {
+         BlockGrad->SetBlock(i, j, Grads(i, j));
+      }
+   }
    return *BlockGrad;
 }
 

--- a/fem/pnonlinearform.hpp
+++ b/fem/pnonlinearform.hpp
@@ -103,6 +103,7 @@ public:
    virtual void SetEssentialBC(const Array<Array<int> *>&bdr_attr_is_ess,
                                Array<Vector *> &rhs);
 
+   /// Block T-Vector to Block T-Vector
    virtual void Mult(const Vector &x, Vector &y) const;
 
    /// Return the local block gradient matrix for the given true-dof vector x

--- a/general/array.hpp
+++ b/general/array.hpp
@@ -411,6 +411,9 @@ public:
    inline void operator=(const T &a)
    { array1d = a; }
 
+   inline Array2D& operator=(const Array2D &a)
+   { array1d = a.array1d; return *this; }
+
    /// Make this Array a reference to 'master'
    inline void MakeRef(const Array2D &master)
    { M = master.M; N = master.N; array1d.MakeRef(master.array1d); }

--- a/general/array.hpp
+++ b/general/array.hpp
@@ -411,8 +411,7 @@ public:
    inline void operator=(const T &a)
    { array1d = a; }
 
-   inline Array2D& operator=(const Array2D &a)
-   { M = a.M; N = a.N; array1d = a.array1d; return *this; }
+   inline Array2D& operator=(const Array2D &a) = default;
 
    /// Make this Array a reference to 'master'
    inline void MakeRef(const Array2D &master)

--- a/general/array.hpp
+++ b/general/array.hpp
@@ -412,7 +412,7 @@ public:
    { array1d = a; }
 
    inline Array2D& operator=(const Array2D &a)
-   { array1d = a.array1d; return *this; }
+   { M = a.M; N = a.N; array1d = a.array1d; return *this; }
 
    /// Make this Array a reference to 'master'
    inline void MakeRef(const Array2D &master)

--- a/linalg/handle.cpp
+++ b/linalg/handle.cpp
@@ -306,7 +306,11 @@ void OperatorHandle::EliminateRows(const Array<int> &ess_dof_list)
    {
       case Operator::Hypre_ParCSR:
       {
+#ifdef MFEM_USE_MPI
          this->As<HypreParMatrix>()->EliminateRows(ess_dof_list);
+#else
+         MFEM_ABORT("type id = Hypre_ParCSR requires MFEM_USE_MPI");
+#endif
          break;
       }
       default:
@@ -320,8 +324,12 @@ void OperatorHandle::EliminateCols(const Array<int> &ess_dof_list)
    {
       case Operator::Hypre_ParCSR:
       {
+#ifdef MFEM_USE_MPI
          auto Ae = this->As<HypreParMatrix>()->EliminateCols(ess_dof_list);
          delete Ae;
+#else
+         MFEM_ABORT("type id = Hypre_ParCSR requires MFEM_USE_MPI");
+#endif
          break;
       }
       default:

--- a/linalg/handle.cpp
+++ b/linalg/handle.cpp
@@ -300,6 +300,33 @@ void OperatorHandle::EliminateRowsCols(OperatorHandle &A,
    }
 }
 
+void OperatorHandle::EliminateRows(const Array<int> &ess_dof_list)
+{
+   switch (Type())
+   {
+   case Operator::Hypre_ParCSR: {
+      this->As<HypreParMatrix>()->EliminateRows(ess_dof_list);
+      break;
+   }
+   default:
+      MFEM_ABORT(not_supported_msg << Type());
+   }
+}
+
+void OperatorHandle::EliminateCols(const Array<int> &ess_dof_list)
+{
+   switch (Type())
+   {
+   case Operator::Hypre_ParCSR: {
+      auto Ae = this->As<HypreParMatrix>()->EliminateCols(ess_dof_list);
+      delete Ae;
+      break;
+   }
+   default:
+      MFEM_ABORT(not_supported_msg << Type());
+   }
+}
+
 void OperatorHandle::EliminateBC(const OperatorHandle &A_e,
                                  const Array<int> &ess_dof_list,
                                  const Vector &X, Vector &B) const

--- a/linalg/handle.cpp
+++ b/linalg/handle.cpp
@@ -304,12 +304,13 @@ void OperatorHandle::EliminateRows(const Array<int> &ess_dof_list)
 {
    switch (Type())
    {
-   case Operator::Hypre_ParCSR: {
-      this->As<HypreParMatrix>()->EliminateRows(ess_dof_list);
-      break;
-   }
-   default:
-      MFEM_ABORT(not_supported_msg << Type());
+      case Operator::Hypre_ParCSR:
+      {
+         this->As<HypreParMatrix>()->EliminateRows(ess_dof_list);
+         break;
+      }
+      default:
+         MFEM_ABORT(not_supported_msg << Type());
    }
 }
 
@@ -317,13 +318,14 @@ void OperatorHandle::EliminateCols(const Array<int> &ess_dof_list)
 {
    switch (Type())
    {
-   case Operator::Hypre_ParCSR: {
-      auto Ae = this->As<HypreParMatrix>()->EliminateCols(ess_dof_list);
-      delete Ae;
-      break;
-   }
-   default:
-      MFEM_ABORT(not_supported_msg << Type());
+      case Operator::Hypre_ParCSR:
+      {
+         auto Ae = this->As<HypreParMatrix>()->EliminateCols(ess_dof_list);
+         delete Ae;
+         break;
+      }
+      default:
+         MFEM_ABORT(not_supported_msg << Type());
    }
 }
 

--- a/linalg/handle.hpp
+++ b/linalg/handle.hpp
@@ -186,6 +186,12 @@ public:
        elimination of the essential dofs @a ess_dof_list. */
    void EliminateRowsCols(OperatorHandle &A, const Array<int> &ess_dof_list);
 
+   /// Eliminate the rows corresponding to the essential dofs @a ess_dof_list
+   void EliminateRows(const Array<int> &ess_dof_list);
+
+   /// Eliminate columns corresponding to the essential dofs @a ess_dof_list
+   void EliminateCols(const Array<int> &ess_dof_list);
+
    /// Eliminate essential dofs from the solution @a X into the r.h.s. @a B.
    /** The argument @a A_e is expected to be the result of the method
        EliminateRowsCols(). */


### PR DESCRIPTION
This PR adds support for support non-conforming meshes with BlockNonlinearForm and ParBlockNonlinearForm. I made changes to ex19 and ex19p to provide test cases.

I changed the name and return type of an internal function in BlockNonlinearForm to reflect the functionality change.

The changes work in a dependent code as well.

Obligatory GLVis snapshot
<img width="1019" alt="Screen Shot 2020-09-07 at 11 58 41 AM" src="https://user-images.githubusercontent.com/5412886/92412668-96791380-f101-11ea-972a-8a00d247a97b.png">
<!--GHEX{"id":1744,"author":"jandrej","editor":"tzanio","reviewers":["jakubcerveny","jamiebramwell","mlstowell"],"assignment":"2020-09-08T13:38:58-07:00","approval":"2020-09-22T19:42:36.444Z","merge":"2020-10-04T19:12:32.207Z"}XEHG--><!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge| 
 | --- | --- | --- | --- | --- | --- | --- | 
| [#1744](https://github.com/mfem/mfem/pull/1744) | @jandrej | @tzanio | @jakubcerveny + @jamiebramwell + @mlstowell | 09/08/20 | 09/22/20 | 10/04/20 | |
<!--ELBATXEHG-->