### PR TITLE
Point Boundary for 1D Meshes

### DIFF
--- a/mesh/mesh.cpp
+++ b/mesh/mesh.cpp
@@ -1463,6 +1463,13 @@ void Mesh::AddBdrQuadAsTriangles(const int *vi, int attr)
    }
 }
 
+int Mesh::AddBdrPoint(int v, int attr)
+{
+   CheckEnlarge(boundary, NumOfBdrElements);
+   boundary[NumOfBdrElements] = new Point(&v, attr);
+   return NumOfBdrElements++;
+}
+
 void Mesh::GenerateBoundaryElements()
 {
    int i, j;

--- a/mesh/mesh.hpp
+++ b/mesh/mesh.hpp
@@ -555,6 +555,8 @@ public:
    int AddBdrQuad(const int *vi, int attr = 1);
    void AddBdrQuadAsTriangles(const int *vi, int attr = 1);
 
+   int AddBdrPoint(int v, int attr = 1);
+
    void GenerateBoundaryElements();
    /// Finalize the construction of a triangular Mesh.
    void FinalizeTriMesh(int generate_edges = 0, int refine = 0,


### PR DESCRIPTION
The mesh class lacks a method to add boundary elements to 1D meshes. This PR adds a method for adding point boundary elements to fix this problem.
<!--GHEX{"id":1856,"author":"termi-official","editor":"v-dobrev","reviewers":["v-dobrev","kmittal2"],"assignment":"2020-11-01T04:18:58-08:00","approval":"2020-11-04T12:43:56.992Z","merge":"2020-11-11T12:43:56.992Z"}XEHG--><!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge| 
 | --- | --- | --- | --- | --- | --- | --- | 
| [#1856](https://github.com/mfem/mfem/pull/1856) | @termi-official | @v-dobrev | @v-dobrev + @kmittal2 | 11/01/20 | 11/04/20 | ⌛due 11/11/20 | |
<!--ELBATXEHG-->