### PR TITLE
Add option to skip all zeros in SparseMatrix

### DIFF
--- a/linalg/amgxsolver.cpp
+++ b/linalg/amgxsolver.cpp
@@ -604,7 +604,7 @@ void AmgXSolver::SetMatrix(const HypreParMatrix &A, const bool update_mat)
    hypre_CSRMatrix *A_csr = hypre_MergeDiagAndOffd(A_ptr);
 
    Array<double> loc_A(A_csr->data, (int)A_csr->num_nonzeros);
-   const Array<HYPRE_Int> loc_I(A_csr->i, (int)A_csr->num_rows+1);
+   const Array<int> loc_I(A_csr->i, (int)A_csr->num_rows+1);
 
    // Column index must be int64_t so we must promote here
    Array<int64_t> loc_J((int)A_csr->num_nonzeros);

--- a/linalg/amgxsolver.cpp
+++ b/linalg/amgxsolver.cpp
@@ -604,7 +604,7 @@ void AmgXSolver::SetMatrix(const HypreParMatrix &A, const bool update_mat)
    hypre_CSRMatrix *A_csr = hypre_MergeDiagAndOffd(A_ptr);
 
    Array<double> loc_A(A_csr->data, (int)A_csr->num_nonzeros);
-   const Array<int> loc_I(A_csr->i, (int)A_csr->num_rows+1);
+   const Array<HYPRE_Int> loc_I(A_csr->i, (int)A_csr->num_rows+1);
 
    // Column index must be int64_t so we must promote here
    Array<int64_t> loc_J((int)A_csr->num_nonzeros);

--- a/linalg/sparsemat.cpp
+++ b/linalg/sparsemat.cpp
@@ -1,5 +1,3 @@
-// vim: ts=3 sw=3 sts=3:
-
 // Copyright (c) 2010-2021, Lawrence Livermore National Security, LLC. Produced
 // at the Lawrence Livermore National Laboratory. All Rights reserved. See files
 // LICENSE and NOTICE for details. LLNL-CODE-806117.

