### PR TITLE
Write time and cycle to conduit data collection root file [conduitdc-time-cycle-fix]

### DIFF
--- a/fem/conduitdatacollection.cpp
+++ b/fem/conduitdatacollection.cpp
@@ -981,6 +981,11 @@ ConduitDataCollection::SaveRootFile(int num_domains,
    n_root["file_pattern"]     = MeshFilePattern(relay_protocol);
    n_root["tree_pattern"]     = "";
 
+   // Add the time, time step, and cycle
+   n_root["blueprint_index/mesh/state/time"] = time;
+   n_root["blueprint_index/mesh/state/time_step"] = time_step;
+   n_root["blueprint_index/mesh/state/cycle"] = cycle;
+
    relay::io::save(n_root, RootFileName(), root_proto);
 }
 


### PR DESCRIPTION
This pull request writes the time, time step, and cycle to the conduit data collection root file. 
<!--GHEX{"id":1864,"author":"greene30","editor":"tzanio","reviewers":["tzanio","v-dobrev"],"assignment":"2020-11-03T15:34:58-08:00","approval":"2020-11-04T17:06:57.385Z","merge":"2020-11-08T21:31:31.069Z"}XEHG--><!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge| 
 | --- | --- | --- | --- | --- | --- | --- | 
| [#1864](https://github.com/mfem/mfem/pull/1864) | @greene30 | @tzanio | @tzanio + @v-dobrev | 11/03/20 | 11/04/20 | 11/08/20 | |
<!--ELBATXEHG-->