### PR TITLE
Improve const correctness of hypre interface [hypre-const]

### DIFF
--- a/linalg/hypre.cpp
+++ b/linalg/hypre.cpp
@@ -2295,7 +2295,7 @@ HypreSmoother::HypreSmoother() : Solver()
    A_is_symmetric = false;
 }
 
-HypreSmoother::HypreSmoother(HypreParMatrix &_A, int _type,
+HypreSmoother::HypreSmoother(const HypreParMatrix &_A, int _type,
                              int _relax_times, double _relax_weight, double _omega,
                              int _poly_order, double _poly_fraction, int _eig_est_cg_iter)
 {
@@ -2637,7 +2637,7 @@ HypreSolver::HypreSolver()
    error_mode = ABORT_HYPRE_ERRORS;
 }
 
-HypreSolver::HypreSolver(HypreParMatrix *_A)
+HypreSolver::HypreSolver(const HypreParMatrix *_A)
    : Solver(_A->Height(), _A->Width())
 {
    A = _A;
@@ -2732,7 +2732,7 @@ HyprePCG::HyprePCG(MPI_Comm comm) : precond(NULL)
    HYPRE_ParCSRPCGCreate(comm, &pcg_solver);
 }
 
-HyprePCG::HyprePCG(HypreParMatrix &_A) : HypreSolver(&_A), precond(NULL)
+HyprePCG::HyprePCG(const HypreParMatrix &_A) : HypreSolver(&_A), precond(NULL)
 {
    MPI_Comm comm;
 
@@ -2897,7 +2897,7 @@ HypreGMRES::HypreGMRES(MPI_Comm comm) : precond(NULL)
    SetDefaultOptions();
 }
 
-HypreGMRES::HypreGMRES(HypreParMatrix &_A) : HypreSolver(&_A), precond(NULL)
+HypreGMRES::HypreGMRES(const HypreParMatrix &_A) : HypreSolver(&_A), precond(NULL)
 {
    MPI_Comm comm;
 
@@ -3062,7 +3062,7 @@ HypreFGMRES::HypreFGMRES(MPI_Comm comm) : precond(NULL)
    SetDefaultOptions();
 }
 
-HypreFGMRES::HypreFGMRES(HypreParMatrix &_A) : HypreSolver(&_A), precond(NULL)
+HypreFGMRES::HypreFGMRES(const HypreParMatrix &_A) : HypreSolver(&_A), precond(NULL)
 {
    MPI_Comm comm;
 
@@ -3235,7 +3235,7 @@ HypreParaSails::HypreParaSails(MPI_Comm comm)
    SetDefaultOptions();
 }
 
-HypreParaSails::HypreParaSails(HypreParMatrix &A) : HypreSolver(&A)
+HypreParaSails::HypreParaSails(const HypreParMatrix &A) : HypreSolver(&A)
 {
    MPI_Comm comm;
 
@@ -3332,7 +3332,7 @@ HypreEuclid::HypreEuclid(MPI_Comm comm)
    SetDefaultOptions();
 }
 
-HypreEuclid::HypreEuclid(HypreParMatrix &A) : HypreSolver(&A)
+HypreEuclid::HypreEuclid(const HypreParMatrix &A) : HypreSolver(&A)
 {
    MPI_Comm comm;
 
@@ -3479,7 +3479,7 @@ HypreBoomerAMG::HypreBoomerAMG()
    SetDefaultOptions();
 }
 
-HypreBoomerAMG::HypreBoomerAMG(HypreParMatrix &A) : HypreSolver(&A)
+HypreBoomerAMG::HypreBoomerAMG(const HypreParMatrix &A) : HypreSolver(&A)
 {
    HYPRE_BoomerAMGCreate(&amg_precond);
    SetDefaultOptions();
@@ -3878,7 +3878,7 @@ HypreAMS::HypreAMS(ParFiniteElementSpace *edge_fespace)
    Init(edge_fespace);
 }
 
-HypreAMS::HypreAMS(HypreParMatrix &A, ParFiniteElementSpace *edge_fespace)
+HypreAMS::HypreAMS(const HypreParMatrix &A, ParFiniteElementSpace *edge_fespace)
    : HypreSolver(&A)
 {
    Init(edge_fespace);
@@ -4114,7 +4114,7 @@ HypreADS::HypreADS(ParFiniteElementSpace *face_fespace)
    Init(face_fespace);
 }
 
-HypreADS::HypreADS(HypreParMatrix &A, ParFiniteElementSpace *face_fespace)
+HypreADS::HypreADS(const HypreParMatrix &A, ParFiniteElementSpace *face_fespace)
    : HypreSolver(&A)
 {
    Init(face_fespace);
@@ -4840,7 +4840,7 @@ HypreAME::SetPreconditioner(HypreSolver & precond)
 }
 
 void
-HypreAME::SetOperator(HypreParMatrix & A)
+HypreAME::SetOperator(const HypreParMatrix & A)
 {
    if ( !setT )
    {
@@ -4855,7 +4855,7 @@ HypreAME::SetOperator(HypreParMatrix & A)
 }
 
 void
-HypreAME::SetMassMatrix(HypreParMatrix & M)
+HypreAME::SetMassMatrix(const HypreParMatrix & M)
 {
    HYPRE_ParCSRMatrix parcsr_M = M;
    HYPRE_AMESetMassMatrix(ame_solver,(HYPRE_ParCSRMatrix)parcsr_M);

--- a/linalg/hypre.cpp
+++ b/linalg/hypre.cpp
@@ -2897,7 +2897,8 @@ HypreGMRES::HypreGMRES(MPI_Comm comm) : precond(NULL)
    SetDefaultOptions();
 }
 
-HypreGMRES::HypreGMRES(const HypreParMatrix &_A) : HypreSolver(&_A), precond(NULL)
+HypreGMRES::HypreGMRES(const HypreParMatrix &_A)
+   : HypreSolver(&_A), precond(NULL)
 {
    MPI_Comm comm;
 
@@ -3062,7 +3063,8 @@ HypreFGMRES::HypreFGMRES(MPI_Comm comm) : precond(NULL)
    SetDefaultOptions();
 }
 
-HypreFGMRES::HypreFGMRES(const HypreParMatrix &_A) : HypreSolver(&_A), precond(NULL)
+HypreFGMRES::HypreFGMRES(const HypreParMatrix &_A)
+   : HypreSolver(&_A), precond(NULL)
 {
    MPI_Comm comm;
 

--- a/linalg/hypre.cpp
+++ b/linalg/hypre.cpp
@@ -1025,7 +1025,7 @@ HypreParMatrix *HypreParMatrix::ExtractSubmatrix(const Array<int> &indices,
 #endif
 
 HYPRE_Int HypreParMatrix::Mult(HypreParVector &x, HypreParVector &y,
-                               double a, double b)
+                               double a, double b) const
 {
    x.HostRead();
    (b == 0.0) ? y.HostWrite() : y.HostReadWrite();
@@ -1094,14 +1094,14 @@ void HypreParMatrix::MultTranspose(double a, const Vector &x,
 }
 
 HYPRE_Int HypreParMatrix::Mult(HYPRE_ParVector x, HYPRE_ParVector y,
-                               double a, double b)
+                               double a, double b) const
 {
    return hypre_ParCSRMatrixMatvec(a, A, (hypre_ParVector *) x, b,
                                    (hypre_ParVector *) y);
 }
 
 HYPRE_Int HypreParMatrix::MultTranspose(HypreParVector & x, HypreParVector & y,
-                                        double a, double b)
+                                        double a, double b) const
 {
    return hypre_ParCSRMatrixMatvecT(a, A, x, b, y);
 }
@@ -1513,7 +1513,8 @@ void HypreParMatrix::EliminateRows(const Array<int> &rows)
    }
 }
 
