### PR TITLE
Resolve #2106

### DIFF
--- a/fem/intrules.hpp
+++ b/fem/intrules.hpp
@@ -84,6 +84,17 @@ public:
    void Set1w(const double x1, const double w) { x = x1; weight = w; }
 
    void Set1w(const double *p) { x = p[0]; weight = p[1]; }
+
+   bool operator==(const IntegrationPoint &rhs) const
+   {
+      return x==rhs.x && y==rhs.y && z==rhs.z && weight==rhs.weight &&
+         index==rhs.index;
+   }
+
+   bool operator!=(const IntegrationPoint &rhs) const
+   {
+      return !(*this==rhs);
+   }
 };
 
 /// Class for an integration rule - an Array of IntegrationPoint.
@@ -254,6 +265,39 @@ public:
    /** If a contiguous array is not required, the weights can be accessed with
        a call like this: `IntPoint(i).weight`. */
    const Array<double> &GetWeights() const;
+
+   /// Returns true if the two IntegrationRules are equal.
+   /** Different memory addresses will always result in false. */
+   bool operator==(const IntegrationRule &rhs) const
+   {
+      if (this==&rhs)
+      {
+         if (Size() == rhs.Size())
+         {
+            for (size_t i = 0; i < Size(); i++)
+            {
+               if ((*this)[i] != rhs[i])
+               {
+                  return false;
+               }
+            }
+            return true;
+         }
+         else
+         {
+            return false;
+         }
+      }
+      else
+      {
+         return false;
+      }
+   }
+
+   bool operator!=(const IntegrationRule &rhs) const
+   {
+      return !(*this==rhs);
+   }
 
    /// Destroys an IntegrationRule object
    ~IntegrationRule() { }

