### PR TITLE
Consistent order/degree in variable order spaces [var-order-space-no-degree]

### DIFF
--- a/fem/estimators.cpp
+++ b/fem/estimators.cpp
@@ -192,7 +192,7 @@ void KellyErrorEstimator::ComputeEstimates()
    {
       auto FT = pmesh->GetFaceElementTransformations(f);
 
-      auto &int_rule = IntRules.Get(FT->FaceGeom, 2*xfes->GetFaceDegree(f));
+      auto &int_rule = IntRules.Get(FT->FaceGeom, 2 * xfes->GetFaceOrder(f));
       const auto nip = int_rule.GetNPoints();
 
       if (pmesh->FaceIsInterior(f))
@@ -314,7 +314,7 @@ void KellyErrorEstimator::ComputeEstimates()
          continue;
       }
 
-      auto &int_rule = IntRules.Get(FT->FaceGeom, 2*xfes->GetFaceDegree(0));
+      auto &int_rule = IntRules.Get(FT->FaceGeom, 2 * xfes->GetFaceOrder(0));
       const auto nip = int_rule.GetNPoints();
 
       IntegrationRule eir;

--- a/fem/fe_coll.cpp
+++ b/fem/fe_coll.cpp
@@ -2232,11 +2232,12 @@ L2_FECollection::~L2_FECollection()
 }
 
 
