### PR TITLE
Bug fix: memory leak in HypreParMatrix * Add(), ParAdd()

### DIFF
--- a/linalg/hypre.cpp
+++ b/linalg/hypre.cpp
@@ -1735,7 +1735,6 @@ HypreParMatrix *Add(double alpha, const HypreParMatrix &A,
 {
    hypre_ParCSRMatrix *C;
    hypre_ParcsrAdd(alpha, A, beta, B, &C);
-   hypre_MatvecCommPkgCreate(C);
 
    return new HypreParMatrix(C);
 }
@@ -1744,8 +1743,6 @@ HypreParMatrix * ParAdd(const HypreParMatrix *A, const HypreParMatrix *B)
 {
    hypre_ParCSRMatrix *C;
    hypre_ParcsrAdd(1.0, *A, 1.0, *B, &C);
-
-   hypre_MatvecCommPkgCreate(C);
 
    return new HypreParMatrix(C);
 }


### PR DESCRIPTION
Fixes #2035

Removes unnecessary `hypre_MatvecCommPkgCreate()` from `Add()` and `ParAdd()`.
`hypre_ParcsrAdd()` creates the commpkg in hypre v2.14.0 and later, so we
don't need to create it ourselves.
<!--GHEX{"id":2147,"author":"barker29","editor":"tzanio","reviewers":["tzanio","v-dobrev"],"assignment":"2021-04-01T11:26:27-07:00","approval":"2021-04-07T14:04:17.301Z","merge":"2021-04-08T23:18:16.564Z"}XEHG--><!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge| 
 | --- | --- | --- | --- | --- | --- | --- | 
| [#2147](https://github.com/mfem/mfem/pull/2147) | @barker29 | @tzanio | @tzanio + @v-dobrev | 04/01/21 | 04/07/21 | 04/08/21 | |
<!--ELBATXEHG-->