### PR TITLE
Documentation/convenience changes for upwind advection

### DIFF
--- a/fem/bilininteg.hpp
+++ b/fem/bilininteg.hpp
@@ -2108,6 +2108,14 @@ public:
                                          ElementTransformation &Trans);
 };
 
+/// alpha (u, q . grad u), transpose of ConvectionIntegrator
+class ConservativeConvectionIntegrator : public TransposeIntegrator
+{
+public:
+   ConservativeConvectionIntegrator(VectorCoefficient &q, double a = 1.0)
+      : TransposeIntegrator(new ConvectionIntegrator(q, a)) { }
+};
+
 /// alpha (q . grad u, v) using the "group" FE discretization
 class GroupConvectionIntegrator : public BilinearFormIntegrator
 {
@@ -2654,13 +2662,21 @@ public:
     where v and w are the trial and test variables, respectively, and rho/u are
     given scalar/vector coefficients. {v} represents the average value of v on
     the face and [v] is the jump such that {v}=(v1+v2)/2 and [v]=(v1-v2) for the
-    face between elements 1 and 2. For boundary elements, v2=0 such that
-    alpha=1, beta=0.5 corresponds to "outflow" on the external boundary. The
-    vector coefficient, u, is assumed to be continuous across the faces and when
-    given the scalar coefficient, rho, is assumed to be discontinuous. The
-    integrator uses the upwind value of rho, rho_u, which is value from the side
-    into which the vector coefficient, u,
-    points. */
+    face between elements 1 and 2. For boundary elements, v2=0. The vector
+    coefficient, u, is assumed to be continuous across the faces and when given
+    the scalar coefficient, rho, is assumed to be discontinuous. The integrator
+    uses the upwind value of rho, rho_u, which is value from the side into which
+    the vector coefficient, u, points.
+
+    When combined with ConservativeConvectionIntegrator integrator, the
+    coefficients alpha=1.0, beta=0.5 can be used to implement the upwind flux
+    and outflow boundary conditions in conservative form.
+
+    For the non-conservative formulation of convection using
+    ConvectionIntegrator, the transpose of this form with alpha=-1.0, beta=0.5
+    can be used to implement the upwind flux, see
+    NonconservativeDGTraceIntegrator and ex9 and ex9p.
+    */
 class DGTraceIntegrator : public BilinearFormIntegrator
 {
 protected:
@@ -2715,6 +2731,24 @@ public:
 
 private:
    void SetupPA(const FiniteElementSpace &fes, FaceType type);
+};
+
+/** Integrator that represents the transpose of DGTraceIntegrator, i.e.
+    alpha < rho_u (u.n) [v],{w} > + beta < rho_u |u.n| [v],[w] >,
+    where the notation is the same as in DGTraceIntegrator.
+
+    This integrator can be used with alpha=-1.0, beta=0.5, together with
+    ConvectionIntegrator to implement an upwind DG discretization in
+    non-conservative form, see ex9 and ex9p. */
+class NonconservativeDGTraceIntegrator : public TransposeIntegrator
+{
+public:
+   NonconservativeDGTraceIntegrator(VectorCoefficient &u_, double a, double b)
+      : TransposeIntegrator(new DGTraceIntegrator(u_, a, b)) { }
+
+   NonconservativeDGTraceIntegrator(Coefficient &rho_, VectorCoefficient &u_,
+                                    double a, double b)
+      : TransposeIntegrator(new DGTraceIntegrator(rho_, u_, a, b)) { }
 };
 
 /** Integrator for the DG form:


### PR DESCRIPTION
Attempt to clarify/make more convenient the different ways of creating conservative/non-conservative advection discretizations.

In conservative form:
```c++
BilinearForm k(&fes);
k.AddDomainIntegrator(new ConservativeConvectionIntegrator(velocity));
k.AddInteriorFaceIntegrator( new DGTraceIntegrator(velocity, -1.0, -0.5));
k.AddBdrFaceIntegrator( new DGTraceIntegrator(velocity, -1.0, -0.5));

LinearForm b(&fes);
b.AddBdrFaceIntegrator(
   new BoundaryFlowIntegrator(inflow, velocity, -1.0, -0.5));
```

In non-conservative form:
```c++
BilinearForm k(&fes);
k.AddDomainIntegrator(new ConvectionIntegrator(velocity, -1.0));
k.AddInteriorFaceIntegrator(
   new NonconservativeDGTraceIntegrator(velocity, 1.0, -0.5));
k.AddBdrFaceIntegrator(
   new NonconservativeDGTraceIntegrator(velocity, 1.0, -0.5));

LinearForm b(&fes);
b.AddBdrFaceIntegrator(
   new BoundaryFlowIntegrator(inflow, velocity, -1.0, -0.5));
```

Added some comments to try to make this clear:

> When combined with ConservativeConvectionIntegrator integrator, the coefficients alpha=1.0, beta=0.5 can be used to implement the upwind flux and outflow boundary conditions in conservative form.
> 
> For the non-conservative formulation of convection using ConvectionIntegrator, the transpose of this form with alpha=-1.0, beta=0.5 can be used to implement the upwind flux, see NonconservativeDGTraceIntegrator and ex9 and ex9p.