### PR TITLE
Fix issue #2120

### DIFF
--- a/fem/geom.cpp
+++ b/fem/geom.cpp
@@ -945,7 +945,7 @@ RefinedGeometry * GeometryRefiner::Refine(Geometry::Type Geom,
    int i, j, k, l, m;
 
    Times = std::max(Times, 1);
-   ETimes = std::max(ETimes, 1);
+   ETimes = Geometry::Dimension[Geom] <= 1 ? 0 : std::max(ETimes, 1);
    const double *cp = poly1d.GetPoints(Times, BasisType::GetNodalBasis(type));
 
    RefinedGeometry *RG = FindInRGeom(Geom, Times, ETimes, type);


### PR DESCRIPTION
Caused since `GeometryRefiner::FindInRGeom` was not properly finding the cached refined geometries for points or segments, because of an inconsistent `ETimes` value.
<!--GHEX{"id":2122,"author":"pazner","editor":"tzanio","reviewers":["tzanio","jandrej"],"assignment":"2021-03-24T08:05:00-07:00","approval":"2021-03-24T15:29:22.736Z","merge":"2021-03-26T15:19:16.130Z"}XEHG--><!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge| 
 | --- | --- | --- | --- | --- | --- | --- | 
| [#2122](https://github.com/mfem/mfem/pull/2122) | @pazner | @tzanio | @tzanio + @jandrej | 03/24/21 | 03/24/21 | 03/26/21 | |
<!--ELBATXEHG-->