### PR TITLE
FESpaces on Subdomains

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -11,6 +11,7 @@
 
 list(APPEND ALL_EXE_SRCS
   ex1.cpp
+  ex1-subdomain.cpp
   ex2.cpp
   ex3.cpp
   ex4.cpp

--- a/examples/ex1-subdomain.cpp
+++ b/examples/ex1-subdomain.cpp
@@ -1,0 +1,283 @@
+//                                MFEM Example 1
+//
+// Compile with: make ex1
+//
+// Sample runs:  ex1 -m ../data/square-disc.mesh
+//               ex1 -m ../data/star.mesh
+//               ex1 -m ../data/star-mixed.mesh
+//               ex1 -m ../data/escher.mesh
+//               ex1 -m ../data/fichera.mesh
+//               ex1 -m ../data/fichera-mixed.mesh
+//               ex1 -m ../data/toroid-wedge.mesh
+//               ex1 -m ../data/periodic-annulus-sector.msh
+//               ex1 -m ../data/periodic-torus-sector.msh
+//               ex1 -m ../data/square-disc-p2.vtk -o 2
+//               ex1 -m ../data/square-disc-p3.mesh -o 3
+//               ex1 -m ../data/square-disc-nurbs.mesh -o -1
+//               ex1 -m ../data/star-mixed-p2.mesh -o 2
+//               ex1 -m ../data/disc-nurbs.mesh -o -1
+//               ex1 -m ../data/pipe-nurbs.mesh -o -1
+//               ex1 -m ../data/fichera-mixed-p2.mesh -o 2
+//               ex1 -m ../data/star-surf.mesh
+//               ex1 -m ../data/square-disc-surf.mesh
+//               ex1 -m ../data/inline-segment.mesh
+//               ex1 -m ../data/amr-quad.mesh
+//               ex1 -m ../data/amr-hex.mesh
+//               ex1 -m ../data/fichera-amr.mesh
+//               ex1 -m ../data/mobius-strip.mesh
+//               ex1 -m ../data/mobius-strip.mesh -o -1 -sc
+//
+// Device sample runs:
+//               ex1 -pa -d cuda
+//               ex1 -pa -d raja-cuda
+//             * ex1 -pa -d raja-hip
+//               ex1 -pa -d occa-cuda
+//               ex1 -pa -d raja-omp
+//               ex1 -pa -d occa-omp
+//               ex1 -pa -d ceed-cpu
+//             * ex1 -pa -d ceed-cuda
+//             * ex1 -pa -d ceed-hip
+//               ex1 -pa -d ceed-cuda:/gpu/cuda/shared
+//               ex1 -m ../data/beam-hex.mesh -pa -d cuda
+//               ex1 -m ../data/beam-tet.mesh -pa -d ceed-cpu
+//               ex1 -m ../data/beam-tet.mesh -pa -d ceed-cuda:/gpu/cuda/ref
+//
+// Description:  This example code demonstrates the use of MFEM to define a
+//               simple finite element discretization of the Laplace problem
+//               -Delta u = 1 with homogeneous Dirichlet boundary conditions.
+//               Specifically, we discretize using a FE space of the specified
+//               order, or if order < 1 using an isoparametric/isogeometric
+//               space (i.e. quadratic for quadratic curvilinear mesh, NURBS for
+//               NURBS mesh, etc.)
+//
+//               The example highlights the use of mesh refinement, finite
+//               element grid functions, as well as linear and bilinear forms
+//               corresponding to the left-hand side and right-hand side of the
+//               discrete linear system. We also cover the explicit elimination
+//               of essential boundary conditions, static condensation, and the
+//               optional connection to the GLVis tool for visualization.
+
+#include "mfem.hpp"
+#include <fstream>
+#include <iostream>
+
+using namespace std;
+using namespace mfem;
+
+int main(int argc, char *argv[])
+{
+   // 1. Parse command-line options.
+   const char *mesh_file = "../data/star.mesh";
+   int order = 1;
+   bool static_cond = false;
+   bool pa = false;
+   const char *device_config = "cpu";
+   bool visualization = true;
+
+   OptionsParser args(argc, argv);
+   args.AddOption(&mesh_file, "-m", "--mesh",
+                  "Mesh file to use.");
+   args.AddOption(&order, "-o", "--order",
+                  "Finite element order (polynomial degree) or -1 for"
+                  " isoparametric space.");
+   args.AddOption(&static_cond, "-sc", "--static-condensation", "-no-sc",
+                  "--no-static-condensation", "Enable static condensation.");
+   args.AddOption(&pa, "-pa", "--partial-assembly", "-no-pa",
+                  "--no-partial-assembly", "Enable Partial Assembly.");
+   args.AddOption(&device_config, "-d", "--device",
+                  "Device configuration string, see Device::Configure().");
+   args.AddOption(&visualization, "-vis", "--visualization", "-no-vis",
+                  "--no-visualization",
+                  "Enable or disable GLVis visualization.");
+   args.Parse();
+   if (!args.Good())
+   {
+      args.PrintUsage(cout);
+      return 1;
+   }
+   args.PrintOptions(cout);
+
+   // 2. Enable hardware devices such as GPUs, and programming models such as
+   //    CUDA, OCCA, RAJA and OpenMP based on command line options.
+   Device device(device_config);
+   device.Print();
+
+   // 3. Read the mesh from the given mesh file. We can handle triangular,
+   //    quadrilateral, tetrahedral, hexahedral, surface and volume meshes with
+   //    the same code.
+   Mesh mesh(mesh_file, 1, 1);
+   int dim = mesh.Dimension();
+
+   // 4. Refine the mesh to increase the resolution. In this example we do
+   //    'ref_levels' of uniform refinement. We choose 'ref_levels' to be the
+   //    largest number that gives a final mesh with no more than 50,000
+   //    elements.
+   {
+      int ref_levels =
+         (int)floor(log(50000./mesh.GetNE())/log(2.)/dim);
+      for (int l = 0; l < ref_levels; l++)
+      {
+         mesh.UniformRefinement();
+      }
+   }
+
+   // 5. Define a finite element space on the mesh. Here we use continuous
+   //    Lagrange finite elements of the specified order. If order < 1, we
+   //    instead use an isoparametric/isogeometric space.
+   FiniteElementCollection *fec;
+   bool delete_fec;
+   if (order > 0)
+   {
+      fec = new H1_FECollection(order, dim);
+      delete_fec = true;
+   }
+   else if (mesh.GetNodes())
+   {
+      fec = mesh.GetNodes()->OwnFEC();
+      delete_fec = false;
+      cout << "Using isoparametric FEs: " << fec->Name() << endl;
+   }
+   else
+   {
+      fec = new H1_FECollection(order = 1, dim);
+      delete_fec = true;
+   }
+
+   Array<int> subdomain_attr(1);
+   subdomain_attr = 1;
+   for(int e=0;e<mesh.GetNE();e++)
+   {
+      Vector center(mesh.SpaceDimension());
+      mesh.GetElementCenter(e, center);
+
+      if(center(0) > 0.0)
+      {
+         mesh.SetAttribute(e, 2);
+      }
+   }
+   auto subdomain = SubdomainFromAttributes(&mesh, subdomain_attr);
+
+   FiniteElementSpace fespace(&mesh, fec, 1, Ordering::byNODES, subdomain);
+   std::cout << "Subdomain with " << fespace.GetNE() << "/" << mesh.GetNE() << std::endl;
+   cout << "Number of finite element unknowns: "
+        << fespace.GetTrueVSize() << endl;
+
+   // 6. Determine the list of true (i.e. conforming) essential boundary dofs.
+   //    In this example, the boundary conditions are defined by marking all
+   //    the boundary attributes from the mesh as essential (Dirichlet) and
+   //    converting them to a list of true dofs.
+   Array<int> ess_tdof_list;
+   if (mesh.bdr_attributes.Size())
+   {
+      Array<int> ess_bdr(mesh.bdr_attributes.Max());
+      ess_bdr = 1;
+      fespace.GetEssentialTrueDofs(ess_bdr, ess_tdof_list);
+   }
+
+   // 7. Set up the linear form b(.) which corresponds to the right-hand side of
+   //    the FEM linear system, which in this case is (1,phi_i) where phi_i are
+   //    the basis functions in the finite element fespace.
+   LinearForm b(&fespace);
+   ConstantCoefficient one(1.0);
+   b.AddDomainIntegrator(new DomainLFIntegrator(one));
+   b.Assemble();
+
+   // 8. Define the solution vector x as a finite element grid function
+   //    corresponding to fespace. Initialize x with initial guess of zero,
+   //    which satisfies the boundary conditions.
+   GridFunction x(&fespace);
+   x = 0.0;
+
+   // 9. Set up the bilinear form a(.,.) on the finite element space
+   //    corresponding to the Laplacian operator -Delta, by adding the Diffusion
+   //    domain integrator.
+   BilinearForm a(&fespace);
+   if (pa) { a.SetAssemblyLevel(AssemblyLevel::PARTIAL); }
+   a.AddDomainIntegrator(new DiffusionIntegrator(one));
+
+   // 10. Assemble the bilinear form and the corresponding linear system,
+   //     applying any necessary transformations such as: eliminating boundary
+   //     conditions, applying conforming constraints for non-conforming AMR,
+   //     static condensation, etc.
+   if (static_cond) { a.EnableStaticCondensation(); }
+   a.Assemble();
+
+   OperatorPtr A;
+   Vector B, X;
+   a.FormLinearSystem(ess_tdof_list, x, b, A, X, B);
+
+   cout << "Size of linear system: " << A->Height() << endl;
+
+   // 11. Solve the linear system A X = B.
+   if (!pa)
+   {
+#ifndef MFEM_USE_SUITESPARSE
+      // Use a simple symmetric Gauss-Seidel preconditioner with PCG.
+      GSSmoother M((SparseMatrix&)(*A));
+      PCG(*A, M, B, X, 1, 200, 1e-12, 0.0);
+#else
+      // If MFEM was compiled with SuiteSparse, use UMFPACK to solve the system.
+      UMFPackSolver umf_solver;
+      umf_solver.Control[UMFPACK_ORDERING] = UMFPACK_ORDERING_METIS;
+      umf_solver.SetOperator(*A);
+      umf_solver.Mult(B, X);
+#endif
+   }
+   else // Jacobi preconditioning in partial assembly mode
+   {
+      if (UsesTensorBasis(fespace))
+      {
+         OperatorJacobiSmoother M(a, ess_tdof_list);
+         PCG(*A, M, B, X, 1, 400, 1e-12, 0.0);
+      }
+      else
+      {
+         CG(*A, B, X, 1, 400, 1e-12, 0.0);
+      }
+   }
+
+   // 12. Recover the solution as a finite element grid function.
+   a.RecoverFEMSolution(X, b, x);
+
+   // 13. Save the refined mesh and the solution. This output can be viewed later
+   //     using GLVis: "glvis -m refined.mesh -g sol.gf".
+   ofstream mesh_ofs("refined.mesh");
+   mesh_ofs.precision(8);
+   mesh.Print(mesh_ofs);
+   ofstream sol_ofs("sol.gf");
+   sol_ofs.precision(8);
+   x.Save(sol_ofs);
+
+   // 14. Send the solution by socket to a GLVis server.
+   if (visualization)
+   {
+      char vishost[] = "localhost";
+      int  visport   = 19916;
+      socketstream sol_sock(vishost, visport);
+      sol_sock.precision(8);
+
+      // Transfer from subspace to full space for visualization.
+      FiniteElementSpace fespace_full(&mesh, fec, 1, Ordering::byNODES);
+      GridFunction x_full(&fespace_full);
+      x_full = 0.0;
+      Array<int> dofs_full, dofs;
+      Vector elemvect;
+      for(int ei = 0; ei < fespace.GetNE(); ei++)
+      {
+         fespace.GetElementDofs(ei, dofs);
+         x.GetSubVector(dofs, elemvect);
+         fespace_full.GetElementDofs(fespace.MapElement(ei), dofs_full);
+         x_full.SetSubVector(dofs_full, elemvect);
+      }
+
+      sol_sock << "solution\n" << mesh << x_full << flush;
+   }
+
+   // 15. Free the used memory.
+   if (delete_fec)
+   {
+      delete fec;
+   }
+
+   return 0;
+}

--- a/fem/bilinearform.cpp
+++ b/fem/bilinearform.cpp
@@ -460,7 +460,7 @@ void BilinearForm::Assemble(int skip_zeros)
 
       for (int i = 0; i < fes -> GetNBE(); i++)
       {
-         const int bdr_attr = mesh->GetBdrAttribute(i);
+         const int bdr_attr = fes->GetBdrAttribute(i);
          if (bdr_attr_marker[bdr_attr-1] == 0) { continue; }
 
          const FiniteElement &be = *fes->GetBE(i);
@@ -504,10 +504,10 @@ void BilinearForm::Assemble(int skip_zeros)
       FaceElementTransformations *tr;
       Array<int> vdofs2;
 
-      int nfaces = mesh->GetNumFaces();
+      int nfaces = fes->GetNF();
       for (int i = 0; i < nfaces; i++)
       {
-         tr = mesh -> GetInteriorFaceTransformations (i);
+         tr = fes -> GetInteriorFaceTransformations (i);
          if (tr != NULL)
          {
             fes -> GetElementVDofs (tr -> Elem1No, vdofs);
@@ -552,10 +552,10 @@ void BilinearForm::Assemble(int skip_zeros)
 
       for (int i = 0; i < fes -> GetNBE(); i++)
       {
-         const int bdr_attr = mesh->GetBdrAttribute(i);
+         const int bdr_attr = fes->GetBdrAttribute(i);
          if (bdr_attr_marker[bdr_attr-1] == 0) { continue; }
 
-         tr = mesh -> GetBdrFaceTransformations (i);
+         tr = fes -> GetBdrFaceTransformations (i);
          if (tr != NULL)
          {
             fes -> GetElementVDofs (tr -> Elem1No, vdofs);
@@ -1111,6 +1111,9 @@ MixedBilinearForm::MixedBilinearForm (FiniteElementSpace *tr_fes,
    extern_bfs = 0;
    assembly = AssemblyLevel::LEGACYFULL;
    ext = NULL;
+
+   MFEM_ASSERT(tr_fes->Subdomain() == te_fes->Subdomain(),
+   "Test and trial space must live on the same domain.");
 }
 
 MixedBilinearForm::MixedBilinearForm (FiniteElementSpace *tr_fes,
@@ -1347,7 +1350,7 @@ void MixedBilinearForm::Assemble (int skip_zeros)
 
       for (int i = 0; i < test_fes -> GetNBE(); i++)
       {
-         const int bdr_attr = mesh->GetBdrAttribute(i);
+         const int bdr_attr = trial_fes->GetBdrAttribute(i);
          if (bdr_attr_marker[bdr_attr-1] == 0) { continue; }
 
          trial_fes -> GetBdrElementVDofs (i, tr_vdofs);
@@ -1372,10 +1375,10 @@ void MixedBilinearForm::Assemble (int skip_zeros)
       Array<int> te_vdofs2;
       const FiniteElement *trial_face_fe, *test_fe1, *test_fe2;
 
-      int nfaces = mesh->GetNumFaces();
+      int nfaces = trial_fes->GetNF();
       for (int i = 0; i < nfaces; i++)
       {
-         ftr = mesh->GetFaceElementTransformations(i);
+         ftr = trial_fes->GetFaceElementTransformations(i);
          trial_fes->GetFaceVDofs(i, tr_vdofs);
          test_fes->GetElementVDofs(ftr->Elem1No, te_vdofs);
          trial_face_fe = trial_fes->GetFaceElement(i);
@@ -1431,10 +1434,10 @@ void MixedBilinearForm::Assemble (int skip_zeros)
 
       for (int i = 0; i < trial_fes -> GetNBE(); i++)
       {
-         const int bdr_attr = mesh->GetBdrAttribute(i);
+         const int bdr_attr = trial_fes->GetBdrAttribute(i);
          if (bdr_attr_marker[bdr_attr-1] == 0) { continue; }
 
-         ftr = mesh->GetBdrFaceTransformations(i);
+         ftr = trial_fes->GetBdrFaceTransformations(i);
          if (ftr)
          {
             trial_fes->GetFaceVDofs(ftr->ElementNo, tr_vdofs);
@@ -1837,12 +1840,12 @@ void DiscreteLinearOperator::Assemble(int skip_zeros)
 
    if (tfbfi.Size())
    {
-      const int nfaces = test_fes->GetMesh()->GetNumFaces();
+      const int nfaces = test_fes->GetNF();
       for (int i = 0; i < nfaces; i++)
       {
          trial_fes->GetFaceVDofs(i, dom_vdofs);
          test_fes->GetFaceVDofs(i, ran_vdofs);
-         T = test_fes->GetMesh()->GetFaceTransformation(i);
+         T = test_fes->GetFaceTransformation(i);
          dom_fe = trial_fes->GetFaceElement(i);
          ran_fe = test_fes->GetFaceElement(i);
 

--- a/fem/linearform.cpp
+++ b/fem/linearform.cpp
@@ -132,7 +132,7 @@ void LinearForm::Assemble()
 
       for (i = 0; i < fes -> GetNBE(); i++)
       {
-         const int bdr_attr = mesh->GetBdrAttribute(i);
+         const int bdr_attr = fes->GetBdrAttribute(i);
          if (bdr_attr_marker[bdr_attr-1] == 0) { continue; }
          fes -> GetBdrElementVDofs (i, vdofs);
          eltrans = fes -> GetBdrElementTransformation (i);
@@ -173,12 +173,12 @@ void LinearForm::Assemble()
          }
       }
 
-      for (i = 0; i < mesh->GetNBE(); i++)
+      for (i = 0; i < fes->GetNBE(); i++)
       {
-         const int bdr_attr = mesh->GetBdrAttribute(i);
+         const int bdr_attr = fes->GetBdrAttribute(i);
          if (bdr_attr_marker[bdr_attr-1] == 0) { continue; }
 
-         tr = mesh->GetBdrFaceTransformations(i);
+         tr = fes->GetBdrFaceTransformations(i);
          if (tr != NULL)
          {
             fes -> GetElementVDofs (tr -> Elem1No, vdofs);


### PR DESCRIPTION
Dear MFEM team,

this PR has the goal to enable finite element spaces on subdomains of the mesh. At the time writing this draft a (fully?) function prototype for arbitrary order serial H1 conforming problems is already done and in this branch.

## Background on Design Decision

My approach to this an extension of the FiniteElementSpace classes to handle this, because this seems to be the most natural way how subspaces could be weaved into MFEM. I decided against an extension of the Mesh classes and against using a management class between. I think the latter is rather problematic in combination with AMR, because it would basically accomplish was the parallel NC mesh class does. In the former case I could think of on design which does not require large chunks of MFEM to be rewritten: The mesh could be extended to "pretend" being a submesh by e.g. introducing methods like ActivateSubdomain, which changes the behavior of all functions to be constrained to a subspace. However this looks very error prone in practice, because we have to ensure to set the correct subdomain all the time.

## Basic Idea

To not take credit for the idea, I want to mention that I basically followed @v-dobrev 's suggestion in the following issue https://github.com/mfem/mfem/issues/1729.
The idea for this extension is based on the fact that we can build bijective maps between "continuous" ranges (i.e. 1...N) and entities living on a subset of the mesh. A naive (and inefficient) realization of this mapping is done in 

https://github.com/mfem/mfem/blob/6b8c7a583b61b94b66da5abb229ccdcd7e42b979/fem/fespace.hpp#L86-L92

and the lines following https://github.com/mfem/mfem/blob/6b8c7a583b61b94b66da5abb229ccdcd7e42b979/fem/fespace.hpp#L425

with these mapping we can in the presence of a subdomain rewire the communication with the mesh. We just have to ensure that algorithms on the finite element space do not make any direct calls to the mesh, which involve specific entity ids. These calls must now be redirected through the FiniteElementSpace class, acting as a proxy. At least in the case a user wants support for subdomains with this approach.

However, now I am not sure how I should proceed for from now or whether is is a bad idea. If the basic idea is fine, then I would like to extend this for NC spaces and distributed parallelism (alongside optimizing the approach a bit and including the relevant unit tests).