### PR TITLE
Hide SLEPc's 'EPS' type in a namespace

### DIFF
--- a/linalg/petsc.cpp
+++ b/linalg/petsc.cpp
@@ -287,7 +287,7 @@ PetscParVector::PetscParVector(const PetscParMatrix &A,
    _SetDataAndSize_();
 }
 
-PetscParVector::PetscParVector(Vec y, bool ref) : Vector()
+PetscParVector::PetscParVector(petsc::Vec y, bool ref) : Vector()
 {
    if (ref)
    {
@@ -1244,7 +1244,7 @@ void PetscParMatrix::Destroy()
    X = Y = NULL;
 }
 
-PetscParMatrix::PetscParMatrix(Mat a, bool ref)
+PetscParMatrix::PetscParMatrix(petsc::Mat a, bool ref)
 {
    if (ref)
    {

--- a/linalg/petsc.hpp
+++ b/linalg/petsc.hpp
@@ -50,17 +50,28 @@ typedef int PetscClassId;
 typedef struct _p_PetscObject *PetscObject;
 #endif
 
-// forward declarations of PETSc objects
-typedef struct _p_Vec *Vec;
-typedef struct _p_Mat *Mat;
-typedef struct _p_KSP *KSP;
-typedef struct _p_PC *PC;
-typedef struct _p_SNES *SNES;
-typedef struct _p_TS *TS;
+// forward declarations of PETSc internal structs
+struct _p_Vec;
+struct _p_Mat;
+struct _p_KSP;
+struct _p_PC;
+struct _p_SNES;
+struct _p_TS;
 
 
 namespace mfem
 {
+
+// Declare aliases of PETSc's types inside the namespace mfem::petsc:
+namespace petsc
+{
+typedef struct ::_p_Vec  *Vec;
+typedef struct ::_p_Mat  *Mat;
+typedef struct ::_p_KSP  *KSP;
+typedef struct ::_p_PC   *PC;
+typedef struct ::_p_SNES *SNES;
+typedef struct ::_p_TS   *TS;
+}
 
 /// Convenience functions to initialize/finalize PETSc
 void MFEMInitializePetsc();
@@ -76,7 +87,7 @@ class PetscParVector : public Vector
 {
 protected:
    /// The actual PETSc object
-   Vec x;
+   petsc::Vec x;
 
    friend class PetscParMatrix;
    friend class PetscODESolver;
@@ -127,7 +138,7 @@ public:
    /// Creates PetscParVector out of PETSc Vec object.
    /** @param[in] y    The PETSc Vec object.
        @param[in] ref  If true, we increase the reference count of @a y. */
-   explicit PetscParVector(Vec y, bool ref=false);
+   explicit PetscParVector(petsc::Vec y, bool ref=false);
 
    /// Create a true dof parallel vector on a given ParFiniteElementSpace
    explicit PetscParVector(ParFiniteElementSpace *pfes);
@@ -142,7 +153,7 @@ public:
    PetscInt GlobalSize() const;
 
    /// Typecasting to PETSc's Vec type
-   operator Vec() const { return x; }
+   operator petsc::Vec() const { return x; }
 
    /// Typecasting to PETSc object
    operator PetscObject() const { return (PetscObject)x; }
@@ -198,7 +209,7 @@ class PetscParMatrix : public Operator
 {
 protected:
    /// The actual PETSc object
-   Mat A;
+   petsc::Mat A;
 
    /// Auxiliary vectors for typecasting
    mutable PetscParVector *X, *Y;
@@ -214,13 +225,13 @@ protected:
 
        This does not take any reference to @a op, that should not be destroyed
        until @a B is needed. */
-   void MakeWrapper(MPI_Comm comm, const Operator* op, Mat *B);
+   void MakeWrapper(MPI_Comm comm, const Operator* op, petsc::Mat *B);
 
    /// Convert an mfem::Operator into a Mat @a B; @a op can be destroyed unless
    /// tid == PETSC_MATSHELL or tid == PETSC_MATHYPRE
    /// if op is a BlockOperator, the operator type is relevant to the individual
    /// blocks
-   void ConvertOperator(MPI_Comm comm, const Operator& op, Mat *B,
+   void ConvertOperator(MPI_Comm comm, const Operator& op, petsc::Mat *B,
                         Operator::Type tid);
 
    friend class PetscLinearSolver;
@@ -230,7 +241,7 @@ private:
    /// Constructs a block-diagonal Mat object
    void BlockDiagonalConstructor(MPI_Comm comm, PetscInt *row_starts,
                                  PetscInt *col_starts, SparseMatrix *diag,
-                                 bool assembled, Mat *A);
+                                 bool assembled, petsc::Mat *A);
 
 public:
    /// Create an empty matrix to be used as a reference to an existing matrix.
@@ -239,7 +250,7 @@ public:
    /// Creates PetscParMatrix out of PETSc's Mat.
    /** @param[in]  a    The PETSc Mat object.
        @param[in]  ref  If true, we increase the reference count of @a a. */
-   PetscParMatrix(Mat a, bool ref=false);
+   PetscParMatrix(petsc::Mat a, bool ref=false);
 
    /** @brief Convert a PetscParMatrix @a pa with a new PETSc format @a tid.
        Note that if @a pa is already a PetscParMatrix of the same type as
@@ -305,7 +316,7 @@ public:
    virtual ~PetscParMatrix() { Destroy(); }
 
    /// Replace the inner Mat Object. The reference count of newA is increased
-   void SetMat(Mat newA);
+   void SetMat(petsc::Mat newA);
 
    /// @name Assignment operators
    ///@{
@@ -331,7 +342,7 @@ public:
    MPI_Comm GetComm() const;
 
    /// Typecasting to PETSc's Mat type
-   operator Mat() const { return A; }
+   operator petsc::Mat() const { return A; }
 
    /// Typecasting to PETSc object
    operator PetscObject() const { return (PetscObject)A; }
@@ -419,7 +430,7 @@ public:
 
    /** @brief Release the PETSc Mat object. If @a dereference is true, decrement
        the refcount of the Mat object. */
-   Mat ReleaseMat(bool dereference);
+   petsc::Mat ReleaseMat(bool dereference);
 
    Type GetType() const;
 };
@@ -645,7 +656,7 @@ public:
    virtual void MultTranspose(const Vector &b, Vector &x) const;
 
    /// Conversion function to PETSc's KSP type.
-   operator KSP() const { return (KSP)obj; }
+   operator petsc::KSP() const { return (petsc::KSP)obj; }
 };
 
 
@@ -681,7 +692,7 @@ public:
    virtual void MultTranspose(const Vector &b, Vector &x) const;
 
    /// Conversion function to PETSc's PC type.
-   operator PC() const { return (PC)obj; }
+   operator petsc::PC() const { return (petsc::PC)obj; }
 };
 
 
@@ -789,7 +800,7 @@ public:
                                  const mfem::Vector& D, const mfem::Vector& P));
 
    /// Conversion function to PETSc's SNES type.
-   operator SNES() const { return (SNES)obj; }
+   operator petsc::SNES() const { return (petsc::SNES)obj; }
 };
 
 