--- a/fem/intrules.hpp
+++ b/fem/intrules.hpp
@@ -274,7 +274,7 @@ public:
       {
          if (Size() == rhs.Size())
          {
-            for (size_t i = 0; i < Size(); i++)
+            for (int i = 0; i < Size(); i++)
             {
                if ((*this)[i] != rhs[i])
                {

--- a/fem/intrules.hpp
+++ b/fem/intrules.hpp
@@ -272,21 +272,7 @@ public:
    {
       if (this==&rhs)
       {
-         if (Size() == rhs.Size())
-         {
-            for (int i = 0; i < Size(); i++)
-            {
-               if ((*this)[i] != rhs[i])
-               {
-                  return false;
-               }
-            }
-            return true;
-         }
-         else
-         {
-            return false;
-         }
+         return static_cast<Array<IntegrationPoint>>(*this) == static_cast<Array<IntegrationPoint>>(rhs);
       }
       else
       {

--- a/fem/intrules.hpp
+++ b/fem/intrules.hpp
@@ -88,7 +88,7 @@ public:
    bool operator==(const IntegrationPoint &rhs) const
    {
       return x==rhs.x && y==rhs.y && z==rhs.z && weight==rhs.weight &&
-         index==rhs.index;
+             index==rhs.index;
    }
 
    bool operator!=(const IntegrationPoint &rhs) const

--- a/fem/intrules.hpp
+++ b/fem/intrules.hpp
@@ -272,7 +272,8 @@ public:
    {
       if (this==&rhs)
       {
-         return static_cast<Array<IntegrationPoint>>(*this) == static_cast<Array<IntegrationPoint>>(rhs);
+         return static_cast<Array<IntegrationPoint>>(*this) ==
+                static_cast<Array<IntegrationPoint>>(rhs);
       }
       else
       {

--- a/fem/intrules.hpp
+++ b/fem/intrules.hpp
@@ -266,26 +266,6 @@ public:
        a call like this: `IntPoint(i).weight`. */
    const Array<double> &GetWeights() const;
 
-   /// Returns true if the two IntegrationRules are equal.
-   /** Different memory addresses will always result in false. */
-   bool operator==(const IntegrationRule &rhs) const
-   {
-      if (this==&rhs)
-      {
-         return static_cast<Array<IntegrationPoint>>(*this) ==
-                static_cast<Array<IntegrationPoint>>(rhs);
-      }
-      else
-      {
-         return false;
-      }
-   }
-
-   bool operator!=(const IntegrationRule &rhs) const
-   {
-      return !(*this==rhs);
-   }
-
    /// Destroys an IntegrationRule object
    ~IntegrationRule() { }
 };

--- a/mesh/mesh.cpp
+++ b/mesh/mesh.cpp
@@ -784,7 +784,7 @@ const GeometricFactors* Mesh::GetGeometricFactors(const IntegrationRule& ir,
    for (int i = 0; i < geom_factors.Size(); i++)
    {
       GeometricFactors *gf = geom_factors[i];
-      if (gf->IntRule == &ir && (gf->computed_factors & flags) == flags)
+      if (gf->IntRule == ir && (gf->computed_factors & flags) == flags)
       {
          return gf;
       }
@@ -792,7 +792,7 @@ const GeometricFactors* Mesh::GetGeometricFactors(const IntegrationRule& ir,
 
    this->EnsureNodes();
 
-   GeometricFactors *gf = new GeometricFactors(this, ir, flags, d_mt);
+   GeometricFactors *gf = new GeometricFactors(*this, ir, flags, d_mt);
    geom_factors.Append(gf);
    return gf;
 }
@@ -804,7 +804,7 @@ const FaceGeometricFactors* Mesh::GetFaceGeometricFactors(
    for (int i = 0; i < face_geom_factors.Size(); i++)
    {
       FaceGeometricFactors *gf = face_geom_factors[i];
-      if (gf->IntRule == &ir && (gf->computed_factors & flags) == flags &&
+      if (gf->IntRule == ir && (gf->computed_factors & flags) == flags &&
           gf->type==type)
       {
          return gf;
@@ -813,7 +813,7 @@ const FaceGeometricFactors* Mesh::GetFaceGeometricFactors(
 
    this->EnsureNodes();
 
-   FaceGeometricFactors *gf = new FaceGeometricFactors(this, ir, flags, type);
+   FaceGeometricFactors *gf = new FaceGeometricFactors(*this, ir, flags, type);
    face_geom_factors.Append(gf);
    return gf;
 }
@@ -11220,14 +11220,13 @@ int Mesh::FindPoints(DenseMatrix &point_mat, Array<int>& elem_ids,
 }
 
 
-GeometricFactors::GeometricFactors(const Mesh *mesh, const IntegrationRule &ir,
+GeometricFactors::GeometricFactors(const Mesh &mesh, const IntegrationRule &ir,
                                    int flags, MemoryType d_mt)
+: mesh(mesh), IntRule(ir)
 {
-   this->mesh = mesh;
-   IntRule = &ir;
    computed_factors = flags;
 
-   const GridFunction *nodes = mesh->GetNodes();
+   const GridFunction *nodes = mesh.GetNodes();
    const FiniteElementSpace *fespace = nodes->FESpace();
    const FiniteElement *fe = fespace->GetFE(0);
    const int dim  = fe->GetDim();
@@ -11275,16 +11274,14 @@ GeometricFactors::GeometricFactors(const Mesh *mesh, const IntegrationRule &ir,
    }
 }
 
-FaceGeometricFactors::FaceGeometricFactors(const Mesh *mesh,
+FaceGeometricFactors::FaceGeometricFactors(const Mesh &mesh,
                                            const IntegrationRule &ir,
                                            int flags, FaceType type)
-   : type(type)
+   : mesh(mesh), IntRule(ir), type(type)
 {
-   this->mesh = mesh;
-   IntRule = &ir;
    computed_factors = flags;
 
-   const GridFunction *nodes = mesh->GetNodes();
+   const GridFunction *nodes = mesh.GetNodes();
    const FiniteElementSpace *fespace = nodes->FESpace();
    const int vdim = fespace->GetVDim();
    const int NF   = fespace->GetNFbyType(type);

--- a/mesh/mesh.cpp
+++ b/mesh/mesh.cpp
@@ -11222,7 +11222,7 @@ int Mesh::FindPoints(DenseMatrix &point_mat, Array<int>& elem_ids,
 
 GeometricFactors::GeometricFactors(const Mesh &mesh, const IntegrationRule &ir,
                                    int flags, MemoryType d_mt)
-: mesh(mesh), IntRule(ir)
+   : mesh(mesh), IntRule(ir)
 {
    computed_factors = flags;
 

--- a/mesh/mesh.hpp
+++ b/mesh/mesh.hpp
@@ -856,6 +856,7 @@ public:
 
    /** @brief Return the mesh geometric factors corresponding to the given
        integration rule.
+
        The IntegrationRule used with GetGeometricFactors
        needs to remain valid until the internally stored GeometricFactors
        objects are destroyed (by either calling Mesh::DeleteGeometricFactors or
@@ -869,10 +870,12 @@ public:
       MemoryType d_mt = MemoryType::DEFAULT);
 
    /** @brief Return the mesh geometric factors for the faces corresponding
-       to the given integration rule. The IntegrationRule used with
-       GetFaceGeometricFactors needs to remain valid until the internally stored
-       FaceGeometricFactors objects are destroyed (by either calling
-       Mesh::DeleteGeometricFactors or the Mesh destructor).*/
+       to the given integration rule.
+
+       The IntegrationRule used with GetFaceGeometricFactors needs to remain
+       valid until the internally stored FaceGeometricFactors objects are
+       destroyed (by either calling Mesh::DeleteGeometricFactors or the Mesh
+       destructor).*/
    const FaceGeometricFactors* GetFaceGeometricFactors(const IntegrationRule& ir,
                                                        const int flags,
                                                        FaceType type);

--- a/mesh/mesh.hpp
+++ b/mesh/mesh.hpp
@@ -1529,8 +1529,8 @@ std::ostream &operator<<(std::ostream &out, const Mesh &mesh);
 class GeometricFactors
 {
 public:
-   const Mesh *mesh;
-   const IntegrationRule *IntRule;
+   const Mesh &mesh;
+   const IntegrationRule &IntRule;
    int computed_factors;
 
    enum FactorFlags
@@ -1540,7 +1540,7 @@ public:
       DETERMINANTS = 1 << 2,
    };
 
-   GeometricFactors(const Mesh *mesh, const IntegrationRule &ir, int flags,
+   GeometricFactors(const Mesh &mesh, const IntegrationRule &ir, int flags,
                     MemoryType d_mt = MemoryType::DEFAULT);
 
    /// Mapped (physical) coordinates of all quadrature points.
@@ -1574,8 +1574,8 @@ public:
 class FaceGeometricFactors
 {
 public:
-   const Mesh *mesh;
-   const IntegrationRule *IntRule;
+   const Mesh &mesh;
+   const IntegrationRule &IntRule;
    int computed_factors;
    FaceType type;
 
@@ -1587,7 +1587,7 @@ public:
       NORMALS      = 1 << 3,
    };
 
-   FaceGeometricFactors(const Mesh *mesh, const IntegrationRule &ir, int flags,
+   FaceGeometricFactors(const Mesh &mesh, const IntegrationRule &ir, int flags,
                         FaceType type);
 
    /// Mapped (physical) coordinates of all quadrature points.

--- a/mesh/mesh.hpp
+++ b/mesh/mesh.hpp
@@ -855,13 +855,14 @@ public:
    long GetGlobalNE() const { return ReduceInt(NumOfElements); }
 
    /** @brief Return the mesh geometric factors corresponding to the given
-       integration rule. */
-   /** If the device MemoryType parameter @a d_mt is specified, then the
-       returned object will use that type unless it was previously allocated
-       with a different type. The IntegrationRule used with GetGeometricFactors
+       integration rule.
+       The IntegrationRule used with GetGeometricFactors
        needs to remain valid until the internally stored GeometricFactors
        objects are destroyed (by either calling Mesh::DeleteGeometricFactors or
-       the Mesh destructor).*/
+       the Mesh destructor).
+       If the device MemoryType parameter @a d_mt is specified, then the
+       returned object will use that type unless it was previously allocated
+       with a different type. */
    const GeometricFactors* GetGeometricFactors(
       const IntegrationRule& ir,
       const int flags,

--- a/mesh/mesh.hpp
+++ b/mesh/mesh.hpp
@@ -858,14 +858,20 @@ public:
        integration rule. */
    /** If the device MemoryType parameter @a d_mt is specified, then the
        returned object will use that type unless it was previously allocated
-       with a different type. */
+       with a different type. The IntegrationRule used with GetGeometricFactors
+       needs to remain valid until the internally stored GeometricFactors
+       objects are destroyed (by either calling Mesh::DeleteGeometricFactors or
+       the Mesh destructor).*/
    const GeometricFactors* GetGeometricFactors(
       const IntegrationRule& ir,
       const int flags,
       MemoryType d_mt = MemoryType::DEFAULT);
 
    /** @brief Return the mesh geometric factors for the faces corresponding
-        to the given integration rule. */
+       to the given integration rule. The IntegrationRule used with
+       GetFaceGeometricFactors needs to remain valid until the internally stored
+       FaceGeometricFactors objects are destroyed (by either calling
+       Mesh::DeleteGeometricFactors or the Mesh destructor).*/
    const FaceGeometricFactors* GetFaceGeometricFactors(const IntegrationRule& ir,
                                                        const int flags,
                                                        FaceType type);


### PR DESCRIPTION
This PR attempts to resolve the #2106 issue:
- Documentation added to `Mesh::GetGeometricFactors` and `Mesh::GetFaceGeometricFactors` on the expected lifetime of the given `IntegrationRule`,
- Add `operator==` and `operator!=` for `IntegrationRule` and `IntegrationPoint`, and use it in `Mesh::GetGeometricFactors` and `Mesh::GetFaceGeometricFactors`,
- Use references instead of pointers in `GeometricFactors` and `FaceGeometricFactors` to catch certain lifetime issues at compilation.
<!--GHEX{"id":2198,"author":"YohannDudouit","editor":"tzanio","reviewers":["acfisher","tzanio"],"assignment":"2021-04-26T13:45:29-07:00","approval":"2021-06-30","merge":"2021-07-07T07:00:00.000Z"}XEHG--><!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge| 
 | --- | --- | --- | --- | --- | --- | --- | 
| [#2198](https://github.com/mfem/mfem/pull/2198) | @YohannDudouit | @tzanio | @acfisher + @tzanio | 04/26/21 | ⌛due 06/30/21 | ⌛due 07/07/21 | |
<!--ELBATXEHG-->