### PR TITLE
Bugfix proposal for issue #1928

### DIFF
--- a/mesh/mesh_readers.cpp
+++ b/mesh/mesh_readers.cpp
@@ -2030,9 +2030,9 @@ void Mesh::ReadGmshMesh(std::istream &input, int &curved, int &read_gf)
             getline(input, buff); // Read end-of-line
          }
 
-         // Follow existing long chains of slave->master in v2v array. 
-         // Upon completion of this loop, each v2v[slave] will point to a true 
-         // master vertex. This algorithm is useful for periodicity defined in 
+         // Follow existing long chains of slave->master in v2v array.
+         // Upon completion of this loop, each v2v[slave] will point to a true
+         // master vertex. This algorithm is useful for periodicity defined in
          // multiple directions.
          for (int slave = 0; slave < v2v.Size(); slave++)
          {

--- a/mesh/mesh_readers.cpp
+++ b/mesh/mesh_readers.cpp
@@ -2030,16 +2030,16 @@ void Mesh::ReadGmshMesh(std::istream &input, int &curved, int &read_gf)
             getline(input, buff); // Read end-of-line
          }
 
-         // Follow existing long chains of slave->master in v2v array. Finally,
-         // we should have v2v[slave] pointing on a true master. This algorithm
-         // is useful for periodicity defined in multiple directions.
+         // Follow existing long chains of slave->master in v2v array. 
+         // Upon completion of this loop, each v2v[slave] will point to a true 
+         // master vertex. This algorithm is useful for periodicity defined in 
+         // multiple directions.
          for (int slave = 0; slave < v2v.Size(); slave++)
          {
             int master = v2v[slave];
             if (master != slave)
             {
-               // This loop is ending even if it happens
-               // that we loop back on slave (circular dependency)
+               // This loop will end if it finds a circular dependency.
                while (v2v[master] != master && master != slave)
                {
                   master = v2v[master];
@@ -2052,8 +2052,7 @@ void Mesh::ReadGmshMesh(std::istream &input, int &curved, int &read_gf)
                }
                else
                {
-                  // the long chain has ended up to the vertex master
-                  // then we store this final master
+                  // the long chain has ended on the true master vertex.
                   v2v[slave] = master;
                }
             }

--- a/mesh/mesh_readers.cpp
+++ b/mesh/mesh_readers.cpp
@@ -2025,9 +2025,31 @@ void Mesh::ReadGmshMesh(std::istream &input, int &curved, int &read_gf)
             for (int j=0; j<num_nodes; j++)
             {
                input >> slave >> master;
-               v2v[slave - 1] = master - 1;
+               // Forces slave to have an index larger to master
+               if (slave > master)
+               {
+                  v2v[slave - 1] = master - 1;
+               }
+               else
+               {
+                  v2v[master - 1] = slave - 1;
+               }
             }
             getline(input, buff); // Read end-of-line
+         }
+
+         // Follow existing long chains of slave->master in v2v array.
+         // Finally, we should have v2v[slave] pointing on a true master.
+         for (int slave = 0; slave < v2v.Size(); slave++)
+         {
+            int master = v2v[slave];
+            if (master != slave)
+            {
+               // This loop is ending because we imposed previously
+               // that a slave has an index larger to master.
+               while (v2v[master] != master) {  master = v2v[master]; }
+               v2v[slave] = master;
+            }
          }
 
          // Convert nodes to discontinuous GridFunction (if they aren't already)

--- a/mesh/mesh_readers.cpp
+++ b/mesh/mesh_readers.cpp
@@ -2053,7 +2053,7 @@ void Mesh::ReadGmshMesh(std::istream &input, int &curved, int &read_gf)
                else
                {
                   // the long chain has ended up to the vertex master
-		  // then we store this final master
+                  // then we store this final master
                   v2v[slave] = master;
                }
             }


### PR DESCRIPTION
Dear MFEM maintainer,
  This contribution intends to fix the reading of bi and tri-periodic meshes using GMSH format.
  Using the test case provided in issue #1928 , it provides satisfactory results.
  
Resolves #1928.

   Guillaume.
<!--GHEX{"id":1929,"author":"latug0","editor":"v-dobrev","reviewers":["bslazarov","mlstowell"],"assignment":"2020-12-09T23:38:23-08:00","approval":"2021-01-19T20:25:27.053Z","merge":"2021-02-04T22:34:33.197Z"}XEHG--><!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge| 
 | --- | --- | --- | --- | --- | --- | --- | 
| [#1929](https://github.com/mfem/mfem/pull/1929) | @latug0 | @v-dobrev | @bslazarov + @mlstowell | 12/09/20 | 01/19/21 | 02/04/21 | |
<!--ELBATXEHG-->