-void HypreParMatrix::Print(const char *fname, HYPRE_Int offi, HYPRE_Int offj)
+void HypreParMatrix::Print(const char *fname, HYPRE_Int offi,
+                           HYPRE_Int offj) const
 {
    hypre_ParCSRMatrixPrintIJ(A,offi,offj,fname);
 }

--- a/linalg/hypre.hpp
+++ b/linalg/hypre.hpp
@@ -127,7 +127,7 @@ public:
    /// Returns the parallel row/column partitioning
    /** See @ref hypre_partitioning_descr "here" for a description of the
        partitioning array. */
-   inline HYPRE_BigInt *Partitioning() const { return x->partitioning; }
+   inline const HYPRE_BigInt *Partitioning() const { return x->partitioning; }
 
    /// Returns the global number of rows
    inline HYPRE_BigInt GlobalSize() const { return x->global_size; }

--- a/linalg/hypre.hpp
+++ b/linalg/hypre.hpp
@@ -129,6 +129,12 @@ public:
        partitioning array. */
    inline const HYPRE_BigInt *Partitioning() const { return x->partitioning; }
 
+   /// @brief Returns a non-const pointer to the parallel row/column
+   /// partitioning.
+   /// Deprecated in favor of HypreParVector::Partitioning() const.
+   MFEM_DEPRECATED
+   inline HYPRE_BigInt *Partitioning() { return x->partitioning; }
+
    /// Returns the global number of rows
    inline HYPRE_BigInt GlobalSize() const { return x->global_size; }
 

