### PR TITLE
Add a deterministic way of computing the dot product with OpenMP

### DIFF
--- a/linalg/vector.cpp
+++ b/linalg/vector.cpp
@@ -1103,7 +1103,7 @@ double Vector::operator*(const Vector &v) const
       }
       return th_dot.Sum();
 #else
-      // The standard way of computing the dot product is non-deterimistic
+      // The standard way of computing the dot product is non-deterministic
       double prod = 0.0;
       #pragma omp parallel for reduction(+:prod)
       for (int i = 0; i < size; i++)

--- a/linalg/vector.cpp
+++ b/linalg/vector.cpp
@@ -1082,7 +1082,7 @@ double Vector::operator*(const Vector &v) const
    {
 #define MFEM_USE_OPENMP_DETERMINISTIC_DOT
 #ifdef MFEM_USE_OPENMP_DETERMINISTIC_DOT
-      // Use a deterimistic way of computing the dot product
+      // By default, use a deterministic way of computing the dot product
       static Vector th_dot;
       #pragma omp parallel
       {

--- a/linalg/vector.cpp
+++ b/linalg/vector.cpp
@@ -22,6 +22,10 @@
 #endif
 #endif
 
+#ifdef MFEM_USE_OPENMP
+#include <omp.h>
+#endif
+
 #include <iostream>
 #include <iomanip>
 #include <cmath>
@@ -1076,6 +1080,30 @@ double Vector::operator*(const Vector &v) const
 #ifdef MFEM_USE_OPENMP
    if (Device::Allows(Backend::OMP_MASK))
    {
+#define MFEM_USE_OPENMP_DETERMINISTIC_DOT
+#ifdef MFEM_USE_OPENMP_DETERMINISTIC_DOT
+      // Use a deterimistic way of computing the dot product
+      static Vector th_dot;
+      #pragma omp parallel
+      {
+         const int nt = omp_get_num_threads();
+         #pragma omp master
+         th_dot.SetSize(nt);
+         const int tid    = omp_get_thread_num();
+         const int stride = (size + nt - 1)/nt;
+         const int start  = tid*stride;
+         const int stop   = std::min(start + stride, size);
+         double my_dot = 0.0;
+         for (int i = start; i < stop; i++)
+         {
+            my_dot += m_data[i] * v_data[i];
+         }
+         #pragma omp barrier
+         th_dot(tid) = my_dot;
+      }
+      return th_dot.Sum();
+#else
+      // The standard way of computing the dot product is non-deterimistic
       double prod = 0.0;
       #pragma omp parallel for reduction(+:prod)
       for (int i = 0; i < size; i++)
@@ -1083,8 +1111,9 @@ double Vector::operator*(const Vector &v) const
          prod += m_data[i] * v_data[i];
       }
       return prod;
+#endif // MFEM_USE_OPENMP_DETERMINISTIC_DOT
    }
-#endif
+#endif // MFEM_USE_OPENMP
    if (Device::Allows(Backend::DEBUG_DEVICE))
    {
       const int N = size;


### PR DESCRIPTION
Use a simple deterministic algorithm instead of the `reduction` directive.
<!--GHEX{"id":1878,"author":"v-dobrev","editor":"tzanio","reviewers":["tzanio","camierjs"],"assignment":"2020-11-16T15:02:33-08:00","approval":"2020-11-17T23:28:17.587Z","merge":"2020-11-18T20:55:03.260Z"}XEHG--><!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge| 
 | --- | --- | --- | --- | --- | --- | --- | 
| [#1878](https://github.com/mfem/mfem/pull/1878) | @v-dobrev | @tzanio | @tzanio + @camierjs | 11/16/20 | 11/17/20 | 11/18/20 | |
<!--ELBATXEHG-->