@@ -824,7 +835,7 @@ public:
    virtual void Run(Vector &x, double &t, double &dt, double t_final);
 
    /// Conversion function to PETSc's TS type.
-   operator TS() const { return (TS)obj; }
+   operator petsc::TS() const { return (petsc::TS)obj; }
 };
 
 

--- a/linalg/slepc.hpp
+++ b/linalg/slepc.hpp
@@ -19,11 +19,14 @@
 
 #include "petsc.hpp"
 
-// Forward declarations
-typedef struct _p_EPS *EPS;
+// Forward declaration of SLEPc's internal struct _p_EPS:
+struct _p_EPS;
 
 namespace mfem
 {
+
+// Declare an alias of SLEPc's EPS type, mfem::slepc::EPS:
+namespace slepc { typedef struct ::_p_EPS *EPS; }
 
 void MFEMInitializeSlepc();
 void MFEMInitializeSlepc(int*,char***);
@@ -37,7 +40,7 @@ private:
    mutable bool clcustom;
 
    /// SLEPc linear eigensolver object
-   EPS eps;
+   slepc::EPS eps;
 
    /// Real and imaginary part of eigenvector
    mutable PetscParVector *VR, *VC;
@@ -102,7 +105,7 @@ public:
    void SetSpectralTransformation(SpectralTransformation transformation);
 
    /// Conversion function to SLEPc's EPS type.
-   operator EPS() const { return eps; }
+   operator slepc::EPS() const { return eps; }
 
    /// Conversion function to PetscObject
    operator PetscObject() const {return (PetscObject)eps; }


### PR DESCRIPTION
In `slepc.hpp`, instead of defining globally SLEPc's `EPS` type (aka `struct _p_EPS *`), use an alias: `mfem::slepc::EPS`.

Resolves #1962.

Following @stefanozampini's suggestion, I also moved the PETSc types like `Vec`, `Mat` into the namespace `mfem::petsc`.
<!--GHEX{"id":1967,"author":"v-dobrev","editor":"tzanio","reviewers":["tzanio","stefanozampini"],"assignment":"2021-02-04T15:50:38-08:00","approval":"2021-02-09T16:24:08.302Z","merge":"2021-02-15T02:36:27.530Z"}XEHG--><!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge| 
 | --- | --- | --- | --- | --- | --- | --- | 
| [#1967](https://github.com/mfem/mfem/pull/1967) | @v-dobrev | @tzanio | @tzanio + @stefanozampini | 02/04/21 | 02/09/21 | 02/14/21 | |
<!--ELBATXEHG-->