### PR TITLE
ParaView output of boundary elements and attributes

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -267,6 +267,9 @@ Miscellaneous
   ParaView v5.8.1. In addition, ADIOS2 allows for setting a user-defined number
   of data substreams/subfiles at scale. See examples 5, 9, 12, 16.
 
+- Added VTU output of boundary elements and attributes and parallel VTU (PVTU)
+  output of parallel meshes for visualization using ParaView.
+
 - The integration order used in the ComputeLpError and ComputeElementLpError
   methods of class GridFunction has been increased.
 

--- a/fem/datacollection.cpp
+++ b/fem/datacollection.cpp
@@ -908,7 +908,7 @@ void ParaViewDataCollection::Save()
 
       // CELL DATA
       out << "<PCellData>\n";
-      out << "\t<PDataArray type=\"Int32\" Name=\"" << "material"
+      out << "\t<PDataArray type=\"Int32\" Name=\"" << "attribute"
           << "\" NumberOfComponents=\"1\""
           << " format=\"" << GetDataFormatString() << "\"/>\n";
       out << "</PCellData>\n";

--- a/fem/datacollection.hpp
+++ b/fem/datacollection.hpp
@@ -382,6 +382,10 @@ public:
    int Error() const { return error; }
    /// Reset the error state
    void ResetError(int err = NO_ERROR) { error = err; }
+
+#ifdef MFEM_USE_MPI
+   friend class ParMesh;
+#endif
 };
 
 

--- a/mesh/mesh.cpp
+++ b/mesh/mesh.cpp
@@ -9041,7 +9041,8 @@ void Mesh::PrintVTK(std::ostream &out)
 void Mesh::PrintVTU(std::string fname,
                     VTKFormat format,
                     bool high_order_output,
-                    int compression_level)
+                    int compression_level,
+                    bool bdr)
 {
    int ref = (high_order_output && Nodes) ? Nodes->FESpace()->GetOrder(0) : 1;
    fname = fname + ".vtu";
@@ -9053,12 +9054,20 @@ void Mesh::PrintVTU(std::string fname,
    }
    out << " byte_order=\"" << VTKByteOrder() << "\">\n";
    out << "<UnstructuredGrid>\n";
-   PrintVTU(out, ref, format, high_order_output, compression_level);
+   PrintVTU(out, ref, format, high_order_output, compression_level, bdr);
    out << "</Piece>\n"; // need to close the piece open in the PrintVTU method
    out << "</UnstructuredGrid>\n";
    out << "</VTKFile>" << std::endl;
 
    out.close();
+}
+
+void Mesh::PrintBdrVTU(std::string fname,
+                       VTKFormat format,
+                       bool high_order_output,
+                       int compression_level)
+{
+   PrintVTU(fname, format, high_order_output, compression_level, true);
 }
 
 template <typename T>
