### PR TITLE
This is a hotfix for codecov

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -13,7 +13,8 @@ coverage:
         base: auto
         branches:
           - master
-        if_ci_failed: ignore
+        if_ci_failed: error
+        informational: true
         only_pulls: true
     project:
       default:


### PR DESCRIPTION
Makes patch coverage "informational".
<!--GHEX{"id":2212,"author":"adrienbernede","editor":"tzanio","reviewers":["tzanio","pazner"],"assignment":"2021-04-30T18:22:31-07:00","approval":"2021-05-01T01:22:45.376Z","merge":"2021-05-01T01:26:01.490Z"}XEHG--><!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge| 
 | --- | --- | --- | --- | --- | --- | --- | 
| [#2212](https://github.com/mfem/mfem/pull/2212) | @adrienbernede | @tzanio | @tzanio + @pazner | 04/30/21 | 04/30/21 | 04/30/21 | |
<!--ELBATXEHG-->