-RT_FECollection::RT_FECollection(const int p, const int dim,
+RT_FECollection::RT_FECollection(const int order, const int dim,
                                  const int cb_type, const int ob_type)
-   : FiniteElementCollection(p)
+   : FiniteElementCollection(order + 1)
    , ob_type(ob_type)
 {
+   int p = order;
    MFEM_VERIFY(p >= 0, "RT_FECollection requires order >= 0.");
 
    int cp_type = BasisType::GetQuadrature1D(cb_type);

--- a/fem/fe_coll.cpp
+++ b/fem/fe_coll.cpp
@@ -2790,6 +2790,7 @@ Local_FECollection::Local_FECollection(const char *fe_name)
 
 
 NURBSFECollection::NURBSFECollection(int Order)
+   : FiniteElementCollection((Order == VariableOrder) ? 1 : Order)
 {
    const int order = (Order == VariableOrder) ? 1 : Order;
    SegmentFE        = new NURBS1DFiniteElement(order);

--- a/fem/fe_coll.hpp
+++ b/fem/fe_coll.hpp
@@ -495,7 +495,7 @@ private:
    const TriLinear3DFiniteElement ParallelepipedFE;
    const H1_WedgeElement WedgeFE;
 public:
-   LinearFECollection() : WedgeFE(1) { }
+   LinearFECollection() : FiniteElementCollection(1), WedgeFE(1) { }
 
    virtual const FiniteElement *
    FiniteElementForGeometry(Geometry::Type GeomType) const;
@@ -523,7 +523,8 @@ private:
    const H1_WedgeElement WedgeFE;
 
 public:
-   QuadraticFECollection() : ParallelepipedFE(2), WedgeFE(2) { }
+   QuadraticFECollection()
+      : FiniteElementCollection(2), ParallelepipedFE(2), WedgeFE(2) { }
 
    virtual const FiniteElement *
    FiniteElementForGeometry(Geometry::Type GeomType) const;
@@ -546,7 +547,7 @@ private:
    const BiQuadPos2DFiniteElement QuadrilateralFE;
 
 public:
-   QuadraticPosFECollection() { }
+   QuadraticPosFECollection() : FiniteElementCollection(2) { }
 
    virtual const FiniteElement *
    FiniteElementForGeometry(Geometry::Type GeomType) const;
@@ -575,7 +576,9 @@ private:
 
 public:
    CubicFECollection()
-      : ParallelepipedFE(3), WedgeFE(3, BasisType::ClosedUniform) { }
+      : FiniteElementCollection(3),
+        ParallelepipedFE(3), WedgeFE(3, BasisType::ClosedUniform)
+   { }
 
    virtual const FiniteElement *
    FiniteElementForGeometry(Geometry::Type GeomType) const;
@@ -598,7 +601,7 @@ private:
    const CrouzeixRaviartFiniteElement TriangleFE;
    const CrouzeixRaviartQuadFiniteElement QuadrilateralFE;
 public:
-   CrouzeixRaviartFECollection() : SegmentFE(1) { }
+   CrouzeixRaviartFECollection() : FiniteElementCollection(1), SegmentFE(1) { }
 
    virtual const FiniteElement *
    FiniteElementForGeometry(Geometry::Type GeomType) const;
@@ -623,7 +626,7 @@ private:
    const RotTriLinearHexFiniteElement ParallelepipedFE;
 
 public:
-   LinearNonConf3DFECollection () { }
+   LinearNonConf3DFECollection() : FiniteElementCollection(1) { }
 
    virtual const FiniteElement *
    FiniteElementForGeometry(Geometry::Type GeomType) const;
@@ -648,7 +651,7 @@ private:
    const RT0TriangleFiniteElement TriangleFE;
    const RT0QuadFiniteElement QuadrilateralFE;
 public:
-   RT0_2DFECollection() : SegmentFE(0) { }
+   RT0_2DFECollection() : FiniteElementCollection(1), SegmentFE(0) { }
 
    virtual const FiniteElement *
    FiniteElementForGeometry(Geometry::Type GeomType) const;
@@ -672,7 +675,7 @@ private:
    const RT1TriangleFiniteElement TriangleFE;
    const RT1QuadFiniteElement QuadrilateralFE;
 public:
-   RT1_2DFECollection() { }
+   RT1_2DFECollection() : FiniteElementCollection(2) { }
 
    virtual const FiniteElement *
    FiniteElementForGeometry(Geometry::Type GeomType) const;
@@ -696,7 +699,7 @@ private:
    const RT2TriangleFiniteElement TriangleFE;
    const RT2QuadFiniteElement QuadrilateralFE;
 public:
-   RT2_2DFECollection() { }
+   RT2_2DFECollection() : FiniteElementCollection(3) { }
 
    virtual const FiniteElement *
    FiniteElementForGeometry(Geometry::Type GeomType) const;
@@ -720,7 +723,7 @@ private:
    const P0TriangleFiniteElement TriangleFE;
    const P0QuadFiniteElement QuadrilateralFE;
 public:
-   Const2DFECollection() { }
+   Const2DFECollection() : FiniteElementCollection(0) { }
 
    virtual const FiniteElement *
    FiniteElementForGeometry(Geometry::Type GeomType) const;
@@ -745,7 +748,7 @@ private:
    const BiLinear2DFiniteElement QuadrilateralFE;
 
 public:
-   LinearDiscont2DFECollection() { }
+   LinearDiscont2DFECollection() : FiniteElementCollection(1) { }
 
    virtual const FiniteElement *
    FiniteElementForGeometry(Geometry::Type GeomType) const;
@@ -769,7 +772,7 @@ private:
    const GaussBiLinear2DFiniteElement QuadrilateralFE;
 
 public:
-   GaussLinearDiscont2DFECollection() { }
+   GaussLinearDiscont2DFECollection() : FiniteElementCollection(1) { }
 
    virtual const FiniteElement *
    FiniteElementForGeometry(Geometry::Type GeomType) const;
@@ -790,7 +793,7 @@ class P1OnQuadFECollection : public FiniteElementCollection
 private:
    const P1OnQuadFiniteElement QuadrilateralFE;
 public:
-   P1OnQuadFECollection() { }
+   P1OnQuadFECollection() : FiniteElementCollection(1) { }
    virtual const FiniteElement *
    FiniteElementForGeometry(Geometry::Type GeomType) const;
    virtual int DofForGeometry(Geometry::Type GeomType) const;
@@ -810,7 +813,7 @@ private:
    const BiQuad2DFiniteElement QuadrilateralFE;
 
 public:
-   QuadraticDiscont2DFECollection() { }
+   QuadraticDiscont2DFECollection() : FiniteElementCollection(2) { }
 
    virtual const FiniteElement *
    FiniteElementForGeometry(Geometry::Type GeomType) const;
@@ -831,7 +834,7 @@ private:
    const BiQuadPos2DFiniteElement QuadrilateralFE;
 
 public:
-   QuadraticPosDiscont2DFECollection() { }
+   QuadraticPosDiscont2DFECollection() : FiniteElementCollection(2) { }
    virtual const FiniteElement *
    FiniteElementForGeometry(Geometry::Type GeomType) const;
    virtual int DofForGeometry(Geometry::Type GeomType) const;
@@ -851,7 +854,7 @@ private:
    const GaussBiQuad2DFiniteElement QuadrilateralFE;
 
 public:
-   GaussQuadraticDiscont2DFECollection() { }
+   GaussQuadraticDiscont2DFECollection() : FiniteElementCollection(2) { }
 
    virtual const FiniteElement *
    FiniteElementForGeometry(Geometry::Type GeomType) const;
@@ -875,7 +878,7 @@ private:
    const BiCubic2DFiniteElement QuadrilateralFE;
 
 public:
-   CubicDiscont2DFECollection() { }
+   CubicDiscont2DFECollection() : FiniteElementCollection(3) { }
 
    virtual const FiniteElement *
    FiniteElementForGeometry(Geometry::Type GeomType) const;
@@ -900,7 +903,7 @@ private:
    const L2_WedgeElement WedgeFE;
 
 public:
-   Const3DFECollection() : WedgeFE(0) { }
+   Const3DFECollection() : FiniteElementCollection(0), WedgeFE(0) { }
 
    virtual const FiniteElement *
    FiniteElementForGeometry(Geometry::Type GeomType) const;
@@ -924,7 +927,7 @@ private:
    const TriLinear3DFiniteElement ParallelepipedFE;
 
 public:
-   LinearDiscont3DFECollection () { }
+   LinearDiscont3DFECollection() : FiniteElementCollection(1) { }
 
    virtual const FiniteElement *
    FiniteElementForGeometry(Geometry::Type GeomType) const;
@@ -948,7 +951,8 @@ private:
    const LagrangeHexFiniteElement ParallelepipedFE;
 
 public:
-   QuadraticDiscont3DFECollection () : ParallelepipedFE(2) { }
+   QuadraticDiscont3DFECollection()
+      : FiniteElementCollection(2), ParallelepipedFE(2) { }
 
    virtual const FiniteElement *
    FiniteElementForGeometry(Geometry::Type GeomType) const;
@@ -974,7 +978,7 @@ private:
    const RefinedTriLinear3DFiniteElement ParallelepipedFE;
 
 public:
-   RefinedLinearFECollection() { }
+   RefinedLinearFECollection() : FiniteElementCollection(1) { }
 
    virtual const FiniteElement *
    FiniteElementForGeometry(Geometry::Type GeomType) const;
@@ -998,7 +1002,7 @@ private:
    const Nedelec1TetFiniteElement TetrahedronFE;
 
 public:
-   ND1_3DFECollection() { }
+   ND1_3DFECollection() : FiniteElementCollection(1) { }
 
    virtual const FiniteElement *
    FiniteElementForGeometry(Geometry::Type GeomType) const;
@@ -1022,7 +1026,7 @@ private:
    const RT0HexFiniteElement HexahedronFE;
    const RT0TetFiniteElement TetrahedronFE;
 public:
-   RT0_3DFECollection() { }
+   RT0_3DFECollection() : FiniteElementCollection(1) { }
 
    virtual const FiniteElement *
    FiniteElementForGeometry(Geometry::Type GeomType) const;
@@ -1045,7 +1049,7 @@ private:
    const BiLinear2DFiniteElement QuadrilateralFE;
    const RT1HexFiniteElement HexahedronFE;
 public:
-   RT1_3DFECollection() { }
+   RT1_3DFECollection() : FiniteElementCollection(2) { }
 
    virtual const FiniteElement *
    FiniteElementForGeometry(Geometry::Type GeomType) const;

--- a/fem/fe_coll.hpp
+++ b/fem/fe_coll.hpp
@@ -178,7 +178,8 @@ public:
       return var_orders[p]->DofOrderForOrientation(geom, ori);
    }
 
-   /// Return the order the FE collection was constructed with.
+   /** Return the polynomial degree of the FE collection (corresponds also to
+       the degree returned by GetOrder() of the contained FiniteElements).*/
    int GetOrder() const { return base_p; }
 
 protected:
@@ -343,7 +344,11 @@ protected:
                    const int ob_type = BasisType::GaussLegendre);
 
 public:
-   RT_FECollection(const int p, const int dim,
+   /** Construct an RT<order> collection. Note that in accordance with the
+       literature, the polynomial degree of RT<order> collection is (order+1).
+       For example, RT0 collection contains vector-valued linear functions.
+       FiniteElementCollection::GetOrder() will then return 1. */
+   RT_FECollection(const int order, const int dim,
                    const int cb_type = BasisType::GaussLobatto,
                    const int ob_type = BasisType::GaussLegendre);
 

--- a/fem/fespace.cpp
+++ b/fem/fespace.cpp
@@ -2189,6 +2189,17 @@ int FiniteElementSpace::GetEdgeOrder(int edge, int variant) const
    return var_edge_orders[var_edge_dofs.GetI()[edge] + variant];
 }
 
+int FiniteElementSpace::GetFaceOrder(int face, int variant) const
+{
+   if (!IsVariableOrder()) { return fec->GetOrder(); }
+
+   const int* beg = var_face_dofs.GetRow(face);
+   const int* end = var_face_dofs.GetRow(face + 1);
+   if (variant >= end - beg) { return -1; } // past last variant
+
+   return var_face_orders[var_face_dofs.GetI()[face] + variant];
+}
+
 int FiniteElementSpace::GetNVariants(int entity, int index) const
 {
    MFEM_ASSERT(IsVariableOrder(), "");

--- a/fem/fespace.cpp
+++ b/fem/fespace.cpp
@@ -2315,6 +2315,19 @@ const FiniteElement *FiniteElementSpace::GetFE(int i) const
    {
       NURBSext->LoadFE(i, FE);
    }
+   else
+   {
+#ifdef MFEM_DEBUG
+      // consistency check: fec->GetOrder() and FE->GetOrder() should return
+      // the same value (for standard, constant-order spaces)
+      if (!IsVariableOrder() && FE->GetDim() > 0)
+      {
+         MFEM_ASSERT(FE->GetOrder() == fec->GetOrder(),
+                     "internal error: " <<
+                     FE->GetOrder() << " != " << fec->GetOrder());
+      }
+#endif
+   }
 
    return FE;
 }

--- a/fem/fespace.hpp
+++ b/fem/fespace.hpp
@@ -352,10 +352,6 @@ protected:
                     const FiniteElementCollection *fec,
                     int vdim = 1, int ordering = Ordering::byNODES);
 
