### PR TITLE
Ensure class Array can be used only with trivial types

### DIFF
--- a/general/array.hpp
+++ b/general/array.hpp
@@ -37,9 +37,9 @@ void Swap(Array<T> &, Array<T> &);
    Abstract data type Array.
 
    Array<T> is an automatically increasing array containing elements of the
-   generic type T, which must be a POD (plain old data) type. The allocated size
-   may be larger then the logical size of the array. The elements can be
-   accessed by the [] operator, the range is 0 to size-1.
+   generic type T, which must be a trivial type, see `std::is_trivial`. The
+   allocated size may be larger then the logical size of the array. The elements
+   can be accessed by the [] operator, the range is 0 to size-1.
 */
 template <class T>
 class Array
@@ -54,14 +54,7 @@ protected:
 
    static inline void TypeAssert()
    {
-      // FIXME: we use Array with some non-trivial types:
-      // * mfem::NCMesh::MeshId
-
       static_assert(std::is_trivial<T>::value, "type T must be trivial");
-
-      // Do we also assume that T "is_standard_layout"?
-      // Note that "is_pod" = "is_trivial" + "is_standard_layout", however,
-      // "is_pod" is deprecated in c++20.
    }
 
 public:

--- a/general/array.hpp
+++ b/general/array.hpp
@@ -22,6 +22,7 @@
 #include <cstdlib>
 #include <cstring>
 #include <algorithm>
+#include <type_traits>
 
 namespace mfem
 {
@@ -50,6 +51,18 @@ protected:
    int size;
 
    inline void GrowSize(int minsize);
+
+   static inline void TypeAssert()
+   {
+      // FIXME: we use Array with some non-trivial types:
+      // * mfem::NCMesh::MeshId
+
+      static_assert(std::is_trivial<T>::value, "type T must be trivial");
+
+      // Do we also assume that T "is_standard_layout"?
+      // Note that "is_pod" = "is_trivial" + "is_standard_layout", however,
+      // "is_pod" is deprecated in c++20.
+   }
 
 public:
    friend void Swap<T>(Array<T> &, Array<T> &);
@@ -83,7 +96,7 @@ public:
    explicit inline Array(const CT (&values)[N]);
 
    /// Destructor
-   inline ~Array() { data.Delete(); }
+   inline ~Array() { TypeAssert(); data.Delete(); }
 
    /// Assignment operator: deep copy from 'src'.
    Array<T> &operator=(const Array<T> &src) { src.Copy(*this); return *this; }

--- a/general/sort_pairs.hpp
+++ b/general/sort_pairs.hpp
@@ -61,7 +61,7 @@ public:
    B two;
    C three;
 
-   Triple() { }
+   Triple() = default;
 
    Triple(const A &one, const B &two, const C &three)
       : one(one), two(two), three(three) { }

--- a/linalg/solvers.cpp
+++ b/linalg/solvers.cpp
@@ -3132,7 +3132,7 @@ KLUSolver::~KLUSolver()
 DirectSubBlockSolver::DirectSubBlockSolver(const SparseMatrix &A,
                                            const SparseMatrix &block_dof_)
    : Solver(A.NumRows()), block_dof(const_cast<SparseMatrix&>(block_dof_)),
-     block_solvers(block_dof.NumRows())
+     block_solvers(new DenseMatrixInverse[block_dof.NumRows()])
 {
    DenseMatrix sub_A;
    for (int i = 0; i < block_dof.NumRows(); ++i)

--- a/linalg/solvers.hpp
+++ b/linalg/solvers.hpp
@@ -895,13 +895,14 @@ class DirectSubBlockSolver : public Solver
    mutable Array<int> local_dofs;
    mutable Vector sub_rhs;
    mutable Vector sub_sol;
-   Array<DenseMatrixInverse> block_solvers;
+   DenseMatrixInverse *block_solvers;
 public:
    /// block_dof is a boolean matrix, block_dof(i, j) = 1 if j-th dof belongs to
    /// i-th block, block_dof(i, j) = 0 otherwise.
    DirectSubBlockSolver(const SparseMatrix& A, const SparseMatrix& block_dof);
    virtual void Mult(const Vector &x, Vector &y) const;
    virtual void SetOperator(const Operator &op) { }
+   virtual ~DirectSubBlockSolver() { delete [] block_solvers; }
 };
 
 /// Solver S such that I - A * S = (I - A * S1) * (I - A * S0).

--- a/linalg/solvers.hpp
+++ b/linalg/solvers.hpp
@@ -15,6 +15,7 @@
 #include "../config/config.hpp"
 #include "densemat.hpp"
 #include "handle.hpp"
+#include <memory>
 
 #ifdef MFEM_USE_MPI
 #include <mpi.h>
@@ -895,14 +896,13 @@ class DirectSubBlockSolver : public Solver
    mutable Array<int> local_dofs;
    mutable Vector sub_rhs;
    mutable Vector sub_sol;
-   DenseMatrixInverse *block_solvers;
+   std::unique_ptr<DenseMatrixInverse[]> block_solvers;
 public:
    /// block_dof is a boolean matrix, block_dof(i, j) = 1 if j-th dof belongs to
    /// i-th block, block_dof(i, j) = 0 otherwise.
    DirectSubBlockSolver(const SparseMatrix& A, const SparseMatrix& block_dof);
    virtual void Mult(const Vector &x, Vector &y) const;
    virtual void SetOperator(const Operator &op) { }
-   virtual ~DirectSubBlockSolver() { delete [] block_solvers; }
 };
 
 /// Solver S such that I - A * S = (I - A * S1) * (I - A * S0).

