### PR TITLE
Update the CUDA version requirement

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -692,7 +692,7 @@ The specific libraries and their options are:
 - CUDA (optional), used when MFEM_USE_CUDA = YES.
   URL: https://developer.nvidia.com/cuda-toolkit
   Options: CUDA_CXX, CUDA_ARCH, CUDA_OPT, CUDA_LIB.
-  Versions: CUDA >= 9.1, older versions may work too.
+  Versions: CUDA >= 10.1.168.
 
 - HIP (optional), used when MFEM_USE_HIP = YES.
   URL: https://rocm.github.io/ROCmInstall.html


### PR DESCRIPTION
This has been wrong for some time, since cusparse was added, before the v4.2 release.
<!--GHEX{"id":2051,"author":"v-dobrev","editor":"tzanio","reviewers":["tzanio","artv3"],"assignment":"2021-02-12T21:41:20-08:00","approval":"2021-02-15T02:17:41.258Z","merge":"2021-02-15T20:00:12.619Z"}XEHG--><!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge| 
 | --- | --- | --- | --- | --- | --- | --- | 
| [#2051](https://github.com/mfem/mfem/pull/2051) | @v-dobrev | @tzanio | @tzanio + @artv3 | 02/12/21 | 02/14/21 | 02/15/21 | |
<!--ELBATXEHG-->