### PR TITLE
Fix for newer versions of Umpire [new-umpire-fix]

### DIFF
--- a/general/mem_manager.cpp
+++ b/general/mem_manager.cpp
@@ -482,7 +482,8 @@ public:
       HostMemorySpace(),
       name(mm.GetUmpireAllocatorHostName()),
       rm(umpire::ResourceManager::getInstance()),
-      h_allocator(rm.isAllocator(name)? rm.getAllocator(name):
+      h_allocator((!std::strcmp(name, "HOST") || rm.isAllocator(name)) ?
+                  rm.getAllocator(name) :
                   rm.makeAllocator<umpire::strategy::DynamicPool>
                   (name, rm.getAllocator("HOST"))),
       strat(h_allocator.getAllocationStrategy()) { }
@@ -506,7 +507,8 @@ public:
       DeviceMemorySpace(),
       name(mm.GetUmpireAllocatorDeviceName()),
       rm(umpire::ResourceManager::getInstance()),
-      d_allocator(rm.isAllocator(name)? rm.getAllocator(name):
+      d_allocator((!std::strcmp(name, "DEVICE") || rm.isAllocator(name)) ?
+                  rm.getAllocator(name) :
                   rm.makeAllocator<umpire::strategy::DynamicPool>
                   (name, rm.getAllocator("DEVICE"))) { }
    void Alloc(Memory &base) { base.d_ptr = d_allocator.allocate(base.bytes); }


### PR DESCRIPTION
Newer versions of Umpire (e.g. v4.1.0) cause examples and miniapps to fail before calling `main()`. This is due to an exception thrown by Umpire when MFEM attempts to initialize its Umpire host allocator.

This only affects builds with `MFEM_USE_UMPIRE=YES` and Umpire versions after some unknown version > v2.0.0.
<!--GHEX{"id":1862,"author":"v-dobrev","editor":"tzanio","reviewers":["tzanio","camierjs"],"assignment":"2020-11-03T07:29:04-08:00","approval":"2020-11-16T02:45:33.377Z","merge":"2020-11-18T21:06:29.018Z"}XEHG--><!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge| 
 | --- | --- | --- | --- | --- | --- | --- | 
| [#1862](https://github.com/mfem/mfem/pull/1862) | @v-dobrev | @tzanio | @tzanio + @camierjs | 11/03/20 | 11/15/20 | 11/18/20 | |
<!--ELBATXEHG-->