### PR TITLE
Update QuadratureSpace with a GetOrder

### DIFF
--- a/fem/fespace.hpp
+++ b/fem/fespace.hpp
@@ -755,6 +755,9 @@ public:
 
    /// Return the total number of quadrature points.
    int GetSize() const { return size; }
+    
+   /// Return the order used by the global rules from #IntRules.
+   int GetOrder() const { return order; }
 
    /// Returns the mesh
    inline Mesh *GetMesh() const { return mesh; }

--- a/fem/fespace.hpp
+++ b/fem/fespace.hpp
@@ -756,7 +756,7 @@ public:
    /// Return the total number of quadrature points.
    int GetSize() const { return size; }
 
-   /// Return the order of the quadrature rules used by all elements.
+   /// Return the order of the quadrature rule used by all elements.
    int GetOrder() const { return order; }
 
    /// Returns the mesh

--- a/fem/fespace.hpp
+++ b/fem/fespace.hpp
@@ -756,7 +756,7 @@ public:
    /// Return the total number of quadrature points.
    int GetSize() const { return size; }
 
-   /// Return the order used by the global rules from #IntRules.
+   /// Return the order of the quadrature rules used by all elements.
    int GetOrder() const { return order; }
 
    /// Returns the mesh

--- a/fem/fespace.hpp
+++ b/fem/fespace.hpp
@@ -755,7 +755,7 @@ public:
 
    /// Return the total number of quadrature points.
    int GetSize() const { return size; }
-    
+
    /// Return the order used by the global rules from #IntRules.
    int GetOrder() const { return order; }
 

--- a/fem/fespace.hpp
+++ b/fem/fespace.hpp
@@ -756,7 +756,7 @@ public:
    /// Return the total number of quadrature points.
    int GetSize() const { return size; }
 
-   /// Return the order of the quadrature rule used by all elements.
+   /// Return the order of the quadrature rule(s) used by all elements.
    int GetOrder() const { return order; }
 
    /// Returns the mesh


### PR DESCRIPTION
It can sometimes be useful to know what the order of the integration rule is for quadrature space is. So, this PR adds a very simple getter function to QuadratureSpace to get this already stored value.
<!--GHEX{"id":1956,"author":"rcarson3","editor":"v-dobrev","reviewers":["v-dobrev","jakubcerveny","tzanio"],"assignment":"2020-12-21T12:33:11-08:00","approval":"2020-12-22T21:58:12.071Z","merge":"2020-12-30T23:23:27.170Z"}XEHG--><!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge| 
 | --- | --- | --- | --- | --- | --- | --- | 
| [#1956](https://github.com/mfem/mfem/pull/1956) | @rcarson3 | @v-dobrev | @v-dobrev + @jakubcerveny + @tzanio | 12/21/20 | 12/22/20 | 12/30/20 | |
<!--ELBATXEHG-->