### PR TITLE
Fix for reusing HypreSmoother

### DIFF
--- a/linalg/hypre.cpp
+++ b/linalg/hypre.cpp
@@ -2268,7 +2268,6 @@ void HypreSmoother::SetOperator(const Operator &op)
       Vector ones(height), diag(l1_norms, height);
       ones = 1.0;
       A->Mult(ones, diag);
-      type = 1;
    }
    else
    {
@@ -2420,13 +2419,17 @@ void HypreSmoother::Mult(const HypreParVector &b, HypreParVector &x) const
    }
    else
    {
+      int hypre_type = type;
+      // hypre doesn't have lumped Jacobi, so treat the action as l1-Jacobi
+      if (type == 5) { hypre_type = 1; }
+
       if (Z == NULL)
-         hypre_ParCSRRelax(*A, b, type,
+         hypre_ParCSRRelax(*A, b, hypre_type,
                            relax_times, l1_norms, relax_weight, omega,
                            max_eig_est, min_eig_est, poly_order, poly_fraction,
                            x, *V, NULL);
       else
-         hypre_ParCSRRelax(*A, b, type,
+         hypre_ParCSRRelax(*A, b, hypre_type,
                            relax_times, l1_norms, relax_weight, omega,
                            max_eig_est, min_eig_est, poly_order, poly_fraction,
                            x, *V, *Z);


### PR DESCRIPTION
Closes #1795
<!--GHEX{"id":1802,"author":"tzanio","editor":"v-dobrev","reviewers":["v-dobrev","vladotomov"],"assignment":"2020-10-06T18:58:28-07:00","approval":"2020-10-07T17:13:02.407Z","merge":"2020-10-15T01:04:07.002Z"}XEHG--><!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge| 
 | --- | --- | --- | --- | --- | --- | --- | 
| [#1802](https://github.com/mfem/mfem/pull/1802) | @tzanio | @v-dobrev | @v-dobrev + @vladotomov | 10/06/20 | 10/07/20 | 10/14/20 | |
<!--ELBATXEHG-->