### PR TITLE
Fix the size of shared dofs in `ParL2FaceRestriction::Mult`.

### DIFF
--- a/fem/prestriction.cpp
+++ b/fem/prestriction.cpp
@@ -273,6 +273,7 @@ void ParL2FaceRestriction::Mult(const Vector& x, Vector& y) const
    const int vd = vdim;
    const bool t = byvdim;
    const int threshold = ndofs;
+   const int nsdofs = pfes.GetFaceNbrVSize();
 
    if (m==L2FaceValues::DoubleValued)
    {
@@ -280,7 +281,7 @@ void ParL2FaceRestriction::Mult(const Vector& x, Vector& y) const
       auto d_indices2 = scatter_indices2.Read();
       auto d_x = Reshape(x.Read(), t?vd:ndofs, t?ndofs:vd);
       auto d_x_shared = Reshape(x_gf.FaceNbrData().Read(),
-                                t?vd:ndofs, t?ndofs:vd);
+                                t?vd:nsdofs, t?nsdofs:vd);
       auto d_y = Reshape(y.Write(), nd, vd, 2, nf);
       MFEM_FORALL(i, nfdofs,
       {


### PR DESCRIPTION
Fix a bug in `ParL2FaceRestriction::Mult` where the shared dofs were initialized with wrong size. Resolve #2108 
<!--GHEX{"id":2109,"author":"YohannDudouit","editor":"tzanio","reviewers":["artv3","tzanio"],"assignment":"2021-03-21T14:16:21-07:00","approval":"2021-03-21T21:18:55.005Z","merge":"2021-03-22T23:18:12.789Z"}XEHG--><!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge| 
 | --- | --- | --- | --- | --- | --- | --- | 
| [#2109](https://github.com/mfem/mfem/pull/2109) | @YohannDudouit | @tzanio | @artv3 + @tzanio | 03/21/21 | 03/21/21 | 03/22/21 | |
<!--ELBATXEHG-->