--- a/linalg/sparsemat.cpp
+++ b/linalg/sparsemat.cpp
@@ -2473,7 +2473,7 @@ void SparseMatrix::AddSubMatrix(const Array<int> &rows, const Array<int> &cols,
          {
             // if the element is zero do not assemble it unless this breaks
             // the symmetric structure
-            if ((skip_zeros == 2) || (&rows != &cols || subm(j, i) == 0.0))
+            if (skip_zeros == 2 || &rows != &cols || subm(j, i) == 0.0)
             {
                continue;
             }

--- a/linalg/sparsemat.cpp
+++ b/linalg/sparsemat.cpp
@@ -2471,8 +2471,9 @@ void SparseMatrix::AddSubMatrix(const Array<int> &rows, const Array<int> &cols,
          a = subm(i, j);
          if (skip_zeros && a == 0.0)
          {
-            // if the element is zero do not assemble it unless this breaks
-            // the symmetric structure
+            // Skip assembly of zero elements if either:
+            // (i) user specified to skip zeros regardless of symmetry, or
+            // (ii) symmetry is not broken.
             if (skip_zeros == 2 || &rows != &cols || subm(j, i) == 0.0)
             {
                continue;

--- a/linalg/sparsemat.cpp
+++ b/linalg/sparsemat.cpp
@@ -1,3 +1,5 @@
+// vim: ts=3 sw=3 sts=3:
+
 // Copyright (c) 2010-2021, Lawrence Livermore National Security, LLC. Produced
 // at the Lawrence Livermore National Laboratory. All Rights reserved. See files
 // LICENSE and NOTICE for details. LLNL-CODE-806117.
@@ -1159,7 +1161,26 @@ void SparseMatrix::Finalize(int skip_zeros, bool fix_empty_rows)
       nr = 0;
       for (aux = Rows[i-1]; aux != NULL; aux = aux->Prev)
       {
-         if (!skip_zeros || aux->Value != 0.0) { nr++; }
+         if (skip_zeros && aux->Value == 0.0)
+         {
+            if (skip_zeros == 2) { continue; }
+            if ((i-1) != aux->Column) { continue; }
+
+            bool found = false;
+            double found_val;
+            for (RowNode *other = Rows[aux->Column]; other != NULL; other = other->Prev)
+            {
+               if (other->Column == (i-1))
+               {
+                  found = true;
+                  found_val = other->Value;
+                  break;
+               }
+            }
+            if (found && found_val == 0.0) { continue; }
+
+         }
+         nr++;
       }
       if (fix_empty_rows && !nr) { nr = 1; }
       I[i] = I[i-1] + nr;
@@ -1176,20 +1197,36 @@ void SparseMatrix::Finalize(int skip_zeros, bool fix_empty_rows)
       nr = 0;
       for (aux = Rows[i]; aux != NULL; aux = aux->Prev)
       {
-         if (!skip_zeros || aux->Value != 0.0)
+         if (skip_zeros && aux->Value == 0.0)
          {
-            J[j] = aux->Column;
-            A[j] = aux->Value;
+            if (skip_zeros == 2) { continue; }
+            if (i != aux->Column) { continue; }
 
-            if ( lastCol > J[j] )
+            bool found = false;
+            double found_val;
+            for (RowNode *other = Rows[aux->Column]; other != NULL; other = other->Prev)
             {
-               isSorted = false;
+               if (other->Column == i)
+               {
+                  found = true;
+                  found_val = other->Value;
+                  break;
+               }
             }
-            lastCol = J[j];
-
-            j++;
-            nr++;
+            if (found && found_val == 0.0) { continue; }
          }
+
+         J[j] = aux->Column;
+         A[j] = aux->Value;
+
+         if ( lastCol > J[j] )
+         {
+            isSorted = false;
+         }
+         lastCol = J[j];
+
+         j++;
+         nr++;
       }
       if (fix_empty_rows && !nr)
       {
@@ -2543,7 +2580,13 @@ void SparseMatrix::SetSubMatrix(const Array<int> &rows, const Array<int> &cols,
          a = subm(i, j);
          if (skip_zeros && a == 0.0)
          {
-            continue;
+            // Skip assembly of zero elements if either:
+            // (i) user specified to skip zeros regardless of symmetry, or
+            // (ii) symmetry is not broken.
+            if (skip_zeros == 2 || &rows != &cols || subm(j, i) == 0.0)
+            {
+               continue;
+            }
          }
          if ((gj=cols[j]) < 0) { gj = -1-gj, t = -s; }
          else { t = s; }
@@ -2578,7 +2621,13 @@ void SparseMatrix::SetSubMatrixTranspose(const Array<int> &rows,
          a = subm(j, i);
          if (skip_zeros && a == 0.0)
          {
-            continue;
+            // Skip assembly of zero elements if either:
+            // (i) user specified to skip zeros regardless of symmetry, or
+            // (ii) symmetry is not broken.
+            if (skip_zeros == 2 || &rows != &cols || subm(j, i) == 0.0)
+            {
+               continue;
+            }
          }
          if ((gj=cols[j]) < 0) { gj = -1-gj, t = -s; }
          else { t = s; }

--- a/linalg/sparsemat.cpp
+++ b/linalg/sparsemat.cpp
@@ -2473,7 +2473,7 @@ void SparseMatrix::AddSubMatrix(const Array<int> &rows, const Array<int> &cols,
          {
             // if the element is zero do not assemble it unless this breaks
             // the symmetric structure
-            if (&rows != &cols || subm(j, i) == 0.0)
+            if ((skip_zeros == 2) || (&rows != &cols || subm(j, i) == 0.0))
             {
                continue;
             }

--- a/linalg/sparsemat.hpp
+++ b/linalg/sparsemat.hpp
@@ -523,6 +523,12 @@ public:
    void SetSubMatrixTranspose(const Array<int> &rows, const Array<int> &cols,
                               const DenseMatrix &subm, int skip_zeros = 1);
 
+   /** Insert the DenseMatrix into this SparseMatrix at the specified rows and
+       columns. If \c skip_zeros==0 , all entries from the DenseMatrix are
+       added including zeros. If \c skip_zeros==2 , no zeros are added to the
+       SparseMatrix regardless of their position in the matrix. Otherwise, the
+       default \c skip_zeros behavior is to omit the zero from the SparseMatrix
+       unless it would break the symmetric structure of the SparseMatrix. */
    void AddSubMatrix(const Array<int> &rows, const Array<int> &cols,
                      const DenseMatrix &subm, int skip_zeros = 1);
 


### PR DESCRIPTION
Currently, `SparseMatrix::AddSubmatrix()` will not add zeros to the sparse matrix "unless this breaks the symmetric structure." However, I have encountered problems where this desire to preserve symmetry doubles the memory requirement and makes the problem unwieldy to solve. Therefore, I have proposed a change that will allow users to set `skip_zeros=2` to skip all zeros regardless of symmetry.

I looked into implementing this choice as an enum but it would change the signature of many functions.

Thanks!
<!--GHEX{"id":2087,"author":"wcdawn","editor":"tzanio","reviewers":["cjvogl","acfisher"],"assignment":"2021-03-07T12:24:08-08:00","approval":"2021-04-07T19:07:00.624Z","merge":"2021-04-10T23:06:03.334Z"}XEHG--><!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge| 
 | --- | --- | --- | --- | --- | --- | --- | 
| [#2087](https://github.com/mfem/mfem/pull/2087) | @wcdawn | @tzanio | @cjvogl + @acfisher | 03/07/21 | 04/07/21 | 04/10/21 | |
<!--ELBATXEHG-->