### PR TITLE
Fix: New commit in mfem-uberenv that point to working commit in spack

### DIFF
--- a/tests/gitlab/get_mfem_uberenv
+++ b/tests/gitlab/get_mfem_uberenv
@@ -18,7 +18,7 @@ set -o errexit
 set -o nounset
 
 uberenv_url="https://github.com/mfem/mfem-uberenv.git"
-uberenv_ref="e70b6f83b6a9db0370ea067fe3b3c140e8b0a5b0"
+uberenv_ref="af5f7f9ef3fbdc70d441a605e2b2f84be245682e"
 
 [[ ! -d tests/uberenv ]] && git clone ${uberenv_url} tests/uberenv
 cd tests/uberenv


### PR DESCRIPTION
This is a hotfix.
<!--GHEX{"id":2151,"author":"adrienbernede","editor":"tzanio","reviewers":["tzanio","pazner"],"assignment":"2021-04-01T21:15:14-07:00","approval":"2021-04-02T05:24:38.605Z","merge":"2021-04-02T05:25:55.228Z"}XEHG--><!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge| 
 | --- | --- | --- | --- | --- | --- | --- | 
| [#2151](https://github.com/mfem/mfem/pull/2151) | @adrienbernede | @tzanio | @tzanio + @pazner | 04/01/21 | 04/01/21 | 04/01/21 | |
<!--ELBATXEHG-->