### PR TITLE
Fix cusparseSpMV warnings for CUDA-11.2

### DIFF
--- a/linalg/sparsemat.cpp
+++ b/linalg/sparsemat.cpp
@@ -687,7 +687,12 @@ void SparseMatrix::AddMult(const Vector &x, Vector &y, const double a) const
       // Allocate kernel space. Buffer is shared between different sparsemats
       size_t newBufferSize = 0;
 
-#if CUDA_VERSION > 10010 || CUDA_VERSION == 10010
+#if CUDA_VERSION > 10020 || CUDA_VERSION == 10020
+      cusparseSpMV_bufferSize(handle, CUSPARSE_OPERATION_NON_TRANSPOSE, &alpha,
+                              matA_descr,
+                              vecX_descr, &beta, vecY_descr, CUDA_R_64F,
+                              CUSPARSE_SPMV_CSR_ALG1, &newBufferSize);
+#elif CUDA_VERSION > 10010 || CUDA_VERSION == 10010
       cusparseSpMV_bufferSize(handle, CUSPARSE_OPERATION_NON_TRANSPOSE, &alpha,
                               matA_descr,
                               vecX_descr, &beta, vecY_descr, CUDA_R_64F,
@@ -702,7 +707,15 @@ void SparseMatrix::AddMult(const Vector &x, Vector &y, const double a) const
          CuMemAlloc(&dBuffer, bufferSize);
       }
 
-#if CUDA_VERSION > 10010 || CUDA_VERSION == 10010
+#if CUDA_VERSION > 10020 || CUDA_VERSION == 10020
+      // Update input/output vectors
+      cusparseDnVecSetValues(vecX_descr, const_cast<double *>(d_x));
+      cusparseDnVecSetValues(vecY_descr, d_y);
+
+      // Y = alpha A * X + beta * Y
+      cusparseSpMV(handle, CUSPARSE_OPERATION_NON_TRANSPOSE, &alpha, matA_descr,
+                   vecX_descr, &beta, vecY_descr, CUDA_R_64F, CUSPARSE_SPMV_CSR_ALG1, dBuffer);
+#elif CUDA_VERSION > 10010 || CUDA_VERSION == 10010
       // Update input/output vectors
       cusparseDnVecSetValues(vecX_descr, const_cast<double *>(d_x));
       cusparseDnVecSetValues(vecY_descr, d_y);

--- a/linalg/sparsemat.cpp
+++ b/linalg/sparsemat.cpp
@@ -687,7 +687,7 @@ void SparseMatrix::AddMult(const Vector &x, Vector &y, const double a) const
       // Allocate kernel space. Buffer is shared between different sparsemats
       size_t newBufferSize = 0;
 
