### PR TITLE
Default implementation of AssembleElementVector and AssembleFaceVector for bilinear integrators [blfi-default-assemble-vector-dev]

### DIFF
--- a/fem/bilininteg.cpp
+++ b/fem/bilininteg.cpp
@@ -133,6 +133,7 @@ void BilinearFormIntegrator::AssembleElementVector(
    const FiniteElement &el, ElementTransformation &Tr, const Vector &elfun,
    Vector &elvect)
 {
+   // Note: This default implementation is general but not efficient
    DenseMatrix elmat;
    AssembleElementMatrix(el, Tr, elmat);
    elvect.SetSize(elmat.Height());
@@ -143,6 +144,7 @@ void BilinearFormIntegrator::AssembleFaceVector(
    const FiniteElement &el1, const FiniteElement &el2,
    FaceElementTransformations &Tr, const Vector &elfun, Vector &elvect)
 {
+   // Note: This default implementation is general but not efficient
    DenseMatrix elmat;
    AssembleFaceMatrix(el1, el2, Tr, elmat);
    elvect.SetSize(elmat.Height());

--- a/fem/bilininteg.cpp
+++ b/fem/bilininteg.cpp
@@ -133,8 +133,18 @@ void BilinearFormIntegrator::AssembleElementVector(
    const FiniteElement &el, ElementTransformation &Tr, const Vector &elfun,
    Vector &elvect)
 {
-   mfem_error("BilinearFormIntegrator::AssembleElementVector\n"
-              "   is not implemented for this class.");
+   DenseMatrix elmat;
+   AssembleElementMatrix(el, Tr, elmat);
+   elmat.Mult(elfun, elvect);
+}
+
+void BilinearFormIntegrator::AssembleFaceVector(
+   const FiniteElement &el1, const FiniteElement &el2,
+   FaceElementTransformations &Tr, const Vector &elfun, Vector &elvect)
+{
+   DenseMatrix elmat;
+   AssembleFaceMatrix(el1, el2, Tr, elmat);
+   elmat.Mult(elfun, elvect);
 }
 
 

--- a/fem/bilininteg.cpp
+++ b/fem/bilininteg.cpp
@@ -135,6 +135,7 @@ void BilinearFormIntegrator::AssembleElementVector(
 {
    DenseMatrix elmat;
    AssembleElementMatrix(el, Tr, elmat);
+   elvect.SetSize(elmat.Height());
    elmat.Mult(elfun, elvect);
 }
 
@@ -144,6 +145,7 @@ void BilinearFormIntegrator::AssembleFaceVector(
 {
    DenseMatrix elmat;
    AssembleFaceMatrix(el1, el2, Tr, elmat);
+   elvect.SetSize(elmat.Height());
    elmat.Mult(elfun, elvect);
 }
 

--- a/fem/bilininteg.hpp
+++ b/fem/bilininteg.hpp
@@ -142,7 +142,7 @@ public:
                                    const FiniteElement &el2,
                                    FaceElementTransformations &Tr,
                                    const Vector &elfun, Vector &elvect);
-   
+
    virtual void AssembleElementGrad(const FiniteElement &el,
                                     ElementTransformation &Tr,
                                     const Vector &elfun, DenseMatrix &elmat)

--- a/fem/bilininteg.hpp
+++ b/fem/bilininteg.hpp
@@ -131,13 +131,17 @@ public:
                                    FaceElementTransformations &Trans,
                                    DenseMatrix &elmat);
 
-   /// @brief Perform the local action of the BilinearFormIntegrator
+   /// @brief Perform the local action of the BilinearFormIntegrator.
+   /// Note that the default implementation in the base class is general but not
+   /// efficient.
    virtual void AssembleElementVector(const FiniteElement &el,
                                       ElementTransformation &Tr,
                                       const Vector &elfun, Vector &elvect);
 
    /// @brief Perform the local action of the BilinearFormIntegrator resulting
    /// from a face integral term.
+   /// Note that the default implementation in the base class is general but not
+   /// efficient.
    virtual void AssembleFaceVector(const FiniteElement &el1,
                                    const FiniteElement &el2,
                                    FaceElementTransformations &Tr,

--- a/fem/bilininteg.hpp
+++ b/fem/bilininteg.hpp
@@ -131,11 +131,18 @@ public:
                                    FaceElementTransformations &Trans,
                                    DenseMatrix &elmat);
 
-   /// Perform the local action of the BilinearFormIntegrator
+   /// @brief Perform the local action of the BilinearFormIntegrator
    virtual void AssembleElementVector(const FiniteElement &el,
                                       ElementTransformation &Tr,
                                       const Vector &elfun, Vector &elvect);
 
+   /// @brief Perform the local action of the BilinearFormIntegrator resulting
+   /// from a face integral term.
+   virtual void AssembleFaceVector(const FiniteElement &el1,
+                                   const FiniteElement &el2,
+                                   FaceElementTransformations &Tr,
+                                   const Vector &elfun, Vector &elvect);
+   
    virtual void AssembleElementGrad(const FiniteElement &el,
                                     ElementTransformation &Tr,
                                     const Vector &elfun, DenseMatrix &elmat)


### PR DESCRIPTION
As stated in the title, this adds a default implementation of `BilinearFormIntegrator::AssembleElementVector` and `BilinearFormIntegrator::AssembleFaceVector`that simply multiply the state vector by the element/face stiffness matrix to compute the action of the integrator.

I realize this isn't necessarily a very efficient implementation, but it should allow someone to easily use a bilinear form integrator in a `NonlinearForm`, and the necessary functions can be overridden if need be for performance. Thoughts?

Thanks,

Tucker
<!--GHEX{"id":1765,"author":"tuckerbabcock","editor":"tzanio","reviewers":["rcarson3","jandrej"],"assignment":"2020-09-22T17:16:47-07:00","approval":"2020-09-27T20:06:20.530Z","merge":"2020-10-04T18:49:11.914Z"}XEHG--><!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge| 
 | --- | --- | --- | --- | --- | --- | --- | 
| [#1765](https://github.com/mfem/mfem/pull/1765) | @tuckerbabcock | @tzanio | @rcarson3 + @jandrej | 09/22/20 | 09/27/20 | 10/04/20 | |
<!--ELBATXEHG-->