### PR TITLE
Action of HypreSmoother::MultTranspose

### DIFF
--- a/linalg/hypre.cpp
+++ b/linalg/hypre.cpp
@@ -2471,22 +2471,12 @@ void HypreSmoother::Mult(const Vector &b, Vector &x) const
 
 void HypreSmoother::MultTranspose(const Vector &b, Vector &x) const
 {
-   if (A_is_symmetric)
+   if (A_is_symmetric || type == 0 || type == 1 || type == 5)
    {
       Mult(b, x);
+      return;
    }
-   else
-   {
-      bool smoother_is_symmetric = (type == 0 || type == 1 || type == 5);
-      if (!iterative_mode && relax_times < 2 && smoother_is_symmetric)
-      {
-         Mult(b, x);
-      }
-      else
-      {
-         mfem_error("HypreSmoother::MultTranspose (...) : undefined!\n");
-      }
-   }
+   mfem_error("HypreSmoother::MultTranspose (...) : undefined!\n");
 }
 
 HypreSmoother::~HypreSmoother()

--- a/linalg/hypre.cpp
+++ b/linalg/hypre.cpp
@@ -2161,7 +2161,7 @@ HypreSmoother::HypreSmoother() : Solver()
    B = X = V = Z = NULL;
    X0 = X1 = NULL;
    fir_coeffs = NULL;
-   transpose_action = Undefined;
+   is_symmetric = false;
 }
 
 HypreSmoother::HypreSmoother(HypreParMatrix &_A, int _type,
@@ -2181,7 +2181,6 @@ HypreSmoother::HypreSmoother(HypreParMatrix &_A, int _type,
    B = X = V = Z = NULL;
    X0 = X1 = NULL;
    fir_coeffs = NULL;
-   transpose_action = Undefined;
 
    SetOperator(_A);
 }
@@ -2471,13 +2470,8 @@ void HypreSmoother::Mult(const Vector &b, Vector &x) const
 
 void HypreSmoother::MultTranspose(const Vector &b, Vector &x) const
 {
-   if (transpose_action == SameAsMult)
-   {
-      Mult(b, x);
-      return;
-   }
-
-   mfem_error("HypreSmoother::MultTranspose (...) : transpose is undefined!");
+   if (is_symmetric) { Mult(b, x); return; }
+   mfem_error("HypreSmoother::MultTranspose (...) : transpose is undefined!\n");
 }
 
 HypreSmoother::~HypreSmoother()

--- a/linalg/hypre.cpp
+++ b/linalg/hypre.cpp
@@ -2161,7 +2161,7 @@ HypreSmoother::HypreSmoother() : Solver()
    B = X = V = Z = NULL;
    X0 = X1 = NULL;
    fir_coeffs = NULL;
-   is_symmetric = false;
+   A_is_symmetric = false;
 }
 
 HypreSmoother::HypreSmoother(HypreParMatrix &_A, int _type,
@@ -2181,6 +2181,7 @@ HypreSmoother::HypreSmoother(HypreParMatrix &_A, int _type,
    B = X = V = Z = NULL;
    X0 = X1 = NULL;
    fir_coeffs = NULL;
+   A_is_symmetric = false;
 
    SetOperator(_A);
 }
@@ -2470,8 +2471,22 @@ void HypreSmoother::Mult(const Vector &b, Vector &x) const
 
 void HypreSmoother::MultTranspose(const Vector &b, Vector &x) const
 {
-   if (is_symmetric) { Mult(b, x); return; }
-   mfem_error("HypreSmoother::MultTranspose (...) : transpose is undefined!\n");
+   if (A_is_symmetric)
+   {
+      Mult(b, x);
+   }
+   else
+   {
+      bool smoother_is_symmetric = (type == 0 || type == 1 || type == 5);
+      if (!iterative_mode && relax_times < 2 && smoother_is_symmetric)
+      {
+         Mult(b, x);
+      }
+      else
+      {
+         mfem_error("HypreSmoother::MultTranspose (...) : undefined!\n");
+      }
+   }
 }
 
 HypreSmoother::~HypreSmoother()

--- a/linalg/hypre.cpp
+++ b/linalg/hypre.cpp
@@ -2161,6 +2161,7 @@ HypreSmoother::HypreSmoother() : Solver()
    B = X = V = Z = NULL;
    X0 = X1 = NULL;
    fir_coeffs = NULL;
+   transpose_action = Undefined;
 }
 
 HypreSmoother::HypreSmoother(HypreParMatrix &_A, int _type,
@@ -2180,6 +2181,7 @@ HypreSmoother::HypreSmoother(HypreParMatrix &_A, int _type,
    B = X = V = Z = NULL;
    X0 = X1 = NULL;
    fir_coeffs = NULL;
+   transpose_action = Undefined;
 
    SetOperator(_A);
 }
@@ -2465,6 +2467,17 @@ void HypreSmoother::Mult(const Vector &b, Vector &x) const
    }
 
    Mult(*B, *X);
