### PR TITLE
Making VTK reader more versatile

### DIFF
--- a/mesh/mesh_readers.cpp
+++ b/mesh/mesh_readers.cpp
@@ -786,17 +786,13 @@ void Mesh::ReadVTKMesh(std::istream &input, int &curved, int &read_gf,
       MFEM_ABORT("VTK mesh is not in ASCII format!");
       return;
    }
-   buff = "";
-   while (buff == "") // allow blanklines
+   do
    {
       getline(input, buff);
       filter_dos(buff);
+      if (!input.good()) { MFEM_ABORT("VTK mesh is not UNSTRUCTURED_GRID!"); }
    }
-   if (buff != "DATASET UNSTRUCTURED_GRID")
-   {
-      MFEM_ABORT("VTK mesh is not UNSTRUCTURED_GRID!");
-      return;
-   }
+   while (buff != "DATASET UNSTRUCTURED_GRID");
 
    // Read the points, skipping optional sections such as the FIELD data from
    // VisIt's VTK export (or from Mesh::PrintVTK with field_data==1).
@@ -860,11 +856,9 @@ void Mesh::ReadVTKMesh(std::istream &input, int &curved, int &read_gf,
    input >> ws >> buff;
    Array<int> cell_types;
    int ncells;
-   if (buff == "CELL_TYPES")
-   {
-      input >> ncells;
-      cell_types.Load(ncells, input);
-   }
+   MFEM_VERIFY(buff == "CELL_TYPES", "CELL_TYPES not provided in VTK mesh.")
+   input >> ncells;
+   cell_types.Load(ncells, input);
 
    while ((input.good()) && (buff != "CELL_DATA"))
    {

--- a/mesh/mesh_readers.cpp
+++ b/mesh/mesh_readers.cpp
@@ -889,11 +889,11 @@ void Mesh::ReadVTKMesh(std::istream &input, int &curved, int &read_gf,
       }
    }
 
-   if (!found_material)
-   {
-      MFEM_WARNING("Material array not found in VTK file. "
-                   "Assuming uniform material composition.");
-   }
+   // if (!found_material)
+   // {
+   //    MFEM_WARNING("Material array not found in VTK file. "
+   //                 "Assuming uniform material composition.");
+   // }
 
    CreateVTKMesh(points, cell_data, cell_offsets, cell_types, cell_attributes,
                  curved, read_gf, finalize_topo);

--- a/mesh/mesh_readers.cpp
+++ b/mesh/mesh_readers.cpp
@@ -762,7 +762,7 @@ void Mesh::ReadXML_VTKMesh(std::istream &input, int &curved, int &read_gf,
    }
    if (cells_xml == NULL) { MFEM_ABORT(erstr); }
 
-   // Currently don't support reading cell attributes from VTK mesh
+   // Currently don't support reading cell attributes from XML VTK mesh
    Array<int> cell_attributes;
    CreateVTKMesh(points, cell_data, cell_offsets, cell_types, cell_attributes,
                  curved, read_gf, finalize_topo);

--- a/mesh/mesh_readers.cpp
+++ b/mesh/mesh_readers.cpp
@@ -867,7 +867,7 @@ void Mesh::ReadVTKMesh(std::istream &input, int &curved, int &read_gf,
    getline(input, buff); // finish the line
 
    // Read the cell materials
-   bool found_material{false};
+   // bool found_material = false;
    Array<int> cell_attributes;
    while ((input.good()))
    {
@@ -884,7 +884,7 @@ void Mesh::ReadVTKMesh(std::istream &input, int &curved, int &read_gf,
             MFEM_ABORT("Invalid LOOKUP_TABLE for material array in VTK file.");
          }
          cell_attributes.Load(ncells, input);
-         found_material = true;
+         // found_material = true;
          break;
       }
    }


### PR DESCRIPTION
This allows blank lines in the header block of the VTK file and allows the `material` data to appear anywhere in the file allowed by the VTK format.

Resolves #2001 
<!--GHEX{"id":2028,"author":"wcdawn","editor":"tzanio","reviewers":["pazner","bslazarov","mlstowell"],"assignment":"2021-02-07T14:39:37-08:00","approval":"2021-02-22T21:39:04.305Z","merge":"2021-03-02T19:24:57.461Z"}XEHG--><!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge| 
 | --- | --- | --- | --- | --- | --- | --- | 
| [#2028](https://github.com/mfem/mfem/pull/2028) | @wcdawn | @tzanio | @pazner + @bslazarov + @mlstowell | 02/07/21 | 02/22/21 | 03/02/21 | |
<!--ELBATXEHG-->