### PR TITLE
Allow user to specify initial guess in AmgXSolver

### DIFF
--- a/linalg/amgxsolver.cpp
+++ b/linalg/amgxsolver.cpp
@@ -888,7 +888,7 @@ void AmgXSolver::Mult(const Vector& B, Vector& X) const
 {
    // Set initial guess to zero
    X.UseDevice(true);
-   if (zero_guess) X = 0.0;
+   if (zero_guess) { X = 0.0; }
 
    // Mult for serial, and mpi-exclusive modes
    if (mpi_gpu_mode != "mpi-teams")

--- a/linalg/amgxsolver.cpp
+++ b/linalg/amgxsolver.cpp
@@ -888,7 +888,7 @@ void AmgXSolver::Mult(const Vector& B, Vector& X) const
 {
    // Set initial guess to zero
    X.UseDevice(true);
-   X = 0.0;
+   if (zero_guess) X = 0.0;
 
    // Mult for serial, and mpi-exclusive modes
    if (mpi_gpu_mode != "mpi-teams")

--- a/linalg/amgxsolver.cpp
+++ b/linalg/amgxsolver.cpp
@@ -227,6 +227,8 @@ void AmgXSolver::DefaultParameters(const AMGX_MODE amgxMode_,
          amgx_config = amgx_config + "\n";
       }
       amgx_config = amgx_config + " }\n" + "}\n";
+      // use a zero initial guess in Mult()
+      iterative_mode = false;
    }
    else if (amgxMode == AMGX_MODE::SOLVER)
    {
@@ -269,6 +271,8 @@ void AmgXSolver::DefaultParameters(const AMGX_MODE amgxMode_,
          amgx_config = amgx_config + "\n";
       }
       amgx_config = amgx_config + "   } \n" + "} \n";
+      // use the user-specified vector as an initial guess in Mult()
+      iterative_mode = true;
    }
    else
    {
@@ -888,7 +892,7 @@ void AmgXSolver::Mult(const Vector& B, Vector& X) const
 {
    // Set initial guess to zero
    X.UseDevice(true);
-   if (zero_guess) { X = 0.0; }
+   if (!iterative_mode) { X = 0.0; }
 
    // Mult for serial, and mpi-exclusive modes
    if (mpi_gpu_mode != "mpi-teams")

--- a/linalg/amgxsolver.hpp
+++ b/linalg/amgxsolver.hpp
@@ -168,11 +168,6 @@ public:
    /// Add a check for convergence after applying Mult.
    void SetConvergenceCheck(bool setConvergenceCheck_=true);
 
-   /** Choice whether solver will use a zero initial guess (default/true) or the
-       value of the X vector (false).
-   */
-   void SetZeroGuess(bool val) { zero_guess = val; }
-
    ~AmgXSolver();
 
    void Finalize();

--- a/linalg/amgxsolver.hpp
+++ b/linalg/amgxsolver.hpp
@@ -313,8 +313,6 @@ private:
    int64_t mat_local_rows;
 
    std::string mpi_gpu_mode;
-
-   bool zero_guess = true;
 };
 }
 #endif // MFEM_USE_AMGX

--- a/linalg/amgxsolver.hpp
+++ b/linalg/amgxsolver.hpp
@@ -168,6 +168,11 @@ public:
    /// Add a check for convergence after applying Mult.
    void SetConvergenceCheck(bool setConvergenceCheck_=true);
 
+   /** Choice whether solver will use a zero initial guess (default/true) or the
+       value of the X vector (false).
+   */
+   void SetZeroGuess(bool val) { zero_guess = val; }
+
    ~AmgXSolver();
 
    void Finalize();
@@ -313,6 +318,8 @@ private:
    int64_t mat_local_rows;
 
    std::string mpi_gpu_mode;
+
+   bool zero_guess = true;
 };
 }
 #endif // MFEM_USE_AMGX


### PR DESCRIPTION
I'm using an `AmgXSolver` in a power iteration eigensolver algorithm so the linear solver is called many times. Eventually, I have a pretty good initial guess for the solution vector. I can cut my runtimes in half by specifying an initial guess instead of a zero guess.
<!--GHEX{"id":2132,"author":"wcdawn","editor":"tzanio","reviewers":["artv3","barker29"],"assignment":"2021-03-25T07:34:23-07:00","approval":"2021-03-25T17:55:31.260Z","merge":"2021-03-27T19:11:12.432Z"}XEHG--><!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge| 
 | --- | --- | --- | --- | --- | --- | --- | 
| [#2132](https://github.com/mfem/mfem/pull/2132) | @wcdawn | @tzanio | @artv3 + @barker29 | 03/25/21 | 03/25/21 | 03/27/21 | |
<!--ELBATXEHG-->