--- a/linalg/hypre.hpp
+++ b/linalg/hypre.hpp
@@ -848,7 +848,7 @@ public:
 
    const HypreParMatrix* GetData() const { return A; }
 
-   /// Deprecated. Use %ref HypreTriSolve::GetData() const
+   /// Deprecated. Use HypreTriSolve::GetData() const instead.
    MFEM_DEPRECATED HypreParMatrix* GetData()
    { return const_cast<HypreParMatrix*>(A); }
 
@@ -1046,7 +1046,7 @@ public:
 
    const HypreParMatrix* GetData() const { return A; }
 
-   /// Deprecated. Use %ref HypreDiagScale::GetData() const
+   /// Deprecated. Use HypreDiagScale::GetData() const instead.
    MFEM_DEPRECATED HypreParMatrix* GetData()
    { return const_cast<HypreParMatrix*>(A); }
 

--- a/linalg/hypre.hpp
+++ b/linalg/hypre.hpp
@@ -119,7 +119,7 @@ public:
    explicit HypreParVector(ParFiniteElementSpace *pfes);
 
    /// MPI communicator
-   MPI_Comm GetComm() { return x->comm; }
+   MPI_Comm GetComm() const { return x->comm; }
 
    /// Converts hypre's format to HypreParVector
    void WrapHypreParVector(hypre_ParVector *y, bool owner=true);
@@ -720,7 +720,7 @@ public:
 
    HypreSmoother();
 