@@ -9117,7 +9126,8 @@ void WriteBase64WithSizeAndClear(std::ostream &out, std::vector<char> &buf,
 }
 
 void Mesh::PrintVTU(std::ostream &out, int ref, VTKFormat format,
-                    bool high_order_output, int compression_level)
+                    bool high_order_output, int compression_level,
+                    bool bdr_elements)
 {
    RefinedGeometry *RefG;
    DenseMatrix pmat;
@@ -9126,11 +9136,18 @@ void Mesh::PrintVTU(std::ostream &out, int ref, VTKFormat format,
    const char *type_str = (format != VTKFormat::BINARY32) ? "Float64" : "Float32";
    std::vector<char> buf;
 
+   auto get_geom = [&](int i)
+   {
+      if (bdr_elements) { return GetBdrElementBaseGeometry(i); }
+      else { return GetElementBaseGeometry(i); }
+   };
+
+   int ne = bdr_elements ? GetNBE() : GetNE();
    // count the points, cells, size
    int np = 0, nc_ref = 0, size = 0;
-   for (int i = 0; i < GetNE(); i++)
+   for (int i = 0; i < ne; i++)
    {
-      Geometry::Type geom = GetElementBaseGeometry(i);
+      Geometry::Type geom = get_geom(i);
       int nv = Geometries.GetVertices(geom)->GetNPoints();
       RefG = GlobGeometryRefiner.Refine(geom, ref, 1);
       np += RefG->RefPts.GetNPoints();
@@ -9139,18 +9156,24 @@ void Mesh::PrintVTU(std::ostream &out, int ref, VTKFormat format,
    }
 
    out << "<Piece NumberOfPoints=\"" << np << "\" NumberOfCells=\""
-       << (high_order_output ? GetNE() : nc_ref) << "\">\n";
+       << (high_order_output ? ne : nc_ref) << "\">\n";
 
    // print out the points
    out << "<Points>\n";
    out << "<DataArray type=\"" << type_str
        << "\" NumberOfComponents=\"3\" format=\"" << fmt_str << "\">\n";
-   for (int i = 0; i < GetNE(); i++)
+   for (int i = 0; i < ne; i++)
    {
-      RefG = GlobGeometryRefiner.Refine(
-                GetElementBaseGeometry(i), ref, 1);
+      RefG = GlobGeometryRefiner.Refine(get_geom(i), ref, 1);
 
-      GetElementTransformation(i)->Transform(RefG->RefPts, pmat);
+      if (bdr_elements)
+      {
+         GetBdrElementTransformation(i)->Transform(RefG->RefPts, pmat);
+      }
+      else
+      {
+         GetElementTransformation(i)->Transform(RefG->RefPts, pmat);
+      }
 
       for (int j = 0; j < pmat.Width(); j++)
       {
@@ -9191,9 +9214,9 @@ void Mesh::PrintVTU(std::ostream &out, int ref, VTKFormat format,
    if (high_order_output)
    {
       Array<int> local_connectivity;
-      for (int iel = 0; iel < GetNE(); iel++)
+      for (int iel = 0; iel < ne; iel++)
       {
-         Geometry::Type geom = GetElementBaseGeometry(iel);
+         Geometry::Type geom = get_geom(iel);
          CreateVTKElementConnectivity(local_connectivity, geom, ref);
          int nnodes = local_connectivity.Size();
          for (int i=0; i<nnodes; ++i)
@@ -9208,18 +9231,16 @@ void Mesh::PrintVTU(std::ostream &out, int ref, VTKFormat format,
    else
    {
       int coff = 0;
-      for (int i = 0; i < GetNE(); i++)
+      for (int i = 0; i < ne; i++)
       {
-         Geometry::Type geom = GetElementBaseGeometry(i);
+         Geometry::Type geom = get_geom(i);
          int nv = Geometries.GetVertices(geom)->GetNPoints();
          RefG = GlobGeometryRefiner.Refine(geom, ref, 1);
          Array<int> &RG = RefG->RefGeoms;
          for (int j = 0; j < RG.Size(); )
          {
-            // out << nv;
             coff = coff+nv;
             offset.push_back(coff);
-
             for (int k = 0; k < nv; k++, j++)
             {
                WriteBinaryOrASCII(out, buf, np + RG[j], " ", format);
@@ -9250,9 +9271,9 @@ void Mesh::PrintVTU(std::ostream &out, int ref, VTKFormat format,
    out << "<DataArray type=\"UInt8\" Name=\"types\" format=\""
        << fmt_str << "\">" << std::endl;
    // cell types
-   for (int i = 0; i < GetNE(); i++)
+   for (int i = 0; i < ne; i++)
    {
-      Geometry::Type geom = GetElementBaseGeometry(i);
+      Geometry::Type geom = get_geom(i);
       uint8_t vtk_cell_type = 5;
 
       // VTK element types defined at: https://git.io/JvZLm
@@ -9306,19 +9327,19 @@ void Mesh::PrintVTU(std::ostream &out, int ref, VTKFormat format,
    out << "</DataArray>" << std::endl;
    out << "</Cells>" << std::endl;
 
-   out << "<CellData Scalars=\"material\">" << std::endl;
-   out << "<DataArray type=\"Int32\" Name=\"material\" format=\""
+   out << "<CellData Scalars=\"attribute\">" << std::endl;
+   out << "<DataArray type=\"Int32\" Name=\"attribute\" format=\""
        << fmt_str << "\">" << std::endl;
-   for (int i = 0; i < GetNE(); i++)
+   for (int i = 0; i < ne; i++)
    {
-      int attr = GetAttribute(i);
+      int attr = bdr_elements ? GetBdrAttribute(i) : GetAttribute(i);
       if (high_order_output)
       {
          WriteBinaryOrASCII(out, buf, attr, "\n", format);
       }
       else
       {
-         Geometry::Type geom = GetElementBaseGeometry(i);
+         Geometry::Type geom = get_geom(i);
          int nv = Geometries.GetVertices(geom)->GetNPoints();
          RefG = GlobGeometryRefiner.Refine(geom, ref, 1);
          for (int j = 0; j < RefG->RefGeoms.Size(); j += nv)

--- a/mesh/mesh.hpp
+++ b/mesh/mesh.hpp
@@ -1257,11 +1257,11 @@ public:
                  int compression_level=0,
                  bool bdr_elements=false);
    /** Print the mesh in VTU format with file name fname. */
-   void PrintVTU(std::string fname,
-                 VTKFormat format=VTKFormat::ASCII,
-                 bool high_order_output=false,
-                 int compression_level=0,
-                 bool bdr=false);
+   virtual void PrintVTU(std::string fname,
+                         VTKFormat format=VTKFormat::ASCII,
+                         bool high_order_output=false,
+                         int compression_level=0,
+                         bool bdr=false);
    /** Print the boundary elements of the mesh in VTU format, and output the
        boundary attributes as a data array (useful for boundary conditions). */
    void PrintBdrVTU(std::string fname,

--- a/mesh/mesh.hpp
+++ b/mesh/mesh.hpp
@@ -1247,17 +1247,27 @@ public:
    /// \see mfem::ofgzstream() for on-the-fly compression of ascii outputs
    void PrintVTK(std::ostream &out, int ref, int field_data=0);
    /** Print the mesh in VTU format. The parameter ref > 0 specifies an element
-       subdivision number (useful for high order fields and curved meshes). */
+       subdivision number (useful for high order fields and curved meshes).
+       If @a bdr_elements is true, then output (only) the boundary elements,
+       otherwise output only the non-boundary elements. */
    void PrintVTU(std::ostream &out,
                  int ref=1,
                  VTKFormat format=VTKFormat::ASCII,
                  bool high_order_output=false,
-                 int compression_level=0);
+                 int compression_level=0,
+                 bool bdr_elements=false);
    /** Print the mesh in VTU format with file name fname. */
    void PrintVTU(std::string fname,
                  VTKFormat format=VTKFormat::ASCII,
                  bool high_order_output=false,
-                 int compression_level=0);
+                 int compression_level=0,
+                 bool bdr=false);
+   /** Print the boundary elements of the mesh in VTU format, and output the
+       boundary attributes as a data array (useful for boundary conditions). */
+   void PrintBdrVTU(std::string fname,
+                    VTKFormat format=VTKFormat::ASCII,
+                    bool high_order_output=false,
+                    int compression_level=0);
 
    void GetElementColoring(Array<int> &colors, int el0 = 0);
 

--- a/mesh/pmesh.cpp
+++ b/mesh/pmesh.cpp
@@ -5365,18 +5365,22 @@ void ParMesh::ParPrint(ostream &out) const
    out << "\nmfem_mesh_end" << endl;
 }
 
-void ParMesh::PrintVTU(std::string fname,
+void ParMesh::PrintVTU(std::string pathname,
                        VTKFormat format,
                        bool high_order_output,
                        int compression_level,
                        bool bdr)
 {
    int pad_digits_rank = 6;
-   DataCollection::create_directory(fname, this, MyRank);
+   DataCollection::create_directory(pathname, this, MyRank);
+
+   std::string::size_type pos = pathname.find_last_of('/');
+   std::string fname
+      = (pos == std::string::npos) ? pathname : pathname.substr(pos+1);
 
    if (MyRank == 0)
    {
-      std::string pvtu_name = fname + "/" + fname + ".pvtu";
+      std::string pvtu_name = pathname + "/" + fname + ".pvtu";
       std::ofstream out(pvtu_name);
 
       std::string data_type = (format == VTKFormat::BINARY32) ? "Float32" : "Float64";
@@ -5413,9 +5417,8 @@ void ParMesh::PrintVTU(std::string fname,
 
       for (int ii=0; ii<NRanks; ii++)
       {
-
-         std::string piece = "proc" + to_padded_string(ii, pad_digits_rank)
-                             + ".vtu";
+         std::string piece = fname + ".proc"
+                             + to_padded_string(ii, pad_digits_rank) + ".vtu";
          out << "<Piece Source=\"" << piece << "\"/>\n";
       }
 
@@ -5424,8 +5427,8 @@ void ParMesh::PrintVTU(std::string fname,
       out.close();
    }
 
-   std::string vtu_fname
-      = fname + "/proc" + to_padded_string(MyRank, pad_digits_rank);
+   std::string vtu_fname = pathname + "/" + fname + ".proc"
+                           + to_padded_string(MyRank, pad_digits_rank);
    Mesh::PrintVTU(vtu_fname, format, high_order_output, compression_level, bdr);
 }
 

--- a/mesh/pmesh.cpp
+++ b/mesh/pmesh.cpp
@@ -5365,6 +5365,70 @@ void ParMesh::ParPrint(ostream &out) const
    out << "\nmfem_mesh_end" << endl;
 }
 
+void ParMesh::PrintVTU(std::string fname,
+                       VTKFormat format,
+                       bool high_order_output,
+                       int compression_level,
+                       bool bdr)
+{
+   int pad_digits_rank = 6;
+   DataCollection::create_directory(fname, this, MyRank);
+
+   if (MyRank == 0)
+   {
+      std::string pvtu_name = fname + "/" + fname + ".pvtu";
+      std::ofstream out(pvtu_name);
+
+      std::string data_type = (format == VTKFormat::BINARY32) ? "Float32" : "Float64";
+      std::string data_format = (format == VTKFormat::ASCII) ? "ascii" : "binary";
+
+      out << "<?xml version=\"1.0\"?>\n";
+      out << "<VTKFile type=\"PUnstructuredGrid\"";
+      out << " version =\"0.1\" byte_order=\"" << VTKByteOrder() << "\">\n";
+      out << "<PUnstructuredGrid GhostLevel=\"0\">\n";
+
+      out << "<PPoints>\n";
+      out << "\t<PDataArray type=\"" << data_type << "\" ";
+      out << " Name=\"Points\" NumberOfComponents=\"3\""
+          << " format=\"" << data_format << "\"/>\n";
+      out << "</PPoints>\n";
+
+      out << "<PCells>\n";
+      out << "\t<PDataArray type=\"Int32\" ";
+      out << " Name=\"connectivity\" NumberOfComponents=\"1\""
+          << " format=\"" << data_format << "\"/>\n";
+      out << "\t<PDataArray type=\"Int32\" ";
+      out << " Name=\"offsets\"      NumberOfComponents=\"1\""
+          << " format=\"" << data_format << "\"/>\n";
+      out << "\t<PDataArray type=\"UInt8\" ";
+      out << " Name=\"types\"        NumberOfComponents=\"1\""
+          << " format=\"" << data_format << "\"/>\n";
+      out << "</PCells>\n";
+
+      out << "<PCellData>\n";
+      out << "\t<PDataArray type=\"Int32\" Name=\"" << "attribute"
+          << "\" NumberOfComponents=\"1\""
+          << " format=\"" << data_format << "\"/>\n";
+      out << "</PCellData>\n";
+
+      for (int ii=0; ii<NRanks; ii++)
+      {
+
+         std::string piece = "proc" + to_padded_string(ii, pad_digits_rank)
+                             + ".vtu";
+         out << "<Piece Source=\"" << piece << "\"/>\n";
+      }
+
+      out << "</PUnstructuredGrid>\n";
+      out << "</VTKFile>\n";
+      out.close();
+   }
+
+   std::string vtu_fname
+      = fname + "/proc" + to_padded_string(MyRank, pad_digits_rank);
+   Mesh::PrintVTU(vtu_fname, format, high_order_output, compression_level, bdr);
+}
+
 int ParMesh::FindPoints(DenseMatrix& point_mat, Array<int>& elem_id,
                         Array<IntegrationPoint>& ip, bool warn,
                         InverseElementTransformation *inv_trans)

--- a/mesh/pmesh.hpp
+++ b/mesh/pmesh.hpp
@@ -362,8 +362,10 @@ public:
    /// Save the mesh in a parallel mesh format.
    void ParPrint(std::ostream &out) const;
 
-   /** Print the mesh in parallel PVTU format with filename fname. */
-   virtual void PrintVTU(std::string fname,
+   /** Print the mesh in parallel PVTU format. The PVTU and VTU files will be
+       stored in the directory specified by @a pathname. If the directory does
+       not exist, it will be created. */
+   virtual void PrintVTU(std::string pathname,
                          VTKFormat format=VTKFormat::ASCII,
                          bool high_order_output=false,
                          int compression_level=0,

--- a/mesh/pmesh.hpp
+++ b/mesh/pmesh.hpp
@@ -362,6 +362,13 @@ public:
    /// Save the mesh in a parallel mesh format.
    void ParPrint(std::ostream &out) const;
 
+   /** Print the mesh in parallel PVTU format with filename fname. */
+   virtual void PrintVTU(std::string fname,
+                         VTKFormat format=VTKFormat::ASCII,
+                         bool high_order_output=false,
+                         int compression_level=0,
+                         bool bdr=false);
+
    virtual int FindPoints(DenseMatrix& point_mat, Array<int>& elem_ids,
                           Array<IntegrationPoint>& ips, bool warn = true,
                           InverseElementTransformation *inv_trans = NULL);


### PR DESCRIPTION
Add `Mesh::PrintBdrVTU` ﻿to output the boundary elements and attributes of the mesh for visualization using ParaView (useful for checking boundary conditions).

Also allows for output of parallel meshes in the PVTU format (so now both `ParMesh::PrintVTU` and `ParMesh::PrintBdrVTU` should work properly).

![2d_bdr](https://user-images.githubusercontent.com/11493037/96528223-fac9df80-1236-11eb-82ef-c103408f77a5.png)
![3d_bdr](https://user-images.githubusercontent.com/11493037/96528226-fbfb0c80-1236-11eb-962f-47c641706480.png)

<!--GHEX{"id":1825,"author":"pazner","editor":"tzanio","reviewers":["tzanio","jandrej","rcarson3"],"assignment":"2020-10-20T20:11:31-07:00","approval":"2020-10-23T00:51:48.653Z","merge":"2020-10-23T14:18:43.579Z"}XEHG--><!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge| 
 | --- | --- | --- | --- | --- | --- | --- | 
| [#1825](https://github.com/mfem/mfem/pull/1825) | @pazner | @tzanio | @tzanio + @jandrej + @rcarson3 | 10/20/20 | 10/22/20 | 10/23/20 | |
<!--ELBATXEHG-->