### PR TITLE
Mesh bug fix and unit test

### DIFF
--- a/mesh/mesh.cpp
+++ b/mesh/mesh.cpp
@@ -1394,7 +1394,6 @@ void Mesh::AddHexAsWedges(const int *vi, int attr)
 
 int Mesh::AddElement(Element *elem)
 {
-   CheckEnlarge(boundary, NumOfBdrElements);
    elements[NumOfElements] = elem;
    return NumOfElements++;
 }

--- a/mesh/mesh.cpp
+++ b/mesh/mesh.cpp
@@ -1394,6 +1394,7 @@ void Mesh::AddHexAsWedges(const int *vi, int attr)
 
 int Mesh::AddElement(Element *elem)
 {
+   CheckEnlarge(elements, NumOfElements);
    elements[NumOfElements] = elem;
    return NumOfElements++;
 }

--- a/tests/unit/mesh/test_mesh.cpp
+++ b/tests/unit/mesh/test_mesh.cpp
@@ -14,6 +14,54 @@ using namespace mfem;
 
 #include "unit_tests.hpp"
 
+TEST_CASE("Element-wise construction", "[Mesh]")
+{
+   SECTION("Quadrilateral")
+   {
+      const int numVertices = 9;
+      const int numElements = 4;
+
+      Mesh mesh(2, numVertices, numElements);
+
+      // Add each vertex by coordinates
+      for (int i=0; i<3; ++i)
+         for (int j=0; j<3; ++j)
+         {
+            mesh.AddVertex(i, j);
+         }
+
+      // Add each element by vertices
+      const int geom = Geometry::SQUARE;
+
+      Array<int> elvert(4);
+
+      Element *el = mesh.NewElement(geom);
+      elvert[0] = 0; elvert[1] = 1; elvert[2] = 3; elvert[3] = 4;
+      el->SetVertices(elvert);
+      mesh.AddElement(el);
+
+      el = mesh.NewElement(geom);
+      elvert[0] = 1; elvert[1] = 2; elvert[2] = 4; elvert[3] = 5;
+      el->SetVertices(elvert);
+      mesh.AddElement(el);
+
+      el = mesh.NewElement(geom);
+      elvert[0] = 3; elvert[1] = 4; elvert[2] = 6; elvert[3] = 7;
+      el->SetVertices(elvert);
+      mesh.AddElement(el);
+
+      el = mesh.NewElement(geom);
+      elvert[0] = 4; elvert[1] = 5; elvert[2] = 7; elvert[3] = 8;
+      el->SetVertices(elvert);
+      mesh.AddElement(el);
+
+      mesh.FinalizeTopology();
+
+      REQUIRE(numVertices == mesh.GetNV());
+      REQUIRE(numElements == mesh.GetNE());
+   }
+}
+
 TEST_CASE("Gecko integration in MFEM", "[Mesh]")
 {
    Array<int> perm;


### PR DESCRIPTION
In addition to the one-line bug fix, there is a small, fast unit test for mesh construction by adding vertices and elements, which would have caught the bug. This is an unusual way to construct a mesh, but it is used in some codes that construct submeshes of an existing mesh. The test should help to catch other bugs in the future and ensure that this type of mesh construction is not broken.
<!--GHEX{"id":1764,"author":"dylan-copeland","editor":"tzanio","reviewers":["tzanio","mlstowell"],"assignment":"2020-09-17T18:21:36-07:00","approval":"2020-09-18T18:35:46.987Z","merge":"2020-09-20T17:32:16.265Z"}XEHG--><!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge| 
 | --- | --- | --- | --- | --- | --- | --- | 
| [#1764](https://github.com/mfem/mfem/pull/1764) | @dylan-copeland | @tzanio | @tzanio + @mlstowell | 09/17/20 | 09/18/20 | 09/20/20 | |
<!--ELBATXEHG-->