### PR TITLE
CuSparseClear for clearing CuSparse Descriptors 

### DIFF
--- a/linalg/sparsemat.cpp
+++ b/linalg/sparsemat.cpp
@@ -47,6 +47,19 @@ void SparseMatrix::InitCuSparse()
 #endif
 }
 
+void SparseMatrix::ClearCuSparse()
+{
+#ifdef MFEM_USE_CUDA
+   if (initBuffers)
+   {
+      cusparseDestroySpMat(matA_descr);
+      cusparseDestroyDnVec(vecX_descr);
+      cusparseDestroyDnVec(vecY_descr);
+      initBuffers = false;
+   }
+#endif
+}
+
 SparseMatrix::SparseMatrix(int nrows, int ncols)
    : AbstractSparseMatrix(nrows, (ncols >= 0) ? ncols : nrows),
      Rows(new RowNode *[nrows]),
@@ -282,15 +295,7 @@ void SparseMatrix::SetEmpty()
 #endif
    isSorted = false;
 
-#ifdef MFEM_USE_CUDA
-   if (initBuffers)
-   {
-      cusparseDestroySpMat(matA_descr);
-      cusparseDestroyDnVec(vecX_descr);
-      cusparseDestroyDnVec(vecY_descr);
-      initBuffers = false;
-   }
-#endif
+   ClearCuSparse();
 }
 
 int SparseMatrix::RowSize(const int i) const

--- a/linalg/sparsemat.cpp
+++ b/linalg/sparsemat.cpp
@@ -3165,13 +3165,7 @@ void SparseMatrix::Destroy()
    delete At;
 
 #ifdef MFEM_USE_CUDA
-   if (initBuffers)
-   {
-      cusparseDestroySpMat(matA_descr);
-      cusparseDestroyDnVec(vecX_descr);
-      cusparseDestroyDnVec(vecY_descr);
-      initBuffers = false;
-   }
+   ClearCuSparse();
 #endif
 }
 

--- a/linalg/sparsemat.hpp
+++ b/linalg/sparsemat.hpp
@@ -166,6 +166,10 @@ public:
    /// Clear the contents of the SparseMatrix.
    void Clear() { Destroy(); SetEmpty(); }
 
+   /** @brief Clear the CuSparse descriptors.
+       This must be called after releasing the device memory of A. */
+   void ClearCuSparse();
+
    /// Check if the SparseMatrix is empty.
    bool Empty() const { return (A == NULL) && (Rows == NULL); }
 


### PR DESCRIPTION
Moved the CuSparse descriptor cleanup to its own method since it needs to be used after releasing the CuSparse device memory
<!--GHEX{"id":2010,"author":"tomstitt","editor":"tzanio","reviewers":["artv3","YohannDudouit","tzanio"],"assignment":"2021-01-22T12:46:58-08:00","approval":"2021-01-24T21:08:13.339Z","merge":"2021-01-28T23:57:40.993Z"}XEHG--><!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge| 
 | --- | --- | --- | --- | --- | --- | --- | 
| [#2010](https://github.com/mfem/mfem/pull/2010) | @tomstitt | @tzanio | @artv3 + @YohannDudouit + @tzanio | 01/22/21 | 01/24/21 | 01/28/21 | |
<!--ELBATXEHG-->