-   /** Return the order of an edge. In a variable order space, return the order
-       of a specific variant, or -1 if there are no more variants. */
-   int GetEdgeOrder(int edge, int variant = 0) const;
-
    /// Resize the elem_order array on mesh change.
    void UpdateElementOrders();
 
@@ -411,8 +407,6 @@ public:
    void SetElementOrder(int i, int p);
 
    /// Returns the order of the i'th finite element.
-   /** @note This is the 'order' of the FiniteElementCollection. The actual
-       polynomial degree may differ for RT elements, see @a GetElementDegree().*/
    int GetElementOrder(int i) const;
 
    /// Return the maximum polynomial order.
@@ -510,26 +504,19 @@ public:
    const FaceQuadratureInterpolator *GetFaceQuadratureInterpolator(
       const IntegrationRule &ir, FaceType type) const;
 
-   /// Returns vector dimension.
-   inline int GetVDim() const { return vdim; }
-
-   /// Returns the polynomial degree of the i'th element.
-   /** This is normally the same as GetElementOrder(i), except for RT finite
-       element spaces, where the actual degree of the RTp collection is p+1.*/
-   int GetElementDegree(int i) const { return GetFE(i)->GetOrder(); }
-
-   /** Returns the polynomial degree of the FiniteElement associated with the
-       i'th face. This is normally the same as the order of the FE collection,
-       except for RTp collections, where the actual polynomial degree is p+1.*/
-   int GetFaceDegree(int i) const { return GetFaceElement(i)->GetOrder(); }
-
    /// Returns the polynomial degree of the i'th finite element.