-   HypreSmoother(HypreParMatrix &_A, int type = l1GS,
+   HypreSmoother(const HypreParMatrix &_A, int type = l1GS,
                  int relax_times = 1, double relax_weight = 1.0,
                  double omega = 1.0, int poly_order = 2,
                  double poly_fraction = .3, int eig_est_cg_iter = 10);
@@ -784,7 +784,7 @@ public:
 
 protected:
    /// The linear system matrix
-   HypreParMatrix *A;
+   const HypreParMatrix *A;
 
    /// Right-hand side and solution vector
    mutable HypreParVector *B, *X;
@@ -798,7 +798,7 @@ protected:
 public:
    HypreSolver();
 
-   HypreSolver(HypreParMatrix *_A);
+   HypreSolver(const HypreParMatrix *_A);
 
    /// Typecast to HYPRE_Solver -- return the solver
    virtual operator HYPRE_Solver() const = 0;
@@ -838,7 +838,7 @@ class HypreTriSolve : public HypreSolver
 {
 public:
    HypreTriSolve() : HypreSolver() { }
-   explicit HypreTriSolve(HypreParMatrix &A) : HypreSolver(&A) { }
+   explicit HypreTriSolve(const HypreParMatrix &A) : HypreSolver(&A) { }
    virtual operator HYPRE_Solver() const { return NULL; }
 
    virtual HYPRE_PtrToParSolverFcn SetupFcn() const
@@ -846,7 +846,12 @@ public:
    virtual HYPRE_PtrToParSolverFcn SolveFcn() const
    { return (HYPRE_PtrToParSolverFcn) HYPRE_ParCSROnProcTriSolve; }
 
-   HypreParMatrix* GetData() { return A; }
+   const HypreParMatrix* GetData() const { return A; }
+
+   /// Deprecated. Use %ref HypreTriSolve::GetData() const
+   MFEM_DEPRECATED HypreParMatrix* GetData()
+   { return const_cast<HypreParMatrix*>(A); }
+
    virtual ~HypreTriSolve() { }
 };
 #endif
@@ -862,7 +867,7 @@ private:
 public:
    HyprePCG(MPI_Comm comm);
 
-   HyprePCG(HypreParMatrix &_A);
+   HyprePCG(const HypreParMatrix &_A);
 
    virtual void SetOperator(const Operator &op);
 
@@ -885,7 +890,7 @@ public:
    /// non-hypre setting
    void SetZeroInitialIterate() { iterative_mode = false; }
 
-   void GetNumIterations(int &num_iterations)
+   void GetNumIterations(int &num_iterations) const
    {
       HYPRE_Int num_it;
       HYPRE_ParCSRPCGGetNumIterations(pcg_solver, &num_it);
@@ -923,7 +928,7 @@ private:
 public:
    HypreGMRES(MPI_Comm comm);
 
-   HypreGMRES(HypreParMatrix &_A);
+   HypreGMRES(const HypreParMatrix &_A);
 
    virtual void SetOperator(const Operator &op);
 
@@ -974,7 +979,7 @@ private:
 public:
    HypreFGMRES(MPI_Comm comm);
 
-   HypreFGMRES(HypreParMatrix &_A);
+   HypreFGMRES(const HypreParMatrix &_A);
 
    virtual void SetOperator(const Operator &op);
 
@@ -1029,7 +1034,7 @@ class HypreDiagScale : public HypreSolver
 {
 public:
    HypreDiagScale() : HypreSolver() { }
-   explicit HypreDiagScale(HypreParMatrix &A) : HypreSolver(&A) { }
+   explicit HypreDiagScale(const HypreParMatrix &A) : HypreSolver(&A) { }
    virtual operator HYPRE_Solver() const { return NULL; }
 
    virtual void SetOperator(const Operator &op);
@@ -1039,7 +1044,12 @@ public:
    virtual HYPRE_PtrToParSolverFcn SolveFcn() const
    { return (HYPRE_PtrToParSolverFcn) HYPRE_ParCSRDiagScale; }
 
-   HypreParMatrix* GetData() { return A; }
+   const HypreParMatrix* GetData() const { return A; }
+
+   /// Deprecated. Use %ref HypreDiagScale::GetData() const
+   MFEM_DEPRECATED HypreParMatrix* GetData()
+   { return const_cast<HypreParMatrix*>(A); }
+
    virtual ~HypreDiagScale() { }
 };
 
@@ -1060,7 +1070,7 @@ private:
 public:
    HypreParaSails(MPI_Comm comm);
 
-   HypreParaSails(HypreParMatrix &A);
+   HypreParaSails(const HypreParMatrix &A);
 
    virtual void SetOperator(const Operator &op);
 
@@ -1101,7 +1111,7 @@ private:
 public:
    HypreEuclid(MPI_Comm comm);
 
-   HypreEuclid(HypreParMatrix &A);
+   HypreEuclid(const HypreParMatrix &A);
 
    virtual void SetOperator(const Operator &op);
 
@@ -1198,7 +1208,7 @@ private:
 public:
    HypreBoomerAMG();
 
-   HypreBoomerAMG(HypreParMatrix &A);
+   HypreBoomerAMG(const HypreParMatrix &A);
 
    virtual void SetOperator(const Operator &op);
 
@@ -1287,7 +1297,7 @@ public:
    void SetCycleType(int cycle_type)
    { HYPRE_BoomerAMGSetCycleType(amg_precond, cycle_type); }
 
-   void GetNumIterations(int &num_iterations)
+   void GetNumIterations(int &num_iterations) const
    {
       HYPRE_Int num_it;
       HYPRE_BoomerAMGGetNumIterations(amg_precond, &num_it);
@@ -1344,7 +1354,7 @@ private:
 public:
    HypreAMS(ParFiniteElementSpace *edge_fespace);
 
-   HypreAMS(HypreParMatrix &A, ParFiniteElementSpace *edge_fespace);
+   HypreAMS(const HypreParMatrix &A, ParFiniteElementSpace *edge_fespace);
 
    virtual void SetOperator(const Operator &op);
 
@@ -1387,7 +1397,7 @@ private:
 public:
    HypreADS(ParFiniteElementSpace *face_fespace);
 
-   HypreADS(HypreParMatrix &A, ParFiniteElementSpace *face_fespace);
+   HypreADS(const HypreParMatrix &A, ParFiniteElementSpace *face_fespace);
 
    virtual void SetOperator(const Operator &op);
 
@@ -1602,8 +1612,8 @@ public:
 
    // The following four methods support operators of type HypreParMatrix.
    void SetPreconditioner(HypreSolver & precond);
-   void SetOperator(HypreParMatrix & A);
-   void SetMassMatrix(HypreParMatrix & M);
+   void SetOperator(const HypreParMatrix & A);
+   void SetMassMatrix(const HypreParMatrix & M);
 
    /// Solve the eigenproblem
    void Solve();

--- a/linalg/hypre.hpp
+++ b/linalg/hypre.hpp
@@ -127,10 +127,10 @@ public:
    /// Returns the parallel row/column partitioning
    /** See @ref hypre_partitioning_descr "here" for a description of the
        partitioning array. */
-   inline HYPRE_Int *Partitioning() { return x->partitioning; }
+   inline HYPRE_Int *Partitioning() const { return x->partitioning; }
 
    /// Returns the global number of rows
-   inline HYPRE_Int GlobalSize() { return x->global_size; }
+   inline HYPRE_Int GlobalSize() const { return x->global_size; }
 
    /// Typecasting to hypre's hypre_ParVector*
    operator hypre_ParVector*() const { return x; }
@@ -468,13 +468,13 @@ public:
 
    /// Computes y = alpha * A * x + beta * y
    HYPRE_Int Mult(HypreParVector &x, HypreParVector &y,
-                  double alpha = 1.0, double beta = 0.0);
+                  double alpha = 1.0, double beta = 0.0) const;
    /// Computes y = alpha * A * x + beta * y
    HYPRE_Int Mult(HYPRE_ParVector x, HYPRE_ParVector y,
-                  double alpha = 1.0, double beta = 0.0);
+                  double alpha = 1.0, double beta = 0.0) const;
    /// Computes y = alpha * A^t * x + beta * y
    HYPRE_Int MultTranspose(HypreParVector &x, HypreParVector &y,
-                           double alpha = 1.0, double beta = 0.0);
+                           double alpha = 1.0, double beta = 0.0) const;
 
    void Mult(double a, const Vector &x, double b, Vector &y) const;
    void MultTranspose(double a, const Vector &x, double b, Vector &y) const;
