### PR TITLE
Fix a minor typo in hip.cpp

### DIFF
--- a/general/hip.cpp
+++ b/general/hip.cpp
@@ -125,7 +125,7 @@ void* HipMemcpyDtoDAsync(void* dst, const void *src, size_t bytes)
 void* HipMemcpyDtoH(void *dst, const void *src, size_t bytes)
 {
 #ifdef MFEM_USE_HIP
-#ifdef MFEM_TRACK_HPI_MEM
+#ifdef MFEM_TRACK_HIP_MEM
    mfem::out << "HipMemcpyDtoH(): copying " << bytes << " bytes from "
              << src << " to " << dst << " ... " << std::flush;
 #endif


### PR DESCRIPTION
`MFEM_TRACK_HPI_MEM` -> `MFEM_TRACK_HIP_MEM`

<!--GHEX{"id":1971,"author":"v-dobrev","editor":"tzanio","reviewers":["tzanio","jakubcerveny"],"assignment":"2020-12-24T14:09:35-08:00","approval":"2020-12-26T21:17:55.800Z","merge":"2020-12-26T21:36:09.352Z"}XEHG--><!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge| 
 | --- | --- | --- | --- | --- | --- | --- | 
| [#1971](https://github.com/mfem/mfem/pull/1971) | @v-dobrev | @tzanio | @tzanio + @jakubcerveny | 12/24/20 | 12/26/20 | 12/26/20 | |
<!--ELBATXEHG-->