### PR TITLE
Expanding unit tests to include L2 basis with MapType INTEGRAL [l2-integral-dev]

### DIFF
--- a/fem/bilininteg.cpp
+++ b/fem/bilininteg.cpp
@@ -907,9 +907,10 @@ void MassIntegrator::AssembleElementMatrix
    for (int i = 0; i < ir->GetNPoints(); i++)
    {
       const IntegrationPoint &ip = ir->IntPoint(i);
-      el.CalcShape(ip, shape);
-
       Trans.SetIntPoint (&ip);
+
+      el.CalcPhysShape(Trans, shape);
+
       w = Trans.Weight() * ip.weight;
       if (Q)
       {

--- a/fem/gridfunc.cpp
+++ b/fem/gridfunc.cpp
@@ -467,14 +467,25 @@ const
    fes->GetElementDofs(i, dofs);
    fes->DofsToVDofs(vdim-1, dofs);
    const FiniteElement *FElem = fes->GetFE(i);
-   MFEM_ASSERT(FElem->GetMapType() == FiniteElement::VALUE,
-               "invalid FE map type");
+   ElementTransformation *Tr = NULL;
+   if (FElem->GetMapType() != FiniteElement::VALUE)
+   {
+      Tr = fes->GetElementTransformation(i);
+   }
    int dof = FElem->GetDof();
    Vector DofVal(dof), loc_data(dof);
    GetSubVector(dofs, loc_data);
    for (int k = 0; k < n; k++)
    {
-      FElem->CalcShape(ir.IntPoint(k), DofVal);
+      if (FElem->GetMapType() == FiniteElement::VALUE)
+      {
+         FElem->CalcShape(ir.IntPoint(k), DofVal);
+      }
+      else
+      {
+         Tr->SetIntPoint(&ir.IntPoint(k));
+         FElem->CalcPhysShape(*Tr, DofVal);
+      }
       vals(k) = DofVal * loc_data;
    }
 }

--- a/tests/unit/fem/test_1d_bilininteg.cpp
+++ b/tests/unit/fem/test_1d_bilininteg.cpp
@@ -30,6 +30,21 @@ double dvf1(const Vector & x) { return dv1(x) * f1(x) + v1(x) * df1(x); }
 double ddf1(const Vector & x) { return 0.0; }
 double dvdf1(const Vector & x) { return - dv1(x) * df1(x); }
 
+const std::string MapTypeName(FiniteElement::MapType map_type)
+{
+   switch (map_type)
+   {
+      case FiniteElement::VALUE:
+         return "VALUE";
+      case FiniteElement::INTEGRAL:
+         return "INTEGRAL";
+      case FiniteElement::H_CURL:
+         return "H_CURL";
+      case FiniteElement::H_DIV:
+         return "H_DIV";
+   }
+}
+
 TEST_CASE("1D Bilinear Mass Integrators",
           "[MixedScalarMassIntegrator]"
           "[MixedScalarIntegrator]"
@@ -53,61 +68,68 @@ TEST_CASE("1D Bilinear Mass Integrators",
 
       GridFunction f_h1(&fespace_h1); f_h1.ProjectCoefficient(f1_coef);
 
-      SECTION("Mapping H1 to L2")
+      for (int map_type = (int)FiniteElement::VALUE;
+           map_type <= (int)FiniteElement::INTEGRAL; map_type++)
       {
-         L2_FECollection    fec_l2(order, dim);
-         FiniteElementSpace fespace_l2(&mesh, &fec_l2);
-
-         BilinearForm m_l2(&fespace_l2);
-         m_l2.AddDomainIntegrator(new MassIntegrator());
-         m_l2.Assemble();
-         m_l2.Finalize();
-
-         GridFunction g_l2(&fespace_l2);
-
-         Vector tmp_l2(fespace_l2.GetNDofs());
-
-         SECTION("Without Coefficient")
+         SECTION("Mapping H1 to L2 (" +
+                 MapTypeName((FiniteElement::MapType)map_type) + ")")
          {
-            MixedBilinearForm blf(&fespace_h1, &fespace_l2);
-            blf.AddDomainIntegrator(new MixedScalarMassIntegrator());
-            blf.Assemble();
-            blf.Finalize();
+            L2_FECollection    fec_l2(order, dim,
+                                      BasisType::GaussLegendre,
+                                      (FiniteElement::MapType)map_type);
+            FiniteElementSpace fespace_l2(&mesh, &fec_l2);
 
-            blf.Mult(f_h1,tmp_l2); g_l2 = 0.0;
-            CG(m_l2, tmp_l2, g_l2, 0, 200, cg_rtol * cg_rtol, 0.0);
+            BilinearForm m_l2(&fespace_l2);
+            m_l2.AddDomainIntegrator(new MassIntegrator());
+            m_l2.Assemble();
+            m_l2.Finalize();
 
-            REQUIRE( g_l2.ComputeL2Error(f1_coef) < tol );
+            GridFunction g_l2(&fespace_l2);
 
-            MixedBilinearForm blfw(&fespace_l2, &fespace_h1);
-            blfw.AddDomainIntegrator(new MixedScalarMassIntegrator());
-            blfw.Assemble();
-            blfw.Finalize();
+            Vector tmp_l2(fespace_l2.GetNDofs());
 
-            SparseMatrix * blfT = Transpose(blfw.SpMat());
-            SparseMatrix * diff = Add(1.0,blf.SpMat(),-1.0,*blfT);
-            REQUIRE( diff->MaxNorm() < tol );
-         }
-         SECTION("With Coefficient")
-         {
-            MixedBilinearForm blf(&fespace_h1, &fespace_l2);
-            blf.AddDomainIntegrator(new MixedScalarMassIntegrator(v1_coef));
-            blf.Assemble();
-            blf.Finalize();
+            SECTION("Without Coefficient")
+            {
+               MixedBilinearForm blf(&fespace_h1, &fespace_l2);
+               blf.AddDomainIntegrator(new MixedScalarMassIntegrator());
+               blf.Assemble();
+               blf.Finalize();
 
-            blf.Mult(f_h1,tmp_l2); g_l2 = 0.0;
-            CG(m_l2, tmp_l2, g_l2, 0, 200, cg_rtol * cg_rtol, 0.0);
+               blf.Mult(f_h1,tmp_l2); g_l2 = 0.0;
+               CG(m_l2, tmp_l2, g_l2, 0, 200, cg_rtol * cg_rtol, 0.0);
 
-            REQUIRE( g_l2.ComputeL2Error(vf1_coef) < tol );
+               REQUIRE( g_l2.ComputeL2Error(f1_coef) < tol );
 
-            MixedBilinearForm blfw(&fespace_l2, &fespace_h1);
-            blfw.AddDomainIntegrator(new MixedScalarMassIntegrator(v1_coef));
-            blfw.Assemble();
-            blfw.Finalize();
+               MixedBilinearForm blfw(&fespace_l2, &fespace_h1);
+               blfw.AddDomainIntegrator(new MixedScalarMassIntegrator());
+               blfw.Assemble();
+               blfw.Finalize();
 
-            SparseMatrix * blfT = Transpose(blfw.SpMat());
-            SparseMatrix * diff = Add(1.0,blf.SpMat(),-1.0,*blfT);
-            REQUIRE( diff->MaxNorm() < tol );
+               SparseMatrix * blfT = Transpose(blfw.SpMat());
+               SparseMatrix * diff = Add(1.0,blf.SpMat(),-1.0,*blfT);
+               REQUIRE( diff->MaxNorm() < tol );
+            }
+            SECTION("With Coefficient")
+            {
+               MixedBilinearForm blf(&fespace_h1, &fespace_l2);
+               blf.AddDomainIntegrator(new MixedScalarMassIntegrator(v1_coef));
+               blf.Assemble();
+               blf.Finalize();
+
+               blf.Mult(f_h1,tmp_l2); g_l2 = 0.0;
+               CG(m_l2, tmp_l2, g_l2, 0, 200, cg_rtol * cg_rtol, 0.0);
+
+               REQUIRE( g_l2.ComputeL2Error(vf1_coef) < tol );
+
+               MixedBilinearForm blfw(&fespace_l2, &fespace_h1);
+               blfw.AddDomainIntegrator(new MixedScalarMassIntegrator(v1_coef));
+               blfw.Assemble();
+               blfw.Finalize();
+
+               SparseMatrix * blfT = Transpose(blfw.SpMat());
+               SparseMatrix * diff = Add(1.0,blf.SpMat(),-1.0,*blfT);
+               REQUIRE( diff->MaxNorm() < tol );
+            }
          }
       }
       SECTION("Mapping H1 to H1")
@@ -147,104 +169,125 @@ TEST_CASE("1D Bilinear Mass Integrators",
          }
       }
    }
-   SECTION("Operators on L2")
+   for (int map_type_d = (int)FiniteElement::VALUE;
+        map_type_d <= (int)FiniteElement::INTEGRAL; map_type_d++)
    {
-      L2_FECollection    fec_l2(order, dim);
-      FiniteElementSpace fespace_l2(&mesh, &fec_l2);
-
-      GridFunction f_l2(&fespace_l2); f_l2.ProjectCoefficient(f1_coef);
-
-      SECTION("Mapping L2 to L2")
+      SECTION("Operators on L2 (" +
+              MapTypeName((FiniteElement::MapType)map_type_d) + ")")
       {
-         BilinearForm m_l2(&fespace_l2);
-         m_l2.AddDomainIntegrator(new MassIntegrator());
-         m_l2.Assemble();
-         m_l2.Finalize();
+         L2_FECollection    fec_l2_d(order, dim,
+                                     BasisType::GaussLegendre,
+                                     (FiniteElement::MapType)map_type_d);
+         FiniteElementSpace fespace_l2_d(&mesh, &fec_l2_d);
 
-         GridFunction g_l2(&fespace_l2);
+         GridFunction f_l2(&fespace_l2_d); f_l2.ProjectCoefficient(f1_coef);
 
-         Vector tmp_l2(fespace_l2.GetNDofs());
-
-         SECTION("Without Coefficient")
+         for (int map_type_r = (int)FiniteElement::VALUE;
+              map_type_r <= (int)FiniteElement::INTEGRAL; map_type_r++)
          {
-            MixedBilinearForm blf(&fespace_l2, &fespace_l2);
-            blf.AddDomainIntegrator(new MixedScalarMassIntegrator());
-            blf.Assemble();
-            blf.Finalize();
+            SECTION("Mapping L2 (" +
+                    MapTypeName((FiniteElement::MapType)map_type_d) +
+                    ") to L2 (" +
+                    MapTypeName((FiniteElement::MapType)map_type_r) + ")")
+            {
+               L2_FECollection    fec_l2_r(order, dim,
+                                           BasisType::GaussLegendre,
+                                           (FiniteElement::MapType)map_type_r);
+               FiniteElementSpace fespace_l2_r(&mesh, &fec_l2_r);
 
-            blf.Mult(f_l2,tmp_l2); g_l2 = 0.0;
-            CG(m_l2, tmp_l2, g_l2, 0, 200, cg_rtol * cg_rtol, 0.0);
+               BilinearForm m_l2(&fespace_l2_r);
+               m_l2.AddDomainIntegrator(new MassIntegrator());
+               m_l2.Assemble();
+               m_l2.Finalize();
 
-            REQUIRE( g_l2.ComputeL2Error(f1_coef) < tol );
+               GridFunction g_l2(&fespace_l2_r);
+
+               Vector tmp_l2(fespace_l2_r.GetNDofs());
+
+               SECTION("Without Coefficient")
+               {
+                  MixedBilinearForm blf(&fespace_l2_d, &fespace_l2_r);
+                  blf.AddDomainIntegrator(new MixedScalarMassIntegrator());
+                  blf.Assemble();
+                  blf.Finalize();
+
+                  blf.Mult(f_l2,tmp_l2); g_l2 = 0.0;
+                  CG(m_l2, tmp_l2, g_l2, 0, 200, cg_rtol * cg_rtol, 0.0);
+
+                  REQUIRE( g_l2.ComputeL2Error(f1_coef) < tol );
+               }
+               SECTION("With Coefficient")
+               {
+                  MixedBilinearForm blf(&fespace_l2_d, &fespace_l2_r);
+                  blf.AddDomainIntegrator(new MixedScalarMassIntegrator(v1_coef));
+                  blf.Assemble();
+                  blf.Finalize();
+
+                  blf.Mult(f_l2,tmp_l2); g_l2 = 0.0;
+                  CG(m_l2, tmp_l2, g_l2, 0, 200, cg_rtol * cg_rtol, 0.0);
+
+                  REQUIRE( g_l2.ComputeL2Error(vf1_coef) < tol );
+               }
+            }
          }
-         SECTION("With Coefficient")
+         SECTION("Mapping L2 (" +
+                 MapTypeName((FiniteElement::MapType)map_type_d) +
+                 ") to H1")
          {
-            MixedBilinearForm blf(&fespace_l2, &fespace_l2);
-            blf.AddDomainIntegrator(new MixedScalarMassIntegrator(v1_coef));
-            blf.Assemble();
-            blf.Finalize();
+            H1_FECollection    fec_h1(order, dim);
+            FiniteElementSpace fespace_h1(&mesh, &fec_h1);
 
-            blf.Mult(f_l2,tmp_l2); g_l2 = 0.0;
-            CG(m_l2, tmp_l2, g_l2, 0, 200, cg_rtol * cg_rtol, 0.0);
+            BilinearForm m_h1(&fespace_h1);
+            m_h1.AddDomainIntegrator(new MassIntegrator());
+            m_h1.Assemble();
+            m_h1.Finalize();
 
-            REQUIRE( g_l2.ComputeL2Error(vf1_coef) < tol );
-         }
-      }
-      SECTION("Mapping L2 to H1")
-      {
-         H1_FECollection    fec_h1(order, dim);
-         FiniteElementSpace fespace_h1(&mesh, &fec_h1);
+            GridFunction g_h1(&fespace_h1);
 
-         BilinearForm m_h1(&fespace_h1);
-         m_h1.AddDomainIntegrator(new MassIntegrator());
-         m_h1.Assemble();
-         m_h1.Finalize();
+            Vector tmp_h1(fespace_h1.GetNDofs());
 
-         GridFunction g_h1(&fespace_h1);
+            SECTION("Without Coefficient")
+            {
+               MixedBilinearForm blf(&fespace_l2_d, &fespace_h1);
+               blf.AddDomainIntegrator(new MixedScalarMassIntegrator());
+               blf.Assemble();
+               blf.Finalize();
 
-         Vector tmp_h1(fespace_h1.GetNDofs());
+               blf.Mult(f_l2,tmp_h1); g_h1 = 0.0;
+               CG(m_h1, tmp_h1, g_h1, 0, 200, cg_rtol * cg_rtol, 0.0);
 
-         SECTION("Without Coefficient")
-         {
-            MixedBilinearForm blf(&fespace_l2, &fespace_h1);
-            blf.AddDomainIntegrator(new MixedScalarMassIntegrator());
-            blf.Assemble();
-            blf.Finalize();
+               REQUIRE( g_h1.ComputeL2Error(f1_coef) < tol );
 
-            blf.Mult(f_l2,tmp_h1); g_h1 = 0.0;
-            CG(m_h1, tmp_h1, g_h1, 0, 200, cg_rtol * cg_rtol, 0.0);
+               MixedBilinearForm blfw(&fespace_h1, &fespace_l2_d);
+               blfw.AddDomainIntegrator(new MixedScalarMassIntegrator());
+               blfw.Assemble();
+               blfw.Finalize();
 
-            REQUIRE( g_h1.ComputeL2Error(f1_coef) < tol );
+               SparseMatrix * blfT = Transpose(blfw.SpMat());
+               SparseMatrix * diff = Add(1.0,blf.SpMat(),-1.0,*blfT);
+               REQUIRE( diff->MaxNorm() < tol );
+            }
+            SECTION("With Coefficient")
+            {
+               MixedBilinearForm blf(&fespace_l2_d, &fespace_h1);
+               blf.AddDomainIntegrator(new MixedScalarMassIntegrator(v1_coef));
+               blf.Assemble();
+               blf.Finalize();
 
-            MixedBilinearForm blfw(&fespace_h1, &fespace_l2);
-            blfw.AddDomainIntegrator(new MixedScalarMassIntegrator());
-            blfw.Assemble();
-            blfw.Finalize();
+               blf.Mult(f_l2,tmp_h1); g_h1 = 0.0;
+               CG(m_h1, tmp_h1, g_h1, 0, 200, cg_rtol * cg_rtol, 0.0);
 
-            SparseMatrix * blfT = Transpose(blfw.SpMat());
-            SparseMatrix * diff = Add(1.0,blf.SpMat(),-1.0,*blfT);
-            REQUIRE( diff->MaxNorm() < tol );
-         }
-         SECTION("With Coefficient")
-         {
-            MixedBilinearForm blf(&fespace_l2, &fespace_h1);
-            blf.AddDomainIntegrator(new MixedScalarMassIntegrator(v1_coef));
-            blf.Assemble();
-            blf.Finalize();
+               REQUIRE( g_h1.ComputeL2Error(vf1_coef) < tol );
 
-            blf.Mult(f_l2,tmp_h1); g_h1 = 0.0;
-            CG(m_h1, tmp_h1, g_h1, 0, 200, cg_rtol * cg_rtol, 0.0);
+               MixedBilinearForm blfw(&fespace_h1, &fespace_l2_d);
+               blfw.AddDomainIntegrator(new MixedScalarMassIntegrator(v1_coef));
+               blfw.Assemble();
+               blfw.Finalize();
 
-            REQUIRE( g_h1.ComputeL2Error(vf1_coef) < tol );
-
-            MixedBilinearForm blfw(&fespace_h1, &fespace_l2);
-            blfw.AddDomainIntegrator(new MixedScalarMassIntegrator(v1_coef));
-            blfw.Assemble();
-            blfw.Finalize();
-
-            SparseMatrix * blfT = Transpose(blfw.SpMat());
-            SparseMatrix * diff = Add(1.0,blf.SpMat(),-1.0,*blfT);
-            REQUIRE( diff->MaxNorm() < tol );
+               SparseMatrix * blfT = Transpose(blfw.SpMat());
+               SparseMatrix * diff = Add(1.0,blf.SpMat(),-1.0,*blfT);
+               REQUIRE( diff->MaxNorm() < tol );
+            }
          }
       }
    }
@@ -274,44 +317,51 @@ TEST_CASE("1D Bilinear Derivative Integrator",
 
       GridFunction f_h1(&fespace_h1); f_h1.ProjectCoefficient(f1_coef);
 
-      SECTION("Mapping H1 to L2")
+      for (int map_type = (int)FiniteElement::VALUE;
+           map_type <= (int)FiniteElement::INTEGRAL; map_type++)
       {
-         L2_FECollection    fec_l2(order - 1, dim);
-         FiniteElementSpace fespace_l2(&mesh, &fec_l2);
-
-         BilinearForm m_l2(&fespace_l2);
-         m_l2.AddDomainIntegrator(new MassIntegrator());
-         m_l2.Assemble();
-         m_l2.Finalize();
-
-         GridFunction g_l2(&fespace_l2);
-
-         Vector tmp_l2(fespace_l2.GetNDofs());
-
-         SECTION("Without Coefficient")
+         SECTION("Mapping H1 to L2 (" +
+                 MapTypeName((FiniteElement::MapType)map_type) + ")")
          {
-            MixedBilinearForm blf(&fespace_h1, &fespace_l2);
-            blf.AddDomainIntegrator(new MixedScalarDerivativeIntegrator());
-            blf.Assemble();
-            blf.Finalize();
+            L2_FECollection    fec_l2(order - 1, dim,
+                                      BasisType::GaussLegendre,
+                                      (FiniteElement::MapType)map_type);
+            FiniteElementSpace fespace_l2(&mesh, &fec_l2);
 
-            blf.Mult(f_h1,tmp_l2); g_l2 = 0.0;
-            CG(m_l2, tmp_l2, g_l2, 0, 200, cg_rtol * cg_rtol, 0.0);
+            BilinearForm m_l2(&fespace_l2);
+            m_l2.AddDomainIntegrator(new MassIntegrator());
+            m_l2.Assemble();
+            m_l2.Finalize();
 
-            REQUIRE( g_l2.ComputeL2Error(df1_coef) < tol );
-         }
-         SECTION("With Coefficient")
-         {
-            MixedBilinearForm blf(&fespace_h1, &fespace_l2);
-            blf.AddDomainIntegrator(
-               new MixedScalarDerivativeIntegrator(v1_coef));
-            blf.Assemble();
-            blf.Finalize();
+            GridFunction g_l2(&fespace_l2);
 
-            blf.Mult(f_h1,tmp_l2); g_l2 = 0.0;
-            CG(m_l2, tmp_l2, g_l2, 0, 200, cg_rtol * cg_rtol, 0.0);
+            Vector tmp_l2(fespace_l2.GetNDofs());
 
-            REQUIRE( g_l2.ComputeL2Error(vdf1_coef) < tol );
+            SECTION("Without Coefficient")
+            {
+               MixedBilinearForm blf(&fespace_h1, &fespace_l2);
+               blf.AddDomainIntegrator(new MixedScalarDerivativeIntegrator());
+               blf.Assemble();
+               blf.Finalize();
+
+               blf.Mult(f_h1,tmp_l2); g_l2 = 0.0;
+               CG(m_l2, tmp_l2, g_l2, 0, 200, cg_rtol * cg_rtol, 0.0);
+
+               REQUIRE( g_l2.ComputeL2Error(df1_coef) < tol );
+            }
+            SECTION("With Coefficient")
+            {
+               MixedBilinearForm blf(&fespace_h1, &fespace_l2);
+               blf.AddDomainIntegrator(
+                  new MixedScalarDerivativeIntegrator(v1_coef));
+               blf.Assemble();
+               blf.Finalize();
+
+               blf.Mult(f_h1,tmp_l2); g_l2 = 0.0;
+               CG(m_l2, tmp_l2, g_l2, 0, 200, cg_rtol * cg_rtol, 0.0);
+
+               REQUIRE( g_l2.ComputeL2Error(vdf1_coef) < tol );
+            }
          }
       }
       SECTION("Mapping H1 to H1")
@@ -444,78 +494,86 @@ TEST_CASE("1D Bilinear Weak Derivative Integrator",
          }
       }
    }
-   SECTION("Operators on L2")
+   for (int map_type = (int)FiniteElement::VALUE;
+        map_type <= (int)FiniteElement::INTEGRAL; map_type++)
    {
-      L2_FECollection    fec_l2(order, dim);
-      FiniteElementSpace fespace_l2(&mesh, &fec_l2);
-
-      GridFunction f_l2(&fespace_l2); f_l2.ProjectCoefficient(f1_coef);
-
-      SECTION("Mapping L2 to H1")
+      SECTION("Operators on L2 (" +
+              MapTypeName((FiniteElement::MapType)map_type) + ")")
       {
-         H1_FECollection    fec_h1(order, dim);
-         FiniteElementSpace fespace_h1(&mesh, &fec_h1);
+         L2_FECollection    fec_l2(order, dim,
+                                   BasisType::GaussLegendre,
+                                   (FiniteElement::MapType)map_type);
+         FiniteElementSpace fespace_l2(&mesh, &fec_l2);
 
-         BilinearForm m_h1(&fespace_h1);
-         m_h1.AddDomainIntegrator(new MassIntegrator());
-         m_h1.Assemble();
-         m_h1.Finalize();
+         GridFunction f_l2(&fespace_l2); f_l2.ProjectCoefficient(f1_coef);
 
-         GridFunction g_h1(&fespace_h1);
-
-         Vector tmp_h1(fespace_h1.GetNDofs());
-
-         SECTION("Without Coefficient")
+         SECTION("Mapping L2 (" +
+                 MapTypeName((FiniteElement::MapType)map_type) + ") to H1")
          {
-            MixedBilinearForm blf(&fespace_l2, &fespace_h1);
-            blf.AddDomainIntegrator(new MixedScalarWeakDerivativeIntegrator());
-            blf.Assemble();
-            blf.Finalize();
+            H1_FECollection    fec_h1(order, dim);
+            FiniteElementSpace fespace_h1(&mesh, &fec_h1);
 
-            LinearForm b(&fespace_h1);
-            b.AddBoundaryIntegrator(new BoundaryLFIntegrator(f1_coef));
-            b.Assemble();
+            BilinearForm m_h1(&fespace_h1);
+            m_h1.AddDomainIntegrator(new MassIntegrator());
+            m_h1.Assemble();
+            m_h1.Finalize();
 
-            blf.Mult(f_l2,tmp_h1); tmp_h1 += b; g_h1 = 0.0;
-            CG(m_h1, tmp_h1, g_h1, 0, 200, cg_rtol * cg_rtol, 0.0);
+            GridFunction g_h1(&fespace_h1);
 
-            REQUIRE( g_h1.ComputeL2Error(df1_coef) < tol );
+            Vector tmp_h1(fespace_h1.GetNDofs());
 
-            MixedBilinearForm blfw(&fespace_h1, &fespace_l2);
-            blfw.AddDomainIntegrator(new MixedScalarDerivativeIntegrator());
-            blfw.Assemble();
-            blfw.Finalize();
+            SECTION("Without Coefficient")
+            {
+               MixedBilinearForm blf(&fespace_l2, &fespace_h1);
+               blf.AddDomainIntegrator(new MixedScalarWeakDerivativeIntegrator());
+               blf.Assemble();
+               blf.Finalize();
 
-            SparseMatrix * blfT = Transpose(blfw.SpMat());
-            SparseMatrix * diff = Add(1.0,blf.SpMat(),1.0,*blfT);
-            REQUIRE( diff->MaxNorm() < tol );
-         }
-         SECTION("With Coefficient")
-         {
-            MixedBilinearForm blf(&fespace_l2, &fespace_h1);
-            blf.AddDomainIntegrator(
-               new MixedScalarWeakDerivativeIntegrator(v1_coef));
-            blf.Assemble();
-            blf.Finalize();
+               LinearForm b(&fespace_h1);
+               b.AddBoundaryIntegrator(new BoundaryLFIntegrator(f1_coef));
+               b.Assemble();
 
-            LinearForm b(&fespace_h1);
-            b.AddBoundaryIntegrator(new BoundaryLFIntegrator(vf1_coef));
-            b.Assemble();
+               blf.Mult(f_l2,tmp_h1); tmp_h1 += b; g_h1 = 0.0;
+               CG(m_h1, tmp_h1, g_h1, 0, 200, cg_rtol * cg_rtol, 0.0);
 
-            blf.Mult(f_l2,tmp_h1); tmp_h1 += b; g_h1 = 0.0;
-            CG(m_h1, tmp_h1, g_h1, 0, 200, cg_rtol * cg_rtol, 0.0);
+               REQUIRE( g_h1.ComputeL2Error(df1_coef) < tol );
 
-            REQUIRE( g_h1.ComputeL2Error(dvf1_coef) < tol );
+               MixedBilinearForm blfw(&fespace_h1, &fespace_l2);
+               blfw.AddDomainIntegrator(new MixedScalarDerivativeIntegrator());
+               blfw.Assemble();
+               blfw.Finalize();
 
-            MixedBilinearForm blfw(&fespace_h1, &fespace_l2);
-            blfw.AddDomainIntegrator(
-               new MixedScalarDerivativeIntegrator(v1_coef));
-            blfw.Assemble();
-            blfw.Finalize();
+               SparseMatrix * blfT = Transpose(blfw.SpMat());
+               SparseMatrix * diff = Add(1.0,blf.SpMat(),1.0,*blfT);
+               REQUIRE( diff->MaxNorm() < tol );
+            }
+            SECTION("With Coefficient")
+            {
+               MixedBilinearForm blf(&fespace_l2, &fespace_h1);
+               blf.AddDomainIntegrator(
+                  new MixedScalarWeakDerivativeIntegrator(v1_coef));
+               blf.Assemble();
+               blf.Finalize();
 
-            SparseMatrix * blfT = Transpose(blfw.SpMat());
-            SparseMatrix * diff = Add(1.0,blf.SpMat(),1.0,*blfT);
-            REQUIRE( diff->MaxNorm() < tol );
+               LinearForm b(&fespace_h1);
+               b.AddBoundaryIntegrator(new BoundaryLFIntegrator(vf1_coef));
+               b.Assemble();
+
+               blf.Mult(f_l2,tmp_h1); tmp_h1 += b; g_h1 = 0.0;
+               CG(m_h1, tmp_h1, g_h1, 0, 200, cg_rtol * cg_rtol, 0.0);
+
+               REQUIRE( g_h1.ComputeL2Error(dvf1_coef) < tol );
+
+               MixedBilinearForm blfw(&fespace_h1, &fespace_l2);
+               blfw.AddDomainIntegrator(
+                  new MixedScalarDerivativeIntegrator(v1_coef));
+               blfw.Assemble();
+               blfw.Finalize();
+
+               SparseMatrix * blfT = Transpose(blfw.SpMat());
+               SparseMatrix * diff = Add(1.0,blf.SpMat(),1.0,*blfT);
+               REQUIRE( diff->MaxNorm() < tol );
+            }
          }
       }
    }

