### PR TITLE
Unify DGTraceIntegrator and NonconservativeDGTraceIntegrator

### DIFF
--- a/examples/ex9.cpp
+++ b/examples/ex9.cpp
@@ -292,9 +292,9 @@ int main(int argc, char *argv[])
    m.AddDomainIntegrator(new MassIntegrator);
    k.AddDomainIntegrator(new ConvectionIntegrator(velocity, -1.0));
    k.AddInteriorFaceIntegrator(
-      new NonconservativeDGTraceIntegrator(velocity, 1.0, -0.5));
+      new NonconservativeDGTraceIntegrator(velocity, -1.0, -0.5));
    k.AddBdrFaceIntegrator(
-      new NonconservativeDGTraceIntegrator(velocity, 1.0, -0.5));
+      new NonconservativeDGTraceIntegrator(velocity, -1.0, -0.5));
 
    LinearForm b(&fes);
    b.AddBdrFaceIntegrator(

--- a/examples/ex9p.cpp
+++ b/examples/ex9p.cpp
@@ -344,9 +344,9 @@ int main(int argc, char *argv[])
    m->AddDomainIntegrator(new MassIntegrator);
    k->AddDomainIntegrator(new ConvectionIntegrator(velocity, -1.0));
    k->AddInteriorFaceIntegrator(
-      new NonconservativeDGTraceIntegrator(velocity, 1.0, -0.5));
+      new NonconservativeDGTraceIntegrator(velocity, -1.0, -0.5));
    k->AddBdrFaceIntegrator(
-      new NonconservativeDGTraceIntegrator(velocity, 1.0, -0.5));
+      new NonconservativeDGTraceIntegrator(velocity, -1.0, -0.5));
 
    ParLinearForm *b = new ParLinearForm(fes);
    b->AddBdrFaceIntegrator(

--- a/fem/bilininteg.cpp
+++ b/fem/bilininteg.cpp
@@ -2888,6 +2888,40 @@ const IntegrationRule &DGTraceIntegrator::GetRule(
    return IntRules.Get(geom, int_order);
 }
 
+NonconservativeDGTraceIntegrator::NonconservativeDGTraceIntegrator(
+   VectorCoefficient &u, double a, double b)
+{
+   double s_a = (a >= 0) ? 1.0 : -1.0;
+   if (a*s_a == 1.0)
+   {
+      // Simplified case when a cancelation occurs and we can use one integrator
+      AddIntegrator(new TransposeIntegrator(new DGTraceIntegrator(u, -s_a, b)));
+   }
+   else
+   {
+      AddIntegrator(new DGTraceIntegrator(u, a-s_a, b));
+      AddIntegrator(new TransposeIntegrator(new DGTraceIntegrator(u, -s_a, 0)));
+   }
+}
+
+NonconservativeDGTraceIntegrator::NonconservativeDGTraceIntegrator(
+   Coefficient &rho, VectorCoefficient &u, double a, double b)
+{
+   double sgn_a = (a >= 0) ? 1.0 : -1.0;
+   if (a*sgn_a == 1.0)
+   {
+      // Simplified case when a cancelation occurs and we can use one integrator
+      AddIntegrator(new TransposeIntegrator(
+         new DGTraceIntegrator(rho, u, -sgn_a, b)));
+   }
+   else
+   {
+      AddIntegrator(new DGTraceIntegrator(u, a-sgn_a, b));
+      AddIntegrator(new TransposeIntegrator(
+         new DGTraceIntegrator(rho, u, -sgn_a, 0)));
+   }
+}
+
 void DGDiffusionIntegrator::AssembleFaceMatrix(
    const FiniteElement &el1, const FiniteElement &el2,
    FaceElementTransformations &Trans, DenseMatrix &elmat)

--- a/fem/bilininteg.cpp
+++ b/fem/bilininteg.cpp
@@ -229,6 +229,159 @@ void SumIntegrator::AssembleElementMatrix(
    }
 }
 
