### PR TITLE
Build cuda debug on lassen with O2 to speed up [fix/lassen-debug-ci]

### DIFF
--- a/.gitlab/lassen.yml
+++ b/.gitlab/lassen.yml
@@ -37,7 +37,7 @@ build_mfem_debug_ser_lassen:
     - mkdir -p ${BUILD_PATH}
     - cp -r ${CI_PROJECT_DIR} ${BUILD_PATH}/${CI_PROJECT_NAME}_lassen_ser_debug
     - cd ${BUILD_PATH}/${CI_PROJECT_NAME}_lassen_ser_debug
-    - lalloc 1 -W 5 -q pdebug make -j cuda MFEM_DEBUG="YES" CUDA_ARCH=sm_70
+    - lalloc 1 -W 5 -q pdebug make -j cuda MFEM_DEBUG="YES" CPPFLAGS=-O2 CUDA_ARCH=sm_70
 
 # Sanity check
 sanitycheck_mfem_ser_lassen:


### PR DESCRIPTION
Since those debug builds are not meant to be analyzed with debugging tools, optimizing makes sense.

This works fine, and drastically reduces the execution time.
<!--GHEX{"id":1803,"author":"adrienbernede","editor":"tzanio","reviewers":["tzanio","v-dobrev"],"assignment":"2020-10-06T17:23:10-07:00","approval":"2020-10-07T02:14:43.491Z","merge":"2020-10-07T22:51:32.162Z"}XEHG--><!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge| 
 | --- | --- | --- | --- | --- | --- | --- | 
| [#1803](https://github.com/mfem/mfem/pull/1803) | @adrienbernede | @tzanio | @tzanio + @v-dobrev | 10/06/20 | 10/06/20 | 10/07/20 | |
<!--ELBATXEHG-->