### PR TITLE
Quadrature function size fix

### DIFF
--- a/fem/gridfunc.cpp
+++ b/fem/gridfunc.cpp
@@ -3670,7 +3670,7 @@ QuadratureFunction & QuadratureFunction::operator=(double value)
 
 QuadratureFunction & QuadratureFunction::operator=(const Vector &v)
 {
-   MFEM_ASSERT(qspace && v.Size() == qspace->GetSize(), "");
+   MFEM_ASSERT(qspace && v.Size() == this->Size(), "");
    Vector::operator=(v);
    return *this;
 }

--- a/fem/gridfunc.hpp
+++ b/fem/gridfunc.hpp
@@ -752,7 +752,7 @@ public:
 
    /// Copy the data from @a v.
    /** The size of @a v must be equal to the size of the associated
-       QuadratureSpace #qspace times the QuadratureFunction dimension 
+       QuadratureSpace #qspace times the QuadratureFunction dimension
        i.e. QuadratureFunction::Size(). */
    QuadratureFunction &operator=(const Vector &v);
 

--- a/fem/gridfunc.hpp
+++ b/fem/gridfunc.hpp
@@ -752,7 +752,8 @@ public:
 
    /// Copy the data from @a v.
    /** The size of @a v must be equal to the size of the associated
-       QuadratureSpace #qspace. */
+       QuadratureSpace #qspace times the QuadratureFunction dimension 
+       i.e. QuadratureFunction::Size(). */
    QuadratureFunction &operator=(const Vector &v);
 
    /// Copy assignment. Only the data of the base class Vector is copied.


### PR DESCRIPTION
Fix for issue #1871  : take the QuadratureFunction size instead of the QuadratureSpace size
<!--GHEX{"id":1873,"author":"gauthier12","editor":"v-dobrev","reviewers":["rcarson3","v-dobrev"],"assignment":"2020-11-10T17:07:48-08:00","approval":"2020-11-11T20:55:15.912Z","merge":"2020-11-18T21:15:16.649Z"}XEHG--><!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge| 
 | --- | --- | --- | --- | --- | --- | --- | 
| [#1873](https://github.com/mfem/mfem/pull/1873) | @gauthier12 | @v-dobrev | @rcarson3 + @v-dobrev | 11/10/20 | 11/11/20 | 11/18/20 | |
<!--ELBATXEHG-->