### PR TITLE
Rearrange sample runs in ex6p [ex6p-runs-dev]

### DIFF
--- a/examples/ex6p.cpp
+++ b/examples/ex6p.cpp
@@ -15,8 +15,8 @@
 //               mpirun -np 4 ex6p -m ../data/pipe-nurbs.mesh
 //               mpirun -np 4 ex6p -m ../data/star-surf.mesh -o 2
 //               mpirun -np 4 ex6p -m ../data/square-disc-surf.mesh -rm 2 -o 2
-//               mpirun -np 4 ex6p -m ../data/amr-quad.mesh
 //               mpirun -np 4 ex6p -m ../data/inline-segment.mesh -o 1 -md 200
+//               mpirun -np 4 ex6p -m ../data/amr-quad.mesh
 //               mpirun -np 4 ex6p --restart
 //
 // Device sample runs:

--- a/examples/ex6p.cpp
+++ b/examples/ex6p.cpp
@@ -2,19 +2,19 @@
 //
 // Compile with: make ex6p
 //
-// Sample runs:  mpirun -np 4 ex6p -m ../data/star-hilbert.mesh -o 2
-//               mpirun -np 4 ex6p -m ../data/square-disc.mesh -rm 1 -o 1
-//               mpirun -np 4 ex6p -m ../data/square-disc.mesh -rm 1 -o 2
-//               mpirun -np 4 ex6p -m ../data/square-disc.mesh -rm 1 -o 2 -h1
+// Sample runs:  mpirun -np 4 ex6p -m ../data/star.mesh -o 3
+//               mpirun -np 4 ex6p -m ../data/square-disc.mesh -o 1 -cs
+//               mpirun -np 4 ex6p -m ../data/square-disc.mesh -o 2 -cs
+//               mpirun -np 4 ex6p -m ../data/square-disc.mesh -o 2
 //               mpirun -np 4 ex6p -m ../data/square-disc-nurbs.mesh -o 2
 //               mpirun -np 4 ex6p -m ../data/fichera.mesh -o 2
-//               mpirun -np 4 ex6p -m ../data/escher.mesh -rm 2 -o 2
+//               mpirun -np 4 ex6p -m ../data/escher.mesh -o 2
 //               mpirun -np 4 ex6p -m ../data/escher.mesh -o 2 -cs
 //               mpirun -np 4 ex6p -m ../data/disc-nurbs.mesh -o 2
 //               mpirun -np 4 ex6p -m ../data/ball-nurbs.mesh
 //               mpirun -np 4 ex6p -m ../data/pipe-nurbs.mesh
 //               mpirun -np 4 ex6p -m ../data/star-surf.mesh -o 2
-//               mpirun -np 4 ex6p -m ../data/square-disc-surf.mesh -rm 2 -o 2
+//               mpirun -np 4 ex6p -m ../data/square-disc-surf.mesh -o 2 -cs
 //               mpirun -np 4 ex6p -m ../data/inline-segment.mesh -o 1 -md 200
 //               mpirun -np 4 ex6p -m ../data/amr-quad.mesh
 //               mpirun -np 4 ex6p --restart

--- a/examples/ex6p.cpp
+++ b/examples/ex6p.cpp
@@ -2,21 +2,21 @@
 //
 // Compile with: make ex6p
 //
-// Sample runs:  mpirun -np 4 ex6p -m ../data/square-disc.mesh -o 1 -cs
-//               mpirun -np 4 ex6p -m ../data/square-disc.mesh -o 2 -cs
-//               mpirun -np 4 ex6p -m ../data/square-disc.mesh -o 2
+// Sample runs:  mpirun -np 4 ex6p -m ../data/star-hilbert.mesh -o 2
+//               mpirun -np 4 ex6p -m ../data/square-disc.mesh -rm 1 -o 1
+//               mpirun -np 4 ex6p -m ../data/square-disc.mesh -rm 1 -o 2
+//               mpirun -np 4 ex6p -m ../data/square-disc.mesh -rm 1 -o 2 -h1
 //               mpirun -np 4 ex6p -m ../data/square-disc-nurbs.mesh -o 2
-//               mpirun -np 4 ex6p -m ../data/star.mesh -o 3
-//               mpirun -np 4 ex6p -m ../data/escher.mesh -o 2 -cs
-//               mpirun -np 4 ex6p -m ../data/escher.mesh -o 2
 //               mpirun -np 4 ex6p -m ../data/fichera.mesh -o 2
+//               mpirun -np 4 ex6p -m ../data/escher.mesh -rm 2 -o 2
+//               mpirun -np 4 ex6p -m ../data/escher.mesh -o 2 -cs
 //               mpirun -np 4 ex6p -m ../data/disc-nurbs.mesh -o 2
 //               mpirun -np 4 ex6p -m ../data/ball-nurbs.mesh
 //               mpirun -np 4 ex6p -m ../data/pipe-nurbs.mesh
 //               mpirun -np 4 ex6p -m ../data/star-surf.mesh -o 2
-//               mpirun -np 4 ex6p -m ../data/square-disc-surf.mesh -o 2 -cs
-//               mpirun -np 4 ex6p -m ../data/inline-segment.mesh -o 1 -md 200
+//               mpirun -np 4 ex6p -m ../data/square-disc-surf.mesh -rm 2 -o 2
 //               mpirun -np 4 ex6p -m ../data/amr-quad.mesh
+//               mpirun -np 4 ex6p -m ../data/inline-segment.mesh -o 1 -md 200
 //               mpirun -np 4 ex6p --restart
 //
 // Device sample runs:


### PR DESCRIPTION
After merging #2038, I would like to modify the sample runs in `ex6p` so that:

* The most representative runs are at the top.
* Conforming runs, which are much less useful due to the lack of load balancing, should be scarce and not at the top.
* `star-hilbert.mesh` is used instead of `star.mesh` because of ordering.
* Runs that benefit from coarse mesh reordering use the new `-rm` option.

I realize this interferes with autotesting but hopefully with no other changes in the PR this will be more manageable.
<!--GHEX{"id":2105,"author":"jakubcerveny","editor":"tzanio","reviewers":["tzanio","v-dobrev"],"assignment":"2021-03-17T10:48:43-07:00","approval":"2021-03-26T04:48:40.988Z","merge":"2021-03-27T19:12:18.191Z"}XEHG--><!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge| 
 | --- | --- | --- | --- | --- | --- | --- | 
| [#2105](https://github.com/mfem/mfem/pull/2105) | @jakubcerveny | @tzanio | @tzanio + @v-dobrev | 03/17/21 | 03/25/21 | 03/27/21 | |
<!--ELBATXEHG-->