### PR TITLE
List initialization for Array/Vector/DenseMatrix

### DIFF
--- a/general/array.hpp
+++ b/general/array.hpp
@@ -78,6 +78,10 @@ public:
    template <typename CT>
    inline Array(const Array<CT> &src);
 
+   /// Deep copy from a braced init-list of convertible type
+   template <typename CT, int N>
+   explicit inline Array(const CT (&values)[N]);
+
    /// Destructor
    inline ~Array() { data.Delete(); }
 
@@ -629,6 +633,12 @@ inline Array<T>::Array(const Array<CT> &src)
 {
    size > 0 ? data.New(size) : data.Reset();
    for (int i = 0; i < size; i++) { (*this)[i] = T(src[i]); }
+}
+
+template <typename T> template <typename CT, int N>
+inline Array<T>::Array(const CT (&values)[N]) : Array(N)
+{
+   for (int i = 0; i < size; i++) { (*this)[i] = T(values[i]); }
 }
 
 template <class T>

--- a/linalg/densemat.hpp
+++ b/linalg/densemat.hpp
@@ -58,6 +58,20 @@ public:
    DenseMatrix(double *d, int h, int w)
       : Matrix(h, w) { UseExternalData(d, h, w); }
 
+   /// Create a dense matrix using a braced initializer list
+   template <int M, int N>
+   explicit DenseMatrix(const double (&values)[M][N]) : DenseMatrix(M, N)
+   {
+      // DenseMatrix is column-major so copies have to be element-wise
+      for (int i = 0; i < M; i++)
+      {
+         for (int j = 0; j < N; j++)
+         {
+            Elem(i,j) = values[i][j];
+         }
+      }
+   }
+
    /// Change the data array and the size of the DenseMatrix.
    /** The DenseMatrix does not assume ownership of the data array, i.e. it will
        not delete the data array @a d. This method should not be used with

--- a/linalg/densemat.hpp
+++ b/linalg/densemat.hpp
@@ -59,6 +59,7 @@ public:
       : Matrix(h, w) { UseExternalData(d, h, w); }
 
    /// Create a dense matrix using a braced initializer list
+   /// The inner lists correspond to rows of the matrix
    template <int M, int N>
    explicit DenseMatrix(const double (&values)[M][N]) : DenseMatrix(M, N)
    {

--- a/linalg/densemat.hpp
+++ b/linalg/densemat.hpp
@@ -67,7 +67,7 @@ public:
       {
          for (int j = 0; j < N; j++)
          {
-            Elem(i,j) = values[i][j];
+            (*this)(i,j) = values[i][j];
          }
       }
    }

--- a/linalg/vector.hpp
+++ b/linalg/vector.hpp
@@ -89,7 +89,7 @@ public:
    /// Create a vector using a braced initializer list
    template <int N>
    explicit Vector(const double (&values)[N]) : Vector(N)
-   {std::copy(values, values + N, GetData());}
+   { std::copy(values, values + N, GetData()); }
 
    /// Enable execution of Vector operations using the mfem::Device.
    /** The default is to use Backend::CPU (serial execution on each MPI rank),

--- a/linalg/vector.hpp
+++ b/linalg/vector.hpp
@@ -86,6 +86,11 @@ public:
    Vector(int size_, MemoryType mt)
       : data(size_, mt), size(size_) { }
 
+   /// Create a vector using a braced initializer list
+   template <int N>
+   explicit Vector(const double (&values)[N]) : Vector(N)
+   {std::copy(values, values + N, GetData());}
+
    /// Enable execution of Vector operations using the mfem::Device.
    /** The default is to use Backend::CPU (serial execution on each MPI rank),
        regardless of the mfem::Device configuration.

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -18,6 +18,7 @@ include_directories(BEFORE ${PROJECT_BINARY_DIR})
 include_directories(BEFORE ${CMAKE_CURRENT_SOURCE_DIR})
 
 set(UNIT_TESTS_SRCS
+  general/test_array.cpp
   general/test_mem.cpp
   general/test_text.cpp
   general/test_zlib.cpp

--- a/tests/unit/general/test_array.cpp
+++ b/tests/unit/general/test_array.cpp
@@ -1,0 +1,27 @@
+// Copyright (c) 2010-2021, Lawrence Livermore National Security, LLC. Produced
+// at the Lawrence Livermore National Laboratory. All Rights reserved. See files
+// LICENSE and NOTICE for details. LLNL-CODE-806117.
+//
+// This file is part of the MFEM library. For more information and source code
+// availability visit https://mfem.org.
+//
+// MFEM is free software; you can redistribute it and/or modify it under the
+// terms of the BSD-3 license. We welcome feedback and contributions, see file
+// CONTRIBUTING.md for details.
+
+#include "mfem.hpp"
+#include "unit_tests.hpp"
+
+using namespace mfem;
+
+TEST_CASE("Array init-list construction", "[Array]")
+{
+   int ContigData[6] = {6, 5, 4, 3, 2, 1};
+   Array<int> a(ContigData, 6);
+   Array<int> b({6.0, 5.0, 4.0, 3.0, 2.0, 1.0});
+
+   for (int i = 0; i < a.Size(); i++)
+   {
+      REQUIRE(a[i] == b[i]);
+   }
+}

--- a/tests/unit/linalg/test_matrix_dense.cpp
+++ b/tests/unit/linalg/test_matrix_dense.cpp
@@ -15,6 +15,25 @@
 
 using namespace mfem;
 
+TEST_CASE("DenseMatrix init-list construction", "[DenseMatrix]")
+{
+   double ContigData[6] = {6.0, 5.0,
+                           4.0, 3.0,
+                           2.0, 1.0
+                          };
+   DenseMatrix Contiguous(ContigData, 2, 3);
+
+   DenseMatrix Nested({{6.0, 4.0, 2.0}, {5.0, 3.0, 1.0}});
+
+   for (int i = 0; i < Contiguous.Height(); i++)
+   {
+      for (int j = 0; j < Contiguous.Width(); j++)
+      {
+         REQUIRE(Nested(i,j) == Contiguous(i,j));
+      }
+   }
+}
+
 TEST_CASE("DenseMatrix LinearSolve methods",
           "[DenseMatrix]")
 {

--- a/tests/unit/linalg/test_matrix_dense.cpp
+++ b/tests/unit/linalg/test_matrix_dense.cpp
@@ -17,13 +17,14 @@ using namespace mfem;
 
 TEST_CASE("DenseMatrix init-list construction", "[DenseMatrix]")
 {
-   double ContigData[6] = {6.0, 5.0,
-                           4.0, 3.0,
-                           2.0, 1.0
-                          };
+   double ContigData[6] = {6.0, 5.0, 4.0, 3.0, 2.0, 1.0};
    DenseMatrix Contiguous(ContigData, 2, 3);
 
-   DenseMatrix Nested({{6.0, 4.0, 2.0}, {5.0, 3.0, 1.0}});
+   DenseMatrix Nested(
+   {
+      {6.0, 4.0, 2.0},
+      {5.0, 3.0, 1.0}
+   });
 
    for (int i = 0; i < Contiguous.Height(); i++)
    {

--- a/tests/unit/linalg/test_vector.cpp
+++ b/tests/unit/linalg/test_vector.cpp
@@ -14,6 +14,21 @@
 
 using namespace mfem;
 
+TEST_CASE("Vector init-list construction", "[Vector]")
+{
+   double ContigData[6] = {6.0, 5.0,
+                           4.0, 3.0,
+                           2.0, 1.0
+                          };
+   Vector a(ContigData, 6);
+   Vector b({6.0, 5.0, 4.0, 3.0, 2.0, 1.0});
+
+   for (int i = 0; i < a.Size(); i++)
+   {
+      REQUIRE(a(i) == b(i));
+   }
+}
+
 TEST_CASE("Vector Tests", "[Vector]")
 {
    double tol = 1e-12;

--- a/tests/unit/linalg/test_vector.cpp
+++ b/tests/unit/linalg/test_vector.cpp
@@ -16,10 +16,7 @@ using namespace mfem;
 
 TEST_CASE("Vector init-list construction", "[Vector]")
 {
-   double ContigData[6] = {6.0, 5.0,
-                           4.0, 3.0,
-                           2.0, 1.0
-                          };
+   double ContigData[6] = {6.0, 5.0, 4.0, 3.0, 2.0, 1.0};
    Vector a(ContigData, 6);
    Vector b({6.0, 5.0, 4.0, 3.0, 2.0, 1.0});
 


### PR DESCRIPTION
This is a small enhancement that makes initialization a little easier.  Ownership of the array parameter is taken (i.e., via a deep copy) as the intended usage is with an immediate: `mfem::Vector vec({6, 7, 8})`.

These constructors are all marked `explicit` to avoid clashing with existing code.
<!--GHEX{"id":2034,"author":"joshessman-llnl","editor":"tzanio","reviewers":["jandrej","cjvogl","pazner"],"assignment":"2021-02-03T12:42:54-08:00","approval":"2021-02-05T00:48:14.944Z","merge":"2021-02-09T16:13:06.747Z"}XEHG--><!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge| 
 | --- | --- | --- | --- | --- | --- | --- | 
| [#2034](https://github.com/mfem/mfem/pull/2034) | @joshessman-llnl | @tzanio | @jandrej + @cjvogl + @pazner | 02/03/21 | 02/04/21 | 02/09/21 | |
<!--ELBATXEHG-->