-   /** Deprecated: please use @a GetElementDegree instead. */
-   MFEM_DEPRECATED int GetOrder(int i) const { return GetElementDegree(i); }
+   /** NOTE: it is recommended to use GetElementOrder in new code. */
+   int GetOrder(int i) const { return GetElementOrder(i); }
+
+   /** Return the order of an edge. In a variable order space, return the order
+       of a specific variant, or -1 if there are no more variants. */
+   int GetEdgeOrder(int edge, int variant = 0) const;
 
    /// Returns the polynomial degree of the i'th face finite element
-   /** Deprecated: please use @a GetFaceDegree instead. */
-   MFEM_DEPRECATED int GetFaceOrder(int i) const { return GetFaceDegree(i); }
+   int GetFaceOrder(int face, int variant = 0) const;
+
+   /// Returns vector dimension.
+   inline int GetVDim() const { return vdim; }
 
    /// Returns number of degrees of freedom.
    inline int GetNDofs() const { return ndofs; }

--- a/linalg/hypre.cpp
+++ b/linalg/hypre.cpp
@@ -3917,12 +3917,12 @@ void HypreAMS::Init(ParFiniteElementSpace *edge_fespace)
       MFEM_VERIFY(!edge_fespace->IsVariableOrder(), "");
       if (trace_space)
       {
-         p = edge_fespace->GetFaceDegree(0);
+         p = edge_fespace->GetFaceOrder(0);
          if (dim == 2) { p++; }
       }
       else
       {
-         p = edge_fespace->GetElementDegree(0);
+         p = edge_fespace->GetElementOrder(0);
       }
    }
 
