### PR TITLE
segfault in CheckElementOrientation method

### DIFF
--- a/mesh/mesh.cpp
+++ b/mesh/mesh.cpp
@@ -4246,7 +4246,7 @@ int Mesh::CheckElementOrientation(bool fix_it)
 
       for (i = 0; i < NumOfElements; i++)
       {
-	 int *vi = elements[i]->GetVertices();
+         int *vi = elements[i]->GetVertices();
          if (Nodes == NULL)
          {
             for (j = 0; j < 3; j++)

--- a/mesh/mesh.cpp
+++ b/mesh/mesh.cpp
@@ -4237,7 +4237,7 @@ static const char *fixed_or_not[] = { "fixed", "NOT FIXED" };
 
 int Mesh::CheckElementOrientation(bool fix_it)
 {
-   int i, j, k, wo = 0, fo = 0, *vi = 0;
+   int i, j, k, wo = 0, fo = 0;
    double *v[4];
 
    if (Dim == 2 && spaceDim == 2)
@@ -4246,9 +4246,9 @@ int Mesh::CheckElementOrientation(bool fix_it)
 
       for (i = 0; i < NumOfElements; i++)
       {
+	 int *vi = elements[i]->GetVertices();
          if (Nodes == NULL)
          {
-            vi = elements[i]->GetVertices();
             for (j = 0; j < 3; j++)
             {
                v[j] = vertices[vi[j]]();
@@ -4294,7 +4294,7 @@ int Mesh::CheckElementOrientation(bool fix_it)
 
       for (i = 0; i < NumOfElements; i++)
       {
-         vi = elements[i]->GetVertices();
+         int *vi = elements[i]->GetVertices();
          switch (GetElementType(i))
          {
             case Element::TETRAHEDRON:

--- a/mesh/mesh.hpp
+++ b/mesh/mesh.hpp
@@ -1040,9 +1040,22 @@ public:
    Geometry::Type GetFaceGeometryType(int Face) const;
    Element::Type  GetFaceElementType(int Face) const;
 
-   /// Check the orientation of the elements
-   /** @return The number of elements with wrong orientation. */
+   /// Check (and optionally attempt to fix) the orientation of the elements
+   /** @param[in] fix_it  If `true`, attempt to fix the orientations of some
+                          elements: triangles, quads, and tets.
+       @return The number of elements with wrong orientation.
+
+       @note For meshes with nodes (e.g. high-order or periodic meshes), fixing
+       the element orientations may require additional permutation of the nodal
+       GridFunction of the mesh which is not performed by this method. Instead,
+       the method Finalize() should be used with the parameter
+       @a fix_orientation set to `true`.
+
+       @note This method performs a simple check if an element is inverted, e.g.
+       for most elements types, it checks if the Jacobian of the mapping from
+       the reference element is non-negative at the center of the element. */
    int CheckElementOrientation(bool fix_it = true);
+
    /// Check the orientation of the boundary elements
    /** @return The number of boundary elements with wrong orientation. */
    int CheckBdrElementOrientation(bool fix_it = true);


### PR DESCRIPTION
For 2D case, and negative determinant (J.Det()<0), the variable `vi `is not initialized.
It leads to segmentation fault in the code block that begins with  `switch(GetElementType(i))` at mesh.cpp:4271.
<!--GHEX{"id":1936,"author":"latug0","editor":"v-dobrev","reviewers":["v-dobrev","adrienbernede"],"assignment":"2020-12-09T23:44:32-08:00","approval":"2021-02-17T01:41:44.134Z","merge":"2021-02-23T20:11:41.291Z"}XEHG--><!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge| 
 | --- | --- | --- | --- | --- | --- | --- | 
| [#1936](https://github.com/mfem/mfem/pull/1936) | @latug0 | @v-dobrev | @v-dobrev + @adrienbernede | 12/09/20 | 02/16/21 | 02/23/21 | |
<!--ELBATXEHG-->