### PR TITLE
Add checks for invalid higher dimensional branching [face-check-dev]

### DIFF
--- a/mesh/mesh.cpp
+++ b/mesh/mesh.cpp
@@ -5262,10 +5262,22 @@ void Mesh::AddPointFaceElement(int lf, int gf, int el)
    }
    else  //  this will be elem2
    {
+      /* FIX THIS: Without the following check the faces_info data structure
+         may contain unreliable data. Normally the order in which elements are
+         processed could swap which elements appear as Elem1No and Elem2No.
+         In branched meshes, where more than two elements can meet at a given
+         node, the  indices stored in Elem1No and Elem2No will be the first and
+         last, respectively, elements found which touch a given node. This can
+         lead to inconsistencies in any algorithms which rely on this data
+         structure. To properly support branched meshes this data structure
+         should be extended to support multiple elements per face.
+      */
+      /*
       MFEM_VERIFY(faces_info[gf].Elem2No < 0, "Invalid mesh topology.  "
                   "Interior point found connecting 1D elements "
                   << faces_info[gf].Elem1No << ", " << faces_info[gf].Elem2No
                   << " and " << el << ".");
+      */
       faces_info[gf].Elem2No  = el;
       faces_info[gf].Elem2Inf = 64 * lf + 1;
    }

--- a/mesh/mesh.cpp
+++ b/mesh/mesh.cpp
@@ -2641,7 +2641,7 @@ void Mesh::Finalize(bool refine, bool fix_orientation)
       {
          MFEM_VERIFY(faces_info[i].Elem2No < 0 ||
                      faces_info[i].Elem2Inf%2 != 0, "Invalid mesh topology."
-                     "  Interior face with incompatible orientations.");
+                     " Interior face with incompatible orientations.");
       }
    }
 #endif
@@ -5262,18 +5262,17 @@ void Mesh::AddPointFaceElement(int lf, int gf, int el)
    }
    else  //  this will be elem2
    {
-      /* FIX THIS: Without the following check the faces_info data structure
-         may contain unreliable data. Normally the order in which elements are
-         processed could swap which elements appear as Elem1No and Elem2No.
-         In branched meshes, where more than two elements can meet at a given
-         node, the  indices stored in Elem1No and Elem2No will be the first and
-         last, respectively, elements found which touch a given node. This can
-         lead to inconsistencies in any algorithms which rely on this data
-         structure. To properly support branched meshes this data structure
-         should be extended to support multiple elements per face.
-      */
+      /* WARNING: Without the following check the mesh faces_info data structure
+         may contain unreliable data. Normally, the order in which elements are
+         processed could swap which elements appear as Elem1No and Elem2No. In
+         branched meshes, where more than two elements can meet at a given node,
+         the indices stored in Elem1No and Elem2No will be the first and last,
+         respectively, elements found which touch a given node. This can lead to
+         inconsistencies in any algorithms which rely on this data structure. To
+         properly support branched meshes this data structure should be extended
+         to support multiple elements per face. */
       /*
-      MFEM_VERIFY(faces_info[gf].Elem2No < 0, "Invalid mesh topology.  "
+      MFEM_VERIFY(faces_info[gf].Elem2No < 0, "Invalid mesh topology. "
                   "Interior point found connecting 1D elements "
                   << faces_info[gf].Elem1No << ", " << faces_info[gf].Elem2No
                   << " and " << el << ".");

--- a/mesh/mesh.cpp
+++ b/mesh/mesh.cpp
@@ -2640,7 +2640,8 @@ void Mesh::Finalize(bool refine, bool fix_orientation)
       for (int i = 0; i < num_faces; i++)
       {
          MFEM_VERIFY(faces_info[i].Elem2No < 0 ||
-                     faces_info[i].Elem2Inf%2 != 0, "invalid mesh topology");
+                     faces_info[i].Elem2Inf%2 != 0, "Invalid mesh topology."
+                     "  Interior face with incompatible orientations.");
       }
    }
 #endif
@@ -5261,6 +5262,10 @@ void Mesh::AddPointFaceElement(int lf, int gf, int el)
    }
    else  //  this will be elem2
    {
+      MFEM_VERIFY(faces_info[gf].Elem2No < 0, "Invalid mesh topology.  "
+                  "Interior point found connecting 1D elements "
+                  << faces_info[gf].Elem1No << ", " << faces_info[gf].Elem2No
+                  << " and " << el << ".");
       faces_info[gf].Elem2No  = el;
       faces_info[gf].Elem2Inf = 64 * lf + 1;
    }
@@ -5278,6 +5283,10 @@ void Mesh::AddSegmentFaceElement(int lf, int gf, int el, int v0, int v1)
    }
    else  //  this will be elem2
    {
+      MFEM_VERIFY(faces_info[gf].Elem2No < 0, "Invalid mesh topology.  "
+                  "Interior edge found between 2D elements "
+                  << faces_info[gf].Elem1No << ", " << faces_info[gf].Elem2No
+                  << " and " << el << ".");
       int *v = faces[gf]->GetVertices();
       faces_info[gf].Elem2No  = el;
       if ( v[1] == v0 && v[0] == v1 )
@@ -5312,6 +5321,10 @@ void Mesh::AddTriangleFaceElement(int lf, int gf, int el,
    }
    else  //  this will be elem2
    {
+      MFEM_VERIFY(faces_info[gf].Elem2No < 0, "Invalid mesh topology.  "
+                  "Interior triangular face found connecting elements "
+                  << faces_info[gf].Elem1No << ", " << faces_info[gf].Elem2No
+                  << " and " << el << ".");
       int orientation, vv[3] = { v0, v1, v2 };
       orientation = GetTriOrientation(faces[gf]->GetVertices(), vv);
       // In a valid mesh, we should have (orientation % 2 != 0), however, if
@@ -5336,6 +5349,10 @@ void Mesh::AddQuadFaceElement(int lf, int gf, int el,
    }
    else  //  this will be elem2
    {
+      MFEM_VERIFY(faces_info[gf].Elem2No < 0, "Invalid mesh topology.  "
+                  "Interior quadrilateral face found connecting elements "
+                  << faces_info[gf].Elem1No << ", " << faces_info[gf].Elem2No
+                  << " and " << el << ".");
       int vv[4] = { v0, v1, v2, v3 };
       int oo = GetQuadOrientation(faces[gf]->GetVertices(), vv);
       // Temporarily allow even face orientations: see the remark in


### PR DESCRIPTION
MFEM meshes only support two elements being attached to any given face (see the `FaceInfo` struct in `mesh.hpp`).  This PR adds `MFEM_VERIFY` checks that fail when a face is found that seems to be connected to at least three elements.

An examples of invalid an mesh would include a collection of 1D segment elements with branching: ____/____

Meshes like this can be accidentally created when eliminating master/slave pairs of vertices in a periodic domain.

This PR is related to a discussion in PR  #1929 .
<!--GHEX{"id":1981,"author":"mlstowell","editor":"tzanio","reviewers":["bslazarov","pazner"],"assignment":"2021-01-09T16:21:21-08:00","approval":"2021-02-05T00:41:28.249Z","merge":"2021-02-07T23:03:13.832Z"}XEHG--><!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge| 
 | --- | --- | --- | --- | --- | --- | --- | 
| [#1981](https://github.com/mfem/mfem/pull/1981) | @mlstowell | @tzanio | @bslazarov + @pazner | 01/09/21 | 02/04/21 | 02/07/21 | |
<!--ELBATXEHG-->