### PR TITLE
Improve PA advection coefficient handling

### DIFF
--- a/fem/bilininteg_convection_pa.cpp
+++ b/fem/bilininteg_convection_pa.cpp
@@ -806,16 +806,16 @@ void ConvectionIntegrator::AssemblePA(const FiniteElementSpace &fes)
    {
       vel.SetSize(dim * nq * ne);
       auto C = Reshape(vel.HostWrite(), dim, nq, ne);
-      Vector Vq(dim);
+      DenseMatrix Q_ir;
       for (int e = 0; e < ne; ++e)
       {
          ElementTransformation& T = *fes.GetElementTransformation(e);
+         Q->Eval(Q_ir, T, *ir);
          for (int q = 0; q < nq; ++q)
          {
-            Q->Eval(Vq, T, ir->IntPoint(q));
             for (int i = 0; i < dim; ++i)
             {
-               C(i,q,e) = Vq(i);
+               C(i,q,e) = Q_ir(i,q);
             }
          }
       }

--- a/fem/bilininteg_dgtrace_pa.cpp
+++ b/fem/bilininteg_dgtrace_pa.cpp
@@ -43,7 +43,7 @@ static void PADGTraceSetup2D(const int Q1D,
    auto W = w.Read();
    auto qd = Reshape(op.Write(), Q1D, 2, 2, NF);
 
-   MFEM_FORALL(f, NF,//can be optimized with Q1D thread for NF blocks
+   MFEM_FORALL(f, NF, // can be optimized with Q1D thread for NF blocks
    {
       for (int q = 0; q < Q1D; ++q)
       {
@@ -85,7 +85,7 @@ static void PADGTraceSetup3D(const int Q1D,
    auto W = w.Read();
    auto qd = Reshape(op.Write(), Q1D, Q1D, 2, 2, NF);
 
-   MFEM_FORALL(f, NF,//can be optimized with Q1D*Q1D threads for NF blocks
+   MFEM_FORALL(f, NF, // can be optimized with Q1D*Q1D threads for NF blocks
    {
       for (int q1 = 0; q1 < Q1D; ++q1)
       {

--- a/fem/bilininteg_dgtrace_pa.cpp
+++ b/fem/bilininteg_dgtrace_pa.cpp
@@ -243,12 +243,15 @@ void DGTraceIntegrator::SetupPA(const FiniteElementSpace &fes, FaceType type)
          if ((type==FaceType::Interior && (e2>=0 || (e2<0 && inf2>=0))) ||
              (type==FaceType::Boundary && e2<0 && inf2<0) )
          {
-            ElementTransformation& T = *fes.GetMesh()->GetFaceTransformation(f);
+            FaceElementTransformations &T = *fes.GetMesh()->GetFaceElementTransformations(
+                                               f);
             for (int q = 0; q < nq; ++q)
             {
                // Convert to lexicographic ordering
                int iq = ToLexOrdering(dim, face_id, quad1D, q);
-               u->Eval(Vq, T, ir->IntPoint(q));
+               T.SetAllIntPoints(&ir->IntPoint(q));
+               const IntegrationPoint &eip1 = T.GetElement1IntPoint();
+               u->Eval(Vq, *T.Elem1, eip1);
                for (int i = 0; i < dim; ++i)
                {
                   C(i,iq,f_ind) = Vq(i);

--- a/tests/unit/fem/test_pa_kernels.cpp
+++ b/tests/unit/fem/test_pa_kernels.cpp
@@ -341,30 +341,30 @@ void velocity_function(const Vector &x, Vector &v)
    }
 }
 
-void AddConvectionIntegrators(BilinearForm &k, VectorCoefficient &velocity,
-                              bool dg)
+void AddConvectionIntegrators(BilinearForm &k, Coefficient &rho,
+                              VectorCoefficient &velocity, bool dg)
 {
    k.AddDomainIntegrator(new ConvectionIntegrator(velocity, -1.0));
 
    if (dg)
    {
       k.AddInteriorFaceIntegrator(
-         new TransposeIntegrator(new DGTraceIntegrator(velocity, 1.0, -0.5)));
+         new TransposeIntegrator(new DGTraceIntegrator(rho, velocity, 1.0, -0.5)));
       k.AddBdrFaceIntegrator(
-         new TransposeIntegrator(new DGTraceIntegrator(velocity, 1.0, -0.5)));
+         new TransposeIntegrator(new DGTraceIntegrator(rho, velocity, 1.0, -0.5)));
    }
 }
 
-void test_pa_convection(const char *meshname, int order, bool dg)
+void test_pa_convection(const char *meshname, int order, int prob)
 {
-   INFO("mesh=" << meshname << ", order=" << order << ", DG=" << dg);
+   INFO("mesh=" << meshname << ", order=" << order << ", prob=" << prob);
    Mesh mesh(meshname, 1, 1);
    mesh.EnsureNodes();
    mesh.SetCurvature(mesh.GetNodalFESpace()->GetOrder(0));
    int dim = mesh.Dimension();
 
    FiniteElementCollection *fec;
-   if (dg)
+   if (prob)
    {
       fec = new L2_FECollection(order, dim, BasisType::GaussLobatto);
    }
@@ -372,16 +372,36 @@ void test_pa_convection(const char *meshname, int order, bool dg)
    {
       fec = new H1_FECollection(order, dim);
    }
-
    FiniteElementSpace fespace(&mesh, fec);
+
+   L2_FECollection vel_fec(order, dim, BasisType::GaussLobatto);
+   FiniteElementSpace vel_fespace(&mesh, &vel_fec, dim);
+   GridFunction vel_gf(&vel_fespace);
+   GridFunction rho_gf(&fespace);
 
    BilinearForm k_pa(&fespace);
    BilinearForm k_fa(&fespace);
 
-   VectorFunctionCoefficient vel_coeff(dim, velocity_function);
+   VectorCoefficient *vel_coeff;
+   Coefficient *rho;
 
-   AddConvectionIntegrators(k_fa, vel_coeff, dg);
-   AddConvectionIntegrators(k_pa, vel_coeff, dg);
+   // prob: 0: CG, 1: DG continuous coeff, 2: DG discontinuous coeff
+   if (prob == 2)
+   {
+      vel_gf.Randomize(1);
+      vel_coeff = new VectorGridFunctionCoefficient(&vel_gf);
+      rho_gf.Randomize(1);
+      rho = new GridFunctionCoefficient(&rho_gf);
+   }
+   else
+   {
+      vel_coeff = new VectorFunctionCoefficient(dim, velocity_function);
+      rho = new ConstantCoefficient(1.0);
+   }
+
+
+   AddConvectionIntegrators(k_fa, *rho, *vel_coeff, prob > 0);
+   AddConvectionIntegrators(k_pa, *rho, *vel_coeff, prob > 0);
 
    k_fa.Assemble();
    k_fa.Finalize();
@@ -400,38 +420,41 @@ void test_pa_convection(const char *meshname, int order, bool dg)
 
    REQUIRE(y_pa.Norml2() < 1.e-12);
 
+   delete vel_coeff;
+   delete rho;
    delete fec;
 }
 
 //Basic unit test for convection
 TEST_CASE("PA Convection", "[PartialAssembly]")
 {
-   auto dg = GENERATE(true, false);
+   // prob: 0: CG, 1: DG continuous coeff, 2: DG discontinuous coeff
+   auto prob = GENERATE(0, 1, 2);
    auto order_2d = GENERATE(2, 3, 4);
    auto order_3d = GENERATE(2);
 
    SECTION("2D")
    {
-      test_pa_convection("../../data/periodic-square.mesh", order_2d, dg);
-      test_pa_convection("../../data/periodic-hexagon.mesh", order_2d, dg);
-      test_pa_convection("../../data/star-q3.mesh", order_2d, dg);
+      test_pa_convection("../../data/periodic-square.mesh", order_2d, prob);
+      test_pa_convection("../../data/periodic-hexagon.mesh", order_2d, prob);
+      test_pa_convection("../../data/star-q3.mesh", order_2d, prob);
    }
 
    SECTION("3D")
    {
-      test_pa_convection("../../data/periodic-cube.mesh", order_3d, dg);
-      test_pa_convection("../../data/fichera-q3.mesh", order_3d, dg);
+      test_pa_convection("../../data/periodic-cube.mesh", order_3d, prob);
+      test_pa_convection("../../data/fichera-q3.mesh", order_3d, prob);
    }
 
    // Test AMR cases (DG not implemented)
    SECTION("AMR 2D")
    {
-      test_pa_convection("../../data/amr-quad.mesh", order_2d, false);
+      test_pa_convection("../../data/amr-quad.mesh", order_2d, 0);
    }
 
    SECTION("AMR 3D")
    {
-      test_pa_convection("../../data/fichera-amr.mesh", order_3d, false);
+      test_pa_convection("../../data/fichera-amr.mesh", order_3d, 0);
    }
 }//test case
 

--- a/tests/unit/fem/test_pa_kernels.cpp
+++ b/tests/unit/fem/test_pa_kernels.cpp
@@ -425,7 +425,7 @@ void test_pa_convection(const char *meshname, int order, int prob)
    delete fec;
 }
 
-//Basic unit test for convection
+// Basic unit test for convection
 TEST_CASE("PA Convection", "[PartialAssembly]")
 {
    // prob: 0: CG, 1: DG continuous coeff, 2: DG discontinuous coeff
@@ -456,6 +456,7 @@ TEST_CASE("PA Convection", "[PartialAssembly]")
    {
       test_pa_convection("../../data/fichera-amr.mesh", order_3d, 0);
    }
-}//test case
 
-}// namespace pa_kernels
+} // test case
+
+} // namespace pa_kernels


### PR DESCRIPTION
Speed up the evaluation of coefficients like `VectorGridFunctionCoefficient` for the velocity field of `ConvectionIntegrator` in the PA assembly by batching over all integration points in each element.

Change the handling of discontinuous velocity fields in PA assembly of `DGTraceIntegrator` to match that of the legacy integrator (always evaluate velocity in "element 1").

Properly handle PA upwinding of the density coefficient according to the velocity field.

Add unit test to ensure the PA results match the legacy results.
<!--GHEX{"id":1745,"author":"pazner","editor":"tzanio","reviewers":["YohannDudouit","tzanio"],"assignment":"2020-09-08T13:43:25-07:00","approval":"2020-09-18T00:44:46.816Z","merge":"2020-09-27T18:55:42.826Z"}XEHG--><!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge| 
 | --- | --- | --- | --- | --- | --- | --- | 
| [#1745](https://github.com/mfem/mfem/pull/1745) | @pazner | @tzanio | @YohannDudouit + @tzanio | 09/08/20 | 09/17/20 | 09/27/20 | |
<!--ELBATXEHG-->