### PR TITLE
Minor fixes to amgx:ex1p, adjust amgx defaults

### DIFF
--- a/examples/amgx/amg_pcg.json
+++ b/examples/amgx/amg_pcg.json
@@ -17,7 +17,7 @@
             "interpolator": "D2",
             "max_row_sum" : 0.9,
             "strength_threshold" : 0.25,
-            "max_iters": 1,
+            "max_iters": 2,
             "monitor_residual": 0,
             "store_res_history": 0,
             "scope": "amg",

--- a/examples/amgx/ex1p.cpp
+++ b/examples/amgx/ex1p.cpp
@@ -227,7 +227,7 @@ int main(int argc, char *argv[])
    else if (amgx_lib && strcmp(amgx_json_file,"") == 0)
    {
       MFEM_VERIFY(!amgx_mpi_teams,
-                  "Please add JSON file to try AmgX with teams");
+                  "Please add JSON file to try AmgX with MPI teams mode");
 
       bool amgx_verbose = false;
       prec = new AmgXSolver(MPI_COMM_WORLD, AmgXSolver::PRECONDITIONER,

--- a/examples/amgx/ex1p.cpp
+++ b/examples/amgx/ex1p.cpp
@@ -67,14 +67,14 @@ int main(int argc, char *argv[])
                   "AMGX solver config file (overrides --amgx-solver, --amgx-verbose)");
    args.AddOption(&amgx_mpi_teams, "--amgx-mpi-teams", "--amgx-mpi-teams",
                   "--amgx-mpi-gpu-exclusive", "--amgx-mpi-gpu-exclusive",
-                  "Create MPI teams when using AMGX.");
+                  "Create MPI teams when using AmgX to load balance between ranks and GPUs.");
    args.AddOption(&device_config, "-d", "--device",
                   "Device configuration string, see Device::Configure().");
    args.AddOption(&visualization, "-vis", "--visualization", "-no-vis",
                   "--no-visualization",
                   "Enable or disable GLVis visualization.");
-   args.AddOption(&ndevices, "-nd","--gpus-per-node",
-                  "Number of GPU devices per node (Only used amgx_mpi_teams mode).");
+   args.AddOption(&ndevices, "-nd","--gpus-per-node-in-teams-mode",
+                  "Number of GPU devices per node (Only used if amgx_mpi_teams is true).");
 
    args.Parse();
    if (!args.Good())

--- a/examples/amgx/ex1p.cpp
+++ b/examples/amgx/ex1p.cpp
@@ -6,8 +6,8 @@
 // AmgX sample runs:
 //               mpirun -np 4 ex1p
 //               mpirun -np 4 ex1p -d cuda
-//               mpirun -n 10 ex1p --amgx-file amg_pcg.json
-//               mpirun -n 4 ex1p --amgx-file amg_pcg.json --amgx-mpi-gpu-exclusive
+//               mpirun -np 10 ex1p --amgx-file amg_pcg.json --amgx-mpi-teams
+//               mpirun -np 4 ex1p --amgx-file amg_pcg.json
 //
 // Description:  This example code demonstrates the use of MFEM to define a
 //               simple finite element discretization of the Laplace problem
@@ -47,7 +47,7 @@ int main(int argc, char *argv[])
    const char *device_config = "cpu";
    bool visualization = true;
    bool amgx_lib = true;
-   bool amgx_mpi_teams = true;
+   bool amgx_mpi_teams = false;
    const char* amgx_json_file = ""; // JSON file for AmgX
    int ndevices = 1;
 
@@ -73,7 +73,8 @@ int main(int argc, char *argv[])
    args.AddOption(&visualization, "-vis", "--visualization", "-no-vis",
                   "--no-visualization",
                   "Enable or disable GLVis visualization.");
-   args.AddOption(&ndevices, "-nd","--nd","Number of GPU devices.");
+   args.AddOption(&ndevices, "-nd","--gpus-per-node",
+                  "Number of GPU devices per node (Only used amgx_mpi_teams mode).");
 
    args.Parse();
    if (!args.Good())

--- a/examples/amgx/ex1p.cpp
+++ b/examples/amgx/ex1p.cpp
@@ -226,6 +226,9 @@ int main(int argc, char *argv[])
    }
    else if (amgx_lib && strcmp(amgx_json_file,"") == 0)
    {
+      MFEM_VERIFY(!amgx_mpi_teams,
+                  "Please add JSON file to try AmgX with teams");
+
       bool amgx_verbose = false;
       prec = new AmgXSolver(MPI_COMM_WORLD, AmgXSolver::PRECONDITIONER,
                             amgx_verbose);

--- a/linalg/amgxsolver.cpp
+++ b/linalg/amgxsolver.cpp
@@ -225,7 +225,7 @@ void AmgXSolver::DefaultParameters(const AMGX_MODE amgxMode_,
                     "     \"interpolator\": \"D2\", \n"
                     "     \"max_row_sum\" : 0.9, \n"
                     "     \"strength_threshold\" : 0.25, \n"
-                    "     \"max_iters\": 1, \n"
+                    "     \"max_iters\": 2, \n"
                     "     \"scope\": \"amg\", \n"
                     "     \"max_levels\": 100, \n"
                     "     \"cycle\": \"V\", \n"


### PR DESCRIPTION
This PR makes small edits to amgx ex1p so the output is a bit more clear. It also adjust the number of v cycle steps in ::SOLVER mode to match that of the ::PRECONDITIONER mode. 
<!--GHEX{"id":1819,"author":"artv3","editor":"tzanio","reviewers":["tzanio","dylan-copeland","barker29"],"assignment":"2020-10-19T08:31:38-07:00","approval":"2020-10-19T23:12:38.264Z","merge":"2020-10-21T17:55:02.697Z"}XEHG--><!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge| 
 | --- | --- | --- | --- | --- | --- | --- | 
| [#1819](https://github.com/mfem/mfem/pull/1819) | @artv3 | @tzanio | @tzanio + @dylan-copeland + @barker29 | 10/19/20 | 10/19/20 | 10/21/20 | |
<!--ELBATXEHG-->