### PR TITLE
CMake update

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,8 @@
 # terms of the BSD-3 license. We welcome feedback and contributions, see file
 # CONTRIBUTING.md for details.
 
-cmake_minimum_required(VERSION 2.8.11)
+# The variable CMAKE_CXX_STANDARD and related were introduced in CMake v3.1
+cmake_minimum_required(VERSION 3.1)
 set(USER_CONFIG "${CMAKE_CURRENT_SOURCE_DIR}/config/user.cmake" CACHE PATH
   "Path to optional user configuration file.")
 

--- a/config/cmake/modules/MfemCmakeUtilities.cmake
+++ b/config/cmake/modules/MfemCmakeUtilities.cmake
@@ -754,7 +754,13 @@ function(mfem_export_mk_files)
   set(MFEM_CXX ${CMAKE_CXX_COMPILER})
   set(MFEM_HOST_CXX ${MFEM_CXX})
   set(MFEM_CPPFLAGS "")
-  string(STRIP "${CMAKE_CXX_FLAGS_${BUILD_TYPE}} ${CMAKE_CXX_FLAGS}"
+  get_target_property(cxx_std mfem CXX_STANDARD)
+  # For now, we ignore the setting of the CXX_EXTENSIONS property. If this
+  # property is set, then we need to use a variable like:
+  #    CMAKE_CXX11_EXTENSION_COMPILE_OPTION
+  set(cxx_std_flag ${CMAKE_CXX${cxx_std}_STANDARD_COMPILE_OPTION})
+  string(STRIP
+         "${cxx_std_flag} ${CMAKE_CXX_FLAGS_${BUILD_TYPE}} ${CMAKE_CXX_FLAGS}"
          MFEM_CXXFLAGS)
   set(MFEM_TPLFLAGS "")
   foreach(dir ${MFEM_TPL_INCLUDE_DIRS})


### PR DESCRIPTION
Make sure CMake exports the C++ language flag to config.mk.

Bump the minimum CMake version requirement to 3.1.

Reported by: @kanye-quest

<!--GHEX{"id":1934,"author":"v-dobrev","editor":"tzanio","reviewers":["tzanio","jandrej"],"assignment":"2020-12-09T08:20:48-08:00","approval":"2020-12-09T16:56:58.153Z","merge":"2020-12-15T21:26:52.229Z"}XEHG--><!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge| 
 | --- | --- | --- | --- | --- | --- | --- | 
| [#1934](https://github.com/mfem/mfem/pull/1934) | @v-dobrev | @tzanio | @tzanio + @jandrej | 12/09/20 | 12/09/20 | 12/15/20 | |
<!--ELBATXEHG-->