### PR TITLE
Fix a bug in BlockVector::Update

### DIFF
--- a/linalg/blockvector.cpp
+++ b/linalg/blockvector.cpp
@@ -101,6 +101,7 @@ void BlockVector::Update(Vector & data, const Array<int> & bOffsets)
    {
       blocks[i].MakeRef(data, blockOffsets[i], BlockSize(i));
    }
+   MakeRef(data, 0, blockOffsets[numBlocks]);
 }
 
 void BlockVector::Update(const Array<int> &bOffsets)


### PR DESCRIPTION
Fix a bug in `BlockVector::Update(Vector & data, const Array<int> & bOffsets)` -- the data in the base `Vector` (the big vector) was not updated.

Reported by: @vkorchagova in https://github.com/mfem/mfem/issues/1628#issuecomment-733758717
<!--GHEX{"id":1907,"author":"v-dobrev","editor":"tzanio","reviewers":["tzanio","dylan-copeland"],"assignment":"2020-11-30T14:20:28-08:00","approval":"2020-12-01T00:49:31.280Z","merge":"2020-12-02T20:29:39.008Z"}XEHG--><!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge| 
 | --- | --- | --- | --- | --- | --- | --- | 
| [#1907](https://github.com/mfem/mfem/pull/1907) | @v-dobrev | @tzanio | @tzanio + @dylan-copeland | 11/30/20 | 11/30/20 | 12/02/20 | |
<!--ELBATXEHG-->