--- a/tests/unit/fem/test_1d_bilininteg.cpp
+++ b/tests/unit/fem/test_1d_bilininteg.cpp
@@ -42,6 +42,8 @@ const std::string MapTypeName(FiniteElement::MapType map_type)
          return "H_CURL";
       case FiniteElement::H_DIV:
          return "H_DIV";
+      default:
+         return "UNKNOWN";
    }
 }
 

--- a/tests/unit/fem/test_1d_bilininteg.cpp
+++ b/tests/unit/fem/test_1d_bilininteg.cpp
@@ -97,7 +97,7 @@ TEST_CASE("1D Bilinear Mass Integrators",
                blf.Assemble();
                blf.Finalize();
 
-               blf.Mult(f_h1,tmp_l2); g_l2 = 0.0;
+               blf.Mult(f_h1, tmp_l2); g_l2 = 0.0;
                CG(m_l2, tmp_l2, g_l2, 0, 200, cg_rtol * cg_rtol, 0.0);
 
                REQUIRE( g_l2.ComputeL2Error(f1_coef) < tol );
@@ -108,7 +108,7 @@ TEST_CASE("1D Bilinear Mass Integrators",
                blfw.Finalize();
 
                SparseMatrix * blfT = Transpose(blfw.SpMat());
-               SparseMatrix * diff = Add(1.0,blf.SpMat(),-1.0,*blfT);
+               SparseMatrix * diff = Add(1.0, blf.SpMat(), -1.0, *blfT);
                REQUIRE( diff->MaxNorm() < tol );
             }
             SECTION("With Coefficient")
@@ -118,7 +118,7 @@ TEST_CASE("1D Bilinear Mass Integrators",
                blf.Assemble();
                blf.Finalize();
 
-               blf.Mult(f_h1,tmp_l2); g_l2 = 0.0;
+               blf.Mult(f_h1, tmp_l2); g_l2 = 0.0;
                CG(m_l2, tmp_l2, g_l2, 0, 200, cg_rtol * cg_rtol, 0.0);
 
                REQUIRE( g_l2.ComputeL2Error(vf1_coef) < tol );
@@ -129,7 +129,7 @@ TEST_CASE("1D Bilinear Mass Integrators",
                blfw.Finalize();
 
                SparseMatrix * blfT = Transpose(blfw.SpMat());
-               SparseMatrix * diff = Add(1.0,blf.SpMat(),-1.0,*blfT);
+               SparseMatrix * diff = Add(1.0, blf.SpMat(), -1.0, *blfT);
                REQUIRE( diff->MaxNorm() < tol );
             }
          }
@@ -152,7 +152,7 @@ TEST_CASE("1D Bilinear Mass Integrators",
             blf.Assemble();
             blf.Finalize();
 
-            blf.Mult(f_h1,tmp_h1); g_h1 = 0.0;
+            blf.Mult(f_h1, tmp_h1); g_h1 = 0.0;
             CG(m_h1, tmp_h1, g_h1, 0, 200, cg_rtol * cg_rtol, 0.0);
 
             REQUIRE( g_h1.ComputeL2Error(f1_coef) < tol );
@@ -164,7 +164,7 @@ TEST_CASE("1D Bilinear Mass Integrators",
             blf.Assemble();
             blf.Finalize();
 
-            blf.Mult(f_h1,tmp_h1); g_h1 = 0.0;
+            blf.Mult(f_h1, tmp_h1); g_h1 = 0.0;
             CG(m_h1, tmp_h1, g_h1, 0, 200, cg_rtol * cg_rtol, 0.0);
 
             REQUIRE( g_h1.ComputeL2Error(vf1_coef) < tol );
@@ -213,7 +213,7 @@ TEST_CASE("1D Bilinear Mass Integrators",
                   blf.Assemble();
                   blf.Finalize();
 
-                  blf.Mult(f_l2,tmp_l2); g_l2 = 0.0;
+                  blf.Mult(f_l2, tmp_l2); g_l2 = 0.0;
                   CG(m_l2, tmp_l2, g_l2, 0, 200, cg_rtol * cg_rtol, 0.0);
 
                   REQUIRE( g_l2.ComputeL2Error(f1_coef) < tol );
@@ -225,7 +225,7 @@ TEST_CASE("1D Bilinear Mass Integrators",
                   blf.Assemble();
                   blf.Finalize();
 
-                  blf.Mult(f_l2,tmp_l2); g_l2 = 0.0;
+                  blf.Mult(f_l2, tmp_l2); g_l2 = 0.0;
                   CG(m_l2, tmp_l2, g_l2, 0, 200, cg_rtol * cg_rtol, 0.0);
 
                   REQUIRE( g_l2.ComputeL2Error(vf1_coef) < tol );
@@ -255,7 +255,7 @@ TEST_CASE("1D Bilinear Mass Integrators",
                blf.Assemble();
                blf.Finalize();
 
-               blf.Mult(f_l2,tmp_h1); g_h1 = 0.0;
+               blf.Mult(f_l2, tmp_h1); g_h1 = 0.0;
                CG(m_h1, tmp_h1, g_h1, 0, 200, cg_rtol * cg_rtol, 0.0);
 
                REQUIRE( g_h1.ComputeL2Error(f1_coef) < tol );
@@ -266,7 +266,7 @@ TEST_CASE("1D Bilinear Mass Integrators",
                blfw.Finalize();
 
                SparseMatrix * blfT = Transpose(blfw.SpMat());
-               SparseMatrix * diff = Add(1.0,blf.SpMat(),-1.0,*blfT);
+               SparseMatrix * diff = Add(1.0, blf.SpMat(), -1.0, *blfT);
                REQUIRE( diff->MaxNorm() < tol );
             }
             SECTION("With Coefficient")
@@ -276,7 +276,7 @@ TEST_CASE("1D Bilinear Mass Integrators",
                blf.Assemble();
                blf.Finalize();
 
-               blf.Mult(f_l2,tmp_h1); g_h1 = 0.0;
+               blf.Mult(f_l2, tmp_h1); g_h1 = 0.0;
                CG(m_h1, tmp_h1, g_h1, 0, 200, cg_rtol * cg_rtol, 0.0);
 
                REQUIRE( g_h1.ComputeL2Error(vf1_coef) < tol );
@@ -287,7 +287,7 @@ TEST_CASE("1D Bilinear Mass Integrators",
                blfw.Finalize();
 
                SparseMatrix * blfT = Transpose(blfw.SpMat());
-               SparseMatrix * diff = Add(1.0,blf.SpMat(),-1.0,*blfT);
+               SparseMatrix * diff = Add(1.0, blf.SpMat(), -1.0, *blfT);
                REQUIRE( diff->MaxNorm() < tol );
             }
          }
@@ -346,7 +346,7 @@ TEST_CASE("1D Bilinear Derivative Integrator",
                blf.Assemble();
                blf.Finalize();
 
-               blf.Mult(f_h1,tmp_l2); g_l2 = 0.0;
+               blf.Mult(f_h1, tmp_l2); g_l2 = 0.0;
                CG(m_l2, tmp_l2, g_l2, 0, 200, cg_rtol * cg_rtol, 0.0);
 
                REQUIRE( g_l2.ComputeL2Error(df1_coef) < tol );
@@ -359,7 +359,7 @@ TEST_CASE("1D Bilinear Derivative Integrator",
                blf.Assemble();
                blf.Finalize();
 
-               blf.Mult(f_h1,tmp_l2); g_l2 = 0.0;
+               blf.Mult(f_h1, tmp_l2); g_l2 = 0.0;
                CG(m_l2, tmp_l2, g_l2, 0, 200, cg_rtol * cg_rtol, 0.0);
 
                REQUIRE( g_l2.ComputeL2Error(vdf1_coef) < tol );
@@ -384,7 +384,7 @@ TEST_CASE("1D Bilinear Derivative Integrator",
             blf.Assemble();
             blf.Finalize();
 
-            blf.Mult(f_h1,tmp_h1); g_h1 = 0.0;
+            blf.Mult(f_h1, tmp_h1); g_h1 = 0.0;
             CG(m_h1, tmp_h1, g_h1, 0, 200, cg_rtol * cg_rtol, 0.0);
 
             REQUIRE( g_h1.ComputeL2Error(df1_coef) < tol );
@@ -397,7 +397,7 @@ TEST_CASE("1D Bilinear Derivative Integrator",
             blf.Assemble();
             blf.Finalize();
 
-            blf.Mult(f_h1,tmp_h1); g_h1 = 0.0;
+            blf.Mult(f_h1, tmp_h1); g_h1 = 0.0;
             CG(m_h1, tmp_h1, g_h1, 0, 200, cg_rtol * cg_rtol, 0.0);
 
             REQUIRE( g_h1.ComputeL2Error(vdf1_coef) < tol );
@@ -453,7 +453,7 @@ TEST_CASE("1D Bilinear Weak Derivative Integrator",
             b.AddBoundaryIntegrator(new BoundaryLFIntegrator(f1_coef));
             b.Assemble();
 
-            blf.Mult(f_h1,tmp_h1); tmp_h1 += b; g_h1 = 0.0;
+            blf.Mult(f_h1, tmp_h1); tmp_h1 += b; g_h1 = 0.0;
             CG(m_h1, tmp_h1, g_h1, 0, 200, cg_rtol * cg_rtol, 0.0);
 
             REQUIRE( g_h1.ComputeL2Error(df1_coef) < tol );
@@ -464,7 +464,7 @@ TEST_CASE("1D Bilinear Weak Derivative Integrator",
             blfw.Finalize();
 
             SparseMatrix * blfT = Transpose(blfw.SpMat());
-            SparseMatrix * diff = Add(1.0,blf.SpMat(),1.0,*blfT);
+            SparseMatrix * diff = Add(1.0, blf.SpMat(), 1.0, *blfT);
             REQUIRE( diff->MaxNorm() < tol );
          }
          SECTION("With Coefficient")
@@ -479,7 +479,7 @@ TEST_CASE("1D Bilinear Weak Derivative Integrator",
             b.AddBoundaryIntegrator(new BoundaryLFIntegrator(vf1_coef));
             b.Assemble();
 
-            blf.Mult(f_h1,tmp_h1); tmp_h1 += b; g_h1 = 0.0;
+            blf.Mult(f_h1, tmp_h1); tmp_h1 += b; g_h1 = 0.0;
             CG(m_h1, tmp_h1, g_h1, 0, 200, cg_rtol * cg_rtol, 0.0);
 
             REQUIRE( g_h1.ComputeL2Error(dvf1_coef) < tol );
@@ -491,7 +491,7 @@ TEST_CASE("1D Bilinear Weak Derivative Integrator",
             blfw.Finalize();
 
             SparseMatrix * blfT = Transpose(blfw.SpMat());
-            SparseMatrix * diff = Add(1.0,blf.SpMat(),1.0,*blfT);
+            SparseMatrix * diff = Add(1.0, blf.SpMat(), 1.0, *blfT);
             REQUIRE( diff->MaxNorm() < tol );
          }
       }
@@ -535,7 +535,7 @@ TEST_CASE("1D Bilinear Weak Derivative Integrator",
                b.AddBoundaryIntegrator(new BoundaryLFIntegrator(f1_coef));
                b.Assemble();
 
-               blf.Mult(f_l2,tmp_h1); tmp_h1 += b; g_h1 = 0.0;
+               blf.Mult(f_l2, tmp_h1); tmp_h1 += b; g_h1 = 0.0;
                CG(m_h1, tmp_h1, g_h1, 0, 200, cg_rtol * cg_rtol, 0.0);
 
                REQUIRE( g_h1.ComputeL2Error(df1_coef) < tol );
@@ -546,7 +546,7 @@ TEST_CASE("1D Bilinear Weak Derivative Integrator",
                blfw.Finalize();
 
                SparseMatrix * blfT = Transpose(blfw.SpMat());
-               SparseMatrix * diff = Add(1.0,blf.SpMat(),1.0,*blfT);
+               SparseMatrix * diff = Add(1.0, blf.SpMat(), 1.0, *blfT);
                REQUIRE( diff->MaxNorm() < tol );
             }
             SECTION("With Coefficient")
@@ -561,7 +561,7 @@ TEST_CASE("1D Bilinear Weak Derivative Integrator",
                b.AddBoundaryIntegrator(new BoundaryLFIntegrator(vf1_coef));
                b.Assemble();
 
-               blf.Mult(f_l2,tmp_h1); tmp_h1 += b; g_h1 = 0.0;
+               blf.Mult(f_l2, tmp_h1); tmp_h1 += b; g_h1 = 0.0;
                CG(m_h1, tmp_h1, g_h1, 0, 200, cg_rtol * cg_rtol, 0.0);
 
                REQUIRE( g_h1.ComputeL2Error(dvf1_coef) < tol );
@@ -573,7 +573,7 @@ TEST_CASE("1D Bilinear Weak Derivative Integrator",
                blfw.Finalize();
 
                SparseMatrix * blfT = Transpose(blfw.SpMat());
-               SparseMatrix * diff = Add(1.0,blf.SpMat(),1.0,*blfT);
+               SparseMatrix * diff = Add(1.0, blf.SpMat(), 1.0, *blfT);
                REQUIRE( diff->MaxNorm() < tol );
             }
          }
@@ -624,7 +624,7 @@ TEST_CASE("1D Bilinear Diffusion Integrator",
       b.Assemble();
       b[0] *=-1.0;
 
-      blf.Mult(f_h1,tmp_h1); tmp_h1 -= b; g_h1 = 0.0;
+      blf.Mult(f_h1, tmp_h1); tmp_h1 -= b; g_h1 = 0.0;
       CG(m_h1, tmp_h1, g_h1, 0, 200, cg_rtol * cg_rtol, 0.0);
 
       REQUIRE( g_h1.ComputeL2Error(ddf1_coef) < tol );
@@ -641,7 +641,7 @@ TEST_CASE("1D Bilinear Diffusion Integrator",
       b.Assemble();
       b[0] *=-1.0;
 
-      blf.Mult(f_h1,tmp_h1); tmp_h1 -= b; g_h1 = 0.0;
+      blf.Mult(f_h1, tmp_h1); tmp_h1 -= b; g_h1 = 0.0;
       CG(m_h1, tmp_h1, g_h1, 0, 200, cg_rtol * cg_rtol, 0.0);
 
       REQUIRE( g_h1.ComputeL2Error(dvdf1_coef) < tol );

--- a/tests/unit/fem/test_2d_bilininteg.cpp
+++ b/tests/unit/fem/test_2d_bilininteg.cpp
@@ -225,7 +225,7 @@ TEST_CASE("2D Bilinear Mass Integrators",
                blf.Assemble();
                blf.Finalize();
 
-               blf.Mult(f_h1,tmp_l2); g_l2 = 0.0;
+               blf.Mult(f_h1, tmp_l2); g_l2 = 0.0;
                CG(m_l2, tmp_l2, g_l2, 0, 200, cg_rtol * cg_rtol, 0.0);
 
                REQUIRE( g_l2.ComputeL2Error(f2_coef) < tol );
@@ -236,7 +236,7 @@ TEST_CASE("2D Bilinear Mass Integrators",
                blfw.Finalize();
 
                SparseMatrix * blfT = Transpose(blfw.SpMat());
-               SparseMatrix * diff = Add(1.0,blf.SpMat(),-1.0,*blfT);
+               SparseMatrix * diff = Add(1.0, blf.SpMat(), -1.0, *blfT);
                REQUIRE( diff->MaxNorm() < tol );
             }
             SECTION("With Coefficient")
@@ -246,7 +246,7 @@ TEST_CASE("2D Bilinear Mass Integrators",
                blf.Assemble();
                blf.Finalize();
 
-               blf.Mult(f_h1,tmp_l2); g_l2 = 0.0;
+               blf.Mult(f_h1, tmp_l2); g_l2 = 0.0;
                CG(m_l2, tmp_l2, g_l2, 0, 200, cg_rtol * cg_rtol, 0.0);
 
                REQUIRE( g_l2.ComputeL2Error(qf2_coef) < tol );
@@ -257,7 +257,7 @@ TEST_CASE("2D Bilinear Mass Integrators",
                blfw.Finalize();
 
                SparseMatrix * blfT = Transpose(blfw.SpMat());
-               SparseMatrix * diff = Add(1.0,blf.SpMat(),-1.0,*blfT);
+               SparseMatrix * diff = Add(1.0, blf.SpMat(), -1.0, *blfT);
                REQUIRE( diff->MaxNorm() < tol );
             }
          }
@@ -280,7 +280,7 @@ TEST_CASE("2D Bilinear Mass Integrators",
             blf.Assemble();
             blf.Finalize();
 
-            blf.Mult(f_h1,tmp_h1); g_h1 = 0.0;
+            blf.Mult(f_h1, tmp_h1); g_h1 = 0.0;
             CG(m_h1, tmp_h1, g_h1, 0, 200, cg_rtol * cg_rtol, 0.0);
 
             REQUIRE( g_h1.ComputeL2Error(f2_coef) < tol );
@@ -292,7 +292,7 @@ TEST_CASE("2D Bilinear Mass Integrators",
             blf.Assemble();
             blf.Finalize();
 
-            blf.Mult(f_h1,tmp_h1); g_h1 = 0.0;
+            blf.Mult(f_h1, tmp_h1); g_h1 = 0.0;
             CG(m_h1, tmp_h1, g_h1, 0, 200, cg_rtol * cg_rtol, 0.0);
 
             REQUIRE( g_h1.ComputeL2Error(qf2_coef) < tol );
@@ -341,7 +341,7 @@ TEST_CASE("2D Bilinear Mass Integrators",
                   blf.Assemble();
                   blf.Finalize();
 
-                  blf.Mult(f_l2,tmp_l2); g_l2 = 0.0;
+                  blf.Mult(f_l2, tmp_l2); g_l2 = 0.0;
                   CG(m_l2, tmp_l2, g_l2, 0, 200, cg_rtol * cg_rtol, 0.0);
 
                   REQUIRE( g_l2.ComputeL2Error(f2_coef) < tol );
@@ -353,7 +353,7 @@ TEST_CASE("2D Bilinear Mass Integrators",
                   blf.Assemble();
                   blf.Finalize();
 
-                  blf.Mult(f_l2,tmp_l2); g_l2 = 0.0;
+                  blf.Mult(f_l2, tmp_l2); g_l2 = 0.0;
                   CG(m_l2, tmp_l2, g_l2, 0, 200, cg_rtol * cg_rtol, 0.0);
 
                   REQUIRE( g_l2.ComputeL2Error(qf2_coef) < tol );
@@ -383,7 +383,7 @@ TEST_CASE("2D Bilinear Mass Integrators",
                blf.Assemble();
                blf.Finalize();
 
-               blf.Mult(f_l2,tmp_h1); g_h1 = 0.0;
+               blf.Mult(f_l2, tmp_h1); g_h1 = 0.0;
                CG(m_h1, tmp_h1, g_h1, 0, 200, cg_rtol * cg_rtol, 0.0);
 
                REQUIRE( g_h1.ComputeL2Error(f2_coef) < tol );
@@ -394,7 +394,7 @@ TEST_CASE("2D Bilinear Mass Integrators",
                blfw.Finalize();
 
                SparseMatrix * blfT = Transpose(blfw.SpMat());
-               SparseMatrix * diff = Add(1.0,blf.SpMat(),-1.0,*blfT);
+               SparseMatrix * diff = Add(1.0, blf.SpMat(), -1.0, *blfT);
                REQUIRE( diff->MaxNorm() < tol );
             }
             SECTION("With Coefficient")
@@ -404,7 +404,7 @@ TEST_CASE("2D Bilinear Mass Integrators",
                blf.Assemble();
                blf.Finalize();
 
-               blf.Mult(f_l2,tmp_h1); g_h1 = 0.0;
+               blf.Mult(f_l2, tmp_h1); g_h1 = 0.0;
                CG(m_h1, tmp_h1, g_h1, 0, 200, cg_rtol * cg_rtol, 0.0);
 
                REQUIRE( g_h1.ComputeL2Error(qf2_coef) < tol );
@@ -415,7 +415,7 @@ TEST_CASE("2D Bilinear Mass Integrators",
                blfw.Finalize();
 
                SparseMatrix * blfT = Transpose(blfw.SpMat());
-               SparseMatrix * diff = Add(1.0,blf.SpMat(),-1.0,*blfT);
+               SparseMatrix * diff = Add(1.0, blf.SpMat(), -1.0, *blfT);
                REQUIRE( diff->MaxNorm() < tol );
             }
          }
@@ -475,7 +475,7 @@ TEST_CASE("2D Bilinear Vector Mass Integrators",
                blf.Assemble();
                blf.Finalize();
 
-               blf.Mult(f_nd,tmp_rt); g_rt = 0.0;
+               blf.Mult(f_nd, tmp_rt); g_rt = 0.0;
                CG(m_rt, tmp_rt, g_rt, 0, 200, cg_rtol * cg_rtol, 0.0);
 
                REQUIRE( g_rt.ComputeL2Error(F2_coef) < tol );
@@ -486,7 +486,7 @@ TEST_CASE("2D Bilinear Vector Mass Integrators",
                blfw.Finalize();
 
                SparseMatrix * blfT = Transpose(blfw.SpMat());
-               SparseMatrix * diff = Add(1.0,blf.SpMat(),-1.0,*blfT);
+               SparseMatrix * diff = Add(1.0, blf.SpMat(), -1.0, *blfT);
 
                REQUIRE( diff->MaxNorm() < tol );
 
@@ -498,7 +498,7 @@ TEST_CASE("2D Bilinear Vector Mass Integrators",
                blfv.Assemble();
                blfv.Finalize();
 
-               SparseMatrix * diffv = Add(1.0,blf.SpMat(),-1.0,blfv.SpMat());
+               SparseMatrix * diffv = Add(1.0, blf.SpMat(), -1.0, blfv.SpMat());
 
                REQUIRE( diffv->MaxNorm() < tol );
 
@@ -526,7 +526,7 @@ TEST_CASE("2D Bilinear Vector Mass Integrators",
                blf.Assemble();
                blf.Finalize();
 
-               blf.Mult(f_nd,tmp_rt); g_rt = 0.0;
+               blf.Mult(f_nd, tmp_rt); g_rt = 0.0;
                CG(m_rt, tmp_rt, g_rt, 0, 200, cg_rtol * cg_rtol, 0.0);
 
                REQUIRE( g_rt.ComputeL2Error(qF2_coef) < tol );
@@ -537,7 +537,7 @@ TEST_CASE("2D Bilinear Vector Mass Integrators",
                blfw.Finalize();
 
                SparseMatrix * blfT = Transpose(blfw.SpMat());
-               SparseMatrix * diff = Add(1.0,blf.SpMat(),-1.0,*blfT);
+               SparseMatrix * diff = Add(1.0, blf.SpMat(), -1.0, *blfT);
 
                REQUIRE( diff->MaxNorm() < tol );
 
@@ -551,7 +551,7 @@ TEST_CASE("2D Bilinear Vector Mass Integrators",
                blf.Assemble();
                blf.Finalize();
 
-               blf.Mult(f_nd,tmp_rt); g_rt = 0.0;
+               blf.Mult(f_nd, tmp_rt); g_rt = 0.0;
                CG(m_rt, tmp_rt, g_rt, 0, 200, cg_rtol * cg_rtol, 0.0);
 
                REQUIRE( g_rt.ComputeL2Error(DF2_coef) < tol );
@@ -563,7 +563,7 @@ TEST_CASE("2D Bilinear Vector Mass Integrators",
                blfw.Finalize();
 
                SparseMatrix * blfT = Transpose(blfw.SpMat());
-               SparseMatrix * diff = Add(1.0,blf.SpMat(),-1.0,*blfT);
+               SparseMatrix * diff = Add(1.0, blf.SpMat(), -1.0, *blfT);
 
                REQUIRE( diff->MaxNorm() < tol );
 
@@ -577,7 +577,7 @@ TEST_CASE("2D Bilinear Vector Mass Integrators",
                blf.Assemble();
                blf.Finalize();
 
-               blf.Mult(f_nd,tmp_rt); g_rt = 0.0;
+               blf.Mult(f_nd, tmp_rt); g_rt = 0.0;
                CG(m_rt, tmp_rt, g_rt, 0, 200, cg_rtol * cg_rtol, 0.0);
 
                REQUIRE( g_rt.ComputeL2Error(MF2_coef) < tol );
@@ -589,7 +589,7 @@ TEST_CASE("2D Bilinear Vector Mass Integrators",
                blfw.Finalize();
 
                SparseMatrix * blfT = Transpose(blfw.SpMat());
-               SparseMatrix * diff = Add(1.0,blf.SpMat(),-1.0,*blfT);
+               SparseMatrix * diff = Add(1.0, blf.SpMat(), -1.0, *blfT);
 
                REQUIRE( diff->MaxNorm() < tol );
 
@@ -619,7 +619,7 @@ TEST_CASE("2D Bilinear Vector Mass Integrators",
                blf.Assemble();
                blf.Finalize();
 
-               blf.Mult(f_nd,tmp_nd); g_nd = 0.0;
+               blf.Mult(f_nd, tmp_nd); g_nd = 0.0;
                CG(m_nd, tmp_nd, g_nd, 0, 200, cg_rtol * cg_rtol, 0.0);
 
                REQUIRE( g_nd.ComputeL2Error(F2_coef) < tol );
@@ -630,7 +630,7 @@ TEST_CASE("2D Bilinear Vector Mass Integrators",
                blfw.Finalize();
 
                SparseMatrix * blfT = Transpose(blfw.SpMat());
-               SparseMatrix * diff = Add(1.0,blf.SpMat(),-1.0,*blfT);
+               SparseMatrix * diff = Add(1.0, blf.SpMat(), -1.0, *blfT);
 
                REQUIRE( diff->MaxNorm() < tol );
 
@@ -642,7 +642,7 @@ TEST_CASE("2D Bilinear Vector Mass Integrators",
                blfv.Assemble();
                blfv.Finalize();
 
-               SparseMatrix * diffv = Add(1.0,blf.SpMat(),-1.0,blfv.SpMat());
+               SparseMatrix * diffv = Add(1.0, blf.SpMat(), -1.0, blfv.SpMat());
 
                REQUIRE( diffv->MaxNorm() < tol );
 
@@ -670,7 +670,7 @@ TEST_CASE("2D Bilinear Vector Mass Integrators",
                blf.Assemble();
                blf.Finalize();
 
-               blf.Mult(f_nd,tmp_ndp); g_ndp = 0.0;
+               blf.Mult(f_nd, tmp_ndp); g_ndp = 0.0;
                CG(m_ndp, tmp_ndp, g_ndp, 0, 200, cg_rtol * cg_rtol, 0.0);
 
                REQUIRE( g_ndp.ComputeL2Error(qF2_coef) < tol );
@@ -681,7 +681,7 @@ TEST_CASE("2D Bilinear Vector Mass Integrators",
                blfw.Finalize();
 
                SparseMatrix * blfT = Transpose(blfw.SpMat());
-               SparseMatrix * diff = Add(1.0,blf.SpMat(),-1.0,*blfT);
+               SparseMatrix * diff = Add(1.0, blf.SpMat(), -1.0, *blfT);
 
                REQUIRE( diff->MaxNorm() < tol );
 
@@ -695,7 +695,7 @@ TEST_CASE("2D Bilinear Vector Mass Integrators",
                blf.Assemble();
                blf.Finalize();
 
-               blf.Mult(f_nd,tmp_ndp); g_ndp = 0.0;
+               blf.Mult(f_nd, tmp_ndp); g_ndp = 0.0;
                CG(m_ndp, tmp_ndp, g_ndp, 0, 200, cg_rtol * cg_rtol, 0.0);
 
                REQUIRE( g_ndp.ComputeL2Error(DF2_coef) < tol );
@@ -707,7 +707,7 @@ TEST_CASE("2D Bilinear Vector Mass Integrators",
                blfw.Finalize();
 
                SparseMatrix * blfT = Transpose(blfw.SpMat());
-               SparseMatrix * diff = Add(1.0,blf.SpMat(),-1.0,*blfT);
+               SparseMatrix * diff = Add(1.0, blf.SpMat(), -1.0, *blfT);
 
                REQUIRE( diff->MaxNorm() < tol );
 
@@ -721,7 +721,7 @@ TEST_CASE("2D Bilinear Vector Mass Integrators",
                blf.Assemble();
                blf.Finalize();
 
-               blf.Mult(f_nd,tmp_ndp); g_ndp = 0.0;
+               blf.Mult(f_nd, tmp_ndp); g_ndp = 0.0;
                CG(m_ndp, tmp_ndp, g_ndp, 0, 200, cg_rtol * cg_rtol, 0.0);
 
                REQUIRE( g_ndp.ComputeL2Error(MF2_coef) < tol );
@@ -733,7 +733,7 @@ TEST_CASE("2D Bilinear Vector Mass Integrators",
                blfw.Finalize();
 
                SparseMatrix * blfT = Transpose(blfw.SpMat());
-               SparseMatrix * diff = Add(1.0,blf.SpMat(),-1.0,*blfT);
+               SparseMatrix * diff = Add(1.0, blf.SpMat(), -1.0, *blfT);
 
                REQUIRE( diff->MaxNorm() < tol );
 
@@ -774,7 +774,7 @@ TEST_CASE("2D Bilinear Vector Mass Integrators",
                blf.Assemble();
                blf.Finalize();
 
-               blf.Mult(f_rt,tmp_nd); g_nd = 0.0;
+               blf.Mult(f_rt, tmp_nd); g_nd = 0.0;
                CG(m_nd, tmp_nd, g_nd, 0, 200, cg_rtol * cg_rtol, 0.0);
 
                REQUIRE( g_nd.ComputeL2Error(F2_coef) < tol );
@@ -785,7 +785,7 @@ TEST_CASE("2D Bilinear Vector Mass Integrators",
                blfw.Finalize();
 
                SparseMatrix * blfT = Transpose(blfw.SpMat());
-               SparseMatrix * diff = Add(1.0,blf.SpMat(),-1.0,*blfT);
+               SparseMatrix * diff = Add(1.0, blf.SpMat(), -1.0, *blfT);
 
                REQUIRE( diff->MaxNorm() < tol );
 
@@ -797,7 +797,7 @@ TEST_CASE("2D Bilinear Vector Mass Integrators",
                blfv.Assemble();
                blfv.Finalize();
 
-               SparseMatrix * diffv = Add(1.0,blf.SpMat(),-1.0,blfv.SpMat());
+               SparseMatrix * diffv = Add(1.0, blf.SpMat(), -1.0, blfv.SpMat());
 
                REQUIRE( diffv->MaxNorm() < tol );
 
@@ -825,7 +825,7 @@ TEST_CASE("2D Bilinear Vector Mass Integrators",
                blf.Assemble();
                blf.Finalize();
 
-               blf.Mult(f_rt,tmp_nd); g_nd = 0.0;
+               blf.Mult(f_rt, tmp_nd); g_nd = 0.0;
                CG(m_nd, tmp_nd, g_nd, 0, 200, cg_rtol * cg_rtol, 0.0);
 
                REQUIRE( g_nd.ComputeL2Error(qF2_coef) < tol );
@@ -836,7 +836,7 @@ TEST_CASE("2D Bilinear Vector Mass Integrators",
                blfw.Finalize();
 
                SparseMatrix * blfT = Transpose(blfw.SpMat());
-               SparseMatrix * diff = Add(1.0,blf.SpMat(),-1.0,*blfT);
+               SparseMatrix * diff = Add(1.0, blf.SpMat(), -1.0, *blfT);
 
                REQUIRE( diff->MaxNorm() < tol );
 
@@ -850,7 +850,7 @@ TEST_CASE("2D Bilinear Vector Mass Integrators",
                blf.Assemble();
                blf.Finalize();
 
-               blf.Mult(f_rt,tmp_nd); g_nd = 0.0;
+               blf.Mult(f_rt, tmp_nd); g_nd = 0.0;
                CG(m_nd, tmp_nd, g_nd, 0, 200, cg_rtol * cg_rtol, 0.0);
 
                REQUIRE( g_nd.ComputeL2Error(DF2_coef) < tol );
@@ -862,7 +862,7 @@ TEST_CASE("2D Bilinear Vector Mass Integrators",
                blfw.Finalize();
 
                SparseMatrix * blfT = Transpose(blfw.SpMat());
-               SparseMatrix * diff = Add(1.0,blf.SpMat(),-1.0,*blfT);
+               SparseMatrix * diff = Add(1.0, blf.SpMat(), -1.0, *blfT);
 
                REQUIRE( diff->MaxNorm() < tol );
 
@@ -876,7 +876,7 @@ TEST_CASE("2D Bilinear Vector Mass Integrators",
                blf.Assemble();
                blf.Finalize();
 
-               blf.Mult(f_rt,tmp_nd); g_nd = 0.0;
+               blf.Mult(f_rt, tmp_nd); g_nd = 0.0;
                CG(m_nd, tmp_nd, g_nd, 0, 200, cg_rtol * cg_rtol, 0.0);
 
                REQUIRE( g_nd.ComputeL2Error(MF2_coef) < tol );
@@ -888,7 +888,7 @@ TEST_CASE("2D Bilinear Vector Mass Integrators",
                blfw.Finalize();
 
                SparseMatrix * blfT = Transpose(blfw.SpMat());
-               SparseMatrix * diff = Add(1.0,blf.SpMat(),-1.0,*blfT);
+               SparseMatrix * diff = Add(1.0, blf.SpMat(), -1.0, *blfT);
 
                REQUIRE( diff->MaxNorm() < tol );
 
@@ -918,7 +918,7 @@ TEST_CASE("2D Bilinear Vector Mass Integrators",
                blf.Assemble();
                blf.Finalize();
 
-               blf.Mult(f_rt,tmp_rt); g_rt = 0.0;
+               blf.Mult(f_rt, tmp_rt); g_rt = 0.0;
                CG(m_rt, tmp_rt, g_rt, 0, 200, cg_rtol * cg_rtol, 0.0);
 
                REQUIRE( g_rt.ComputeL2Error(F2_coef) < tol );
@@ -929,7 +929,7 @@ TEST_CASE("2D Bilinear Vector Mass Integrators",
                blfw.Finalize();
 
                SparseMatrix * blfT = Transpose(blfw.SpMat());
-               SparseMatrix * diff = Add(1.0,blf.SpMat(),-1.0,*blfT);
+               SparseMatrix * diff = Add(1.0, blf.SpMat(), -1.0, *blfT);
 
                REQUIRE( diff->MaxNorm() < tol );
 
@@ -941,7 +941,7 @@ TEST_CASE("2D Bilinear Vector Mass Integrators",
                blfv.Assemble();
                blfv.Finalize();
 
-               SparseMatrix * diffv = Add(1.0,blf.SpMat(),-1.0,blfv.SpMat());
+               SparseMatrix * diffv = Add(1.0, blf.SpMat(), -1.0, blfv.SpMat());
 
                REQUIRE( diffv->MaxNorm() < tol );
 
@@ -969,7 +969,7 @@ TEST_CASE("2D Bilinear Vector Mass Integrators",
                blf.Assemble();
                blf.Finalize();
 
-               blf.Mult(f_rt,tmp_rtp); g_rtp = 0.0;
+               blf.Mult(f_rt, tmp_rtp); g_rtp = 0.0;
                CG(m_rtp, tmp_rtp, g_rtp, 0, 200, cg_rtol * cg_rtol, 0.0);
 
                REQUIRE( g_rtp.ComputeL2Error(qF2_coef) < tol );
@@ -980,7 +980,7 @@ TEST_CASE("2D Bilinear Vector Mass Integrators",
                blfw.Finalize();
 
                SparseMatrix * blfT = Transpose(blfw.SpMat());
-               SparseMatrix * diff = Add(1.0,blf.SpMat(),-1.0,*blfT);
+               SparseMatrix * diff = Add(1.0, blf.SpMat(), -1.0, *blfT);
 
                REQUIRE( diff->MaxNorm() < tol );
 
@@ -994,7 +994,7 @@ TEST_CASE("2D Bilinear Vector Mass Integrators",
                blf.Assemble();
                blf.Finalize();
 
-               blf.Mult(f_rt,tmp_rtp); g_rtp = 0.0;
+               blf.Mult(f_rt, tmp_rtp); g_rtp = 0.0;
                CG(m_rtp, tmp_rtp, g_rtp, 0, 200, cg_rtol * cg_rtol, 0.0);
 
                REQUIRE( g_rtp.ComputeL2Error(DF2_coef) < tol );
@@ -1006,7 +1006,7 @@ TEST_CASE("2D Bilinear Vector Mass Integrators",
                blfw.Finalize();
 
                SparseMatrix * blfT = Transpose(blfw.SpMat());
-               SparseMatrix * diff = Add(1.0,blf.SpMat(),-1.0,*blfT);
+               SparseMatrix * diff = Add(1.0, blf.SpMat(), -1.0, *blfT);
 
                REQUIRE( diff->MaxNorm() < tol );
 
@@ -1020,7 +1020,7 @@ TEST_CASE("2D Bilinear Vector Mass Integrators",
                blf.Assemble();
                blf.Finalize();
 
-               blf.Mult(f_rt,tmp_rtp); g_rtp = 0.0;
+               blf.Mult(f_rt, tmp_rtp); g_rtp = 0.0;
                CG(m_rtp, tmp_rtp, g_rtp, 0, 200, cg_rtol * cg_rtol, 0.0);
 
                REQUIRE( g_rtp.ComputeL2Error(MF2_coef) < tol );
@@ -1032,7 +1032,7 @@ TEST_CASE("2D Bilinear Vector Mass Integrators",
                blfw.Finalize();
 
                SparseMatrix * blfT = Transpose(blfw.SpMat());
-               SparseMatrix * diff = Add(1.0,blf.SpMat(),-1.0,*blfT);
+               SparseMatrix * diff = Add(1.0, blf.SpMat(), -1.0, *blfT);
 
                REQUIRE( diff->MaxNorm() < tol );
 
@@ -1094,7 +1094,7 @@ TEST_CASE("2D Bilinear Gradient Integrator",
             blf.Finalize();
             g_nd.ProjectCoefficient(df2_coef);
 
-            blf.Mult(f_h1,tmp_nd); g_nd = 0.0;
+            blf.Mult(f_h1, tmp_nd); g_nd = 0.0;
             CG(m_nd, tmp_nd, g_nd, 0, 200, cg_rtol * cg_rtol, 0.0);
 
             REQUIRE( g_nd.ComputeL2Error(df2_coef) < tol );
@@ -1107,7 +1107,7 @@ TEST_CASE("2D Bilinear Gradient Integrator",
             blf.Assemble();
             blf.Finalize();
 
-            blf.Mult(f_h1,tmp_nd); g_nd = 0.0;
+            blf.Mult(f_h1, tmp_nd); g_nd = 0.0;
             CG(m_nd, tmp_nd, g_nd, 0, 200, cg_rtol * cg_rtol, 0.0);
 
             REQUIRE( g_nd.ComputeL2Error(qdf2_coef) < tol );
@@ -1120,7 +1120,7 @@ TEST_CASE("2D Bilinear Gradient Integrator",
             blf.Assemble();
             blf.Finalize();
 
-            blf.Mult(f_h1,tmp_nd); g_nd = 0.0;
+            blf.Mult(f_h1, tmp_nd); g_nd = 0.0;
             CG(m_nd, tmp_nd, g_nd, 0, 200, cg_rtol * cg_rtol, 0.0);
 
             REQUIRE( g_nd.ComputeL2Error(Ddf2_coef) < tol );
@@ -1133,7 +1133,7 @@ TEST_CASE("2D Bilinear Gradient Integrator",
             blf.Assemble();
             blf.Finalize();
 
-            blf.Mult(f_h1,tmp_nd); g_nd = 0.0;
+            blf.Mult(f_h1, tmp_nd); g_nd = 0.0;
             CG(m_nd, tmp_nd, g_nd, 0, 200, cg_rtol * cg_rtol, 0.0);
 
             REQUIRE( g_nd.ComputeL2Error(Mdf2_coef) < tol );
@@ -1160,7 +1160,7 @@ TEST_CASE("2D Bilinear Gradient Integrator",
             blf.Assemble();
             blf.Finalize();
 
-            blf.Mult(f_h1,tmp_rt); g_rt = 0.0;
+            blf.Mult(f_h1, tmp_rt); g_rt = 0.0;
             CG(m_rt, tmp_rt, g_rt, 0, 200, cg_rtol * cg_rtol, 0.0);
 
             REQUIRE( g_rt.ComputeL2Error(df2_coef) < tol );
@@ -1173,7 +1173,7 @@ TEST_CASE("2D Bilinear Gradient Integrator",
             blf.Assemble();
             blf.Finalize();
 
-            blf.Mult(f_h1,tmp_rt); g_rt = 0.0;
+            blf.Mult(f_h1, tmp_rt); g_rt = 0.0;
             CG(m_rt, tmp_rt, g_rt, 0, 200, cg_rtol * cg_rtol, 0.0);
 
             REQUIRE( g_rt.ComputeL2Error(qdf2_coef) < tol );
@@ -1186,7 +1186,7 @@ TEST_CASE("2D Bilinear Gradient Integrator",
             blf.Assemble();
             blf.Finalize();
 
-            blf.Mult(f_h1,tmp_rt); g_rt = 0.0;
+            blf.Mult(f_h1, tmp_rt); g_rt = 0.0;
             CG(m_rt, tmp_rt, g_rt, 0, 200, cg_rtol * cg_rtol, 0.0);
 
             REQUIRE( g_rt.ComputeL2Error(Ddf2_coef) < tol );
@@ -1199,7 +1199,7 @@ TEST_CASE("2D Bilinear Gradient Integrator",
             blf.Assemble();
             blf.Finalize();
 
-            blf.Mult(f_h1,tmp_rt); g_rt = 0.0;
+            blf.Mult(f_h1, tmp_rt); g_rt = 0.0;
             CG(m_rt, tmp_rt, g_rt, 0, 200, cg_rtol * cg_rtol, 0.0);
 
             REQUIRE( g_rt.ComputeL2Error(Mdf2_coef) < tol );
@@ -1259,7 +1259,7 @@ TEST_CASE("2D Bilinear Scalar Curl Integrator",
                blf.Assemble();
                blf.Finalize();
 
-               blf.Mult(f_nd,tmp_l2); g_l2 = 0.0;
+               blf.Mult(f_nd, tmp_l2); g_l2 = 0.0;
                CG(m_l2, tmp_l2, g_l2, 0, 200, cg_rtol * cg_rtol, 0.0);
 
                REQUIRE( g_l2.ComputeL2Error(dF2_coef) < tol );
@@ -1272,7 +1272,7 @@ TEST_CASE("2D Bilinear Scalar Curl Integrator",
                blf.Assemble();
                blf.Finalize();
 
-               blf.Mult(f_nd,tmp_l2); g_l2 = 0.0;
+               blf.Mult(f_nd, tmp_l2); g_l2 = 0.0;
                CG(m_l2, tmp_l2, g_l2, 0, 200, cg_rtol * cg_rtol, 0.0);
 
                REQUIRE( g_l2.ComputeL2Error(qdF2_coef) < tol );
@@ -1300,7 +1300,7 @@ TEST_CASE("2D Bilinear Scalar Curl Integrator",
             blf.Assemble();
             blf.Finalize();
 
-            blf.Mult(f_nd,tmp_h1); g_h1 = 0.0;
+            blf.Mult(f_nd, tmp_h1); g_h1 = 0.0;
             CG(m_h1, tmp_h1, g_h1, 0, 200, cg_rtol * cg_rtol, 0.0);
 
             REQUIRE( g_h1.ComputeL2Error(dF2_coef) < tol );
@@ -1313,7 +1313,7 @@ TEST_CASE("2D Bilinear Scalar Curl Integrator",
             blf.Assemble();
             blf.Finalize();
 
-            blf.Mult(f_nd,tmp_h1); g_h1 = 0.0;
+            blf.Mult(f_nd, tmp_h1); g_h1 = 0.0;
             CG(m_h1, tmp_h1, g_h1, 0, 200, cg_rtol * cg_rtol, 0.0);
 
             REQUIRE( g_h1.ComputeL2Error(qdF2_coef) < tol );
@@ -1373,7 +1373,7 @@ TEST_CASE("2D Bilinear Scalar Cross Product Gradient Integrator",
                blf.Assemble();
                blf.Finalize();
 
-               blf.Mult(f_h1,tmp_l2); g_l2 = 0.0;
+               blf.Mult(f_h1, tmp_l2); g_l2 = 0.0;
                CG(m_l2, tmp_l2, g_l2, 0, 200, cg_rtol * cg_rtol, 0.0);
 
                REQUIRE( g_l2.ComputeL2Error(Vxdf2_coef) < tol );
@@ -1399,7 +1399,7 @@ TEST_CASE("2D Bilinear Scalar Cross Product Gradient Integrator",
             blf.Assemble();
             blf.Finalize();
 
-            blf.Mult(f_h1,tmp_h1); g_h1 = 0.0;
+            blf.Mult(f_h1, tmp_h1); g_h1 = 0.0;
             CG(m_h1, tmp_h1, g_h1, 0, 200, cg_rtol * cg_rtol, 0.0);
 
             REQUIRE( g_h1.ComputeL2Error(Vxdf2_coef) < tol );
@@ -1459,7 +1459,7 @@ TEST_CASE("2D Bilinear Divergence Integrator",
                blf.Assemble();
                blf.Finalize();
 
-               blf.Mult(f_rt,tmp_l2); g_l2 = 0.0;
+               blf.Mult(f_rt, tmp_l2); g_l2 = 0.0;
                CG(m_l2, tmp_l2, g_l2, 0, 200, cg_rtol * cg_rtol, 0.0);
 
                REQUIRE( g_l2.ComputeL2Error(dF2_coef) < tol );
@@ -1472,7 +1472,7 @@ TEST_CASE("2D Bilinear Divergence Integrator",
                blf.Assemble();
                blf.Finalize();
 
-               blf.Mult(f_rt,tmp_l2); g_l2 = 0.0;
+               blf.Mult(f_rt, tmp_l2); g_l2 = 0.0;
                CG(m_l2, tmp_l2, g_l2, 0, 200, cg_rtol * cg_rtol, 0.0);
 
                REQUIRE( g_l2.ComputeL2Error(qdF2_coef) < tol );
@@ -1500,7 +1500,7 @@ TEST_CASE("2D Bilinear Divergence Integrator",
             blf.Assemble();
             blf.Finalize();
 
-            blf.Mult(f_rt,tmp_h1); g_h1 = 0.0;
+            blf.Mult(f_rt, tmp_h1); g_h1 = 0.0;
             CG(m_h1, tmp_h1, g_h1, 0, 200, cg_rtol * cg_rtol, 0.0);
 
             REQUIRE( g_h1.ComputeL2Error(dF2_coef) < tol );
@@ -1513,7 +1513,7 @@ TEST_CASE("2D Bilinear Divergence Integrator",
             blf.Assemble();
             blf.Finalize();
 
-            blf.Mult(f_rt,tmp_h1); g_h1 = 0.0;
+            blf.Mult(f_rt, tmp_h1); g_h1 = 0.0;
             CG(m_h1, tmp_h1, g_h1, 0, 200, cg_rtol * cg_rtol, 0.0);
 
             REQUIRE( g_h1.ComputeL2Error(qdF2_coef) < tol );
@@ -1564,7 +1564,7 @@ TEST_CASE("2D Bilinear Vector Divergence Integrator",
             blf.Assemble();
             blf.Finalize();
 
-            blf.Mult(f_rt,tmp_rt); g_rt = 0.0;
+            blf.Mult(f_rt, tmp_rt); g_rt = 0.0;
             CG(m_rt, tmp_rt, g_rt, 0, 200, cg_rtol * cg_rtol, 0.0);
 
             REQUIRE( g_rt.ComputeL2Error(VdF2_coef) < tol );
@@ -1592,7 +1592,7 @@ TEST_CASE("2D Bilinear Vector Divergence Integrator",
             blf.Assemble();
             blf.Finalize();
 
-            blf.Mult(f_rt,tmp_nd); g_nd = 0.0;
+            blf.Mult(f_rt, tmp_nd); g_nd = 0.0;
             CG(m_nd, tmp_nd, g_nd, 0, 200, cg_rtol * cg_rtol, 0.0);
 
             REQUIRE( g_nd.ComputeL2Error(VdF2_coef) < tol );
@@ -1645,7 +1645,7 @@ TEST_CASE("2D Bilinear Vector Product Integrators",
             blf.Assemble();
             blf.Finalize();
 
-            blf.Mult(f_h1,tmp_nd); g_nd = 0.0;
+            blf.Mult(f_h1, tmp_nd); g_nd = 0.0;
             CG(m_nd, tmp_nd, g_nd, 0, 200, cg_rtol * cg_rtol, 0.0);
 
             REQUIRE( g_nd.ComputeL2Error(Vf2_coef) < tol );
@@ -1657,7 +1657,7 @@ TEST_CASE("2D Bilinear Vector Product Integrators",
             blfw.Finalize();
 
             SparseMatrix * blfT = Transpose(blfw.SpMat());
-            SparseMatrix * diff = Add(1.0,blf.SpMat(),-1.0,*blfT);
+            SparseMatrix * diff = Add(1.0, blf.SpMat(), -1.0, *blfT);
 
             REQUIRE( diff->MaxNorm() < tol );
 
@@ -1686,7 +1686,7 @@ TEST_CASE("2D Bilinear Vector Product Integrators",
             blf.Assemble();
             blf.Finalize();
 
-            blf.Mult(f_h1,tmp_rt); g_rt = 0.0;
+            blf.Mult(f_h1, tmp_rt); g_rt = 0.0;
             CG(m_rt, tmp_rt, g_rt, 0, 200, cg_rtol * cg_rtol, 0.0);
 
             REQUIRE( g_rt.ComputeL2Error(Vf2_coef) < tol );
@@ -1698,7 +1698,7 @@ TEST_CASE("2D Bilinear Vector Product Integrators",
             blfw.Finalize();
 
             SparseMatrix * blfT = Transpose(blfw.SpMat());
-            SparseMatrix * diff = Add(1.0,blf.SpMat(),-1.0,*blfT);
+            SparseMatrix * diff = Add(1.0, blf.SpMat(), -1.0, *blfT);
 
             REQUIRE( diff->MaxNorm() < tol );
 
@@ -1742,7 +1742,7 @@ TEST_CASE("2D Bilinear Vector Product Integrators",
                blf.Assemble();
                blf.Finalize();
 
-               blf.Mult(f_l2,tmp_nd); g_nd = 0.0;
+               blf.Mult(f_l2, tmp_nd); g_nd = 0.0;
                CG(m_nd, tmp_nd, g_nd, 0, 200, cg_rtol * cg_rtol, 0.0);
 
                REQUIRE( g_nd.ComputeL2Error(Vf2_coef) < tol );
@@ -1754,7 +1754,7 @@ TEST_CASE("2D Bilinear Vector Product Integrators",
                blfw.Finalize();
 
                SparseMatrix * blfT = Transpose(blfw.SpMat());
-               SparseMatrix * diff = Add(1.0,blf.SpMat(),-1.0,*blfT);
+               SparseMatrix * diff = Add(1.0, blf.SpMat(), -1.0, *blfT);
 
                REQUIRE( diff->MaxNorm() < tol );
 
@@ -1784,7 +1784,7 @@ TEST_CASE("2D Bilinear Vector Product Integrators",
                blf.Assemble();
                blf.Finalize();
 
-               blf.Mult(f_l2,tmp_rt); g_rt = 0.0;
+               blf.Mult(f_l2, tmp_rt); g_rt = 0.0;
                CG(m_rt, tmp_rt, g_rt, 0, 200, cg_rtol * cg_rtol, 0.0);
 
                REQUIRE( g_rt.ComputeL2Error(Vf2_coef) < tol );
@@ -1796,7 +1796,7 @@ TEST_CASE("2D Bilinear Vector Product Integrators",
                blfw.Finalize();
 
                SparseMatrix * blfT = Transpose(blfw.SpMat());
-               SparseMatrix * diff = Add(1.0,blf.SpMat(),-1.0,*blfT);
+               SparseMatrix * diff = Add(1.0, blf.SpMat(), -1.0, *blfT);
 
                REQUIRE( diff->MaxNorm() < tol );
 
@@ -1853,7 +1853,7 @@ TEST_CASE("2D Bilinear Scalar Cross Product Integrators",
             blf.Assemble();
             blf.Finalize();
 
-            blf.Mult(f_nd,tmp_h1p); g_h1p = 0.0;
+            blf.Mult(f_nd, tmp_h1p); g_h1p = 0.0;
             CG(m_h1p, tmp_h1p, g_h1p, 0, 200, cg_rtol * cg_rtol, 0.0);
 
             REQUIRE( g_h1p.ComputeL2Error(VxF2_coef) < tol );
@@ -1887,7 +1887,7 @@ TEST_CASE("2D Bilinear Scalar Cross Product Integrators",
                blf.Assemble();
                blf.Finalize();
 
-               blf.Mult(f_nd,tmp_l2); g_l2 = 0.0;
+               blf.Mult(f_nd, tmp_l2); g_l2 = 0.0;
                CG(m_l2, tmp_l2, g_l2, 0, 200, cg_rtol * cg_rtol, 0.0);
 
                REQUIRE( g_l2.ComputeL2Error(VxF2_coef) < tol );
@@ -1924,7 +1924,7 @@ TEST_CASE("2D Bilinear Scalar Cross Product Integrators",
             blf.Assemble();
             blf.Finalize();
 
-            blf.Mult(f_rt,tmp_h1); g_h1 = 0.0;
+            blf.Mult(f_rt, tmp_h1); g_h1 = 0.0;
             CG(m_h1, tmp_h1, g_h1, 0, 200, cg_rtol * cg_rtol, 0.0);
 
             REQUIRE( g_h1.ComputeL2Error(VxF2_coef) < tol );
@@ -1958,7 +1958,7 @@ TEST_CASE("2D Bilinear Scalar Cross Product Integrators",
                blf.Assemble();
                blf.Finalize();
 
-               blf.Mult(f_rt,tmp_l2p); g_l2p = 0.0;
+               blf.Mult(f_rt, tmp_l2p); g_l2p = 0.0;
                CG(m_l2p, tmp_l2p, g_l2p, 0, 200, cg_rtol * cg_rtol, 0.0);
 
                REQUIRE( g_l2p.ComputeL2Error(VxF2_coef) < tol );
@@ -2013,7 +2013,7 @@ TEST_CASE("2D Bilinear Scalar Weak Cross Product Integrators",
             blf.Assemble();
             blf.Finalize();
 
-            blf.Mult(f_h1,tmp_ndp); g_ndp = 0.0;
+            blf.Mult(f_h1, tmp_ndp); g_ndp = 0.0;
             CG(m_ndp, tmp_ndp, g_ndp, 0, 200, cg_rtol * cg_rtol, 0.0);
 
             REQUIRE( g_ndp.ComputeL2Error(Vxf2_coef) < tol );
@@ -2025,7 +2025,7 @@ TEST_CASE("2D Bilinear Scalar Weak Cross Product Integrators",
             blfw.Finalize();
 
             SparseMatrix * blfT = Transpose(blfw.SpMat());
-            SparseMatrix * diff = Add(1.0,blf.SpMat(),1.0,*blfT);
+            SparseMatrix * diff = Add(1.0, blf.SpMat(), 1.0, *blfT);
 
             REQUIRE( diff->MaxNorm() < tol );
 
@@ -2055,7 +2055,7 @@ TEST_CASE("2D Bilinear Scalar Weak Cross Product Integrators",
             blf.Assemble();
             blf.Finalize();
 
-            blf.Mult(f_h1,tmp_rt); g_rt = 0.0;
+            blf.Mult(f_h1, tmp_rt); g_rt = 0.0;
             CG(m_rt, tmp_rt, g_rt, 0, 200, cg_rtol * cg_rtol, 0.0);
 
             REQUIRE( g_rt.ComputeL2Error(Vxf2_coef) < tol );
@@ -2067,7 +2067,7 @@ TEST_CASE("2D Bilinear Scalar Weak Cross Product Integrators",
             blfw.Finalize();
 
             SparseMatrix * blfT = Transpose(blfw.SpMat());
-            SparseMatrix * diff = Add(1.0,blf.SpMat(),1.0,*blfT);
+            SparseMatrix * diff = Add(1.0, blf.SpMat(), 1.0, *blfT);
 
             REQUIRE( diff->MaxNorm() < tol );
 
@@ -2112,7 +2112,7 @@ TEST_CASE("2D Bilinear Scalar Weak Cross Product Integrators",
                blf.Assemble();
                blf.Finalize();
 
-               blf.Mult(f_l2,tmp_ndp); g_ndp = 0.0;
+               blf.Mult(f_l2, tmp_ndp); g_ndp = 0.0;
                CG(m_ndp, tmp_ndp, g_ndp, 0, 200, cg_rtol * cg_rtol, 0.0);
 
                REQUIRE( g_ndp.ComputeL2Error(Vxf2_coef) < tol );
@@ -2124,7 +2124,7 @@ TEST_CASE("2D Bilinear Scalar Weak Cross Product Integrators",
                blfw.Finalize();
 
                SparseMatrix * blfT = Transpose(blfw.SpMat());
-               SparseMatrix * diff = Add(1.0,blf.SpMat(),1.0,*blfT);
+               SparseMatrix * diff = Add(1.0, blf.SpMat(), 1.0, *blfT);
 
                REQUIRE( diff->MaxNorm() < tol );
 
@@ -2155,7 +2155,7 @@ TEST_CASE("2D Bilinear Scalar Weak Cross Product Integrators",
                blf.Assemble();
                blf.Finalize();
 
-               blf.Mult(f_l2,tmp_rt); g_rt = 0.0;
+               blf.Mult(f_l2, tmp_rt); g_rt = 0.0;
                CG(m_rt, tmp_rt, g_rt, 0, 200, cg_rtol * cg_rtol, 0.0);
 
                REQUIRE( g_rt.ComputeL2Error(Vxf2_coef) < tol );
@@ -2167,7 +2167,7 @@ TEST_CASE("2D Bilinear Scalar Weak Cross Product Integrators",
                blfw.Finalize();
 
                SparseMatrix * blfT = Transpose(blfw.SpMat());
-               SparseMatrix * diff = Add(1.0,blf.SpMat(),1.0,*blfT);
+               SparseMatrix * diff = Add(1.0, blf.SpMat(), 1.0, *blfT);
 
                REQUIRE( diff->MaxNorm() < tol );
 
@@ -2217,7 +2217,7 @@ TEST_CASE("2D Bilinear Scalar Weak Curl Integrators",
             blfw.Finalize();
 
             SparseMatrix * blfT = Transpose(blfw.SpMat());
-            SparseMatrix * diff = Add(1.0,blf.SpMat(),-1.0,*blfT);
+            SparseMatrix * diff = Add(1.0, blf.SpMat(), -1.0, *blfT);
 
             REQUIRE( diff->MaxNorm() < tol );
 
@@ -2239,7 +2239,7 @@ TEST_CASE("2D Bilinear Scalar Weak Curl Integrators",
             blfw.Finalize();
 
             SparseMatrix * blfT = Transpose(blfw.SpMat());
-            SparseMatrix * diff = Add(1.0,blf.SpMat(),-1.0,*blfT);
+            SparseMatrix * diff = Add(1.0, blf.SpMat(), -1.0, *blfT);
 
             REQUIRE( diff->MaxNorm() < tol );
 
@@ -2280,7 +2280,7 @@ TEST_CASE("2D Bilinear Scalar Weak Curl Integrators",
                blfw.Finalize();
 
                SparseMatrix * blfT = Transpose(blfw.SpMat());
-               SparseMatrix * diff = Add(1.0,blf.SpMat(),-1.0,*blfT);
+               SparseMatrix * diff = Add(1.0, blf.SpMat(), -1.0, *blfT);
 
                REQUIRE( diff->MaxNorm() < tol );
 
@@ -2302,7 +2302,7 @@ TEST_CASE("2D Bilinear Scalar Weak Curl Integrators",
                blfw.Finalize();
 
                SparseMatrix * blfT = Transpose(blfw.SpMat());
-               SparseMatrix * diff = Add(1.0,blf.SpMat(),-1.0,*blfT);
+               SparseMatrix * diff = Add(1.0, blf.SpMat(), -1.0, *blfT);
 
                REQUIRE( diff->MaxNorm() < tol );
 
@@ -2352,7 +2352,7 @@ TEST_CASE("2D Bilinear Scalar Weak Gradient Integrators",
             blfw.Finalize();
 
             SparseMatrix * blfT = Transpose(blfw.SpMat());
-            SparseMatrix * diff = Add(1.0,blf.SpMat(),1.0,*blfT);
+            SparseMatrix * diff = Add(1.0, blf.SpMat(), 1.0, *blfT);
 
             REQUIRE( diff->MaxNorm() < tol );
 
@@ -2374,7 +2374,7 @@ TEST_CASE("2D Bilinear Scalar Weak Gradient Integrators",
             blfw.Finalize();
 
             SparseMatrix * blfT = Transpose(blfw.SpMat());
-            SparseMatrix * diff = Add(1.0,blf.SpMat(),1.0,*blfT);
+            SparseMatrix * diff = Add(1.0, blf.SpMat(), 1.0, *blfT);
 
             REQUIRE( diff->MaxNorm() < tol );
 
@@ -2415,7 +2415,7 @@ TEST_CASE("2D Bilinear Scalar Weak Gradient Integrators",
                blfw.Finalize();
 
                SparseMatrix * blfT = Transpose(blfw.SpMat());
-               SparseMatrix * diff = Add(1.0,blf.SpMat(),1.0,*blfT);
+               SparseMatrix * diff = Add(1.0, blf.SpMat(), 1.0, *blfT);
 
                REQUIRE( diff->MaxNorm() < tol );
 
@@ -2437,7 +2437,7 @@ TEST_CASE("2D Bilinear Scalar Weak Gradient Integrators",
                blfw.Finalize();
 
                SparseMatrix * blfT = Transpose(blfw.SpMat());
-               SparseMatrix * diff = Add(1.0,blf.SpMat(),1.0,*blfT);
+               SparseMatrix * diff = Add(1.0, blf.SpMat(), 1.0, *blfT);
 
                REQUIRE( diff->MaxNorm() < tol );
 
@@ -2491,7 +2491,7 @@ TEST_CASE("2D Bilinear Directional Derivative Integrators",
             blf.Assemble();
             blf.Finalize();
 
-            blf.Mult(f_h1,tmp_h1); g_h1 = 0.0;
+            blf.Mult(f_h1, tmp_h1); g_h1 = 0.0;
             CG(m_h1, tmp_h1, g_h1, 0, 200, cg_rtol * cg_rtol, 0.0);
 
             REQUIRE( g_h1.ComputeL2Error(Vdf2_coef) < tol );
@@ -2525,7 +2525,7 @@ TEST_CASE("2D Bilinear Directional Derivative Integrators",
                blf.Assemble();
                blf.Finalize();
 
-               blf.Mult(f_h1,tmp_l2); g_l2 = 0.0;
+               blf.Mult(f_h1, tmp_l2); g_l2 = 0.0;
                CG(m_l2, tmp_l2, g_l2, 0, 200, cg_rtol * cg_rtol, 0.0);
 
                REQUIRE( g_l2.ComputeL2Error(Vdf2_coef) < tol );
@@ -2571,7 +2571,7 @@ TEST_CASE("2D Bilinear Scalar Weak Divergence Integrators",
             blfw.Finalize();
 
             SparseMatrix * blfT = Transpose(blfw.SpMat());
-            SparseMatrix * diff = Add(1.0,blf.SpMat(),1.0,*blfT);
+            SparseMatrix * diff = Add(1.0, blf.SpMat(), 1.0, *blfT);
 
             REQUIRE( diff->MaxNorm() < tol );
 
@@ -2612,7 +2612,7 @@ TEST_CASE("2D Bilinear Scalar Weak Divergence Integrators",
                blfw.Finalize();
 
                SparseMatrix * blfT = Transpose(blfw.SpMat());
-               SparseMatrix * diff = Add(1.0,blf.SpMat(),1.0,*blfT);
+               SparseMatrix * diff = Add(1.0, blf.SpMat(), 1.0, *blfT);
 
                REQUIRE( diff->MaxNorm() < tol );
 
@@ -2666,7 +2666,7 @@ TEST_CASE("2D Bilinear Vector Weak Divergence Integrators",
             blfw.Finalize();
 
             SparseMatrix * blfT = Transpose(blfw.SpMat());
-            SparseMatrix * diff = Add(1.0,blf.SpMat(),1.0,*blfT);
+            SparseMatrix * diff = Add(1.0, blf.SpMat(), 1.0, *blfT);
 
             REQUIRE( diff->MaxNorm() < tol );
 
@@ -2688,7 +2688,7 @@ TEST_CASE("2D Bilinear Vector Weak Divergence Integrators",
             blfw.Finalize();
 
             SparseMatrix * blfT = Transpose(blfw.SpMat());
-            SparseMatrix * diff = Add(1.0,blf.SpMat(),1.0,*blfT);
+            SparseMatrix * diff = Add(1.0, blf.SpMat(), 1.0, *blfT);
 
             REQUIRE( diff->MaxNorm() < tol );
 
@@ -2710,7 +2710,7 @@ TEST_CASE("2D Bilinear Vector Weak Divergence Integrators",
             blfw.Finalize();
 
             SparseMatrix * blfT = Transpose(blfw.SpMat());
-            SparseMatrix * diff = Add(1.0,blf.SpMat(),1.0,*blfT);
+            SparseMatrix * diff = Add(1.0, blf.SpMat(), 1.0, *blfT);
 
             REQUIRE( diff->MaxNorm() < tol );
 
@@ -2732,7 +2732,7 @@ TEST_CASE("2D Bilinear Vector Weak Divergence Integrators",
             blfw.Finalize();
 
             SparseMatrix * blfT = Transpose(blfw.SpMat());
-            SparseMatrix * diff = Add(1.0,blf.SpMat(),1.0,*blfT);
+            SparseMatrix * diff = Add(1.0, blf.SpMat(), 1.0, *blfT);
 
             REQUIRE( diff->MaxNorm() < tol );
 
@@ -2766,7 +2766,7 @@ TEST_CASE("2D Bilinear Vector Weak Divergence Integrators",
             blfw.Finalize();
 
             SparseMatrix * blfT = Transpose(blfw.SpMat());
-            SparseMatrix * diff = Add(1.0,blf.SpMat(),1.0,*blfT);
+            SparseMatrix * diff = Add(1.0, blf.SpMat(), 1.0, *blfT);
 
             REQUIRE( diff->MaxNorm() < tol );
 
@@ -2788,7 +2788,7 @@ TEST_CASE("2D Bilinear Vector Weak Divergence Integrators",
             blfw.Finalize();
 
             SparseMatrix * blfT = Transpose(blfw.SpMat());
-            SparseMatrix * diff = Add(1.0,blf.SpMat(),1.0,*blfT);
+            SparseMatrix * diff = Add(1.0, blf.SpMat(), 1.0, *blfT);
 
             REQUIRE( diff->MaxNorm() < tol );
 
@@ -2810,7 +2810,7 @@ TEST_CASE("2D Bilinear Vector Weak Divergence Integrators",
             blfw.Finalize();
 
             SparseMatrix * blfT = Transpose(blfw.SpMat());
-            SparseMatrix * diff = Add(1.0,blf.SpMat(),1.0,*blfT);
+            SparseMatrix * diff = Add(1.0, blf.SpMat(), 1.0, *blfT);
 
             REQUIRE( diff->MaxNorm() < tol );
 
@@ -2832,7 +2832,7 @@ TEST_CASE("2D Bilinear Vector Weak Divergence Integrators",
             blfw.Finalize();
 
             SparseMatrix * blfT = Transpose(blfw.SpMat());
-            SparseMatrix * diff = Add(1.0,blf.SpMat(),1.0,*blfT);
+            SparseMatrix * diff = Add(1.0, blf.SpMat(), 1.0, *blfT);
 
             REQUIRE( diff->MaxNorm() < tol );
 
@@ -2889,7 +2889,7 @@ TEST_CASE("2D Bilinear Dot Product Integrators",
             blf.Assemble();
             blf.Finalize();
 
-            blf.Mult(f_nd,tmp_h1); g_h1 = 0.0;
+            blf.Mult(f_nd, tmp_h1); g_h1 = 0.0;
             CG(m_h1, tmp_h1, g_h1, 0, 200, cg_rtol * cg_rtol, 0.0);
 
             REQUIRE( g_h1.ComputeL2Error(VF2_coef) < tol );
@@ -2923,7 +2923,7 @@ TEST_CASE("2D Bilinear Dot Product Integrators",
                blf.Assemble();
                blf.Finalize();
 
-               blf.Mult(f_nd,tmp_l2); g_l2 = 0.0;
+               blf.Mult(f_nd, tmp_l2); g_l2 = 0.0;
                CG(m_l2, tmp_l2, g_l2, 0, 200, cg_rtol * cg_rtol, 0.0);
 
                REQUIRE( g_l2.ComputeL2Error(VF2_coef) < tol );
@@ -2960,7 +2960,7 @@ TEST_CASE("2D Bilinear Dot Product Integrators",
             blf.Assemble();
             blf.Finalize();
 
-            blf.Mult(f_rt,tmp_h1); g_h1 = 0.0;
+            blf.Mult(f_rt, tmp_h1); g_h1 = 0.0;
             CG(m_h1, tmp_h1, g_h1, 0, 200, cg_rtol * cg_rtol, 0.0);
 
             REQUIRE( g_h1.ComputeL2Error(VF2_coef) < tol );
@@ -2994,7 +2994,7 @@ TEST_CASE("2D Bilinear Dot Product Integrators",
                blf.Assemble();
                blf.Finalize();
 
-               blf.Mult(f_rt,tmp_l2); g_l2 = 0.0;
+               blf.Mult(f_rt, tmp_l2); g_l2 = 0.0;
                CG(m_l2, tmp_l2, g_l2, 0, 200, cg_rtol * cg_rtol, 0.0);
 
                REQUIRE( g_l2.ComputeL2Error(VF2_coef) < tol );
@@ -3042,7 +3042,7 @@ TEST_CASE("2D Bilinear Weak Gradient Dot Product Integrators",
             blfw.Finalize();
 
             SparseMatrix * blfT = Transpose(blfw.SpMat());
-            SparseMatrix * diff = Add(1.0,blf.SpMat(),1.0,*blfT);
+            SparseMatrix * diff = Add(1.0, blf.SpMat(), 1.0, *blfT);
 
             REQUIRE( diff->MaxNorm() < tol );
 
@@ -3073,7 +3073,7 @@ TEST_CASE("2D Bilinear Weak Gradient Dot Product Integrators",
             blfw.Finalize();
 
             SparseMatrix * blfT = Transpose(blfw.SpMat());
-            SparseMatrix * diff = Add(1.0,blf.SpMat(),1.0,*blfT);
+            SparseMatrix * diff = Add(1.0, blf.SpMat(), 1.0, *blfT);
 
             REQUIRE( diff->MaxNorm() < tol );
 
@@ -3129,7 +3129,7 @@ TEST_CASE("2D Bilinear Scalar Cross Product Curl Integrator",
             blf.Assemble();
             blf.Finalize();
 
-            blf.Mult(f_nd,tmp_rt); g_rt = 0.0;
+            blf.Mult(f_nd, tmp_rt); g_rt = 0.0;
             CG(m_rt, tmp_rt, g_rt, 0, 200, cg_rtol * cg_rtol, 0.0);
 
             REQUIRE( g_rt.ComputeL2Error(VxdF2_coef) < tol );
@@ -3154,7 +3154,7 @@ TEST_CASE("2D Bilinear Scalar Cross Product Curl Integrator",
             blf.Assemble();
             blf.Finalize();
 
-            blf.Mult(f_nd,tmp_nd); g_nd = 0.0;
+            blf.Mult(f_nd, tmp_nd); g_nd = 0.0;
             CG(m_nd, tmp_nd, g_nd, 0, 200, cg_rtol * cg_rtol, 0.0);
 
             REQUIRE( g_nd.ComputeL2Error(VxdF2_coef) < tol );
@@ -3198,7 +3198,7 @@ TEST_CASE("2D Bilinear Scalar Weak Curl Cross Integrators",
             blfw.Finalize();
 
             SparseMatrix * blfT = Transpose(blfw.SpMat());
-            SparseMatrix * diff = Add(1.0,blf.SpMat(),1.0,*blfT);
+            SparseMatrix * diff = Add(1.0, blf.SpMat(), 1.0, *blfT);
 
             REQUIRE( diff->MaxNorm() < tol );
 
@@ -3232,7 +3232,7 @@ TEST_CASE("2D Bilinear Scalar Weak Curl Cross Integrators",
             blfw.Finalize();
 
             SparseMatrix * blfT = Transpose(blfw.SpMat());
-            SparseMatrix * diff = Add(1.0,blf.SpMat(),1.0,*blfT);
+            SparseMatrix * diff = Add(1.0, blf.SpMat(), 1.0, *blfT);
 
             REQUIRE( diff->MaxNorm() < tol );
 

--- a/tests/unit/fem/test_2d_bilininteg.cpp
+++ b/tests/unit/fem/test_2d_bilininteg.cpp
@@ -170,6 +170,8 @@ const std::string MapTypeName(FiniteElement::MapType map_type)
          return "H_CURL";
       case FiniteElement::H_DIV:
          return "H_DIV";
+      default:
+         return "UNKNOWN";
    }
 }
 

--- a/tests/unit/fem/test_3d_bilininteg.cpp
+++ b/tests/unit/fem/test_3d_bilininteg.cpp
@@ -512,6 +512,8 @@ const std::string MapTypeName(FiniteElement::MapType map_type)
          return "H_CURL";
       case FiniteElement::H_DIV:
          return "H_DIV";
+      default:
+         return "UNKNOWN";
    }
 }
 

--- a/tests/unit/fem/test_3d_bilininteg.cpp
+++ b/tests/unit/fem/test_3d_bilininteg.cpp
@@ -570,7 +570,7 @@ TEST_CASE("3D Bilinear Mass Integrators",
                   blf.Assemble();
                   blf.Finalize();
 
-                  blf.Mult(f_h1,tmp_l2); g_l2 = 0.0;
+                  blf.Mult(f_h1, tmp_l2); g_l2 = 0.0;
                   CG(m_l2, tmp_l2, g_l2, 0, 200, cg_rtol * cg_rtol, 0.0);
 
                   REQUIRE( g_l2.ComputeL2Error(f3_coef) < tol );
@@ -581,7 +581,7 @@ TEST_CASE("3D Bilinear Mass Integrators",
                   blfw.Finalize();
 
                   SparseMatrix * blfT = Transpose(blfw.SpMat());
-                  SparseMatrix * diff = Add(1.0,blf.SpMat(),-1.0,*blfT);
+                  SparseMatrix * diff = Add(1.0, blf.SpMat(), -1.0, *blfT);
 
                   REQUIRE( diff->MaxNorm() < tol );
 
@@ -595,7 +595,7 @@ TEST_CASE("3D Bilinear Mass Integrators",
                   blf.Assemble();
                   blf.Finalize();
 
-                  blf.Mult(f_h1,tmp_l2); g_l2 = 0.0;
+                  blf.Mult(f_h1, tmp_l2); g_l2 = 0.0;
                   CG(m_l2, tmp_l2, g_l2, 0, 200, cg_rtol * cg_rtol, 0.0);
 
                   REQUIRE( g_l2.ComputeL2Error(qf3_coef) < tol );
@@ -606,7 +606,7 @@ TEST_CASE("3D Bilinear Mass Integrators",
                   blfw.Finalize();
 
                   SparseMatrix * blfT = Transpose(blfw.SpMat());
-                  SparseMatrix * diff = Add(1.0,blf.SpMat(),-1.0,*blfT);
+                  SparseMatrix * diff = Add(1.0, blf.SpMat(), -1.0, *blfT);
 
                   REQUIRE( diff->MaxNorm() < tol );
 
@@ -633,7 +633,7 @@ TEST_CASE("3D Bilinear Mass Integrators",
                blf.Assemble();
                blf.Finalize();
 
-               blf.Mult(f_h1,tmp_h1); g_h1 = 0.0;
+               blf.Mult(f_h1, tmp_h1); g_h1 = 0.0;
                CG(m_h1, tmp_h1, g_h1, 0, 200, cg_rtol * cg_rtol, 0.0);
 
                REQUIRE( g_h1.ComputeL2Error(f3_coef) < tol );
@@ -645,7 +645,7 @@ TEST_CASE("3D Bilinear Mass Integrators",
                blf.Assemble();
                blf.Finalize();
 
-               blf.Mult(f_h1,tmp_h1); g_h1 = 0.0;
+               blf.Mult(f_h1, tmp_h1); g_h1 = 0.0;
                CG(m_h1, tmp_h1, g_h1, 0, 200, cg_rtol * cg_rtol, 0.0);
 
                REQUIRE( g_h1.ComputeL2Error(qf3_coef) < tol );
@@ -695,7 +695,7 @@ TEST_CASE("3D Bilinear Mass Integrators",
                      blf.Assemble();
                      blf.Finalize();
 
-                     blf.Mult(f_l2,tmp_l2); g_l2 = 0.0;
+                     blf.Mult(f_l2, tmp_l2); g_l2 = 0.0;
                      CG(m_l2, tmp_l2, g_l2, 0, 200, cg_rtol * cg_rtol, 0.0);
 
                      REQUIRE( g_l2.ComputeL2Error(f3_coef) < tol );
@@ -707,7 +707,7 @@ TEST_CASE("3D Bilinear Mass Integrators",
                      blf.Assemble();
                      blf.Finalize();
 
-                     blf.Mult(f_l2,tmp_l2); g_l2 = 0.0;
+                     blf.Mult(f_l2, tmp_l2); g_l2 = 0.0;
                      CG(m_l2, tmp_l2, g_l2, 0, 200, cg_rtol * cg_rtol, 0.0);
 
                      REQUIRE( g_l2.ComputeL2Error(qf3_coef) < tol );
@@ -737,7 +737,7 @@ TEST_CASE("3D Bilinear Mass Integrators",
                   blf.Assemble();
                   blf.Finalize();
 
-                  blf.Mult(f_l2,tmp_h1); g_h1 = 0.0;
+                  blf.Mult(f_l2, tmp_h1); g_h1 = 0.0;
                   CG(m_h1, tmp_h1, g_h1, 0, 200, cg_rtol * cg_rtol, 0.0);
 
                   REQUIRE( g_h1.ComputeL2Error(f3_coef) < tol );
@@ -748,7 +748,7 @@ TEST_CASE("3D Bilinear Mass Integrators",
                   blfw.Finalize();
 
                   SparseMatrix * blfT = Transpose(blfw.SpMat());
-                  SparseMatrix * diff = Add(1.0,blf.SpMat(),-1.0,*blfT);
+                  SparseMatrix * diff = Add(1.0, blf.SpMat(), -1.0, *blfT);
 
                   REQUIRE( diff->MaxNorm() < tol );
 
@@ -762,7 +762,7 @@ TEST_CASE("3D Bilinear Mass Integrators",
                   blf.Assemble();
                   blf.Finalize();
 
-                  blf.Mult(f_l2,tmp_h1); g_h1 = 0.0;
+                  blf.Mult(f_l2, tmp_h1); g_h1 = 0.0;
                   CG(m_h1, tmp_h1, g_h1, 0, 200, cg_rtol * cg_rtol, 0.0);
 
                   REQUIRE( g_h1.ComputeL2Error(qf3_coef) < tol );
@@ -773,7 +773,7 @@ TEST_CASE("3D Bilinear Mass Integrators",
                   blfw.Finalize();
 
                   SparseMatrix * blfT = Transpose(blfw.SpMat());
-                  SparseMatrix * diff = Add(1.0,blf.SpMat(),-1.0,*blfT);
+                  SparseMatrix * diff = Add(1.0, blf.SpMat(), -1.0, *blfT);
 
                   REQUIRE( diff->MaxNorm() < tol );
 
@@ -844,7 +844,7 @@ TEST_CASE("3D Bilinear Vector Mass Integrators",
                   blf.Assemble();
                   blf.Finalize();
 
-                  blf.Mult(f_nd,tmp_rt); g_rt = 0.0;
+                  blf.Mult(f_nd, tmp_rt); g_rt = 0.0;
                   PCG(m_rt, s_rt, tmp_rt, g_rt, 0, 200, cg_rtol * cg_rtol, 0.0);
 
                   REQUIRE( g_rt.ComputeL2Error(F3_coef) < tol );
@@ -855,7 +855,7 @@ TEST_CASE("3D Bilinear Vector Mass Integrators",
                   blfw.Finalize();
 
                   SparseMatrix * blfT = Transpose(blfw.SpMat());
-                  SparseMatrix * diff = Add(1.0,blf.SpMat(),-1.0,*blfT);
+                  SparseMatrix * diff = Add(1.0, blf.SpMat(), -1.0, *blfT);
 
                   REQUIRE( diff->MaxNorm() < tol );
 
@@ -867,7 +867,7 @@ TEST_CASE("3D Bilinear Vector Mass Integrators",
                   blfv.Assemble();
                   blfv.Finalize();
 
-                  SparseMatrix * diffv = Add(1.0,blf.SpMat(),-1.0,blfv.SpMat());
+                  SparseMatrix * diffv = Add(1.0, blf.SpMat(), -1.0, blfv.SpMat());
 
                   REQUIRE( diffv->MaxNorm() < tol );
 
@@ -880,7 +880,7 @@ TEST_CASE("3D Bilinear Vector Mass Integrators",
                   blf.Assemble();
                   blf.Finalize();
 
-                  blf.Mult(f_nd,tmp_rt); g_rt = 0.0;
+                  blf.Mult(f_nd, tmp_rt); g_rt = 0.0;
                   PCG(m_rt, s_rt, tmp_rt, g_rt, 0, 200, cg_rtol * cg_rtol, 0.0);
 
                   REQUIRE( g_rt.ComputeL2Error(F3_coef) < tol );
@@ -891,7 +891,7 @@ TEST_CASE("3D Bilinear Vector Mass Integrators",
                   blfw.Finalize();
 
                   SparseMatrix * blfT = Transpose(blfw.SpMat());
-                  SparseMatrix * diff = Add(1.0,blf.SpMat(),-1.0,*blfT);
+                  SparseMatrix * diff = Add(1.0, blf.SpMat(), -1.0, *blfT);
 
                   REQUIRE( diff->MaxNorm() < tol );
 
@@ -923,7 +923,7 @@ TEST_CASE("3D Bilinear Vector Mass Integrators",
                   blf.Assemble();
                   blf.Finalize();
 
-                  blf.Mult(f_nd,tmp_rt); g_rt = 0.0;
+                  blf.Mult(f_nd, tmp_rt); g_rt = 0.0;
                   PCG(m_rt, s_rt, tmp_rt, g_rt, 0, 200, cg_rtol * cg_rtol, 0.0);
 
                   REQUIRE( g_rt.ComputeL2Error(qF3_coef) < tol );
@@ -935,7 +935,7 @@ TEST_CASE("3D Bilinear Vector Mass Integrators",
                   blfw.Finalize();
 
                   SparseMatrix * blfT = Transpose(blfw.SpMat());
-                  SparseMatrix * diff = Add(1.0,blf.SpMat(),-1.0,*blfT);
+                  SparseMatrix * diff = Add(1.0, blf.SpMat(), -1.0, *blfT);
 
                   REQUIRE( diff->MaxNorm() < tol );
 
@@ -949,7 +949,7 @@ TEST_CASE("3D Bilinear Vector Mass Integrators",
                   blf.Assemble();
                   blf.Finalize();
 
-                  blf.Mult(f_nd,tmp_rt); g_rt = 0.0;
+                  blf.Mult(f_nd, tmp_rt); g_rt = 0.0;
                   PCG(m_rt, s_rt, tmp_rt, g_rt, 0, 200, cg_rtol * cg_rtol, 0.0);
 
                   REQUIRE( g_rt.ComputeL2Error(qF3_coef) < tol );
@@ -960,7 +960,7 @@ TEST_CASE("3D Bilinear Vector Mass Integrators",
                   blfw.Finalize();
 
                   SparseMatrix * blfT = Transpose(blfw.SpMat());
-                  SparseMatrix * diff = Add(1.0,blf.SpMat(),-1.0,*blfT);
+                  SparseMatrix * diff = Add(1.0, blf.SpMat(), -1.0, *blfT);
 
                   REQUIRE( diff->MaxNorm() < tol );
 
@@ -975,7 +975,7 @@ TEST_CASE("3D Bilinear Vector Mass Integrators",
                   blf.Assemble();
                   blf.Finalize();
 
-                  blf.Mult(f_nd,tmp_rt); g_rt = 0.0;
+                  blf.Mult(f_nd, tmp_rt); g_rt = 0.0;
                   PCG(m_rt, s_rt, tmp_rt, g_rt, 0, 200, cg_rtol * cg_rtol, 0.0);
 
                   REQUIRE( g_rt.ComputeL2Error(DF3_coef) < tol );
@@ -987,7 +987,7 @@ TEST_CASE("3D Bilinear Vector Mass Integrators",
                   blfw.Finalize();
 
                   SparseMatrix * blfT = Transpose(blfw.SpMat());
-                  SparseMatrix * diff = Add(1.0,blf.SpMat(),-1.0,*blfT);
+                  SparseMatrix * diff = Add(1.0, blf.SpMat(), -1.0, *blfT);
 
                   REQUIRE( diff->MaxNorm() < tol );
 
@@ -1002,7 +1002,7 @@ TEST_CASE("3D Bilinear Vector Mass Integrators",
                   blf.Assemble();
                   blf.Finalize();
 
-                  blf.Mult(f_nd,tmp_rt); g_rt = 0.0;
+                  blf.Mult(f_nd, tmp_rt); g_rt = 0.0;
                   PCG(m_rt, s_rt, tmp_rt, g_rt, 0, 200, cg_rtol * cg_rtol, 0.0);
 
                   REQUIRE( g_rt.ComputeL2Error(DF3_coef) < tol );
@@ -1014,7 +1014,7 @@ TEST_CASE("3D Bilinear Vector Mass Integrators",
                   blfw.Finalize();
 
                   SparseMatrix * blfT = Transpose(blfw.SpMat());
-                  SparseMatrix * diff = Add(1.0,blf.SpMat(),-1.0,*blfT);
+                  SparseMatrix * diff = Add(1.0, blf.SpMat(), -1.0, *blfT);
 
                   REQUIRE( diff->MaxNorm() < tol );
 
@@ -1029,7 +1029,7 @@ TEST_CASE("3D Bilinear Vector Mass Integrators",
                   blf.Assemble();
                   blf.Finalize();
 
-                  blf.Mult(f_nd,tmp_rt); g_rt = 0.0;
+                  blf.Mult(f_nd, tmp_rt); g_rt = 0.0;
                   PCG(m_rt, s_rt, tmp_rt, g_rt, 0, 200, cg_rtol * cg_rtol, 0.0);
 
                   REQUIRE( g_rt.ComputeL2Error(MF3_coef) < tol );
@@ -1041,7 +1041,7 @@ TEST_CASE("3D Bilinear Vector Mass Integrators",
                   blfw.Finalize();
 
                   SparseMatrix * blfT = Transpose(blfw.SpMat());
-                  SparseMatrix * diff = Add(1.0,blf.SpMat(),-1.0,*blfT);
+                  SparseMatrix * diff = Add(1.0, blf.SpMat(), -1.0, *blfT);
 
                   REQUIRE( diff->MaxNorm() < tol );
 
@@ -1055,7 +1055,7 @@ TEST_CASE("3D Bilinear Vector Mass Integrators",
                   blf.Assemble();
                   blf.Finalize();
 
-                  blf.Mult(f_nd,tmp_rt); g_rt = 0.0;
+                  blf.Mult(f_nd, tmp_rt); g_rt = 0.0;
                   PCG(m_rt, s_rt, tmp_rt, g_rt, 0, 200, cg_rtol * cg_rtol, 0.0);
 
                   REQUIRE( g_rt.ComputeL2Error(MF3_coef) < tol );
@@ -1067,7 +1067,7 @@ TEST_CASE("3D Bilinear Vector Mass Integrators",
                   blfw.Finalize();
 
                   SparseMatrix * blfT = Transpose(blfw.SpMat());
-                  SparseMatrix * diff = Add(1.0,blf.SpMat(),-1.0,*blfT);
+                  SparseMatrix * diff = Add(1.0, blf.SpMat(), -1.0, *blfT);
 
                   REQUIRE( diff->MaxNorm() < tol );
 
@@ -1100,7 +1100,7 @@ TEST_CASE("3D Bilinear Vector Mass Integrators",
                   blf.Assemble();
                   blf.Finalize();
 
-                  blf.Mult(f_nd,tmp_nd); g_nd = 0.0;
+                  blf.Mult(f_nd, tmp_nd); g_nd = 0.0;
                   PCG(m_nd, s_nd, tmp_nd, g_nd, 0, 200, cg_rtol * cg_rtol, 0.0);
 
                   REQUIRE( g_nd.ComputeL2Error(F3_coef) < tol );
@@ -1111,7 +1111,7 @@ TEST_CASE("3D Bilinear Vector Mass Integrators",
                   blfw.Finalize();
 
                   SparseMatrix * blfT = Transpose(blfw.SpMat());
-                  SparseMatrix * diff = Add(1.0,blf.SpMat(),-1.0,*blfT);
+                  SparseMatrix * diff = Add(1.0, blf.SpMat(), -1.0, *blfT);
 
                   REQUIRE( diff->MaxNorm() < tol );
 
@@ -1123,7 +1123,7 @@ TEST_CASE("3D Bilinear Vector Mass Integrators",
                   blfv.Assemble();
                   blfv.Finalize();
 
-                  SparseMatrix * diffv = Add(1.0,blf.SpMat(),-1.0,blfv.SpMat());
+                  SparseMatrix * diffv = Add(1.0, blf.SpMat(), -1.0, blfv.SpMat());
 
                   REQUIRE( diffv->MaxNorm() < tol );
 
@@ -1136,7 +1136,7 @@ TEST_CASE("3D Bilinear Vector Mass Integrators",
                   blf.Assemble();
                   blf.Finalize();
 
-                  blf.Mult(f_nd,tmp_nd); g_nd = 0.0;
+                  blf.Mult(f_nd, tmp_nd); g_nd = 0.0;
                   PCG(m_nd, s_nd, tmp_nd, g_nd, 0, 200, cg_rtol * cg_rtol, 0.0);
 
                   REQUIRE( g_nd.ComputeL2Error(F3_coef) < tol );
@@ -1147,7 +1147,7 @@ TEST_CASE("3D Bilinear Vector Mass Integrators",
                   blfw.Finalize();
 
                   SparseMatrix * blfT = Transpose(blfw.SpMat());
-                  SparseMatrix * diff = Add(1.0,blf.SpMat(),-1.0,*blfT);
+                  SparseMatrix * diff = Add(1.0, blf.SpMat(), -1.0, *blfT);
 
                   REQUIRE( diff->MaxNorm() < tol );
 
@@ -1179,7 +1179,7 @@ TEST_CASE("3D Bilinear Vector Mass Integrators",
                   blf.Assemble();
                   blf.Finalize();
 
-                  blf.Mult(f_nd,tmp_ndp); g_ndp = 0.0;
+                  blf.Mult(f_nd, tmp_ndp); g_ndp = 0.0;
                   PCG(m_ndp, s_ndp, tmp_ndp, g_ndp, 0, 200,
                       cg_rtol * cg_rtol, 0.0);
 
@@ -1192,7 +1192,7 @@ TEST_CASE("3D Bilinear Vector Mass Integrators",
                   blfw.Finalize();
 
                   SparseMatrix * blfT = Transpose(blfw.SpMat());
-                  SparseMatrix * diff = Add(1.0,blf.SpMat(),-1.0,*blfT);
+                  SparseMatrix * diff = Add(1.0, blf.SpMat(), -1.0, *blfT);
 
                   REQUIRE( diff->MaxNorm() < tol );
 
@@ -1206,7 +1206,7 @@ TEST_CASE("3D Bilinear Vector Mass Integrators",
                   blf.Assemble();
                   blf.Finalize();
 
-                  blf.Mult(f_nd,tmp_ndp); g_ndp = 0.0;
+                  blf.Mult(f_nd, tmp_ndp); g_ndp = 0.0;
                   PCG(m_ndp, s_ndp, tmp_ndp, g_ndp, 0, 200,
                       cg_rtol * cg_rtol, 0.0);
 
@@ -1218,7 +1218,7 @@ TEST_CASE("3D Bilinear Vector Mass Integrators",
                   blfw.Finalize();
 
                   SparseMatrix * blfT = Transpose(blfw.SpMat());
-                  SparseMatrix * diff = Add(1.0,blf.SpMat(),-1.0,*blfT);
+                  SparseMatrix * diff = Add(1.0, blf.SpMat(), -1.0, *blfT);
 
                   REQUIRE( diff->MaxNorm() < tol );
 
@@ -1233,7 +1233,7 @@ TEST_CASE("3D Bilinear Vector Mass Integrators",
                   blf.Assemble();
                   blf.Finalize();
 
-                  blf.Mult(f_nd,tmp_ndp); g_ndp = 0.0;
+                  blf.Mult(f_nd, tmp_ndp); g_ndp = 0.0;
                   PCG(m_ndp, s_ndp, tmp_ndp, g_ndp, 0, 200,
                       cg_rtol * cg_rtol, 0.0);
 
@@ -1246,7 +1246,7 @@ TEST_CASE("3D Bilinear Vector Mass Integrators",
                   blfw.Finalize();
 
                   SparseMatrix * blfT = Transpose(blfw.SpMat());
-                  SparseMatrix * diff = Add(1.0,blf.SpMat(),-1.0,*blfT);
+                  SparseMatrix * diff = Add(1.0, blf.SpMat(), -1.0, *blfT);
 
                   REQUIRE( diff->MaxNorm() < tol );
 
@@ -1261,7 +1261,7 @@ TEST_CASE("3D Bilinear Vector Mass Integrators",
                   blf.Assemble();
                   blf.Finalize();
 
-                  blf.Mult(f_nd,tmp_ndp); g_ndp = 0.0;
+                  blf.Mult(f_nd, tmp_ndp); g_ndp = 0.0;
                   PCG(m_ndp, s_ndp, tmp_ndp, g_ndp, 0, 200,
                       cg_rtol * cg_rtol, 0.0);
 
@@ -1274,7 +1274,7 @@ TEST_CASE("3D Bilinear Vector Mass Integrators",
                   blfw.Finalize();
 
                   SparseMatrix * blfT = Transpose(blfw.SpMat());
-                  SparseMatrix * diff = Add(1.0,blf.SpMat(),-1.0,*blfT);
+                  SparseMatrix * diff = Add(1.0, blf.SpMat(), -1.0, *blfT);
 
                   REQUIRE( diff->MaxNorm() < tol );
 
@@ -1289,7 +1289,7 @@ TEST_CASE("3D Bilinear Vector Mass Integrators",
                   blf.Assemble();
                   blf.Finalize();
 
-                  blf.Mult(f_nd,tmp_ndp); g_ndp = 0.0;
+                  blf.Mult(f_nd, tmp_ndp); g_ndp = 0.0;
                   PCG(m_ndp, s_ndp, tmp_ndp, g_ndp, 0, 200,
                       cg_rtol * cg_rtol, 0.0);
 
@@ -1302,7 +1302,7 @@ TEST_CASE("3D Bilinear Vector Mass Integrators",
                   blfw.Finalize();
 
                   SparseMatrix * blfT = Transpose(blfw.SpMat());
-                  SparseMatrix * diff = Add(1.0,blf.SpMat(),-1.0,*blfT);
+                  SparseMatrix * diff = Add(1.0, blf.SpMat(), -1.0, *blfT);
 
                   REQUIRE( diff->MaxNorm() < tol );
 
@@ -1316,7 +1316,7 @@ TEST_CASE("3D Bilinear Vector Mass Integrators",
                   blf.Assemble();
                   blf.Finalize();
 
-                  blf.Mult(f_nd,tmp_ndp); g_ndp = 0.0;
+                  blf.Mult(f_nd, tmp_ndp); g_ndp = 0.0;
                   PCG(m_ndp, s_ndp, tmp_ndp, g_ndp, 0, 200,
                       cg_rtol * cg_rtol, 0.0);
 
@@ -1329,7 +1329,7 @@ TEST_CASE("3D Bilinear Vector Mass Integrators",
                   blfw.Finalize();
 
                   SparseMatrix * blfT = Transpose(blfw.SpMat());
-                  SparseMatrix * diff = Add(1.0,blf.SpMat(),-1.0,*blfT);
+                  SparseMatrix * diff = Add(1.0, blf.SpMat(), -1.0, *blfT);
 
                   REQUIRE( diff->MaxNorm() < tol );
 
@@ -1372,7 +1372,7 @@ TEST_CASE("3D Bilinear Vector Mass Integrators",
                   blf.Assemble();
                   blf.Finalize();
 
-                  blf.Mult(f_rt,tmp_nd); g_nd = 0.0;
+                  blf.Mult(f_rt, tmp_nd); g_nd = 0.0;
                   PCG(m_nd, s_nd, tmp_nd, g_nd, 0, 200, cg_rtol * cg_rtol, 0.0);
 
                   REQUIRE( g_nd.ComputeL2Error(F3_coef) < tol );
@@ -1383,7 +1383,7 @@ TEST_CASE("3D Bilinear Vector Mass Integrators",
                   blfw.Finalize();
 
                   SparseMatrix * blfT = Transpose(blfw.SpMat());
-                  SparseMatrix * diff = Add(1.0,blf.SpMat(),-1.0,*blfT);
+                  SparseMatrix * diff = Add(1.0, blf.SpMat(), -1.0, *blfT);
 
                   REQUIRE( diff->MaxNorm() < tol );
 
@@ -1395,7 +1395,7 @@ TEST_CASE("3D Bilinear Vector Mass Integrators",
                   blfv.Assemble();
                   blfv.Finalize();
 
-                  SparseMatrix * diffv = Add(1.0,blf.SpMat(),-1.0,blfv.SpMat());
+                  SparseMatrix * diffv = Add(1.0, blf.SpMat(), -1.0, blfv.SpMat());
 
                   REQUIRE( diffv->MaxNorm() < tol );
 
@@ -1408,7 +1408,7 @@ TEST_CASE("3D Bilinear Vector Mass Integrators",
                   blf.Assemble();
                   blf.Finalize();
 
-                  blf.Mult(f_rt,tmp_nd); g_nd = 0.0;
+                  blf.Mult(f_rt, tmp_nd); g_nd = 0.0;
                   PCG(m_nd, s_nd, tmp_nd, g_nd, 0, 200, cg_rtol * cg_rtol, 0.0);
 
                   REQUIRE( g_nd.ComputeL2Error(F3_coef) < tol );
@@ -1419,7 +1419,7 @@ TEST_CASE("3D Bilinear Vector Mass Integrators",
                   blfw.Finalize();
 
                   SparseMatrix * blfT = Transpose(blfw.SpMat());
-                  SparseMatrix * diff = Add(1.0,blf.SpMat(),-1.0,*blfT);
+                  SparseMatrix * diff = Add(1.0, blf.SpMat(), -1.0, *blfT);
 
                   REQUIRE( diff->MaxNorm() < tol );
 
@@ -1451,7 +1451,7 @@ TEST_CASE("3D Bilinear Vector Mass Integrators",
                   blf.Assemble();
                   blf.Finalize();
 
-                  blf.Mult(f_rt,tmp_nd); g_nd = 0.0;
+                  blf.Mult(f_rt, tmp_nd); g_nd = 0.0;
                   PCG(m_nd, s_nd, tmp_nd, g_nd, 0, 200, cg_rtol * cg_rtol, 0.0);
 
                   REQUIRE( g_nd.ComputeL2Error(qF3_coef) < tol );
@@ -1463,7 +1463,7 @@ TEST_CASE("3D Bilinear Vector Mass Integrators",
                   blfw.Finalize();
 
                   SparseMatrix * blfT = Transpose(blfw.SpMat());
-                  SparseMatrix * diff = Add(1.0,blf.SpMat(),-1.0,*blfT);
+                  SparseMatrix * diff = Add(1.0, blf.SpMat(), -1.0, *blfT);
 
                   REQUIRE( diff->MaxNorm() < tol );
 
@@ -1477,7 +1477,7 @@ TEST_CASE("3D Bilinear Vector Mass Integrators",
                   blf.Assemble();
                   blf.Finalize();
 
-                  blf.Mult(f_rt,tmp_nd); g_nd = 0.0;
+                  blf.Mult(f_rt, tmp_nd); g_nd = 0.0;
                   PCG(m_nd, s_nd, tmp_nd, g_nd, 0, 200, cg_rtol * cg_rtol, 0.0);
 
                   REQUIRE( g_nd.ComputeL2Error(qF3_coef) < tol );
@@ -1488,7 +1488,7 @@ TEST_CASE("3D Bilinear Vector Mass Integrators",
                   blfw.Finalize();
 
                   SparseMatrix * blfT = Transpose(blfw.SpMat());
-                  SparseMatrix * diff = Add(1.0,blf.SpMat(),-1.0,*blfT);
+                  SparseMatrix * diff = Add(1.0, blf.SpMat(), -1.0, *blfT);
 
                   REQUIRE( diff->MaxNorm() < tol );
 
@@ -1503,7 +1503,7 @@ TEST_CASE("3D Bilinear Vector Mass Integrators",
                   blf.Assemble();
                   blf.Finalize();
 
-                  blf.Mult(f_rt,tmp_nd); g_nd = 0.0;
+                  blf.Mult(f_rt, tmp_nd); g_nd = 0.0;
                   PCG(m_nd, s_nd, tmp_nd, g_nd, 0, 200, cg_rtol * cg_rtol, 0.0);
 
                   REQUIRE( g_nd.ComputeL2Error(DF3_coef) < tol );
@@ -1515,7 +1515,7 @@ TEST_CASE("3D Bilinear Vector Mass Integrators",
                   blfw.Finalize();
 
                   SparseMatrix * blfT = Transpose(blfw.SpMat());
-                  SparseMatrix * diff = Add(1.0,blf.SpMat(),-1.0,*blfT);
+                  SparseMatrix * diff = Add(1.0, blf.SpMat(), -1.0, *blfT);
 
                   REQUIRE( diff->MaxNorm() < tol );
 
@@ -1530,7 +1530,7 @@ TEST_CASE("3D Bilinear Vector Mass Integrators",
                   blf.Assemble();
                   blf.Finalize();
 
-                  blf.Mult(f_rt,tmp_nd); g_nd = 0.0;
+                  blf.Mult(f_rt, tmp_nd); g_nd = 0.0;
                   PCG(m_nd, s_nd, tmp_nd, g_nd, 0, 200, cg_rtol * cg_rtol, 0.0);
 
                   REQUIRE( g_nd.ComputeL2Error(DF3_coef) < tol );
@@ -1542,7 +1542,7 @@ TEST_CASE("3D Bilinear Vector Mass Integrators",
                   blfw.Finalize();
 
                   SparseMatrix * blfT = Transpose(blfw.SpMat());
-                  SparseMatrix * diff = Add(1.0,blf.SpMat(),-1.0,*blfT);
+                  SparseMatrix * diff = Add(1.0, blf.SpMat(), -1.0, *blfT);
 
                   REQUIRE( diff->MaxNorm() < tol );
 
@@ -1557,7 +1557,7 @@ TEST_CASE("3D Bilinear Vector Mass Integrators",
                   blf.Assemble();
                   blf.Finalize();
 
-                  blf.Mult(f_rt,tmp_nd); g_nd = 0.0;
+                  blf.Mult(f_rt, tmp_nd); g_nd = 0.0;
                   PCG(m_nd, s_nd, tmp_nd, g_nd, 0, 200, cg_rtol * cg_rtol, 0.0);
 
                   REQUIRE( g_nd.ComputeL2Error(MF3_coef) < tol );
@@ -1569,7 +1569,7 @@ TEST_CASE("3D Bilinear Vector Mass Integrators",
                   blfw.Finalize();
 
                   SparseMatrix * blfT = Transpose(blfw.SpMat());
-                  SparseMatrix * diff = Add(1.0,blf.SpMat(),-1.0,*blfT);
+                  SparseMatrix * diff = Add(1.0, blf.SpMat(), -1.0, *blfT);
 
                   REQUIRE( diff->MaxNorm() < tol );
 
@@ -1583,7 +1583,7 @@ TEST_CASE("3D Bilinear Vector Mass Integrators",
                   blf.Assemble();
                   blf.Finalize();
 
-                  blf.Mult(f_rt,tmp_nd); g_nd = 0.0;
+                  blf.Mult(f_rt, tmp_nd); g_nd = 0.0;
                   PCG(m_nd, s_nd, tmp_nd, g_nd, 0, 200, cg_rtol * cg_rtol, 0.0);
 
                   REQUIRE( g_nd.ComputeL2Error(MF3_coef) < tol );
@@ -1595,7 +1595,7 @@ TEST_CASE("3D Bilinear Vector Mass Integrators",
                   blfw.Finalize();
 
                   SparseMatrix * blfT = Transpose(blfw.SpMat());
-                  SparseMatrix * diff = Add(1.0,blf.SpMat(),-1.0,*blfT);
+                  SparseMatrix * diff = Add(1.0, blf.SpMat(), -1.0, *blfT);
 
                   REQUIRE( diff->MaxNorm() < tol );
 
@@ -1628,7 +1628,7 @@ TEST_CASE("3D Bilinear Vector Mass Integrators",
                   blf.Assemble();
                   blf.Finalize();
 
-                  blf.Mult(f_rt,tmp_rt); g_rt = 0.0;
+                  blf.Mult(f_rt, tmp_rt); g_rt = 0.0;
                   PCG(m_rt, s_rt, tmp_rt, g_rt, 0, 200, cg_rtol * cg_rtol, 0.0);
 
                   REQUIRE( g_rt.ComputeL2Error(F3_coef) < tol );
@@ -1639,7 +1639,7 @@ TEST_CASE("3D Bilinear Vector Mass Integrators",
                   blfw.Finalize();
 
                   SparseMatrix * blfT = Transpose(blfw.SpMat());
-                  SparseMatrix * diff = Add(1.0,blf.SpMat(),-1.0,*blfT);
+                  SparseMatrix * diff = Add(1.0, blf.SpMat(), -1.0, *blfT);
 
                   REQUIRE( diff->MaxNorm() < tol );
 
@@ -1651,7 +1651,7 @@ TEST_CASE("3D Bilinear Vector Mass Integrators",
                   blfv.Assemble();
                   blfv.Finalize();
 
-                  SparseMatrix * diffv = Add(1.0,blf.SpMat(),-1.0,blfv.SpMat());
+                  SparseMatrix * diffv = Add(1.0, blf.SpMat(), -1.0, blfv.SpMat());
 
                   REQUIRE( diffv->MaxNorm() < tol );
 
@@ -1664,7 +1664,7 @@ TEST_CASE("3D Bilinear Vector Mass Integrators",
                   blf.Assemble();
                   blf.Finalize();
 
-                  blf.Mult(f_rt,tmp_rt); g_rt = 0.0;
+                  blf.Mult(f_rt, tmp_rt); g_rt = 0.0;
                   PCG(m_rt, s_rt, tmp_rt, g_rt, 0, 200, cg_rtol * cg_rtol, 0.0);
 
                   REQUIRE( g_rt.ComputeL2Error(F3_coef) < tol );
@@ -1675,7 +1675,7 @@ TEST_CASE("3D Bilinear Vector Mass Integrators",
                   blfw.Finalize();
 
                   SparseMatrix * blfT = Transpose(blfw.SpMat());
-                  SparseMatrix * diff = Add(1.0,blf.SpMat(),-1.0,*blfT);
+                  SparseMatrix * diff = Add(1.0, blf.SpMat(), -1.0, *blfT);
 
                   REQUIRE( diff->MaxNorm() < tol );
 
@@ -1707,7 +1707,7 @@ TEST_CASE("3D Bilinear Vector Mass Integrators",
                   blf.Assemble();
                   blf.Finalize();
 
-                  blf.Mult(f_rt,tmp_rtp); g_rtp = 0.0;
+                  blf.Mult(f_rt, tmp_rtp); g_rtp = 0.0;
                   PCG(m_rtp, s_rtp, tmp_rtp, g_rtp, 0, 200,
                       cg_rtol * cg_rtol, 0.0);
 
@@ -1720,7 +1720,7 @@ TEST_CASE("3D Bilinear Vector Mass Integrators",
                   blfw.Finalize();
 
                   SparseMatrix * blfT = Transpose(blfw.SpMat());
-                  SparseMatrix * diff = Add(1.0,blf.SpMat(),-1.0,*blfT);
+                  SparseMatrix * diff = Add(1.0, blf.SpMat(), -1.0, *blfT);
 
                   REQUIRE( diff->MaxNorm() < tol );
 
@@ -1734,7 +1734,7 @@ TEST_CASE("3D Bilinear Vector Mass Integrators",
                   blf.Assemble();
                   blf.Finalize();
 
-                  blf.Mult(f_rt,tmp_rtp); g_rtp = 0.0;
+                  blf.Mult(f_rt, tmp_rtp); g_rtp = 0.0;
                   PCG(m_rtp, s_rtp, tmp_rtp, g_rtp, 0, 200,
                       cg_rtol * cg_rtol, 0.0);
 
@@ -1746,7 +1746,7 @@ TEST_CASE("3D Bilinear Vector Mass Integrators",
                   blfw.Finalize();
 
                   SparseMatrix * blfT = Transpose(blfw.SpMat());
-                  SparseMatrix * diff = Add(1.0,blf.SpMat(),-1.0,*blfT);
+                  SparseMatrix * diff = Add(1.0, blf.SpMat(), -1.0, *blfT);
 
                   REQUIRE( diff->MaxNorm() < tol );
 
@@ -1761,7 +1761,7 @@ TEST_CASE("3D Bilinear Vector Mass Integrators",
                   blf.Assemble();
                   blf.Finalize();
 
-                  blf.Mult(f_rt,tmp_rtp); g_rtp = 0.0;
+                  blf.Mult(f_rt, tmp_rtp); g_rtp = 0.0;
                   PCG(m_rtp, s_rtp, tmp_rtp, g_rtp, 0, 200,
                       cg_rtol * cg_rtol, 0.0);
 
@@ -1774,7 +1774,7 @@ TEST_CASE("3D Bilinear Vector Mass Integrators",
                   blfw.Finalize();
 
                   SparseMatrix * blfT = Transpose(blfw.SpMat());
-                  SparseMatrix * diff = Add(1.0,blf.SpMat(),-1.0,*blfT);
+                  SparseMatrix * diff = Add(1.0, blf.SpMat(), -1.0, *blfT);
 
                   REQUIRE( diff->MaxNorm() < tol );
 
@@ -1789,7 +1789,7 @@ TEST_CASE("3D Bilinear Vector Mass Integrators",
                   blf.Assemble();
                   blf.Finalize();
 
-                  blf.Mult(f_rt,tmp_rtp); g_rtp = 0.0;
+                  blf.Mult(f_rt, tmp_rtp); g_rtp = 0.0;
                   PCG(m_rtp, s_rtp, tmp_rtp, g_rtp, 0, 200,
                       cg_rtol * cg_rtol, 0.0);
 
@@ -1802,7 +1802,7 @@ TEST_CASE("3D Bilinear Vector Mass Integrators",
                   blfw.Finalize();
 
                   SparseMatrix * blfT = Transpose(blfw.SpMat());
-                  SparseMatrix * diff = Add(1.0,blf.SpMat(),-1.0,*blfT);
+                  SparseMatrix * diff = Add(1.0, blf.SpMat(), -1.0, *blfT);
 
                   REQUIRE( diff->MaxNorm() < tol );
 
@@ -1817,7 +1817,7 @@ TEST_CASE("3D Bilinear Vector Mass Integrators",
                   blf.Assemble();
                   blf.Finalize();
 
-                  blf.Mult(f_rt,tmp_rtp); g_rtp = 0.0;
+                  blf.Mult(f_rt, tmp_rtp); g_rtp = 0.0;
                   PCG(m_rtp, s_rtp, tmp_rtp, g_rtp, 0, 200,
                       cg_rtol * cg_rtol, 0.0);
 
@@ -1830,7 +1830,7 @@ TEST_CASE("3D Bilinear Vector Mass Integrators",
                   blfw.Finalize();
 
                   SparseMatrix * blfT = Transpose(blfw.SpMat());
-                  SparseMatrix * diff = Add(1.0,blf.SpMat(),-1.0,*blfT);
+                  SparseMatrix * diff = Add(1.0, blf.SpMat(), -1.0, *blfT);
 
                   REQUIRE( diff->MaxNorm() < tol );
 
@@ -1844,7 +1844,7 @@ TEST_CASE("3D Bilinear Vector Mass Integrators",
                   blf.Assemble();
                   blf.Finalize();
 
-                  blf.Mult(f_rt,tmp_rtp); g_rtp = 0.0;
+                  blf.Mult(f_rt, tmp_rtp); g_rtp = 0.0;
                   PCG(m_rtp, s_rtp, tmp_rtp, g_rtp, 0, 200,
                       cg_rtol * cg_rtol, 0.0);
 
@@ -1857,7 +1857,7 @@ TEST_CASE("3D Bilinear Vector Mass Integrators",
                   blfw.Finalize();
 
                   SparseMatrix * blfT = Transpose(blfw.SpMat());
-                  SparseMatrix * diff = Add(1.0,blf.SpMat(),-1.0,*blfT);
+                  SparseMatrix * diff = Add(1.0, blf.SpMat(), -1.0, *blfT);
 
                   REQUIRE( diff->MaxNorm() < tol );
 
@@ -1922,7 +1922,7 @@ TEST_CASE("3D Bilinear Gradient Integrator",
                blf.Assemble();
                blf.Finalize();
 
-               blf.Mult(f_h1,tmp_nd); g_nd = 0.0;
+               blf.Mult(f_h1, tmp_nd); g_nd = 0.0;
                CG(m_nd, tmp_nd, g_nd, 0, 200, cg_rtol * cg_rtol, 0.0);
 
                REQUIRE( g_nd.ComputeL2Error(df3_coef) < tol );
@@ -1935,7 +1935,7 @@ TEST_CASE("3D Bilinear Gradient Integrator",
                blf.Assemble();
                blf.Finalize();
 
-               blf.Mult(f_h1,tmp_nd); g_nd = 0.0;
+               blf.Mult(f_h1, tmp_nd); g_nd = 0.0;
                CG(m_nd, tmp_nd, g_nd, 0, 200, cg_rtol * cg_rtol, 0.0);
 
                REQUIRE( g_nd.ComputeL2Error(qdf3_coef) < tol );
@@ -1948,7 +1948,7 @@ TEST_CASE("3D Bilinear Gradient Integrator",
                blf.Assemble();
                blf.Finalize();
 
-               blf.Mult(f_h1,tmp_nd); g_nd = 0.0;
+               blf.Mult(f_h1, tmp_nd); g_nd = 0.0;
                CG(m_nd, tmp_nd, g_nd, 0, 200, cg_rtol * cg_rtol, 0.0);
 
                REQUIRE( g_nd.ComputeL2Error(Ddf3_coef) < tol );
@@ -1961,7 +1961,7 @@ TEST_CASE("3D Bilinear Gradient Integrator",
                blf.Assemble();
                blf.Finalize();
 
-               blf.Mult(f_h1,tmp_nd); g_nd = 0.0;
+               blf.Mult(f_h1, tmp_nd); g_nd = 0.0;
                CG(m_nd, tmp_nd, g_nd, 0, 200, cg_rtol * cg_rtol, 0.0);
 
                REQUIRE( g_nd.ComputeL2Error(Mdf3_coef) < tol );
@@ -1991,7 +1991,7 @@ TEST_CASE("3D Bilinear Gradient Integrator",
                blf.Assemble();
                blf.Finalize();
 
-               blf.Mult(f_h1,tmp_rt); g_rt = 0.0;
+               blf.Mult(f_h1, tmp_rt); g_rt = 0.0;
                CG(m_rt, tmp_rt, g_rt, 0, 200, cg_rtol * cg_rtol, 0.0);
 
                REQUIRE( g_rt.ComputeL2Error(df3_coef) < tol );
@@ -2004,7 +2004,7 @@ TEST_CASE("3D Bilinear Gradient Integrator",
                blf.Assemble();
                blf.Finalize();
 
-               blf.Mult(f_h1,tmp_rt); g_rt = 0.0;
+               blf.Mult(f_h1, tmp_rt); g_rt = 0.0;
                CG(m_rt, tmp_rt, g_rt, 0, 200, cg_rtol * cg_rtol, 0.0);
 
                REQUIRE( g_rt.ComputeL2Error(qdf3_coef) < tol );
@@ -2017,7 +2017,7 @@ TEST_CASE("3D Bilinear Gradient Integrator",
                blf.Assemble();
                blf.Finalize();
 
-               blf.Mult(f_h1,tmp_rt); g_rt = 0.0;
+               blf.Mult(f_h1, tmp_rt); g_rt = 0.0;
                CG(m_rt, tmp_rt, g_rt, 0, 200, cg_rtol * cg_rtol, 0.0);
 
                REQUIRE( g_rt.ComputeL2Error(Ddf3_coef) < tol );
@@ -2030,7 +2030,7 @@ TEST_CASE("3D Bilinear Gradient Integrator",
                blf.Assemble();
                blf.Finalize();
 
-               blf.Mult(f_h1,tmp_rt); g_rt = 0.0;
+               blf.Mult(f_h1, tmp_rt); g_rt = 0.0;
                CG(m_rt, tmp_rt, g_rt, 0, 200, cg_rtol * cg_rtol, 0.0);
 
                REQUIRE( g_rt.ComputeL2Error(Mdf3_coef) < tol );
@@ -2092,7 +2092,7 @@ TEST_CASE("3D Bilinear Curl Integrator",
                blf.Assemble();
                blf.Finalize();
 
-               blf.Mult(f_nd,tmp_rt); g_rt = 0.0;
+               blf.Mult(f_nd, tmp_rt); g_rt = 0.0;
                CG(m_rt, tmp_rt, g_rt, 0, 200, cg_rtol * cg_rtol, 0.0);
 
                REQUIRE( g_rt.ComputeL2Error(dF3_coef) < tol );
@@ -2105,7 +2105,7 @@ TEST_CASE("3D Bilinear Curl Integrator",
                blf.Assemble();
                blf.Finalize();
 
-               blf.Mult(f_nd,tmp_rt); g_rt = 0.0;
+               blf.Mult(f_nd, tmp_rt); g_rt = 0.0;
                CG(m_rt, tmp_rt, g_rt, 0, 200, cg_rtol * cg_rtol, 0.0);
 
                REQUIRE( g_rt.ComputeL2Error(qdF3_coef) < tol );
@@ -2118,7 +2118,7 @@ TEST_CASE("3D Bilinear Curl Integrator",
                blf.Assemble();
                blf.Finalize();
 
-               blf.Mult(f_nd,tmp_rt); g_rt = 0.0;
+               blf.Mult(f_nd, tmp_rt); g_rt = 0.0;
                CG(m_rt, tmp_rt, g_rt, 0, 200, cg_rtol * cg_rtol, 0.0);
 
                REQUIRE( g_rt.ComputeL2Error(DdF3_coef) < tol );
@@ -2131,7 +2131,7 @@ TEST_CASE("3D Bilinear Curl Integrator",
                blf.Assemble();
                blf.Finalize();
 
-               blf.Mult(f_nd,tmp_rt); g_rt = 0.0;
+               blf.Mult(f_nd, tmp_rt); g_rt = 0.0;
                CG(m_rt, tmp_rt, g_rt, 0, 200, cg_rtol * cg_rtol, 0.0);
 
                REQUIRE( g_rt.ComputeL2Error(MdF3_coef) < tol );
@@ -2155,7 +2155,7 @@ TEST_CASE("3D Bilinear Curl Integrator",
                blf.Assemble();
                blf.Finalize();
 
-               blf.Mult(f_nd,tmp_nd); g_nd = 0.0;
+               blf.Mult(f_nd, tmp_nd); g_nd = 0.0;
                CG(m_nd, tmp_nd, g_nd, 0, 200, cg_rtol * cg_rtol, 0.0);
 
                REQUIRE( g_nd.ComputeL2Error(dF3_coef) < tol );
@@ -2168,7 +2168,7 @@ TEST_CASE("3D Bilinear Curl Integrator",
                blf.Assemble();
                blf.Finalize();
 
-               blf.Mult(f_nd,tmp_nd); g_nd = 0.0;
+               blf.Mult(f_nd, tmp_nd); g_nd = 0.0;
                CG(m_nd, tmp_nd, g_nd, 0, 200, cg_rtol * cg_rtol, 0.0);
 
                REQUIRE( g_nd.ComputeL2Error(qdF3_coef) < tol );
@@ -2181,7 +2181,7 @@ TEST_CASE("3D Bilinear Curl Integrator",
                blf.Assemble();
                blf.Finalize();
 
-               blf.Mult(f_nd,tmp_nd); g_nd = 0.0;
+               blf.Mult(f_nd, tmp_nd); g_nd = 0.0;
                CG(m_nd, tmp_nd, g_nd, 0, 200, cg_rtol * cg_rtol, 0.0);
 
                REQUIRE( g_nd.ComputeL2Error(DdF3_coef) < tol );
@@ -2194,7 +2194,7 @@ TEST_CASE("3D Bilinear Curl Integrator",
                blf.Assemble();
                blf.Finalize();
 
-               blf.Mult(f_nd,tmp_nd); g_nd = 0.0;
+               blf.Mult(f_nd, tmp_nd); g_nd = 0.0;
                CG(m_nd, tmp_nd, g_nd, 0, 200, cg_rtol * cg_rtol, 0.0);
 
                REQUIRE( g_nd.ComputeL2Error(MdF3_coef) < tol );
@@ -2252,7 +2252,7 @@ TEST_CASE("3D Bilinear Cross Product Gradient Integrator",
                blf.Assemble();
                blf.Finalize();
 
-               blf.Mult(f_h1,tmp_rt); g_rt = 0.0;
+               blf.Mult(f_h1, tmp_rt); g_rt = 0.0;
                CG(m_rt, tmp_rt, g_rt, 0, 200, cg_rtol * cg_rtol, 0.0);
 
                REQUIRE( g_rt.ComputeL2Error(Vxdf3_coef) < tol );
@@ -2280,7 +2280,7 @@ TEST_CASE("3D Bilinear Cross Product Gradient Integrator",
                blf.Assemble();
                blf.Finalize();
 
-               blf.Mult(f_h1,tmp_nd); g_nd = 0.0;
+               blf.Mult(f_h1, tmp_nd); g_nd = 0.0;
                CG(m_nd, tmp_nd, g_nd, 0, 200, cg_rtol * cg_rtol, 0.0);
 
                REQUIRE( g_nd.ComputeL2Error(Vxdf3_coef) < tol );
@@ -2338,7 +2338,7 @@ TEST_CASE("3D Bilinear Cross Product Curl Integrator",
                blf.Assemble();
                blf.Finalize();
 
-               blf.Mult(f_nd,tmp_rt); g_rt = 0.0;
+               blf.Mult(f_nd, tmp_rt); g_rt = 0.0;
                CG(m_rt, tmp_rt, g_rt, 0, 200, cg_rtol * cg_rtol, 0.0);
 
                REQUIRE( g_rt.ComputeL2Error(VxdF3_coef) < tol );
@@ -2363,7 +2363,7 @@ TEST_CASE("3D Bilinear Cross Product Curl Integrator",
                blf.Assemble();
                blf.Finalize();
 
-               blf.Mult(f_nd,tmp_nd); g_nd = 0.0;
+               blf.Mult(f_nd, tmp_nd); g_nd = 0.0;
                CG(m_nd, tmp_nd, g_nd, 0, 200, cg_rtol * cg_rtol, 0.0);
 
                REQUIRE( g_nd.ComputeL2Error(VxdF3_coef) < tol );
@@ -2427,7 +2427,7 @@ TEST_CASE("3D Bilinear Divergence Integrator",
                   blf.Assemble();
                   blf.Finalize();
 
-                  blf.Mult(f_rt,tmp_l2); g_l2 = 0.0;
+                  blf.Mult(f_rt, tmp_l2); g_l2 = 0.0;
                   CG(m_l2, tmp_l2, g_l2, 0, 200, cg_rtol * cg_rtol, 0.0);
 
                   REQUIRE( g_l2.ComputeL2Error(dF3_coef) < tol );
@@ -2440,7 +2440,7 @@ TEST_CASE("3D Bilinear Divergence Integrator",
                   blf.Assemble();
                   blf.Finalize();
 
-                  blf.Mult(f_rt,tmp_l2); g_l2 = 0.0;
+                  blf.Mult(f_rt, tmp_l2); g_l2 = 0.0;
                   CG(m_l2, tmp_l2, g_l2, 0, 200, cg_rtol * cg_rtol, 0.0);
 
                   REQUIRE( g_l2.ComputeL2Error(qdF3_coef) < tol );
@@ -2468,7 +2468,7 @@ TEST_CASE("3D Bilinear Divergence Integrator",
                blf.Assemble();
                blf.Finalize();
 
-               blf.Mult(f_rt,tmp_h1); g_h1 = 0.0;
+               blf.Mult(f_rt, tmp_h1); g_h1 = 0.0;
                CG(m_h1, tmp_h1, g_h1, 0, 200, cg_rtol * cg_rtol, 0.0);
 
                REQUIRE( g_h1.ComputeL2Error(dF3_coef) < tol );
@@ -2481,7 +2481,7 @@ TEST_CASE("3D Bilinear Divergence Integrator",
                blf.Assemble();
                blf.Finalize();
 
-               blf.Mult(f_rt,tmp_h1); g_h1 = 0.0;
+               blf.Mult(f_rt, tmp_h1); g_h1 = 0.0;
                CG(m_h1, tmp_h1, g_h1, 0, 200, cg_rtol * cg_rtol, 0.0);
 
                REQUIRE( g_h1.ComputeL2Error(qdF3_coef) < tol );
@@ -2536,7 +2536,7 @@ TEST_CASE("3D Bilinear Vector Divergence Integrator",
                blf.Assemble();
                blf.Finalize();
 
-               blf.Mult(f_rt,tmp_rt); g_rt = 0.0;
+               blf.Mult(f_rt, tmp_rt); g_rt = 0.0;
                CG(m_rt, tmp_rt, g_rt, 0, 200, cg_rtol * cg_rtol, 0.0);
 
                REQUIRE( g_rt.ComputeL2Error(VdF3_coef) < tol );
@@ -2564,7 +2564,7 @@ TEST_CASE("3D Bilinear Vector Divergence Integrator",
                blf.Assemble();
                blf.Finalize();
 
-               blf.Mult(f_rt,tmp_nd); g_nd = 0.0;
+               blf.Mult(f_rt, tmp_nd); g_nd = 0.0;
                CG(m_nd, tmp_nd, g_nd, 0, 200, cg_rtol * cg_rtol, 0.0);
 
                REQUIRE( g_nd.ComputeL2Error(VdF3_coef) < tol );
@@ -2624,7 +2624,7 @@ TEST_CASE("3D Bilinear Vector Product Integrators",
                blf.Assemble();
                blf.Finalize();
 
-               blf.Mult(f_h1,tmp_nd); g_nd = 0.0;
+               blf.Mult(f_h1, tmp_nd); g_nd = 0.0;
                PCG(m_nd, s_nd, tmp_nd, g_nd, 0, 200, cg_rtol * cg_rtol, 0.0);
 
                REQUIRE( g_nd.ComputeL2Error(Vf3_coef) < tol );
@@ -2636,7 +2636,7 @@ TEST_CASE("3D Bilinear Vector Product Integrators",
                blfw.Finalize();
 
                SparseMatrix * blfT = Transpose(blfw.SpMat());
-               SparseMatrix * diff = Add(1.0,blf.SpMat(),-1.0,*blfT);
+               SparseMatrix * diff = Add(1.0, blf.SpMat(), -1.0, *blfT);
 
                REQUIRE( diff->MaxNorm() < tol );
 
@@ -2668,7 +2668,7 @@ TEST_CASE("3D Bilinear Vector Product Integrators",
                blf.Assemble();
                blf.Finalize();
 
-               blf.Mult(f_h1,tmp_rt); g_rt = 0.0;
+               blf.Mult(f_h1, tmp_rt); g_rt = 0.0;
                PCG(m_rt, s_rt, tmp_rt, g_rt, 0, 200, cg_rtol * cg_rtol, 0.0);
 
                REQUIRE( g_rt.ComputeL2Error(Vf3_coef) < tol );
@@ -2680,7 +2680,7 @@ TEST_CASE("3D Bilinear Vector Product Integrators",
                blfw.Finalize();
 
                SparseMatrix * blfT = Transpose(blfw.SpMat());
-               SparseMatrix * diff = Add(1.0,blf.SpMat(),-1.0,*blfT);
+               SparseMatrix * diff = Add(1.0, blf.SpMat(), -1.0, *blfT);
 
                REQUIRE( diff->MaxNorm() < tol );
 
@@ -2729,7 +2729,7 @@ TEST_CASE("3D Bilinear Vector Product Integrators",
                   blf.Assemble();
                   blf.Finalize();
 
-                  blf.Mult(f_l2,tmp_nd); g_nd = 0.0;
+                  blf.Mult(f_l2, tmp_nd); g_nd = 0.0;
                   PCG(m_nd, s_nd, tmp_nd, g_nd, 0, 200, cg_rtol * cg_rtol, 0.0);
 
                   REQUIRE( g_nd.ComputeL2Error(Vf3_coef) < tol );
@@ -2741,7 +2741,7 @@ TEST_CASE("3D Bilinear Vector Product Integrators",
                   blfw.Finalize();
 
                   SparseMatrix * blfT = Transpose(blfw.SpMat());
-                  SparseMatrix * diff = Add(1.0,blf.SpMat(),-1.0,*blfT);
+                  SparseMatrix * diff = Add(1.0, blf.SpMat(), -1.0, *blfT);
 
                   REQUIRE( diff->MaxNorm() < tol );
 
@@ -2774,7 +2774,7 @@ TEST_CASE("3D Bilinear Vector Product Integrators",
                   blf.Assemble();
                   blf.Finalize();
 
-                  blf.Mult(f_l2,tmp_rt); g_rt = 0.0;
+                  blf.Mult(f_l2, tmp_rt); g_rt = 0.0;
                   PCG(m_rt, s_rt, tmp_rt, g_rt, 0, 200, cg_rtol * cg_rtol, 0.0);
 
                   REQUIRE( g_rt.ComputeL2Error(Vf3_coef) < tol );
@@ -2786,7 +2786,7 @@ TEST_CASE("3D Bilinear Vector Product Integrators",
                   blfw.Finalize();
 
                   SparseMatrix * blfT = Transpose(blfw.SpMat());
-                  SparseMatrix * diff = Add(1.0,blf.SpMat(),-1.0,*blfT);
+                  SparseMatrix * diff = Add(1.0, blf.SpMat(), -1.0, *blfT);
 
                   REQUIRE( diff->MaxNorm() < tol );
 
@@ -2849,7 +2849,7 @@ TEST_CASE("3D Bilinear Vector Cross Product Integrators",
                blf.Assemble();
                blf.Finalize();
 
-               blf.Mult(f_nd,tmp_ndp); g_ndp = 0.0;
+               blf.Mult(f_nd, tmp_ndp); g_ndp = 0.0;
                PCG(m_ndp, s_ndp, tmp_ndp, g_ndp, 0, 200,
                    cg_rtol * cg_rtol, 0.0);
 
@@ -2862,7 +2862,7 @@ TEST_CASE("3D Bilinear Vector Cross Product Integrators",
                blfw.Finalize();
 
                SparseMatrix * blfT = Transpose(blfw.SpMat());
-               SparseMatrix * diff = Add(1.0,blf.SpMat(),1.0,*blfT);
+               SparseMatrix * diff = Add(1.0, blf.SpMat(), 1.0, *blfT);
 
                REQUIRE( diff->MaxNorm() < tol );
 
@@ -2894,7 +2894,7 @@ TEST_CASE("3D Bilinear Vector Cross Product Integrators",
                blf.Assemble();
                blf.Finalize();
 
-               blf.Mult(f_nd,tmp_rt); g_rt = 0.0;
+               blf.Mult(f_nd, tmp_rt); g_rt = 0.0;
                PCG(m_rt, s_rt, tmp_rt, g_rt, 0, 200, cg_rtol * cg_rtol, 0.0);
 
                REQUIRE( g_rt.ComputeL2Error(VxF3_coef) < tol );
@@ -2906,7 +2906,7 @@ TEST_CASE("3D Bilinear Vector Cross Product Integrators",
                blfw.Finalize();
 
                SparseMatrix * blfT = Transpose(blfw.SpMat());
-               SparseMatrix * diff = Add(1.0,blf.SpMat(),1.0,*blfT);
+               SparseMatrix * diff = Add(1.0, blf.SpMat(), 1.0, *blfT);
 
                REQUIRE( diff->MaxNorm() < tol );
 
@@ -2946,7 +2946,7 @@ TEST_CASE("3D Bilinear Vector Cross Product Integrators",
                blf.Assemble();
                blf.Finalize();
 
-               blf.Mult(f_rt,tmp_nd); g_nd = 0.0;
+               blf.Mult(f_rt, tmp_nd); g_nd = 0.0;
                PCG(m_nd, s_nd, tmp_nd, g_nd, 0, 200, cg_rtol * cg_rtol, 0.0);
 
                REQUIRE( g_nd.ComputeL2Error(VxF3_coef) < tol );
@@ -2958,7 +2958,7 @@ TEST_CASE("3D Bilinear Vector Cross Product Integrators",
                blfw.Finalize();
 
                SparseMatrix * blfT = Transpose(blfw.SpMat());
-               SparseMatrix * diff = Add(1.0,blf.SpMat(),1.0,*blfT);
+               SparseMatrix * diff = Add(1.0, blf.SpMat(), 1.0, *blfT);
 
                REQUIRE( diff->MaxNorm() < tol );
 
@@ -2990,7 +2990,7 @@ TEST_CASE("3D Bilinear Vector Cross Product Integrators",
                blf.Assemble();
                blf.Finalize();
 
-               blf.Mult(f_rt,tmp_rtp); g_rtp = 0.0;
+               blf.Mult(f_rt, tmp_rtp); g_rtp = 0.0;
                PCG(m_rtp, s_rtp, tmp_rtp, g_rtp, 0, 200,
                    cg_rtol * cg_rtol, 0.0);
 
@@ -3003,7 +3003,7 @@ TEST_CASE("3D Bilinear Vector Cross Product Integrators",
                blfw.Finalize();
 
                SparseMatrix * blfT = Transpose(blfw.SpMat());
-               SparseMatrix * diff = Add(1.0,blf.SpMat(),1.0,*blfT);
+               SparseMatrix * diff = Add(1.0, blf.SpMat(), 1.0, *blfT);
 
                REQUIRE( diff->MaxNorm() < tol );
 
@@ -3063,7 +3063,7 @@ TEST_CASE("3D Bilinear Vector Dot Product Integrators",
                blf.Assemble();
                blf.Finalize();
 
-               blf.Mult(f_nd,tmp_h1); g_h1 = 0.0;
+               blf.Mult(f_nd, tmp_h1); g_h1 = 0.0;
                CG(m_h1, tmp_h1, g_h1, 0, 200, cg_rtol * cg_rtol, 0.0);
 
                REQUIRE( g_h1.ComputeL2Error(VF3_coef) < tol );
@@ -3097,7 +3097,7 @@ TEST_CASE("3D Bilinear Vector Dot Product Integrators",
                   blf.Assemble();
                   blf.Finalize();
 
-                  blf.Mult(f_nd,tmp_l2); g_l2 = 0.0;
+                  blf.Mult(f_nd, tmp_l2); g_l2 = 0.0;
                   CG(m_l2, tmp_l2, g_l2, 0, 200, cg_rtol * cg_rtol, 0.0);
 
                   REQUIRE( g_l2.ComputeL2Error(VF3_coef) < tol );
@@ -3134,7 +3134,7 @@ TEST_CASE("3D Bilinear Vector Dot Product Integrators",
                blf.Assemble();
                blf.Finalize();
 
-               blf.Mult(f_rt,tmp_h1); g_h1 = 0.0;
+               blf.Mult(f_rt, tmp_h1); g_h1 = 0.0;
                CG(m_h1, tmp_h1, g_h1, 0, 200, cg_rtol * cg_rtol, 0.0);
 
                REQUIRE( g_h1.ComputeL2Error(VF3_coef) < tol );
@@ -3168,7 +3168,7 @@ TEST_CASE("3D Bilinear Vector Dot Product Integrators",
                   blf.Assemble();
                   blf.Finalize();
 
-                  blf.Mult(f_rt,tmp_l2); g_l2 = 0.0;
+                  blf.Mult(f_rt, tmp_l2); g_l2 = 0.0;
                   CG(m_l2, tmp_l2, g_l2, 0, 200, cg_rtol * cg_rtol, 0.0);
 
                   REQUIRE( g_l2.ComputeL2Error(VF3_coef) < tol );
@@ -3224,7 +3224,7 @@ TEST_CASE("3D Bilinear Directional Derivative Integrator",
                blf.Assemble();
                blf.Finalize();
 
-               blf.Mult(f_h1,tmp_h1); g_h1 = 0.0;
+               blf.Mult(f_h1, tmp_h1); g_h1 = 0.0;
                CG(m_h1, tmp_h1, g_h1, 0, 200, cg_rtol * cg_rtol, 0.0);
 
                REQUIRE( g_h1.ComputeL2Error(Vdf3_coef) < tol );
@@ -3258,7 +3258,7 @@ TEST_CASE("3D Bilinear Directional Derivative Integrator",
                   blf.Assemble();
                   blf.Finalize();
 
-                  blf.Mult(f_h1,tmp_l2); g_l2 = 0.0;
+                  blf.Mult(f_h1, tmp_l2); g_l2 = 0.0;
                   CG(m_l2, tmp_l2, g_l2, 0, 200, cg_rtol * cg_rtol, 0.0);
 
                   REQUIRE( g_l2.ComputeL2Error(Vdf3_coef) < tol );
@@ -3328,7 +3328,7 @@ TEST_CASE("3D Bilinear Weak Gradient Integrators",
                blfw.Finalize();
 
                SparseMatrix * blfT = Transpose(blfw.SpMat());
-               SparseMatrix * diff = Add(1.0,blf.SpMat(),1.0,*blfT);
+               SparseMatrix * diff = Add(1.0, blf.SpMat(), 1.0, *blfT);
 
                REQUIRE( diff->MaxNorm() < tol );
 
@@ -3340,7 +3340,7 @@ TEST_CASE("3D Bilinear Weak Gradient Integrators",
                   new VectorFEBoundaryFluxLFIntegrator(f3_coef));
                lf.Assemble();
 
-               blfw.Mult(f_h1,tmp_rt); tmp_rt += lf; g_rt = 0.0;
+               blfw.Mult(f_h1, tmp_rt); tmp_rt += lf; g_rt = 0.0;
                CG(m_rt, tmp_rt, g_rt, 0, 200, cg_rtol * cg_rtol, 0.0);
 
                REQUIRE( g_rt.ComputeL2Error(df3_coef) < tol );
@@ -3360,7 +3360,7 @@ TEST_CASE("3D Bilinear Weak Gradient Integrators",
                blfw.Finalize();
 
                SparseMatrix * blfT = Transpose(blfw.SpMat());
-               SparseMatrix * diff = Add(1.0,blf.SpMat(),1.0,*blfT);
+               SparseMatrix * diff = Add(1.0, blf.SpMat(), 1.0, *blfT);
 
                REQUIRE( diff->MaxNorm() < tol );
 
@@ -3372,7 +3372,7 @@ TEST_CASE("3D Bilinear Weak Gradient Integrators",
                   new VectorFEBoundaryFluxLFIntegrator(qf3_coef, 1, 2));
                lf.Assemble();
 
-               blfw.Mult(f_h1,tmp_rt); tmp_rt += lf; g_rt = 0.0;
+               blfw.Mult(f_h1, tmp_rt); tmp_rt += lf; g_rt = 0.0;
                CG(m_rt, tmp_rt, g_rt, 0, 200, cg_rtol * cg_rtol, 0.0);
 
                REQUIRE( g_rt.ComputeL2Error(dqf3_coef) < tol );
@@ -3424,7 +3424,7 @@ TEST_CASE("3D Bilinear Weak Gradient Integrators",
                   blfw.Finalize();
 
                   SparseMatrix * blfT = Transpose(blfw.SpMat());
-                  SparseMatrix * diff = Add(1.0,blf.SpMat(),1.0,*blfT);
+                  SparseMatrix * diff = Add(1.0, blf.SpMat(), 1.0, *blfT);
 
                   REQUIRE( diff->MaxNorm() < tol );
 
@@ -3436,7 +3436,7 @@ TEST_CASE("3D Bilinear Weak Gradient Integrators",
                      new VectorFEBoundaryFluxLFIntegrator(f3_coef));
                   lf.Assemble();
 
-                  blfw.Mult(f_l2,tmp_rt); tmp_rt += lf; g_rt = 0.0;
+                  blfw.Mult(f_l2, tmp_rt); tmp_rt += lf; g_rt = 0.0;
                   CG(m_rt, tmp_rt, g_rt, 0, 200, cg_rtol * cg_rtol, 0.0);
 
                   REQUIRE( g_rt.ComputeL2Error(df3_coef) < tol );
@@ -3456,7 +3456,7 @@ TEST_CASE("3D Bilinear Weak Gradient Integrators",
                   blfw.Finalize();
 
                   SparseMatrix * blfT = Transpose(blfw.SpMat());
-                  SparseMatrix * diff = Add(1.0,blf.SpMat(),1.0,*blfT);
+                  SparseMatrix * diff = Add(1.0, blf.SpMat(), 1.0, *blfT);
 
                   REQUIRE( diff->MaxNorm() < tol );
 
@@ -3468,7 +3468,7 @@ TEST_CASE("3D Bilinear Weak Gradient Integrators",
                      new VectorFEBoundaryFluxLFIntegrator(qf3_coef, 1, 2));
                   lf.Assemble();
 
-                  blfw.Mult(f_l2,tmp_rt); tmp_rt += lf; g_rt = 0.0;
+                  blfw.Mult(f_l2, tmp_rt); tmp_rt += lf; g_rt = 0.0;
                   CG(m_rt, tmp_rt, g_rt, 0, 200, cg_rtol * cg_rtol, 0.0);
 
                   REQUIRE( g_rt.ComputeL2Error(dqf3_coef) < tol );
@@ -3535,7 +3535,7 @@ TEST_CASE("3D Bilinear Scalar Weak Divergence Integrators",
                blfw.Finalize();
 
                SparseMatrix * blfT = Transpose(blfw.SpMat());
-               SparseMatrix * diff = Add(1.0,blf.SpMat(),1.0,*blfT);
+               SparseMatrix * diff = Add(1.0, blf.SpMat(), 1.0, *blfT);
 
                REQUIRE( diff->MaxNorm() < tol );
 
@@ -3547,7 +3547,7 @@ TEST_CASE("3D Bilinear Scalar Weak Divergence Integrators",
                   new BoundaryNormalLFIntegrator(Vf3_coef, 1, 2));
                lf.Assemble();
 
-               blfw.Mult(f_h1,tmp_h1); tmp_h1 += lf; g_h1 = 0.0;
+               blfw.Mult(f_h1, tmp_h1); tmp_h1 += lf; g_h1 = 0.0;
                CG(m_h1, tmp_h1, g_h1, 0, 200, cg_rtol * cg_rtol, 0.0);
 
                REQUIRE( g_h1.ComputeL2Error(dVf3_coef) < tol );
@@ -3599,7 +3599,7 @@ TEST_CASE("3D Bilinear Scalar Weak Divergence Integrators",
                   blfw.Finalize();
 
                   SparseMatrix * blfT = Transpose(blfw.SpMat());
-                  SparseMatrix * diff = Add(1.0,blf.SpMat(),1.0,*blfT);
+                  SparseMatrix * diff = Add(1.0, blf.SpMat(), 1.0, *blfT);
 
                   REQUIRE( diff->MaxNorm() < tol );
 
@@ -3611,7 +3611,7 @@ TEST_CASE("3D Bilinear Scalar Weak Divergence Integrators",
                      new BoundaryNormalLFIntegrator(Vf3_coef, 1, 2));
                   lf.Assemble();
 
-                  blfw.Mult(f_l2,tmp_h1); tmp_h1 += lf; g_h1 = 0.0;
+                  blfw.Mult(f_l2, tmp_h1); tmp_h1 += lf; g_h1 = 0.0;
                   CG(m_h1, tmp_h1, g_h1, 0, 200, cg_rtol * cg_rtol, 0.0);
 
                   REQUIRE( g_h1.ComputeL2Error(dVf3_coef) < tol );
@@ -3688,7 +3688,7 @@ TEST_CASE("3D Bilinear Weak Divergence Integrators",
                blfw.Finalize();
 
                SparseMatrix * blfT = Transpose(blfw.SpMat());
-               SparseMatrix * diff = Add(1.0,blf.SpMat(),1.0,*blfT);
+               SparseMatrix * diff = Add(1.0, blf.SpMat(), 1.0, *blfT);
 
                REQUIRE( diff->MaxNorm() < tol );
 
@@ -3700,7 +3700,7 @@ TEST_CASE("3D Bilinear Weak Divergence Integrators",
                   new BoundaryNormalLFIntegrator(F3_coef));
                lf.Assemble();
 
-               blfw.Mult(f_nd,tmp_h1); tmp_h1 += lf; g_h1 = 0.0;
+               blfw.Mult(f_nd, tmp_h1); tmp_h1 += lf; g_h1 = 0.0;
                CG(m_h1, tmp_h1, g_h1, 0, 200, cg_rtol * cg_rtol, 0.0);
 
                REQUIRE( g_h1.ComputeL2Error(dF3_coef) < tol );
@@ -3720,7 +3720,7 @@ TEST_CASE("3D Bilinear Weak Divergence Integrators",
                blfw.Finalize();
 
                SparseMatrix * blfT = Transpose(blfw.SpMat());
-               SparseMatrix * diff = Add(1.0,blf.SpMat(),1.0,*blfT);
+               SparseMatrix * diff = Add(1.0, blf.SpMat(), 1.0, *blfT);
 
                REQUIRE( diff->MaxNorm() < tol );
 
@@ -3732,7 +3732,7 @@ TEST_CASE("3D Bilinear Weak Divergence Integrators",
                   new BoundaryNormalLFIntegrator(qF3_coef, 1, 2));
                lf.Assemble();
 
-               blfw.Mult(f_nd,tmp_h1); tmp_h1 += lf; g_h1 = 0.0;
+               blfw.Mult(f_nd, tmp_h1); tmp_h1 += lf; g_h1 = 0.0;
                CG(m_h1, tmp_h1, g_h1, 0, 200, cg_rtol * cg_rtol, 0.0);
 
                REQUIRE( g_h1.ComputeL2Error(dqF3_coef) < tol );
@@ -3752,7 +3752,7 @@ TEST_CASE("3D Bilinear Weak Divergence Integrators",
                blfw.Finalize();
 
                SparseMatrix * blfT = Transpose(blfw.SpMat());
-               SparseMatrix * diff = Add(1.0,blf.SpMat(),1.0,*blfT);
+               SparseMatrix * diff = Add(1.0, blf.SpMat(), 1.0, *blfT);
 
                REQUIRE( diff->MaxNorm() < tol );
 
@@ -3764,7 +3764,7 @@ TEST_CASE("3D Bilinear Weak Divergence Integrators",
                   new BoundaryNormalLFIntegrator(DF3_coef, 1, 2));
                lf.Assemble();
 
-               blfw.Mult(f_nd,tmp_h1); tmp_h1 += lf; g_h1 = 0.0;
+               blfw.Mult(f_nd, tmp_h1); tmp_h1 += lf; g_h1 = 0.0;
                CG(m_h1, tmp_h1, g_h1, 0, 200, cg_rtol * cg_rtol, 0.0);
 
                REQUIRE( g_h1.ComputeL2Error(dDF3_coef) < tol );
@@ -3784,7 +3784,7 @@ TEST_CASE("3D Bilinear Weak Divergence Integrators",
                blfw.Finalize();
 
                SparseMatrix * blfT = Transpose(blfw.SpMat());
-               SparseMatrix * diff = Add(1.0,blf.SpMat(),1.0,*blfT);
+               SparseMatrix * diff = Add(1.0, blf.SpMat(), 1.0, *blfT);
 
                REQUIRE( diff->MaxNorm() < tol );
 
@@ -3796,7 +3796,7 @@ TEST_CASE("3D Bilinear Weak Divergence Integrators",
                   new BoundaryNormalLFIntegrator(MF3_coef, 1, 2));
                lf.Assemble();
 
-               blfw.Mult(f_nd,tmp_h1); tmp_h1 += lf; g_h1 = 0.0;
+               blfw.Mult(f_nd, tmp_h1); tmp_h1 += lf; g_h1 = 0.0;
                CG(m_h1, tmp_h1, g_h1, 0, 200, cg_rtol * cg_rtol, 0.0);
 
                REQUIRE( g_h1.ComputeL2Error(dMF3_coef) < tol );
@@ -3839,7 +3839,7 @@ TEST_CASE("3D Bilinear Weak Divergence Integrators",
                blfw.Finalize();
 
                SparseMatrix * blfT = Transpose(blfw.SpMat());
-               SparseMatrix * diff = Add(1.0,blf.SpMat(),1.0,*blfT);
+               SparseMatrix * diff = Add(1.0, blf.SpMat(), 1.0, *blfT);
 
                REQUIRE( diff->MaxNorm() < tol );
 
@@ -3851,7 +3851,7 @@ TEST_CASE("3D Bilinear Weak Divergence Integrators",
                   new BoundaryNormalLFIntegrator(F3_coef));
                lf.Assemble();
 
-               blfw.Mult(f_rt,tmp_h1); tmp_h1 += lf; g_h1 = 0.0;
+               blfw.Mult(f_rt, tmp_h1); tmp_h1 += lf; g_h1 = 0.0;
                CG(m_h1, tmp_h1, g_h1, 0, 200, cg_rtol * cg_rtol, 0.0);
 
                REQUIRE( g_h1.ComputeL2Error(dF3_coef) < tol );
@@ -3871,7 +3871,7 @@ TEST_CASE("3D Bilinear Weak Divergence Integrators",
                blfw.Finalize();
 
                SparseMatrix * blfT = Transpose(blfw.SpMat());
-               SparseMatrix * diff = Add(1.0,blf.SpMat(),1.0,*blfT);
+               SparseMatrix * diff = Add(1.0, blf.SpMat(), 1.0, *blfT);
 
                REQUIRE( diff->MaxNorm() < tol );
 
@@ -3883,7 +3883,7 @@ TEST_CASE("3D Bilinear Weak Divergence Integrators",
                   new BoundaryNormalLFIntegrator(qF3_coef, 1, 2));
                lf.Assemble();
 
-               blfw.Mult(f_rt,tmp_h1); tmp_h1 += lf; g_h1 = 0.0;
+               blfw.Mult(f_rt, tmp_h1); tmp_h1 += lf; g_h1 = 0.0;
                CG(m_h1, tmp_h1, g_h1, 0, 200, cg_rtol * cg_rtol, 0.0);
 
                REQUIRE( g_h1.ComputeL2Error(dqF3_coef) < tol );
@@ -3903,7 +3903,7 @@ TEST_CASE("3D Bilinear Weak Divergence Integrators",
                blfw.Finalize();
 
                SparseMatrix * blfT = Transpose(blfw.SpMat());
-               SparseMatrix * diff = Add(1.0,blf.SpMat(),1.0,*blfT);
+               SparseMatrix * diff = Add(1.0, blf.SpMat(), 1.0, *blfT);
 
                REQUIRE( diff->MaxNorm() < tol );
 
@@ -3915,7 +3915,7 @@ TEST_CASE("3D Bilinear Weak Divergence Integrators",
                   new BoundaryNormalLFIntegrator(DF3_coef, 1, 2));
                lf.Assemble();
 
-               blfw.Mult(f_rt,tmp_h1); tmp_h1 += lf; g_h1 = 0.0;
+               blfw.Mult(f_rt, tmp_h1); tmp_h1 += lf; g_h1 = 0.0;
                CG(m_h1, tmp_h1, g_h1, 0, 200, cg_rtol * cg_rtol, 0.0);
 
                REQUIRE( g_h1.ComputeL2Error(dDF3_coef) < tol );
@@ -3935,7 +3935,7 @@ TEST_CASE("3D Bilinear Weak Divergence Integrators",
                blfw.Finalize();
 
                SparseMatrix * blfT = Transpose(blfw.SpMat());
-               SparseMatrix * diff = Add(1.0,blf.SpMat(),1.0,*blfT);
+               SparseMatrix * diff = Add(1.0, blf.SpMat(), 1.0, *blfT);
 
                REQUIRE( diff->MaxNorm() < tol );
 
@@ -3947,7 +3947,7 @@ TEST_CASE("3D Bilinear Weak Divergence Integrators",
                   new BoundaryNormalLFIntegrator(MF3_coef, 1, 2));
                lf.Assemble();
 
-               blfw.Mult(f_rt,tmp_h1); tmp_h1 += lf; g_h1 = 0.0;
+               blfw.Mult(f_rt, tmp_h1); tmp_h1 += lf; g_h1 = 0.0;
                CG(m_h1, tmp_h1, g_h1, 0, 200, cg_rtol * cg_rtol, 0.0);
 
                REQUIRE( g_h1.ComputeL2Error(dMF3_coef) < tol );
@@ -4025,7 +4025,7 @@ TEST_CASE("3D Bilinear Weak Curl Integrators",
                blfw.Finalize();
 
                SparseMatrix * blfT = Transpose(blfw.SpMat());
-               SparseMatrix * diff = Add(1.0,blf.SpMat(),-1.0,*blfT);
+               SparseMatrix * diff = Add(1.0, blf.SpMat(), -1.0, *blfT);
 
                REQUIRE( diff->MaxNorm() < tol );
 
@@ -4037,7 +4037,7 @@ TEST_CASE("3D Bilinear Weak Curl Integrators",
                   new VectorFEBoundaryTangentLFIntegrator(F3_coef));
                lf.Assemble();
 
-               blfw.Mult(f_nd,tmp_nd); tmp_nd += lf; g_nd = 0.0;
+               blfw.Mult(f_nd, tmp_nd); tmp_nd += lf; g_nd = 0.0;
                CG(m_nd, tmp_nd, g_nd, 0, 200, cg_rtol * cg_rtol, 0.0);
 
                REQUIRE( g_nd.ComputeL2Error(dF3_coef) < tol );
@@ -4057,7 +4057,7 @@ TEST_CASE("3D Bilinear Weak Curl Integrators",
                blfw.Finalize();
 
                SparseMatrix * blfT = Transpose(blfw.SpMat());
-               SparseMatrix * diff = Add(1.0,blf.SpMat(),-1.0,*blfT);
+               SparseMatrix * diff = Add(1.0, blf.SpMat(), -1.0, *blfT);
 
                REQUIRE( diff->MaxNorm() < tol );
 
@@ -4069,7 +4069,7 @@ TEST_CASE("3D Bilinear Weak Curl Integrators",
                   new VectorFEBoundaryTangentLFIntegrator(qF3_coef, 1, 2));
                lf.Assemble();
 
-               blfw.Mult(f_nd,tmp_nd); tmp_nd += lf; g_nd = 0.0;
+               blfw.Mult(f_nd, tmp_nd); tmp_nd += lf; g_nd = 0.0;
                CG(m_nd, tmp_nd, g_nd, 0, 200, cg_rtol * cg_rtol, 0.0);
 
                REQUIRE( g_nd.ComputeL2Error(dqF3_coef) < tol );
@@ -4089,7 +4089,7 @@ TEST_CASE("3D Bilinear Weak Curl Integrators",
                blfw.Finalize();
 
                SparseMatrix * blfT = Transpose(blfw.SpMat());
-               SparseMatrix * diff = Add(1.0,blf.SpMat(),-1.0,*blfT);
+               SparseMatrix * diff = Add(1.0, blf.SpMat(), -1.0, *blfT);
 
                REQUIRE( diff->MaxNorm() < tol );
 
@@ -4101,7 +4101,7 @@ TEST_CASE("3D Bilinear Weak Curl Integrators",
                   new VectorFEBoundaryTangentLFIntegrator(DF3_coef, 1, 2));
                lf.Assemble();
 
-               blfw.Mult(f_nd,tmp_nd); tmp_nd += lf; g_nd = 0.0;
+               blfw.Mult(f_nd, tmp_nd); tmp_nd += lf; g_nd = 0.0;
                CG(m_nd, tmp_nd, g_nd, 0, 200, cg_rtol * cg_rtol, 0.0);
 
                REQUIRE( g_nd.ComputeL2Error(dDF3_coef) < tol );
@@ -4121,7 +4121,7 @@ TEST_CASE("3D Bilinear Weak Curl Integrators",
                blfw.Finalize();
 
                SparseMatrix * blfT = Transpose(blfw.SpMat());
-               SparseMatrix * diff = Add(1.0,blf.SpMat(),-1.0,*blfT);
+               SparseMatrix * diff = Add(1.0, blf.SpMat(), -1.0, *blfT);
 
                REQUIRE( diff->MaxNorm() < tol );
 
@@ -4133,7 +4133,7 @@ TEST_CASE("3D Bilinear Weak Curl Integrators",
                   new VectorFEBoundaryTangentLFIntegrator(MF3_coef, 1, 2));
                lf.Assemble();
 
-               blfw.Mult(f_nd,tmp_nd); tmp_nd += lf; g_nd = 0.0;
+               blfw.Mult(f_nd, tmp_nd); tmp_nd += lf; g_nd = 0.0;
                CG(m_nd, tmp_nd, g_nd, 0, 200, cg_rtol * cg_rtol, 0.0);
 
                REQUIRE( g_nd.ComputeL2Error(dMF3_coef) < tol );
@@ -4176,7 +4176,7 @@ TEST_CASE("3D Bilinear Weak Curl Integrators",
                blfw.Finalize();
 
                SparseMatrix * blfT = Transpose(blfw.SpMat());
-               SparseMatrix * diff = Add(1.0,blf.SpMat(),-1.0,*blfT);
+               SparseMatrix * diff = Add(1.0, blf.SpMat(), -1.0, *blfT);
 
                REQUIRE( diff->MaxNorm() < tol );
 
@@ -4188,7 +4188,7 @@ TEST_CASE("3D Bilinear Weak Curl Integrators",
                   new VectorFEBoundaryTangentLFIntegrator(F3_coef));
                lf.Assemble();
 
-               blfw.Mult(f_rt,tmp_nd); tmp_nd += lf; g_nd = 0.0;
+               blfw.Mult(f_rt, tmp_nd); tmp_nd += lf; g_nd = 0.0;
                CG(m_nd, tmp_nd, g_nd, 0, 200, cg_rtol * cg_rtol, 0.0);
 
                REQUIRE( g_nd.ComputeL2Error(dF3_coef) < tol );
@@ -4208,7 +4208,7 @@ TEST_CASE("3D Bilinear Weak Curl Integrators",
                blfw.Finalize();
 
                SparseMatrix * blfT = Transpose(blfw.SpMat());
-               SparseMatrix * diff = Add(1.0,blf.SpMat(),-1.0,*blfT);
+               SparseMatrix * diff = Add(1.0, blf.SpMat(), -1.0, *blfT);
 
                REQUIRE( diff->MaxNorm() < tol );
 
@@ -4220,7 +4220,7 @@ TEST_CASE("3D Bilinear Weak Curl Integrators",
                   new VectorFEBoundaryTangentLFIntegrator(qF3_coef, 1, 2));
                lf.Assemble();
 
-               blfw.Mult(f_rt,tmp_nd); tmp_nd += lf; g_nd = 0.0;
+               blfw.Mult(f_rt, tmp_nd); tmp_nd += lf; g_nd = 0.0;
                CG(m_nd, tmp_nd, g_nd, 0, 200, cg_rtol * cg_rtol, 0.0);
 
                REQUIRE( g_nd.ComputeL2Error(dqF3_coef) < tol );
@@ -4240,7 +4240,7 @@ TEST_CASE("3D Bilinear Weak Curl Integrators",
                blfw.Finalize();
 
                SparseMatrix * blfT = Transpose(blfw.SpMat());
-               SparseMatrix * diff = Add(1.0,blf.SpMat(),-1.0,*blfT);
+               SparseMatrix * diff = Add(1.0, blf.SpMat(), -1.0, *blfT);
 
                REQUIRE( diff->MaxNorm() < tol );
 
@@ -4252,7 +4252,7 @@ TEST_CASE("3D Bilinear Weak Curl Integrators",
                   new VectorFEBoundaryTangentLFIntegrator(DF3_coef, 1, 2));
                lf.Assemble();
 
-               blfw.Mult(f_rt,tmp_nd); tmp_nd += lf; g_nd = 0.0;
+               blfw.Mult(f_rt, tmp_nd); tmp_nd += lf; g_nd = 0.0;
                CG(m_nd, tmp_nd, g_nd, 0, 200, cg_rtol * cg_rtol, 0.0);
 
                REQUIRE( g_nd.ComputeL2Error(dDF3_coef) < tol );
@@ -4272,7 +4272,7 @@ TEST_CASE("3D Bilinear Weak Curl Integrators",
                blfw.Finalize();
 
                SparseMatrix * blfT = Transpose(blfw.SpMat());
-               SparseMatrix * diff = Add(1.0,blf.SpMat(),-1.0,*blfT);
+               SparseMatrix * diff = Add(1.0, blf.SpMat(), -1.0, *blfT);
 
                REQUIRE( diff->MaxNorm() < tol );
 
@@ -4284,7 +4284,7 @@ TEST_CASE("3D Bilinear Weak Curl Integrators",
                   new VectorFEBoundaryTangentLFIntegrator(MF3_coef, 1, 2));
                lf.Assemble();
 
-               blfw.Mult(f_rt,tmp_nd); tmp_nd += lf; g_nd = 0.0;
+               blfw.Mult(f_rt, tmp_nd); tmp_nd += lf; g_nd = 0.0;
                CG(m_nd, tmp_nd, g_nd, 0, 200, cg_rtol * cg_rtol, 0.0);
 
                REQUIRE( g_nd.ComputeL2Error(dMF3_coef) < tol );
@@ -4350,7 +4350,7 @@ TEST_CASE("3D Bilinear Weak Div Cross Integrators",
                blfw.Finalize();
 
                SparseMatrix * blfT = Transpose(blfw.SpMat());
-               SparseMatrix * diff = Add(1.0,blf.SpMat(),-1.0,*blfT);
+               SparseMatrix * diff = Add(1.0, blf.SpMat(), -1.0, *blfT);
 
                REQUIRE( diff->MaxNorm() < tol );
 
@@ -4362,7 +4362,7 @@ TEST_CASE("3D Bilinear Weak Div Cross Integrators",
                   new BoundaryNormalLFIntegrator(VF3_coef, 1, 2));
                lf.Assemble();
 
-               blfw.Mult(f_nd,tmp_h1); tmp_h1 += lf; g_h1 = 0.0;
+               blfw.Mult(f_nd, tmp_h1); tmp_h1 += lf; g_h1 = 0.0;
                CG(m_h1, tmp_h1, g_h1, 0, 200, cg_rtol * cg_rtol, 0.0);
 
                REQUIRE( g_h1.ComputeL2Error(dVF3_coef) < tol );
@@ -4405,7 +4405,7 @@ TEST_CASE("3D Bilinear Weak Div Cross Integrators",
                blfw.Finalize();
 
                SparseMatrix * blfT = Transpose(blfw.SpMat());
-               SparseMatrix * diff = Add(1.0,blf.SpMat(),-1.0,*blfT);
+               SparseMatrix * diff = Add(1.0, blf.SpMat(), -1.0, *blfT);
 
                REQUIRE( diff->MaxNorm() < tol );
 
@@ -4417,7 +4417,7 @@ TEST_CASE("3D Bilinear Weak Div Cross Integrators",
                   new BoundaryNormalLFIntegrator(VF3_coef, 1, 2));
                lf.Assemble();
 
-               blfw.Mult(f_rt,tmp_h1); tmp_h1 += lf; g_h1 = 0.0;
+               blfw.Mult(f_rt, tmp_h1); tmp_h1 += lf; g_h1 = 0.0;
                CG(m_h1, tmp_h1, g_h1, 0, 200, cg_rtol * cg_rtol, 0.0);
 
                REQUIRE( g_h1.ComputeL2Error(dVF3_coef) < tol );
@@ -4487,7 +4487,7 @@ TEST_CASE("3D Bilinear Weak Curl Cross Integrators",
                blfw.Finalize();
 
                SparseMatrix * blfT = Transpose(blfw.SpMat());
-               SparseMatrix * diff = Add(1.0,blf.SpMat(),1.0,*blfT);
+               SparseMatrix * diff = Add(1.0, blf.SpMat(), 1.0, *blfT);
 
                REQUIRE( diff->MaxNorm() < tol );
 
@@ -4499,7 +4499,7 @@ TEST_CASE("3D Bilinear Weak Curl Cross Integrators",
                   new VectorFEBoundaryTangentLFIntegrator(VxF3_coef, 1, 2));
                lf.Assemble();
 
-               blfw.Mult(f_nd,tmp_nd); tmp_nd += lf; g_nd = 0.0;
+               blfw.Mult(f_nd, tmp_nd); tmp_nd += lf; g_nd = 0.0;
                CG(m_nd, tmp_nd, g_nd, 0, 200, cg_rtol * cg_rtol, 0.0);
 
                REQUIRE( g_nd.ComputeL2Error(dVxF3_coef) < tol );
@@ -4542,7 +4542,7 @@ TEST_CASE("3D Bilinear Weak Curl Cross Integrators",
                blfw.Finalize();
 
                SparseMatrix * blfT = Transpose(blfw.SpMat());
-               SparseMatrix * diff = Add(1.0,blf.SpMat(),1.0,*blfT);
+               SparseMatrix * diff = Add(1.0, blf.SpMat(), 1.0, *blfT);
 
                REQUIRE( diff->MaxNorm() < tol );
 
@@ -4554,7 +4554,7 @@ TEST_CASE("3D Bilinear Weak Curl Cross Integrators",
                   new VectorFEBoundaryTangentLFIntegrator(VxF3_coef, 1, 2));
                lf.Assemble();
 
-               blfw.Mult(f_rt,tmp_nd); tmp_nd += lf; g_nd = 0.0;
+               blfw.Mult(f_rt, tmp_nd); tmp_nd += lf; g_nd = 0.0;
                CG(m_nd, tmp_nd, g_nd, 0, 200, cg_rtol * cg_rtol, 0.0);
 
                REQUIRE( g_nd.ComputeL2Error(dVxF3_coef) < tol );
@@ -4622,7 +4622,7 @@ TEST_CASE("3D Bilinear Weak Grad Dot Product Integrators",
                blfw.Finalize();
 
                SparseMatrix * blfT = Transpose(blfw.SpMat());
-               SparseMatrix * diff = Add(1.0,blf.SpMat(),1.0,*blfT);
+               SparseMatrix * diff = Add(1.0, blf.SpMat(), 1.0, *blfT);
 
                REQUIRE( diff->MaxNorm() < tol );
 
@@ -4634,7 +4634,7 @@ TEST_CASE("3D Bilinear Weak Grad Dot Product Integrators",
                   new VectorFEBoundaryFluxLFIntegrator(VdotF3_coef, 1, 2));
                lf.Assemble();
 
-               blfw.Mult(f_nd,tmp_rt); tmp_rt += lf; g_rt = 0.0;
+               blfw.Mult(f_nd, tmp_rt); tmp_rt += lf; g_rt = 0.0;
                CG(m_rt, tmp_rt, g_rt, 0, 200, cg_rtol * cg_rtol, 0.0);
 
                REQUIRE( g_rt.ComputeL2Error(dVF3_coef) < tol );
@@ -4674,7 +4674,7 @@ TEST_CASE("3D Bilinear Weak Grad Dot Product Integrators",
                blfw.Finalize();
 
                SparseMatrix * blfT = Transpose(blfw.SpMat());
-               SparseMatrix * diff = Add(1.0,blf.SpMat(),1.0,*blfT);
+               SparseMatrix * diff = Add(1.0, blf.SpMat(), 1.0, *blfT);
 
                REQUIRE( diff->MaxNorm() < tol );
 
@@ -4686,7 +4686,7 @@ TEST_CASE("3D Bilinear Weak Grad Dot Product Integrators",
                   new VectorFEBoundaryFluxLFIntegrator(VdotF3_coef, 1, 2));
                lf.Assemble();
 
-               blfw.Mult(f_rt,tmp_rt); tmp_rt += lf; g_rt = 0.0;
+               blfw.Mult(f_rt, tmp_rt); tmp_rt += lf; g_rt = 0.0;
                CG(m_rt, tmp_rt, g_rt, 0, 200, cg_rtol * cg_rtol, 0.0);
 
                REQUIRE( g_rt.ComputeL2Error(dVF3_coef) < tol );
@@ -4759,7 +4759,7 @@ TEST_CASE("3D Bilinear Grad Div Integrators",
                blfw.Finalize();
 
                SparseMatrix * blfT = Transpose(blfw.SpMat());
-               SparseMatrix * diff = Add(1.0,blf.SpMat(),-1.0,*blfT);
+               SparseMatrix * diff = Add(1.0, blf.SpMat(), -1.0, *blfT);
 
                REQUIRE( diff->MaxNorm() < tol );
 
@@ -4771,7 +4771,7 @@ TEST_CASE("3D Bilinear Grad Div Integrators",
                   new VectorFEBoundaryFluxLFIntegrator(Vdf3_coef));
                lf.Assemble();
 
-               blfw.Mult(f_h1,tmp_rt); tmp_rt += lf; g_rt = 0.0;
+               blfw.Mult(f_h1, tmp_rt); tmp_rt += lf; g_rt = 0.0;
                CG(m_rt, tmp_rt, g_rt, 0, 200, cg_rtol * cg_rtol, 0.0);
 
                REQUIRE( g_rt.ComputeL2Error(dVdf3_coef) < tol );
@@ -4812,7 +4812,7 @@ TEST_CASE("3D Bilinear Grad Div Integrators",
                   new BoundaryNormalLFIntegrator(VdF3_coef));
                lf.Assemble();
 
-               blfw.Mult(f_rt,tmp_h1); tmp_h1 += lf; g_h1 = 0.0;
+               blfw.Mult(f_rt, tmp_h1); tmp_h1 += lf; g_h1 = 0.0;
                CG(m_h1, tmp_h1, g_h1, 0, 200, cg_rtol * cg_rtol, 0.0);
 
                REQUIRE( g_h1.ComputeL2Error(dVdF3_coef) < tol );
@@ -4875,7 +4875,7 @@ TEST_CASE("3D Bilinear Grad Grad Integrators",
                blf.Finalize();
 
                SparseMatrix * blfT = Transpose(blf.SpMat());
-               SparseMatrix * diff = Add(1.0,blf.SpMat(),-1.0,*blfT);
+               SparseMatrix * diff = Add(1.0, blf.SpMat(), -1.0, *blfT);
 
                REQUIRE( diff->MaxNorm() < tol );
 
@@ -4887,7 +4887,7 @@ TEST_CASE("3D Bilinear Grad Grad Integrators",
                   new BoundaryNormalLFIntegrator(df3_coef));
                lf.Assemble();
 
-               blf.Mult(f_h1,tmp_h1); tmp_h1 -= lf; g_h1 = 0.0;
+               blf.Mult(f_h1, tmp_h1); tmp_h1 -= lf; g_h1 = 0.0;
                CG(m_h1, tmp_h1, g_h1, 0, 200, cg_rtol * cg_rtol, 0.0);
 
                REQUIRE( g_h1.ComputeL2Error(zero3_coef) < tol );
@@ -4900,7 +4900,7 @@ TEST_CASE("3D Bilinear Grad Grad Integrators",
                blf.Finalize();
 
                SparseMatrix * blfT = Transpose(blf.SpMat());
-               SparseMatrix * diff = Add(1.0,blf.SpMat(),-1.0,*blfT);
+               SparseMatrix * diff = Add(1.0, blf.SpMat(), -1.0, *blfT);
 
                REQUIRE( diff->MaxNorm() < tol );
 
@@ -4912,7 +4912,7 @@ TEST_CASE("3D Bilinear Grad Grad Integrators",
                   new BoundaryNormalLFIntegrator(qdf3_coef));
                lf.Assemble();
 
-               blf.Mult(f_h1,tmp_h1); tmp_h1 -= lf; g_h1 = 0.0;
+               blf.Mult(f_h1, tmp_h1); tmp_h1 -= lf; g_h1 = 0.0;
                CG(m_h1, tmp_h1, g_h1, 0, 200, cg_rtol * cg_rtol, 0.0);
                g_h1 *= -1.0;
 
@@ -4931,7 +4931,7 @@ TEST_CASE("3D Bilinear Grad Grad Integrators",
                blft.Finalize();
 
                SparseMatrix * blfT = Transpose(blf.SpMat());
-               SparseMatrix * diff = Add(1.0,blft.SpMat(),-1.0,*blfT);
+               SparseMatrix * diff = Add(1.0, blft.SpMat(), -1.0, *blfT);
 
                REQUIRE( diff->MaxNorm() < tol );
 
@@ -4943,7 +4943,7 @@ TEST_CASE("3D Bilinear Grad Grad Integrators",
                   new BoundaryNormalLFIntegrator(Mdf3_coef));
                lf.Assemble();
 
-               blf.Mult(f_h1,tmp_h1); tmp_h1 -= lf; g_h1 = 0.0;
+               blf.Mult(f_h1, tmp_h1); tmp_h1 -= lf; g_h1 = 0.0;
                CG(m_h1, tmp_h1, g_h1, 0, 200, cg_rtol * cg_rtol, 0.0);
                g_h1 *= -1.0;
 
@@ -5012,7 +5012,7 @@ TEST_CASE("3D Bilinear Mixed Grad Grad Integrators",
                blf.Finalize();
 
                SparseMatrix * blfT = Transpose(blf.SpMat());
-               SparseMatrix * diff = Add(1.0,blf.SpMat(),-1.0,*blfT);
+               SparseMatrix * diff = Add(1.0, blf.SpMat(), -1.0, *blfT);
 
                REQUIRE( diff->MaxNorm() < tol );
 
@@ -5024,7 +5024,7 @@ TEST_CASE("3D Bilinear Mixed Grad Grad Integrators",
                   new BoundaryNormalLFIntegrator(df3_coef));
                lf.Assemble();
 
-               blf.Mult(f_h1,tmp_h1); tmp_h1 -= lf; g_h1 = 0.0;
+               blf.Mult(f_h1, tmp_h1); tmp_h1 -= lf; g_h1 = 0.0;
                CG(m_h1, tmp_h1, g_h1, 0, 200, cg_rtol * cg_rtol, 0.0);
 
                REQUIRE( g_h1.ComputeL2Error(zero3_coef) < tol );
@@ -5038,7 +5038,7 @@ TEST_CASE("3D Bilinear Mixed Grad Grad Integrators",
                blf.Finalize();
 
                SparseMatrix * blfT = Transpose(blf.SpMat());
-               SparseMatrix * diff = Add(1.0,blf.SpMat(),-1.0,*blfT);
+               SparseMatrix * diff = Add(1.0, blf.SpMat(), -1.0, *blfT);
 
                REQUIRE( diff->MaxNorm() < tol );
 
@@ -5050,7 +5050,7 @@ TEST_CASE("3D Bilinear Mixed Grad Grad Integrators",
                   new BoundaryNormalLFIntegrator(qdf3_coef));
                lf.Assemble();
 
-               blf.Mult(f_h1,tmp_h1); tmp_h1 -= lf; g_h1 = 0.0;
+               blf.Mult(f_h1, tmp_h1); tmp_h1 -= lf; g_h1 = 0.0;
                CG(m_h1, tmp_h1, g_h1, 0, 200, cg_rtol * cg_rtol, 0.0);
                g_h1 *= -1.0;
 
@@ -5065,7 +5065,7 @@ TEST_CASE("3D Bilinear Mixed Grad Grad Integrators",
                blf.Finalize();
 
                SparseMatrix * blfT = Transpose(blf.SpMat());
-               SparseMatrix * diff = Add(1.0,blf.SpMat(),-1.0,*blfT);
+               SparseMatrix * diff = Add(1.0, blf.SpMat(), -1.0, *blfT);
 
                REQUIRE( diff->MaxNorm() < tol );
 
@@ -5077,7 +5077,7 @@ TEST_CASE("3D Bilinear Mixed Grad Grad Integrators",
                   new BoundaryNormalLFIntegrator(Ddf3_coef));
                lf.Assemble();
 
-               blf.Mult(f_h1,tmp_h1); tmp_h1 -= lf; g_h1 = 0.0;
+               blf.Mult(f_h1, tmp_h1); tmp_h1 -= lf; g_h1 = 0.0;
                CG(m_h1, tmp_h1, g_h1, 0, 200, cg_rtol * cg_rtol, 0.0);
                g_h1 *= -1.0;
 
@@ -5098,7 +5098,7 @@ TEST_CASE("3D Bilinear Mixed Grad Grad Integrators",
                blft.Finalize();
 
                SparseMatrix * blfT = Transpose(blf.SpMat());
-               SparseMatrix * diff = Add(1.0,blft.SpMat(),-1.0,*blfT);
+               SparseMatrix * diff = Add(1.0, blft.SpMat(), -1.0, *blfT);
 
                REQUIRE( diff->MaxNorm() < tol );
 
@@ -5110,7 +5110,7 @@ TEST_CASE("3D Bilinear Mixed Grad Grad Integrators",
                   new BoundaryNormalLFIntegrator(Mdf3_coef));
                lf.Assemble();
 
-               blf.Mult(f_h1,tmp_h1); tmp_h1 -= lf; g_h1 = 0.0;
+               blf.Mult(f_h1, tmp_h1); tmp_h1 -= lf; g_h1 = 0.0;
                CG(m_h1, tmp_h1, g_h1, 0, 200, cg_rtol * cg_rtol, 0.0);
                g_h1 *= -1.0;
 
@@ -5170,7 +5170,7 @@ TEST_CASE("3D Bilinear Mixed Cross Grad Grad Integrators",
                blf.Finalize();
 
                SparseMatrix * blfT = Transpose(blf.SpMat());
-               SparseMatrix * diff = Add(1.0,blf.SpMat(),1.0,*blfT);
+               SparseMatrix * diff = Add(1.0, blf.SpMat(), 1.0, *blfT);
 
                REQUIRE( diff->MaxNorm() < tol );
 
@@ -5182,7 +5182,7 @@ TEST_CASE("3D Bilinear Mixed Cross Grad Grad Integrators",
                   new BoundaryNormalLFIntegrator(Vxdf3_coef));
                lf.Assemble();
 
-               blf.Mult(f_h1,tmp_h1); tmp_h1 -= lf; g_h1 = 0.0;
+               blf.Mult(f_h1, tmp_h1); tmp_h1 -= lf; g_h1 = 0.0;
                CG(m_h1, tmp_h1, g_h1, 0, 200, cg_rtol * cg_rtol, 0.0);
                g_h1 *= -1.0;
 
@@ -5251,7 +5251,7 @@ TEST_CASE("3D Bilinear Mixed Cross Curl Grad Integrators",
                blfw.Finalize();
 
                SparseMatrix * blfT = Transpose(blfw.SpMat());
-               SparseMatrix * diff = Add(1.0,blf.SpMat(),1.0,*blfT);
+               SparseMatrix * diff = Add(1.0, blf.SpMat(), 1.0, *blfT);
 
                REQUIRE( diff->MaxNorm() < tol );
 
@@ -5263,7 +5263,7 @@ TEST_CASE("3D Bilinear Mixed Cross Curl Grad Integrators",
                   new BoundaryNormalLFIntegrator(VxdF3_coef));
                lf.Assemble();
 
-               blfw.Mult(f_nd,tmp_h1); tmp_h1 -= lf; g_h1 = 0.0;
+               blfw.Mult(f_nd, tmp_h1); tmp_h1 -= lf; g_h1 = 0.0;
                CG(m_h1, tmp_h1, g_h1, 0, 200, cg_rtol * cg_rtol, 0.0);
                g_h1 *= -1.0;
 
@@ -5330,7 +5330,7 @@ TEST_CASE("3D Bilinear Curl Curl Integrators",
                blf.Finalize();
 
                SparseMatrix * blfT = Transpose(blf.SpMat());
-               SparseMatrix * diff = Add(1.0,blf.SpMat(),-1.0,*blfT);
+               SparseMatrix * diff = Add(1.0, blf.SpMat(), -1.0, *blfT);
 
                REQUIRE( diff->MaxNorm() < tol );
 
@@ -5342,7 +5342,7 @@ TEST_CASE("3D Bilinear Curl Curl Integrators",
                   new VectorFEBoundaryTangentLFIntegrator(dF3_coef));
                lf.Assemble();
 
-               blf.Mult(f_nd,tmp_nd); tmp_nd += lf; g_nd = 0.0;
+               blf.Mult(f_nd, tmp_nd); tmp_nd += lf; g_nd = 0.0;
                CG(m_nd, tmp_nd, g_nd, 0, 200, cg_rtol * cg_rtol, 0.0);
 
                REQUIRE( g_nd.ComputeL2Error(Zero3_coef) < tol );
@@ -5355,7 +5355,7 @@ TEST_CASE("3D Bilinear Curl Curl Integrators",
                blf.Finalize();
 
                SparseMatrix * blfT = Transpose(blf.SpMat());
-               SparseMatrix * diff = Add(1.0,blf.SpMat(),-1.0,*blfT);
+               SparseMatrix * diff = Add(1.0, blf.SpMat(), -1.0, *blfT);
 
                REQUIRE( diff->MaxNorm() < tol );
 
@@ -5367,7 +5367,7 @@ TEST_CASE("3D Bilinear Curl Curl Integrators",
                   new VectorFEBoundaryTangentLFIntegrator(qdF3_coef, 1, 2));
                lf.Assemble();
 
-               blf.Mult(f_nd,tmp_nd); tmp_nd += lf; g_nd = 0.0;
+               blf.Mult(f_nd, tmp_nd); tmp_nd += lf; g_nd = 0.0;
                CG(m_nd, tmp_nd, g_nd, 0, 200, cg_rtol * cg_rtol, 0.0);
 
                REQUIRE( g_nd.ComputeL2Error(dqdF3_coef) < tol );
@@ -5441,7 +5441,7 @@ TEST_CASE("3D Bilinear Mixed Curl Curl Integrators",
                blf.Finalize();
 
                SparseMatrix * blfT = Transpose(blf.SpMat());
-               SparseMatrix * diff = Add(1.0,blf.SpMat(),-1.0,*blfT);
+               SparseMatrix * diff = Add(1.0, blf.SpMat(), -1.0, *blfT);
 
                REQUIRE( diff->MaxNorm() < tol );
 
@@ -5453,7 +5453,7 @@ TEST_CASE("3D Bilinear Mixed Curl Curl Integrators",
                   new VectorFEBoundaryTangentLFIntegrator(dF3_coef));
                lf.Assemble();
 
-               blf.Mult(f_nd,tmp_nd); tmp_nd += lf; g_nd = 0.0;
+               blf.Mult(f_nd, tmp_nd); tmp_nd += lf; g_nd = 0.0;
                CG(m_nd, tmp_nd, g_nd, 0, 200, cg_rtol * cg_rtol, 0.0);
 
                REQUIRE( g_nd.ComputeL2Error(Zero3_coef) < tol );
@@ -5467,7 +5467,7 @@ TEST_CASE("3D Bilinear Mixed Curl Curl Integrators",
                blf.Finalize();
 
                SparseMatrix * blfT = Transpose(blf.SpMat());
-               SparseMatrix * diff = Add(1.0,blf.SpMat(),-1.0,*blfT);
+               SparseMatrix * diff = Add(1.0, blf.SpMat(), -1.0, *blfT);
 
                REQUIRE( diff->MaxNorm() < tol );
 
@@ -5479,7 +5479,7 @@ TEST_CASE("3D Bilinear Mixed Curl Curl Integrators",
                   new VectorFEBoundaryTangentLFIntegrator(qdF3_coef, 1, 2));
                lf.Assemble();
 
-               blf.Mult(f_nd,tmp_nd); tmp_nd += lf; g_nd = 0.0;
+               blf.Mult(f_nd, tmp_nd); tmp_nd += lf; g_nd = 0.0;
                CG(m_nd, tmp_nd, g_nd, 0, 200, cg_rtol * cg_rtol, 0.0);
 
                REQUIRE( g_nd.ComputeL2Error(dqdF3_coef) < tol );
@@ -5493,7 +5493,7 @@ TEST_CASE("3D Bilinear Mixed Curl Curl Integrators",
                blf.Finalize();
 
                SparseMatrix * blfT = Transpose(blf.SpMat());
-               SparseMatrix * diff = Add(1.0,blf.SpMat(),-1.0,*blfT);
+               SparseMatrix * diff = Add(1.0, blf.SpMat(), -1.0, *blfT);
 
                REQUIRE( diff->MaxNorm() < tol );
 
@@ -5505,7 +5505,7 @@ TEST_CASE("3D Bilinear Mixed Curl Curl Integrators",
                   new VectorFEBoundaryTangentLFIntegrator(DdF3_coef));
                lf.Assemble();
 
-               blf.Mult(f_nd,tmp_nd); tmp_nd += lf; g_nd = 0.0;
+               blf.Mult(f_nd, tmp_nd); tmp_nd += lf; g_nd = 0.0;
                CG(m_nd, tmp_nd, g_nd, 0, 200, cg_rtol * cg_rtol, 0.0);
 
                REQUIRE( g_nd.ComputeL2Error(dDdF3_coef) < tol );
@@ -5525,7 +5525,7 @@ TEST_CASE("3D Bilinear Mixed Curl Curl Integrators",
                blft.Finalize();
 
                SparseMatrix * blfT = Transpose(blf.SpMat());
-               SparseMatrix * diff = Add(1.0,blft.SpMat(),-1.0,*blfT);
+               SparseMatrix * diff = Add(1.0, blft.SpMat(), -1.0, *blfT);
 
                REQUIRE( diff->MaxNorm() < tol );
 
@@ -5537,7 +5537,7 @@ TEST_CASE("3D Bilinear Mixed Curl Curl Integrators",
                   new VectorFEBoundaryTangentLFIntegrator(MdF3_coef));
                lf.Assemble();
 
-               blf.Mult(f_nd,tmp_nd); tmp_nd += lf; g_nd = 0.0;
+               blf.Mult(f_nd, tmp_nd); tmp_nd += lf; g_nd = 0.0;
                CG(m_nd, tmp_nd, g_nd, 0, 200, cg_rtol * cg_rtol, 0.0);
 
                REQUIRE( g_nd.ComputeL2Error(dMdF3_coef) < tol );
@@ -5602,7 +5602,7 @@ TEST_CASE("3D Bilinear Mixed Cross Curl Curl Integrators",
                blf.Finalize();
 
                SparseMatrix * blfT = Transpose(blf.SpMat());
-               SparseMatrix * diff = Add(1.0,blf.SpMat(),1.0,*blfT);
+               SparseMatrix * diff = Add(1.0, blf.SpMat(), 1.0, *blfT);
 
                REQUIRE( diff->MaxNorm() < tol );
 
@@ -5614,7 +5614,7 @@ TEST_CASE("3D Bilinear Mixed Cross Curl Curl Integrators",
                   new VectorFEBoundaryTangentLFIntegrator(VdF3_coef));
                lf.Assemble();
 
-               blf.Mult(f_nd,tmp_nd); tmp_nd += lf; g_nd = 0.0;
+               blf.Mult(f_nd, tmp_nd); tmp_nd += lf; g_nd = 0.0;
                CG(m_nd, tmp_nd, g_nd, 0, 200, cg_rtol * cg_rtol, 0.0);
 
                REQUIRE( g_nd.ComputeL2Error(dVdF3_coef) < tol );
@@ -5687,7 +5687,7 @@ TEST_CASE("3D Bilinear Mixed Cross Grad Curl Integrators",
                blfw.Finalize();
 
                SparseMatrix * blfT = Transpose(blfw.SpMat());
-               SparseMatrix * diff = Add(1.0,blf.SpMat(),1.0,*blfT);
+               SparseMatrix * diff = Add(1.0, blf.SpMat(), 1.0, *blfT);
 
                REQUIRE( diff->MaxNorm() < tol );
 
@@ -5699,7 +5699,7 @@ TEST_CASE("3D Bilinear Mixed Cross Grad Curl Integrators",
                   new VectorFEBoundaryTangentLFIntegrator(Vdf3_coef));
                lf.Assemble();
 
-               blfw.Mult(f_h1,tmp_nd); tmp_nd += lf; g_nd = 0.0;
+               blfw.Mult(f_h1, tmp_nd); tmp_nd += lf; g_nd = 0.0;
                CG(m_nd, tmp_nd, g_nd, 0, 200, cg_rtol * cg_rtol, 0.0);
 
                REQUIRE( g_nd.ComputeL2Error(dVdf3_coef) < tol );
@@ -5762,7 +5762,7 @@ TEST_CASE("3D Bilinear Div Div Integrators",
                blf.Finalize();
 
                SparseMatrix * blfT = Transpose(blf.SpMat());
-               SparseMatrix * diff = Add(1.0,blf.SpMat(),-1.0,*blfT);
+               SparseMatrix * diff = Add(1.0, blf.SpMat(), -1.0, *blfT);
 
                REQUIRE( diff->MaxNorm() < tol );
 
@@ -5774,7 +5774,7 @@ TEST_CASE("3D Bilinear Div Div Integrators",
                   new VectorFEBoundaryFluxLFIntegrator(dF3_coef));
                lf.Assemble();
 
-               blf.Mult(f_rt,tmp_rt); tmp_rt -= lf; g_rt = 0.0;
+               blf.Mult(f_rt, tmp_rt); tmp_rt -= lf; g_rt = 0.0;
                CG(m_rt, tmp_rt, g_rt, 0, 200, cg_rtol * cg_rtol, 0.0);
 
                REQUIRE( g_rt.ComputeL2Error(Zero3_coef) < tol );
@@ -5787,7 +5787,7 @@ TEST_CASE("3D Bilinear Div Div Integrators",
                blf.Finalize();
 
                SparseMatrix * blfT = Transpose(blf.SpMat());
-               SparseMatrix * diff = Add(1.0,blf.SpMat(),-1.0,*blfT);
+               SparseMatrix * diff = Add(1.0, blf.SpMat(), -1.0, *blfT);
 
                REQUIRE( diff->MaxNorm() < tol );
 
@@ -5799,7 +5799,7 @@ TEST_CASE("3D Bilinear Div Div Integrators",
                   new VectorFEBoundaryFluxLFIntegrator(qdF3_coef));
                lf.Assemble();
 
-               blf.Mult(f_rt,tmp_rt); tmp_rt -= lf; g_rt = 0.0;
+               blf.Mult(f_rt, tmp_rt); tmp_rt -= lf; g_rt = 0.0;
                CG(m_rt, tmp_rt, g_rt, 0, 200, cg_rtol * cg_rtol, 0.0);
                g_rt *= -1.0;
 


### PR DESCRIPTION
The goal of this PR is to expand the unit tests to identify and remove any inconsistencies that may exist in the implementation of BilinearForm and LinearForm integrators related to the two map types supported by the L2 basis functions.  Some of these issues have already been addressed in other PRs, notably PR #1931. 

This PR was created in response to issue #1037.

<!--GHEX{"id":1995,"author":"mlstowell","editor":"v-dobrev","reviewers":["barker29","kmittal2"],"assignment":"2021-01-25T16:34:31-08:00","approval":"2021-03-03T01:13:24.249Z","merge":"2021-03-16T18:08:52.891Z"}XEHG--><!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge| 
 | --- | --- | --- | --- | --- | --- | --- | 
| [#1995](https://github.com/mfem/mfem/pull/1995) | @mlstowell | @v-dobrev | @barker29 + @kmittal2 | 01/25/21 | 03/02/21 | 03/16/21 | |
<!--ELBATXEHG-->