### PR TITLE
libceed - update to v0.7

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -657,13 +657,13 @@ The specific libraries and their options are:
 - OCCA (optional), used when MFEM_USE_OCCA = YES.
   URL: https://libocca.org
   Options: OCCA_DIR, OCCA_OPT, OCCA_LIB.
-  Versions: OCCA >= 1.0.9.
+  Versions: OCCA >= 1.1.0.
 
 - libCEED (optional), used when MFEM_USE_CEED = YES.
   URL: https://github.com/CEED/libCEED
        https://ceed.exascaleproject.org/libceed
   Options: CEED_DIR, CEED_OPT, CEED_LIB.
-  Versions: libCEED > 0.6, git-hash bdfed75.
+  Versions: libCEED >= 0.7.
 
 - RAJA (optional), used when MFEM_USE_RAJA = YES.
   Beginning with MFEM v4.1, only RAJA v0.10.0+ is supported.


### PR DESCRIPTION
libCEED 0.7 has been released, so this PR updates the version number and drops the commit hash.
<!--GHEX{"id":1792,"author":"jeremylt","editor":"tzanio","reviewers":["tzanio","YohannDudouit"],"assignment":"2020-09-30T07:26:57-07:00","approval":"2020-10-06T19:27:46.917Z","merge":"2020-10-11T02:05:40.331Z"}XEHG--><!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge| 
 | --- | --- | --- | --- | --- | --- | --- | 
| [#1792](https://github.com/mfem/mfem/pull/1792) | @jeremylt | @tzanio | @tzanio + @YohannDudouit | 09/30/20 | 10/06/20 | 10/10/20 | |
<!--ELBATXEHG-->