-#if CUDA_VERSION > 10020 || CUDA_VERSION == 10020
+#if CUDA_VERSION > 11020 || CUDA_VERSION == 11020
       cusparseSpMV_bufferSize(handle, CUSPARSE_OPERATION_NON_TRANSPOSE, &alpha,
                               matA_descr,
                               vecX_descr, &beta, vecY_descr, CUDA_R_64F,

--- a/linalg/sparsemat.cpp
+++ b/linalg/sparsemat.cpp
@@ -57,7 +57,7 @@ void SparseMatrix::ClearCuSparse()
 #ifdef MFEM_USE_CUDA
    if (initBuffers)
    {
-#if CUDA_VERSION > 10010 || CUDA_VERSION == 10010
+#if CUDA_VERSION >= 10010
       cusparseDestroySpMat(matA_descr);
       cusparseDestroyDnVec(vecX_descr);
       cusparseDestroyDnVec(vecY_descr);
@@ -664,7 +664,7 @@ void SparseMatrix::AddMult(const Vector &x, Vector &y, const double a) const
       // Setup descriptors
       if (!initBuffers)
       {
-#if CUDA_VERSION > 10010 || CUDA_VERSION == 10010
+#if CUDA_VERSION >= 10010
          // Setup matrix descriptor
          cusparseCreateCsr(&matA_descr,Height(), Width(), J.Capacity(),
                            const_cast<int *>(d_I),
@@ -687,12 +687,12 @@ void SparseMatrix::AddMult(const Vector &x, Vector &y, const double a) const
       // Allocate kernel space. Buffer is shared between different sparsemats
       size_t newBufferSize = 0;
 
-#if CUDA_VERSION > 11020 || CUDA_VERSION == 11020
+#if CUDA_VERSION >= 11020
       cusparseSpMV_bufferSize(handle, CUSPARSE_OPERATION_NON_TRANSPOSE, &alpha,
                               matA_descr,
                               vecX_descr, &beta, vecY_descr, CUDA_R_64F,
                               CUSPARSE_SPMV_CSR_ALG1, &newBufferSize);
-#elif CUDA_VERSION > 10010 || CUDA_VERSION == 10010
+#elif CUDA_VERSION >= 10010
       cusparseSpMV_bufferSize(handle, CUSPARSE_OPERATION_NON_TRANSPOSE, &alpha,
                               matA_descr,
                               vecX_descr, &beta, vecY_descr, CUDA_R_64F,
@@ -707,7 +707,7 @@ void SparseMatrix::AddMult(const Vector &x, Vector &y, const double a) const
          CuMemAlloc(&dBuffer, bufferSize);
       }
 
-#if CUDA_VERSION > 11020 || CUDA_VERSION == 11020
+#if CUDA_VERSION >= 11020
       // Update input/output vectors
       cusparseDnVecSetValues(vecX_descr, const_cast<double *>(d_x));
       cusparseDnVecSetValues(vecY_descr, d_y);
@@ -715,7 +715,7 @@ void SparseMatrix::AddMult(const Vector &x, Vector &y, const double a) const
       // Y = alpha A * X + beta * Y
       cusparseSpMV(handle, CUSPARSE_OPERATION_NON_TRANSPOSE, &alpha, matA_descr,
                    vecX_descr, &beta, vecY_descr, CUDA_R_64F, CUSPARSE_SPMV_CSR_ALG1, dBuffer);
-#elif CUDA_VERSION > 10010 || CUDA_VERSION == 10010
+#elif CUDA_VERSION >= 10010
       // Update input/output vectors
       cusparseDnVecSetValues(vecX_descr, const_cast<double *>(d_x));
       cusparseDnVecSetValues(vecY_descr, d_y);

--- a/linalg/sparsemat.cpp
+++ b/linalg/sparsemat.cpp
@@ -707,7 +707,7 @@ void SparseMatrix::AddMult(const Vector &x, Vector &y, const double a) const
          CuMemAlloc(&dBuffer, bufferSize);
       }
 
-#if CUDA_VERSION > 10020 || CUDA_VERSION == 10020
+#if CUDA_VERSION > 11020 || CUDA_VERSION == 11020
       // Update input/output vectors
       cusparseDnVecSetValues(vecX_descr, const_cast<double *>(d_x));
       cusparseDnVecSetValues(vecY_descr, d_y);

--- a/linalg/sparsemat.hpp
+++ b/linalg/sparsemat.hpp
@@ -94,7 +94,7 @@ protected:
    static size_t bufferSize;
    static void *dBuffer;
    mutable bool initBuffers{false};
-#if CUDA_VERSION > 10010 || CUDA_VERSION == 10010
+#if CUDA_VERSION >= 10010
    mutable cusparseSpMatDescr_t matA_descr;
    mutable cusparseDnVecDescr_t vecX_descr;
    mutable cusparseDnVecDescr_t vecY_descr;


### PR DESCRIPTION
Resolves #2164.
<!--GHEX{"id":2200,"author":"adam-sim-dev","editor":"tzanio","reviewers":["YohannDudouit","artv3"],"assignment":"2021-06-02T10:58:37-07:00","approval":"2021-06-03T17:03:04.529Z","merge":"2021-06-10T23:20:59.472Z"}XEHG--><!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge| 
 | --- | --- | --- | --- | --- | --- | --- | 
| [#2200](https://github.com/mfem/mfem/pull/2200) | @adam-sim-dev | @tzanio | @YohannDudouit + @artv3 | 06/02/21 | 06/03/21 | 06/10/21 | |
<!--ELBATXEHG-->