### PR TITLE
Implementing a missed c'tor in CrossCrossCoefficient [cross-cross-dev]

### DIFF
--- a/fem/bilininteg.hpp
+++ b/fem/bilininteg.hpp
@@ -2050,8 +2050,6 @@ public:
    static const IntegrationRule &GetRule(const FiniteElement &trial_fe,
                                          const FiniteElement &test_fe,
                                          ElementTransformation &Trans);
-
-   void SetupPA(const FiniteElementSpace &fes);
 };
 
 /** Mass integrator (u, v) restricted to the boundary of a domain */

--- a/fem/coefficient.cpp
+++ b/fem/coefficient.cpp
@@ -697,6 +697,11 @@ void OuterProductCoefficient::Eval(DenseMatrix &M, ElementTransformation &T,
    }
 }
 
+CrossCrossCoefficient::CrossCrossCoefficient(double A, VectorCoefficient &K)
+   : MatrixCoefficient(K.GetVDim(), K.GetVDim()), aConst(A), a(NULL), k(&K),
+     vk(K.GetVDim())
+{}
+
 CrossCrossCoefficient::CrossCrossCoefficient(Coefficient &A,
                                              VectorCoefficient &K)
    : MatrixCoefficient(K.GetVDim(), K.GetVDim()), aConst(0.0), a(&A), k(&K),


### PR DESCRIPTION
This is a quick fix to address an issue pointed out in issue #1838.
<!--GHEX{"id":1872,"author":"mlstowell","editor":"tzanio","reviewers":["tzanio","YohannDudouit"],"assignment":"2020-11-17T15:30:36-08:00","approval":"2020-11-18T00:52:16.575Z","merge":"2020-11-18T20:59:39.740Z"}XEHG--><!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge| 
 | --- | --- | --- | --- | --- | --- | --- | 
| [#1872](https://github.com/mfem/mfem/pull/1872) | @mlstowell | @tzanio | @tzanio + @YohannDudouit | 11/17/20 | 11/17/20 | 11/18/20 | |
<!--ELBATXEHG-->