### PR TITLE
Absolute value function 'abs' when argument is of floating point type [tbnlf]

### DIFF
--- a/tests/unit/fem/test_blocknonlinearform.cpp
+++ b/tests/unit/fem/test_blocknonlinearform.cpp
@@ -154,7 +154,7 @@ TEST_CASE("ParBlockNonlinearForm",
                 << " Expected" << M_PI / 6.0 << " diff=" << (A4 - M_PI / 6.0)
                 << std::endl;
 
-      REQUIRE(abs(A4 - M_PI / 6.0) < 1e-2);
+      REQUIRE(fabs(A4 - M_PI / 6.0) < 1e-2);
 
       delete nf;
       delete pmesh;


### PR DESCRIPTION
Removes `using integer absolute value function 'abs' when argument is of floating point type` warning.
<!--GHEX{"id":1826,"author":"camierjs","editor":"tzanio","reviewers":["tzanio","jandrej"],"assignment":"2020-10-20T10:04:58-07:00","approval":"2020-10-20T19:07:25.853Z","merge":"2020-10-21T17:53:32.300Z"}XEHG--><!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge| 
 | --- | --- | --- | --- | --- | --- | --- | 
| [#1826](https://github.com/mfem/mfem/pull/1826) | @camierjs | @tzanio | @tzanio + @jandrej | 10/20/20 | 10/20/20 | 10/21/20 | |
<!--ELBATXEHG-->