+void SumIntegrator::AssembleElementMatrix2(
+   const FiniteElement &el1, const FiniteElement &el2,
+   ElementTransformation &Trans, DenseMatrix &elmat)
+{
+   MFEM_ASSERT(integrators.Size() > 0, "empty SumIntegrator.");
+
+   integrators[0]->AssembleElementMatrix2(el1, el2, Trans, elmat);
+   for (int i = 1; i < integrators.Size(); i++)
+   {
+      integrators[i]->AssembleElementMatrix2(el1, el2, Trans, elem_mat);
+      elmat += elem_mat;
+   }
+}
+
+void SumIntegrator::AssembleFaceMatrix(
+   const FiniteElement &el1, const FiniteElement &el2,
+   FaceElementTransformations &Trans, DenseMatrix &elmat)
+{
+   MFEM_ASSERT(integrators.Size() > 0, "empty SumIntegrator.");
+
+   integrators[0]->AssembleFaceMatrix(el1, el2, Trans, elmat);
+   for (int i = 1; i < integrators.Size(); i++)
+   {
+      integrators[i]->AssembleFaceMatrix(el1, el2, Trans, elem_mat);
+      elmat += elem_mat;
+   }
+}
+
+void SumIntegrator::AssembleFaceMatrix(
+   const FiniteElement &tr_fe,
+   const FiniteElement &te_fe1, const FiniteElement &te_fe2,
+   FaceElementTransformations &Trans, DenseMatrix &elmat)
+{
+   MFEM_ASSERT(integrators.Size() > 0, "empty SumIntegrator.");
+
+   integrators[0]->AssembleFaceMatrix(tr_fe, te_fe1, te_fe2, Trans, elmat);
+   for (int i = 1; i < integrators.Size(); i++)
+   {
+      integrators[i]->AssembleFaceMatrix(tr_fe, te_fe1, te_fe2, Trans, elem_mat);
+      elmat += elem_mat;
+   }
+}
+
+void SumIntegrator::AssemblePA(const FiniteElementSpace& fes)
+{
+   for (int i = 0; i < integrators.Size(); i++)
+   {
+      integrators[i]->AssemblePA(fes);
+   }
+}
+
+void SumIntegrator::AssembleDiagonalPA(Vector &diag)
+{
+   for (int i = 0; i < integrators.Size(); i++)
+   {
+      integrators[i]->AssembleDiagonalPA(diag);
+   }
+}
+
+void SumIntegrator::AssemblePAInteriorFaces(const FiniteElementSpace &fes)
+{
+   for (int i = 0; i < integrators.Size(); i++)
+   {
+      integrators[i]->AssemblePAInteriorFaces(fes);
+   }
+}
+
+void SumIntegrator::AssemblePABoundaryFaces(const FiniteElementSpace &fes)
+{
+   for (int i = 0; i < integrators.Size(); i++)
+   {
+      integrators[i]->AssemblePABoundaryFaces(fes);
+   }
+}
+
+void SumIntegrator::AddMultPA(const Vector& x, Vector& y) const
+{
+   for (int i = 0; i < integrators.Size(); i++)
+   {
+      integrators[i]->AddMultPA(x, y);
+   }
+}
+
+void SumIntegrator::AddMultTransposePA(const Vector &x, Vector &y) const
+{
+   for (int i = 0; i < integrators.Size(); i++)
+   {
+      integrators[i]->AddMultTransposePA(x, y);
+   }
+}
+
+void SumIntegrator::AssembleMF(const FiniteElementSpace &fes)
+{
+   for (int i = 0; i < integrators.Size(); i++)
+   {
+      integrators[i]->AssembleMF(fes);
+   }
+}
+
+void SumIntegrator::AddMultMF(const Vector& x, Vector& y) const
+{
+   for (int i = 0; i < integrators.Size(); i++)
+   {
+      integrators[i]->AddMultTransposeMF(x, y);
+   }
+}
+
+void SumIntegrator::AddMultTransposeMF(const Vector &x, Vector &y) const
+{
+   for (int i = 0; i < integrators.Size(); i++)
+   {
+      integrators[i]->AddMultMF(x, y);
+   }
+}
+
+void SumIntegrator::AssembleDiagonalMF(Vector &diag)
+{
+   for (int i = 0; i < integrators.Size(); i++)
+   {
+      integrators[i]->AssembleDiagonalMF(diag);
+   }
+}
+
+void SumIntegrator::AssembleEA(const FiniteElementSpace &fes, Vector &emat,
+                        const bool add)
+{
+   for (int i = 0; i < integrators.Size(); i++)
+   {
+      integrators[i]->AssembleEA(fes, emat, add);
+   }
+}
+
+void SumIntegrator::AssembleEAInteriorFaces(const FiniteElementSpace &fes,
+                                            Vector &ea_data_int,
+                                            Vector &ea_data_ext,
+                                            const bool add)
+{
+   for (int i = 0; i < integrators.Size(); i++)
+   {
+      integrators[i]->AssembleEAInteriorFaces(fes,ea_data_int,ea_data_ext,add);
+   }
+}
+
+void SumIntegrator::AssembleEABoundaryFaces(const FiniteElementSpace &fes,
+                                            Vector &ea_data_bdr,
+                                            const bool add)
+{
+   for (int i = 0; i < integrators.Size(); i++)
+   {
+      integrators[i]->AssembleEABoundaryFaces(fes, ea_data_bdr, add);
+   }
+}
+
 SumIntegrator::~SumIntegrator()
 {
    if (own_integrators)

--- a/fem/bilininteg.hpp
+++ b/fem/bilininteg.hpp
@@ -367,6 +367,55 @@ public:
    virtual void AssembleElementMatrix(const FiniteElement &el,
                                       ElementTransformation &Trans,
                                       DenseMatrix &elmat);
+   virtual void AssembleElementMatrix2(const FiniteElement &trial_fe,
+                                       const FiniteElement &test_fe,
+                                       ElementTransformation &Trans,
+                                       DenseMatrix &elmat);
+
+   using BilinearFormIntegrator::AssembleFaceMatrix;
+   virtual void AssembleFaceMatrix(const FiniteElement &el1,
+                                   const FiniteElement &el2,
+                                   FaceElementTransformations &Trans,
+                                   DenseMatrix &elmat);
+
+   virtual void AssembleFaceMatrix(const FiniteElement &trial_face_fe,
+                                   const FiniteElement &test_fe1,
+                                   const FiniteElement &test_fe2,
+                                   FaceElementTransformations &Trans,
+                                   DenseMatrix &elmat);
+
+   using BilinearFormIntegrator::AssemblePA;
+   virtual void AssemblePA(const FiniteElementSpace& fes);
+
+   virtual void AssembleDiagonalPA(Vector &diag);
+
+   virtual void AssemblePAInteriorFaces(const FiniteElementSpace &fes);
+
+   virtual void AssemblePABoundaryFaces(const FiniteElementSpace &fes);
+
+   virtual void AddMultTransposePA(const Vector &x, Vector &y) const;
+
+   virtual void AddMultPA(const Vector& x, Vector& y) const;
+
+   virtual void AssembleMF(const FiniteElementSpace &fes);
+
+   virtual void AddMultMF(const Vector &x, Vector &y) const;
+
+   virtual void AddMultTransposeMF(const Vector &x, Vector &y) const;
+
+   virtual void AssembleDiagonalMF(Vector &diag);
+
+   virtual void AssembleEA(const FiniteElementSpace &fes, Vector &emat,
+                           const bool add);
+
+   virtual void AssembleEAInteriorFaces(const FiniteElementSpace &fes,
+                                        Vector &ea_data_int,
+                                        Vector &ea_data_ext,
+                                        const bool add);
+
+   virtual void AssembleEABoundaryFaces(const FiniteElementSpace &fes,
+                                        Vector &ea_data_bdr,
+                                        const bool add);
 
    virtual ~SumIntegrator();
 };