@@ -578,7 +578,7 @@ public:
    void EliminateRows(const Array<int> &rows);
 
    /// Prints the locally owned rows in parallel
-   void Print(const char *fname, HYPRE_Int offi = 0, HYPRE_Int offj = 0);
+   void Print(const char *fname, HYPRE_Int offi = 0, HYPRE_Int offj = 0) const;
    /// Reads the matrix from a file
    void Read(MPI_Comm comm, const char *fname);
    /// Read a matrix saved as a HYPRE_IJMatrix


### PR DESCRIPTION
In the spirit of improving MFEM's const-correctness, this PR adds const qualifiers to several member functions and parameters in the hypre interface. The changes should all be non-breaking, with the exception of the `GetData` member functions of `HypreDiagScale` and `HypreTriSolve`, which returned non-const pointers to the underlying matrix. I changed those to use `const_cast` and marked them as deprecated — I don't think they are widely used (if at all). const-correct versions of those two functions are added as well.
<!--GHEX{"id":2197,"author":"pazner","editor":"tzanio","reviewers":["YohannDudouit","jandrej","mlstowell"],"assignment":"2021-04-24T18:40:00-07:00","approval":"2021-04-30T20:19:59.211Z","merge":"2021-05-04T15:46:13.890Z"}XEHG--><!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge| 
 | --- | --- | --- | --- | --- | --- | --- | 
| [#2197](https://github.com/mfem/mfem/pull/2197) | @pazner | @tzanio | @YohannDudouit + @jandrej + @mlstowell | 04/24/21 | 04/30/21 | 05/04/21 | |
<!--ELBATXEHG-->