### PR TITLE
Bugfix for periodic NURBS meshes in parallel [periodic-nurbs-dev]

### DIFF
--- a/data/periodic-square-nurbs.mesh
+++ b/data/periodic-square-nurbs.mesh
@@ -1,0 +1,62 @@
+MFEM NURBS mesh v1.0
+
+#
+# MFEM Geometry Types (see mesh/geom.hpp):
+#
+# SEGMENT     = 1
+# SQUARE      = 3
+# CUBE        = 5
+#
+
+dimension
+2
+
+elements
+1
+1 3 0 1 2 3
+
+boundary
+4
+1 1 0 1
+3 1 2 3
+4 1 3 0
+2 1 1 2
+
+
+
+edges
+4
+0 0 1
+0 3 2
+1 0 3
+1 1 2
+
+vertices
+4
+
+knotvectors
+2
+1 2 0 0 1 1
+1 2 0 0 1 1
+
+periodic
+1 1
+1 3
+
+weights
+1
+1
+1
+1
+
+MFEM FiniteElementSpace v1.0
+FiniteElementCollection: NURBS
+VDim: 2
+Ordering: 1
+End: MFEM FiniteElementSpace v1.0
+
+0 0
+1 0
+1 1
+0 1
+

--- a/data/periodic-square-nurbs.mesh
+++ b/data/periodic-square-nurbs.mesh
@@ -22,8 +22,6 @@ boundary
 4 1 3 0
 2 1 1 2
 
-
-
 edges
 4
 0 0 1

--- a/fem/datacollection.cpp
+++ b/fem/datacollection.cpp
@@ -620,7 +620,7 @@ void VisItDataCollection::LoadFields()
       {
          if ((it->second).association == "nodes")
          {
-            field_map.Register(it->first, new GridFunction(mesh, file), own_data);
+            field_map.Register(it->first, new GridFunction(mesh, file, true), own_data);
          }
          else if ((it->second).association == "elements")
          {

--- a/fem/fespace.cpp
+++ b/fem/fespace.cpp
@@ -2376,7 +2376,8 @@ void FiniteElementSpace::Save(std::ostream &out) const
    }
 }
 
-FiniteElementCollection *FiniteElementSpace::Load(Mesh *m, std::istream &input)
+FiniteElementCollection *FiniteElementSpace::Load(Mesh *m, std::istream &input,
+                                                  bool connect)
 {
    string buff;
    int fes_format = 0, ord;
@@ -2471,7 +2472,7 @@ FiniteElementCollection *FiniteElementSpace::Load(Mesh *m, std::istream &input)
          }
       }
    }
-
+   if (connect && NURBSext) { NURBSext->ConnectBoundaries(); }
    Constructor(m, NURBSext, r_fec, vdim, ord);
 
    return r_fec;

--- a/fem/fespace.hpp
+++ b/fem/fespace.hpp
@@ -729,7 +729,7 @@ public:
 
    /** @brief Read a FiniteElementSpace from a stream. The returned
        FiniteElementCollection is owned by the caller. */
-   FiniteElementCollection *Load(Mesh *m, std::istream &input);
+   FiniteElementCollection *Load(Mesh *m, std::istream &input, bool connect=false);
 
    virtual ~FiniteElementSpace();
 };

--- a/fem/gridfunc.cpp
+++ b/fem/gridfunc.cpp
@@ -32,14 +32,14 @@ namespace mfem
 
 using namespace std;
 
