### PR TITLE
Broadening support for linear interpolators [test-lin-interp-dev]

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -28,13 +28,15 @@ Version 4.2.1 (development)
 - Implemented a filter method for the Navier miniapp to stabilize highly
   turbulent flows in direct numerical simulation.
 
-- Added partial assembly and device support to Example 25/25p, with diagonal 
+- Added partial assembly and device support to Example 25/25p, with diagonal
   preconditioning.
 
 - Implemented a variable step-size IMEX (VSSIMEX) method for the Navier miniapp.
 
 - Added new mesh quality metrics for TMOP-based mesh optimization.
 
+- Extending support for L2 basis functions using MapTypes VALUE and INTEGRAL in
+  linear interpolators and GridFunction "GetValue" methods.
 
 Version 4.2, released on October 30, 2020
 =========================================

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -38,6 +38,7 @@ Version 4.2.1 (development)
 - Extending support for L2 basis functions using MapTypes VALUE and INTEGRAL in
   linear interpolators and GridFunction "GetValue" methods.
 
+
 Version 4.2, released on October 30, 2020
 =========================================
 

--- a/fem/bilininteg.cpp
+++ b/fem/bilininteg.cpp
@@ -3516,6 +3516,47 @@ VectorScalarProductInterpolator::AssembleElementMatrix2(
 
 
 void
+ScalarCrossProductInterpolator::AssembleElementMatrix2(
+   const FiniteElement &dom_fe,
+   const FiniteElement &ran_fe,
+   ElementTransformation &Trans,
+   DenseMatrix &elmat)
+{
+   // Vector coefficient product with vector shape functions
+   struct VCrossVShapeCoefficient : public VectorCoefficient
+   {
+      VectorCoefficient &VQ;
+      const FiniteElement &fe;
+      DenseMatrix vshape;
+      Vector vc;
+
+      VCrossVShapeCoefficient(VectorCoefficient &vq, const FiniteElement &fe_)
+         : VectorCoefficient(fe_.GetDof()), VQ(vq), fe(fe_),
+           vshape(vdim, vq.GetVDim()), vc(vq.GetVDim()) { }
+
+      virtual void Eval(Vector &V, ElementTransformation &T,
+                        const IntegrationPoint &ip)
+      {
+         V.SetSize(vdim);
+         VQ.Eval(vc, T, ip);
+         fe.CalcPhysVShape(T, vshape);
+         for (int k = 0; k < vdim; k++)
+         {
+            V(k) = vc(0) * vshape(k,1) - vc(1) * vshape(k,0);
+         }
+      }
+   };
+
+   VCrossVShapeCoefficient dom_shape_coeff(*VQ, dom_fe);
+
+   elmat.SetSize(ran_fe.GetDof(),dom_fe.GetDof());
+
+   Vector elmat_as_vec(elmat.Data(), elmat.Height()*elmat.Width());
+
+   ran_fe.Project(dom_shape_coeff, Trans, elmat_as_vec);
+}
+
+void
 VectorCrossProductInterpolator::AssembleElementMatrix2(
    const FiniteElement &dom_fe,
    const FiniteElement &ran_fe,

--- a/fem/bilininteg.hpp
+++ b/fem/bilininteg.hpp
@@ -3071,6 +3071,22 @@ protected:
    VectorCoefficient *VQ;
 };
 
+/** Interpolator of the 2D cross product between a vector coefficient and an
+    H(curl)-conforming field onto an L2-conforming field. */
+class ScalarCrossProductInterpolator : public DiscreteInterpolator
+{
+public:
+   ScalarCrossProductInterpolator(VectorCoefficient & vc)
+      : VQ(&vc) { }
+
+   virtual void AssembleElementMatrix2(const FiniteElement &nd_fe,
+                                       const FiniteElement &l2_fe,
+                                       ElementTransformation &Trans,
+                                       DenseMatrix &elmat);
+protected:
+   VectorCoefficient *VQ;
+};
+
 /** Interpolator of the cross product between a vector coefficient and an
     H(curl)-conforming field onto an H(div)-conforming field. The range space
     can also be vector L2. */

--- a/fem/fe.cpp
+++ b/fem/fe.cpp
@@ -722,17 +722,34 @@ void NodalFiniteElement::Project(
 {
    if (fe.GetRangeType() == SCALAR)
    {
-      MFEM_ASSERT(map_type == fe.GetMapType(), "");
-
       Vector shape(fe.GetDof());
 
       I.SetSize(dof, fe.GetDof());
-      for (int k = 0; k < dof; k++)
+      if (map_type == fe.GetMapType())
       {
-         fe.CalcShape(Nodes.IntPoint(k), shape);
-         for (int j = 0; j < shape.Size(); j++)
+         for (int k = 0; k < dof; k++)
          {
-            I(k,j) = (fabs(shape(j)) < 1e-12) ? 0.0 : shape(j);
+            fe.CalcShape(Nodes.IntPoint(k), shape);
+            for (int j = 0; j < shape.Size(); j++)
+            {
+               I(k,j) = (fabs(shape(j)) < 1e-12) ? 0.0 : shape(j);
+            }
+         }
+      }
+      else
+      {
+         for (int k = 0; k < dof; k++)
+         {
+            Trans.SetIntPoint(&Nodes.IntPoint(k));
+            fe.CalcPhysShape(Trans, shape);
+            if (map_type == INTEGRAL)
+            {
+               shape *= Trans.Weight();
+            }
+            for (int j = 0; j < shape.Size(); j++)
+            {
+               I(k,j) = (fabs(shape(j)) < 1e-12) ? 0.0 : shape(j);
+            }
          }
       }
    }

--- a/fem/fe.cpp
+++ b/fem/fe.cpp
@@ -1048,6 +1048,8 @@ void VectorFiniteElement::Project_RT(
 
          fe.CalcShape(ip, shape);
          Trans.SetIntPoint(&ip);
+         // Transform RT face normals from reference to physical space
+         // vk = adj(J)^T nk
          Trans.AdjugateJacobian().MultTranspose(nk + d2n[k]*dim, vk);
          if (fe.GetMapType() == INTEGRAL)
          {
@@ -1065,6 +1067,8 @@ void VectorFiniteElement::Project_RT(
             {
                s = 0.0;
             }
+            // Project scalar basis function multiplied by each coordinate
+            // direction onto the transformed face normals
             for (int d = 0; d < sdim; d++)
             {
                I(k,j+d*shape.Size()) = s*vk[d];
@@ -1086,8 +1090,12 @@ void VectorFiniteElement::Project_RT(
          const IntegrationPoint &ip = Nodes.IntPoint(k);
 
          Trans.SetIntPoint(&ip);
+         // Transform RT face normals from reference to physical space
+         // vk = adj(J)^T nk
          Trans.AdjugateJacobian().MultTranspose(nk + d2n[k]*dim, vk);
+         // Compute fe basis functions in physical space
          fe.CalcVShape(Trans, vshape);
+         // Project fe basis functions onto transformed face normals
          vshape.Mult(vk, vshapenk);
          if (!square_J) { vshapenk /= Trans.Weight(); }
          for (int j=0; j<vshapenk.Size(); j++)
@@ -1255,6 +1263,8 @@ void VectorFiniteElement::Project_ND(
 
          fe.CalcShape(ip, shape);
          Trans.SetIntPoint(&ip);
+         // Transform ND edge tengents from reference to physical space
+         // vk = J tk
          Trans.Jacobian().Mult(tk + d2t[k]*dim, vk);
          if (fe.GetMapType() == INTEGRAL)
          {
@@ -1272,6 +1282,8 @@ void VectorFiniteElement::Project_ND(
             {
                s = 0.0;
             }
+            // Project scalar basis function multiplied by each coordinate
+            // direction onto the transformed edge tangents
             for (int d = 0; d < sdim; d++)
             {
                I(k, j + d*shape.Size()) = s*vk[d];
@@ -1292,8 +1304,12 @@ void VectorFiniteElement::Project_ND(
          const IntegrationPoint &ip = Nodes.IntPoint(k);
 
          Trans.SetIntPoint(&ip);
+         // Transform ND edge tangents from reference to physical space
+         // vk = J tk
          Trans.Jacobian().Mult(tk + d2t[k]*dim, vk);
+         // Compute fe basis functions in physical space
          fe.CalcVShape(Trans, vshape);
+         // Project fe basis functions onto transformed edge tangents
          vshape.Mult(vk, vshapetk);
          for (int j=0; j<vshapetk.Size(); j++)
          {

--- a/fem/fe.cpp
+++ b/fem/fe.cpp
@@ -1074,7 +1074,27 @@ void VectorFiniteElement::Project_RT(
    }
    else
    {
-      mfem_error("VectorFiniteElement::Project_RT (fe version)");
+      int sdim = Trans.GetSpaceDim();
+      double vk[Geometry::MaxDim];
+      DenseMatrix vshape(fe.GetDof(), sdim);
+      Vector vshapenk(fe.GetDof());
+      const bool square_J = (dim == sdim);
+
+      I.SetSize(dof, fe.GetDof());
+      for (int k = 0; k < dof; k++)
+      {
+         const IntegrationPoint &ip = Nodes.IntPoint(k);
+
+         Trans.SetIntPoint(&ip);
+         Trans.AdjugateJacobian().MultTranspose(nk + d2n[k]*dim, vk);
+         fe.CalcVShape(Trans, vshape);
+         vshape.Mult(vk, vshapenk);
+         if (!square_J) { vshapenk /= Trans.Weight(); }
+         for (int j=0; j<vshapenk.Size(); j++)
+         {
+            I(k,j) = vshapenk(j);
+         }
+      }
    }
 }
 
@@ -1261,7 +1281,25 @@ void VectorFiniteElement::Project_ND(
    }
    else
    {
-      mfem_error("VectorFiniteElement::Project_ND (fe version)");
+      int sdim = Trans.GetSpaceDim();
+      double vk[Geometry::MaxDim];
+      DenseMatrix vshape(fe.GetDof(), sdim);
+      Vector vshapetk(fe.GetDof());
+
+      I.SetSize(dof, fe.GetDof());
+      for (int k = 0; k < dof; k++)
+      {
+         const IntegrationPoint &ip = Nodes.IntPoint(k);
+
+         Trans.SetIntPoint(&ip);
+         Trans.Jacobian().Mult(tk + d2t[k]*dim, vk);
+         fe.CalcVShape(Trans, vshape);
+         vshape.Mult(vk, vshapetk);
+         for (int j=0; j<vshapetk.Size(); j++)
+         {
+            I(k, j) = vshapetk(j);
+         }
+      }
    }
 }
 

--- a/fem/fe.cpp
+++ b/fem/fe.cpp
@@ -596,17 +596,22 @@ void NodalFiniteElement::ProjectCurl_2D(
    const FiniteElement &fe, ElementTransformation &Trans,
    DenseMatrix &curl) const
 {
-   MFEM_ASSERT(GetMapType() == FiniteElement::INTEGRAL, "");
-
    DenseMatrix curl_shape(fe.GetDof(), 1);
 
    curl.SetSize(dof, fe.GetDof());
    for (int i = 0; i < dof; i++)
    {
       fe.CalcCurlShape(Nodes.IntPoint(i), curl_shape);
+
+      double w = 1.0;
+      if (GetMapType() == FiniteElement::VALUE)
+      {
+         Trans.SetIntPoint(&Nodes.IntPoint(i));
+         w /= Trans.Weight();
+      }
       for (int j = 0; j < fe.GetDof(); j++)
       {
-         curl(i,j) = curl_shape(j,0);
+         curl(i,j) = w * curl_shape(j,0);
       }
    }
 }

--- a/fem/fe.hpp
+++ b/fem/fe.hpp
@@ -813,11 +813,25 @@ protected:
    void CalcVShape_ND(ElementTransformation &Trans,
                       DenseMatrix &shape) const;
 
+   /** @brief Project a vector coefficient onto the RT basis functions
+       @param nk    Face normal vectors for this element type
+       @param d2n   Offset into nk for each degree of freedom
+       @param vc    Vector coefficient to be projected
+       @param Trans Transformation from reference to physical coordinates
+       @param dofs  Expansion coefficients for the approximation of vc
+   */
    void Project_RT(const double *nk, const Array<int> &d2n,
                    VectorCoefficient &vc, ElementTransformation &Trans,
                    Vector &dofs) const;
 
    /// Projects the vector of values given at FE nodes to RT space
+   /** Project vector values onto the RT basis functions
+       @param nk    Face normal vectors for this element type
+       @param d2n   Offset into nk for each degree of freedom
+       @param vc    Vector values at each interpolation point
+       @param Trans Transformation from reference to physical coordinates
+       @param dofs  Expansion coefficients for the approximation of vc
+   */
    void Project_RT(const double *nk, const Array<int> &d2n,
                    Vector &vc, ElementTransformation &Trans,
                    Vector &dofs) const;
@@ -827,6 +841,19 @@ protected:
       const double *nk, const Array<int> &d2n,
       MatrixCoefficient &mc, ElementTransformation &T, Vector &dofs) const;
 
+   /** @brief Project vector-valued basis functions onto the RT basis functions
+       @param nk    Face normal vectors for this element type
+       @param d2n   Offset into nk for each degree of freedom
+       @param fe    Vector-valued finite element basis
+       @param Trans Transformation from reference to physical coordinates
+       @param I     Expansion coefficients for the approximation of each basis
+                    function
+
+       Note: If the FiniteElement, fe, is scalar-valued the projection will
+             assume that a FiniteElementSpace is being used to define a vector
+             field using the scalar basis functions for each component of the
+             vector field.
+   */
    void Project_RT(const double *nk, const Array<int> &d2n,
                    const FiniteElement &fe, ElementTransformation &Trans,
                    DenseMatrix &I) const;
@@ -846,11 +873,25 @@ protected:
                        const FiniteElement &fe, ElementTransformation &Trans,
                        DenseMatrix &curl) const;
 
+   /** @brief Project a vector coefficient onto the ND basis functions
+       @param tk    Edge tangent vectors for this element type
+       @param d2t   Offset into tk for each degree of freedom
+       @param vc    Vector coefficient to be projected
+       @param Trans Transformation from reference to physical coordinates
+       @param dofs  Expansion coefficients for the approximation of vc
+   */
    void Project_ND(const double *tk, const Array<int> &d2t,
                    VectorCoefficient &vc, ElementTransformation &Trans,
                    Vector &dofs) const;
 
    /// Projects the vector of values given at FE nodes to ND space
+   /** Project vector values onto the ND basis functions
+       @param tk    Edge tangent vectors for this element type
+       @param d2t   Offset into tk for each degree of freedom
+       @param vc    Vector values at each interpolation point
+       @param Trans Transformation from reference to physical coordinates
+       @param dofs  Expansion coefficients for the approximation of vc
+   */
    void Project_ND(const double *tk, const Array<int> &d2t,
                    Vector &vc, ElementTransformation &Trans,
                    Vector &dofs) const;
@@ -860,6 +901,19 @@ protected:
       const double *tk, const Array<int> &d2t,
       MatrixCoefficient &mc, ElementTransformation &T, Vector &dofs) const;
 
+   /** @brief Project vector-valued basis functions onto the ND basis functions
+       @param tk    Edge tangent vectors for this element type
+       @param d2t   Offset into tk for each degree of freedom
+       @param fe    Vector-valued finite element basis
+       @param Trans Transformation from reference to physical coordinates
+       @param I     Expansion coefficients for the approximation of each basis
+                    function
+
+       Note: If the FiniteElement, fe, is scalar-valued the projection will
+             assume that a FiniteElementSpace is being used to define a vector
+             field using the scalar basis functions for each component of the
+             vector field.
+   */
    void Project_ND(const double *tk, const Array<int> &d2t,
                    const FiniteElement &fe, ElementTransformation &Trans,
                    DenseMatrix &I) const;

--- a/fem/gridfunc.cpp
+++ b/fem/gridfunc.cpp
@@ -995,15 +995,14 @@ void GridFunction::GetVectorValues(ElementTransformation &T,
 
    if (FElem->GetRangeType() == FiniteElement::SCALAR)
    {
-      MFEM_ASSERT(FElem->GetMapType() == FiniteElement::VALUE,
-                  "invalid FE map type");
       Vector shape(dof);
       int vdim = fes->GetVDim();
       vals.SetSize(vdim, nip);
       for (int j = 0; j < nip; j++)
       {
          const IntegrationPoint &ip = ir.IntPoint(j);
-         FElem->CalcShape(ip, shape);
+         T.SetIntPoint(&ip);
+         FElem->CalcPhysShape(T, shape);
 
          for (int k = 0; k < vdim; k++)
          {

--- a/fem/gridfunc.cpp
+++ b/fem/gridfunc.cpp
@@ -462,15 +462,26 @@ const
    fes->GetElementDofs(i, dofs);
    fes->DofsToVDofs(vdim-1, dofs);
    const FiniteElement *FElem = fes->GetFE(i);
-   MFEM_ASSERT(FElem->GetMapType() == FiniteElement::VALUE,
-               "invalid FE map type");
    int dof = FElem->GetDof();
    Vector DofVal(dof), loc_data(dof);
    GetSubVector(dofs, loc_data);
-   for (int k = 0; k < n; k++)
+   if (FElem->GetMapType() == FiniteElement::VALUE)
    {
-      FElem->CalcShape(ir.IntPoint(k), DofVal);
-      vals(k) = DofVal * loc_data;
+      for (int k = 0; k < n; k++)
+      {
+         FElem->CalcShape(ir.IntPoint(k), DofVal);
+         vals(k) = DofVal * loc_data;
+      }
+   }
+   else
+   {
+      ElementTransformation *Tr = fes->GetElementTransformation(i);
+      for (int k = 0; k < n; k++)
+      {
+         Tr->SetIntPoint(&ir.IntPoint(k));
+         FElem->CalcPhysShape(*Tr, DofVal);
+         vals(k) = DofVal * loc_data;
+      }
    }
 }
 

--- a/tests/unit/fem/test_lin_interp.cpp
+++ b/tests/unit/fem/test_lin_interp.cpp
@@ -17,6 +17,26 @@ using namespace mfem;
 namespace lin_interp
 {
 
+double f1(const Vector & x) { return 2.345 * x[0]; }
+double Grad_f1(const Vector & x) { return 2.345; }
+
+double f2(const Vector & x) { return 2.345 * x[0] + 3.579 * x[1]; }
+void F2(const Vector & x, Vector & v)
+{
+   v.SetSize(2);
+   v[0] = 1.234 * x[0] - 2.357 * x[1];
+   v[1] = 3.572 * x[0] + 4.321 * x[1];
+}
+
+void Grad_f2(const Vector & x, Vector & df)
+{
+   df.SetSize(2);
+   df[0] = 2.345;
+   df[1] = 3.579;
+}
+double CurlF2(const Vector & x) { return 3.572 + 2.357; }
+double DivF2(const Vector & x) { return 1.234 + 4.321; }
+
 double f3(const Vector & x)
 { return 2.345 * x[0] + 3.579 * x[1] + 4.680 * x[2]; }
 void F3(const Vector & x, Vector & v)
@@ -26,6 +46,23 @@ void F3(const Vector & x, Vector & v)
    v[1] =  2.537 * x[0] + 4.321 * x[1] - 1.234 * x[2];
    v[2] = -2.572 * x[0] + 1.321 * x[1] + 3.234 * x[2];
 }
+
+void Grad_f3(const Vector & x, Vector & df)
+{
+   df.SetSize(3);
+   df[0] = 2.345;
+   df[1] = 3.579;
+   df[2] = 4.680;
+}
+void CurlF3(const Vector & x, Vector & df)
+{
+   df.SetSize(3);
+   df[0] = 1.321 + 1.234;
+   df[1] = 3.572 + 2.572;
+   df[2] = 2.537 + 2.357;
+}
+double DivF3(const Vector & x)
+{ return 1.234 + 4.321 + 3.234; }
 
 double g3(const Vector & x)
 { return 4.234 * x[0] + 3.357 * x[1] + 1.572 * x[2]; }
@@ -59,12 +96,1063 @@ double FdotG3(const Vector & x)
    return F * G;
 }
 
-TEST_CASE("Linear Interpolators")
+TEST_CASE("1D Identity Linear Interpolators",
+          "[IdentityInterpolator]")
+{
+   int order_h1 = 1, order_l2 = 1, n = 3, dim = 1;
+   double tol = 1e-9;
+
+   FunctionCoefficient     fCoef(f1);
+
+   for (int type = (int)Element::SEGMENT;
+        type <= (int)Element::SEGMENT; type++)
+   {
+      Mesh mesh(n, (Element::Type)type, 1, 2.0);
+
+      SECTION("Operators on H1 for element type " + std::to_string(type))
+      {
+         H1_FECollection    fec_h1(order_h1, dim);
+         FiniteElementSpace fespace_h1(&mesh, &fec_h1);
+
+         GridFunction f0(&fespace_h1);
+         f0.ProjectCoefficient(fCoef);
+
+         SECTION("Mapping to L2")
+         {
+            L2_FECollection    fec_l2(order_l2, dim);
+            FiniteElementSpace fespace_l2(&mesh, &fec_l2);
+
+            GridFunction f1(&fespace_l2);
+
+            DiscreteLinearOperator Op(&fespace_h1,&fespace_l2);
+            Op.AddDomainInterpolator(new IdentityInterpolator());
+            Op.Assemble();
+
+            Op.Mult(f0,f1);
+
+            REQUIRE( f1.ComputeL2Error(fCoef) < tol );
+         }
+         SECTION("Mapping to L2 (INTEGRAL)")
+         {
+            L2_FECollection    fec_l2(order_l2, dim,
+                                      BasisType::GaussLegendre,
+                                      FiniteElement::INTEGRAL);
+            FiniteElementSpace fespace_l2(&mesh, &fec_l2);
+
+            GridFunction f1(&fespace_l2);
+
+            DiscreteLinearOperator Op(&fespace_h1,&fespace_l2);
+            Op.AddDomainInterpolator(new IdentityInterpolator());
+            Op.Assemble();
+
+            Op.Mult(f0,f1);
+
+            REQUIRE( f1.ComputeL2Error(fCoef) < tol );
+         }
+      }
+   }
+}
+
+TEST_CASE("2D Identity Linear Interpolators",
+          "[IdentityInterpolator]")
+{
+   int order_h1 = 1, order_nd = 2, order_rt = 1, order_l2 = 1, n = 3, dim = 2;
+   double tol = 1e-9;
+
+   FunctionCoefficient     fCoef(f2);
+   VectorFunctionCoefficient FCoef(dim, F2);
+
+   for (int type = (int)Element::TRIANGLE;
+        type <= (int)Element::QUADRILATERAL; type++)
+   {
+      Mesh mesh(n, n, (Element::Type)type, 1, 2.0, 3.0);
+
+      SECTION("Operators on H1 for element type " + std::to_string(type))
+      {
+         H1_FECollection    fec_h1(order_h1, dim);
+         FiniteElementSpace fespace_h1(&mesh, &fec_h1);
+
+         GridFunction f0(&fespace_h1);
+         f0.ProjectCoefficient(fCoef);
+
+         SECTION("Mapping to H1")
+         {
+            H1_FECollection    fec_h1p(order_h1+1, dim);
+            FiniteElementSpace fespace_h1p(&mesh, &fec_h1p);
+
+            GridFunction f0p(&fespace_h1p);
+
+            DiscreteLinearOperator Op(&fespace_h1,&fespace_h1p);
+            Op.AddDomainInterpolator(new IdentityInterpolator());
+            Op.Assemble();
+
+            Op.Mult(f0,f0p);
+
+            REQUIRE( f0p.ComputeL2Error(fCoef) < tol );
+         }
+         SECTION("Mapping to L2")
+         {
+            L2_FECollection    fec_l2(order_l2, dim);
+            FiniteElementSpace fespace_l2(&mesh, &fec_l2);
+
+            GridFunction f1(&fespace_l2);
+
+            DiscreteLinearOperator Op(&fespace_h1,&fespace_l2);
+            Op.AddDomainInterpolator(new IdentityInterpolator());
+            Op.Assemble();
+
+            Op.Mult(f0,f1);
+
+            REQUIRE( f1.ComputeL2Error(fCoef) < tol );
+         }
+         SECTION("Mapping to L2 (INTEGRAL)")
+         {
+            L2_FECollection    fec_l2(order_l2, dim,
+                                      BasisType::GaussLegendre,
+                                      FiniteElement::INTEGRAL);
+            FiniteElementSpace fespace_l2(&mesh, &fec_l2);
+
+            GridFunction f1(&fespace_l2);
+
+            DiscreteLinearOperator Op(&fespace_h1,&fespace_l2);
+            Op.AddDomainInterpolator(new IdentityInterpolator());
+            Op.Assemble();
+
+            Op.Mult(f0,f1);
+
+            REQUIRE( f1.ComputeL2Error(fCoef) < tol );
+         }
+      }
+      SECTION("Operators on L2 for element type " + std::to_string(type))
+      {
+         L2_FECollection    fec_l2(order_l2, dim);
+         FiniteElementSpace fespace_l2(&mesh, &fec_l2);
+
+         GridFunction f0(&fespace_l2);
+         f0.ProjectCoefficient(fCoef);
+
+         SECTION("Mapping to L2")
+         {
+            L2_FECollection    fec_l2p(order_l2+1, dim);
+            FiniteElementSpace fespace_l2p(&mesh, &fec_l2p);
+
+            GridFunction f1(&fespace_l2p);
+
+            DiscreteLinearOperator Op(&fespace_l2,&fespace_l2p);
+            Op.AddDomainInterpolator(new IdentityInterpolator());
+            Op.Assemble();
+
+            Op.Mult(f0,f1);
+
+            REQUIRE( f1.ComputeL2Error(fCoef) < tol );
+         }
+         SECTION("Mapping to L2 (INTEGRAL)")
+         {
+            L2_FECollection    fec_l2p(order_l2+1, dim,
+                                       BasisType::GaussLegendre,
+                                       FiniteElement::INTEGRAL);
+            FiniteElementSpace fespace_l2p(&mesh, &fec_l2p);
+
+            GridFunction f1(&fespace_l2p);
+
+            DiscreteLinearOperator Op(&fespace_l2,&fespace_l2p);
+            Op.AddDomainInterpolator(new IdentityInterpolator());
+            Op.Assemble();
+
+            Op.Mult(f0,f1);
+
+            REQUIRE( f1.ComputeL2Error(fCoef) < tol );
+         }
+      }
+      SECTION("Operators on L2 (INTEGRAL) for element type " +
+              std::to_string(type))
+      {
+         L2_FECollection    fec_l2(order_l2, dim,
+                                   BasisType::GaussLegendre,
+                                   FiniteElement::INTEGRAL);
+         FiniteElementSpace fespace_l2(&mesh, &fec_l2);
+
+         GridFunction f0(&fespace_l2);
+         f0.ProjectCoefficient(fCoef);
+
+         SECTION("Mapping to L2")
+         {
+            L2_FECollection    fec_l2p(order_l2+1, dim);
+            FiniteElementSpace fespace_l2p(&mesh, &fec_l2p);
+
+            GridFunction f1(&fespace_l2p);
+
+            DiscreteLinearOperator Op(&fespace_l2,&fespace_l2p);
+            Op.AddDomainInterpolator(new IdentityInterpolator());
+            Op.Assemble();
+
+            Op.Mult(f0,f1);
+
+            REQUIRE( f1.ComputeL2Error(fCoef) < tol );
+         }
+         SECTION("Mapping to L2 (INTEGRAL)")
+         {
+            L2_FECollection    fec_l2p(order_l2+1, dim,
+                                       BasisType::GaussLegendre,
+                                       FiniteElement::INTEGRAL);
+            FiniteElementSpace fespace_l2p(&mesh, &fec_l2p);
+
+            GridFunction f1(&fespace_l2p);
+
+            DiscreteLinearOperator Op(&fespace_l2,&fespace_l2p);
+            Op.AddDomainInterpolator(new IdentityInterpolator());
+            Op.Assemble();
+
+            Op.Mult(f0,f1);
+
+            REQUIRE( f1.ComputeL2Error(fCoef) < tol );
+         }
+      }
+      SECTION("Operators on HCurl for element type " + std::to_string(type))
+      {
+         ND_FECollection    fec_nd(order_nd, dim);
+         FiniteElementSpace fespace_nd(&mesh, &fec_nd);
+
+         GridFunction f1(&fespace_nd);
+         f1.ProjectCoefficient(FCoef);
+
+         SECTION("Mapping to HCurl")
+         {
+            ND_FECollection    fec_ndp(order_nd+1, dim);
+            FiniteElementSpace fespace_ndp(&mesh, &fec_ndp);
+
+            GridFunction f1p(&fespace_ndp);
+
+            DiscreteLinearOperator Op(&fespace_nd,&fespace_ndp);
+            Op.AddDomainInterpolator(new IdentityInterpolator());
+            Op.Assemble();
+
+            Op.Mult(f1,f1p);
+
+            REQUIRE( f1p.ComputeL2Error(FCoef) < tol );
+         }
+         SECTION("Mapping to L2^d")
+         {
+            L2_FECollection    fec_l2(order_l2, dim);
+            FiniteElementSpace fespace_l2(&mesh, &fec_l2, dim);
+
+            GridFunction f2d(&fespace_l2);
+
+            DiscreteLinearOperator Op(&fespace_nd,&fespace_l2);
+            Op.AddDomainInterpolator(new IdentityInterpolator());
+            Op.Assemble();
+
+            Op.Mult(f1,f2d);
+
+            REQUIRE( f2d.ComputeL2Error(FCoef) < tol );
+         }
+         SECTION("Mapping to L2^d (INTEGRAL)")
+         {
+            L2_FECollection    fec_l2(order_l2, dim,
+                                      BasisType::GaussLegendre,
+                                      FiniteElement::INTEGRAL);
+            FiniteElementSpace fespace_l2(&mesh, &fec_l2, dim);
+
+            GridFunction f2d(&fespace_l2);
+
+            DiscreteLinearOperator Op(&fespace_nd,&fespace_l2);
+            Op.AddDomainInterpolator(new IdentityInterpolator());
+            Op.Assemble();
+
+            Op.Mult(f1,f2d);
+
+            REQUIRE( f2d.ComputeL2Error(FCoef) < tol );
+         }
+      }
+      SECTION("Operators on HDiv for element type " + std::to_string(type))
+      {
+         RT_FECollection    fec_rt(order_rt, dim);
+         FiniteElementSpace fespace_rt(&mesh, &fec_rt);
+
+         GridFunction f2(&fespace_rt);
+         f2.ProjectCoefficient(FCoef);
+
+         SECTION("Mapping to HDiv")
+         {
+            RT_FECollection    fec_rtp(order_rt+1, dim);
+            FiniteElementSpace fespace_rtp(&mesh, &fec_rtp);
+
+            GridFunction f2p(&fespace_rtp);
+
+            DiscreteLinearOperator Op(&fespace_rt,&fespace_rtp);
+            Op.AddDomainInterpolator(new IdentityInterpolator());
+            Op.Assemble();
+
+            Op.Mult(f2,f2p);
+
+            REQUIRE( f2p.ComputeL2Error(FCoef) < tol );
+         }
+         SECTION("Mapping to L2^d")
+         {
+            L2_FECollection    fec_l2(order_l2, dim);
+            FiniteElementSpace fespace_l2(&mesh, &fec_l2, dim);
+
+            GridFunction f2d(&fespace_l2);
+
+            DiscreteLinearOperator Op(&fespace_rt,&fespace_l2);
+            Op.AddDomainInterpolator(new IdentityInterpolator());
+            Op.Assemble();
+
+            Op.Mult(f2,f2d);
+
+            REQUIRE( f2d.ComputeL2Error(FCoef) < tol );
+         }
+         SECTION("Mapping to L2^d (INTEGRAL)")
+         {
+            L2_FECollection    fec_l2(order_l2, dim,
+                                      BasisType::GaussLegendre,
+                                      FiniteElement::INTEGRAL);
+            FiniteElementSpace fespace_l2(&mesh, &fec_l2, dim);
+
+            GridFunction f2d(&fespace_l2);
+
+            DiscreteLinearOperator Op(&fespace_rt,&fespace_l2);
+            Op.AddDomainInterpolator(new IdentityInterpolator());
+            Op.Assemble();
+
+            Op.Mult(f2,f2d);
+
+            REQUIRE( f2d.ComputeL2Error(FCoef) < tol );
+         }
+      }
+      SECTION("Operators on H1^d for element type " + std::to_string(type))
+      {
+         H1_FECollection    fec_h1(order_h1, dim);
+         FiniteElementSpace fespace_h1(&mesh, &fec_h1, dim);
+
+         GridFunction f0(&fespace_h1);
+         f0.ProjectCoefficient(FCoef);
+
+         SECTION("Mapping to HCurl")
+         {
+            ND_FECollection    fec_ndp(order_nd, dim);
+            FiniteElementSpace fespace_ndp(&mesh, &fec_ndp);
+
+            GridFunction f1(&fespace_ndp);
+
+            DiscreteLinearOperator Op(&fespace_h1,&fespace_ndp);
+            Op.AddDomainInterpolator(new IdentityInterpolator());
+            Op.Assemble();
+
+            Op.Mult(f0,f1);
+
+            REQUIRE( f1.ComputeL2Error(FCoef) < tol );
+         }
+         SECTION("Mapping to HDiv")
+         {
+            RT_FECollection    fec_rtp(order_rt, dim);
+            FiniteElementSpace fespace_rtp(&mesh, &fec_rtp);
+
+            GridFunction f2(&fespace_rtp);
+
+            DiscreteLinearOperator Op(&fespace_h1,&fespace_rtp);
+            Op.AddDomainInterpolator(new IdentityInterpolator());
+            Op.Assemble();
+
+            Op.Mult(f0,f2);
+
+            REQUIRE( f2.ComputeL2Error(FCoef) < tol );
+         }
+         /// The following tests would fail.  The reason for the
+         /// failure would not be obvious from the user's point of
+         /// view.  I recommend keeping these tests here as a reminder
+         /// that we should consider supporting this, or a very
+         /// similar, usage.
+         /*
+              SECTION("Mapping to L2^d")
+              {
+                 L2_FECollection    fec_l2(order_l2, dim);
+                 FiniteElementSpace fespace_l2(&mesh, &fec_l2, dim);
+
+                 GridFunction f2d(&fespace_l2);
+
+                 DiscreteLinearOperator Op(&fespace_h1,&fespace_l2);
+                 Op.AddDomainInterpolator(new IdentityInterpolator());
+                 Op.Assemble();
+
+                 Op.Mult(f0,f2d);
+
+                 REQUIRE( f2d.ComputeL2Error(FCoef) < tol );
+              }
+              SECTION("Mapping to L2^d (INTEGRAL)")
+              {
+                 L2_FECollection    fec_l2(order_l2, dim,
+                                           BasisType::GaussLegendre,
+                                           FiniteElement::INTEGRAL);
+                 FiniteElementSpace fespace_l2(&mesh, &fec_l2, dim);
+
+                 GridFunction f2d(&fespace_l2);
+
+                 DiscreteLinearOperator Op(&fespace_h1,&fespace_l2);
+                 Op.AddDomainInterpolator(new IdentityInterpolator());
+                 Op.Assemble();
+
+                 Op.Mult(f0,f2d);
+
+                 REQUIRE( f2d.ComputeL2Error(FCoef) < tol );
+              }
+         */
+      }
+   }
+}
+
+TEST_CASE("3D Identity Linear Interpolators",
+          "[IdentityInterpolator]")
+{
+   int order_h1 = 1, order_nd = 2, order_rt = 1, order_l2 = 1, n = 3, dim = 3;
+   double tol = 1e-9;
+
+   FunctionCoefficient     fCoef(f3);
+   VectorFunctionCoefficient FCoef(dim, F3);
+
+   for (int type = (int)Element::TETRAHEDRON;
+        type <= (int)Element::HEXAHEDRON; type++)
+   {
+      Mesh mesh(n, n, n, (Element::Type)type, 1, 2.0, 3.0, 5.0);
+
+      if (type == Element::TETRAHEDRON)
+      {
+         mesh.ReorientTetMesh();
+      }
+
+      SECTION("Operators on H1 for element type " + std::to_string(type))
+      {
+         H1_FECollection    fec_h1(order_h1, dim);
+         FiniteElementSpace fespace_h1(&mesh, &fec_h1);
+
+         GridFunction f0(&fespace_h1);
+         f0.ProjectCoefficient(fCoef);
+
+         SECTION("Mapping to H1")
+         {
+            H1_FECollection    fec_h1p(order_h1+1, dim);
+            FiniteElementSpace fespace_h1p(&mesh, &fec_h1p);
+
+            GridFunction f0p(&fespace_h1p);
+
+            DiscreteLinearOperator Op(&fespace_h1,&fespace_h1p);
+            Op.AddDomainInterpolator(new IdentityInterpolator());
+            Op.Assemble();
+
+            Op.Mult(f0,f0p);
+
+            REQUIRE( f0p.ComputeL2Error(fCoef) < tol );
+         }
+         SECTION("Mapping to L2")
+         {
+            L2_FECollection    fec_l2(order_l2, dim);
+            FiniteElementSpace fespace_l2(&mesh, &fec_l2);
+
+            GridFunction f1(&fespace_l2);
+
+            DiscreteLinearOperator Op(&fespace_h1,&fespace_l2);
+            Op.AddDomainInterpolator(new IdentityInterpolator());
+            Op.Assemble();
+
+            Op.Mult(f0,f1);
+
+            REQUIRE( f1.ComputeL2Error(fCoef) < tol );
+         }
+         SECTION("Mapping to L2 (INTEGRAL)")
+         {
+            L2_FECollection    fec_l2(order_l2, dim,
+                                      BasisType::GaussLegendre,
+                                      FiniteElement::INTEGRAL);
+            FiniteElementSpace fespace_l2(&mesh, &fec_l2);
+
+            GridFunction f1(&fespace_l2);
+
+            DiscreteLinearOperator Op(&fespace_h1,&fespace_l2);
+            Op.AddDomainInterpolator(new IdentityInterpolator());
+            Op.Assemble();
+
+            Op.Mult(f0,f1);
+
+            REQUIRE( f1.ComputeL2Error(fCoef) < tol );
+         }
+      }
+      SECTION("Operators on L2 for element type " + std::to_string(type))
+      {
+         L2_FECollection    fec_l2(order_l2, dim);
+         FiniteElementSpace fespace_l2(&mesh, &fec_l2);
+
+         GridFunction f0(&fespace_l2);
+         f0.ProjectCoefficient(fCoef);
+
+         SECTION("Mapping to L2")
+         {
+            L2_FECollection    fec_l2p(order_l2+1, dim);
+            FiniteElementSpace fespace_l2p(&mesh, &fec_l2p);
+
+            GridFunction f1(&fespace_l2p);
+
+            DiscreteLinearOperator Op(&fespace_l2,&fespace_l2p);
+            Op.AddDomainInterpolator(new IdentityInterpolator());
+            Op.Assemble();
+
+            Op.Mult(f0,f1);
+
+            REQUIRE( f1.ComputeL2Error(fCoef) < tol );
+         }
+         SECTION("Mapping to L2 (INTEGRAL)")
+         {
+            L2_FECollection    fec_l2p(order_l2+1, dim,
+                                       BasisType::GaussLegendre,
+                                       FiniteElement::INTEGRAL);
+            FiniteElementSpace fespace_l2p(&mesh, &fec_l2p);
+
+            GridFunction f1(&fespace_l2p);
+
+            DiscreteLinearOperator Op(&fespace_l2,&fespace_l2p);
+            Op.AddDomainInterpolator(new IdentityInterpolator());
+            Op.Assemble();
+
+            Op.Mult(f0,f1);
+
+            REQUIRE( f1.ComputeL2Error(fCoef) < tol );
+         }
+      }
+      SECTION("Operators on L2 (INTEGRAL) for element type " +
+              std::to_string(type))
+      {
+         L2_FECollection    fec_l2(order_l2, dim,
+                                   BasisType::GaussLegendre,
+                                   FiniteElement::INTEGRAL);
+         FiniteElementSpace fespace_l2(&mesh, &fec_l2);
+
+         GridFunction f0(&fespace_l2);
+         f0.ProjectCoefficient(fCoef);
+
+         SECTION("Mapping to L2")
+         {
+            L2_FECollection    fec_l2p(order_l2+1, dim);
+            FiniteElementSpace fespace_l2p(&mesh, &fec_l2p);
+
+            GridFunction f1(&fespace_l2p);
+
+            DiscreteLinearOperator Op(&fespace_l2,&fespace_l2p);
+            Op.AddDomainInterpolator(new IdentityInterpolator());
+            Op.Assemble();
+
+            Op.Mult(f0,f1);
+
+            REQUIRE( f1.ComputeL2Error(fCoef) < tol );
+         }
+         SECTION("Mapping to L2 (INTEGRAL)")
+         {
+            L2_FECollection    fec_l2p(order_l2+1, dim,
+                                       BasisType::GaussLegendre,
+                                       FiniteElement::INTEGRAL);
+            FiniteElementSpace fespace_l2p(&mesh, &fec_l2p);
+
+            GridFunction f1(&fespace_l2p);
+
+            DiscreteLinearOperator Op(&fespace_l2,&fespace_l2p);
+            Op.AddDomainInterpolator(new IdentityInterpolator());
+            Op.Assemble();
+
+            Op.Mult(f0,f1);
+
+            REQUIRE( f1.ComputeL2Error(fCoef) < tol );
+         }
+      }
+      SECTION("Operators on HCurl for element type " + std::to_string(type))
+      {
+         ND_FECollection    fec_nd(order_nd, dim);
+         FiniteElementSpace fespace_nd(&mesh, &fec_nd);
+
+         GridFunction f1(&fespace_nd);
+         f1.ProjectCoefficient(FCoef);
+
+         SECTION("Mapping to HCurl")
+         {
+            ND_FECollection    fec_ndp(order_nd+1, dim);
+            FiniteElementSpace fespace_ndp(&mesh, &fec_ndp);
+
+            GridFunction f1p(&fespace_ndp);
+
+            DiscreteLinearOperator Op(&fespace_nd,&fespace_ndp);
+            Op.AddDomainInterpolator(new IdentityInterpolator());
+            Op.Assemble();
+
+            Op.Mult(f1,f1p);
+
+            REQUIRE( f1p.ComputeL2Error(FCoef) < tol );
+         }
+         SECTION("Mapping to L2^d")
+         {
+            L2_FECollection    fec_l2(order_l2, dim);
+            FiniteElementSpace fespace_l2(&mesh, &fec_l2, dim);
+
+            GridFunction f2d(&fespace_l2);
+
+            DiscreteLinearOperator Op(&fespace_nd,&fespace_l2);
+            Op.AddDomainInterpolator(new IdentityInterpolator());
+            Op.Assemble();
+
+            Op.Mult(f1,f2d);
+
+            REQUIRE( f2d.ComputeL2Error(FCoef) < tol );
+         }
+         SECTION("Mapping to L2^d (INTEGRAL)")
+         {
+            L2_FECollection    fec_l2(order_l2, dim,
+                                      BasisType::GaussLegendre,
+                                      FiniteElement::INTEGRAL);
+            FiniteElementSpace fespace_l2(&mesh, &fec_l2, dim);
+
+            GridFunction f2d(&fespace_l2);
+
+            DiscreteLinearOperator Op(&fespace_nd,&fespace_l2);
+            Op.AddDomainInterpolator(new IdentityInterpolator());
+            Op.Assemble();
+
+            Op.Mult(f1,f2d);
+
+            REQUIRE( f2d.ComputeL2Error(FCoef) < tol );
+         }
+      }
+      SECTION("Operators on HDiv for element type " + std::to_string(type))
+      {
+         RT_FECollection    fec_rt(order_rt, dim);
+         FiniteElementSpace fespace_rt(&mesh, &fec_rt);
+
+         GridFunction f2(&fespace_rt);
+         f2.ProjectCoefficient(FCoef);
+
+         SECTION("Mapping to HDiv")
+         {
+            RT_FECollection    fec_rtp(order_rt+1, dim);
+            FiniteElementSpace fespace_rtp(&mesh, &fec_rtp);
+
+            GridFunction f2p(&fespace_rtp);
+
+            DiscreteLinearOperator Op(&fespace_rt,&fespace_rtp);
+            Op.AddDomainInterpolator(new IdentityInterpolator());
+            Op.Assemble();
+
+            Op.Mult(f2,f2p);
+
+            REQUIRE( f2p.ComputeL2Error(FCoef) < tol );
+         }
+         SECTION("Mapping to L2^d")
+         {
+            L2_FECollection    fec_l2(order_l2, dim);
+            FiniteElementSpace fespace_l2(&mesh, &fec_l2, dim);
+
+            GridFunction f2d(&fespace_l2);
+
+            DiscreteLinearOperator Op(&fespace_rt,&fespace_l2);
+            Op.AddDomainInterpolator(new IdentityInterpolator());
+            Op.Assemble();
+
+            Op.Mult(f2,f2d);
+
+            REQUIRE( f2d.ComputeL2Error(FCoef) < tol );
+         }
+         SECTION("Mapping to L2^d (INTEGRAL)")
+         {
+            L2_FECollection    fec_l2(order_l2, dim,
+                                      BasisType::GaussLegendre,
+                                      FiniteElement::INTEGRAL);
+            FiniteElementSpace fespace_l2(&mesh, &fec_l2, dim);
+
+            GridFunction f2d(&fespace_l2);
+
+            DiscreteLinearOperator Op(&fespace_rt,&fespace_l2);
+            Op.AddDomainInterpolator(new IdentityInterpolator());
+            Op.Assemble();
+
+            Op.Mult(f2,f2d);
+
+            REQUIRE( f2d.ComputeL2Error(FCoef) < tol );
+         }
+      }
+      SECTION("Operators on H1^d for element type " + std::to_string(type))
+      {
+         H1_FECollection    fec_h1(order_h1, dim);
+         FiniteElementSpace fespace_h1(&mesh, &fec_h1, dim);
+
+         GridFunction f0(&fespace_h1);
+         f0.ProjectCoefficient(FCoef);
+
+         SECTION("Mapping to HCurl")
+         {
+            ND_FECollection    fec_ndp(order_nd, dim);
+            FiniteElementSpace fespace_ndp(&mesh, &fec_ndp);
+
+            GridFunction f1(&fespace_ndp);
+
+            DiscreteLinearOperator Op(&fespace_h1,&fespace_ndp);
+            Op.AddDomainInterpolator(new IdentityInterpolator());
+            Op.Assemble();
+
+            Op.Mult(f0,f1);
+
+            REQUIRE( f1.ComputeL2Error(FCoef) < tol );
+         }
+         SECTION("Mapping to HDiv")
+         {
+            RT_FECollection    fec_rtp(order_rt, dim);
+            FiniteElementSpace fespace_rtp(&mesh, &fec_rtp);
+
+            GridFunction f2(&fespace_rtp);
+
+            DiscreteLinearOperator Op(&fespace_h1,&fespace_rtp);
+            Op.AddDomainInterpolator(new IdentityInterpolator());
+            Op.Assemble();
+
+            Op.Mult(f0,f2);
+
+            REQUIRE( f2.ComputeL2Error(FCoef) < tol );
+         }
+         /// The following tests would fail.  The reason for the
+         /// failure would not be obvious from the user's point of
+         /// view.  I recommend keeping these tests here as a reminder
+         /// that we should consider supporting this, or a very
+         /// similar, usage.
+         /*
+              SECTION("Mapping to L2^d")
+              {
+                 L2_FECollection    fec_l2(order_l2, dim);
+                 FiniteElementSpace fespace_l2(&mesh, &fec_l2, dim);
+
+                 GridFunction f2d(&fespace_l2);
+
+                 DiscreteLinearOperator Op(&fespace_h1,&fespace_l2);
+                 Op.AddDomainInterpolator(new IdentityInterpolator());
+                 Op.Assemble();
+
+                 Op.Mult(f0,f2d);
+
+                 REQUIRE( f2d.ComputeL2Error(FCoef) < tol );
+              }
+              SECTION("Mapping to L2^d (INTEGRAL)")
+              {
+                 L2_FECollection    fec_l2(order_l2, dim,
+                                           BasisType::GaussLegendre,
+                                           FiniteElement::INTEGRAL);
+                 FiniteElementSpace fespace_l2(&mesh, &fec_l2, dim);
+
+                 GridFunction f2d(&fespace_l2);
+
+                 DiscreteLinearOperator Op(&fespace_h1,&fespace_l2);
+                 Op.AddDomainInterpolator(new IdentityInterpolator());
+                 Op.Assemble();
+
+                 Op.Mult(f0,f2d);
+
+                 REQUIRE( f2d.ComputeL2Error(FCoef) < tol );
+              }
+         */
+      }
+   }
+}
+
+TEST_CASE("1D Derivative Linear Interpolators",
+          "[GradientInterpolator]")
+{
+   int order_h1 = 1, order_l2 = 0, n = 3, dim = 1;
+   double tol = 1e-9;
+
+   FunctionCoefficient     fCoef(f1);
+   FunctionCoefficient GradfCoef(Grad_f1);
+
+
+   for (int type = (int)Element::SEGMENT;
+        type <= (int)Element::SEGMENT; type++)
+   {
+      Mesh mesh(n, (Element::Type)type, 1, 2.0);
+
+      SECTION("Operators on H1 for element type " + std::to_string(type))
+      {
+         H1_FECollection    fec_h1(order_h1, dim);
+         FiniteElementSpace fespace_h1(&mesh, &fec_h1);
+
+         GridFunction f0(&fespace_h1);
+         f0.ProjectCoefficient(fCoef);
+
+         SECTION("Mapping to L2")
+         {
+            L2_FECollection    fec_l2(order_l2, dim);
+            FiniteElementSpace fespace_l2(&mesh, &fec_l2);
+
+            GridFunction df0(&fespace_l2);
+
+            DiscreteLinearOperator Op(&fespace_h1,&fespace_l2);
+            Op.AddDomainInterpolator(new GradientInterpolator());
+            Op.Assemble();
+
+            Op.Mult(f0,df0);
+
+            REQUIRE( df0.ComputeL2Error(GradfCoef) < tol );
+         }
+         SECTION("Mapping to L2 (INTEGRAL)")
+         {
+            L2_FECollection    fec_l2(order_l2, dim,
+                                      BasisType::GaussLegendre,
+                                      FiniteElement::INTEGRAL);
+            FiniteElementSpace fespace_l2(&mesh, &fec_l2);
+
+            GridFunction df0(&fespace_l2);
+
+            DiscreteLinearOperator Op(&fespace_h1,&fespace_l2);
+            Op.AddDomainInterpolator(new GradientInterpolator());
+            Op.Assemble();
+
+            Op.Mult(f0,df0);
+
+            REQUIRE( df0.ComputeL2Error(GradfCoef) < tol );
+         }
+      }
+   }
+}
+
+TEST_CASE("2D Derivative Linear Interpolators",
+          "[GradientInterpolator]"
+          "[CurlInterpolator]"
+          "[DivergenceInterpolator]")
+{
+   int order_h1 = 1, order_nd = 1, order_rt = 0, order_l2 = 0, n = 3, dim = 2;
+   double tol = 1e-9;
+
+   FunctionCoefficient       fCoef(f2);
+   VectorFunctionCoefficient FCoef(dim, F2);
+
+   VectorFunctionCoefficient GradfCoef(dim, Grad_f2);
+   FunctionCoefficient       CurlFCoef(CurlF2);
+   FunctionCoefficient       DivFCoef(DivF2);
+
+   for (int type = (int)Element::TRIANGLE;
+        type <= (int)Element::QUADRILATERAL; type++)
+   {
+      Mesh mesh(n, n, (Element::Type)type, 1, 2.0, 3.0);
+
+      SECTION("Operators on H1 for element type " + std::to_string(type))
+      {
+         H1_FECollection    fec_h1(order_h1, dim);
+         FiniteElementSpace fespace_h1(&mesh, &fec_h1);
+
+         GridFunction f0(&fespace_h1);
+         f0.ProjectCoefficient(fCoef);
+
+         SECTION("Mapping to HCurl")
+         {
+            ND_FECollection    fec_nd(order_nd, dim);
+            FiniteElementSpace fespace_nd(&mesh, &fec_nd);
+
+            GridFunction df0(&fespace_nd);
+
+            DiscreteLinearOperator Op(&fespace_h1,&fespace_nd);
+            Op.AddDomainInterpolator(new GradientInterpolator());
+            Op.Assemble();
+
+            Op.Mult(f0,df0);
+
+            REQUIRE( df0.ComputeL2Error(GradfCoef) < tol );
+         }
+      }
+      SECTION("Operators on HCurl for element type " + std::to_string(type))
+      {
+         ND_FECollection    fec_nd(order_nd, dim);
+         FiniteElementSpace fespace_nd(&mesh, &fec_nd);
+
+         GridFunction F1(&fespace_nd);
+         F1.ProjectCoefficient(FCoef);
+
+         SECTION("Mapping to L2 (INTEGRAL)")
+         {
+            L2_FECollection    fec_l2(order_l2, dim,
+                                      BasisType::GaussLegendre,
+                                      FiniteElement::INTEGRAL);
+            FiniteElementSpace fespace_l2(&mesh, &fec_l2);
+
+            GridFunction dF1(&fespace_l2);
+
+            DiscreteLinearOperator Op(&fespace_nd,&fespace_l2);
+            Op.AddDomainInterpolator(new CurlInterpolator());
+            Op.Assemble();
+
+            Op.Mult(F1,dF1);
+
+            REQUIRE( dF1.ComputeL2Error(CurlFCoef) < tol );
+         }
+      }
+      SECTION("Operators on HDiv for element type " + std::to_string(type))
+      {
+         RT_FECollection    fec_rt(order_rt, dim);
+         FiniteElementSpace fespace_rt(&mesh, &fec_rt);
+
+         GridFunction F2(&fespace_rt);
+         F2.ProjectCoefficient(FCoef);
+
+         SECTION("Mapping to L2")
+         {
+            L2_FECollection    fec_l2(order_l2, dim);
+            FiniteElementSpace fespace_l2(&mesh, &fec_l2);
+
+            GridFunction dF2(&fespace_l2);
+
+            DiscreteLinearOperator Op(&fespace_rt,&fespace_l2);
+            Op.AddDomainInterpolator(new DivergenceInterpolator());
+            Op.Assemble();
+
+            Op.Mult(F2,dF2);
+
+            REQUIRE( dF2.ComputeL2Error(DivFCoef) < tol );
+         }
+         SECTION("Mapping to L2 (INTEGRAL)")
+         {
+            L2_FECollection    fec_l2(order_l2, dim,
+                                      BasisType::GaussLegendre,
+                                      FiniteElement::INTEGRAL);
+            FiniteElementSpace fespace_l2(&mesh, &fec_l2);
+
+            GridFunction dF2(&fespace_l2);
+
+            DiscreteLinearOperator Op(&fespace_rt,&fespace_l2);
+            Op.AddDomainInterpolator(new DivergenceInterpolator());
+            Op.Assemble();
+
+            Op.Mult(F2,dF2);
+
+            REQUIRE( dF2.ComputeL2Error(DivFCoef) < tol );
+         }
+      }
+   }
+}
+
+TEST_CASE("3D Derivative Linear Interpolators",
+          "[GradientInterpolator]"
+          "[CurlInterpolator]"
+          "[DivergenceInterpolator]")
+{
+   int order_h1 = 1, order_nd = 1, order_rt = 0, order_l2 = 0, n = 3, dim = 3;
+   double tol = 1e-9;
+
+   FunctionCoefficient       fCoef(f3);
+   VectorFunctionCoefficient FCoef(dim, F3);
+
+   VectorFunctionCoefficient GradfCoef(dim, Grad_f3);
+   VectorFunctionCoefficient CurlFCoef(dim, CurlF3);
+   FunctionCoefficient       DivFCoef(DivF3);
+
+   for (int type = (int)Element::TETRAHEDRON;
+        type <= (int)Element::HEXAHEDRON; type++)
+   {
+      Mesh mesh(n, n, n, (Element::Type)type, 1, 2.0, 3.0, 5.0);
+
+      if (type == Element::TETRAHEDRON)
+      {
+         mesh.ReorientTetMesh();
+      }
+
+      SECTION("Operators on H1 for element type " + std::to_string(type))
+      {
+         H1_FECollection    fec_h1(order_h1, dim);
+         FiniteElementSpace fespace_h1(&mesh, &fec_h1);
+
+         GridFunction f0(&fespace_h1);
+         f0.ProjectCoefficient(fCoef);
+
+         SECTION("Mapping to HCurl")
+         {
+            ND_FECollection    fec_nd(order_nd, dim);
+            FiniteElementSpace fespace_nd(&mesh, &fec_nd);
+
+            GridFunction df0(&fespace_nd);
+
+            DiscreteLinearOperator Op(&fespace_h1,&fespace_nd);
+            Op.AddDomainInterpolator(new GradientInterpolator());
+            Op.Assemble();
+
+            Op.Mult(f0,df0);
+
+            REQUIRE( df0.ComputeL2Error(GradfCoef) < tol );
+         }
+      }
+      SECTION("Operators on HCurl for element type " + std::to_string(type))
+      {
+         ND_FECollection    fec_nd(order_nd, dim);
+         FiniteElementSpace fespace_nd(&mesh, &fec_nd);
+
+         GridFunction F1(&fespace_nd);
+         F1.ProjectCoefficient(FCoef);
+
+         SECTION("Mapping to HDiv")
+         {
+            RT_FECollection    fec_rt(order_rt, dim);
+            FiniteElementSpace fespace_rt(&mesh, &fec_rt);
+
+            GridFunction dF1(&fespace_rt);
+
+            DiscreteLinearOperator Op(&fespace_nd,&fespace_rt);
+            Op.AddDomainInterpolator(new CurlInterpolator());
+            Op.Assemble();
+
+            Op.Mult(F1,dF1);
+
+            REQUIRE( dF1.ComputeL2Error(CurlFCoef) < tol );
+         }
+      }
+      SECTION("Operators on HDiv for element type " + std::to_string(type))
+      {
+         RT_FECollection    fec_rt(order_rt, dim);
+         FiniteElementSpace fespace_rt(&mesh, &fec_rt);
+
+         GridFunction F2(&fespace_rt);
+         F2.ProjectCoefficient(FCoef);
+
+         SECTION("Mapping to L2")
+         {
+            L2_FECollection    fec_l2(order_l2, dim);
+            FiniteElementSpace fespace_l2(&mesh, &fec_l2);
+
+            GridFunction dF2(&fespace_l2);
+
+            DiscreteLinearOperator Op(&fespace_rt,&fespace_l2);
+            Op.AddDomainInterpolator(new DivergenceInterpolator());
+            Op.Assemble();
+
+            Op.Mult(F2,dF2);
+
+            REQUIRE( dF2.ComputeL2Error(DivFCoef) < tol );
+         }
+         SECTION("Mapping to L2 (INTEGRAL)")
+         {
+            L2_FECollection    fec_l2(order_l2, dim,
+                                      BasisType::GaussLegendre,
+                                      FiniteElement::INTEGRAL);
+            FiniteElementSpace fespace_l2(&mesh, &fec_l2);
+
+            GridFunction dF2(&fespace_l2);
+
+            DiscreteLinearOperator Op(&fespace_rt,&fespace_l2);
+            Op.AddDomainInterpolator(new DivergenceInterpolator());
+            Op.Assemble();
+
+            Op.Mult(F2,dF2);
+
+            REQUIRE( dF2.ComputeL2Error(DivFCoef) < tol );
+         }
+      }
+   }
+}
+
+TEST_CASE("3D Product Linear Interpolators",
+          "[ScalarProductInterpolator]"
+          "[VectorScalarProductInterpolator]"
+          "[ScalarVectorProductInterpolator]"
+          "[VectorCrossProductInterpolator]"
+          "[VectorInnerProductInterpolator]")
 {
    int order_h1 = 1, order_nd = 2, order_rt = 2, n = 3, dim = 3;
    double tol = 1e-9;
-
-   Mesh mesh(n, n, n, Element::HEXAHEDRON, 1, 2.0, 3.0, 5.0);
 
    FunctionCoefficient       fCoef(f3);
    VectorFunctionCoefficient FCoef(dim, F3);
@@ -78,145 +1166,156 @@ TEST_CASE("Linear Interpolators")
    VectorFunctionCoefficient  FgCoef(dim, Fg3);
    VectorFunctionCoefficient FxGCoef(dim, FcrossG3);
 
-   SECTION("Operators on H1")
+   for (int type = (int)Element::TETRAHEDRON;
+        type <= (int)Element::HEXAHEDRON; type++)
    {
-      H1_FECollection    fec_h1(order_h1, dim);
-      FiniteElementSpace fespace_h1(&mesh, &fec_h1);
+      Mesh mesh(n, n, n, (Element::Type)type, 1, 2.0, 3.0, 5.0);
 
-      GridFunction g0(&fespace_h1);
-      g0.ProjectCoefficient(gCoef);
-
-      SECTION("Mapping H1 to H1")
+      if (type == Element::TETRAHEDRON)
       {
-         GridFunction f0(&fespace_h1);
-         f0.ProjectCoefficient(fCoef);
-
-         H1_FECollection    fec_h1p(2*order_h1, dim);
-         FiniteElementSpace fespace_h1p(&mesh, &fec_h1p);
-
-         DiscreteLinearOperator Opf0(&fespace_h1,&fespace_h1p);
-         Opf0.AddDomainInterpolator(new ScalarProductInterpolator(fCoef));
-         Opf0.Assemble();
-
-         GridFunction fg0(&fespace_h1p);
-         Opf0.Mult(g0,fg0);
-
-         REQUIRE( fg0.ComputeL2Error(fgCoef) < tol );
+         mesh.ReorientTetMesh();
       }
-      SECTION("Mapping to HCurl")
-      {
-         ND_FECollection    fec_nd(order_nd, dim);
-         FiniteElementSpace fespace_nd(&mesh, &fec_nd);
 
-         GridFunction F1(&fespace_nd);
-         F1.ProjectCoefficient(FCoef);
-
-         ND_FECollection    fec_ndp(order_h1+order_nd, dim);
-         FiniteElementSpace fespace_ndp(&mesh, &fec_ndp);
-
-         DiscreteLinearOperator OpF1(&fespace_h1,&fespace_ndp);
-         OpF1.AddDomainInterpolator(new VectorScalarProductInterpolator(FCoef));
-         OpF1.Assemble();
-
-         GridFunction Fg1(&fespace_ndp);
-         OpF1.Mult(g0,Fg1);
-
-         REQUIRE( Fg1.ComputeL2Error(FgCoef) < tol );
-      }
-   }
-   SECTION("Operators on HCurl")
-   {
-      ND_FECollection    fec_nd(order_nd, dim);
-      FiniteElementSpace fespace_nd(&mesh, &fec_nd);
-
-      GridFunction G1(&fespace_nd);
-      G1.ProjectCoefficient(GCoef);
-
-      SECTION("Mapping HCurl to HCurl")
+      SECTION("Operators on H1 for element type " + std::to_string(type))
       {
          H1_FECollection    fec_h1(order_h1, dim);
          FiniteElementSpace fespace_h1(&mesh, &fec_h1);
 
-         GridFunction f0(&fespace_h1);
-         f0.ProjectCoefficient(fCoef);
+         GridFunction g0(&fespace_h1);
+         g0.ProjectCoefficient(gCoef);
 
-         ND_FECollection    fec_ndp(order_nd+order_h1, dim);
-         FiniteElementSpace fespace_ndp(&mesh, &fec_ndp);
+         SECTION("Mapping H1 to H1")
+         {
+            GridFunction f0(&fespace_h1);
+            f0.ProjectCoefficient(fCoef);
 
-         DiscreteLinearOperator Opf0(&fespace_nd,&fespace_ndp);
-         Opf0.AddDomainInterpolator(new ScalarVectorProductInterpolator(fCoef));
-         Opf0.Assemble();
+            H1_FECollection    fec_h1p(2*order_h1, dim);
+            FiniteElementSpace fespace_h1p(&mesh, &fec_h1p);
 
-         GridFunction fG1(&fespace_ndp);
-         Opf0.Mult(G1,fG1);
+            DiscreteLinearOperator Opf0(&fespace_h1,&fespace_h1p);
+            Opf0.AddDomainInterpolator(new ScalarProductInterpolator(fCoef));
+            Opf0.Assemble();
 
-         REQUIRE( fG1.ComputeL2Error(fGCoef) < tol );
+            GridFunction fg0(&fespace_h1p);
+            Opf0.Mult(g0,fg0);
+
+            REQUIRE( fg0.ComputeL2Error(fgCoef) < tol );
+         }
+         SECTION("Mapping to HCurl")
+         {
+            ND_FECollection    fec_nd(order_nd, dim);
+            FiniteElementSpace fespace_nd(&mesh, &fec_nd);
+
+            GridFunction F1(&fespace_nd);
+            F1.ProjectCoefficient(FCoef);
+
+            ND_FECollection    fec_ndp(order_h1+order_nd, dim);
+            FiniteElementSpace fespace_ndp(&mesh, &fec_ndp);
+
+            DiscreteLinearOperator OpF1(&fespace_h1,&fespace_ndp);
+            OpF1.AddDomainInterpolator(new VectorScalarProductInterpolator(FCoef));
+            OpF1.Assemble();
+
+            GridFunction Fg1(&fespace_ndp);
+            OpF1.Mult(g0,Fg1);
+
+            REQUIRE( Fg1.ComputeL2Error(FgCoef) < tol );
+         }
       }
-      SECTION("Mapping to HDiv")
-      {
-         GridFunction F1(&fespace_nd);
-         F1.ProjectCoefficient(FCoef);
-
-         RT_FECollection    fec_rtp(2*order_nd, dim);
-         FiniteElementSpace fespace_rtp(&mesh, &fec_rtp);
-
-         DiscreteLinearOperator OpF1(&fespace_nd,&fespace_rtp);
-         OpF1.AddDomainInterpolator(new VectorCrossProductInterpolator(FCoef));
-         OpF1.Assemble();
-
-         GridFunction FxG2(&fespace_rtp);
-         OpF1.Mult(G1,FxG2);
-
-         REQUIRE( FxG2.ComputeL2Error(FxGCoef) < tol );
-      }
-      SECTION("Mapping to L2")
-      {
-         RT_FECollection    fec_rt(order_rt, dim);
-         FiniteElementSpace fespace_rt(&mesh, &fec_rt);
-
-         GridFunction F2(&fespace_rt);
-         F2.ProjectCoefficient(FCoef);
-
-         L2_FECollection    fec_l2p(order_nd+order_rt, dim);
-         FiniteElementSpace fespace_l2p(&mesh, &fec_l2p);
-
-         DiscreteLinearOperator OpF2(&fespace_nd,&fespace_l2p);
-         OpF2.AddDomainInterpolator(new VectorInnerProductInterpolator(FCoef));
-         OpF2.Assemble();
-
-         GridFunction FG3(&fespace_l2p);
-         OpF2.Mult(G1,FG3);
-
-         REQUIRE( FG3.ComputeL2Error(FGCoef) < tol );
-      }
-   }
-   SECTION("Operators on HDiv")
-   {
-      RT_FECollection    fec_rt(order_rt, dim);
-      FiniteElementSpace fespace_rt(&mesh, &fec_rt);
-
-      GridFunction G2(&fespace_rt);
-      G2.ProjectCoefficient(GCoef);
-
-      SECTION("Mapping to L2")
+      SECTION("Operators on HCurl for element type " + std::to_string(type))
       {
          ND_FECollection    fec_nd(order_nd, dim);
          FiniteElementSpace fespace_nd(&mesh, &fec_nd);
 
-         GridFunction F1(&fespace_nd);
-         F1.ProjectCoefficient(FCoef);
+         GridFunction G1(&fespace_nd);
+         G1.ProjectCoefficient(GCoef);
 
-         L2_FECollection    fec_l2p(order_nd+order_rt, dim);
-         FiniteElementSpace fespace_l2p(&mesh, &fec_l2p);
+         SECTION("Mapping HCurl to HCurl")
+         {
+            H1_FECollection    fec_h1(order_h1, dim);
+            FiniteElementSpace fespace_h1(&mesh, &fec_h1);
 
-         DiscreteLinearOperator OpF1(&fespace_rt,&fespace_l2p);
-         OpF1.AddDomainInterpolator(new VectorInnerProductInterpolator(FCoef));
-         OpF1.Assemble();
+            GridFunction f0(&fespace_h1);
+            f0.ProjectCoefficient(fCoef);
 
-         GridFunction FG3(&fespace_l2p);
-         OpF1.Mult(G2,FG3);
+            ND_FECollection    fec_ndp(order_nd+order_h1, dim);
+            FiniteElementSpace fespace_ndp(&mesh, &fec_ndp);
 
-         REQUIRE( FG3.ComputeL2Error(FGCoef) < tol );
+            DiscreteLinearOperator Opf0(&fespace_nd,&fespace_ndp);
+            Opf0.AddDomainInterpolator(new ScalarVectorProductInterpolator(fCoef));
+            Opf0.Assemble();
+
+            GridFunction fG1(&fespace_ndp);
+            Opf0.Mult(G1,fG1);
+
+            REQUIRE( fG1.ComputeL2Error(fGCoef) < tol );
+         }
+         SECTION("Mapping to HDiv")
+         {
+            GridFunction F1(&fespace_nd);
+            F1.ProjectCoefficient(FCoef);
+
+            RT_FECollection    fec_rtp(2*order_nd, dim);
+            FiniteElementSpace fespace_rtp(&mesh, &fec_rtp);
+
+            DiscreteLinearOperator OpF1(&fespace_nd,&fespace_rtp);
+            OpF1.AddDomainInterpolator(new VectorCrossProductInterpolator(FCoef));
+            OpF1.Assemble();
+
+            GridFunction FxG2(&fespace_rtp);
+            OpF1.Mult(G1,FxG2);
+
+            REQUIRE( FxG2.ComputeL2Error(FxGCoef) < tol );
+         }
+         SECTION("Mapping to L2")
+         {
+            RT_FECollection    fec_rt(order_rt, dim);
+            FiniteElementSpace fespace_rt(&mesh, &fec_rt);
+
+            GridFunction F2(&fespace_rt);
+            F2.ProjectCoefficient(FCoef);
+
+            L2_FECollection    fec_l2p(order_nd+order_rt, dim);
+            FiniteElementSpace fespace_l2p(&mesh, &fec_l2p);
+
+            DiscreteLinearOperator OpF2(&fespace_nd,&fespace_l2p);
+            OpF2.AddDomainInterpolator(new VectorInnerProductInterpolator(FCoef));
+            OpF2.Assemble();
+
+            GridFunction FG3(&fespace_l2p);
+            OpF2.Mult(G1,FG3);
+
+            REQUIRE( FG3.ComputeL2Error(FGCoef) < tol );
+         }
+      }
+      SECTION("Operators on HDiv for element type " + std::to_string(type))
+      {
+         RT_FECollection    fec_rt(order_rt, dim);
+         FiniteElementSpace fespace_rt(&mesh, &fec_rt);
+
+         GridFunction G2(&fespace_rt);
+         G2.ProjectCoefficient(GCoef);
+
+         SECTION("Mapping to L2")
+         {
+            ND_FECollection    fec_nd(order_nd, dim);
+            FiniteElementSpace fespace_nd(&mesh, &fec_nd);
+
+            GridFunction F1(&fespace_nd);
+            F1.ProjectCoefficient(FCoef);
+
+            L2_FECollection    fec_l2p(order_nd+order_rt, dim);
+            FiniteElementSpace fespace_l2p(&mesh, &fec_l2p);
+
+            DiscreteLinearOperator OpF1(&fespace_rt,&fespace_l2p);
+            OpF1.AddDomainInterpolator(new VectorInnerProductInterpolator(FCoef));
+            OpF1.Assemble();
+
+            GridFunction FG3(&fespace_l2p);
+            OpF1.Mult(G2,FG3);
+
+            REQUIRE( FG3.ComputeL2Error(FGCoef) < tol );
+         }
       }
    }
 }

--- a/tests/unit/fem/test_lin_interp.cpp
+++ b/tests/unit/fem/test_lin_interp.cpp
@@ -641,6 +641,21 @@ TEST_CASE("Derivative Linear Interpolators",
 
             if (dim == 2)
             {
+               SECTION("Mapping to L2")
+               {
+                  L2_FECollection    fec_l2(order_l2, dim);
+                  FiniteElementSpace fespace_l2(mesh, &fec_l2);
+
+                  GridFunction dF1(&fespace_l2);
+
+                  DiscreteLinearOperator Op(&fespace_nd,&fespace_l2);
+                  Op.AddDomainInterpolator(new CurlInterpolator());
+                  Op.Assemble();
+
+                  Op.Mult(F1,dF1);
+
+                  REQUIRE( dF1.ComputeL2Error(curlFCoef) < tol );
+               }
                SECTION("Mapping to L2 (INTEGRAL)")
                {
                   L2_FECollection    fec_l2(order_l2, dim,

--- a/tests/unit/fem/test_lin_interp.cpp
+++ b/tests/unit/fem/test_lin_interp.cpp
@@ -106,434 +106,49 @@ double FdotG3(const Vector & x)
    return F * G;
 }
 
-TEST_CASE("1D Identity Linear Interpolators",
+TEST_CASE("Identity Linear Interpolators",
           "[IdentityInterpolator]")
 {
-   int order_h1 = 1, order_l2 = 1, n = 3, dim = 1;
+   int order_h1 = 1, order_nd = 2, order_rt = 1, order_l2 = 1, n = 3, dim = -1;
    double tol = 1e-9;
-
-   FunctionCoefficient     fCoef(f1);
 
    for (int type = (int)Element::SEGMENT;
-        type <= (int)Element::SEGMENT; type++)
-   {
-      Mesh mesh(n, (Element::Type)type, 1, 2.0);
-
-      SECTION("Operators on H1 for element type " + std::to_string(type))
-      {
-         H1_FECollection    fec_h1(order_h1, dim);
-         FiniteElementSpace fespace_h1(&mesh, &fec_h1);
-
-         GridFunction f0(&fespace_h1);
-         f0.ProjectCoefficient(fCoef);
-
-         SECTION("Mapping to L2")
-         {
-            L2_FECollection    fec_l2(order_l2, dim);
-            FiniteElementSpace fespace_l2(&mesh, &fec_l2);
-
-            GridFunction f1(&fespace_l2);
-
-            DiscreteLinearOperator Op(&fespace_h1,&fespace_l2);
-            Op.AddDomainInterpolator(new IdentityInterpolator());
-            Op.Assemble();
-
-            Op.Mult(f0,f1);
-
-            REQUIRE( f1.ComputeL2Error(fCoef) < tol );
-         }
-         SECTION("Mapping to L2 (INTEGRAL)")
-         {
-            L2_FECollection    fec_l2(order_l2, dim,
-                                      BasisType::GaussLegendre,
-                                      FiniteElement::INTEGRAL);
-            FiniteElementSpace fespace_l2(&mesh, &fec_l2);
-
-            GridFunction f1(&fespace_l2);
-
-            DiscreteLinearOperator Op(&fespace_h1,&fespace_l2);
-            Op.AddDomainInterpolator(new IdentityInterpolator());
-            Op.Assemble();
-
-            Op.Mult(f0,f1);
-
-            REQUIRE( f1.ComputeL2Error(fCoef) < tol );
-         }
-      }
-   }
-}
-
-TEST_CASE("2D Identity Linear Interpolators",
-          "[IdentityInterpolator]")
-{
-   int order_h1 = 1, order_nd = 2, order_rt = 1, order_l2 = 1, n = 3, dim = 2;
-   double tol = 1e-9;
-
-   FunctionCoefficient     fCoef(f2);
-   VectorFunctionCoefficient FCoef(dim, F2);
-
-   for (int type = (int)Element::TRIANGLE;
-        type <= (int)Element::QUADRILATERAL; type++)
-   {
-      Mesh mesh(n, n, (Element::Type)type, 1, 2.0, 3.0);
-
-      SECTION("Operators on H1 for element type " + std::to_string(type))
-      {
-         H1_FECollection    fec_h1(order_h1, dim);
-         FiniteElementSpace fespace_h1(&mesh, &fec_h1);
-
-         GridFunction f0(&fespace_h1);
-         f0.ProjectCoefficient(fCoef);
-
-         SECTION("Mapping to H1")
-         {
-            H1_FECollection    fec_h1p(order_h1+1, dim);
-            FiniteElementSpace fespace_h1p(&mesh, &fec_h1p);
-
-            GridFunction f0p(&fespace_h1p);
-
-            DiscreteLinearOperator Op(&fespace_h1,&fespace_h1p);
-            Op.AddDomainInterpolator(new IdentityInterpolator());
-            Op.Assemble();
-
-            Op.Mult(f0,f0p);
-
-            REQUIRE( f0p.ComputeL2Error(fCoef) < tol );
-         }
-         SECTION("Mapping to L2")
-         {
-            L2_FECollection    fec_l2(order_l2, dim);
-            FiniteElementSpace fespace_l2(&mesh, &fec_l2);
-
-            GridFunction f1(&fespace_l2);
-
-            DiscreteLinearOperator Op(&fespace_h1,&fespace_l2);
-            Op.AddDomainInterpolator(new IdentityInterpolator());
-            Op.Assemble();
-
-            Op.Mult(f0,f1);
-
-            REQUIRE( f1.ComputeL2Error(fCoef) < tol );
-         }
-         SECTION("Mapping to L2 (INTEGRAL)")
-         {
-            L2_FECollection    fec_l2(order_l2, dim,
-                                      BasisType::GaussLegendre,
-                                      FiniteElement::INTEGRAL);
-            FiniteElementSpace fespace_l2(&mesh, &fec_l2);
-
-            GridFunction f1(&fespace_l2);
-
-            DiscreteLinearOperator Op(&fespace_h1,&fespace_l2);
-            Op.AddDomainInterpolator(new IdentityInterpolator());
-            Op.Assemble();
-
-            Op.Mult(f0,f1);
-
-            REQUIRE( f1.ComputeL2Error(fCoef) < tol );
-         }
-      }
-      SECTION("Operators on L2 for element type " + std::to_string(type))
-      {
-         L2_FECollection    fec_l2(order_l2, dim);
-         FiniteElementSpace fespace_l2(&mesh, &fec_l2);
-
-         GridFunction f0(&fespace_l2);
-         f0.ProjectCoefficient(fCoef);
-
-         SECTION("Mapping to L2")
-         {
-            L2_FECollection    fec_l2p(order_l2+1, dim);
-            FiniteElementSpace fespace_l2p(&mesh, &fec_l2p);
-
-            GridFunction f1(&fespace_l2p);
-
-            DiscreteLinearOperator Op(&fespace_l2,&fespace_l2p);
-            Op.AddDomainInterpolator(new IdentityInterpolator());
-            Op.Assemble();
-
-            Op.Mult(f0,f1);
-
-            REQUIRE( f1.ComputeL2Error(fCoef) < tol );
-         }
-         SECTION("Mapping to L2 (INTEGRAL)")
-         {
-            L2_FECollection    fec_l2p(order_l2+1, dim,
-                                       BasisType::GaussLegendre,
-                                       FiniteElement::INTEGRAL);
-            FiniteElementSpace fespace_l2p(&mesh, &fec_l2p);
-
-            GridFunction f1(&fespace_l2p);
-
-            DiscreteLinearOperator Op(&fespace_l2,&fespace_l2p);
-            Op.AddDomainInterpolator(new IdentityInterpolator());
-            Op.Assemble();
-
-            Op.Mult(f0,f1);
-
-            REQUIRE( f1.ComputeL2Error(fCoef) < tol );
-         }
-      }
-      SECTION("Operators on L2 (INTEGRAL) for element type " +
-              std::to_string(type))
-      {
-         L2_FECollection    fec_l2(order_l2, dim,
-                                   BasisType::GaussLegendre,
-                                   FiniteElement::INTEGRAL);
-         FiniteElementSpace fespace_l2(&mesh, &fec_l2);
-
-         GridFunction f0(&fespace_l2);
-         f0.ProjectCoefficient(fCoef);
-
-         SECTION("Mapping to L2")
-         {
-            L2_FECollection    fec_l2p(order_l2+1, dim);
-            FiniteElementSpace fespace_l2p(&mesh, &fec_l2p);
-
-            GridFunction f1(&fespace_l2p);
-
-            DiscreteLinearOperator Op(&fespace_l2,&fespace_l2p);
-            Op.AddDomainInterpolator(new IdentityInterpolator());
-            Op.Assemble();
-
-            Op.Mult(f0,f1);
-
-            REQUIRE( f1.ComputeL2Error(fCoef) < tol );
-         }
-         SECTION("Mapping to L2 (INTEGRAL)")
-         {
-            L2_FECollection    fec_l2p(order_l2+1, dim,
-                                       BasisType::GaussLegendre,
-                                       FiniteElement::INTEGRAL);
-            FiniteElementSpace fespace_l2p(&mesh, &fec_l2p);
-
-            GridFunction f1(&fespace_l2p);
-
-            DiscreteLinearOperator Op(&fespace_l2,&fespace_l2p);
-            Op.AddDomainInterpolator(new IdentityInterpolator());
-            Op.Assemble();
-
-            Op.Mult(f0,f1);
-
-            REQUIRE( f1.ComputeL2Error(fCoef) < tol );
-         }
-      }
-      SECTION("Operators on HCurl for element type " + std::to_string(type))
-      {
-         ND_FECollection    fec_nd(order_nd, dim);
-         FiniteElementSpace fespace_nd(&mesh, &fec_nd);
-
-         GridFunction f1(&fespace_nd);
-         f1.ProjectCoefficient(FCoef);
-
-         SECTION("Mapping to HCurl")
-         {
-            ND_FECollection    fec_ndp(order_nd+1, dim);
-            FiniteElementSpace fespace_ndp(&mesh, &fec_ndp);
-
-            GridFunction f1p(&fespace_ndp);
-
-            DiscreteLinearOperator Op(&fespace_nd,&fespace_ndp);
-            Op.AddDomainInterpolator(new IdentityInterpolator());
-            Op.Assemble();
-
-            Op.Mult(f1,f1p);
-
-            REQUIRE( f1p.ComputeL2Error(FCoef) < tol );
-         }
-         SECTION("Mapping to L2^d")
-         {
-            L2_FECollection    fec_l2(order_l2, dim);
-            FiniteElementSpace fespace_l2(&mesh, &fec_l2, dim);
-
-            GridFunction f2d(&fespace_l2);
-
-            DiscreteLinearOperator Op(&fespace_nd,&fespace_l2);
-            Op.AddDomainInterpolator(new IdentityInterpolator());
-            Op.Assemble();
-
-            Op.Mult(f1,f2d);
-
-            REQUIRE( f2d.ComputeL2Error(FCoef) < tol );
-         }
-         SECTION("Mapping to L2^d (INTEGRAL)")
-         {
-            L2_FECollection    fec_l2(order_l2, dim,
-                                      BasisType::GaussLegendre,
-                                      FiniteElement::INTEGRAL);
-            FiniteElementSpace fespace_l2(&mesh, &fec_l2, dim);
-
-            GridFunction f2d(&fespace_l2);
-
-            DiscreteLinearOperator Op(&fespace_nd,&fespace_l2);
-            Op.AddDomainInterpolator(new IdentityInterpolator());
-            Op.Assemble();
-
-            Op.Mult(f1,f2d);
-
-            REQUIRE( f2d.ComputeL2Error(FCoef) < tol );
-         }
-      }
-      SECTION("Operators on HDiv for element type " + std::to_string(type))
-      {
-         RT_FECollection    fec_rt(order_rt, dim);
-         FiniteElementSpace fespace_rt(&mesh, &fec_rt);
-
-         GridFunction f2(&fespace_rt);
-         f2.ProjectCoefficient(FCoef);
-
-         SECTION("Mapping to HDiv")
-         {
-            RT_FECollection    fec_rtp(order_rt+1, dim);
-            FiniteElementSpace fespace_rtp(&mesh, &fec_rtp);
-
-            GridFunction f2p(&fespace_rtp);
-
-            DiscreteLinearOperator Op(&fespace_rt,&fespace_rtp);
-            Op.AddDomainInterpolator(new IdentityInterpolator());
-            Op.Assemble();
-
-            Op.Mult(f2,f2p);
-
-            REQUIRE( f2p.ComputeL2Error(FCoef) < tol );
-         }
-         SECTION("Mapping to L2^d")
-         {
-            L2_FECollection    fec_l2(order_l2, dim);
-            FiniteElementSpace fespace_l2(&mesh, &fec_l2, dim);
-
-            GridFunction f2d(&fespace_l2);
-
-            DiscreteLinearOperator Op(&fespace_rt,&fespace_l2);
-            Op.AddDomainInterpolator(new IdentityInterpolator());
-            Op.Assemble();
-
-            Op.Mult(f2,f2d);
-
-            REQUIRE( f2d.ComputeL2Error(FCoef) < tol );
-         }
-         SECTION("Mapping to L2^d (INTEGRAL)")
-         {
-            L2_FECollection    fec_l2(order_l2, dim,
-                                      BasisType::GaussLegendre,
-                                      FiniteElement::INTEGRAL);
-            FiniteElementSpace fespace_l2(&mesh, &fec_l2, dim);
-
-            GridFunction f2d(&fespace_l2);
-
-            DiscreteLinearOperator Op(&fespace_rt,&fespace_l2);
-            Op.AddDomainInterpolator(new IdentityInterpolator());
-            Op.Assemble();
-
-            Op.Mult(f2,f2d);
-
-            REQUIRE( f2d.ComputeL2Error(FCoef) < tol );
-         }
-      }
-      SECTION("Operators on H1^d for element type " + std::to_string(type))
-      {
-         H1_FECollection    fec_h1(order_h1, dim);
-         FiniteElementSpace fespace_h1(&mesh, &fec_h1, dim);
-
-         GridFunction f0(&fespace_h1);
-         f0.ProjectCoefficient(FCoef);
-
-         SECTION("Mapping to HCurl")
-         {
-            ND_FECollection    fec_ndp(order_nd, dim);
-            FiniteElementSpace fespace_ndp(&mesh, &fec_ndp);
-
-            GridFunction f1(&fespace_ndp);
-
-            DiscreteLinearOperator Op(&fespace_h1,&fespace_ndp);
-            Op.AddDomainInterpolator(new IdentityInterpolator());
-            Op.Assemble();
-
-            Op.Mult(f0,f1);
-
-            REQUIRE( f1.ComputeL2Error(FCoef) < tol );
-         }
-         SECTION("Mapping to HDiv")
-         {
-            RT_FECollection    fec_rtp(order_rt, dim);
-            FiniteElementSpace fespace_rtp(&mesh, &fec_rtp);
-
-            GridFunction f2(&fespace_rtp);
-
-            DiscreteLinearOperator Op(&fespace_h1,&fespace_rtp);
-            Op.AddDomainInterpolator(new IdentityInterpolator());
-            Op.Assemble();
-
-            Op.Mult(f0,f2);
-
-            REQUIRE( f2.ComputeL2Error(FCoef) < tol );
-         }
-         /// The following tests would fail.  The reason for the
-         /// failure would not be obvious from the user's point of
-         /// view.  I recommend keeping these tests here as a reminder
-         /// that we should consider supporting this, or a very
-         /// similar, usage.
-         /*
-              SECTION("Mapping to L2^d")
-              {
-                 L2_FECollection    fec_l2(order_l2, dim);
-                 FiniteElementSpace fespace_l2(&mesh, &fec_l2, dim);
-
-                 GridFunction f2d(&fespace_l2);
-
-                 DiscreteLinearOperator Op(&fespace_h1,&fespace_l2);
-                 Op.AddDomainInterpolator(new IdentityInterpolator());
-                 Op.Assemble();
-
-                 Op.Mult(f0,f2d);
-
-                 REQUIRE( f2d.ComputeL2Error(FCoef) < tol );
-              }
-              SECTION("Mapping to L2^d (INTEGRAL)")
-              {
-                 L2_FECollection    fec_l2(order_l2, dim,
-                                           BasisType::GaussLegendre,
-                                           FiniteElement::INTEGRAL);
-                 FiniteElementSpace fespace_l2(&mesh, &fec_l2, dim);
-
-                 GridFunction f2d(&fespace_l2);
-
-                 DiscreteLinearOperator Op(&fespace_h1,&fespace_l2);
-                 Op.AddDomainInterpolator(new IdentityInterpolator());
-                 Op.Assemble();
-
-                 Op.Mult(f0,f2d);
-
-                 REQUIRE( f2d.ComputeL2Error(FCoef) < tol );
-              }
-         */
-      }
-   }
-}
-
-TEST_CASE("3D Identity Linear Interpolators",
-          "[IdentityInterpolator]")
-{
-   int order_h1 = 1, order_nd = 2, order_rt = 1, order_l2 = 1, n = 3, dim = 3;
-   double tol = 1e-9;
-
-   FunctionCoefficient     fCoef(f3);
-   VectorFunctionCoefficient FCoef(dim, F3);
-
-   for (int type = (int)Element::TETRAHEDRON;
         type <= (int)Element::HEXAHEDRON; type++)
    {
-      Mesh mesh(n, n, n, (Element::Type)type, 1, 2.0, 3.0, 5.0);
+      Mesh *mesh = NULL;
 
-      if (type == Element::TETRAHEDRON)
+      if (type < (int)Element::TRIANGLE)
       {
-         mesh.ReorientTetMesh();
+         dim = 1;
+         mesh = new Mesh(n, (Element::Type)type, 1, 2.0);
+
       }
+      else if (type < (int)Element::TETRAHEDRON)
+      {
+         dim = 2;
+         mesh = new Mesh(n, n, (Element::Type)type, 1, 2.0, 3.0);
+      }
+      else
+      {
+         dim = 3;
+         mesh = new Mesh(n, n, n, (Element::Type)type, 1, 2.0, 3.0, 5.0);
+
+         if (type == Element::TETRAHEDRON)
+         {
+            mesh->ReorientTetMesh();
+         }
+      }
+
+      FunctionCoefficient        fCoef((dim==1) ? f1 :
+                                       ((dim==2) ? f2 : f3));
+      VectorFunctionCoefficient dfCoef(dim,
+                                       (dim==1) ? Grad_f1 :
+                                       ((dim==2)? Grad_f2 : Grad_f3));
 
       SECTION("Operators on H1 for element type " + std::to_string(type))
       {
          H1_FECollection    fec_h1(order_h1, dim);
-         FiniteElementSpace fespace_h1(&mesh, &fec_h1);
+         FiniteElementSpace fespace_h1(mesh, &fec_h1);
 
          GridFunction f0(&fespace_h1);
          f0.ProjectCoefficient(fCoef);
@@ -541,7 +156,7 @@ TEST_CASE("3D Identity Linear Interpolators",
          SECTION("Mapping to H1")
          {
             H1_FECollection    fec_h1p(order_h1+1, dim);
-            FiniteElementSpace fespace_h1p(&mesh, &fec_h1p);
+            FiniteElementSpace fespace_h1p(mesh, &fec_h1p);
 
             GridFunction f0p(&fespace_h1p);
 
@@ -551,12 +166,12 @@ TEST_CASE("3D Identity Linear Interpolators",
 
             Op.Mult(f0,f0p);
 
-            REQUIRE( f0p.ComputeL2Error(fCoef) < tol );
+            REQUIRE( f0p.ComputeH1Error(&fCoef, &dfCoef) < tol );
          }
          SECTION("Mapping to L2")
          {
             L2_FECollection    fec_l2(order_l2, dim);
-            FiniteElementSpace fespace_l2(&mesh, &fec_l2);
+            FiniteElementSpace fespace_l2(mesh, &fec_l2);
 
             GridFunction f1(&fespace_l2);
 
@@ -573,7 +188,7 @@ TEST_CASE("3D Identity Linear Interpolators",
             L2_FECollection    fec_l2(order_l2, dim,
                                       BasisType::GaussLegendre,
                                       FiniteElement::INTEGRAL);
-            FiniteElementSpace fespace_l2(&mesh, &fec_l2);
+            FiniteElementSpace fespace_l2(mesh, &fec_l2);
 
             GridFunction f1(&fespace_l2);
 
@@ -589,7 +204,7 @@ TEST_CASE("3D Identity Linear Interpolators",
       SECTION("Operators on L2 for element type " + std::to_string(type))
       {
          L2_FECollection    fec_l2(order_l2, dim);
-         FiniteElementSpace fespace_l2(&mesh, &fec_l2);
+         FiniteElementSpace fespace_l2(mesh, &fec_l2);
 
          GridFunction f0(&fespace_l2);
          f0.ProjectCoefficient(fCoef);
@@ -597,7 +212,7 @@ TEST_CASE("3D Identity Linear Interpolators",
          SECTION("Mapping to L2")
          {
             L2_FECollection    fec_l2p(order_l2+1, dim);
-            FiniteElementSpace fespace_l2p(&mesh, &fec_l2p);
+            FiniteElementSpace fespace_l2p(mesh, &fec_l2p);
 
             GridFunction f1(&fespace_l2p);
 
@@ -614,7 +229,7 @@ TEST_CASE("3D Identity Linear Interpolators",
             L2_FECollection    fec_l2p(order_l2+1, dim,
                                        BasisType::GaussLegendre,
                                        FiniteElement::INTEGRAL);
-            FiniteElementSpace fespace_l2p(&mesh, &fec_l2p);
+            FiniteElementSpace fespace_l2p(mesh, &fec_l2p);
 
             GridFunction f1(&fespace_l2p);
 
@@ -633,7 +248,7 @@ TEST_CASE("3D Identity Linear Interpolators",
          L2_FECollection    fec_l2(order_l2, dim,
                                    BasisType::GaussLegendre,
                                    FiniteElement::INTEGRAL);
-         FiniteElementSpace fespace_l2(&mesh, &fec_l2);
+         FiniteElementSpace fespace_l2(mesh, &fec_l2);
 
          GridFunction f0(&fespace_l2);
          f0.ProjectCoefficient(fCoef);
@@ -641,7 +256,7 @@ TEST_CASE("3D Identity Linear Interpolators",
          SECTION("Mapping to L2")
          {
             L2_FECollection    fec_l2p(order_l2+1, dim);
-            FiniteElementSpace fespace_l2p(&mesh, &fec_l2p);
+            FiniteElementSpace fespace_l2p(mesh, &fec_l2p);
 
             GridFunction f1(&fespace_l2p);
 
@@ -658,7 +273,7 @@ TEST_CASE("3D Identity Linear Interpolators",
             L2_FECollection    fec_l2p(order_l2+1, dim,
                                        BasisType::GaussLegendre,
                                        FiniteElement::INTEGRAL);
-            FiniteElementSpace fespace_l2p(&mesh, &fec_l2p);
+            FiniteElementSpace fespace_l2p(mesh, &fec_l2p);
 
             GridFunction f1(&fespace_l2p);
 
@@ -671,155 +286,164 @@ TEST_CASE("3D Identity Linear Interpolators",
             REQUIRE( f1.ComputeL2Error(fCoef) < tol );
          }
       }
-      SECTION("Operators on HCurl for element type " + std::to_string(type))
+      if (dim > 1)
       {
-         ND_FECollection    fec_nd(order_nd, dim);
-         FiniteElementSpace fespace_nd(&mesh, &fec_nd);
+         VectorFunctionCoefficient     FCoef(dim,
+                                             (dim==2) ? F2 : F3);
+         VectorFunctionCoefficient curlFCoef(dim,
+                                             (dim==2) ? CurlF2 : CurlF3);
+         FunctionCoefficient        divFCoef((dim==2) ? DivF2 : DivF3);
 
-         GridFunction f1(&fespace_nd);
-         f1.ProjectCoefficient(FCoef);
-
-         SECTION("Mapping to HCurl")
+         SECTION("Operators on HCurl for element type " + std::to_string(type))
          {
-            ND_FECollection    fec_ndp(order_nd+1, dim);
-            FiniteElementSpace fespace_ndp(&mesh, &fec_ndp);
+            ND_FECollection    fec_nd(order_nd, dim);
+            FiniteElementSpace fespace_nd(mesh, &fec_nd);
 
-            GridFunction f1p(&fespace_ndp);
+            GridFunction f1(&fespace_nd);
+            f1.ProjectCoefficient(FCoef);
 
-            DiscreteLinearOperator Op(&fespace_nd,&fespace_ndp);
-            Op.AddDomainInterpolator(new IdentityInterpolator());
-            Op.Assemble();
+            SECTION("Mapping to HCurl")
+            {
+               ND_FECollection    fec_ndp(order_nd+1, dim);
+               FiniteElementSpace fespace_ndp(mesh, &fec_ndp);
 
-            Op.Mult(f1,f1p);
+               GridFunction f1p(&fespace_ndp);
 
-            REQUIRE( f1p.ComputeL2Error(FCoef) < tol );
+               DiscreteLinearOperator Op(&fespace_nd,&fespace_ndp);
+               Op.AddDomainInterpolator(new IdentityInterpolator());
+               Op.Assemble();
+
+               Op.Mult(f1,f1p);
+
+               REQUIRE( f1p.ComputeHCurlError(&FCoef, &curlFCoef) < tol );
+            }
+            SECTION("Mapping to L2^d")
+            {
+               L2_FECollection    fec_l2(order_l2, dim);
+               FiniteElementSpace fespace_l2(mesh, &fec_l2, dim);
+
+               GridFunction f2d(&fespace_l2);
+
+               DiscreteLinearOperator Op(&fespace_nd,&fespace_l2);
+               Op.AddDomainInterpolator(new IdentityInterpolator());
+               Op.Assemble();
+
+               Op.Mult(f1,f2d);
+
+               REQUIRE( f2d.ComputeL2Error(FCoef) < tol );
+            }
+            SECTION("Mapping to L2^d (INTEGRAL)")
+            {
+               L2_FECollection    fec_l2(order_l2, dim,
+                                         BasisType::GaussLegendre,
+                                         FiniteElement::INTEGRAL);
+               FiniteElementSpace fespace_l2(mesh, &fec_l2, dim);
+
+               GridFunction f2d(&fespace_l2);
+
+               DiscreteLinearOperator Op(&fespace_nd,&fespace_l2);
+               Op.AddDomainInterpolator(new IdentityInterpolator());
+               Op.Assemble();
+
+               Op.Mult(f1,f2d);
+
+               REQUIRE( f2d.ComputeL2Error(FCoef) < tol );
+            }
          }
-         SECTION("Mapping to L2^d")
+         SECTION("Operators on HDiv for element type " + std::to_string(type))
          {
-            L2_FECollection    fec_l2(order_l2, dim);
-            FiniteElementSpace fespace_l2(&mesh, &fec_l2, dim);
+            RT_FECollection    fec_rt(order_rt, dim);
+            FiniteElementSpace fespace_rt(mesh, &fec_rt);
 
-            GridFunction f2d(&fespace_l2);
+            GridFunction f2(&fespace_rt);
+            f2.ProjectCoefficient(FCoef);
 
-            DiscreteLinearOperator Op(&fespace_nd,&fespace_l2);
-            Op.AddDomainInterpolator(new IdentityInterpolator());
-            Op.Assemble();
+            SECTION("Mapping to HDiv")
+            {
+               RT_FECollection    fec_rtp(order_rt+1, dim);
+               FiniteElementSpace fespace_rtp(mesh, &fec_rtp);
 
-            Op.Mult(f1,f2d);
+               GridFunction f2p(&fespace_rtp);
 
-            REQUIRE( f2d.ComputeL2Error(FCoef) < tol );
+               DiscreteLinearOperator Op(&fespace_rt,&fespace_rtp);
+               Op.AddDomainInterpolator(new IdentityInterpolator());
+               Op.Assemble();
+
+               Op.Mult(f2,f2p);
+
+               REQUIRE( f2p.ComputeHDivError(&FCoef, &divFCoef) < tol );
+            }
+            SECTION("Mapping to L2^d")
+            {
+               L2_FECollection    fec_l2(order_l2, dim);
+               FiniteElementSpace fespace_l2(mesh, &fec_l2, dim);
+
+               GridFunction f2d(&fespace_l2);
+
+               DiscreteLinearOperator Op(&fespace_rt,&fespace_l2);
+               Op.AddDomainInterpolator(new IdentityInterpolator());
+               Op.Assemble();
+
+               Op.Mult(f2,f2d);
+
+               REQUIRE( f2d.ComputeL2Error(FCoef) < tol );
+            }
+            SECTION("Mapping to L2^d (INTEGRAL)")
+            {
+               L2_FECollection    fec_l2(order_l2, dim,
+                                         BasisType::GaussLegendre,
+                                         FiniteElement::INTEGRAL);
+               FiniteElementSpace fespace_l2(mesh, &fec_l2, dim);
+
+               GridFunction f2d(&fespace_l2);
+
+               DiscreteLinearOperator Op(&fespace_rt,&fespace_l2);
+               Op.AddDomainInterpolator(new IdentityInterpolator());
+               Op.Assemble();
+
+               Op.Mult(f2,f2d);
+
+               REQUIRE( f2d.ComputeL2Error(FCoef) < tol );
+            }
          }
-         SECTION("Mapping to L2^d (INTEGRAL)")
+         SECTION("Operators on H1^d for element type " + std::to_string(type))
          {
-            L2_FECollection    fec_l2(order_l2, dim,
-                                      BasisType::GaussLegendre,
-                                      FiniteElement::INTEGRAL);
-            FiniteElementSpace fespace_l2(&mesh, &fec_l2, dim);
+            H1_FECollection    fec_h1(order_h1, dim);
+            FiniteElementSpace fespace_h1(mesh, &fec_h1, dim);
 
-            GridFunction f2d(&fespace_l2);
+            GridFunction f0(&fespace_h1);
+            f0.ProjectCoefficient(FCoef);
 
-            DiscreteLinearOperator Op(&fespace_nd,&fespace_l2);
-            Op.AddDomainInterpolator(new IdentityInterpolator());
-            Op.Assemble();
+            SECTION("Mapping to HCurl")
+            {
+               ND_FECollection    fec_ndp(order_nd, dim);
+               FiniteElementSpace fespace_ndp(mesh, &fec_ndp);
 
-            Op.Mult(f1,f2d);
+               GridFunction f1(&fespace_ndp);
 
-            REQUIRE( f2d.ComputeL2Error(FCoef) < tol );
-         }
-      }
-      SECTION("Operators on HDiv for element type " + std::to_string(type))
-      {
-         RT_FECollection    fec_rt(order_rt, dim);
-         FiniteElementSpace fespace_rt(&mesh, &fec_rt);
+               DiscreteLinearOperator Op(&fespace_h1,&fespace_ndp);
+               Op.AddDomainInterpolator(new IdentityInterpolator());
+               Op.Assemble();
 
-         GridFunction f2(&fespace_rt);
-         f2.ProjectCoefficient(FCoef);
+               Op.Mult(f0,f1);
 
-         SECTION("Mapping to HDiv")
-         {
-            RT_FECollection    fec_rtp(order_rt+1, dim);
-            FiniteElementSpace fespace_rtp(&mesh, &fec_rtp);
+               REQUIRE( f1.ComputeHCurlError(&FCoef, &curlFCoef) < tol );
+            }
+            SECTION("Mapping to HDiv")
+            {
+               RT_FECollection    fec_rtp(order_rt, dim);
+               FiniteElementSpace fespace_rtp(mesh, &fec_rtp);
 
-            GridFunction f2p(&fespace_rtp);
+               GridFunction f2(&fespace_rtp);
 
-            DiscreteLinearOperator Op(&fespace_rt,&fespace_rtp);
-            Op.AddDomainInterpolator(new IdentityInterpolator());
-            Op.Assemble();
+               DiscreteLinearOperator Op(&fespace_h1,&fespace_rtp);
+               Op.AddDomainInterpolator(new IdentityInterpolator());
+               Op.Assemble();
 
-            Op.Mult(f2,f2p);
+               Op.Mult(f0,f2);
 
-            REQUIRE( f2p.ComputeL2Error(FCoef) < tol );
-         }
-         SECTION("Mapping to L2^d")
-         {
-            L2_FECollection    fec_l2(order_l2, dim);
-            FiniteElementSpace fespace_l2(&mesh, &fec_l2, dim);
-
-            GridFunction f2d(&fespace_l2);
-
-            DiscreteLinearOperator Op(&fespace_rt,&fespace_l2);
-            Op.AddDomainInterpolator(new IdentityInterpolator());
-            Op.Assemble();
-
-            Op.Mult(f2,f2d);
-
-            REQUIRE( f2d.ComputeL2Error(FCoef) < tol );
-         }
-         SECTION("Mapping to L2^d (INTEGRAL)")
-         {
-            L2_FECollection    fec_l2(order_l2, dim,
-                                      BasisType::GaussLegendre,
-                                      FiniteElement::INTEGRAL);
-            FiniteElementSpace fespace_l2(&mesh, &fec_l2, dim);
-
-            GridFunction f2d(&fespace_l2);
-
-            DiscreteLinearOperator Op(&fespace_rt,&fespace_l2);
-            Op.AddDomainInterpolator(new IdentityInterpolator());
-            Op.Assemble();
-
-            Op.Mult(f2,f2d);
-
-            REQUIRE( f2d.ComputeL2Error(FCoef) < tol );
-         }
-      }
-      SECTION("Operators on H1^d for element type " + std::to_string(type))
-      {
-         H1_FECollection    fec_h1(order_h1, dim);
-         FiniteElementSpace fespace_h1(&mesh, &fec_h1, dim);
-
-         GridFunction f0(&fespace_h1);
-         f0.ProjectCoefficient(FCoef);
-
-         SECTION("Mapping to HCurl")
-         {
-            ND_FECollection    fec_ndp(order_nd, dim);
-            FiniteElementSpace fespace_ndp(&mesh, &fec_ndp);
-
-            GridFunction f1(&fespace_ndp);
-
-            DiscreteLinearOperator Op(&fespace_h1,&fespace_ndp);
-            Op.AddDomainInterpolator(new IdentityInterpolator());
-            Op.Assemble();
-
-            Op.Mult(f0,f1);
-
-            REQUIRE( f1.ComputeL2Error(FCoef) < tol );
-         }
-         SECTION("Mapping to HDiv")
-         {
-            RT_FECollection    fec_rtp(order_rt, dim);
-            FiniteElementSpace fespace_rtp(&mesh, &fec_rtp);
-
-            GridFunction f2(&fespace_rtp);
-
-            DiscreteLinearOperator Op(&fespace_h1,&fespace_rtp);
-            Op.AddDomainInterpolator(new IdentityInterpolator());
-            Op.Assemble();
-
-            Op.Mult(f0,f2);
-
-            REQUIRE( f2.ComputeL2Error(FCoef) < tol );
+               REQUIRE( f2.ComputeHDivError(&FCoef, &divFCoef) < tol );
+            }
          }
          /// The following tests would fail.  The reason for the
          /// failure would not be obvious from the user's point of
@@ -861,6 +485,7 @@ TEST_CASE("3D Identity Linear Interpolators",
               }
          */
       }
+      delete mesh;
    }
 }
 

--- a/tests/unit/fem/test_lin_interp.cpp
+++ b/tests/unit/fem/test_lin_interp.cpp
@@ -474,11 +474,10 @@ TEST_CASE("Identity Linear Interpolators",
                REQUIRE( f2.ComputeHDivError(&FCoef, &divFCoef) < tol );
             }
          }
-         /// The following tests would fail.  The reason for the
-         /// failure would not be obvious from the user's point of
-         /// view.  I recommend keeping these tests here as a reminder
-         /// that we should consider supporting this, or a very
-         /// similar, usage.
+         /// The following tests would fail. The reason for the failure would
+         /// not be obvious from the user's point of view. I recommend keeping
+         /// these tests here as a reminder that we should consider supporting
+         /// this, or a very similar, usage.
          /*
               SECTION("Mapping to L2^d")
               {

--- a/tests/unit/fem/test_lin_interp.cpp
+++ b/tests/unit/fem/test_lin_interp.cpp
@@ -18,7 +18,12 @@ namespace lin_interp
 {
 
 double f1(const Vector & x) { return 2.345 * x[0]; }
-double Grad_f1(const Vector & x) { return 2.345; }
+double grad_f1(const Vector & x) { return 2.345; }
+void Grad_f1(const Vector & x, Vector & df)
+{
+   df.SetSize(1);
+   df[0] = grad_f1(x);
+}
 
 double f2(const Vector & x) { return 2.345 * x[0] + 3.579 * x[1]; }
 void F2(const Vector & x, Vector & v)
@@ -34,7 +39,12 @@ void Grad_f2(const Vector & x, Vector & df)
    df[0] = 2.345;
    df[1] = 3.579;
 }
-double CurlF2(const Vector & x) { return 3.572 + 2.357; }
+double curlF2(const Vector & x) { return 3.572 + 2.357; }
+void CurlF2(const Vector & x, Vector & v)
+{
+   v.SetSize(1);
+   v[0] = curlF2(x);
+}
 double DivF2(const Vector & x) { return 1.234 + 4.321; }
 
 double f3(const Vector & x)
@@ -861,7 +871,7 @@ TEST_CASE("1D Derivative Linear Interpolators",
    double tol = 1e-9;
 
    FunctionCoefficient     fCoef(f1);
-   FunctionCoefficient GradfCoef(Grad_f1);
+   FunctionCoefficient GradfCoef(grad_f1);
 
 
    for (int type = (int)Element::SEGMENT;
@@ -925,7 +935,7 @@ TEST_CASE("2D Derivative Linear Interpolators",
    VectorFunctionCoefficient FCoef(dim, F2);
 
    VectorFunctionCoefficient GradfCoef(dim, Grad_f2);
-   FunctionCoefficient       CurlFCoef(CurlF2);
+   FunctionCoefficient       CurlFCoef(curlF2);
    FunctionCoefficient       DivFCoef(DivF2);
 
    for (int type = (int)Element::TRIANGLE;

--- a/tests/unit/fem/test_lin_interp.cpp
+++ b/tests/unit/fem/test_lin_interp.cpp
@@ -74,15 +74,44 @@ void CurlF3(const Vector & x, Vector & df)
 double DivF3(const Vector & x)
 { return 1.234 + 4.321 + 3.234; }
 
+double g1(const Vector & x) { return 4.234 * x[0]; }
+double g2(const Vector & x) { return 4.234 * x[0] + 3.357 * x[1]; }
 double g3(const Vector & x)
 { return 4.234 * x[0] + 3.357 * x[1] + 1.572 * x[2]; }
 
+void G2(const Vector & x, Vector & v)
+{
+   v.SetSize(2);
+   v[0] = 4.234 * x[0] + 3.357 * x[1];
+   v[1] = 4.537 * x[0] + 1.321 * x[1];
+}
 void G3(const Vector & x, Vector & v)
 {
    v.SetSize(3);
    v[0] = 4.234 * x[0] + 3.357 * x[1] + 1.572 * x[2];
    v[1] = 4.537 * x[0] + 1.321 * x[1] + 2.234 * x[2];
    v[2] = 1.572 * x[0] + 2.321 * x[1] + 3.234 * x[2];
+}
+
+double fg1(const Vector & x) { return f1(x) * g1(x); }
+
+double fg2(const Vector & x) { return f2(x) * g2(x); }
+void   fG2(const Vector & x, Vector & v) { G2(x, v); v *= f2(x); }
+void   Fg2(const Vector & x, Vector & v) { F2(x, v); v *= g2(x); }
+
+void FcrossG2(const Vector & x, Vector & FxG)
+{
+   Vector F; F2(x, F);
+   Vector G; G2(x, G);
+   FxG.SetSize(1);
+   FxG(0) = F(0) * G(1) - F(1) * G(0);
+}
+
+double FdotG2(const Vector & x)
+{
+   Vector F; F2(x, F);
+   Vector G; G2(x, G);
+   return F * G;
 }
 
 double fg3(const Vector & x) { return f3(x) * g3(x); }
@@ -696,56 +725,77 @@ TEST_CASE("Derivative Linear Interpolators",
    }
 }
 
-TEST_CASE("3D Product Linear Interpolators",
+TEST_CASE("Product Linear Interpolators",
           "[ScalarProductInterpolator]"
           "[VectorScalarProductInterpolator]"
           "[ScalarVectorProductInterpolator]"
+          "[ScalarCrossProductInterpolator]"
           "[VectorCrossProductInterpolator]"
           "[VectorInnerProductInterpolator]")
 {
-   int order_h1 = 1, order_nd = 2, order_rt = 2, n = 3, dim = 3;
+   int order_h1 = 1, order_nd = 2, order_rt = 2, n = 3, dim = -1;
    double tol = 1e-9;
 
-   FunctionCoefficient       fCoef(f3);
-   VectorFunctionCoefficient FCoef(dim, F3);
-
-   FunctionCoefficient       gCoef(g3);
-   VectorFunctionCoefficient GCoef(dim, G3);
-
-   FunctionCoefficient        fgCoef(fg3);
-   FunctionCoefficient        FGCoef(FdotG3);
-   VectorFunctionCoefficient  fGCoef(dim, fG3);
-   VectorFunctionCoefficient  FgCoef(dim, Fg3);
-   VectorFunctionCoefficient FxGCoef(dim, FcrossG3);
-
-   for (int type = (int)Element::TETRAHEDRON;
+   for (int type = (int)Element::SEGMENT;
         type <= (int)Element::HEXAHEDRON; type++)
    {
-      Mesh mesh(n, n, n, (Element::Type)type, 1, 2.0, 3.0, 5.0);
+      Mesh *mesh = NULL;
 
-      if (type == Element::TETRAHEDRON)
+      if (type < (int)Element::TRIANGLE)
       {
-         mesh.ReorientTetMesh();
+         dim = 1;
+         mesh = new Mesh(n, (Element::Type)type, 1, 2.0);
+
       }
+      else if (type < (int)Element::TETRAHEDRON)
+      {
+         dim = 2;
+         mesh = new Mesh(n, n, (Element::Type)type, 1, 2.0, 3.0);
+      }
+      else
+      {
+         dim = 3;
+         mesh = new Mesh(n, n, n, (Element::Type)type, 1, 2.0, 3.0, 5.0);
+
+         if (type == Element::TETRAHEDRON)
+         {
+            mesh->ReorientTetMesh();
+         }
+      }
+
+      FunctionCoefficient        fCoef((dim==1) ? f1 :
+                                       ((dim==2) ? f2 : f3));
+      FunctionCoefficient        gCoef((dim==1) ? g1 :
+                                       ((dim==2) ? g2 : g3));
+      FunctionCoefficient        fgCoef((dim==1) ? fg1 :
+                                        ((dim==2) ? fg2 : fg3));
+
+      VectorFunctionCoefficient   FCoef(dim,
+                                        (dim==2) ? F2 : F3);
+      VectorFunctionCoefficient   GCoef(dim,
+                                        (dim==2) ? G2 : G3);
+
+      FunctionCoefficient        FGCoef((dim==2) ? FdotG2 : FdotG3);
+      VectorFunctionCoefficient  fGCoef(dim, (dim==2) ? fG2 : fG3);
+      VectorFunctionCoefficient  FgCoef(dim, (dim==2) ? Fg2 : Fg3);
+      VectorFunctionCoefficient FxGCoef(dim, (dim==2) ? FcrossG2 : FcrossG3);
 
       SECTION("Operators on H1 for element type " + std::to_string(type))
       {
          H1_FECollection    fec_h1(order_h1, dim);
-         FiniteElementSpace fespace_h1(&mesh, &fec_h1);
+         FiniteElementSpace fespace_h1(mesh, &fec_h1);
 
          GridFunction g0(&fespace_h1);
          g0.ProjectCoefficient(gCoef);
 
          SECTION("Mapping H1 to H1")
          {
-            GridFunction f0(&fespace_h1);
-            f0.ProjectCoefficient(fCoef);
-
             H1_FECollection    fec_h1p(2*order_h1, dim);
-            FiniteElementSpace fespace_h1p(&mesh, &fec_h1p);
+            FiniteElementSpace fespace_h1p(mesh, &fec_h1p);
 
             DiscreteLinearOperator Opf0(&fespace_h1,&fespace_h1p);
-            Opf0.AddDomainInterpolator(new ScalarProductInterpolator(fCoef));
+            Opf0.AddDomainInterpolator(
+               new ScalarProductInterpolator(fCoef));
             Opf0.Assemble();
 
             GridFunction fg0(&fespace_h1p);
@@ -753,120 +803,137 @@ TEST_CASE("3D Product Linear Interpolators",
 
             REQUIRE( fg0.ComputeL2Error(fgCoef) < tol );
          }
-         SECTION("Mapping to HCurl")
+         if (dim > 1)
          {
-            ND_FECollection    fec_nd(order_nd, dim);
-            FiniteElementSpace fespace_nd(&mesh, &fec_nd);
+            SECTION("Mapping to HCurl")
+            {
+               ND_FECollection    fec_nd(order_nd, dim);
+               FiniteElementSpace fespace_nd(mesh, &fec_nd);
 
-            GridFunction F1(&fespace_nd);
-            F1.ProjectCoefficient(FCoef);
+               ND_FECollection    fec_ndp(order_h1+order_nd, dim);
+               FiniteElementSpace fespace_ndp(mesh, &fec_ndp);
 
-            ND_FECollection    fec_ndp(order_h1+order_nd, dim);
-            FiniteElementSpace fespace_ndp(&mesh, &fec_ndp);
+               DiscreteLinearOperator OpF1(&fespace_h1,&fespace_ndp);
+               OpF1.AddDomainInterpolator(
+                  new VectorScalarProductInterpolator(FCoef));
+               OpF1.Assemble();
 
-            DiscreteLinearOperator OpF1(&fespace_h1,&fespace_ndp);
-            OpF1.AddDomainInterpolator(new VectorScalarProductInterpolator(FCoef));
-            OpF1.Assemble();
+               GridFunction Fg1(&fespace_ndp);
+               OpF1.Mult(g0,Fg1);
 
-            GridFunction Fg1(&fespace_ndp);
-            OpF1.Mult(g0,Fg1);
-
-            REQUIRE( Fg1.ComputeL2Error(FgCoef) < tol );
+               REQUIRE( Fg1.ComputeL2Error(FgCoef) < tol );
+            }
          }
       }
-      SECTION("Operators on HCurl for element type " + std::to_string(type))
+      if (dim > 1)
       {
-         ND_FECollection    fec_nd(order_nd, dim);
-         FiniteElementSpace fespace_nd(&mesh, &fec_nd);
-
-         GridFunction G1(&fespace_nd);
-         G1.ProjectCoefficient(GCoef);
-
-         SECTION("Mapping HCurl to HCurl")
+         SECTION("Operators on HCurl for element type " + std::to_string(type))
          {
-            H1_FECollection    fec_h1(order_h1, dim);
-            FiniteElementSpace fespace_h1(&mesh, &fec_h1);
+            ND_FECollection    fec_nd(order_nd, dim);
+            FiniteElementSpace fespace_nd(mesh, &fec_nd);
 
-            GridFunction f0(&fespace_h1);
-            f0.ProjectCoefficient(fCoef);
+            GridFunction G1(&fespace_nd);
+            G1.ProjectCoefficient(GCoef);
 
-            ND_FECollection    fec_ndp(order_nd+order_h1, dim);
-            FiniteElementSpace fespace_ndp(&mesh, &fec_ndp);
+            SECTION("Mapping HCurl to HCurl")
+            {
+               H1_FECollection    fec_h1(order_h1, dim);
+               FiniteElementSpace fespace_h1(mesh, &fec_h1);
 
-            DiscreteLinearOperator Opf0(&fespace_nd,&fespace_ndp);
-            Opf0.AddDomainInterpolator(new ScalarVectorProductInterpolator(fCoef));
-            Opf0.Assemble();
+               ND_FECollection    fec_ndp(order_nd+order_h1, dim);
+               FiniteElementSpace fespace_ndp(mesh, &fec_ndp);
 
-            GridFunction fG1(&fespace_ndp);
-            Opf0.Mult(G1,fG1);
+               DiscreteLinearOperator Opf0(&fespace_nd,&fespace_ndp);
+               Opf0.AddDomainInterpolator(
+                  new ScalarVectorProductInterpolator(fCoef));
+               Opf0.Assemble();
 
-            REQUIRE( fG1.ComputeL2Error(fGCoef) < tol );
+               GridFunction fG1(&fespace_ndp);
+               Opf0.Mult(G1,fG1);
+
+               REQUIRE( fG1.ComputeL2Error(fGCoef) < tol );
+            }
+            if (dim == 2)
+            {
+               SECTION("Mapping to L2")
+               {
+                  L2_FECollection    fec_l2p(2*order_nd-1, dim);
+                  FiniteElementSpace fespace_l2p(mesh, &fec_l2p);
+
+                  DiscreteLinearOperator OpF1(&fespace_nd,&fespace_l2p);
+                  OpF1.AddDomainInterpolator(
+                     new ScalarCrossProductInterpolator(FCoef));
+                  OpF1.Assemble();
+
+                  GridFunction FxG2(&fespace_l2p);
+                  OpF1.Mult(G1,FxG2);
+
+                  REQUIRE( FxG2.ComputeL2Error(FxGCoef) < tol );
+               }
+            }
+            else
+            {
+               SECTION("Mapping to HDiv")
+               {
+                  RT_FECollection    fec_rtp(2*order_nd-1, dim);
+                  FiniteElementSpace fespace_rtp(mesh, &fec_rtp);
+
+                  DiscreteLinearOperator OpF1(&fespace_nd,&fespace_rtp);
+                  OpF1.AddDomainInterpolator(
+                     new VectorCrossProductInterpolator(FCoef));
+                  OpF1.Assemble();
+
+                  GridFunction FxG2(&fespace_rtp);
+                  OpF1.Mult(G1,FxG2);
+
+                  REQUIRE( FxG2.ComputeL2Error(FxGCoef) < tol );
+               }
+            }
+            SECTION("Mapping to L2")
+            {
+               RT_FECollection    fec_rt(order_rt, dim);
+               FiniteElementSpace fespace_rt(mesh, &fec_rt);
+
+               L2_FECollection    fec_l2p(order_nd+order_rt, dim);
+               FiniteElementSpace fespace_l2p(mesh, &fec_l2p);
+
+               DiscreteLinearOperator OpF2(&fespace_nd,&fespace_l2p);
+               OpF2.AddDomainInterpolator(
+                  new VectorInnerProductInterpolator(FCoef));
+               OpF2.Assemble();
+
+               GridFunction FG3(&fespace_l2p);
+               OpF2.Mult(G1,FG3);
+
+               REQUIRE( FG3.ComputeL2Error(FGCoef) < tol );
+            }
          }
-         SECTION("Mapping to HDiv")
-         {
-            GridFunction F1(&fespace_nd);
-            F1.ProjectCoefficient(FCoef);
-
-            RT_FECollection    fec_rtp(2*order_nd, dim);
-            FiniteElementSpace fespace_rtp(&mesh, &fec_rtp);
-
-            DiscreteLinearOperator OpF1(&fespace_nd,&fespace_rtp);
-            OpF1.AddDomainInterpolator(new VectorCrossProductInterpolator(FCoef));
-            OpF1.Assemble();
-
-            GridFunction FxG2(&fespace_rtp);
-            OpF1.Mult(G1,FxG2);
-
-            REQUIRE( FxG2.ComputeL2Error(FxGCoef) < tol );
-         }
-         SECTION("Mapping to L2")
+         SECTION("Operators on HDiv for element type " + std::to_string(type))
          {
             RT_FECollection    fec_rt(order_rt, dim);
-            FiniteElementSpace fespace_rt(&mesh, &fec_rt);
+            FiniteElementSpace fespace_rt(mesh, &fec_rt);
 
-            GridFunction F2(&fespace_rt);
-            F2.ProjectCoefficient(FCoef);
+            GridFunction G2(&fespace_rt);
+            G2.ProjectCoefficient(GCoef);
 
-            L2_FECollection    fec_l2p(order_nd+order_rt, dim);
-            FiniteElementSpace fespace_l2p(&mesh, &fec_l2p);
+            SECTION("Mapping to L2")
+            {
+               ND_FECollection    fec_nd(order_nd, dim);
+               FiniteElementSpace fespace_nd(mesh, &fec_nd);
 
-            DiscreteLinearOperator OpF2(&fespace_nd,&fespace_l2p);
-            OpF2.AddDomainInterpolator(new VectorInnerProductInterpolator(FCoef));
-            OpF2.Assemble();
+               L2_FECollection    fec_l2p(order_nd+order_rt, dim);
+               FiniteElementSpace fespace_l2p(mesh, &fec_l2p);
 
-            GridFunction FG3(&fespace_l2p);
-            OpF2.Mult(G1,FG3);
+               DiscreteLinearOperator OpF1(&fespace_rt,&fespace_l2p);
+               OpF1.AddDomainInterpolator(
+                  new VectorInnerProductInterpolator(FCoef));
+               OpF1.Assemble();
 
-            REQUIRE( FG3.ComputeL2Error(FGCoef) < tol );
-         }
-      }
-      SECTION("Operators on HDiv for element type " + std::to_string(type))
-      {
-         RT_FECollection    fec_rt(order_rt, dim);
-         FiniteElementSpace fespace_rt(&mesh, &fec_rt);
+               GridFunction FG3(&fespace_l2p);
+               OpF1.Mult(G2,FG3);
 
-         GridFunction G2(&fespace_rt);
-         G2.ProjectCoefficient(GCoef);
-
-         SECTION("Mapping to L2")
-         {
-            ND_FECollection    fec_nd(order_nd, dim);
-            FiniteElementSpace fespace_nd(&mesh, &fec_nd);
-
-            GridFunction F1(&fespace_nd);
-            F1.ProjectCoefficient(FCoef);
-
-            L2_FECollection    fec_l2p(order_nd+order_rt, dim);
-            FiniteElementSpace fespace_l2p(&mesh, &fec_l2p);
-
-            DiscreteLinearOperator OpF1(&fespace_rt,&fespace_l2p);
-            OpF1.AddDomainInterpolator(new VectorInnerProductInterpolator(FCoef));
-            OpF1.Assemble();
-
-            GridFunction FG3(&fespace_l2p);
-            OpF1.Mult(G2,FG3);
-
-            REQUIRE( FG3.ComputeL2Error(FGCoef) < tol );
+               REQUIRE( FG3.ComputeL2Error(FGCoef) < tol );
+            }
          }
       }
    }


### PR DESCRIPTION
Broaden the testing of the linear interpolators to include the `IdentityInterpolator` and the `Grad`, `Curl`, and `Div` interpolators.  Also expanded these unit tests to validate the relevant operators on various element types.

The impetus for this was the discovery of limitations involving `L2` elements with `INTEGRAL` finite element type and also mapping to vector finite element types from either `ND`, `RT`, or vector versions of `H1` or `L2`.

Support for the various combinations of finite elements when using the `IdentityInterpolator` is still not complete.  Specifically, mapping to `H1^d` or `L2^d` is not currently possible and adding this support seems to be nontrivial. 

<!--GHEX{"id":1931,"author":"mlstowell","editor":"tzanio","reviewers":["dylan-copeland","psocratis"],"assignment":"2020-12-15T18:24:50-08:00","approval":"2021-01-04T16:43:26.932Z","merge":"2021-01-12T23:58:05.183Z"}XEHG--><!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge| 
 | --- | --- | --- | --- | --- | --- | --- | 
| [#1931](https://github.com/mfem/mfem/pull/1931) | @mlstowell | @tzanio | @dylan-copeland + @psocratis | 12/15/20 | 01/04/21 | 01/12/21 | |
<!--ELBATXEHG-->