### PR TITLE
Testing/bernede1/codecov

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -25,4 +25,7 @@ coverage:
         if_ci_failed: error
         only_pulls: true
 
+github_checks:
+  annotations: false
+
 comment: false

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -3,7 +3,7 @@ codecov:
 
 coverage:
   precision: 2
-  round: down
+  round: nearest
   range: "0...100"
   status:
     patch: off
@@ -13,10 +13,4 @@ coverage:
         threshold: 1%  # allows variations around the target
 
 comment:
-  layout: "reach,diff"
-  behavior: default
-  require_changes: false
-  require_base: yes
-  require_head: yes
-  branches:
-    - "master"
+  off:

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -12,5 +12,4 @@ coverage:
         target: auto   # compares coverage to the previous base commit
         threshold: 1%  # allows variations around the target
 
-comment:
-  off:
+comment: false

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -6,10 +6,23 @@ coverage:
   round: nearest
   range: "0...100"
   status:
-    patch: off
+    patch:
+      default:
+        target: auto
+        threshold: 0%
+        base: auto
+        branches:
+          - master
+        if_ci_failed: ignore
+        only_pulls: true
     project:
       default:
         target: auto   # compares coverage to the previous base commit
         threshold: 1%  # allows variations around the target
+        base: auto
+        branches:
+          - master
+        if_ci_failed: error
+        only_pulls: true
 
 comment: false

--- a/.github/workflows/builds-and-tests.yml
+++ b/.github/workflows/builds-and-tests.yml
@@ -82,7 +82,7 @@ jobs:
         export MAKE_CXX_FLAG="MPICXX=mpic++"
 
     - name: get lcov (Linux)
-      if: matrix.coverage == 'YES' && matrix.os == 'ubuntu-18.04'
+      if: matrix.codecov == 'YES' && matrix.os == 'ubuntu-18.04'
       run: |
         sudo apt-get install lcov
 
@@ -98,7 +98,7 @@ jobs:
         export MAKE_CXX_FLAG="MPICXX=mpic++"
 
     - name: get MPI (MacOS)
-      if: matrix.coverage == 'YES' && matrix.os == 'macos-10.15'
+      if: matrix.codecov == 'YES' && matrix.os == 'macos-10.15'
       run: |
         export HOMEBREW_NO_INSTALL_CLEANUP=1
         brew install lcov

--- a/.github/workflows/builds-and-tests.yml
+++ b/.github/workflows/builds-and-tests.yml
@@ -179,4 +179,4 @@ jobs:
         name: ${{ matrix.os }}-${{ matrix.mpi }}
         project_dir: ${{ env.MFEM_TOP_DIR }}
         directories: "fem general linalg mesh"
-        config_files: .codecov.yml
+        config_file: .codecov.yml

--- a/.github/workflows/builds-and-tests.yml
+++ b/.github/workflows/builds-and-tests.yml
@@ -81,8 +81,13 @@ jobs:
         sudo apt-get install mpich libmpich-dev
         export MAKE_CXX_FLAG="MPICXX=mpic++"
 
+    - name: get lcov (Linux)
+      if: matrix.coverage == 'YES' && matrix.os == 'ubuntu-18.04'
+      run: |
+        sudo apt-get install lcov
+
     - name: Set up Homebrew
-      if: matrix.mpi == 'parallel' && matrix.os == 'macos-10.15'
+      if: ( matrix.mpi == 'parallel' || matrix.codecov == 'YES' ) && matrix.os == 'macos-10.15'
       uses: Homebrew/actions/setup-homebrew@master
 
     - name: get MPI (MacOS)
@@ -91,6 +96,12 @@ jobs:
         export HOMEBREW_NO_INSTALL_CLEANUP=1
         brew install openmpi
         export MAKE_CXX_FLAG="MPICXX=mpic++"
+
+    - name: get MPI (MacOS)
+      if: matrix.coverage == 'YES' && matrix.os == 'macos-10.15'
+      run: |
+        export HOMEBREW_NO_INSTALL_CLEANUP=1
+        brew install lcov
 
     # Get Hypre through cache, or build it.
     # Install will only run on cache miss.

--- a/.github/workflows/builds-and-tests.yml
+++ b/.github/workflows/builds-and-tests.yml
@@ -163,7 +163,7 @@ jobs:
     # Code coverage (process and upload reports)
     - name: codecov
       if: matrix.codecov == 'YES'
-      uses: mfem/github-actions/upload-coverage@master
+      uses: mfem/github-actions/upload-coverage@testing/bernede1/codecov
       with:
         name: ${{ matrix.os }}-${{ matrix.mpi }}
         project_dir: ${{ env.MFEM_TOP_DIR }}

--- a/.github/workflows/builds-and-tests.yml
+++ b/.github/workflows/builds-and-tests.yml
@@ -179,4 +179,4 @@ jobs:
         name: ${{ matrix.os }}-${{ matrix.mpi }}
         project_dir: ${{ env.MFEM_TOP_DIR }}
         directories: "fem general linalg mesh"
-        config_files: .codecov
+        config_files: .codecov.yml

--- a/.github/workflows/builds-and-tests.yml
+++ b/.github/workflows/builds-and-tests.yml
@@ -178,4 +178,5 @@ jobs:
       with:
         name: ${{ matrix.os }}-${{ matrix.mpi }}
         project_dir: ${{ env.MFEM_TOP_DIR }}
