### PR TITLE
Fix backward compatibility with v1.1 mesh format [mesh-v1.1-compat-fix]

### DIFF
--- a/mesh/ncmesh.hpp
+++ b/mesh/ncmesh.hpp
@@ -107,7 +107,7 @@ public:
    explicit NCMesh(const Mesh *mesh);
 
    /** Load from a stream. The id header is assumed to have been read already
-       from \param[in] input. \param[in] version is 10 for the v1.0 NC format,
+       from \param[in] input . \param[in] version is 10 for the v1.0 NC format,
        or 1 for the legacy v1.1 format. \param[out] curved is set to 1 if the
        curvature GridFunction follows after mesh data. \param[out] is_nc (again
        treated as a boolean) is set to 0 if the legacy v1.1 format in fact

--- a/mesh/ncmesh.hpp
+++ b/mesh/ncmesh.hpp
@@ -106,12 +106,12 @@ public:
    //// Initialize with elements from an existing 'mesh'.
    explicit NCMesh(const Mesh *mesh);
 
-   /** Load from a stream. The id header is assumed to have been read already.
-       \param[in] version is 10 for the v1.0 NC format, or 1 for the legacy v1.1
-       format. \param[out] curved is set to 1 if the curvature GridFunction
-       follows after mesh data. \param[out] is_nc (again treated as a boolean)
-       is set to 0 if the legacy v1.1 format in fact defines a conforming mesh.
-       See Mesh::Loader for details. */
+   /** Load from a stream. The id header is assumed to have been read already
+       from \param[in] input. \param[in] version is 10 for the v1.0 NC format,
+       or 1 for the legacy v1.1 format. \param[out] curved is set to 1 if the
+       curvature GridFunction follows after mesh data. \param[out] is_nc (again
+       treated as a boolean) is set to 0 if the legacy v1.1 format in fact
+       defines a conforming mesh. See Mesh::Loader for details. */
    NCMesh(std::istream &input, int version, int &curved, int &is_nc);
 
    /// Deep copy of another instance.

--- a/mesh/ncmesh.hpp
+++ b/mesh/ncmesh.hpp
@@ -106,7 +106,12 @@ public:
    //// Initialize with elements from an existing 'mesh'.
    explicit NCMesh(const Mesh *mesh);
 
-   /// Load from a stream. The id header is assumed to have been read already.
+   /** Load from a stream. The id header is assumed to have been read already.
+       \param[in] version is 10 for the v1.0 NC format, or 1 for the legacy v1.1
+       format. \param[out] curved is set to 1 if the curvature GridFunction
+       follows after mesh data. \param[out] is_nc (again treated as a boolean)
+       is set to 0 if the legacy v1.1 format in fact defines a conforming mesh.
+       See Mesh::Loader for details. */
    NCMesh(std::istream &input, int version, int &curved, int &is_nc);
 
    /// Deep copy of another instance.

--- a/mesh/ncmesh.hpp
+++ b/mesh/ncmesh.hpp
@@ -107,7 +107,7 @@ public:
    explicit NCMesh(const Mesh *mesh);
 
    /// Load from a stream. The id header is assumed to have been read already.
-   NCMesh(std::istream &input, int version, int &curved);
+   NCMesh(std::istream &input, int version, int &curved, int &is_nc);
 
    /// Deep copy of another instance.
    NCMesh(const NCMesh &other);
@@ -878,7 +878,7 @@ protected: // implementation
    void LoadCoarseElements(std::istream &input);
    void CopyElements(int elem, const BlockArray<Element> &tmp_elements);
    /// Load the deprecated MFEM mesh v1.1 format for backward compatibility.
-   void LoadLegacyFormat(std::istream &input, int &curved);
+   void LoadLegacyFormat(std::istream &input, int &curved, int &is_nc);
 
 
    // geometry

--- a/mesh/pncmesh.cpp
+++ b/mesh/pncmesh.cpp
@@ -47,8 +47,8 @@ ParNCMesh::ParNCMesh(MPI_Comm comm, const NCMesh &ncmesh, int *part)
 }
 
 ParNCMesh::ParNCMesh(MPI_Comm comm, std::istream &input, int version,
-                     int &curved)
-   : NCMesh(input, version, curved)
+                     int &curved, int &is_nc)
+   : NCMesh(input, version, curved, is_nc)
 {
    MyComm = comm;
    MPI_Comm_size(MyComm, &NRanks);

--- a/mesh/pncmesh.hpp
+++ b/mesh/pncmesh.hpp
@@ -70,7 +70,8 @@ public:
    ParNCMesh(MPI_Comm comm, const NCMesh& ncmesh, int* part = NULL);
 
    /// Load from a stream. The id header is assumed to have been read already.
-   ParNCMesh(MPI_Comm comm, std::istream &input, int version, int &curved);
+   ParNCMesh(MPI_Comm comm, std::istream &input,
+             int version, int &curved, int &is_nc);
 
    /// Deep copy of another instance.
    ParNCMesh(const ParNCMesh &other);

--- a/mesh/pncmesh.hpp
+++ b/mesh/pncmesh.hpp
@@ -69,7 +69,8 @@ public:
        passed in 'part', where part[i] is the desired MPI rank for element i. */
    ParNCMesh(MPI_Comm comm, const NCMesh& ncmesh, int* part = NULL);
 
-   /// Load from a stream. The id header is assumed to have been read already.
+   /** Load from a stream, parallel version. See the serial NCMesh::NCMesh
+       counterpart for a description of the parameters. */
    ParNCMesh(MPI_Comm comm, std::istream &input,
              int version, int &curved, int &is_nc);
 


### PR DESCRIPTION
Addresses #2119. 

While ensuring backward compatibility with the deprecated v1.1 format in #1392, we seem to have overlooked these cases:
* If the `vertex_parents` section is omitted, the file is treated as a `v1.0` conforming mesh with no NCMesh object.
* The number of vertices stated in the file needs to be honored even if `nodes` are present, especially if there are unused vertices

This PR should fix the above issues. 
<!--GHEX{"id":2127,"author":"jakubcerveny","editor":"tzanio","reviewers":["tzanio","v-dobrev","mlstowell"],"assignment":"2021-03-24T08:05:28-07:00","approval":"2021-03-30T01:33:08.906Z","merge":"2021-04-04T23:04:31.180Z"}XEHG--><!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge| 
 | --- | --- | --- | --- | --- | --- | --- | 
| [#2127](https://github.com/mfem/mfem/pull/2127) | @jakubcerveny | @tzanio | @tzanio + @v-dobrev + @mlstowell | 03/24/21 | 03/29/21 | 04/04/21 | |
<!--ELBATXEHG-->