### PR TITLE
Workaround for a bug in gcc 4.9.2 exposed by autotests [gcc-bug-workaround]

### DIFF
--- a/general/mem_manager.hpp
+++ b/general/mem_manager.hpp
@@ -911,7 +911,7 @@ inline void Memory<T>::CopyFrom(const Memory &src, int size)
    {
       if (h_ptr != src.h_ptr && size != 0)
       {
-         MFEM_ASSERT(h_ptr + size <= src || src.h_ptr + size <= h_ptr,
+         MFEM_ASSERT(h_ptr + size <= src.h_ptr || src.h_ptr + size <= h_ptr,
                      "data overlaps!");
          std::memcpy(h_ptr, src, size*sizeof(T));
       }

--- a/general/mem_manager.hpp
+++ b/general/mem_manager.hpp
@@ -911,7 +911,7 @@ inline void Memory<T>::CopyFrom(const Memory &src, int size)
    {
       if (h_ptr != src.h_ptr && size != 0)
       {
-         MFEM_ASSERT(h_ptr + size <= src || src + size <= h_ptr,
+         MFEM_ASSERT(h_ptr + size <= src || src.h_ptr + size <= h_ptr,
                      "data overlaps!");
          std::memcpy(h_ptr, src, size*sizeof(T));
       }


### PR DESCRIPTION
The bug is a compiler segfault that was triggered by a debug MFEM build which was then used in a debug GLVis build.
<!--GHEX{"id":2076,"author":"v-dobrev","editor":"tzanio","reviewers":["tzanio","adrienbernede"],"assignment":"2021-03-03T09:13:35-08:00","approval":"2021-03-04T17:21:09.761Z","merge":"2021-03-04T17:21:23.924Z"}XEHG--><!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge| 
 | --- | --- | --- | --- | --- | --- | --- | 
| [#2076](https://github.com/mfem/mfem/pull/2076) | @v-dobrev | @tzanio | @tzanio + @adrienbernede | 03/03/21 | 03/04/21 | 03/04/21 | |
<!--ELBATXEHG-->