### PR TITLE
hypre.hpp: transition to a correct spelling for SetInitialIterate()

### DIFF
--- a/linalg/hypre.hpp
+++ b/linalg/hypre.hpp
@@ -782,8 +782,11 @@ public:
        2) enable residual-based stopping criteria. */
    void SetResidualConvergenceOptions(int res_frequency=-1, double rtol=0.0);
 
+   /// deprecated: use SetZeroInitialIterate()
+   MFEM_DEPRECATED void SetZeroInintialIterate() { iterative_mode = false; }
+
    /// non-hypre setting
-   void SetZeroInintialIterate() { iterative_mode = false; }
+   void SetZeroInitialIterate() { iterative_mode = false; }
 
    void GetNumIterations(int &num_iterations)
    {
@@ -836,8 +839,11 @@ public:
    /// Set the hypre solver to be used as a preconditioner
    void SetPreconditioner(HypreSolver &precond);
 
+   /// deprecated: use SetZeroInitialIterate()
+   MFEM_DEPRECATED void SetZeroInintialIterate() { iterative_mode = false; }
+
    /// non-hypre setting
-   void SetZeroInintialIterate() { iterative_mode = false; }
+   void SetZeroInitialIterate() { iterative_mode = false; }
 
    /// The typecast to HYPRE_Solver returns the internal gmres_solver
    virtual operator HYPRE_Solver() const  { return gmres_solver; }


### PR DESCRIPTION
In `hypre.hpp`, the method `SetInitialIterate()` is misspelled twice in the public interface. This PR marks the misspelled method as deprecated and adds a correctly spelled replacement.
<!--GHEX{"id":1787,"author":"barker29","editor":"tzanio","reviewers":["tzanio","mlstowell"],"assignment":"2020-09-28T08:51:19-07:00","approval":"2020-10-13T22:35:06.476Z","merge":"2020-10-18T04:41:35.645Z"}XEHG--><!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge| 
 | --- | --- | --- | --- | --- | --- | --- | 
| [#1787](https://github.com/mfem/mfem/pull/1787) | @barker29 | @tzanio | @tzanio + @mlstowell | 09/28/20 | 10/13/20 | 10/17/20 | |
<!--ELBATXEHG-->