### PR TITLE
Mesh::CheckElementOrientation(bool fix_it) [possible_bug_CheckElementOrientation]

### DIFF
--- a/mesh/mesh.cpp
+++ b/mesh/mesh.cpp
@@ -4255,11 +4255,11 @@ int Mesh::CheckElementOrientation(bool fix_it)
       {
          if (Nodes == NULL)
          {
-            vi = elements[i]->GetVertices();
-            for (j = 0; j < 3; j++)
-            {
-               v[j] = vertices[vi[j]]();
-            }
+//            vi = elements[i]->GetVertices();
+//            for (j = 0; j < 3; j++)
+//            {
+//               v[j] = vertices[vi[j]]();
+//           }
             for (j = 0; j < 2; j++)
                for (k = 0; k < 2; k++)
                {
@@ -4275,6 +4275,12 @@ int Mesh::CheckElementOrientation(bool fix_it)
          {
             if (fix_it)
             {
+               vi = elements[i]->GetVertices();
+               for (j = 0; j < 3; j++)
+               {
+                  v[j] = vertices[vi[j]]();
+               }
+               
                switch (GetElementType(i))
                {
                   case Element::TRIANGLE:


### PR DESCRIPTION
In this function if ( Nodes!=NULL and J.Det()<0.0 and fix_it==true ) the mfem::swap function is called with a non-initialized pointer. I believe the modification of this pull request might solve the issue. It certainly solved it for the particular case I was running.