--- a/fem/bilininteg.hpp
+++ b/fem/bilininteg.hpp
@@ -2171,12 +2171,12 @@ public:
                                          ElementTransformation &Trans);
 };
 
-/// alpha (u, q . grad u), transpose of ConvectionIntegrator
+/// -alpha (u, q . grad u), negative transpose of ConvectionIntegrator
 class ConservativeConvectionIntegrator : public TransposeIntegrator
 {
 public:
    ConservativeConvectionIntegrator(VectorCoefficient &q, double a = 1.0)
-      : TransposeIntegrator(new ConvectionIntegrator(q, a)) { }
+      : TransposeIntegrator(new ConvectionIntegrator(q, -a)) { }
 };
 
 /// alpha (q . grad u, v) using the "group" FE discretization
@@ -2805,22 +2805,21 @@ private:
    void SetupPA(const FiniteElementSpace &fes, FaceType type);
 };
 
-/** Integrator that represents the transpose of DGTraceIntegrator, i.e.
-    alpha < rho_u (u.n) [v],{w} > + beta < rho_u |u.n| [v],[w] >,
-    where the notation is the same as in DGTraceIntegrator.
+/** Integrator that represents the face terms used for the non-conservative
+    DG discretization of the convection equation:
+    (alpha - 1*sgn(alpha)) < rho_u (u.n) [v],{w} > - < rho_u (u.n) {v},[w] >
+       + beta < rho_u |u.n| [v],[w] >.
 
-    This integrator can be used with alpha=-1.0, beta=0.5, together with
+    This integrator can be used with alpha=1.0, beta=0.5, together with
     ConvectionIntegrator to implement an upwind DG discretization in
     non-conservative form, see ex9 and ex9p. */