--- a/mesh/ncmesh.hpp
+++ b/mesh/ncmesh.hpp
@@ -169,7 +169,8 @@ public:
 
       Geometry::Type Geom() const { return Geometry::Type(geom); }
 
-      MeshId(int index = -1, int element = -1, int local = -1, int geom = -1)
+      MeshId() = default;
+      MeshId(int index, int element, int local, int geom = -1)
          : index(index), element(element), local(local), geom(geom) {}
    };
 

--- a/mesh/pmesh.hpp
+++ b/mesh/pmesh.hpp
@@ -38,7 +38,7 @@ protected:
    struct Vert3
    {
       int v[3];
-      Vert3() { }
+      Vert3() = default;
       Vert3(int v0, int v1, int v2) { v[0] = v0; v[1] = v1; v[2] = v2; }
       void Set(int v0, int v1, int v2) { v[0] = v0; v[1] = v1; v[2] = v2; }
       void Set(const int *w) { v[0] = w[0]; v[1] = w[1]; v[2] = w[2]; }
@@ -47,7 +47,7 @@ protected:
    struct Vert4
    {
       int v[4];
-      Vert4() { }
+      Vert4() = default;
       Vert4(int v0, int v1, int v2, int v3)
       { v[0] = v0; v[1] = v1; v[2] = v2; v[3] = v3; }
       void Set(int v0, int v1, int v2, int v3)

--- a/mesh/vertex.hpp
+++ b/mesh/vertex.hpp
@@ -25,7 +25,7 @@ protected:
    double coord[3];
 
 public:
-   Vertex() { }
+   Vertex() = default;
 
    // Trivial copy constructor and trivial copy assignment operator
 


### PR DESCRIPTION
Resolves #1648.

A `static_assert` in the destructor of class `Array<T>` is used to make sure `std::is_trivial<T>::value` is true.

As noted in #1648 `std::is_pod` = `std::is_trivial` + `std::is_standard_layout`, however, I'm not sure `std::is_standard_layout` is actually required.

The main remaining issue (that currently breaks the build) is that we use `Array<T>` with `T = mfem::NCMesh::MeshId` and its derived classes which are not trivial-type.

<!--GHEX{"id":2214,"author":"v-dobrev","editor":"tzanio","reviewers":["pazner","jakubcerveny","YohannDudouit"],"assignment":"2021-05-04T18:14:54-07:00","approval":"2021-05-11T21:16:47.355Z","merge":"2021-05-14T15:04:56.874Z"}XEHG--><!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge| 
 | --- | --- | --- | --- | --- | --- | --- | 
| [#2214](https://github.com/mfem/mfem/pull/2214) | @v-dobrev | @tzanio | @pazner + @jakubcerveny + @YohannDudouit | 05/04/21 | 05/11/21 | 05/14/21 | |
<!--ELBATXEHG-->