### PR TITLE
Add field-interp to CMake builds.

### DIFF
--- a/miniapps/gslib/CMakeLists.txt
+++ b/miniapps/gslib/CMakeLists.txt
@@ -19,6 +19,10 @@ if (MFEM_USE_GSLIB)
     MAIN findpts.cpp
     LIBRARIES mfem)
 
+  add_mfem_miniapp(field-interp
+    MAIN field-interp.cpp
+    LIBRARIES mfem)
+
   # Parallel apps.
   if (MFEM_USE_MPI)
     add_mfem_miniapp(pfindpts


### PR DESCRIPTION
The gslib miniapp "field-interp" was missing in CMake builds. Added with this PR. 
<!--GHEX{"id":1876,"author":"termi-official","editor":"tzanio","reviewers":["kmittal2","tzanio"],"assignment":"2020-11-18T13:08:37-08:00","approval":"2020-11-19T05:14:45.663Z","merge":"2020-11-20T18:54:12.289Z"}XEHG--><!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge| 
 | --- | --- | --- | --- | --- | --- | --- | 
| [#1876](https://github.com/mfem/mfem/pull/1876) | @termi-official | @tzanio | @kmittal2 + @tzanio | 11/18/20 | 11/18/20 | 11/20/20 | |
<!--ELBATXEHG-->