### PR TITLE
Fix a bug in Mesh::GeneratePartitioning

### DIFF
--- a/mesh/mesh.cpp
+++ b/mesh/mesh.cpp
@@ -6596,6 +6596,7 @@ int *Mesh::GeneratePartitioning(int nparts, int part_method)
          for (i = 0; i < nparts; i++)
          {
             psize[i].one = 0;
+            psize[i].two = i;
          }
 
          for (i = 0; i < NumOfElements; i++)

--- a/mesh/mesh.cpp
+++ b/mesh/mesh.cpp
@@ -6541,22 +6541,31 @@ int *Mesh::GeneratePartitioning(int nparts, int part_method)
    {
       Array< Pair<int,int> > psize(nparts);
       int empty_parts;
-      for (i = 0; i < nparts; i++)
-      {
-         psize[i].one = 0;
-         psize[i].two = i;
-      }
 
-      for (i = 0; i < NumOfElements; i++)
+      // Count how many elements are in each partition, and store the result in
+      // psize, where psize[i].one is the number of elements, and psize[i].two
+      // is partition index. Keep track of the number of empty parts.
+      auto count_partition_elements = [&]()
       {
-         psize[partitioning[i]].one++;
-      }
+         for (i = 0; i < nparts; i++)
+         {
+            psize[i].one = 0;
+            psize[i].two = i;
+         }
 
-      empty_parts = 0;
-      for (i = 0; i < nparts; i++)
-      {
-         if (psize[i].one == 0) { empty_parts++; }
-      }
+         for (i = 0; i < NumOfElements; i++)
+         {
+            psize[partitioning[i]].one++;
+         }
+
+         empty_parts = 0;
+         for (i = 0; i < nparts; i++)
+         {
+            if (psize[i].one == 0) { empty_parts++; }
+         }
+      };
+
+      count_partition_elements();
 
       // This code just split the largest partitionings in two.
       // Do we need to replace it with something better?
@@ -6593,23 +6602,7 @@ int *Mesh::GeneratePartitioning(int nparts, int part_method)
          }
 
          // Check for empty partitionings again
-         for (i = 0; i < nparts; i++)
-         {
-            psize[i].one = 0;
-            psize[i].two = i;
-         }
-
-         for (i = 0; i < NumOfElements; i++)
-         {
-            psize[partitioning[i]].one++;
-         }
-
-         empty_parts = 0;
-         for (i = 0; i < nparts; i++)
-         {
-            if (psize[i].one == 0) { empty_parts++; }
-         }
-
+         count_partition_elements();
       }
    }
 


### PR DESCRIPTION
The bug was causing an infinite loop in the "empty part fix" loop in some special cases.
<!--GHEX{"id":2207,"author":"v-dobrev","editor":"tzanio","reviewers":["tzanio","pazner"],"assignment":"2021-04-29T12:48:00-07:00","approval":"2021-04-29T23:27:34.373Z","merge":"2021-04-30T16:45:38.502Z"}XEHG--><!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge| 
 | --- | --- | --- | --- | --- | --- | --- | 
| [#2207](https://github.com/mfem/mfem/pull/2207) | @v-dobrev | @tzanio | @tzanio + @pazner | 04/29/21 | 04/29/21 | 04/30/21 | |
<!--ELBATXEHG-->