### PR TITLE
[WIP] Alternative solution to ReorientTetMesh [alt-tet-reorder-dev]

### DIFF
--- a/examples/ex3.cpp
+++ b/examples/ex3.cpp
@@ -106,14 +106,15 @@ int main(int argc, char *argv[])
    //    largest number that gives a final mesh with no more than 50,000
    //    elements.
    {
-      int ref_levels =
-         (int)floor(log(50000./mesh->GetNE())/log(2.)/dim);
+      int ref_levels = 0;
+         //(int)floor(log(50000./mesh->GetNE())/log(2.)/dim);
       for (int l = 0; l < ref_levels; l++)
       {
          mesh->UniformRefinement();
       }
    }
-   mesh->ReorientTetMesh();
+   mesh->EnsureNCMesh(true);
+   //mesh->ReorientTetMesh();
 
    // 5. Define a finite element space on the mesh. Here we use the Nedelec
    //    finite elements of the specified order.
@@ -223,6 +224,30 @@ int main(int argc, char *argv[])
       socketstream sol_sock(vishost, visport);
       sol_sock.precision(8);
       sol_sock << "solution\n" << *mesh << x << flush;
+      sol_sock << "window_title 'solution'\n";
+      if (dim == 2)
+      {
+         sol_sock << "keys ARjlmevv\n";
+      }
+      else
+      {
+         sol_sock << "keys Amevv\n";
+      }
+      sol_sock << "pause\n" << flush;
+
+      // visualize basis functions
+      for (int i = 0; i < x.Size(); i++)
+      {
+         x = 0.0;
+         x(i) = 1.0;
+
+         stringstream title;
+         title << "basis " << i;
+
+         sol_sock << "solution\n" << *mesh << x;
+         sol_sock << "window_title '" << title.str() << "'\n";
+         sol_sock << "pause\n" << flush;
+      }
    }
 
    // 16. Free the used memory.

--- a/fem/fespace.cpp
+++ b/fem/fespace.cpp
@@ -957,6 +957,9 @@ void FiniteElementSpace::BuildConformingInterpolation() const
       order2 = GetFaceDofs(face, slave_dofs,  1); // elem2 side
       MFEM_ASSERT(order1 == order2, "");
 
+      MFEM_ASSERT(mesh->GetFaceGeometry(face) == Geometry::TRIANGLE, "");
+      int nfdof = fec->GetNumDof(Geometry::TRIANGLE, order1);
+
       int ori = inf2 % 64;
       MFEM_ASSERT(ori >= 0 && ori < 6, "");
       if (!i) { T.SetFE(&TriangleFE); }
@@ -965,7 +968,8 @@ void FiniteElementSpace::BuildConformingInterpolation() const
       auto *fe = fec->GetFE(Geometry::TRIANGLE, order1);
       fe->GetLocalInterpolation(T, I);
 
-      AddDependencies(deps, master_dofs, slave_dofs, I);
+      int nskip = master_dofs.Size() - nfdof;
+      AddDependencies(deps, master_dofs, slave_dofs, I, nskip);
    }
 
    deps.Finalize();
@@ -1908,11 +1912,14 @@ void FiniteElementSpace::GetDoubleFaces(Array<int> &double_faces) const
             int ori = inf2 % 64;
             if (elem2 >= 0 && ori >= 1 && ori <= 4)
             {
-               // TODO: check orientation and order
+               // TODO: check order
                double_faces.Append(i);
             }
          }
       }
+
+      // DEBUG
+      mfem::out << "### Number of double faces: " << double_faces.Size() << endl;
    }
 }
 

--- a/fem/fespace.cpp
+++ b/fem/fespace.cpp
@@ -847,6 +847,7 @@ void FiniteElementSpace::AddDoubleFaceDependencies(SparseMatrix &deps) const
 
       auto *fe = fec->GetFE(Geometry::TRIANGLE, order1);
       fe->GetLocalInterpolation(T, I);
+      // TODO: cache I matrices for (order,ori) pairs?
 
       int nskip = master_dofs.Size() - nfdof;
       AddDependencies(deps, master_dofs, slave_dofs, I, nskip);

--- a/fem/fespace.cpp
+++ b/fem/fespace.cpp
@@ -2425,8 +2425,12 @@ const FiniteElement *FiniteElementSpace::GetFE(int i) const
    MFEM_VERIFY(i < mesh->GetNE(),
                "Invalid element id " << i << ", maximum allowed " << mesh->GetNE()-1);
 
