### PR TITLE
Small bug in fe.cpp prevents building in thread safe mode 

### DIFF
--- a/fem/fe.cpp
+++ b/fem/fe.cpp
@@ -8031,7 +8031,7 @@ void H1_HexahedronElement::CalcHessian(const IntegrationPoint &ip,
 #ifdef MFEM_THREAD_SAFE
    Vector shape_x(p+1),  shape_y(p+1),  shape_z(p+1);
    Vector dshape_x(p+1), dshape_y(p+1), dshape_z(p+1);
-   Vector d2shape_x(p+1), d2shape_y(p+1), ds2hape_z(p+1);
+   Vector d2shape_x(p+1), d2shape_y(p+1), d2shape_z(p+1);
 #endif
 
    basis1d.Eval(ip.x, shape_x, dshape_x, d2shape_x);


### PR DESCRIPTION
"d2shape_z" is misspelled on line 8034. Causes compile issues for thread safe mode only.
<!--GHEX{"id":1753,"author":"smsolivier","editor":"v-dobrev","reviewers":["v-dobrev","jandrej"],"assignment":"2020-09-10T19:39:00-07:00","approval":"2020-09-11T04:35:14.709Z","merge":"2020-09-27T18:57:58.222Z"}XEHG--><!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge| 
 | --- | --- | --- | --- | --- | --- | --- | 
| [#1753](https://github.com/mfem/mfem/pull/1753) | @smsolivier | @v-dobrev | @v-dobrev + @jandrej | 09/10/20 | 09/10/20 | 09/27/20 | |
<!--ELBATXEHG-->