+}
+
+void HypreSmoother::MultTranspose(const Vector &b, Vector &x) const
+{
+   if (transpose_action == SameAsMult)
+   {
+      Mult(b, x);
+      return;
+   }
+
+   mfem_error("HypreSmoother::MultTranspose (...) : transpose is undefined!");
 }
 
 HypreSmoother::~HypreSmoother()

--- a/linalg/hypre.hpp
+++ b/linalg/hypre.hpp
@@ -591,6 +591,10 @@ void EliminateBC(HypreParMatrix &A, HypreParMatrix &Ae,
 /// Parallel smoothers in hypre
 class HypreSmoother : public Solver
 {
+public:
+   /// Options of what MultTranspose would do when it is called.
+   enum TransposeAction { Undefined, SameAsMult };
+
 protected:
    /// The linear system matrix
    HypreParMatrix *A;
@@ -638,6 +642,9 @@ protected:
    /// Combined coefficients for windowing and Chebyshev polynomials.
    double* fir_coeffs;
 
+   /// Indicate what MultTranspose would do when it is called.
+   TransposeAction transpose_action;
+
 public:
    /** Hypre smoother types:
        0    = Jacobi
@@ -684,6 +691,12 @@ public:
        entries in the associated matrix. */
    void SetPositiveDiagonal(bool pos = true) { pos_l1_norms = pos; }
 
+   /// Set the flag transpose_action that indicates the action of MultTranspose
+   /** By default, transpose_action is Undefined, in which case MultTranspose
+       should not be called. By setting transpose_action = SameAsMult, calling
+       MultTranspose will be redirected to Mult. */
+   void SetTransposeAction(TransposeAction act) { transpose_action = act; }
+
    /** Set/update the associated operator. Must be called after setting the
        HypreSmoother type and options. */
    virtual void SetOperator(const Operator &op);
@@ -691,6 +704,9 @@ public:
    /// Relax the linear system Ax=b
    virtual void Mult(const HypreParVector &b, HypreParVector &x) const;
    virtual void Mult(const Vector &b, Vector &x) const;
+
+   /// Apply transpose of the smoother
+   virtual void MultTranspose(const Vector &b, Vector &x) const;
 
    virtual ~HypreSmoother();
 };

--- a/linalg/hypre.hpp
+++ b/linalg/hypre.hpp
@@ -591,10 +591,6 @@ void EliminateBC(HypreParMatrix &A, HypreParMatrix &Ae,
 /// Parallel smoothers in hypre
 class HypreSmoother : public Solver
 {
-public:
-   /// Options of what MultTranspose would do when it is called.
-   enum TransposeAction { Undefined, SameAsMult };
-
 protected:
    /// The linear system matrix
    HypreParMatrix *A;
@@ -642,9 +638,8 @@ protected:
    /// Combined coefficients for windowing and Chebyshev polynomials.
    double* fir_coeffs;
 
-   /// Indicate what MultTranspose would do when it is called.
-   TransposeAction transpose_action;
-
+   /// A flag that indicates whether the smoother is symmetric
+   bool is_symmetric;
 public:
    /** Hypre smoother types:
        0    = Jacobi
@@ -691,11 +686,9 @@ public:
        entries in the associated matrix. */
    void SetPositiveDiagonal(bool pos = true) { pos_l1_norms = pos; }
 
-   /// Set the flag transpose_action that indicates the action of MultTranspose
-   /** By default, transpose_action is Undefined, in which case MultTranspose
-       should not be called. By setting transpose_action = SameAsMult, calling
-       MultTranspose will be redirected to Mult. */
-   void SetTransposeAction(TransposeAction act) { transpose_action = act; }
+   /** Explicitly set the symmetry flag is_symmetric.
+       If is_symmetric is true, MultTranspose will call Mult. */
+   void SetSymmetryFlag(bool is_sym) { is_symmetric = is_sym; }
 
    /** Set/update the associated operator. Must be called after setting the
        HypreSmoother type and options. */

--- a/linalg/hypre.hpp
+++ b/linalg/hypre.hpp
@@ -687,7 +687,8 @@ public:
    void SetPositiveDiagonal(bool pos = true) { pos_l1_norms = pos; }
 
    /** Explicitly indicate whether the linear system A is symmetric.
-       If A is symmetric, calling MultTranspose will be redirected to Mult.
+       If A is symmetric, the smoother will also be symmetric.
+       In this case, calling MultTranspose will be redirected to Mult.
        By default, A is assumed to be nonsymmetric. */
    void SetOperatorSymmetry(bool is_sym) { A_is_symmetric = is_sym; }
 
@@ -699,7 +700,7 @@ public:
    virtual void Mult(const HypreParVector &b, HypreParVector &x) const;
    virtual void Mult(const Vector &b, Vector &x) const;
 
-   /// Apply transpose of the smoother
+   /// Apply transpose of the smoother to relax the linear system Ax=b
    virtual void MultTranspose(const Vector &b, Vector &x) const;
 
    virtual ~HypreSmoother();

--- a/linalg/hypre.hpp
+++ b/linalg/hypre.hpp
@@ -638,8 +638,8 @@ protected:
    /// Combined coefficients for windowing and Chebyshev polynomials.
    double* fir_coeffs;
 
-   /// A flag that indicates whether the smoother is symmetric
-   bool is_symmetric;
+   /// A flag that indicates whether the linear system A is symmetric
+   bool A_is_symmetric;
 public:
    /** Hypre smoother types:
        0    = Jacobi
@@ -686,9 +686,10 @@ public:
        entries in the associated matrix. */
    void SetPositiveDiagonal(bool pos = true) { pos_l1_norms = pos; }
 
-   /** Explicitly set the symmetry flag is_symmetric.
-       If is_symmetric is true, MultTranspose will call Mult. */
-   void SetSymmetryFlag(bool is_sym) { is_symmetric = is_sym; }
+   /** Explicitly indicate whether the linear system A is symmetric.
+       If A is symmetric, calling MultTranspose will be redirected to Mult.
+       By default, A is assumed to be nonsymmetric. */
+   void SetOperatorSymmetry(bool is_sym) { A_is_symmetric = is_sym; }
 
    /** Set/update the associated operator. Must be called after setting the
        HypreSmoother type and options. */

--- a/linalg/hypre.hpp
+++ b/linalg/hypre.hpp
@@ -638,8 +638,9 @@ protected:
    /// Combined coefficients for windowing and Chebyshev polynomials.
    double* fir_coeffs;
 
-   /// A flag that indicates whether the linear system A is symmetric
+   /// A flag that indicates whether the linear system matrix A is symmetric
    bool A_is_symmetric;
+
 public:
    /** Hypre smoother types:
        0    = Jacobi
@@ -686,10 +687,10 @@ public:
        entries in the associated matrix. */
    void SetPositiveDiagonal(bool pos = true) { pos_l1_norms = pos; }
 
-   /** Explicitly indicate whether the linear system A is symmetric.
-       If A is symmetric, the smoother will also be symmetric.
-       In this case, calling MultTranspose will be redirected to Mult.
-       By default, A is assumed to be nonsymmetric. */
+   /** Explicitly indicate whether the linear system matrix A is symmetric. If A
+       is symmetric, the smoother will also be symmetric. In this case, calling
+       MultTranspose will be redirected to Mult. (This is also done if the
+       smoother is diagonal.) By default, A is assumed to be nonsymmetric. */
    void SetOperatorSymmetry(bool is_sym) { A_is_symmetric = is_sym; }
 
    /** Set/update the associated operator. Must be called after setting the


### PR DESCRIPTION
The goal of this PR is to allow `HypreSmoother::MultTranspose` to be defined when the smoother is symmetric.

Specifically, it adds an `enum` type `TransposeAction` in `HypreSmoother`, a member `transpose_action`, and a public member function to set the value of `transpose_action` (default is `Undefined`). When `transpose_action` is set to be `SameAsMult` (e.g., when the user knows the smoother is symmetric), calling `MultTranspose` will be redirected to `Mult`. 

Later on one may add another option (something like `BasedOnType`) in `TransposeAction` if a specific action of transpose (that is different from `Mult`) is defined for certain types of smoothers.

I also thought about a simpler option (for achieving the goal of this PR), which is to simply use a boolean flag (something like `is_symmetric`), and when the flag is `true`, `Transpose` will just call `Mult`. In this case, again, the default value would be `false`. But I am a bit worried that this may potentially be misleading (for example, if I initialize a Jacobi smoother, by default the flag would still indicate that it is not symmetric).
<!--GHEX{"id":1879,"author":"chakshinglee","editor":"tzanio","reviewers":["barker29","tzanio","v-dobrev"],"assignment":"2020-11-16T07:42:05-08:00","approval":"2021-01-07T16:26:36.135Z","merge":"2021-01-15T00:30:41.514Z"}XEHG--><!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge| 
 | --- | --- | --- | --- | --- | --- | --- | 
| [#1879](https://github.com/mfem/mfem/pull/1879) | @chakshinglee | @tzanio | @barker29 + @tzanio + @v-dobrev | 11/16/20 | 01/07/21 | 01/14/21 | |
<!--ELBATXEHG-->