### PR TITLE
Fixed add_custom_target to not clash in global CMake namespace

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -547,15 +547,15 @@ endif()
 
 # Add 'check' target - quick test
 if (NOT MFEM_USE_MPI)
-  add_custom_target(check
+  add_custom_target(mfem_check
     ${CMAKE_CTEST_COMMAND} -R \"^ex1_ser\" -C ${CMAKE_CFG_INTDIR}
     USES_TERMINAL)
-  add_dependencies(check ex1)
+  add_dependencies(mfem_check ex1)
 else()
-  add_custom_target(check
+  add_custom_target(mfem_check
     ${CMAKE_CTEST_COMMAND} -R \"^ex1p\" -C ${CMAKE_CFG_INTDIR}
     USES_TERMINAL)
-  add_dependencies(check ex1p)
+  add_dependencies(mfem_check ex1p)
 endif()
 
 #-------------------------------------------------------------------------------


### PR DESCRIPTION
This fixes conflicts with other CMake based projects when including MFEM via add_subdirectory (mfem as a sub project).

The issue is that the add_custom_target namespace is global, so if any other CMake project uses that name it collides.

Fix: make the custom target's name more project-unique.

<!--GHEX{"id":1923,"author":"ajkunen","editor":"tzanio","reviewers":["v-dobrev","jandrej"],"assignment":"2020-12-15T18:21:10-08:00","approval":"2020-12-29T18:21:10-08:00","merge":"2021-01-05T18:21:10-08:00"}XEHG--><!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge| 
 | --- | --- | --- | --- | --- | --- | --- | 
| [#1923](https://github.com/mfem/mfem/pull/1923) | @ajkunen | @tzanio | @v-dobrev + @jandrej | 12/15/20 | ⌛due 12/29/20 | ⌛due 01/05/21 | |
<!--ELBATXEHG-->