@@ -4147,11 +4147,11 @@ void HypreADS::Init(ParFiniteElementSpace *face_fespace)
       MFEM_VERIFY(!face_fespace->IsVariableOrder(), "");
       if (trace_space)
       {
-         p = face_fespace->GetFaceDegree(0) + 1;
+         p = face_fespace->GetFaceOrder(0) + 1;
       }
       else
       {
-         p = face_fespace->GetElementDegree(0);
+         p = face_fespace->GetElementOrder(0);
       }
    }
 

--- a/linalg/petsc.cpp
+++ b/linalg/petsc.cpp
@@ -3061,11 +3061,11 @@ void PetscBDDCSolver::BDDCSolverConstructor(const PetscBDDCSolverParams &opts)
       {
          if (!tracespace)
          {
-            p = fespace->GetElementDegree(0);
+            p = fespace->GetElementOrder(0);
          }
          else
          {
-            p = fespace->GetFaceDegree(0);
+            p = fespace->GetFaceOrder(0);
             if (dim == 2) { p++; }
          }
       }

--- a/mesh/mesh.cpp
+++ b/mesh/mesh.cpp
@@ -4282,7 +4282,7 @@ void Mesh::EnsureNodes()
       }
       else // Mesh using a legacy FE_Collection
       {
-         const int order = GetNodalFESpace()->GetElementDegree(0);
+         const int order = GetNodalFESpace()->GetElementOrder(0);
          SetCurvature(order, false, -1, Ordering::byVDIM);
       }
    }