-   const FiniteElement *FE =
-      fec->GetFE(mesh->GetElementGeometry(i), GetElementOrderImpl(i));
+   Geometry::Type geom = mesh->GetElementGeometry(i);
+   const FiniteElement *FE = fec->GetFE(geom, GetElementOrderImpl(i));
+
+   MFEM_VERIFY(FE != NULL, "FiniteElementCollection " << fec->Name()
+               << " does not support element geometry " << geom
+               << " (" << Geometry::Name[geom] << ").");
 
    if (NURBSext)
    {

--- a/fem/fespace.hpp
+++ b/fem/fespace.hpp
@@ -124,6 +124,11 @@ protected:
        (these are basically alternate J arrays for var_edge/face_dofs). */
    Array<char> var_edge_orders, var_face_orders;
 
+   /** List of faces with two sets of DOFs. This is a special feature for
+       triangular Nedelec faces with orientations 1-4 that we disconnect and
+       constrain with the P matrix. Normally the list is empty. */
+   Array<int> double_faces;
+
    // precalculated DOFs for each element, boundary element, and face
    mutable Table *elem_dof; // owned (except in NURBS FE space)
    mutable Table *bdr_elem_dof; // owned (except in NURBS FE space)

--- a/fem/fespace.hpp
+++ b/fem/fespace.hpp
@@ -277,6 +277,10 @@ protected:
                                 Array<int> &slave_dofs, int slave_face,
                                 const DenseMatrix *pm) const;
 
+   void AddVarOrderDependencies(SparseMatrix &deps) const;
+
+   void AddDoubleFaceDependencies(SparseMatrix &deps) const;
+
    /// Replicate 'mat' in the vector dimension, according to vdim ordering mode.
    void MakeVDimMatrix(SparseMatrix &mat) const;
 

--- a/fem/fespace.hpp
+++ b/fem/fespace.hpp
@@ -125,9 +125,9 @@ protected:
    Array<char> var_edge_orders, var_face_orders;
 
    /** List of faces with two sets of DOFs. This is a special feature for
-       triangular Nedelec faces with orientations 1-4 that we disconnect and
-       constrain with the P matrix. Normally the list is empty. */
-   Array<int> double_faces;
+       triangular Nedelec faces with orientations 1-4 and order >= 2, that we
+       disconnect and constrain with the P matrix. Normally the list is empty. */
+   Array<int> nd_double_faces;
 
    // precalculated DOFs for each element, boundary element, and face
    mutable Table *elem_dof; // owned (except in NURBS FE space)
@@ -279,6 +279,9 @@ protected:
 
    /// Replicate 'mat' in the vector dimension, according to vdim ordering mode.
    void MakeVDimMatrix(SparseMatrix &mat) const;
+
+   void GetDoubleFaces(Array<int> &double_faces) const;
+   bool IsDoubleFace(int face) const;
 
    /// GridFunction interpolation operator applicable after mesh refinement.
    class RefinementOperator : public Operator

--- a/fem/fespace.hpp
+++ b/fem/fespace.hpp
@@ -118,7 +118,7 @@ protected:
    /** Variable order spaces only: DOF assignments for edges and faces, see
        docs in MakeDofTable. For constant order spaces the tables are empty. */
    Table var_edge_dofs;
-   Table var_face_dofs; ///< NOTE: also used for spaces with mixed faces
+   Table var_face_dofs; ///< NOTE: also used for spaces with mixed/double faces
 
    /** Additional data for the var_*_dofs tables: individual variant orders
        (these are basically alternate J arrays for var_edge/face_dofs). */

--- a/mesh/mesh.cpp
+++ b/mesh/mesh.cpp
@@ -5860,6 +5860,23 @@ void Mesh::ReorientTetMesh()
    }
 }
 