-        coverage-directories: "fem general linalg mesh"
+        directories: "fem general linalg mesh"
+        config_files: .codecov

--- a/.github/workflows/builds-and-tests.yml
+++ b/.github/workflows/builds-and-tests.yml
@@ -179,4 +179,3 @@ jobs:
         name: ${{ matrix.os }}-${{ matrix.mpi }}
         project_dir: ${{ env.MFEM_TOP_DIR }}
         directories: "fem general linalg mesh"
-        config_file: .codecov.yml

--- a/.github/workflows/builds-and-tests.yml
+++ b/.github/workflows/builds-and-tests.yml
@@ -88,7 +88,7 @@ jobs:
 
     - name: Set up Homebrew
       if: ( matrix.mpi == 'parallel' || matrix.codecov == 'YES' ) && matrix.os == 'macos-10.15'
-      uses: Homebrew/actions/setup-homebrew@master
+      uses: Homebrew/actions/setup-homebrew@c4aafe8c4620bf08883dd4679c374f11e73329d3
 
     - name: get MPI (MacOS)
       if: matrix.mpi == 'parallel' && matrix.os == 'macos-10.15'
@@ -115,7 +115,7 @@ jobs:
 
     - name: get hypre
       if: matrix.mpi == 'parallel' && steps.hypre-cache.outputs.cache-hit != 'true'
-      uses: mfem/github-actions/build-hypre@master
+      uses: mfem/github-actions/build-hypre@v1.0
       with:
         hypre-archive: ${{ env.HYPRE_ARCHIVE }}
         hypre-dir: ${{ env.HYPRE_TOP_DIR }}
@@ -132,14 +132,14 @@ jobs:
 
     - name: install metis
       if: matrix.mpi == 'parallel' && steps.metis-cache.outputs.cache-hit != 'true'
-      uses: mfem/github-actions/build-metis@master
+      uses: mfem/github-actions/build-metis@v1.0
       with:
         metis-archive: ${{ env.METIS_ARCHIVE }}
         metis-dir: ${{ env.METIS_TOP_DIR }}
 
     # MFEM build and test
     - name: build
-      uses: mfem/github-actions/build-mfem@master
+      uses: mfem/github-actions/build-mfem@v1.0
       with:
         os: ${{ matrix.os }}
         target: ${{ matrix.target }}
@@ -174,7 +174,7 @@ jobs:
     # Code coverage (process and upload reports)
     - name: codecov
       if: matrix.codecov == 'YES'
-      uses: mfem/github-actions/upload-coverage@testing/bernede1/codecov
+      uses: mfem/github-actions/upload-coverage@v1.0
       with:
         name: ${{ matrix.os }}-${{ matrix.mpi }}
         project_dir: ${{ env.MFEM_TOP_DIR }}

--- a/.github/workflows/builds-and-tests.yml
+++ b/.github/workflows/builds-and-tests.yml
@@ -167,3 +167,4 @@ jobs:
       with:
         name: ${{ matrix.os }}-${{ matrix.mpi }}
         project_dir: ${{ env.MFEM_TOP_DIR }}
+        coverage-directories: "fem general linalg mesh"

--- a/codecov.yml
+++ b/codecov.yml
@@ -6,6 +6,7 @@ coverage:
   round: down
   range: "0...100"
   status:
+    patch: off
     project:
       default:
         target: auto   # compares coverage to the previous base commit

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,21 @@
+codecov:
+  require_ci_to_pass: yes
+
+coverage:
+  precision: 2
+  round: down
+  range: "0...100"
+  status:
+    project:
+      default:
+        target: auto   # compares coverage to the previous base commit
+        threshold: 1%  # allows variations around the target
+
+comment:
+  layout: "reach,diff"
+  behavior: default
+  require_changes: false
+  require_base: yes
+  require_head: yes
+  branches:
+    - "master"


### PR DESCRIPTION
Testing new coverage options.

closes #2192 

Main changes
- Coverage analysis is restricted to mfem core source dirs.
- Adds a .codecov.yml file to configure codecov.
- Coverage will result in a failure if coverage drops more than 1%. Here dropping 4% because test directories were removed from the statistics.
- Deactivate annotations in the diff (no demo of this, corresponding change is
https://github.com/mfem/mfem/blob/8e1de064e2125c47fb62f9c845b8ca80ef48d1ea/.codecov.yml#L29
- The coverage status comment is removed

Additional changes:
- Coverage will only show up on a PR targeting master.
- Coverage will only show up if there is a change in coverage.

<!--GHEX{"id":2186,"author":"adrienbernede","editor":"tzanio","reviewers":["tzanio","pazner"],"assignment":"2021-04-22T10:54:43-07:00","approval":"2021-04-30T19:28:11.889Z","merge":"2021-04-30T19:29:40.316Z"}XEHG--><!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge| 
 | --- | --- | --- | --- | --- | --- | --- | 
| [#2186](https://github.com/mfem/mfem/pull/2186) | @adrienbernede | @tzanio | @tzanio + @pazner | 04/22/21 | 04/30/21 | 04/30/21 | |
<!--ELBATXEHG-->