### PR TITLE
Add missing examples and miniapps to samples-runs script

### DIFF
--- a/config/sample-runs.sh
+++ b/config/sample-runs.sh
@@ -43,7 +43,7 @@ groups_serial=(
    "miniapps/performance"
    "ex1.cpp"'
 '"amgx"
-   "Amgx examples:"
+   "AmgX examples:"
    "examples/amgx"
    "ex1.cpp"'
 '"caliper"
@@ -55,11 +55,11 @@ groups_serial=(
    "examples/ginkgo"
    "ex1.cpp"'
 '"hiop"
-   "Hiop examples:"
+   "HiOp examples:"
    "examples/hiop"
    "ex9.cpp"'
 '"pumi"
-   "Pumi examples:"
+   "PUMI examples:"
    "examples/pumi"
    "ex1.cpp ex2.cpp"'
 #   ""'
@@ -73,11 +73,11 @@ groups_serial=(
    "miniapps/adjoint"
    "cvsRoberts_ASAi_dns.cpp"'
 '"gslib"
-   "Gslib miniapps:"
+   "GSLIB miniapps:"
    "miniapps/gslib"
    "field-diff.cpp field-interp.cpp findpts.cpp schwarz_ex1.cpp "'
 '"nurbs"
-   "Nurbs miniapps:"
+   "NURBS miniapps:"
    "miniapps/nurbs"
    "nurbs_ex1.cpp"'
 '"tools"
@@ -113,7 +113,7 @@ groups_parallel=(
    "miniapps/performance"
    "ex1p.cpp"'
 '"amgx"
-   "Amgx examples:"
+   "AmgX examples:"
    "examples/amgx"
    "ex1p.cpp"'
 '"caliper"
@@ -121,11 +121,11 @@ groups_parallel=(
    "examples/caliper"
    "ex1p.cpp"'
 '"hiop"
-   "Hiop examples:"
+   "HiOp examples:"
    "examples/hiop"
    "ex9p.cpp"'
 '"pumi"
-   "Pumi examples:"
+   "PUMI examples:"
    "examples/pumi"
    "ex1p.cpp ex6p.cpp"'
 '"superlu"
@@ -147,7 +147,7 @@ groups_parallel=(
    "miniapps/adjoint"
    "adjoint_advection_diffusion.cpp"'
 '"gslib"
-   "Gslib miniapps:"
+   "GSLIB miniapps:"
    "miniapps/gslib"
    "pfindpts.cpp schwarz_ex1p.cpp"'
 '"navier"
@@ -155,7 +155,7 @@ groups_parallel=(
    "miniapps/navier"
    "navier_cht.cpp"'
 '"nurbs"
-   "Nurbs miniapps:"
+   "NURBS miniapps:"
    "miniapps/nurbs"
    "nurbs_ex1p.cpp nurbs_ex11p.cpp"'
 '"shifted"
@@ -198,7 +198,7 @@ groups_all=(
    "miniapps/performance"
    "ex1{,p}.cpp"'
 '"amgx"
-   "Amgx examples:"
+   "AmgX examples:"
    "examples/amgx"
    "ex1.cpp ex1p.cpp"'
 '"caliper"
@@ -210,11 +210,11 @@ groups_all=(
    "examples/ginkgo"
    "ex1.cpp"'
 '"hiop"
-   "Hiop examples:"
+   "HiOp examples:"
    "examples/hiop"
    "ex9.cpp ex9p.cpp"'
 '"pumi"
-   "Pumi examples:"
+   "PUMI examples:"
    "examples/pumi"
    "ex1.cpp ex1p.cpp ex2.cpp ex6p.cpp"'
 '"superlu"
@@ -236,7 +236,7 @@ groups_all=(
    "miniapps/adjoint"
    "adjoint_advection_diffusion.cpp cvsRoberts_ASAi_dns.cpp"'
 '"gslib"
-   "Gslib miniapps:"
+   "GSLIB miniapps:"
    "miniapps/gslib"
    "field-diff.cpp field-interp.cpp findpts.cpp schwarz_ex1.cpp pfindpts.cpp schwarz_ex1p.cpp"'
 '"navier"
@@ -244,7 +244,7 @@ groups_all=(
    "miniapps/navier"
    "navier_cht.cpp"'
 '"nurbs"
-   "Nurbs miniapps:"
+   "NURBS miniapps:"
    "miniapps/nurbs"
    "nurbs_ex1.cpp nurbs_ex1p.cpp nurbs_ex11p.cpp"'
 '"shifted"

--- a/config/sample-runs.sh
+++ b/config/sample-runs.sh
@@ -42,12 +42,52 @@ groups_serial=(
    "Performance miniapps:"
    "miniapps/performance"
    "ex1.cpp"'
+'"amgx"
+   "Amgx examples:"
+   "examples/amgx"
+   "ex1.cpp"'
+'"caliper"
+   "Caliper examples:"
+   "examples/caliper"
+   "ex1.cpp"'
+'"ginkgo"
+   "Ginkgo examples:"
+   "examples/ginkgo"
+   "ex1.cpp"'
+'"hiop"
+   "Hiop examples:"
+   "examples/hiop"
+   "ex9.cpp"'
+'"pumi"
+   "Pumi examples:"
+   "examples/pumi"
+   "ex1.cpp ex2.cpp"'
 #   ""'
 '"meshing"
    "Meshing miniapps:"
    "miniapps/meshing"
    "mobius-strip.cpp klein-bottle.cpp extruder.cpp toroid.cpp
     mesh-optimizer.cpp minimal-surface.cpp"'
+'"adjoint"
+   "Adjoint miniapps:"
+   "miniapps/adjoint"
+   "cvsRoberts_ASAi_dns.cpp"'
+'"gslib"
+   "Gslib miniapps:"
+   "miniapps/gslib"
+   "field-diff.cpp field-interp.cpp findpts.cpp schwarz_ex1.cpp "'
+'"nurbs"
+   "Nurbs miniapps:"
+   "miniapps/nurbs"
+   "nurbs_ex1.cpp"'
+'"tools"
+   "Tools miniapps:"
+   "miniapps/tools"
+   "convert-dc.cpp display-basis.cpp get-values.cpp load-dc.cpp lor-transfer.cpp"'
+'"toys"
+   "Toys miniapps:"
+   "miniapps/toys"
+   "automata.cpp life.cpp lissajous.cpp mandel.cpp mondrian.cpp rubik.cpp snake.cpp"'
 '"convergence"
    "Convergence tests:"
    "tests/convergence"
@@ -72,6 +112,26 @@ groups_parallel=(
    "Performance miniapps:"
    "miniapps/performance"
    "ex1p.cpp"'
+'"amgx"
+   "Amgx examples:"
+   "examples/amgx"
+   "ex1p.cpp"'
+'"caliper"
+   "Caliper examples:"
+   "examples/caliper"
+   "ex1p.cpp"'
+'"hiop"
+   "Hiop examples:"
+   "examples/hiop"
+   "ex9p.cpp"'
+'"pumi"
+   "Pumi examples:"
+   "examples/pumi"
+   "ex1p.cpp ex6p.cpp"'
+'"superlu"
+   "Superlu examples:"
+   "examples/superlu"
+   "ex1p.cpp"'
 #   ""'
 '"meshing"
    "Meshing miniapps:"
@@ -82,6 +142,34 @@ groups_parallel=(
    "miniapps/electromagnetics"
    "joule.cpp"'
 #   "{volta,tesla,joule}.cpp"' # todo: multiline sample runs
+'"adjoint"
+   "Adjoint miniapps:"
+   "miniapps/adjoint"
+   "adjoint_advection_diffusion.cpp"'
+'"gslib"
+   "Gslib miniapps:"
+   "miniapps/gslib"
+   "pfindpts.cpp schwarz_ex1p.cpp"'
+'"navier"
+   "Navier miniapps:"
+   "miniapps/navier"
+   "navier_cht.cpp"'
+'"nurbs"
+   "Nurbs miniapps:"
+   "miniapps/nurbs"
+   "nurbs_ex1p.cpp nurbs_ex11p.cpp"'
+'"shifted"
+   "Shifted miniapps:"
+   "miniapps/shifted"
+   "distance.cpp"'
+'"solvers"
+   "Solvers miniapps:"
+   "miniapps/solvers"
+   "block-solvers.cpp"'
+'"tools"
+   "Tools miniapps:"
+   "miniapps/tools"
+   "convert-cd.cpp get-values.cpp load-dc.cpp"'
 '"convergence"
    "Convergence tests:"
    "tests/convergence"
@@ -109,6 +197,30 @@ groups_all=(
    "Performance miniapps:"
    "miniapps/performance"
    "ex1{,p}.cpp"'
+'"amgx"
+   "Amgx examples:"
+   "examples/amgx"
+   "ex1.cpp ex1p.cpp"'
+'"caliper"
+   "Caliper examples:"
+   "examples/caliper"
+   "ex1.cpp ex1p.cpp"'
+'"ginkgo"
+   "Ginkgo examples:"
+   "examples/ginkgo"
+   "ex1.cpp"'
+'"hiop"
+   "Hiop examples:"
+   "examples/hiop"
+   "ex9.cpp ex9p.cpp"'
+'"pumi"
+   "Pumi examples:"
+   "examples/pumi"
+   "ex1.cpp ex1p.cpp ex2.cpp ex6p.cpp"'
+'"superlu"
+   "Superlu examples:"
+   "examples/superlu"
+   "ex1p.cpp"'
 '"meshing"
    "Meshing miniapps:"
    "miniapps/meshing"
@@ -119,6 +231,38 @@ groups_all=(
    "miniapps/electromagnetics"
    "joule.cpp"'
 #   "{volta,tesla,joule}.cpp"' # todo: multiline sample runs
+'"adjoint"
+   "Adjoint miniapps:"
+   "miniapps/adjoint"
+   "adjoint_advection_diffusion.cpp cvsRoberts_ASAi_dns.cpp"'
+'"gslib"
+   "Gslib miniapps:"
+   "miniapps/gslib"
+   "field-diff.cpp field-interp.cpp findpts.cpp schwarz_ex1.cpp pfindpts.cpp schwarz_ex1p.cpp"'
+'"navier"
+   "Navier miniapps:"
+   "miniapps/navier"
+   "navier_cht.cpp"'
+'"nurbs"
+   "Nurbs miniapps:"
+   "miniapps/nurbs"
+   "nurbs_ex1.cpp nurbs_ex1p.cpp nurbs_ex11p.cpp"'
+'"shifted"
+   "Shifted miniapps:"
+   "miniapps/shifted"
+   "distance.cpp"'
+'"solvers"
+   "Solvers miniapps:"
+   "miniapps/solvers"
+   "block-solvers.cpp"'
+'"tools"
+   "Tools miniapps:"
+   "miniapps/tools"
+   "convert-dc.cpp display-basis.cpp get-values.cpp load-dc.cpp lor-transfer.cpp"'
+'"toys"
+   "Toys miniapps:"
+   "miniapps/toys"
+   "automata.cpp life.cpp lissajous.cpp mandel.cpp mondrian.cpp rubik.cpp snake.cpp"'
 '"convergence"
    "Convergence tests:"
    "tests/convergence"

--- a/miniapps/nurbs/nurbs_ex1.cpp
+++ b/miniapps/nurbs/nurbs_ex1.cpp
@@ -2,10 +2,10 @@
 //
 // Compile with: make nurbs_ex1
 //
-// Sample runs:  nurbs_ex1 -m square-nurbs.mesh -o 2 -no-ibp
-//               nurbs_ex1 -m square-nurbs.mesh -o 2 --weak-bc
-//               nurbs_ex1 -m cube-nurbs.mesh -o 2 -no-ibp
-//               nurbs_ex1 -m pipe-nurbs-2d.mesh -o 2 -no-ibp
+// Sample runs:  nurbs_ex1 -m ../../data/square-nurbs.mesh -o 2 -no-ibp
+//               nurbs_ex1 -m ../../data/square-nurbs.mesh -o 2 --weak-bc
+//               nurbs_ex1 -m ../../data/cube-nurbs.mesh -o 2 -no-ibp
+//               nurbs_ex1 -m ../../data/pipe-nurbs-2d.mesh -o 2 -no-ibp
 //               nurbs_ex1 -m ../../data/square-disc-nurbs.mesh -o -1
 //               nurbs_ex1 -m ../../data/disc-nurbs.mesh -o -1
 //               nurbs_ex1 -m ../../data/pipe-nurbs.mesh -o -1

--- a/miniapps/nurbs/nurbs_ex1p.cpp
+++ b/miniapps/nurbs/nurbs_ex1p.cpp
@@ -22,9 +22,9 @@
 //               mpirun -np 4 nurbs_ex1p -m ../../data/square-disc-nurbs.mesh -o -1
 //               mpirun -np 4 nurbs_ex1p -m ../../data/disc-nurbs.mesh -o -1
 //               mpirun -np 4 nurbs_ex1p -m ../../data/pipe-nurbs.mesh -o -1
-//               mpirun -np 4 nurbs_ex1p -m square-nurbs.mesh -o 2 -no-ibp
-//               mpirun -np 4 nurbs_ex1p -m cube-nurbs.mesh -o 2 -no-ibp
-//               mpirun -np 4 nurbs_ex1p -m pipe-nurbs-2d.mesh -o 2 -no-ibp
+//               mpirun -np 4 nurbs_ex1p -m ../../data/square-nurbs.mesh -o 2 -no-ibp
+//               mpirun -np 4 nurbs_ex1p -m ../../data/cube-nurbs.mesh -o 2 -no-ibp
+//               mpirun -np 4 nurbs_ex1p -m ../../data/pipe-nurbs-2d.mesh -o 2 -no-ibp
 
 // Description:  This example code demonstrates the use of MFEM to define a
 //               simple finite element discretization of the Laplace problem


### PR DESCRIPTION
I did what it seems needed to be done to add those examples and miniapps.

Namely:
- Create a section for each directory (example or miniapp)
- Add all the source files that contain sequential examples to the sequential list.
- Add all the source files that contain parallel examples to the parallel list.
- Add all of them to the comprehensive group.

Currently running some testing. If I feel brave enough, I will pursue with installing the dependencies I need to run all the tests.

closes #2213
<!--GHEX{"id":2224,"author":"adrienbernede","editor":"tzanio","reviewers":["tzanio","acfisher"],"assignment":"2021-05-11T14:19:08-07:00","approval":"2021-05-12T20:39:23.052Z","merge":"2021-05-14T15:05:21.512Z"}XEHG--><!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge| 
 | --- | --- | --- | --- | --- | --- | --- | 
| [#2224](https://github.com/mfem/mfem/pull/2224) | @adrienbernede | @tzanio | @tzanio + @acfisher | 05/11/21 | 05/12/21 | 05/14/21 | |
<!--ELBATXEHG-->