### PR TITLE
Fix issue #1937

### DIFF
--- a/mesh/mesh_readers.cpp
+++ b/mesh/mesh_readers.cpp
@@ -2019,9 +2019,15 @@ void Mesh::ReadGmshMesh(std::istream &input, int &curved, int &read_gf)
          for (int i = 0; i < num_per_ent; i++)
          {
             getline(input, buff); // Read and ignore entity dimension and tags
-            getline(input, buff); // Read and ignore affine mapping
-            // Read master/slave vertex pairs
-            input >> num_nodes;
+            getline(input, buff); // If affine mapping exist, read and ignore
+            if (!strncmp(buff.c_str(), "Affine", 6))
+            {
+               input >> num_nodes;
+            }
+            else
+            {
+               num_nodes = atoi(buff.c_str());
+            }
             for (int j=0; j<num_nodes; j++)
             {
                input >> slave >> master;


### PR DESCRIPTION
Reading GMSH mesh as input file, in the $Periodic section, we now consider that the Affine keyword and associated line are optional.

Resolves #1937.
<!--GHEX{"id":1938,"author":"latug0","editor":"v-dobrev","reviewers":["mlstowell","bslazarov"],"assignment":"2020-12-21T12:52:42-08:00","approval":"2021-01-26T01:03:47.019Z","merge":"2021-02-04T22:37:05.716Z"}XEHG--><!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge| 
 | --- | --- | --- | --- | --- | --- | --- | 
| [#1938](https://github.com/mfem/mfem/pull/1938) | @latug0 | @v-dobrev | @mlstowell + @bslazarov | 12/21/20 | 01/25/21 | 02/04/21 | |
<!--ELBATXEHG-->