-GridFunction::GridFunction(Mesh *m, std::istream &input)
+GridFunction::GridFunction(Mesh *m, std::istream &input, bool connect)
    : Vector()
 {
    // Grid functions are stored on the device
    UseDevice(true);
 
    fes = new FiniteElementSpace;
-   fec = fes->Load(m, input);
+   fec = fes->Load(m, input, connect);
 
    skip_comment_lines(input, '#');
    istream::int_type next_char = input.peek();

--- a/fem/gridfunc.hpp
+++ b/fem/gridfunc.hpp
@@ -99,7 +99,7 @@ public:
    /** The content of @a input should be in the format created by the method
        Save(). The reconstructed FiniteElementSpace and FiniteElementCollection
        are owned by the GridFunction. */
-   GridFunction(Mesh *m, std::istream &input);
+   GridFunction(Mesh *m, std::istream &input, bool connect = false);
 
    GridFunction(Mesh *m, GridFunction *gf_array[], int num_pieces);
 

--- a/mesh/nurbs.cpp
+++ b/mesh/nurbs.cpp
@@ -1520,9 +1520,6 @@ NURBSExtension::NURBSExtension(std::istream &input)
          weights = 1.0;
       }
    }
-
-   // periodic
-   ConnectBoundaries();
 }
 
 NURBSExtension::NURBSExtension(NURBSExtension *parent, int newOrder)
@@ -1573,7 +1570,6 @@ NURBSExtension::NURBSExtension(NURBSExtension *parent, int newOrder)
    // periodic
    parent->master.Copy(master);
    parent->slave.Copy(slave);
-   ConnectBoundaries();
 }
 
 NURBSExtension::NURBSExtension(NURBSExtension *parent,
@@ -1627,7 +1623,6 @@ NURBSExtension::NURBSExtension(NURBSExtension *parent,
 
    parent->master.Copy(master);
    parent->slave.Copy(slave);
-   ConnectBoundaries();
 }
 
 NURBSExtension::NURBSExtension(Mesh *mesh_array[], int num_pieces)
@@ -1672,6 +1667,9 @@ NURBSExtension::NURBSExtension(Mesh *mesh_array[], int num_pieces)
 
    weights.SetSize(GetNDof());
    MergeWeights(mesh_array, num_pieces);
+
+   parent->master.Copy(master);
+   parent->slave.Copy(slave);
 }
 
 NURBSExtension::~NURBSExtension()
@@ -1778,8 +1776,6 @@ void NURBSExtension::PrintFunctions(const char *basename, int samples) const
 
 void NURBSExtension::InitDofMap()
 {
-   master.SetSize(0);
-   slave.SetSize(0);
    d_to_d.SetSize(0);
 }
 
@@ -1787,7 +1783,6 @@ void NURBSExtension::ConnectBoundaries(Array<int> &bnds0, Array<int> &bnds1)
 {
    bnds0.Copy(master);
    bnds1.Copy(slave);
-   ConnectBoundaries();
 }
 
 void NURBSExtension::ConnectBoundaries()
@@ -3007,8 +3002,6 @@ void NURBSExtension::SetKnotsFromPatches()
    GenerateElementDofTable();
    GenerateActiveBdrElems();
    GenerateBdrElementDofTable();
-
-   ConnectBoundaries();
 }
 
 void NURBSExtension::LoadSolution(std::istream &input, GridFunction &sol) const
@@ -3341,7 +3334,8 @@ ParNURBSExtension::ParNURBSExtension(MPI_Comm comm, NURBSExtension *parent,
    }
    own_topo = 1;
    parent->own_topo = 0;
-
+   parent->master.Copy(master);
+   parent->slave.Copy(slave);
    parent->edge_to_knot.Copy(edge_to_knot);
 
    parent->GetOrders().Copy(mOrders);
@@ -3545,7 +3539,7 @@ Table *ParNURBSExtension::Get2DGlobalElementDofTable()
                   {
                      for (int ii = 0; ii <= ord0; ii++)
                      {
-                        conn.to = p2g(i+ii,j+jj);
+                        conn.to = DofMap(p2g(i+ii,j+jj));
                         gel_dof_list.Append(conn);
                      }
                   }
@@ -3593,7 +3587,7 @@ Table *ParNURBSExtension::Get3DGlobalElementDofTable()
                            {
                               for (int ii = 0; ii <= ord0; ii++)
                               {
-                                 conn.to = p2g(i+ii,j+jj,k+kk);
+                                 conn.to = DofMap(p2g(i+ii,j+jj,k+kk));
                                  gel_dof_list.Append(conn);
                               }
                            }