-class NonconservativeDGTraceIntegrator : public TransposeIntegrator
+class NonconservativeDGTraceIntegrator : public SumIntegrator
 {
 public:
-   NonconservativeDGTraceIntegrator(VectorCoefficient &u_, double a, double b)
-      : TransposeIntegrator(new DGTraceIntegrator(u_, a, b)) { }
+   NonconservativeDGTraceIntegrator(VectorCoefficient &u, double a, double b);
 
-   NonconservativeDGTraceIntegrator(Coefficient &rho_, VectorCoefficient &u_,
-                                    double a, double b)
-      : TransposeIntegrator(new DGTraceIntegrator(rho_, u_, a, b)) { }
+   NonconservativeDGTraceIntegrator(Coefficient &rho, VectorCoefficient &u,
+                                    double a, double b);
 };
 
 /** Integrator for the DG form:

--- a/fem/bilininteg.hpp
+++ b/fem/bilininteg.hpp
@@ -1994,6 +1994,8 @@ public:
 
    virtual void AddMultPA(const Vector&, Vector&) const;
 
+   virtual void AddMultTransposePA(const Vector&, Vector&) const;
+
    static const IntegrationRule &GetRule(const FiniteElement &trial_fe,
                                          const FiniteElement &test_fe);
 };
@@ -2056,6 +2058,8 @@ public:
    virtual void AddMultMF(const Vector&, Vector&) const;
 
    virtual void AddMultPA(const Vector&, Vector&) const;
+
+   virtual void AddMultTransposePA(const Vector&, Vector&) const;
 
    static const IntegrationRule &GetRule(const FiniteElement &trial_fe,
                                          const FiniteElement &test_fe,

--- a/fem/bilininteg_diffusion_pa.cpp
+++ b/fem/bilininteg_diffusion_pa.cpp
@@ -1904,4 +1904,17 @@ void DiffusionIntegrator::AddMultPA(const Vector &x, Vector &y) const
    }
 }
 
+void DiffusionIntegrator::AddMultTransposePA(const Vector &x, Vector &y) const
+{
+   if (symmetric)
+   {
+      AddMultPA(x, y);
+   }
+   else
+   {
+      MFEM_ABORT("DiffusionIntegrator::AddMultTransposePA only implemented in "
+                 "the symmetric case.")
+   }
+}
+
 } // namespace mfem

--- a/fem/bilininteg_mass_pa.cpp
+++ b/fem/bilininteg_mass_pa.cpp
@@ -1226,4 +1226,10 @@ void MassIntegrator::AddMultPA(const Vector &x, Vector &y) const
    }
 }
 
+void MassIntegrator::AddMultTransposePA(const Vector &x, Vector &y) const
+{
+   // Mass integrator is symmetric
+   AddMultPA(x, y);
+}
+
 } // namespace mfem

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -41,6 +41,7 @@ set(UNIT_TESTS_SRCS
   fem/test_2d_bilininteg.cpp
   fem/test_3d_bilininteg.cpp
   fem/test_assemblediagonalpa.cpp
+  fem/test_blocknonlinearform.cpp
   fem/test_calcshape.cpp
   fem/test_datacollection.cpp
   fem/test_estimator.cpp
@@ -56,7 +57,7 @@ set(UNIT_TESTS_SRCS
   fem/test_pa_kernels.cpp
   fem/test_quadf_coef.cpp
   fem/test_quadraturefunc.cpp
-  fem/test_blocknonlinearform.cpp
+  fem/test_sum_bilin.cpp
   miniapps/test_sedov.cpp
 )
 

--- a/tests/unit/fem/test_sum_bilin.cpp
+++ b/tests/unit/fem/test_sum_bilin.cpp
@@ -1,0 +1,232 @@
+// Copyright (c) 2010-2020, Lawrence Livermore National Security, LLC. Produced
+// at the Lawrence Livermore National Laboratory. All Rights reserved. See files
+// LICENSE and NOTICE for details. LLNL-CODE-806117.
+//
+// This file is part of the MFEM library. For more information and source code
+// availability visit https://mfem.org.
+//
+// MFEM is free software; you can redistribute it and/or modify it under the
+// terms of the BSD-3 license. We welcome feedback and contributions, see file
+// CONTRIBUTING.md for details.
+
+#include "unit_tests.hpp"
+#include "mfem.hpp"
+#include <fstream>
+#include <iostream>
+
+using namespace mfem;
+
+namespace pa_kernels
+{
+
+TEST_CASE("H1 SumIntegrator", "[SumIntegrator][PartialAssembly]")
+{
+   Mesh mesh(1, 1, 1, Element::HEXAHEDRON);
+   H1_FECollection fec(2, mesh.Dimension());
+   FiniteElementSpace fes(&mesh, &fec);
+
+   MassIntegrator integ1;
+   DiffusionIntegrator integ2;
+
+   SumIntegrator integ_sum(true);
+   integ_sum.AddIntegrator(new MassIntegrator);
+   integ_sum.AddIntegrator(new DiffusionIntegrator);
+
+   const FiniteElement &el = *fes.GetFE(0);
+   ElementTransformation &T = *mesh.GetElementTransformation(0);
+   DenseMatrix m1, m_tmp, m2;
+
+   // AssembleElementMatrix
+   integ1.AssembleElementMatrix(el, T, m1);
+   integ2.AssembleElementMatrix(el, T, m_tmp);
+   m1 += m_tmp;
+   integ_sum.AssembleElementMatrix(el, T, m2);
+   m1 -= m2;
+   REQUIRE(m1.MaxMaxNorm() == MFEM_Approx(0.0));
+
+   // AssembleElementMatrix2
+   integ1.AssembleElementMatrix2(el, el, T, m1);
+   integ2.AssembleElementMatrix2(el, el, T, m_tmp);
+   m1 += m_tmp;
+   integ_sum.AssembleElementMatrix2(el, el, T, m2);
+   m1 -= m2;
+   REQUIRE(m1.MaxMaxNorm() == MFEM_Approx(0.0));
+
+   // PA
+   integ1.AssemblePA(fes);
+   integ2.AssemblePA(fes);
+   integ_sum.AssemblePA(fes);
+
+   int n = fes.GetTrueVSize();
+   Vector x(n), y1(n), y2(n);
+   Vector diag1(n), diag_tmp(n), diag2(n);
+   x.Randomize(1);
+
+   // AddMultPA
+   y1 = 0.0;
+   y2 = 0.0;
+   integ1.AddMultPA(x, y1);
+   integ2.AddMultPA(x, y1);
+   integ_sum.AddMultPA(x, y2);
+   y1 -= y2;
+   REQUIRE(y1.Normlinf() == MFEM_Approx(0.0));
+
+   // AddMultTransposePA
+   y1 = 0.0;
+   y2 = 0.0;
+   integ1.AddMultTransposePA(x, y1);
+   integ2.AddMultTransposePA(x, y1);
+   integ_sum.AddMultTransposePA(x, y2);
+   y1 -= y2;
+   REQUIRE(y1.Normlinf() == MFEM_Approx(0.0));
+
+   // AssembleDiagonalPA
+   diag1 = 0.0;
+   diag_tmp = 0.0;
+   diag2 = 0.0;
+   integ1.AssembleDiagonalPA(diag1);
+   integ2.AssembleDiagonalPA(diag_tmp);
+   diag1 += diag_tmp;
+   integ_sum.AssembleDiagonalPA(diag2);
+   diag1 -= diag2;
+   REQUIRE(diag1.Normlinf() == MFEM_Approx(0.0));
+
+   // MF
+#ifdef MFEM_USE_CEED
+   if (DeviceCanUseCeed())
+   {
+      integ1.AssembleMF(fes);
+      integ2.AssembleMF(fes);
+      integ_sum.AssembleMF(fes);
+
+      // AddMultMF
+      y1 = 0.0;
+      y2 = 0.0;
+      integ1.AddMultMF(x, y1);
+      integ2.AddMultMF(x, y1);
+      integ_sum.AddMultMF(x, y2);
+      y1 -= y2;
+      REQUIRE(y1.Normlinf() == MFEM_Approx(0.0));
+
+      // AddMultTransposeMF
+      y1 = 0.0;
+      y2 = 0.0;
+      integ1.AddMultTransposeMF(x, y1);
+      integ2.AddMultTransposeMF(x, y1);
+      integ_sum.AddMultTransposeMF(x, y2);
+      y1 -= y2;
+      REQUIRE(y1.Normlinf() == MFEM_Approx(0.0));
+
+      // AssembleDiagonalMF
+      integ1.AssembleDiagonalMF(diag1);
+      integ2.AssembleDiagonalMF(diag_tmp);
+      diag1 += diag_tmp;
+      integ_sum.AssembleDiagonalMF(diag2);
+      diag1 -= diag2;
+      REQUIRE(diag1.Normlinf() == MFEM_Approx(0.0));
+   }
+#endif
+}
+
+TEST_CASE("DG SumIntegrator", "[SumIntegrator][PartialAssembly]")
+{
+   Mesh mesh(2, 1, 1, Element::HEXAHEDRON);
+   DG_FECollection fec(2, mesh.Dimension(), BasisType::GaussLobatto);
+   FiniteElementSpace fes(&mesh, &fec);
+
+   Vector v(mesh.Dimension());
+   v = 1.0;
+   VectorConstantCoefficient v_coeff(v);
+
+   DGTraceIntegrator integ1(v_coeff, 1.0, 2.0);
+   DGTraceIntegrator integ2(v_coeff, 3.0, 4.0);
+
+   SumIntegrator integ_sum(true);
+   integ_sum.AddIntegrator(new DGTraceIntegrator(v_coeff, 1.0, 2.0));
+   integ_sum.AddIntegrator(new DGTraceIntegrator(v_coeff, 3.0, 4.0));
+
+   DenseMatrix m1, m_tmp, m2;
+
+   // AssembleFaceMatrix
+   int nfaces = mesh.GetNumFaces();
+   for (int i = 0; i < nfaces; i++)
+   {
+      FaceElementTransformations *tr = mesh.GetFaceElementTransformations(i);
+      const FiniteElement &el0 = *fes.GetFE(tr->Elem1No);
+      const FiniteElement &el1 = (tr->Elem2No >= 0) ? *fes.GetFE(tr->Elem2No) : el0;
+      integ1.AssembleFaceMatrix(el0, el1, *tr, m1);
+      integ2.AssembleFaceMatrix(el0, el1, *tr, m_tmp);
+      m1 += m_tmp;
+      integ_sum.AssembleFaceMatrix(el0, el1, *tr, m2);
+      m1 -= m2;
+      REQUIRE(m1.MaxMaxNorm() == MFEM_Approx(0.0));
+   }
+
+   // PA interior
+   integ1.AssemblePAInteriorFaces(fes);
+   integ2.AssemblePAInteriorFaces(fes);
+   integ_sum.AssemblePAInteriorFaces(fes);
+
+   const Operator *R_int = fes.GetFaceRestriction(
+      ElementDofOrdering::LEXICOGRAPHIC,
+      FaceType::Interior);
+
+   int n_int = R_int->Height();
+   Vector x(n_int), y1(n_int), y2(n_int);
+   x.Randomize(1);
+
+   // AddMultPA
+   y1 = 0.0;
+   y2 = 0.0;
+   integ1.AddMultPA(x, y1);
+   integ2.AddMultPA(x, y1);
+   integ_sum.AddMultPA(x, y2);
+   y1 -= y2;
+   REQUIRE(y1.Normlinf() == MFEM_Approx(0.0));
+
+   // AddMultTransposePA
+   y1 = 0.0;
+   y2 = 0.0;
+   integ1.AddMultTransposePA(x, y1);
+   integ2.AddMultTransposePA(x, y1);
+   integ_sum.AddMultTransposePA(x, y2);
+   y1 -= y2;
+   REQUIRE(y1.Normlinf() == MFEM_Approx(0.0));
+
+   // PA boundary
+   integ1.AssemblePABoundaryFaces(fes);
+   integ2.AssemblePABoundaryFaces(fes);
+   integ_sum.AssemblePABoundaryFaces(fes);
+
+   const Operator *R_bdr = fes.GetFaceRestriction(
+      ElementDofOrdering::LEXICOGRAPHIC,
+      FaceType::Boundary,
+      L2FaceValues::DoubleValued);
+
+   int n_bdr = R_bdr->Height();
+   x.SetSize(n_bdr);
+   y1.SetSize(n_bdr);
+   y2.SetSize(n_bdr);
+   x.Randomize(1);
+
+   // AddMultPA
+   y1 = 0.0;
+   y2 = 0.0;
+   integ1.AddMultPA(x, y1);
+   integ2.AddMultPA(x, y1);
+   integ_sum.AddMultPA(x, y2);
+   y1 -= y2;
+   REQUIRE(y1.Normlinf() == MFEM_Approx(0.0));
+
+   // AddMultTransposePA
+   y1 = 0.0;
+   y2 = 0.0;
+   integ1.AddMultTransposePA(x, y1);
+   integ2.AddMultTransposePA(x, y1);
+   integ_sum.AddMultTransposePA(x, y2);
+   y1 -= y2;
+   REQUIRE(y1.Normlinf() == MFEM_Approx(0.0));
+}
+
+
+} // namespace pa_kernels


### PR DESCRIPTION
Depends on #1965.

Unifies the coefficients in `DGTraceIntegrator` and `NonconservativeDGTraceIntegrator` by implementing `NonconservativeDGTraceIntegrator` as the sum of `DGTraceIntegrator` and its transpose. Handles the special case when a cancellation occurs and one of the terms can be omitted.

Example 9 should now work with both of the following (note that all coefficients are the same in both cases):

Option 1:
```c++
   k.AddDomainIntegrator(new ConvectionIntegrator(velocity, -1.0));
   k.AddInteriorFaceIntegrator(
      new NonconservativeDGTraceIntegrator(velocity, -1.0, -0.5));
   k.AddBdrFaceIntegrator(
      new NonconservativeDGTraceIntegrator(velocity, -1.0, -0.5));
```

Option 2:
```c++
   k.AddDomainIntegrator(new ConservativeConvectionIntegrator(velocity, -1.0));
   k.AddInteriorFaceIntegrator(
      new DGTraceIntegrator(velocity, -1.0, -0.5));
   k.AddBdrFaceIntegrator(
      new DGTraceIntegrator(velocity, -1.0, -0.5));
```

See the [attached document](https://github.com/mfem/mfem/files/5732813/dg_trace.pdf) for relevant derivations.