### PR TITLE
Fix error handling with AmgX

### DIFF
--- a/linalg/amgxsolver.cpp
+++ b/linalg/amgxsolver.cpp
@@ -664,11 +664,11 @@ void AmgXSolver::SetMatrixMPIGPUExclusive(const HypreParMatrix &A,
    {
       AMGX_distribution_handle dist;
       AMGX_SAFE_CALL(AMGX_distribution_create(&dist, cfg));
-      AMGX_SAFE_CALL(AMGX_distribution_set_partition_data(dist, 
+      AMGX_SAFE_CALL(AMGX_distribution_set_partition_data(dist,
                                                           AMGX_DIST_PARTITION_OFFSETS,
                                                           rowPart.GetData()));
 
-      AMGX_SAFE_CALL(AMGX_matrix_upload_distributed(AmgXA, nGlobalRows, 
+      AMGX_SAFE_CALL(AMGX_matrix_upload_distributed(AmgXA, nGlobalRows,
                                                     local_rows, num_nnz, 1, 1,
                                                     loc_I.Read(), loc_J.Read(),
                                                     loc_A.Read(), NULL, dist));
@@ -819,7 +819,7 @@ void AmgXSolver::SetMatrixMPITeams(const HypreParMatrix &A,
       {
          AMGX_distribution_handle dist;
          AMGX_SAFE_CALL(AMGX_distribution_create(&dist, cfg));
-         AMGX_SAFE_CALL(AMGX_distribution_set_partition_data(dist, 
+         AMGX_SAFE_CALL(AMGX_distribution_set_partition_data(dist,
                                                              AMGX_DIST_PARTITION_OFFSETS,
                                                              rowPart.GetData()));
 


### PR DESCRIPTION
The AmgX API uses the `AMGX_SAFE_CALL()` macro (like `CHKERRQ()` in PETSc) to handle errors. This is not used uniformly in the MFEM interface so sometimes, errors are not handled and the code does not crash despite an error being encountered. This PR `AMGX_SAFE_CALL()` for all calls to the AmgX API.

For example, I was running problems and a GPU out of memory error was thrown (from Thrust) but never handled so the code continued to run. This is a problem with HPC queues where we pay for queue time.
<!--GHEX{"id":2156,"author":"wcdawn","editor":"v-dobrev","reviewers":["artv3","dylan-copeland"],"assignment":"2021-04-06T13:05:59-07:00","approval":"2021-04-09T02:58:23.423Z","merge":"2021-04-20T19:12:37.043Z"}XEHG--><!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge| 
 | --- | --- | --- | --- | --- | --- | --- | 
| [#2156](https://github.com/mfem/mfem/pull/2156) | @wcdawn | @v-dobrev | @artv3 + @dylan-copeland | 04/06/21 | 04/08/21 | 04/20/21 | |
<!--ELBATXEHG-->