### PR TITLE
Use filtered link flags for shared lib install

### DIFF
--- a/makefile
+++ b/makefile
@@ -536,7 +536,7 @@ clean: $(addsuffix /clean,$(EM_DIRS) $(TEST_DIRS))
 distclean: clean config/clean doc/clean
 	rm -rf mfem/
 
-INSTALL_SHARED_LIB = $(MFEM_CXX) $(MFEM_BUILD_FLAGS) $(INSTALL_SOFLAGS)\
+INSTALL_SHARED_LIB = $(MFEM_CXX) $(MFEM_LINK_FLAGS) $(INSTALL_SOFLAGS)\
    $(OBJECT_FILES) $(EXT_LIBS) -o $(PREFIX_LIB)/libmfem.$(SO_VER) && \
    cd $(PREFIX_LIB) && ln -sf libmfem.$(SO_VER) libmfem.$(SO_EXT)
 


### PR DESCRIPTION
This PR adjusts the shared library install command:
https://github.com/mfem/mfem/blob/735b4de627e4904b53daeda4920d7c95460d498e/makefile#L539-L541
to match the shared library build command:
https://github.com/mfem/mfem/blob/735b4de627e4904b53daeda4920d7c95460d498e/makefile#L458-L460

This was causing issues when both `MFEM_USE_CUDA` and `MFEM_SHARED` were enabled, as the `-x=cu` is present in the `MFEM_BUILD_FLAGS` (it's only filtered out of the `MFEM_LINK_FLAGS`).