### PR TITLE
Change int to PetscInt to support 64-bit indices in SLEPc

### DIFF
--- a/linalg/slepc.cpp
+++ b/linalg/slepc.cpp
@@ -183,7 +183,7 @@ int SlepcEigenSolver::GetNumConverged()
 {
    PetscInt num_conv;
    ierr = EPSGetConverged(eps,&num_conv); PCHKERRQ(eps,ierr);
-   return num_conv;
+   return static_cast<int>(num_conv);
 }
 
 void SlepcEigenSolver::SetWhichEigenpairs(SlepcEigenSolver::Which which)

--- a/linalg/slepc.cpp
+++ b/linalg/slepc.cpp
@@ -99,7 +99,7 @@ void SlepcEigenSolver::SetOperators(const PetscParMatrix &op,
 
 void SlepcEigenSolver::SetTol(double tol)
 {
-   int max_its;
+   PetscInt max_its;
 
    ierr = EPSGetTolerances(eps,NULL,&max_its); PCHKERRQ(eps,ierr);
    // Work around uninitialized maximum iterations
@@ -181,7 +181,7 @@ void SlepcEigenSolver::GetEigenvector(unsigned int i, Vector & vr,
 
 int SlepcEigenSolver::GetNumConverged()
 {
-   int num_conv;
+   PetscInt num_conv;
    ierr = EPSGetConverged(eps,&num_conv); PCHKERRQ(eps,ierr);
    return num_conv;
 }


### PR DESCRIPTION
Addressing an overflow problem in my code, I rebuilt METIS, HYPRE, PETSc, and SLEPc with 64-bit integers. Everything worked except the SLEPc code which failed to compile. This PR will allow 64-bit integers through the SLEPc interface.
<!--GHEX{"id":2049,"author":"wcdawn","editor":"tzanio","reviewers":["stefanozampini","tzanio"],"assignment":"2021-02-17T11:24:23-08:00","approval":"2021-02-17T19:26:51.602Z","merge":"2021-02-19T02:04:18.072Z"}XEHG--><!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge| 
 | --- | --- | --- | --- | --- | --- | --- | 
| [#2049](https://github.com/mfem/mfem/pull/2049) | @wcdawn | @tzanio | @stefanozampini + @tzanio | 02/17/21 | 02/17/21 | 02/18/21 | |
<!--ELBATXEHG-->