### PR TITLE
Fix usage of HYPRE_Int in hypre.hpp/hypre.cpp [robertchiodi/bugfix/air_hypre_int]

### DIFF
--- a/linalg/hypre.cpp
+++ b/linalg/hypre.cpp
@@ -999,7 +999,7 @@ HypreParMatrix *HypreParMatrix::ExtractSubmatrix(const Array<int> &indices,
    int local_num_vars = hypre_CSRMatrixNumRows(hypre_ParCSRMatrixDiag(A));
 
    // Form hypre CF-splitting array designating submatrix as F-points (-1)
-   Array<int> CF_marker(local_num_vars);
+   Array<HYPRE_Int> CF_marker(local_num_vars);
    CF_marker = 1;
    for (int j=0; j<indices.Size(); j++)
    {

--- a/linalg/hypre.hpp
+++ b/linalg/hypre.hpp
@@ -1277,8 +1277,12 @@ public:
    void SetCycleType(int cycle_type)
    { HYPRE_BoomerAMGSetCycleType(amg_precond, cycle_type); }
 
-   void GetNumIterations(int &num_it)
-   { HYPRE_BoomerAMGGetNumIterations(amg_precond, &num_it); }
+   void GetNumIterations(int &num_iterations)
+   {
+      HYPRE_Int num_it;
+      HYPRE_BoomerAMGGetNumIterations(amg_precond, &num_it);      
+      num_iterations = internal::to_int(num_it);
+   }
 
    /// Expert option - consult hypre documentation/team
    void SetNodal(int blocksize)

--- a/linalg/hypre.hpp
+++ b/linalg/hypre.hpp
@@ -1280,7 +1280,7 @@ public:
    void GetNumIterations(int &num_iterations)
    {
       HYPRE_Int num_it;
-      HYPRE_BoomerAMGGetNumIterations(amg_precond, &num_it);      
+      HYPRE_BoomerAMGGetNumIterations(amg_precond, &num_it);
       num_iterations = internal::to_int(num_it);
    }
 


### PR DESCRIPTION
Hello all,

This pull-request fixes two problems introduced in #1053 when hypre is compiled with the `--enable-bigint` option by replacing `int` with `HYPRE_Int`. The argument name in `HypreBoomerAMG::GetNumIterations`was also changed to match that from `HyprePCG::GetNumIterations`.

Please let me know if anything else needs to be updated.

Cheers
<!--GHEX{"id":2015,"author":"robert-chiodi","editor":"tzanio","reviewers":["tzanio","acfisher"],"assignment":"2021-01-31T11:36:31-08:00","approval":"2021-02-04T23:39:03.947Z","merge":"2021-02-05T16:00:06.212Z"}XEHG--><!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge| 
 | --- | --- | --- | --- | --- | --- | --- | 
| [#2015](https://github.com/mfem/mfem/pull/2015) | @robert-chiodi | @tzanio | @tzanio + @acfisher | 01/31/21 | 02/04/21 | 02/05/21 | |
<!--ELBATXEHG-->