--- a/mesh/nurbs.cpp
+++ b/mesh/nurbs.cpp
@@ -1381,7 +1381,6 @@ NURBSExtension::NURBSExtension(std::istream &input)
    // CheckBdrPatches();
 
    skip_comment_lines(input, '#');
-
    // Read knotvectors or patches
    string ident;
    input >> ws >> ident; // 'knotvectors' or 'patches'
@@ -1497,7 +1496,7 @@ NURBSExtension::NURBSExtension(std::istream &input)
    GenerateActiveBdrElems();
    GenerateBdrElementDofTable();
 
-   // periodic
+   // Read periodicity info
    if (ident == "periodic")
    {
       master.Load(input);
@@ -1507,9 +1506,9 @@ NURBSExtension::NURBSExtension(std::istream &input)
       input >> ws >> ident;
    }
 
+   // Read weights
    if (patches.Size() == 0)
    {
-      // weights
       if (ident == "weights")
       {
          weights.Load(input, GetNDof());
@@ -1717,6 +1716,13 @@ void NURBSExtension::Print(std::ostream &out) const
             }
       }
 
+      if (master.Size() > 0)
+      {
+         out << "\nperiodic\n";
+         master.Save(out);
+         slave.Save(out);
+      }
+
       out << "\nweights\n";
       weights.Print(out, 1);
    }
@@ -1728,6 +1734,14 @@ void NURBSExtension::Print(std::ostream &out) const
          out << "\n# patch " << p << "\n\n";
          patches[p]->Print(out);
       }
+
+      if (master.Size() > 0)
+      {
+         out << "\nperiodic\n";
+         master.Save(out);
+         slave.Save(out);
+      }
+
    }
 }
 

--- a/mesh/nurbs.hpp
+++ b/mesh/nurbs.hpp
@@ -235,7 +235,6 @@ protected:
 
    // periodic BC helper functions
    void InitDofMap();
-   void ConnectBoundaries();
    void ConnectBoundaries2D(int bnd0, int bnd1);
    void ConnectBoundaries3D(int bnd0, int bnd1);
    int DofMap(int dof) const
@@ -320,6 +319,7 @@ public:
    NURBSExtension(Mesh *mesh_array[], int num_pieces);
 
    // Generate connections between boundaries, such as periodic BCs
+   void ConnectBoundaries();
    void ConnectBoundaries(Array<int> &master, Array<int> &slave);
    const Array<int> &GetMaster() const { return  master; };
    Array<int> &GetMaster()  { return  master; };

--- a/miniapps/nurbs/CMakeLists.txt
+++ b/miniapps/nurbs/CMakeLists.txt
@@ -51,6 +51,10 @@ add_test(NAME nurbs_ex1_weak_patch_format_r1_ser
   COMMAND $<TARGET_FILE:nurbs_ex1> -no-vis
   -m ${PROJECT_SOURCE_DIR}/data/square-disc-nurbs-patch.mesh -o 2 --weak-bc -r 1)
 
+add_test(NAME nurbs_ex1_periodic_r1_ser
+  COMMAND $<TARGET_FILE:nurbs_ex1> -no-vis
+  -m ${PROJECT_SOURCE_DIR}/data/periodic-square-nurbs.mesh -o 2 -r 1)
+
 if (MFEM_USE_MPI)
   add_mfem_miniapp(nurbs_ex1p
     MAIN nurbs_ex1p.cpp
@@ -73,15 +77,20 @@ if (MFEM_USE_MPI)
     -m ${PROJECT_SOURCE_DIR}/data/ball-nurbs.mesh -o 2 --weak-bc -r 0
     ${MPIEXEC_POSTFLAGS})
 
