### PR TITLE
Fix emscripten build

### DIFF
--- a/general/zstr.hpp
+++ b/general/zstr.hpp
@@ -71,7 +71,7 @@ static std::string strerror()
    }
 #elif (_POSIX_C_SOURCE >= 200112L || _XOPEN_SOURCE >= 600) && ! _GNU_SOURCE || \
       defined(__APPLE__) || defined(__FreeBSD__) || defined(__OpenBSD__) || \
-      defined(__NetBSD__) || defined(__DragonFly__)
+      defined(__NetBSD__) || defined(__DragonFly__) || defined(__EMSCRIPTEN__)
    // XSI-compliant strerror_r()
    if (strerror_r(errno, &buff[0], buff.size()) != 0)
    {


### PR DESCRIPTION
use "XSI-compliant" `strerror_r` with emscripten instead of default GNU style that was causing compilation errors
<!--GHEX{"id":1918,"author":"tomstitt","editor":"tzanio","reviewers":["tzanio","v-dobrev"],"assignment":"2020-12-03T10:50:02-08:00","approval":"2020-12-03T22:11:43.052Z","merge":"2020-12-06T22:16:11.888Z"}XEHG--><!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge| 
 | --- | --- | --- | --- | --- | --- | --- | 
| [#1918](https://github.com/mfem/mfem/pull/1918) | @tomstitt | @tzanio | @tzanio + @v-dobrev | 12/03/20 | 12/03/20 | 12/06/20 | |
<!--ELBATXEHG-->