@@ -9215,7 +9215,7 @@ void Mesh::PrintVTU(std::string fname,
                     bool bdr)
 {
    int ref = (high_order_output && Nodes)
-             ? Nodes->FESpace()->GetElementDegree(0) : 1;
+             ? Nodes->FESpace()->GetElementOrder(0) : 1;
 
    fname = fname + ".vtu";
    std::fstream out(fname.c_str(),std::ios::out);

--- a/miniapps/gslib/field-diff.cpp
+++ b/miniapps/gslib/field-diff.cpp
@@ -75,7 +75,7 @@ int main (int argc, char *argv[])
    // The Nodes GridFunctions for each mesh are required.
    if (mesh_1.GetNodes() == NULL) { mesh_1.SetCurvature(1, false, dim, 0); }
    if (mesh_2.GetNodes() == NULL) { mesh_2.SetCurvature(1, false, dim, 0); }
-   const int mesh_poly_deg = mesh_1.GetNodes()->FESpace()->GetElementDegree(0);
+   const int mesh_poly_deg = mesh_1.GetNodes()->FESpace()->GetElementOrder(0);
    cout << "Mesh curvature: "
         << mesh_1.GetNodes()->OwnFEC()->Name() << " " << mesh_poly_deg << endl;
 

--- a/miniapps/gslib/field-interp.cpp
+++ b/miniapps/gslib/field-interp.cpp
@@ -112,7 +112,7 @@ int main (int argc, char *argv[])
    if (mesh_1.GetNodes() == NULL) { mesh_1.SetCurvature(1); }
    if (mesh_2.GetNodes() == NULL) { mesh_2.SetCurvature(1); }
    const int mesh_poly_deg =
-      mesh_2.GetNodes()->FESpace()->GetElementDegree(0);
+      mesh_2.GetNodes()->FESpace()->GetElementOrder(0);
    cout << "Source mesh curvature: "
         << mesh_1.GetNodes()->OwnFEC()->Name() << endl
         << "Target mesh curvature: "

--- a/miniapps/meshing/extruder.cpp
+++ b/miniapps/meshing/extruder.cpp
@@ -105,7 +105,7 @@ int main(int argc, char *argv[])
    int meshOrder = 1;
    if (mesh->GetNodalFESpace() != NULL)
    {
-      meshOrder = mesh->GetNodalFESpace()->GetElementDegree(0);
+      meshOrder = mesh->GetNodalFESpace()->GetElementOrder(0);
    }
    if (order < 0 && trans)
    {

--- a/miniapps/navier/navier_solver.cpp
+++ b/miniapps/navier/navier_solver.cpp
@@ -878,7 +878,7 @@ double NavierSolver::ComputeCFL(ParGridFunction &u, double dt)
       }
 
       double hmin = pmesh->GetElementSize(e, 1) /
-                    (double) fes->GetElementDegree(0);
+                    (double) fes->GetElementOrder(0);
 
       for (int i = 0; i < ir.GetNPoints(); ++i)
       {

--- a/tests/unit/fem/test_pa_kernels.cpp
+++ b/tests/unit/fem/test_pa_kernels.cpp
@@ -360,7 +360,7 @@ void test_pa_convection(const char *meshname, int order, int prob)
    INFO("mesh=" << meshname << ", order=" << order << ", prob=" << prob);
    Mesh mesh(meshname, 1, 1);
    mesh.EnsureNodes();
-   mesh.SetCurvature(mesh.GetNodalFESpace()->GetElementDegree(0));
+   mesh.SetCurvature(mesh.GetNodalFESpace()->GetElementOrder(0));
    int dim = mesh.Dimension();
 
    FiniteElementCollection *fec;

--- a/tests/unit/miniapps/test_sedov.cpp
+++ b/tests/unit/miniapps/test_sedov.cpp
@@ -1512,7 +1512,7 @@ void QUpdate::UpdateQuadratureData(const Vector &S,
    Vector* S_p = const_cast<Vector*>(&S);
    const int H1_size = H1.GetVSize();
    const int nqp1D = tensors1D->LQshape1D.Width();
-   const double h1order = (double) H1.GetElementDegree(0);
+   const double h1order = (double) H1.GetElementOrder(0);
    const double infinity = std::numeric_limits<double>::infinity();
    GridFunction d_x, d_v, d_e;
    d_x.MakeRef(&H1,*S_p, 0);
@@ -1645,8 +1645,8 @@ public:
       Me_inv(l2dofs_cnt, l2dofs_cnt, nzones),
       integ_rule(IntRules.Get(h1_fes.GetMesh()->GetElementBaseGeometry(0),
                               (order_q > 0) ? order_q :
-                              3*h1_fes.GetElementDegree(0)
-                              + l2_fes.GetElementDegree(0) - 1)),
+                              3*h1_fes.GetElementOrder(0)
+                              + l2_fes.GetElementOrder(0) - 1)),
       quad_data(dim, nzones, integ_rule.GetNPoints()),
       quad_data_is_current(false), forcemat_is_assembled(false),
       T1D(H1FESpace.GetFE(0)->GetOrder(), L2FESpace.GetFE(0)->GetOrder(),
@@ -1710,7 +1710,7 @@ public:
             quad_data.h0 = pow(glob_area / glob_z_cnt, 1.0/3.0); break;
          default: MFEM_ABORT("Unknown zone type!");
       }
-      quad_data.h0 /= (double) H1FESpace.GetElementDegree(0);
+      quad_data.h0 /= (double) H1FESpace.GetElementOrder(0);
       {
          Vector d;
          (dim == 2) ? VMassPA->ComputeDiagonal2D(d) : VMassPA->ComputeDiagonal3D(d);


### PR DESCRIPTION
This is a modification of #1817 to resolve the problem of `FiniteElementSpace::GetElementOrder` and `GetElementDegree` returning different values for RT spaces. 

In this version, the vast majority of the code works with a single meaning of "order", which is the polynomial degree. The order of elements in `FiniteElementSpace` is the actual degree, which should match the return value of `FiniteElement::GetOrder`. The methods `GetElementDegree` and `GetFaceDegree` are gone. `FiniteElementSpace::GetOrder` is no longer deprecated and returns the same thing as `GetElementOrder`.

The only deviation is limited to `RT_FiniteElementCollection`, which takes an "order" in the RT sense, e.g., 0 means linear polynomials. `GetOrder` in the `FiniteElementCollection` base class will however return 1, and the default order of elements in the space is also 1. 

Also added a consistency check inside `FiniteElementSpace::GetFE` which verifies that `FiniteElementCollection::GetOrder` returns the same thing as `FiniteElement::GetOrder` (in debug build only).
