### PR TITLE
Fixes a bug in pumi.cpp mentioned in #2161 [bugfix/pumi-dev]

### DIFF
--- a/mesh/pumi.cpp
+++ b/mesh/pumi.cpp
@@ -138,7 +138,7 @@ static void rotateSimplex(int type,
       MFEM_ASSERT(r>=0 && r<6, "incorrect rotation");
       n = 3;
    }
-   else if (type = apf::Mesh::TET) // tets
+   else if (type == apf::Mesh::TET) // tets
    {
       MFEM_ASSERT(r>=0 && r<12, "incorrect rotation");
       n = 4;


### PR DESCRIPTION
Assignment used instead of equality in else if condition
<!--GHEX{"id":2162,"author":"mortezah","editor":"tzanio","reviewers":["jandrej","tzanio"],"assignment":"2021-04-09T09:25:08-07:00","approval":"2021-04-09T16:29:12.995Z","merge":"2021-04-10T23:09:08.880Z"}XEHG--><!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge| 
 | --- | --- | --- | --- | --- | --- | --- | 
| [#2162](https://github.com/mfem/mfem/pull/2162) | @mortezah | @tzanio | @jandrej + @tzanio | 04/09/21 | 04/09/21 | 04/10/21 | |
<!--ELBATXEHG-->