### PR TITLE
Update secondordertimedep operator comment

### DIFF
--- a/linalg/operator.hpp
+++ b/linalg/operator.hpp
@@ -606,23 +606,22 @@ public:
 
    using TimeDependentOperator::ImplicitSolve;
    /** @brief Solve the equation:
-       @a k = f(@a x + 1/2 @a dt0^2 @a k, @a dxdt + @a dt1 @a k, t), for the
+       @a k = f(@a x + @a fac0 @a k, @a dxdt + @a fac1 @a k, t), for the
        unknown @a k at the current time t.
 
        For general F and G, the equation for @a k becomes:
-       F(@a x + 1/2 @a dt0^2 @a k, @a dxdt + @a dt1 @a k, t)
-                        = G(@a x + 1/2 @a dt0^2 @a k, @a dxdt + @a dt1 @a k, t).
+       F(@a x +  @a fac0 @a k, @a dxdt + @a fac1 @a k, t)
+                        = G(@a x +  @a fac0 @a k, @a dxdt + @a fac1 @a k, t).
 
-       The input vector @a x corresponds to time index (or cycle) n, while the
+       The input vectors @a x and @a dxdt corresponds to time index (or cycle) n, while the
        currently set time, #t, and the result vector @a k correspond to time
-       index n+1. The time step @a dt corresponds to the time interval between
-       cycles n and n+1.
+       index n+1.
 
        This method allows for the abstract implementation of some time
        integration methods.
 
        If not re-implemented, this method simply generates an error. */
-   virtual void ImplicitSolve(const double dt0, const double dt1,
+   virtual void ImplicitSolve(const double fac0, const double fac1,
                               const Vector &x, const Vector &dxdt, Vector &k);
 
 


### PR DESCRIPTION
Fixes wrong comment as reported in #1813
<!--GHEX{"id":1892,"author":"IdoAkkerman","editor":"tzanio","reviewers":["cjvogl","jandrej"],"assignment":"2020-11-19T08:23:38-08:00","approval":"2020-11-19T23:28:53.238Z","merge":"2020-11-20T18:53:22.931Z"}XEHG--><!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge| 
 | --- | --- | --- | --- | --- | --- | --- | 
| [#1892](https://github.com/mfem/mfem/pull/1892) | @IdoAkkerman | @tzanio | @cjvogl + @jandrej | 11/19/20 | 11/19/20 | 11/20/20 | |
<!--ELBATXEHG-->