-add_test(NAME nurbs_ex1_weak_patch_format_np=4
+  add_test(NAME nurbs_ex1_weak_patch_format_np=4
     COMMAND ${MPIEXEC} ${MPIEXEC_NUMPROC_FLAG} ${MFEM_MPI_NP}
     ${MPIEXEC_PREFLAGS}  $<TARGET_FILE:nurbs_ex1p> -no-vis
     -m ${PROJECT_SOURCE_DIR}/data/square-disc-nurbs-patch.mesh -o 2 --weak-bc -r 0)
 
-add_test(NAME nurbs_ex1_weak_patch_format_r1_np=4
+  add_test(NAME nurbs_ex1_weak_patch_format_r1_np=4
     COMMAND ${MPIEXEC} ${MPIEXEC_NUMPROC_FLAG} ${MFEM_MPI_NP}
     ${MPIEXEC_PREFLAGS}  $<TARGET_FILE:nurbs_ex1p> -no-vis
     -m ${PROJECT_SOURCE_DIR}/data/square-disc-nurbs-patch.mesh -o 2 --weak-bc -r 1)
+
+  add_test(NAME nurbs_ex1_periodic_r1_np=4
+    COMMAND ${MPIEXEC} ${MPIEXEC_NUMPROC_FLAG} ${MFEM_MPI_NP}
+    ${MPIEXEC_PREFLAGS} $<TARGET_FILE:nurbs_ex1p> -no-vis
+    -m ${PROJECT_SOURCE_DIR}/data/periodic-square-nurbs.mesh -o 2 -r 1)
 
   add_mfem_miniapp(nurbs_ex11p
     MAIN nurbs_ex11p.cpp

--- a/miniapps/nurbs/nurbs_ex1.cpp
+++ b/miniapps/nurbs/nurbs_ex1.cpp
@@ -223,23 +223,7 @@ int main(int argc, char *argv[])
 
       if (order.Size() != nkv ) { mfem_error("Wrong number of orders set."); }
       NURBSext = new NURBSExtension(mesh->NURBSext, order);
-
-      // Read periodic BCs from file
-      std::ifstream in;
-      in.open(per_file, std::ifstream::in);
-      if (in.is_open())
-      {
-         int psize;
-         in >> psize;
-         master.SetSize(psize);
-         slave.SetSize(psize);
-         master.Load(in, psize);
-         slave.Load(in, psize);
-         in.close();
-      }
-      master.Print();
-      slave.Print();
-      NURBSext->ConnectBoundaries(master,slave);
+      NURBSext->ConnectBoundaries();
    }
    else if (order[0] == -1) // Isoparametric
    {
@@ -306,12 +290,16 @@ int main(int argc, char *argv[])
       {
          ess_bdr = 0;
       }
-
-      // Remove periodic BCs
-      for (int i = 0; i < master.Size(); i++)
+      if ( NURBSext)
       {
-         ess_bdr[master[i]-1] = 0;
-         ess_bdr[slave[i]-1] = 0;
+         Array<int> master = NURBSext->GetMaster();
+         Array<int> slave = NURBSext->GetSlave();
+         // Remove periodic BCs
+         for (int i = 0; i < master.Size(); i++)
+         {
+            ess_bdr[master[i]-1] = 0;
+            ess_bdr[slave[i]-1] = 0;
+         }
       }
       fespace->GetEssentialTrueDofs(ess_bdr, ess_tdof_list);
    }

--- a/miniapps/nurbs/nurbs_ex11p.cpp
+++ b/miniapps/nurbs/nurbs_ex11p.cpp
@@ -185,6 +185,7 @@ int main(int argc, char *argv[])
       }
       if (order.Size() != nkv ) { mfem_error("Wrong number of orders set."); }
       NURBSext = new NURBSExtension(pmesh->NURBSext, order);
+      NURBSext->ConnectBoundaries();
    }
    else
    {


### PR DESCRIPTION
This PR fixes a bug that precluded running periodic BCs in parallel.
It also fixes some issues when specifying the periodicity in the mesh file instead of a seperate file.

Please not, one important issue here is that the fespace for the nodal values  remains non-periodic. While the fespaces for the solutions are, that is the reason for the extra "ConnectBoundaries()" calls. This could potentially also been done by including a flag to the constructor params.