### PR TITLE
Set operator size in AmgXSolver

### DIFF
--- a/linalg/amgxsolver.cpp
+++ b/linalg/amgxsolver.cpp
@@ -818,6 +818,9 @@ void AmgXSolver::SetMatrixMPITeams(const HypreParMatrix &A,
 
 void AmgXSolver::SetOperator(const Operator& op)
 {
+   height = op.Height();
+   width = op.Width();
+
    if (const SparseMatrix* Aptr =
           dynamic_cast<const SparseMatrix*>(&op))
    {


### PR DESCRIPTION
This is a small fix, to set the operator size in `AmgXSolver`. Without this, the `height` and `width` are just `0`. 