### PR TITLE
Add convective and skew-symmetric integrator for Navier-Stoke equations [NSE-nonlinear-update]

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -40,6 +40,9 @@ Version 4.2.1 (development)
 - Added new mesh quality metrics and improved the untangling capabilities of the
   TMOP-based mesh optimization algorithms.
 
+- Add convective and skew-symmetric integrators for the nonlinear term in the
+  Navier-Stokes equations.
+
 - Changed the interface for the error estimator.
 
 - Implemented the parallel Kelly error indicator for scalar-valued problems.

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -40,7 +40,7 @@ Version 4.2.1 (development)
 - Added new mesh quality metrics and improved the untangling capabilities of the
   TMOP-based mesh optimization algorithms.
 
-- Add convective and skew-symmetric integrators for the nonlinear term in the
+- Added convective and skew-symmetric integrators for the nonlinear term in the
   Navier-Stokes equations.
 
 - Changed the interface for the error estimator.

--- a/fem/nonlininteg.cpp
+++ b/fem/nonlininteg.cpp
@@ -914,12 +914,7 @@ void SkewSymmetricVectorConvectionNLFIntegrator::AssembleElementGrad(
    double w;
    Vector vec1(dim), vec2(dim), vec3(nd), vec4(dim), vec5(nd);
 
-   const IntegrationRule *ir = IntRule;
-   if (ir == nullptr)
-   {
-      int order = 2 * el.GetOrder() + trans.OrderGrad(&el);
-      ir = &IntRules.Get(el.GetGeomType(), order);
-   }
+   const IntegrationRule *ir = IntRule ? IntRule : &GetRule(el, trans);
 
    elmat = 0.0;
    elmat_comp_T = 0.0;

--- a/fem/nonlininteg.cpp
+++ b/fem/nonlininteg.cpp
@@ -876,8 +876,8 @@ void SkewSymmetricVectorConvectionNLFIntegrator::AssembleElementGrad(
    const Vector &elfun,
    DenseMatrix &elmat)
 {
-   int nd = el.GetDof();
-   int dim = el.GetDim();
+   const int nd = el.GetDof();
+   const int dim = el.GetDim();
 
    shape.SetSize(nd);
    dshape.SetSize(nd, dim);

--- a/fem/nonlininteg.cpp
+++ b/fem/nonlininteg.cpp
@@ -728,10 +728,8 @@ void VectorConvectionNLFIntegrator::AssembleElementVector(
       el.CalcShape(ip, shape);
       el.CalcPhysDShape(T, dshape);
       double w = ip.weight * T.Weight();
-      if (Q)
-      {
-         w *= Q->Eval(T, ip);
-      }
+      if (Q) { w *= Q->Eval(T, ip); }
+
       MultAtB(EF, dshape, gradEF);
       EF.MultTranspose(shape, vec1);
       gradEF.Mult(vec1, vec2);
@@ -746,8 +744,8 @@ void VectorConvectionNLFIntegrator::AssembleElementGrad(
    const Vector &elfun,
    DenseMatrix &elmat)
 {
-   int nd = el.GetDof();
-   int dim = el.GetDim();
+   const int nd = el.GetDof();
+   const int dim = el.GetDim();
 
    shape.SetSize(nd);
    dshape.SetSize(nd, dim);
@@ -823,8 +821,8 @@ void ConvectiveVectorConvectionNLFIntegrator::AssembleElementGrad(
    const Vector &elfun,
    DenseMatrix &elmat)
 {
-   int nd = el.GetDof();
-   int dim = el.GetDim();
+   const int nd = el.GetDof();
+   const int dim = el.GetDim();
 
    shape.SetSize(nd);
    dshape.SetSize(nd, dim);

--- a/fem/nonlininteg.cpp
+++ b/fem/nonlininteg.cpp
@@ -833,7 +833,6 @@ void ConvectiveVectorConvectionNLFIntegrator::AssembleElementGrad(
 
    EF.UseExternalData(elfun.GetData(), nd, dim);
 
-   double w;
    Vector vec1(dim), vec2(dim), vec3(nd);
 
    const IntegrationRule *ir = IntRule ? IntRule : &GetRule(el, trans);
@@ -847,12 +846,7 @@ void ConvectiveVectorConvectionNLFIntegrator::AssembleElementGrad(
       el.CalcShape(ip, shape);
       el.CalcDShape(ip, dshape);
 
-      w = ip.weight;
-
-      if (Q)
-      {
-         w *= Q->Eval(trans, ip);
-      }
+      const double w = Q ? Q->Eval(trans, ip) * ip.weight : ip.weight;
 
       EF.MultTranspose(shape, vec1); // u^n
 
@@ -890,7 +884,6 @@ void SkewSymmetricVectorConvectionNLFIntegrator::AssembleElementGrad(
 
    EF.UseExternalData(elfun.GetData(), nd, dim);
 
-   double w;
    Vector vec1(dim), vec2(dim), vec3(nd), vec4(dim), vec5(nd);
 
    const IntegrationRule *ir = IntRule ? IntRule : &GetRule(el, trans);
@@ -907,12 +900,7 @@ void SkewSymmetricVectorConvectionNLFIntegrator::AssembleElementGrad(
 
       Mult(dshape, trans.InverseJacobian(), dshapex);
 
-      w = ip.weight;
-
-      if (Q)
-      {
-         w *= Q->Eval(trans, ip);
-      }
+      const double w = Q ? Q->Eval(trans, ip) * ip.weight : ip.weight;
 
       EF.MultTranspose(shape, vec1); // u^n
 

--- a/fem/nonlininteg.cpp
+++ b/fem/nonlininteg.cpp
@@ -845,12 +845,7 @@ void ConvectiveVectorConvectionNLFIntegrator::AssembleElementGrad(
    double w;
    Vector vec1(dim), vec2(dim), vec3(nd);
 
-   const IntegrationRule *ir = IntRule;
-   if (ir == nullptr)
-   {
-      int order = 2 * el.GetOrder() + trans.OrderGrad(&el);
-      ir = &IntRules.Get(el.GetGeomType(), order);
-   }
+   const IntegrationRule *ir = IntRule ? IntRule : &GetRule(el, trans);
 
    elmat = 0.0;
    for (int i = 0; i < ir->GetNPoints(); i++)

--- a/fem/nonlininteg.cpp
+++ b/fem/nonlininteg.cpp
@@ -954,8 +954,6 @@ void SkewSymmetricVectorConvectionNLFIntegrator::AssembleElementGrad(
          elmat.AddMatrix(.5, elmat_comp, i * nd, i * nd);
          elmat.AddMatrix(-.5, elmat_comp_T, i * nd, i * nd);
       }
-
-
    }
 }
 

--- a/fem/nonlininteg.cpp
+++ b/fem/nonlininteg.cpp
@@ -816,13 +816,6 @@ void VectorConvectionNLFIntegrator::AssembleElementGrad(
    }
 }
 
-const IntegrationRule&
-ConvectiveVectorConvectionNLFIntegrator::GetRule(const FiniteElement &fe,
-                                                 ElementTransformation &T)
-{
-   const int order = 2 * fe.GetOrder() + T.OrderGrad(&fe);
-   return IntRules.Get(fe.GetGeomType(), order);
-}
 
 void ConvectiveVectorConvectionNLFIntegrator::AssembleElementGrad(
    const FiniteElement &el,
@@ -878,13 +871,6 @@ void ConvectiveVectorConvectionNLFIntegrator::AssembleElementGrad(
    }
 }
 
-const IntegrationRule&
-SkewSymmetricVectorConvectionNLFIntegrator::GetRule(const FiniteElement &fe,
-                                                    ElementTransformation &T)
-{
-   const int order = 2 * fe.GetOrder() + T.OrderGrad(&fe);
-   return IntRules.Get(fe.GetGeomType(), order);
-}
 
 void SkewSymmetricVectorConvectionNLFIntegrator::AssembleElementGrad(
    const FiniteElement &el,

--- a/fem/nonlininteg.cpp
+++ b/fem/nonlininteg.cpp
@@ -880,8 +880,6 @@ void ConvectiveVectorConvectionNLFIntegrator::AssembleElementGrad(
       {
          elmat.AddMatrix(elmat_comp, i * nd, i * nd);
       }
-
-
    }
 }
 

--- a/fem/nonlininteg.hpp
+++ b/fem/nonlininteg.hpp
@@ -359,18 +359,10 @@ nonlinear  term arising in the Navier Stokes equations
 \f$(u \cdot \nabla v, w )\f$*/
 class ConvectiveVectorConvectionNLFIntegrator : public VectorConvectionNLFIntegrator
 {
-private:
-   Coefficient *Q{};
-   DenseMatrix dshape, dshapex, EF, gradEF, ELV, elmat_comp;
-   Vector shape;
 public:
    ConvectiveVectorConvectionNLFIntegrator(Coefficient &q): Q(&q) { }
 
    ConvectiveVectorConvectionNLFIntegrator() = default;
-
-   static const IntegrationRule &GetRule(const FiniteElement &fe,
-                                         ElementTransformation &T);
-
 
    virtual void AssembleElementGrad(const FiniteElement &el,
                                     ElementTransformation &trans,
@@ -382,20 +374,12 @@ public:
 term arising in the Navier Stokes equations \f$.5*(u \cdot \nabla v, w ) -
 .5*(u \cdot \nabla w, v )\f$ */
 class SkewSymmetricVectorConvectionNLFIntegrator : public
-   NonlinearFormIntegrator
+   VectorConvectionNLFIntegrator
 {
-private:
-   Coefficient *Q{};
-   DenseMatrix dshape, dshapex, EF, gradEF, ELV, elmat_comp;
-   Vector shape;
 public:
    SkewSymmetricVectorConvectionNLFIntegrator(Coefficient &q): Q(&q) { }
 
    SkewSymmetricVectorConvectionNLFIntegrator() = default;
-
-   static const IntegrationRule &GetRule(const FiniteElement &fe,
-                                         ElementTransformation &T);
-
 
    virtual void AssembleElementGrad(const FiniteElement &el,
                                     ElementTransformation &trans,

--- a/fem/nonlininteg.hpp
+++ b/fem/nonlininteg.hpp
@@ -354,10 +354,9 @@ public:
    virtual void AddMultPA(const Vector &x, Vector &y) const;
 };
 
-
-/** @brief This class is used to assemble the convective form of the nonlinear term arising in the Navier Stokes
-equations (u \cdot \nabla v, w )
- */
+/** @brief This class is used to assemble the skew-symmetric form of the 
+nonlinear  term arising in the Navier Stokes equations 
+\f$(u \cdot \nabla v, w )\f$*/
 class ConvectiveVectorConvectionNLFIntegrator : public NonlinearFormIntegrator
 {
 private:
@@ -384,9 +383,9 @@ public:
                                     DenseMatrix &elmat);
 
 };
-/** @brief This class is used to assemble the skew-symmetric form of the nonlinear term arising in the Navier Stokes
-equations .5*(u \cdot \nabla v, w ) - .5*(u \cdot \nabla w, v )
- */
+/** @brief This class is used to assemble the skew-symmetric form of the nonlinear 
+term arising in the Navier Stokes equations \f$.5*(u \cdot \nabla v, w ) - 
+.5*(u \cdot \nabla w, v )\f$ */
 class SkewSymmetricVectorConvectionNLFIntegrator : public
    NonlinearFormIntegrator
 {

--- a/fem/nonlininteg.hpp
+++ b/fem/nonlininteg.hpp
@@ -363,9 +363,9 @@ public:
                                     DenseMatrix &elmat);
 
 };
-/** @brief This class is used to assemble the skew-symmetric form of the nonlinear
-term arising in the Navier Stokes equations \f$.5*(u \cdot \nabla v, w ) -
-.5*(u \cdot \nabla w, v )\f$ */
+/** @brief This class is used to assemble the skew-symmetric form of
+the nonlinear term arising in the Navier Stokes equations
+\f$.5*(u \cdot \nabla v, w ) - .5*(u \cdot \nabla w, v )\f$ */
 class SkewSymmetricVectorConvectionNLFIntegrator : public
    VectorConvectionNLFIntegrator
 {

--- a/fem/nonlininteg.hpp
+++ b/fem/nonlininteg.hpp
@@ -363,11 +363,6 @@ private:
    Coefficient *Q{};
    DenseMatrix dshape, dshapex, EF, gradEF, ELV, elmat_comp;
    Vector shape;
-   // PA extension
-   Vector pa_data;
-   const DofToQuad *maps;         ///< Not owned
-   const GeometricFactors *geom;  ///< Not owned
-   int dim, ne, nq;
 public:
    ConvectiveVectorConvectionNLFIntegrator(Coefficient &q): Q(&q) { }
 
@@ -393,11 +388,6 @@ private:
    Coefficient *Q{};
    DenseMatrix dshape, dshapex, EF, gradEF, ELV, elmat_comp;
    Vector shape;
-   // PA extension
-   Vector pa_data;
-   const DofToQuad *maps;         ///< Not owned
-   const GeometricFactors *geom;  ///< Not owned
-   int dim, ne, nq;
 public:
    SkewSymmetricVectorConvectionNLFIntegrator(Coefficient &q): Q(&q) { }
 

--- a/fem/nonlininteg.hpp
+++ b/fem/nonlininteg.hpp
@@ -379,7 +379,7 @@ public:
 term arising in the Navier Stokes equations \f$.5*(u \cdot \nabla v, w ) -
 .5*(u \cdot \nabla w, v )\f$ */
 class SkewSymmetricVectorConvectionNLFIntegrator : public
-   NonlinearFormIntegrator
+   VectorConvectionNLFIntegrator
 {
 private:
    Coefficient *Q{};

--- a/fem/nonlininteg.hpp
+++ b/fem/nonlininteg.hpp
@@ -354,8 +354,8 @@ public:
    virtual void AddMultPA(const Vector &x, Vector &y) const;
 };
 
-/** @brief This class is used to assemble the skew-symmetric form of the 
-nonlinear  term arising in the Navier Stokes equations 
+/** @brief This class is used to assemble the skew-symmetric form of the
+nonlinear  term arising in the Navier Stokes equations
 \f$(u \cdot \nabla v, w )\f$*/
 class ConvectiveVectorConvectionNLFIntegrator : public NonlinearFormIntegrator
 {
@@ -383,8 +383,8 @@ public:
                                     DenseMatrix &elmat);
 
 };
-/** @brief This class is used to assemble the skew-symmetric form of the nonlinear 
-term arising in the Navier Stokes equations \f$.5*(u \cdot \nabla v, w ) - 
+/** @brief This class is used to assemble the skew-symmetric form of the nonlinear
+term arising in the Navier Stokes equations \f$.5*(u \cdot \nabla v, w ) -
 .5*(u \cdot \nabla w, v )\f$ */
 class SkewSymmetricVectorConvectionNLFIntegrator : public
    NonlinearFormIntegrator

--- a/fem/nonlininteg.hpp
+++ b/fem/nonlininteg.hpp
@@ -342,16 +342,17 @@ public:
    virtual void AddMultPA(const Vector &x, Vector &y) const;
 };
 
-/** @brief This class is used to assemble the convective form of the
-nonlinear term arising in the Navier Stokes equations
-\f$(u \cdot \nabla v, w )\f$ */
-class ConvectiveVectorConvectionNLFIntegrator : public
-   VectorConvectionNLFIntegrator
+
+/** This class is used to assemble the convective form of the nonlinear term
+    arising in the Navier-Stokes equations \f$(u \cdot \nabla v, w )\f$ */
+class ConvectiveVectorConvectionNLFIntegrator :
+   public VectorConvectionNLFIntegrator
 {
 private:
    Coefficient *Q{};
    DenseMatrix dshape, dshapex, EF, gradEF, ELV, elmat_comp;
    Vector shape;
+
 public:
    ConvectiveVectorConvectionNLFIntegrator(Coefficient &q): Q(&q) { }
 
@@ -361,18 +362,20 @@ public:
                                     ElementTransformation &trans,
                                     const Vector &elfun,
                                     DenseMatrix &elmat);
-
 };
-/** @brief This class is used to assemble the skew-symmetric form of
-the nonlinear term arising in the Navier Stokes equations
-\f$.5*(u \cdot \nabla v, w ) - .5*(u \cdot \nabla w, v )\f$ */
-class SkewSymmetricVectorConvectionNLFIntegrator : public
-   VectorConvectionNLFIntegrator
+
+
+/** This class is used to assemble the skew-symmetric form of the nonlinear term
+    arising in the Navier-Stokes equations
+    \f$.5*(u \cdot \nabla v, w ) - .5*(u \cdot \nabla w, v )\f$ */
+class SkewSymmetricVectorConvectionNLFIntegrator :
+   public VectorConvectionNLFIntegrator
 {
 private:
    Coefficient *Q{};
    DenseMatrix dshape, dshapex, EF, gradEF, ELV, elmat_comp;
    Vector shape;
+
 public:
    SkewSymmetricVectorConvectionNLFIntegrator(Coefficient &q): Q(&q) { }
 
@@ -382,7 +385,6 @@ public:
                                     ElementTransformation &trans,
                                     const Vector &elfun,
                                     DenseMatrix &elmat);
-
 };
 
 }

--- a/fem/nonlininteg.hpp
+++ b/fem/nonlininteg.hpp
@@ -357,7 +357,7 @@ public:
 /** @brief This class is used to assemble the skew-symmetric form of the
 nonlinear  term arising in the Navier Stokes equations
 \f$(u \cdot \nabla v, w )\f$*/
-class ConvectiveVectorConvectionNLFIntegrator : public NonlinearFormIntegrator
+class ConvectiveVectorConvectionNLFIntegrator : public VectorConvectionNLFIntegrator
 {
 private:
    Coefficient *Q{};

--- a/fem/nonlininteg.hpp
+++ b/fem/nonlininteg.hpp
@@ -357,8 +357,13 @@ public:
 /** @brief This class is used to assemble the skew-symmetric form of the
 nonlinear  term arising in the Navier Stokes equations
 \f$(u \cdot \nabla v, w )\f$*/
-class ConvectiveVectorConvectionNLFIntegrator : public VectorConvectionNLFIntegrator
+class ConvectiveVectorConvectionNLFIntegrator : public
+   VectorConvectionNLFIntegrator
 {
+private:
+   Coefficient *Q{};
+   DenseMatrix dshape, dshapex, EF, gradEF, ELV, elmat_comp;
+   Vector shape;
 public:
    ConvectiveVectorConvectionNLFIntegrator(Coefficient &q): Q(&q) { }
 
@@ -374,8 +379,12 @@ public:
 term arising in the Navier Stokes equations \f$.5*(u \cdot \nabla v, w ) -
 .5*(u \cdot \nabla w, v )\f$ */
 class SkewSymmetricVectorConvectionNLFIntegrator : public
-   VectorConvectionNLFIntegrator
+   NonlinearFormIntegrator
 {
+private:
+   Coefficient *Q{};
+   DenseMatrix dshape, dshapex, EF, gradEF, ELV, elmat_comp;
+   Vector shape;
 public:
    SkewSymmetricVectorConvectionNLFIntegrator(Coefficient &q): Q(&q) { }
 

--- a/fem/nonlininteg.hpp
+++ b/fem/nonlininteg.hpp
@@ -34,16 +34,10 @@ protected:
 public:
    /** @brief Prescribe a fixed IntegrationRule to use (when @a ir != NULL) or
        let the integrator choose (when @a ir == NULL). */
-   void SetIntRule(const IntegrationRule *ir)
-   {
-      IntRule = ir;
-   }
+   void SetIntRule(const IntegrationRule *ir) { IntRule = ir; }
 
    /// Prescribe a fixed IntegrationRule to use.
-   void SetIntegrationRule(const IntegrationRule &irule)
-   {
-      IntRule = &irule;
-   }
+   void SetIntegrationRule(const IntegrationRule &irule) { IntRule = &irule; }
 
    /// Perform the local action of the NonlinearFormIntegrator
    virtual void AssembleElementVector(const FiniteElement &el,
@@ -151,10 +145,7 @@ public:
    /// evaluate Coefficient%s.
    /** @note It is assumed that _Ttr.SetIntPoint() is already called for the
        point of interest. */
-   void SetTransformation(ElementTransformation &_Ttr)
-   {
-      Ttr = &_Ttr;
-   }
+   void SetTransformation(ElementTransformation &_Ttr) { Ttr = &_Ttr; }
 
    /** @brief Evaluate the strain energy density function, W = W(Jpt).
        @param[in] Jpt  Represents the target->physical transformation
@@ -223,10 +214,7 @@ protected:
 
 public:
    NeoHookeanModel(double _mu, double _K, double _g = 1.0)
-      : mu(_mu), K(_K), g(_g), have_coeffs(false)
-   {
-      c_mu = c_K = c_g = NULL;
-   }
+      : mu(_mu), K(_K), g(_g), have_coeffs(false) { c_mu = c_K = c_g = NULL; }
 
    NeoHookeanModel(Coefficient &_mu, Coefficient &_K, Coefficient *_g = NULL)
       : mu(0.0), K(0.0), g(1.0), c_mu(&_mu), c_K(&_K), c_g(_g),
@@ -354,9 +342,9 @@ public:
    virtual void AddMultPA(const Vector &x, Vector &y) const;
 };
 
-/** @brief This class is used to assemble the skew-symmetric form of the
-nonlinear  term arising in the Navier Stokes equations
-\f$(u \cdot \nabla v, w )\f$*/
+/** @brief This class is used to assemble the convective form of the
+nonlinear term arising in the Navier Stokes equations
+\f$(u \cdot \nabla v, w )\f$ */
 class ConvectiveVectorConvectionNLFIntegrator : public
    VectorConvectionNLFIntegrator
 {


### PR DESCRIPTION
Adds the convective form and skew symmetric form of the nonlinear term arising in the Navier-Stokes equations. The current implementation within MFEM, which does not require partial assembly can only be used for obtaining the Gateaux derivative. However, other versions of the nonlinear form are needed for approaches such as a Picard iterations or IMEX time stepping schemes.
<!--GHEX{"id":1983,"author":"nnpp-schneier","editor":"tzanio","reviewers":["jandrej","rcarson3","YohannDudouit"],"assignment":"2021-01-09T16:20:11-08:00","approval":"2021-02-02T05:14:49.375Z","merge":"2021-02-07T23:00:04.535Z"}XEHG--><!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge| 
 | --- | --- | --- | --- | --- | --- | --- | 
| [#1983](https://github.com/mfem/mfem/pull/1983) | @nnpp-schneier | @tzanio | @jandrej + @rcarson3 + @YohannDudouit | 01/09/21 | 02/01/21 | 02/07/21 | |
<!--ELBATXEHG-->