### PR TITLE
Bug fix for MixedVectorCurlIntegrator PA

### DIFF
--- a/examples/ex25.cpp
+++ b/examples/ex25.cpp
@@ -93,6 +93,9 @@ public:
                             CartesianPML * pml_)
       : VectorCoefficient(dim), pml(pml_), Function(F)
    {}
+
+   using VectorCoefficient::Eval;
+
    virtual void Eval(Vector &K, ElementTransformation &T,
                      const IntegrationPoint &ip)
    {

--- a/examples/ex25p.cpp
+++ b/examples/ex25p.cpp
@@ -93,6 +93,9 @@ public:
                             CartesianPML * pml_)
       : VectorCoefficient(dim), pml(pml_), Function(F)
    {}
+
+   using VectorCoefficient::Eval;
+
    virtual void Eval(Vector &K, ElementTransformation &T,
                      const IntegrationPoint &ip)
    {

--- a/fem/bilininteg_hcurl.cpp
+++ b/fem/bilininteg_hcurl.cpp
@@ -2197,9 +2197,9 @@ void MixedVectorCurlIntegrator::AssemblePA(const FiniteElementSpace &trial_fes,
    trialType = trial_el->GetDerivType();
 
    const int symmDims = (dims * (dims + 1)) / 2; // 1x1: 1, 2x2: 3, 3x3: 6
-   coeffDim = (testType == mfem::FiniteElement::DIV) ? symmDims : (DQ ? 3 : 1);
+   coeffDim = (DQ ? 3 : 1);
 
-   pa_data.SetSize(coeffDim * nq * ne, Device::GetMemoryType());
+   pa_data.SetSize(symmDims * nq * ne, Device::GetMemoryType());
 
    Vector coeff(coeffDim * nq * ne);
    coeff = 1.0;

--- a/tests/unit/fem/test_pa_coeff.cpp
+++ b/tests/unit/fem/test_pa_coeff.cpp
@@ -432,13 +432,13 @@ TEST_CASE("Hcurl/Hdiv pa_coeff",
                      {
                         if (coeffType == 2)
                         {
-                           paform.AddDomainIntegrator(new MixedVectorCurlIntegrator(*vcoeff));
-                           assemblyform.AddDomainIntegrator(new MixedVectorCurlIntegrator(*vcoeff));
+                           paform->AddDomainIntegrator(new MixedVectorCurlIntegrator(*vcoeff));
+                           assemblyform->AddDomainIntegrator(new MixedVectorCurlIntegrator(*vcoeff));
                         }
                         else if (coeffType < 2)
                         {
-                           paform.AddDomainIntegrator(new MixedVectorCurlIntegrator(*coeff));
-                           assemblyform.AddDomainIntegrator(new MixedVectorCurlIntegrator(*coeff));
+                           paform->AddDomainIntegrator(new MixedVectorCurlIntegrator(*coeff));
+                           assemblyform->AddDomainIntegrator(new MixedVectorCurlIntegrator(*coeff));
                         }
                      }
 

--- a/tests/unit/fem/test_pa_coeff.cpp
+++ b/tests/unit/fem/test_pa_coeff.cpp
@@ -427,6 +427,20 @@ TEST_CASE("Hcurl/Hdiv pa_coeff")
                         assemblyform.AddDomainIntegrator(new VectorFEMassIntegrator(*coeff));
                      }
 
+                     if (spaceType == HcurlHdiv && dimension == 3)
+                     {
+                        if (coeffType == 2)
+                        {
+                           paform.AddDomainIntegrator(new MixedVectorCurlIntegrator(*vcoeff));
+                           assemblyform.AddDomainIntegrator(new MixedVectorCurlIntegrator(*vcoeff));
+                        }
+                        else if (coeffType < 2)
+                        {
+                           paform.AddDomainIntegrator(new MixedVectorCurlIntegrator(*coeff));
+                           assemblyform.AddDomainIntegrator(new MixedVectorCurlIntegrator(*coeff));
+                        }
+                     }
+
                      Array<int> empty_ess; // empty
 
                      paform.Assemble();


### PR DESCRIPTION
A bug is fixed, which affected ex24, and a unit test case is added.
<!--GHEX{"id":1754,"author":"dylan-copeland","editor":"v-dobrev","reviewers":["psocratis","mlstowell"],"assignment":"2020-09-10T15:29:58-07:00","approval":"2020-09-22T19:45:10.436Z","merge":"2020-09-29T15:04:59.660Z"}XEHG--><!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge| 
 | --- | --- | --- | --- | --- | --- | --- | 
| [#1754](https://github.com/mfem/mfem/pull/1754) | @dylan-copeland | @v-dobrev | @psocratis + @mlstowell | 09/10/20 | 09/22/20 | 09/29/20 | |
<!--ELBATXEHG-->