### PR TITLE
Simple implementation for D2QValues1D

### DIFF
--- a/fem/quadinterpolator.cpp
+++ b/fem/quadinterpolator.cpp
@@ -443,8 +443,8 @@ static void D2QValues1D(const int NE,
             {
                y(c, q, e) += b(q, d) * x(d, c, e);
             }
-          }
-       }
+         }
+      }
    });
 }
 

--- a/fem/quadinterpolator.cpp
+++ b/fem/quadinterpolator.cpp
@@ -420,6 +420,34 @@ void QuadratureInterpolator::MultTranspose(
    MFEM_ABORT("this method is not implemented yet");
 }
 
+static void D2QValues1D(const int NE,
+                        const Array<double> &b_,
+                        const Vector &x_,
+                        Vector &y_,
+                        const int vdim = 1,
+                        const int d1d = 0,
+                        const int q1d = 0)
+{
+   auto b = Reshape(b_.Read(), q1d, d1d);
+   auto x = Reshape(x_.Read(), d1d, vdim, NE);
+   auto y = Reshape(y_.Write(), vdim, q1d, NE);
+
+   MFEM_FORALL(e, NE,
+   {
+      for (int c = 0; c < vdim; c++)
+      {
+         for (int q = 0; q < q1d; ++q)
+         {
+            y(c, q, e) = 0.0;
+            for (int d = 0; d < d1d; ++d)
+            {
+               y(c, q, e) += b(q, d) * x(d, c, e);
+            }
+          }
+       }
+   });
+}
+
 
 template<int T_VDIM = 0, int T_D1D = 0, int T_Q1D = 0, int T_NBZ = 0>
 static void D2QValues2D(const int NE,
@@ -631,6 +659,15 @@ static void D2QValues(const FiniteElementSpace &fes,
    const int Q1D = maps->nqpt;
    const int id = (vdim<<8) | (D1D<<4) | Q1D;
 
+   if (dim == 1)
+   {
+      MFEM_VERIFY(D1D <= MAX_D1D, "Orders higher than " << MAX_D1D-1
+                  << " are not supported!");
+      MFEM_VERIFY(Q1D <= MAX_Q1D, "Quadrature rules with more than "
+                  << MAX_Q1D << " 1D points are not supported!");
+      D2QValues1D(NE, maps->B, e_vec, q_val, vdim, D1D, Q1D);
+      return;
+   }
    if (dim == 2)
    {
       switch (id)

--- a/fem/quadinterpolator.cpp
+++ b/fem/quadinterpolator.cpp
@@ -438,11 +438,12 @@ static void D2QValues1D(const int NE,
       {
          for (int q = 0; q < q1d; ++q)
          {
-            y(c, q, e) = 0.0;
+            double val = 0.0;
             for (int d = 0; d < d1d; ++d)
             {
-               y(c, q, e) += b(q, d) * x(d, c, e);
+               val += b(q, d) * x(d, c, e);
             }
+            y(c, q, e) = val;
          }
       }
    });


### PR DESCRIPTION
This is not important for performance (it's 1D), but `QuadratureInterpolator::Values()` might be called from FA-based codes that are expected to work on 1D meshes. We had this case in Laghos and it was hitting an abort in `D2QValues`.
<!--GHEX{"id":1921,"author":"vladotomov","editor":"tzanio","reviewers":["camierjs","YohannDudouit"],"assignment":"2020-12-07T17:46:05-08:00","approval":"2020-12-21T21:49:55.745Z","merge":"2020-12-26T21:30:44.725Z"}XEHG--><!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge| 
 | --- | --- | --- | --- | --- | --- | --- | 
| [#1921](https://github.com/mfem/mfem/pull/1921) | @vladotomov | @tzanio | @camierjs + @YohannDudouit | 12/07/20 | 12/21/20 | 12/26/20 | |
<!--ELBATXEHG-->