+void Mesh::ReorientBdrElements()
+{
+   // TODO: maybe there is a safer way to do this
+   for (int i = 0; i < boundary.Size(); i++)
+   {
+      int *bv = boundary[i]->GetVertices();
+      int *fv = faces[be_to_face[i]]->GetVertices();
+
+      // make sure boundary element ordering mirrors that of faces
+      int nv = boundary[i]->GetNVertices();
+      for (int j = 0; j < nv; j++)
+      {
+         bv[j] = fv[j];
+      }
+   }
+}
+
 int *Mesh::CartesianPartitioning(int nxyz[])
 {
    int *partitioning;

--- a/mesh/mesh.hpp
+++ b/mesh/mesh.hpp
@@ -1128,6 +1128,9 @@ public:
        @note Refinement does not work after a call to this method! */
    virtual void ReorientTetMesh();
 
+   /** TODO */
+   virtual void ReorientBdrElements();
+
    int *CartesianPartitioning(int nxyz[]);
    int *GeneratePartitioning(int nparts, int part_method = 1);
    void CheckPartitioning(int *partitioning);

--- a/mesh/ncmesh.cpp
+++ b/mesh/ncmesh.cpp
@@ -1328,7 +1328,7 @@ void NCMesh::RefineElement(int elem, char ref_type)
       //     +                         Faces: 0 back (1, 2, 3)
       //     |\\_                             1 left (0, 3, 2)
       //     ||  \_                           2 front (0, 1, 3)
-      //     | \   \_                         3 bottom (0, 1, 2)
+      //     | \   \_                         3 bottom (0, 2, 1)
       //     |  +__  \_
       //     | /2  \__ \_       Z  Y
       //     |/       \__\      | /

--- a/tests/unit/fem/test_double_faces.cpp
+++ b/tests/unit/fem/test_double_faces.cpp
@@ -1,0 +1,67 @@
+// Copyright (c) 2010-2020, Lawrence Livermore National Security, LLC. Produced
+// at the Lawrence Livermore National Laboratory. All Rights reserved. See files
+// LICENSE and NOTICE for details. LLNL-CODE-806117.
+//
+// This file is part of the MFEM library. For more information and source code
+// availability visit https://mfem.org.
+//
+// MFEM is free software; you can redistribute it and/or modify it under the
+// terms of the BSD-3 license. We welcome feedback and contributions, see file
+// CONTRIBUTING.md for details.
+
+#include "mfem.hpp"
+#include "unit_tests.hpp"
+
+namespace mfem
+{
+
+// Check complex orientation constraints for Nedelec elements
+// of order >= 2 on triangular faces with orientations 1-4.
+
+TEST_CASE("Nedelec arbitrary orientation tri faces",
+          "[FiniteElementSpace]"
+          "[NCMesh]")
+{
+   const int dim = 3;
+   const int order = GENERATE(1, 2, 3);
+
+   Mesh mesh(2, 2, 2, Element::TETRAHEDRON);
+   mesh.EnsureNCMesh(true);
+   // NOTE: no mesh.ReorientTetMesh()
+
+   int ncomplex = 0;
+   for (int i = 0; i < mesh.GetNumFaces(); i++)
+   {
+      int elem1, elem2, inf1, inf2;
+      mesh.GetFaceElements(i, &elem1, &elem2);
+      mesh.GetFaceInfos(i, &inf1, &inf2);
+
+      int ori = inf2 % 64;
+      if (elem2 >= 0 && ori >= 1 && ori <= 4)
+      {
+         //mfem::out << "Face orientation " << ori << " found\n";
+         ncomplex++;
+      }
+   }
+
+   // check that there are triangular faces with orientations 1-4 in the mesh
+   // -- if there aren't any it's not an error per se, but the following
+   // test won't work...
+   REQUIRE(ncomplex > 0);
+
+   ND_FECollection fec(order, dim);
+   FiniteElementSpace fespace(&mesh, &fec);
+
+   if (order < 2)
+   {
+      // no need for double faces at order 1
+      REQUIRE(fespace.GetVSize() == fespace.GetTrueVSize());
+   }
+   else
+   {
+      // there are extra DOFs in the space due to the double faces
+      REQUIRE(fespace.GetVSize() > fespace.GetTrueVSize());
+   }
+}
+
+} // namespace mfem


### PR DESCRIPTION
This is an experiment to see if a less intrusive solution than #1046 is possible.

Somewhat in the spirit of `var-order-space-dev`, this PR introduces special faces with two sets of DOFs on them, called "double faces", which are used for Nedelec triangle faces of order >= 2 and orientation 1,2,3,4. The disjoint DOFs are then constrained with the P matrix.

The advantage is that handling of complex orientations is completely hidden inside the FiniteElementSpace.

The disadvantages that I see are 
* the Mesh needs to be NC,
* the concept of double faces is slightly ugly,
* boundary elements still need to be reoriented,
* there are extra DOFs (although they are added only when necessary, and their number can still be minimized with ReorientTetMesh),
* this is a new kind of space so GLVis currently doesn't handle this (I need to project to a vector L2 in ex3),
* if we decide to use this, the I/O of the space will need to be made rock-solid (in a new serialization format probably), or we will be entering a world of pain :-)
* the discontinuous faces might mess up ProjectCoefficient and/or something else.,
* right now this is serial only.

The modified `ex3` should now run without `ReorientTetMesh`, e.g. on `inline-tet.mesh`.
<!--GHEX{"id":2145,"author":"jakubcerveny","editor":"tzanio","reviewers":["psocratis","mlstowell","v-dobrev"],"assignment":"2021-04-01T11:22:29-07:00","approval":"2021-06-03","merge":"2021-06-10T07:00:00.000Z"}XEHG--><!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge| 
 | --- | --- | --- | --- | --- | --- | --- | 
| [#2145](https://github.com/mfem/mfem/pull/2145) | @jakubcerveny | @tzanio | @psocratis + @mlstowell + @v-dobrev | 04/01/21 | ⌛due 06/03/21 | ⌛due 06/10/21 | |
<!--ELBATXEHG-->