### PR TITLE
Add better error messages from SuperLU for invalid parameters [superlu-negative-returncode-dev]

### DIFF
--- a/linalg/superlu.cpp
+++ b/linalg/superlu.cpp
@@ -539,7 +539,7 @@ void SuperLUSolver::Mult( const Vector & x, Vector & y ) const
    {
       if ( info < 0 )
       {
-         switch (-info) 
+         switch (-info)
          {
             case 1:
                MFEM_ABORT("SuperLU:  SuperLU options are invalid.");

--- a/linalg/superlu.cpp
+++ b/linalg/superlu.cpp
@@ -537,7 +537,29 @@ void SuperLUSolver::Mult( const Vector & x, Vector & y ) const
 
    if ( info != 0 )
    {
-      if ( info <= A->ncol )
+      if ( info < 0 )
+      {
+         switch (-info) 
+         {
+            case 1:
+               MFEM_ABORT("SuperLU:  SuperLU options are invalid.");
+               break;
+            case 2:
+               MFEM_ABORT("SuperLU:  Matrix A (in Ax=b) is invalid.");
+               break;
+            case 5:
+               MFEM_ABORT("SuperLU:  Vector b dimension (in Ax=b) is invalid.");
+               break;
+            case 6:
+               MFEM_ABORT("SuperLU:  Number of right-hand sides is invalid.");
+               break;
+            default:
+               MFEM_ABORT("SuperLU:  Parameter with index "
+                          << -info << "invalid. (1-indexed)");
+               break;
+         }
+      }
+      else if ( info <= A->ncol )
       {
          MFEM_ABORT("SuperLU:  Found a singular matrix, U("
                     << info << "," << info << ") is exactly zero.");


### PR DESCRIPTION
Currently `SuperLUSolver` will interpret a negative `info` value (which indicates an invalid parameter) as an indication of a singular matrix, which could be confusing to a user.

A new condition was added to detect these error codes and display a more helpful message to the user.
<!--GHEX{"id":1751,"author":"joshessman-llnl","editor":"tzanio","reviewers":["tzanio","mlstowell"],"assignment":"2020-09-08T14:54:41-07:00","approval":"2020-09-18T18:30:08.586Z","merge":"2020-09-27T18:52:18.323Z"}XEHG--><!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge| 
 | --- | --- | --- | --- | --- | --- | --- | 
| [#1751](https://github.com/mfem/mfem/pull/1751) | @joshessman-llnl | @tzanio | @tzanio + @mlstowell | 09/08/20 | 09/18/20 | 09/27/20 | |
<!--ELBATXEHG-->