### PR TITLE
Add ProjectCoefficient method to GridFunction restricted to certain element attributes

### DIFF
--- a/fem/gridfunc.cpp
+++ b/fem/gridfunc.cpp
@@ -2377,6 +2377,24 @@ void GridFunction::ProjectCoefficient(
    }
 }
 
+void GridFunction::ProjectCoefficient(VectorCoefficient &vcoeff, int attribute)
+{
+   int i;
+   Array<int> vdofs;
+   Vector vals;
+
+   for (i = 0; i < fes->GetNE(); i++)
+   {
+      if (fes->GetAttribute(i) != attribute)
+         continue;
+
+      fes->GetElementVDofs(i, vdofs);
+      vals.SetSize(vdofs.Size());
+      fes->GetFE(i)->Project(vcoeff, *fes->GetElementTransformation(i), vals);
+      SetSubVector(vdofs, vals);
+   }
+}
+
 void GridFunction::ProjectCoefficient(Coefficient *coeff[])
 {
    int i, j, fdof, d, ind, vdim;

--- a/fem/gridfunc.hpp
+++ b/fem/gridfunc.hpp
@@ -374,6 +374,10 @@ public:
        on that element. */
    void ProjectCoefficient(VectorCoefficient &vcoeff, Array<int> &dofs);
 
+   /** @brief Project @a vcoeff VectorCoefficient to @a this GridFunction, only
+       projecting onto elements with the given @a attribute */
+   void ProjectCoefficient(VectorCoefficient &vcoeff, int attribute);
+
    /** @brief Analogous to the version with argument @a vcoeff VectorCoefficient
        but using an array of scalar coefficients for each component. */
    void ProjectCoefficient(Coefficient *coeff[]);


### PR DESCRIPTION
The PR adds a ProjectCoefficient method to the GridFunction class that restricts the projection to elements of the specified attribute. I felt I needed this to have more fine grained control over the order of projection with discontinuous coefficients compared to `ProjectDiscCoefficient`, where I don't want to average the values or have the element with the highest attribute "win".

I think it would make sense to offer this function with a `std::unordered_set` argument so that a subset of attributes could be efficiently projected to at once, but I didn't include that since I haven't seen any other APIs use STL containers. Is there a policy against not using STL containers in MFEM? The same idea could be conveyed using an `Array<int>` argument, but that signature is already taken by the version of ProjectCoefficient that specifies the dofs to project to.

Please let me know what you think, and if there is already a way to project a coefficient onto a subset of elements based on their attribute.