### PR TITLE
Allow first SparseMatrix to not use CUDA

### DIFF
--- a/linalg/sparsemat.cpp
+++ b/linalg/sparsemat.cpp
@@ -30,7 +30,7 @@ using namespace std;
 
 #ifdef MFEM_USE_CUDA
 int SparseMatrix::SparseMatrixCount = 0;
-cusparseHandle_t SparseMatrix::handle;
+cusparseHandle_t SparseMatrix::handle = nullptr;
 size_t SparseMatrix::bufferSize = 0;
 void * SparseMatrix::dBuffer = nullptr;
 #endif
@@ -39,10 +39,15 @@ void SparseMatrix::InitCuSparse()
 {
    // Initialize cuSPARSE library
 #ifdef MFEM_USE_CUDA
-   SparseMatrixCount++;
-   if (SparseMatrixCount == 1 && Device::Allows(Backend::CUDA_MASK))
+   if (Device::Allows(Backend::CUDA_MASK))
    {
-      cusparseCreate(&handle);
+      if (!handle) { cusparseCreate(&handle); }
+      useCuSparse=true;
+      SparseMatrixCount++;
+   }
+   else
+   {
+      useCuSparse=false;
    }
 #endif
 }

--- a/linalg/sparsemat.hpp
+++ b/linalg/sparsemat.hpp
@@ -619,12 +619,24 @@ public:
    {
       Destroy();
 #ifdef MFEM_USE_CUDA
-      if (handle && SparseMatrixCount==1 && Device::Allows(Backend::CUDA_MASK))
+      if (useCuSparse)
       {
-         cusparseDestroy(handle);
-         CuMemFree(dBuffer);
+         if (SparseMatrixCount==1)
+         {
+            if (handle)
+            {
+               cusparseDestroy(handle);
+               handle = nullptr;
+            }
+            if (dBuffer)
+            {
+               CuMemFree(dBuffer);
+               dBuffer = nullptr;
+               bufferSize = 0;
+            }
+         }
+         SparseMatrixCount--;
       }
-      SparseMatrixCount--;
 #endif
    }
 


### PR DESCRIPTION
Currently, if the first `SparseMatrix` is generated without using CUDA, no subsequent `SparseMatrix` can use CUDA because the CUDA handle will not be initialized. This is fixed here.

Resolves #2026 
<!--GHEX{"id":2031,"author":"wcdawn","editor":"tzanio","reviewers":["artv3","YohannDudouit"],"assignment":"2021-02-19T11:05:34-08:00","approval":"2021-02-20T06:19:03.650Z","merge":"2021-02-27T01:42:06.209Z"}XEHG--><!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge| 
 | --- | --- | --- | --- | --- | --- | --- | 
| [#2031](https://github.com/mfem/mfem/pull/2031) | @wcdawn | @tzanio | @artv3 + @YohannDudouit | 02/19/21 | 02/19/21 | 02/26/21 | |
<!--ELBATXEHG-->