### PR TITLE
Fix GLVis issue with subnormals Apple Clang

### DIFF
--- a/fem/datacollection.cpp
+++ b/fem/datacollection.cpp
@@ -1001,7 +1001,7 @@ void ParaViewDataCollection::SaveGFieldVTU(std::ostream &out, int ref_,
          {
             if (pv_data_format == VTKFormat::ASCII)
             {
-               out << val(j) << '\n';
+               out << ZeroSubnormal(val(j)) << '\n';
             }
             else if (pv_data_format == VTKFormat::BINARY)
             {
@@ -1034,7 +1034,7 @@ void ParaViewDataCollection::SaveGFieldVTU(std::ostream &out, int ref_,
             {
                if (pv_data_format == VTKFormat::ASCII)
                {
-                  out << vval(ii,jj) << ' ';
+                  out << ZeroSubnormal(vval(ii,jj)) << ' ';
                }
                else if (pv_data_format == VTKFormat::BINARY)
                {

--- a/linalg/vector.cpp
+++ b/linalg/vector.cpp
@@ -68,12 +68,12 @@ void Vector::Load(std::istream **in, int np, int *dim)
       for (j = 0; j < dim[i]; j++)
       {
          *in[i] >> data[p++];
-#if defined __APPLE__ && defined __clang__
+         // Clang's libc++ sets the failbit when (correctly) parsing subnormals,
+         // so we reset the failbit here.
          if (!*in[i] && errno == ERANGE)
          {
             in[i]->clear();
          }
-#endif
       }
    }
 }
@@ -85,12 +85,12 @@ void Vector::Load(std::istream &in, int Size)
    for (int i = 0; i < size; i++)
    {
       in >> data[i];
-#if defined __APPLE__ && defined __clang__
+      // Clang's libc++ sets the failbit when (correctly) parsing subnormals,
+      // so we reset the failbit here.
       if (!in && errno == ERANGE)
       {
          in.clear();
       }
-#endif
    }
 }
 

--- a/linalg/vector.cpp
+++ b/linalg/vector.cpp
@@ -68,6 +68,12 @@ void Vector::Load(std::istream **in, int np, int *dim)
       for (j = 0; j < dim[i]; j++)
       {
          *in[i] >> data[p++];
+#if defined __APPLE__ && defined __clang__
+         if (!*in[i] && errno == ERANGE)
+         {
+            in[i]->clear();
+         }
+#endif
       }
    }
 }
@@ -79,6 +85,12 @@ void Vector::Load(std::istream &in, int Size)
    for (int i = 0; i < size; i++)
    {
       in >> data[i];
+#if defined __APPLE__ && defined __clang__
+      if (!in && errno == ERANGE)
+      {
+         in.clear();
+      }
+#endif
    }
 }
 
@@ -663,7 +675,7 @@ void Vector::Print(std::ostream &out, int width) const
    data.Read(MemoryClass::HOST, size);
    for (int i = 0; 1; )
    {
-      out << data[i];
+      out << ZeroSubnormal(data[i]);
       i++;
       if (i == size)
       {
@@ -703,7 +715,7 @@ void Vector::Print_HYPRE(std::ostream &out) const
    data.Read(MemoryClass::HOST, size);
    for (i = 0; i < size; i++)
    {
-      out << data[i] << '\n';
+      out << ZeroSubnormal(data[i]) << '\n';
    }
 
    out.precision(old_prec);

--- a/linalg/vector.hpp
+++ b/linalg/vector.hpp
@@ -415,6 +415,12 @@ public:
 
 // Inline methods
 
+template <typename T>
+inline T ZeroSubnormal(T val)
+{
+   return (std::fpclassify(val) == FP_SUBNORMAL) ? 0.0 : val;
+}
+
 inline bool IsFinite(const double &val)
 {
    // isfinite didn't appear in a standard until C99, and later C++11. It wasn't


### PR DESCRIPTION
Fixes #1843.

Zero out subnormal numbers when writing a Vector to an output stream. When reading a Vector from an input stream with Apple Clang, ignore "out of range" errors, which can be caused by (correctly) parsing subnormal numbers.