### PR TITLE
Use the default CUDA stream with RAJA and CUDA [cuda-streams-dev]

### DIFF
--- a/general/backends.hpp
+++ b/general/backends.hpp
@@ -31,6 +31,7 @@
 #endif
 
 #ifdef MFEM_USE_RAJA
+#define CAMP_USE_PLATFORM_DEFAULT_STREAM 1
 #include "RAJA/RAJA.hpp"
 #if defined(RAJA_ENABLE_CUDA) && !defined(MFEM_USE_CUDA)
 #error When RAJA is built with CUDA, MFEM_USE_CUDA=YES is required

--- a/general/device.cpp
+++ b/general/device.cpp
@@ -11,6 +11,9 @@
 
 #include "forall.hpp"
 #include "occa.hpp"
+#if defined(MFEM_USE_CUDA) && OCCA_CUDA_ENABLED
+#include <occa/modes/cuda/stream.hpp>
+#endif
 #ifdef MFEM_USE_CEED
 #include "../fem/libceed/ceed.hpp"
 #endif
@@ -410,6 +413,10 @@ static void OccaDeviceSetup(const int dev)
 #if OCCA_CUDA_ENABLED
       std::string mode("mode: 'CUDA', device_id : ");
       internal::occaDevice.setup(mode.append(1,'0'+dev));
+      auto def_stream = new occa::cuda::stream(
+         internal::occaDevice.getModeDevice(),
+         occa::properties(), (CUstream)0);
+      internal::occaDevice.setStream(def_stream);
 #else
       MFEM_ABORT("the OCCA CUDA backend requires OCCA built with CUDA!");
 #endif


### PR DESCRIPTION
Update the `raja-cuda` and `occa-cuda` backends to use the default stream 0. This fixes an issue with the device configuration `-d occa-cuda,raja-cuda` where kernels were not executed consecutively leading to wrong results.

Optimize `OperatorJacobiSmoother::Mult` by fusing kernels as much as possible.

The current approach of telling RAJA to use stream 0 may be fragile -- if another library/app initializes the RAJA default stream first, we may end up using a different stream.