### PR TITLE
Use "set up homebrew" action to update homebrew

### DIFF
--- a/.github/workflows/builds-and-tests.yml
+++ b/.github/workflows/builds-and-tests.yml
@@ -81,6 +81,10 @@ jobs:
         sudo apt-get install mpich libmpich-dev
         export MAKE_CXX_FLAG="MPICXX=mpic++"
 
+    - name: Set up Homebrew
+      if: matrix.mpi == 'parallel' && matrix.os == 'macos-10.15'
+      uses: Homebrew/actions/setup-homebrew@master
+
     - name: get MPI (MacOS)
       if: matrix.mpi == 'parallel' && matrix.os == 'macos-10.15'
       run: |


### PR DESCRIPTION
The goal is not to rely on bintray anymore, since end of service is schedule for May 1st 2021.
https://github.com/Homebrew/discussions/discussions/691\#discussioncomment-600559

This fixes an issue that is caused by today’s bintray brown-out, bul will reappear "for good" on May 1st.
Github may update their MacOS runners accordingly, and if they do, this can be reverted.
<!--GHEX{"id":2166,"author":"adrienbernede","editor":"tzanio","reviewers":["tzanio","pazner"],"assignment":"2021-04-13T08:57:13-07:00","approval":"2021-04-15T20:40:07.220Z","merge":"2021-04-19T00:50:40.156Z"}XEHG--><!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge| 
 | --- | --- | --- | --- | --- | --- | --- | 
| [#2166](https://github.com/mfem/mfem/pull/2166) | @adrienbernede | @tzanio | @tzanio + @pazner | 04/13/21 | 04/15/21 | 04/18/21 | |
<!--ELBATXEHG-->