### PR TITLE
Setting the size of the output vector in MatrixVectorProductCoefficient [bugfix/matvec-coef-dev]

### DIFF
--- a/fem/coefficient.cpp
+++ b/fem/coefficient.cpp
@@ -625,6 +625,7 @@ void MatrixVectorProductCoefficient::Eval(Vector &V, ElementTransformation &T,
 {
    a->Eval(ma, T, ip);
    b->Eval(vb, T, ip);
+   V.SetSize(vdim);
    ma.Mult(vb, V);
 }
 


### PR DESCRIPTION
Bugfix to resolve #1976 

I also looked through the other `Eval` methods and did not see any other instances of this sort of bug.
<!--GHEX{"id":1977,"author":"mlstowell","editor":"tzanio","reviewers":["psocratis","vladotomov"],"assignment":"2020-12-30T13:46:18-08:00","approval":"2020-12-30T21:49:36.161Z","merge":"2021-01-04T16:55:02.437Z"}XEHG--><!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge| 
 | --- | --- | --- | --- | --- | --- | --- | 
| [#1977](https://github.com/mfem/mfem/pull/1977) | @mlstowell | @tzanio | @psocratis + @vladotomov | 12/30/20 | 12/30/20 | 01/04/21 | |
<!--ELBATXEHG-->