### PR TITLE
Remove leading underscore variables

### DIFF
--- a/examples/ex18.hpp
+++ b/examples/ex18.hpp
@@ -35,8 +35,8 @@ private:
    void GetFlux(const DenseMatrix &state, DenseTensor &flux) const;
 
 public:
-   FE_Evolution(FiniteElementSpace &_vfes,
-                Operator &_A, SparseMatrix &_Aflux);
+   FE_Evolution(FiniteElementSpace &vfes_,
+                Operator &A_, SparseMatrix &Aflux_);
 
    virtual void Mult(const Vector &x, Vector &y) const;
 
@@ -99,13 +99,13 @@ public:
 };
 
 // Implementation of class FE_Evolution
-FE_Evolution::FE_Evolution(FiniteElementSpace &_vfes,
-                           Operator &_A, SparseMatrix &_Aflux)
-   : TimeDependentOperator(_A.Height()),
-     dim(_vfes.GetFE(0)->GetDim()),
-     vfes(_vfes),
-     A(_A),
-     Aflux(_Aflux),
+FE_Evolution::FE_Evolution(FiniteElementSpace &vfes_,
+                           Operator &A_, SparseMatrix &Aflux_)
+   : TimeDependentOperator(A_.Height()),
+     dim(vfes_.GetFE(0)->GetDim()),
+     vfes(vfes_),
+     A(A_),
+     Aflux(Aflux_),
      Me_inv(vfes.GetFE(0)->GetDof(), vfes.GetFE(0)->GetDof(), vfes.GetNE()),
      state(num_equation),
      f(num_equation, dim),

--- a/examples/ex9.cpp
+++ b/examples/ex9.cpp
@@ -129,7 +129,7 @@ private:
    mutable Vector z;
 
 public:
-   FE_Evolution(BilinearForm &_M, BilinearForm &_K, const Vector &_b);
+   FE_Evolution(BilinearForm &M_, BilinearForm &K_, const Vector &b_);
 
    virtual void Mult(const Vector &x, Vector &y) const;
    virtual void ImplicitSolve(const double dt, const Vector &x, Vector &k);
@@ -446,8 +446,8 @@ int main(int argc, char *argv[])
 
 
 // Implementation of class FE_Evolution
-FE_Evolution::FE_Evolution(BilinearForm &_M, BilinearForm &_K, const Vector &_b)
-   : TimeDependentOperator(_M.Height()), M(_M), K(_K), b(_b), z(_M.Height())
+FE_Evolution::FE_Evolution(BilinearForm &M_, BilinearForm &K_, const Vector &b_)
+   : TimeDependentOperator(M_.Height()), M(M_), K(K_), b(b_), z(M_.Height())
 {
    Array<int> ess_tdof_list;
    if (M.GetAssemblyLevel() == AssemblyLevel::LEGACY)

--- a/examples/ex9p.cpp
+++ b/examples/ex9p.cpp
@@ -217,7 +217,7 @@ private:
    mutable Vector z;
 
 public:
-   FE_Evolution(ParBilinearForm &_M, ParBilinearForm &_K, const Vector &_b,
+   FE_Evolution(ParBilinearForm &M_, ParBilinearForm &K_, const Vector &b_,
                 PrecType prec_type);
 
    virtual void Mult(const Vector &x, Vector &y) const;
@@ -649,38 +649,38 @@ int main(int argc, char *argv[])
 
 
 // Implementation of class FE_Evolution
-FE_Evolution::FE_Evolution(ParBilinearForm &_M, ParBilinearForm &_K,
-                           const Vector &_b, PrecType prec_type)
-   : TimeDependentOperator(_M.Height()), b(_b),
-     M_solver(_M.ParFESpace()->GetComm()),
-     z(_M.Height())
+FE_Evolution::FE_Evolution(ParBilinearForm &M_, ParBilinearForm &K_,
+                           const Vector &b_, PrecType prec_type)
+   : TimeDependentOperator(M_.Height()), b(b_),
+     M_solver(M_.ParFESpace()->GetComm()),
+     z(M_.Height())
 {
-   if (_M.GetAssemblyLevel()==AssemblyLevel::LEGACY)
+   if (M_.GetAssemblyLevel()==AssemblyLevel::LEGACY)
    {
-      M.Reset(_M.ParallelAssemble(), true);
-      K.Reset(_K.ParallelAssemble(), true);
+      M.Reset(M_.ParallelAssemble(), true);
+      K.Reset(K_.ParallelAssemble(), true);
    }
    else
    {
-      M.Reset(&_M, false);
-      K.Reset(&_K, false);
+      M.Reset(&M_, false);
+      K.Reset(&K_, false);
    }
 
    M_solver.SetOperator(*M);
 
    Array<int> ess_tdof_list;
-   if (_M.GetAssemblyLevel()==AssemblyLevel::LEGACY)
+   if (M_.GetAssemblyLevel()==AssemblyLevel::LEGACY)
    {
       HypreParMatrix &M_mat = *M.As<HypreParMatrix>();
       HypreParMatrix &K_mat = *K.As<HypreParMatrix>();
       HypreSmoother *hypre_prec = new HypreSmoother(M_mat, HypreSmoother::Jacobi);
       M_prec = hypre_prec;
 
-      dg_solver = new DG_Solver(M_mat, K_mat, *_M.FESpace(), prec_type);
+      dg_solver = new DG_Solver(M_mat, K_mat, *M_.FESpace(), prec_type);
    }
    else
    {
-      M_prec = new OperatorJacobiSmoother(_M, ess_tdof_list);
+      M_prec = new OperatorJacobiSmoother(M_, ess_tdof_list);
       dg_solver = NULL;
    }
 

--- a/examples/hiop/ex9.cpp
+++ b/examples/hiop/ex9.cpp
@@ -201,11 +201,11 @@ private:
    Vector &M_rowsums;
 
 public:
-   FE_Evolution(SparseMatrix &_M, SparseMatrix &_K, const Vector &_b,
-                BilinearForm &_bf, Vector &M_rs);
+   FE_Evolution(SparseMatrix &M_, SparseMatrix &K_, const Vector &b_,
+                BilinearForm &bf_, Vector &M_rs);
 
-   void SetTimeStep(double _dt) { dt = _dt; }
-   void SetK(SparseMatrix &_K) { K = _K; }
+   void SetTimeStep(double dt_) { dt = dt_; }
+   void SetK(SparseMatrix &K_) { K = K_; }
    virtual void Mult(const Vector &x, Vector &y) const;
 
    virtual ~FE_Evolution() { }
@@ -474,11 +474,11 @@ int main(int argc, char *argv[])
 
 
 // Implementation of class FE_Evolution
-FE_Evolution::FE_Evolution(SparseMatrix &_M, SparseMatrix &_K,
-                           const Vector &_b, BilinearForm &_bf, Vector &M_rs)
-   : TimeDependentOperator(_M.Size()),
-     M(_M), K(_K), b(_b), M_prec(), M_solver(), z(_M.Size()),
-     bf(_bf), M_rowsums(M_rs)
+FE_Evolution::FE_Evolution(SparseMatrix &M_, SparseMatrix &K_,
+                           const Vector &b_, BilinearForm &bf_, Vector &M_rs)
+   : TimeDependentOperator(M_.Size()),
+     M(M_), K(K_), b(b_), M_prec(), M_solver(), z(M_.Size()),
+     bf(bf_), M_rowsums(M_rs)
 {
    M_solver.SetPreconditioner(M_prec);
    M_solver.SetOperator(M);

--- a/examples/hiop/ex9p.cpp
+++ b/examples/hiop/ex9p.cpp
@@ -226,11 +226,11 @@ private:
    Vector &M_rowsums;
 
 public:
-   FE_Evolution(HypreParMatrix &_M, HypreParMatrix &_K,
-                const Vector &_b, ParBilinearForm &_pbf, Vector &M_rs);
+   FE_Evolution(HypreParMatrix &M_, HypreParMatrix &K_,
+                const Vector &b_, ParBilinearForm &pbf_, Vector &M_rs);
 
-   void SetTimeStep(double _dt) { dt = _dt; }
-   void SetK(HypreParMatrix &_K) { K = _K; }
+   void SetTimeStep(double dt_) { dt = dt_; }
+   void SetK(HypreParMatrix &K_) { K = K_; }
    virtual void Mult(const Vector &x, Vector &y) const;
 
    virtual ~FE_Evolution() { }
@@ -576,12 +576,12 @@ int main(int argc, char *argv[])
 
 
 // Implementation of class FE_Evolution
-FE_Evolution::FE_Evolution(HypreParMatrix &_M, HypreParMatrix &_K,
-                           const Vector &_b, ParBilinearForm &_pbf,
+FE_Evolution::FE_Evolution(HypreParMatrix &M_, HypreParMatrix &K_,
+                           const Vector &b_, ParBilinearForm &pbf_,
                            Vector &M_rs)
-   : TimeDependentOperator(_M.Height()),
-     M(_M), K(_K), b(_b), M_solver(M.GetComm()), z(_M.Height()),
-     pbf(_pbf), M_rowsums(M_rs)
+   : TimeDependentOperator(M_.Height()),
+     M(M_), K(K_), b(b_), M_solver(M.GetComm()), z(M_.Height()),
+     pbf(pbf_), M_rowsums(M_rs)
 {
    M_prec.SetType(HypreSmoother::Jacobi);
    M_solver.SetPreconditioner(M_prec);

--- a/examples/petsc/ex1p.cpp
+++ b/examples/petsc/ex1p.cpp
@@ -43,21 +43,21 @@ using namespace mfem;
 class UserMonitor : public PetscSolverMonitor
 {
 private:
-   ParBilinearForm *_a;
-   ParLinearForm *_b;
+   ParBilinearForm *a;
+   ParLinearForm *b;
 
 public:
-   UserMonitor(ParBilinearForm *a, ParLinearForm *b)
-      : PetscSolverMonitor(true,false), _a(a), _b(b) {}
+   UserMonitor(ParBilinearForm *a_, ParLinearForm *b_)
+      : PetscSolverMonitor(true,false), a(a_), b(b_) {}
 
    void MonitorSolution(PetscInt it, PetscReal norm, const Vector &X)
    {
       // we plot the first 5 iterates
       if (!it || it > 5) { return; }
-      ParFiniteElementSpace *fespace = _a->ParFESpace();
+      ParFiniteElementSpace *fespace = a->ParFESpace();
       ParMesh *mesh = fespace->GetParMesh();
-      ParGridFunction _x(fespace);
-      _a->RecoverFEMSolution(X, *_b, _x);
+      ParGridFunction x(fespace);
+      a->RecoverFEMSolution(X, *b, x);
 
       char vishost[] = "localhost";
       int  visport   = 19916;
@@ -68,7 +68,7 @@ public:
       socketstream sol_sock(vishost, visport);
       sol_sock << "parallel " << num_procs << " " << myid << "\n";
       sol_sock.precision(8);
-      sol_sock << "solution\n" << *mesh << _x
+      sol_sock << "solution\n" << *mesh << x
                << "window_title 'Iteration no " << it << "'" << flush;
    }
 };

--- a/examples/sundials/ex9.cpp
+++ b/examples/sundials/ex9.cpp
@@ -129,7 +129,7 @@ private:
    mutable Vector z;
 
 public:
-   FE_Evolution(BilinearForm &_M, BilinearForm &_K, const Vector &_b);
+   FE_Evolution(BilinearForm &M_, BilinearForm &K_, const Vector &b_);
 
    virtual void Mult(const Vector &x, Vector &y) const;
    virtual void ImplicitSolve(const double dt, const Vector &x, Vector &k);
@@ -471,8 +471,8 @@ int main(int argc, char *argv[])
 
 
 // Implementation of class FE_Evolution
-FE_Evolution::FE_Evolution(BilinearForm &_M, BilinearForm &_K, const Vector &_b)
-   : TimeDependentOperator(_M.Height()), M(_M), K(_K), b(_b), z(_M.Height())
+FE_Evolution::FE_Evolution(BilinearForm &M_, BilinearForm &K_, const Vector &b_)
+   : TimeDependentOperator(M_.Height()), M(M_), K(K_), b(b_), z(M_.Height())
 {
    Array<int> ess_tdof_list;
    if (M.GetAssemblyLevel() == AssemblyLevel::LEGACY)

--- a/examples/sundials/ex9p.cpp
+++ b/examples/sundials/ex9p.cpp
@@ -141,7 +141,7 @@ private:
    mutable Vector z;
 
 public:
-   FE_Evolution(ParBilinearForm &_M, ParBilinearForm &_K, const Vector &_b);
+   FE_Evolution(ParBilinearForm &M_, ParBilinearForm &K_, const Vector &b_);
 
    virtual void Mult(const Vector &x, Vector &y) const;
    virtual void ImplicitSolve(const double dt, const Vector &x, Vector &k);
@@ -588,39 +588,39 @@ int main(int argc, char *argv[])
 
 
 // Implementation of class FE_Evolution
-FE_Evolution::FE_Evolution(ParBilinearForm &_M, ParBilinearForm &_K,
-                           const Vector &_b)
-   : TimeDependentOperator(_M.Height()),
-     b(_b),
-     M_solver(_M.ParFESpace()->GetComm()),
-     z(_M.Height())
+FE_Evolution::FE_Evolution(ParBilinearForm &M_, ParBilinearForm &K_,
+                           const Vector &b_)
+   : TimeDependentOperator(M_.Height()),
+     b(b_),
+     M_solver(M_.ParFESpace()->GetComm()),
+     z(M_.Height())
 {
-   if (_M.GetAssemblyLevel()==AssemblyLevel::LEGACY)
+   if (M_.GetAssemblyLevel()==AssemblyLevel::LEGACY)
    {
-      M.Reset(_M.ParallelAssemble(), true);
-      K.Reset(_K.ParallelAssemble(), true);
+      M.Reset(M_.ParallelAssemble(), true);
+      K.Reset(K_.ParallelAssemble(), true);
    }
    else
    {
-      M.Reset(&_M, false);
-      K.Reset(&_K, false);
+      M.Reset(&M_, false);
+      K.Reset(&K_, false);
    }
 
    M_solver.SetOperator(*M);
 
    Array<int> ess_tdof_list;
-   if (_M.GetAssemblyLevel()==AssemblyLevel::LEGACY)
+   if (M_.GetAssemblyLevel()==AssemblyLevel::LEGACY)
    {
       HypreParMatrix &M_mat = *M.As<HypreParMatrix>();
       HypreParMatrix &K_mat = *K.As<HypreParMatrix>();
       HypreSmoother *hypre_prec = new HypreSmoother(M_mat, HypreSmoother::Jacobi);
       M_prec = hypre_prec;
 
-      dg_solver = new DG_Solver(M_mat, K_mat, *_M.FESpace());
+      dg_solver = new DG_Solver(M_mat, K_mat, *M_.FESpace());
    }
    else
    {
-      M_prec = new OperatorJacobiSmoother(_M, ess_tdof_list);
+      M_prec = new OperatorJacobiSmoother(M_, ess_tdof_list);
       dg_solver = NULL;
    }
 

--- a/fem/bilininteg.hpp
+++ b/fem/bilininteg.hpp
@@ -254,8 +254,8 @@ private:
    DenseMatrix bfi_elmat;
 
 public:
-   TransposeIntegrator (BilinearFormIntegrator *_bfi, int _own_bfi = 1)
-   { bfi = _bfi; own_bfi = _own_bfi; }
+   TransposeIntegrator (BilinearFormIntegrator *bfi_, int own_bfi_ = 1)
+   { bfi = bfi_; own_bfi = own_bfi_; }
 
    virtual void AssembleElementMatrix(const FiniteElement &el,
                                       ElementTransformation &Trans,
@@ -321,8 +321,8 @@ private:
    BilinearFormIntegrator *bfi;
 
 public:
-   LumpedIntegrator (BilinearFormIntegrator *_bfi, int _own_bfi = 1)
-   { bfi = _bfi; own_bfi = _own_bfi; }
+   LumpedIntegrator (BilinearFormIntegrator *bfi_, int own_bfi_ = 1)
+   { bfi = bfi_; own_bfi = own_bfi_; }
 
    virtual void AssembleElementMatrix(const FiniteElement &el,
                                       ElementTransformation &Trans,
@@ -591,9 +591,9 @@ public:
 
 protected:
 
-   MixedScalarVectorIntegrator(VectorCoefficient &vq, bool _transpose = false,
-                               bool _cross_2d = false)
-      : VQ(&vq), transpose(_transpose), cross_2d(_cross_2d) {}
+   MixedScalarVectorIntegrator(VectorCoefficient &vq, bool transpose_ = false,
+                               bool cross_2d_ = false)
+      : VQ(&vq), transpose(transpose_), cross_2d(cross_2d_) {}
 
    inline virtual bool VerifyFiniteElementTypes(
       const FiniteElement & trial_fe,
@@ -1918,8 +1918,8 @@ public:
    GradientIntegrator() :
       Q{NULL}, trial_maps{NULL}, test_maps{NULL}, geom{NULL}
    { }
-   GradientIntegrator(Coefficient *_q) :
-      Q{_q}, trial_maps{NULL}, test_maps{NULL}, geom{NULL}
+   GradientIntegrator(Coefficient *q_) :
+      Q{q_}, trial_maps{NULL}, test_maps{NULL}, geom{NULL}
    { }
    GradientIntegrator(Coefficient &q) :
       Q{&q}, trial_maps{NULL}, test_maps{NULL}, geom{NULL}
@@ -2505,11 +2505,11 @@ protected:
 
 public:
    VectorFEMassIntegrator() { Init(NULL, NULL, NULL, NULL); }
-   VectorFEMassIntegrator(Coefficient *_q) { Init(_q, NULL, NULL, NULL); }
+   VectorFEMassIntegrator(Coefficient *q_) { Init(q_, NULL, NULL, NULL); }
    VectorFEMassIntegrator(Coefficient &q) { Init(&q, NULL, NULL, NULL); }
-   VectorFEMassIntegrator(DiagonalMatrixCoefficient *_dq) { Init(NULL, _dq, NULL, NULL); }
+   VectorFEMassIntegrator(DiagonalMatrixCoefficient *dq_) { Init(NULL, dq_, NULL, NULL); }
    VectorFEMassIntegrator(DiagonalMatrixCoefficient &dq) { Init(NULL, &dq, NULL, NULL); }
-   VectorFEMassIntegrator(MatrixCoefficient *_mq) { Init(NULL, NULL, _mq, NULL); }
+   VectorFEMassIntegrator(MatrixCoefficient *mq_) { Init(NULL, NULL, mq_, NULL); }
    VectorFEMassIntegrator(MatrixCoefficient &mq) { Init(NULL, NULL, &mq, NULL); }
    VectorFEMassIntegrator(SymmetricMatrixCoefficient &smq) { Init(NULL, NULL, NULL, &smq); }
    VectorFEMassIntegrator(SymmetricMatrixCoefficient *smq) { Init(NULL, NULL, NULL, smq); }
@@ -2554,8 +2554,8 @@ public:
    VectorDivergenceIntegrator() :
       Q(NULL), trial_maps(NULL), test_maps(NULL), geom(NULL)
    {  }
-   VectorDivergenceIntegrator(Coefficient *_q) :
-      Q(_q), trial_maps(NULL), test_maps(NULL), geom(NULL)
+   VectorDivergenceIntegrator(Coefficient *q_) :
+      Q(q_), trial_maps(NULL), test_maps(NULL), geom(NULL)
    { }
    VectorDivergenceIntegrator(Coefficient &q) :
       Q(&q), trial_maps(NULL), test_maps(NULL), geom(NULL)
@@ -2814,9 +2814,9 @@ public:
    DGTraceIntegrator(VectorCoefficient &u_, double a, double b)
    { rho = NULL; u = &u_; alpha = a; beta = b; }
 
-   DGTraceIntegrator(Coefficient &_rho, VectorCoefficient &u_,
+   DGTraceIntegrator(Coefficient &rho_, VectorCoefficient &u_,
                      double a, double b)
-   { rho = &_rho; u = &u_; alpha = a; beta = b; }
+   { rho = &rho_; u = &u_; alpha = a; beta = b; }
 
    using BilinearFormIntegrator::AssembleFaceMatrix;
    virtual void AssembleFaceMatrix(const FiniteElement &el1,

--- a/fem/bilininteg_convection_pa.cpp
+++ b/fem/bilininteg_convection_pa.cpp
@@ -142,9 +142,9 @@ void PAConvectionApply2D(const int ne,
                          const Array<double> &g,
                          const Array<double> &bt,
                          const Array<double> &gt,
-                         const Vector &_op,
-                         const Vector &_x,
-                         Vector &_y,
+                         const Vector &op_,
+                         const Vector &x_,
+                         Vector &y_,
                          const int d1d = 0,
                          const int q1d = 0)
 {
@@ -156,9 +156,9 @@ void PAConvectionApply2D(const int ne,
    auto B = Reshape(b.Read(), Q1D, D1D);
    auto G = Reshape(g.Read(), Q1D, D1D);
    auto Bt = Reshape(bt.Read(), D1D, Q1D);
-   auto op = Reshape(_op.Read(), Q1D, Q1D, 2, NE);
-   auto x = Reshape(_x.Read(), D1D, D1D, NE);
-   auto y = Reshape(_y.ReadWrite(), D1D, D1D, NE);
+   auto op = Reshape(op_.Read(), Q1D, Q1D, 2, NE);
+   auto x = Reshape(x_.Read(), D1D, D1D, NE);
+   auto y = Reshape(y_.ReadWrite(), D1D, D1D, NE);
    MFEM_FORALL(e, NE,
    {
       const int D1D = T_D1D ? T_D1D : d1d;
@@ -261,9 +261,9 @@ void SmemPAConvectionApply2D(const int ne,
                              const Array<double> &g,
                              const Array<double> &bt,
                              const Array<double> &gt,
-                             const Vector &_op,
-                             const Vector &_x,
-                             Vector &_y,
+                             const Vector &op_,
+                             const Vector &x_,
+                             Vector &y_,
                              const int d1d = 0,
                              const int q1d = 0)
 {
@@ -276,9 +276,9 @@ void SmemPAConvectionApply2D(const int ne,
    auto B = Reshape(b.Read(), Q1D, D1D);
    auto G = Reshape(g.Read(), Q1D, D1D);
    auto Bt = Reshape(bt.Read(), D1D, Q1D);
-   auto op = Reshape(_op.Read(), Q1D, Q1D, 2, NE);
-   auto x = Reshape(_x.Read(), D1D, D1D, NE);
-   auto y = Reshape(_y.ReadWrite(), D1D, D1D, NE);
+   auto op = Reshape(op_.Read(), Q1D, Q1D, 2, NE);
+   auto x = Reshape(x_.Read(), D1D, D1D, NE);
+   auto y = Reshape(y_.ReadWrite(), D1D, D1D, NE);
    MFEM_FORALL_2D(e, NE, Q1D, Q1D, NBZ,
    {
       const int tidz = MFEM_THREAD_ID(z);
@@ -389,9 +389,9 @@ void PAConvectionApply3D(const int ne,
                          const Array<double> &g,
                          const Array<double> &bt,
                          const Array<double> &gt,
-                         const Vector &_op,
-                         const Vector &_x,
-                         Vector &_y,
+                         const Vector &op_,
+                         const Vector &x_,
+                         Vector &y_,
                          const int d1d = 0,
                          const int q1d = 0)
 {
@@ -403,9 +403,9 @@ void PAConvectionApply3D(const int ne,
    auto B = Reshape(b.Read(), Q1D, D1D);
    auto G = Reshape(g.Read(), Q1D, D1D);
    auto Bt = Reshape(bt.Read(), D1D, Q1D);
-   auto op = Reshape(_op.Read(), Q1D, Q1D, Q1D, 3, NE);
-   auto x = Reshape(_x.Read(), D1D, D1D, D1D, NE);
-   auto y = Reshape(_y.ReadWrite(), D1D, D1D, D1D, NE);
+   auto op = Reshape(op_.Read(), Q1D, Q1D, Q1D, 3, NE);
+   auto x = Reshape(x_.Read(), D1D, D1D, D1D, NE);
+   auto y = Reshape(y_.ReadWrite(), D1D, D1D, D1D, NE);
    MFEM_FORALL(e, NE,
    {
       const int D1D = T_D1D ? T_D1D : d1d;
@@ -570,9 +570,9 @@ void SmemPAConvectionApply3D(const int ne,
                              const Array<double> &g,
                              const Array<double> &bt,
                              const Array<double> &gt,
-                             const Vector &_op,
-                             const Vector &_x,
-                             Vector &_y,
+                             const Vector &op_,
+                             const Vector &x_,
+                             Vector &y_,
                              const int d1d = 0,
                              const int q1d = 0)
 {
@@ -584,9 +584,9 @@ void SmemPAConvectionApply3D(const int ne,
    auto B = Reshape(b.Read(), Q1D, D1D);
    auto G = Reshape(g.Read(), Q1D, D1D);
    auto Bt = Reshape(bt.Read(), D1D, Q1D);
-   auto op = Reshape(_op.Read(), Q1D, Q1D, Q1D, 3, NE);
-   auto x = Reshape(_x.Read(), D1D, D1D, D1D, NE);
-   auto y = Reshape(_y.ReadWrite(), D1D, D1D, D1D, NE);
+   auto op = Reshape(op_.Read(), Q1D, Q1D, Q1D, 3, NE);
+   auto x = Reshape(x_.Read(), D1D, D1D, D1D, NE);
+   auto y = Reshape(y_.ReadWrite(), D1D, D1D, D1D, NE);
    MFEM_FORALL_3D(e, NE, Q1D, Q1D, Q1D,
    {
       const int D1D = T_D1D ? T_D1D : d1d;

--- a/fem/bilininteg_dgtrace_pa.cpp
+++ b/fem/bilininteg_dgtrace_pa.cpp
@@ -305,9 +305,9 @@ template<int T_D1D = 0, int T_Q1D = 0> static
 void PADGTraceApply2D(const int NF,
                       const Array<double> &b,
                       const Array<double> &bt,
-                      const Vector &_op,
-                      const Vector &_x,
-                      Vector &_y,
+                      const Vector &op_,
+                      const Vector &x_,
+                      Vector &y_,
                       const int d1d = 0,
                       const int q1d = 0)
 {
@@ -318,9 +318,9 @@ void PADGTraceApply2D(const int NF,
    MFEM_VERIFY(Q1D <= MAX_Q1D, "");
    auto B = Reshape(b.Read(), Q1D, D1D);
    auto Bt = Reshape(bt.Read(), D1D, Q1D);
-   auto op = Reshape(_op.Read(), Q1D, 2, 2, NF);
-   auto x = Reshape(_x.Read(), D1D, VDIM, 2, NF);
-   auto y = Reshape(_y.ReadWrite(), D1D, VDIM, 2, NF);
+   auto op = Reshape(op_.Read(), Q1D, 2, 2, NF);
+   auto x = Reshape(x_.Read(), D1D, VDIM, 2, NF);
+   auto y = Reshape(y_.ReadWrite(), D1D, VDIM, 2, NF);
 
    MFEM_FORALL(f, NF,
    {
@@ -396,9 +396,9 @@ template<int T_D1D = 0, int T_Q1D = 0> static
 void PADGTraceApply3D(const int NF,
                       const Array<double> &b,
                       const Array<double> &bt,
-                      const Vector &_op,
-                      const Vector &_x,
-                      Vector &_y,
+                      const Vector &op_,
+                      const Vector &x_,
+                      Vector &y_,
                       const int d1d = 0,
                       const int q1d = 0)
 {
@@ -409,9 +409,9 @@ void PADGTraceApply3D(const int NF,
    MFEM_VERIFY(Q1D <= MAX_Q1D, "");
    auto B = Reshape(b.Read(), Q1D, D1D);
    auto Bt = Reshape(bt.Read(), D1D, Q1D);
-   auto op = Reshape(_op.Read(), Q1D, Q1D, 2, 2, NF);
-   auto x = Reshape(_x.Read(), D1D, D1D, VDIM, 2, NF);
-   auto y = Reshape(_y.ReadWrite(), D1D, D1D, VDIM, 2, NF);
+   auto op = Reshape(op_.Read(), Q1D, Q1D, 2, 2, NF);
+   auto x = Reshape(x_.Read(), D1D, D1D, VDIM, 2, NF);
+   auto y = Reshape(y_.ReadWrite(), D1D, D1D, VDIM, 2, NF);
 
    MFEM_FORALL(f, NF,
    {
@@ -541,9 +541,9 @@ template<int T_D1D = 0, int T_Q1D = 0, int T_NBZ = 0> static
 void SmemPADGTraceApply3D(const int NF,
                           const Array<double> &b,
                           const Array<double> &bt,
-                          const Vector &_op,
-                          const Vector &_x,
-                          Vector &_y,
+                          const Vector &op_,
+                          const Vector &x_,
+                          Vector &y_,
                           const int d1d = 0,
                           const int q1d = 0)
 {
@@ -554,9 +554,9 @@ void SmemPADGTraceApply3D(const int NF,
    MFEM_VERIFY(Q1D <= MAX_Q1D, "");
    auto B = Reshape(b.Read(), Q1D, D1D);
    auto Bt = Reshape(bt.Read(), D1D, Q1D);
-   auto op = Reshape(_op.Read(), Q1D, Q1D, 2, 2, NF);
-   auto x = Reshape(_x.Read(), D1D, D1D, 2, NF);
-   auto y = Reshape(_y.ReadWrite(), D1D, D1D, 2, NF);
+   auto op = Reshape(op_.Read(), Q1D, Q1D, 2, 2, NF);
+   auto x = Reshape(x_.Read(), D1D, D1D, 2, NF);
+   auto y = Reshape(y_.ReadWrite(), D1D, D1D, 2, NF);
 
    MFEM_FORALL_2D(f, NF, Q1D, Q1D, NBZ,
    {
@@ -705,9 +705,9 @@ template<int T_D1D = 0, int T_Q1D = 0> static
 void PADGTraceApplyTranspose2D(const int NF,
                                const Array<double> &b,
                                const Array<double> &bt,
-                               const Vector &_op,
-                               const Vector &_x,
-                               Vector &_y,
+                               const Vector &op_,
+                               const Vector &x_,
+                               Vector &y_,
                                const int d1d = 0,
                                const int q1d = 0)
 {
@@ -718,9 +718,9 @@ void PADGTraceApplyTranspose2D(const int NF,
    MFEM_VERIFY(Q1D <= MAX_Q1D, "");
    auto B = Reshape(b.Read(), Q1D, D1D);
    auto Bt = Reshape(bt.Read(), D1D, Q1D);
-   auto op = Reshape(_op.Read(), Q1D, 2, 2, NF);
-   auto x = Reshape(_x.Read(), D1D, VDIM, 2, NF);
-   auto y = Reshape(_y.ReadWrite(), D1D, VDIM, 2, NF);
+   auto op = Reshape(op_.Read(), Q1D, 2, 2, NF);
+   auto x = Reshape(x_.Read(), D1D, VDIM, 2, NF);
+   auto y = Reshape(y_.ReadWrite(), D1D, VDIM, 2, NF);
 
    MFEM_FORALL(f, NF,
    {
@@ -801,9 +801,9 @@ template<int T_D1D = 0, int T_Q1D = 0> static
 void PADGTraceApplyTranspose3D(const int NF,
                                const Array<double> &b,
                                const Array<double> &bt,
-                               const Vector &_op,
-                               const Vector &_x,
-                               Vector &_y,
+                               const Vector &op_,
+                               const Vector &x_,
+                               Vector &y_,
                                const int d1d = 0,
                                const int q1d = 0)
 {
@@ -814,9 +814,9 @@ void PADGTraceApplyTranspose3D(const int NF,
    MFEM_VERIFY(Q1D <= MAX_Q1D, "");
    auto B = Reshape(b.Read(), Q1D, D1D);
    auto Bt = Reshape(bt.Read(), D1D, Q1D);
-   auto op = Reshape(_op.Read(), Q1D, Q1D, 2, 2, NF);
-   auto x = Reshape(_x.Read(), D1D, D1D, VDIM, 2, NF);
-   auto y = Reshape(_y.ReadWrite(), D1D, D1D, VDIM, 2, NF);
+   auto op = Reshape(op_.Read(), Q1D, Q1D, 2, 2, NF);
+   auto x = Reshape(x_.Read(), D1D, D1D, VDIM, 2, NF);
+   auto y = Reshape(y_.ReadWrite(), D1D, D1D, VDIM, 2, NF);
 
    MFEM_FORALL(f, NF,
    {
@@ -957,9 +957,9 @@ template<int T_D1D = 0, int T_Q1D = 0, int T_NBZ = 0> static
 void SmemPADGTraceApplyTranspose3D(const int NF,
                                    const Array<double> &b,
                                    const Array<double> &bt,
-                                   const Vector &_op,
-                                   const Vector &_x,
-                                   Vector &_y,
+                                   const Vector &op_,
+                                   const Vector &x_,
+                                   Vector &y_,
                                    const int d1d = 0,
                                    const int q1d = 0)
 {
@@ -970,9 +970,9 @@ void SmemPADGTraceApplyTranspose3D(const int NF,
    MFEM_VERIFY(Q1D <= MAX_Q1D, "");
    auto B = Reshape(b.Read(), Q1D, D1D);
    auto Bt = Reshape(bt.Read(), D1D, Q1D);
-   auto op = Reshape(_op.Read(), Q1D, Q1D, 2, 2, NF);
-   auto x = Reshape(_x.Read(), D1D, D1D, 2, NF);
-   auto y = Reshape(_y.ReadWrite(), D1D, D1D, 2, NF);
+   auto op = Reshape(op_.Read(), Q1D, Q1D, 2, 2, NF);
+   auto x = Reshape(x_.Read(), D1D, D1D, 2, NF);
+   auto y = Reshape(y_.ReadWrite(), D1D, D1D, 2, NF);
 
    MFEM_FORALL_2D(f, NF, Q1D, Q1D, NBZ,
    {

--- a/fem/bilininteg_divergence.cpp
+++ b/fem/bilininteg_divergence.cpp
@@ -164,9 +164,9 @@ static void PADivergenceApply2D(const int NE,
                                 const Array<double> &b,
                                 const Array<double> &g,
                                 const Array<double> &bt,
-                                const Vector &_op,
-                                const Vector &_x,
-                                Vector &_y,
+                                const Vector &op_,
+                                const Vector &x_,
+                                Vector &y_,
                                 const int tr_d1d = 0,
                                 const int te_d1d = 0,
                                 const int q1d = 0)
@@ -180,9 +180,9 @@ static void PADivergenceApply2D(const int NE,
    auto B = Reshape(b.Read(), Q1D, TR_D1D);
    auto G = Reshape(g.Read(), Q1D, TR_D1D);
    auto Bt = Reshape(bt.Read(), TE_D1D, Q1D);
-   auto op = Reshape(_op.Read(), Q1D*Q1D, 2,2, NE);
-   auto x = Reshape(_x.Read(), TR_D1D, TR_D1D, 2, NE);
-   auto y = Reshape(_y.ReadWrite(), TE_D1D, TE_D1D, NE);
+   auto op = Reshape(op_.Read(), Q1D*Q1D, 2,2, NE);
+   auto x = Reshape(x_.Read(), TR_D1D, TR_D1D, 2, NE);
+   auto y = Reshape(y_.ReadWrite(), TE_D1D, TE_D1D, NE);
    MFEM_FORALL(e, NE,
    {
       const int TR_D1D = T_TR_D1D ? T_TR_D1D : tr_d1d;
@@ -282,12 +282,12 @@ static void PADivergenceApply2D(const int NE,
 template<const int T_TR_D1D = 0, const int T_TE_D1D = 0, const int T_Q1D = 0,
          const int T_NBZ = 0>
 static void SmemPADivergenceApply2D(const int NE,
-                                    const Array<double> &_b,
-                                    const Array<double> &_g,
-                                    const Array<double> &_bt,
-                                    const Vector &_op,
-                                    const Vector &_x,
-                                    Vector &_y,
+                                    const Array<double> &b_,
+                                    const Array<double> &g_,
+                                    const Array<double> &bt_,
+                                    const Vector &op_,
+                                    const Vector &x_,
+                                    Vector &y_,
                                     const int tr_d1d = 0,
                                     const int te_d1d = 0,
                                     const int q1d = 0)
@@ -302,9 +302,9 @@ static void PADivergenceApplyTranspose2D(const int NE,
                                          const Array<double> &bt,
                                          const Array<double> &gt,
                                          const Array<double> &b,
-                                         const Vector &_op,
-                                         const Vector &_x,
-                                         Vector &_y,
+                                         const Vector &op_,
+                                         const Vector &x_,
+                                         Vector &y_,
                                          const int tr_d1d = 0,
                                          const int te_d1d = 0,
                                          const int q1d = 0)
@@ -318,9 +318,9 @@ static void PADivergenceApplyTranspose2D(const int NE,
    auto Bt = Reshape(bt.Read(), TR_D1D, Q1D);
    auto Gt = Reshape(gt.Read(), TR_D1D, Q1D);
    auto B  = Reshape(b.Read(), Q1D, TE_D1D);
-   auto op = Reshape(_op.Read(), Q1D*Q1D, 2,2, NE);
-   auto x  = Reshape(_x.Read(), TE_D1D, TE_D1D, NE);
-   auto y  = Reshape(_y.ReadWrite(), TR_D1D, TR_D1D, 2, NE);
+   auto op = Reshape(op_.Read(), Q1D*Q1D, 2,2, NE);
+   auto x  = Reshape(x_.Read(), TE_D1D, TE_D1D, NE);
+   auto y  = Reshape(y_.ReadWrite(), TR_D1D, TR_D1D, 2, NE);
    MFEM_FORALL(e, NE,
    {
       const int TR_D1D = T_TR_D1D ? T_TR_D1D : tr_d1d;
@@ -418,9 +418,9 @@ static void PADivergenceApply3D(const int NE,
                                 const Array<double> &b,
                                 const Array<double> &g,
                                 const Array<double> &bt,
-                                const Vector &_op,
-                                const Vector &_x,
-                                Vector &_y,
+                                const Vector &op_,
+                                const Vector &x_,
+                                Vector &y_,
                                 int tr_d1d = 0,
                                 int te_d1d = 0,
                                 int q1d = 0)
@@ -434,9 +434,9 @@ static void PADivergenceApply3D(const int NE,
    auto B = Reshape(b.Read(), Q1D, TR_D1D);
    auto G = Reshape(g.Read(), Q1D, TR_D1D);
    auto Bt = Reshape(bt.Read(), TE_D1D, Q1D);
-   auto op = Reshape(_op.Read(), Q1D*Q1D*Q1D, 3,3, NE);
-   auto x = Reshape(_x.Read(), TR_D1D, TR_D1D, TR_D1D, 3, NE);
-   auto y = Reshape(_y.ReadWrite(), TE_D1D, TE_D1D, TE_D1D, NE);
+   auto op = Reshape(op_.Read(), Q1D*Q1D*Q1D, 3,3, NE);
+   auto x = Reshape(x_.Read(), TR_D1D, TR_D1D, TR_D1D, 3, NE);
+   auto y = Reshape(y_.ReadWrite(), TE_D1D, TE_D1D, TE_D1D, NE);
    MFEM_FORALL(e, NE,
    {
       const int TR_D1D = T_TR_D1D ? T_TR_D1D : tr_d1d;
@@ -601,9 +601,9 @@ static void PADivergenceApplyTranspose3D(const int NE,
                                          const Array<double> &bt,
                                          const Array<double> &gt,
                                          const Array<double> &b,
-                                         const Vector &_op,
-                                         const Vector &_x,
-                                         Vector &_y,
+                                         const Vector &op_,
+                                         const Vector &x_,
+                                         Vector &y_,
                                          int tr_d1d = 0,
                                          int te_d1d = 0,
                                          int q1d = 0)
@@ -617,9 +617,9 @@ static void PADivergenceApplyTranspose3D(const int NE,
    auto Bt = Reshape(bt.Read(), TR_D1D, Q1D);
    auto Gt = Reshape(gt.Read(), TR_D1D, Q1D);
    auto B  = Reshape(b.Read(), Q1D, TE_D1D);
-   auto op = Reshape(_op.Read(), Q1D*Q1D*Q1D, 3,3, NE);
-   auto x  = Reshape(_x.Read(), TE_D1D, TE_D1D, TE_D1D, NE);
-   auto y  = Reshape(_y.ReadWrite(), TR_D1D, TR_D1D, TR_D1D, 3, NE);
+   auto op = Reshape(op_.Read(), Q1D*Q1D*Q1D, 3,3, NE);
+   auto x  = Reshape(x_.Read(), TE_D1D, TE_D1D, TE_D1D, NE);
+   auto y  = Reshape(y_.ReadWrite(), TR_D1D, TR_D1D, TR_D1D, 3, NE);
    MFEM_FORALL(e, NE,
    {
       const int TR_D1D = T_TR_D1D ? T_TR_D1D : tr_d1d;

--- a/fem/bilininteg_gradient.cpp
+++ b/fem/bilininteg_gradient.cpp
@@ -213,9 +213,9 @@ static void PAGradientApply2D(const int NE,
                               const Array<double> &b,
                               const Array<double> &g,
                               const Array<double> &bt,
-                              const Vector &_op,
-                              const Vector &_x,
-                              Vector &_y,
+                              const Vector &op_,
+                              const Vector &x_,
+                              Vector &y_,
                               const int tr_d1d = 0,
                               const int te_d1d = 0,
                               const int q1d = 0)
@@ -229,9 +229,9 @@ static void PAGradientApply2D(const int NE,
    auto B = Reshape(b.Read(), Q1D, TR_D1D);
    auto G = Reshape(g.Read(), Q1D, TR_D1D);
    auto Bt = Reshape(bt.Read(), TE_D1D, Q1D);
-   auto op = Reshape(_op.Read(), Q1D*Q1D, 2,2, NE);
-   auto x = Reshape(_x.Read(), TR_D1D, TR_D1D, NE);
-   auto y = Reshape(_y.ReadWrite(), TE_D1D, TE_D1D, 2, NE);
+   auto op = Reshape(op_.Read(), Q1D*Q1D, 2,2, NE);
+   auto x = Reshape(x_.Read(), TR_D1D, TR_D1D, NE);
+   auto y = Reshape(y_.ReadWrite(), TE_D1D, TE_D1D, 2, NE);
    MFEM_FORALL(e, NE,
    {
       const int TR_D1D = T_TR_D1D ? T_TR_D1D : tr_d1d;
@@ -326,9 +326,9 @@ static void PAGradientApplyTranspose2D(const int NE,
                                        const Array<double> &bt,
                                        const Array<double> &gt,
                                        const Array<double> &b,
-                                       const Vector &_op,
-                                       const Vector &_x,
-                                       Vector &_y,
+                                       const Vector &op_,
+                                       const Vector &x_,
+                                       Vector &y_,
                                        const int tr_d1d = 0,
                                        const int te_d1d = 0,
                                        const int q1d = 0)
@@ -343,9 +343,9 @@ static void PAGradientApply3D(const int NE,
                               const Array<double> &b,
                               const Array<double> &g,
                               const Array<double> &bt,
-                              const Vector &_op,
-                              const Vector &_x,
-                              Vector &_y,
+                              const Vector &op_,
+                              const Vector &x_,
+                              Vector &y_,
                               int tr_d1d = 0,
                               int te_d1d = 0,
                               int q1d = 0)
@@ -359,9 +359,9 @@ static void PAGradientApply3D(const int NE,
    auto B = Reshape(b.Read(), Q1D, TR_D1D);
    auto G = Reshape(g.Read(), Q1D, TR_D1D);
    auto Bt = Reshape(bt.Read(), TE_D1D, Q1D);
-   auto op = Reshape(_op.Read(), Q1D*Q1D*Q1D, 3,3, NE);
-   auto x = Reshape(_x.Read(), TR_D1D, TR_D1D, TR_D1D, NE);
-   auto y = Reshape(_y.ReadWrite(), TE_D1D, TE_D1D, TE_D1D, 3, NE);
+   auto op = Reshape(op_.Read(), Q1D*Q1D*Q1D, 3,3, NE);
+   auto x = Reshape(x_.Read(), TR_D1D, TR_D1D, TR_D1D, NE);
+   auto y = Reshape(y_.ReadWrite(), TE_D1D, TE_D1D, TE_D1D, 3, NE);
    MFEM_FORALL(e, NE,
    {
       const int TR_D1D = T_TR_D1D ? T_TR_D1D : tr_d1d;
@@ -522,9 +522,9 @@ static void PAGradientApplyTranspose3D(const int NE,
                                        const Array<double> &bt,
                                        const Array<double> &gt,
                                        const Array<double> &b,
-                                       const Vector &_op,
-                                       const Vector &_x,
-                                       Vector &_y,
+                                       const Vector &op_,
+                                       const Vector &x_,
+                                       Vector &y_,
                                        int tr_d1d = 0,
                                        int te_d1d = 0,
                                        int q1d = 0)

--- a/fem/bilininteg_hdiv.cpp
+++ b/fem/bilininteg_hdiv.cpp
@@ -27,14 +27,14 @@ void PAHdivSetup2D(const int Q1D,
                    const int NE,
                    const Array<double> &w,
                    const Vector &j,
-                   Vector &_coeff,
+                   Vector &coeff_,
                    Vector &op)
 {
    const int NQ = Q1D*Q1D;
    auto W = w.Read();
 
    auto J = Reshape(j.Read(), NQ, 2, 2, NE);
-   auto coeff = Reshape(_coeff.Read(), NQ, NE);
+   auto coeff = Reshape(coeff_.Read(), NQ, NE);
    auto y = Reshape(op.Write(), NQ, 3, NE);
 
    MFEM_FORALL(e, NE,
@@ -59,13 +59,13 @@ void PAHdivSetup3D(const int Q1D,
                    const int NE,
                    const Array<double> &w,
                    const Vector &j,
-                   Vector &_coeff,
+                   Vector &coeff_,
                    Vector &op)
 {
    const int NQ = Q1D*Q1D*Q1D;
    auto W = w.Read();
    auto J = Reshape(j.Read(), NQ, 3, 3, NE);
-   auto coeff = Reshape(_coeff.Read(), NQ, NE);
+   auto coeff = Reshape(coeff_.Read(), NQ, NE);
    auto y = Reshape(op.Write(), NQ, 6, NE);
 
    MFEM_FORALL(e, NE,
@@ -99,25 +99,25 @@ void PAHdivSetup3D(const int Q1D,
 void PAHdivMassApply2D(const int D1D,
                        const int Q1D,
                        const int NE,
-                       const Array<double> &_Bo,
-                       const Array<double> &_Bc,
-                       const Array<double> &_Bot,
-                       const Array<double> &_Bct,
-                       const Vector &_op,
-                       const Vector &_x,
-                       Vector &_y)
+                       const Array<double> &Bo_,
+                       const Array<double> &Bc_,
+                       const Array<double> &Bot_,
+                       const Array<double> &Bct_,
+                       const Vector &op_,
+                       const Vector &x_,
+                       Vector &y_)
 {
    constexpr static int VDIM = 2;
    constexpr static int MAX_D1D = HDIV_MAX_D1D;
    constexpr static int MAX_Q1D = HDIV_MAX_Q1D;
 
-   auto Bo = Reshape(_Bo.Read(), Q1D, D1D-1);
-   auto Bc = Reshape(_Bc.Read(), Q1D, D1D);
-   auto Bot = Reshape(_Bot.Read(), D1D-1, Q1D);
-   auto Bct = Reshape(_Bct.Read(), D1D, Q1D);
-   auto op = Reshape(_op.Read(), Q1D, Q1D, 3, NE);
-   auto x = Reshape(_x.Read(), 2*(D1D-1)*D1D, NE);
-   auto y = Reshape(_y.ReadWrite(), 2*(D1D-1)*D1D, NE);
+   auto Bo = Reshape(Bo_.Read(), Q1D, D1D-1);
+   auto Bc = Reshape(Bc_.Read(), Q1D, D1D);
+   auto Bot = Reshape(Bot_.Read(), D1D-1, Q1D);
+   auto Bct = Reshape(Bct_.Read(), D1D, Q1D);
+   auto op = Reshape(op_.Read(), Q1D, Q1D, 3, NE);
+   auto x = Reshape(x_.Read(), 2*(D1D-1)*D1D, NE);
+   auto y = Reshape(y_.ReadWrite(), 2*(D1D-1)*D1D, NE);
 
    MFEM_FORALL(e, NE,
    {
@@ -228,18 +228,18 @@ void PAHdivMassApply2D(const int D1D,
 void PAHdivMassAssembleDiagonal2D(const int D1D,
                                   const int Q1D,
                                   const int NE,
-                                  const Array<double> &_Bo,
-                                  const Array<double> &_Bc,
-                                  const Vector &_op,
-                                  Vector &_diag)
+                                  const Array<double> &Bo_,
+                                  const Array<double> &Bc_,
+                                  const Vector &op_,
+                                  Vector &diag_)
 {
    constexpr static int VDIM = 2;
    constexpr static int MAX_Q1D = HDIV_MAX_Q1D;
 
-   auto Bo = Reshape(_Bo.Read(), Q1D, D1D-1);
-   auto Bc = Reshape(_Bc.Read(), Q1D, D1D);
-   auto op = Reshape(_op.Read(), Q1D, Q1D, 3, NE);
-   auto diag = Reshape(_diag.ReadWrite(), 2*(D1D-1)*D1D, NE);
+   auto Bo = Reshape(Bo_.Read(), Q1D, D1D-1);
+   auto Bc = Reshape(Bc_.Read(), Q1D, D1D);
+   auto op = Reshape(op_.Read(), Q1D, Q1D, 3, NE);
+   auto diag = Reshape(diag_.ReadWrite(), 2*(D1D-1)*D1D, NE);
 
    MFEM_FORALL(e, NE,
    {
@@ -283,19 +283,19 @@ void PAHdivMassAssembleDiagonal2D(const int D1D,
 void PAHdivMassAssembleDiagonal3D(const int D1D,
                                   const int Q1D,
                                   const int NE,
-                                  const Array<double> &_Bo,
-                                  const Array<double> &_Bc,
-                                  const Vector &_op,
-                                  Vector &_diag)
+                                  const Array<double> &Bo_,
+                                  const Array<double> &Bc_,
+                                  const Vector &op_,
+                                  Vector &diag_)
 {
    MFEM_VERIFY(D1D <= HDIV_MAX_D1D, "Error: D1D > HDIV_MAX_D1D");
    MFEM_VERIFY(Q1D <= HDIV_MAX_Q1D, "Error: Q1D > HDIV_MAX_Q1D");
    constexpr static int VDIM = 3;
 
-   auto Bo = Reshape(_Bo.Read(), Q1D, D1D-1);
-   auto Bc = Reshape(_Bc.Read(), Q1D, D1D);
-   auto op = Reshape(_op.Read(), Q1D, Q1D, Q1D, 6, NE);
-   auto diag = Reshape(_diag.ReadWrite(), 3*(D1D-1)*(D1D-1)*D1D, NE);
+   auto Bo = Reshape(Bo_.Read(), Q1D, D1D-1);
+   auto Bc = Reshape(Bc_.Read(), Q1D, D1D);
+   auto op = Reshape(op_.Read(), Q1D, Q1D, Q1D, 6, NE);
+   auto diag = Reshape(diag_.ReadWrite(), 3*(D1D-1)*(D1D-1)*D1D, NE);
 
    MFEM_FORALL(e, NE,
    {
@@ -350,25 +350,25 @@ void PAHdivMassAssembleDiagonal3D(const int D1D,
 void PAHdivMassApply3D(const int D1D,
                        const int Q1D,
                        const int NE,
-                       const Array<double> &_Bo,
-                       const Array<double> &_Bc,
-                       const Array<double> &_Bot,
-                       const Array<double> &_Bct,
-                       const Vector &_op,
-                       const Vector &_x,
-                       Vector &_y)
+                       const Array<double> &Bo_,
+                       const Array<double> &Bc_,
+                       const Array<double> &Bot_,
+                       const Array<double> &Bct_,
+                       const Vector &op_,
+                       const Vector &x_,
+                       Vector &y_)
 {
    MFEM_VERIFY(D1D <= HDIV_MAX_D1D, "Error: D1D > HDIV_MAX_D1D");
    MFEM_VERIFY(Q1D <= HDIV_MAX_Q1D, "Error: Q1D > HDIV_MAX_Q1D");
    constexpr static int VDIM = 3;
 
-   auto Bo = Reshape(_Bo.Read(), Q1D, D1D-1);
-   auto Bc = Reshape(_Bc.Read(), Q1D, D1D);
-   auto Bot = Reshape(_Bot.Read(), D1D-1, Q1D);
-   auto Bct = Reshape(_Bct.Read(), D1D, Q1D);
-   auto op = Reshape(_op.Read(), Q1D, Q1D, Q1D, 6, NE);
-   auto x = Reshape(_x.Read(), 3*(D1D-1)*(D1D-1)*D1D, NE);
-   auto y = Reshape(_y.ReadWrite(), 3*(D1D-1)*(D1D-1)*D1D, NE);
+   auto Bo = Reshape(Bo_.Read(), Q1D, D1D-1);
+   auto Bc = Reshape(Bc_.Read(), Q1D, D1D);
+   auto Bot = Reshape(Bot_.Read(), D1D-1, Q1D);
+   auto Bct = Reshape(Bct_.Read(), D1D, Q1D);
+   auto op = Reshape(op_.Read(), Q1D, Q1D, Q1D, 6, NE);
+   auto x = Reshape(x_.Read(), 3*(D1D-1)*(D1D-1)*D1D, NE);
+   auto y = Reshape(y_.ReadWrite(), 3*(D1D-1)*(D1D-1)*D1D, NE);
 
    MFEM_FORALL(e, NE,
    {
@@ -543,13 +543,13 @@ static void PADivDivSetup2D(const int Q1D,
                             const int NE,
                             const Array<double> &w,
                             const Vector &j,
-                            Vector &_coeff,
+                            Vector &coeff_,
                             Vector &op)
 {
    const int NQ = Q1D*Q1D;
    auto W = w.Read();
    auto J = Reshape(j.Read(), NQ, 2, 2, NE);
-   auto coeff = Reshape(_coeff.Read(), NQ, NE);
+   auto coeff = Reshape(coeff_.Read(), NQ, NE);
    auto y = Reshape(op.Write(), NQ, NE);
    MFEM_FORALL(e, NE,
    {
@@ -569,13 +569,13 @@ static void PADivDivSetup3D(const int Q1D,
                             const int NE,
                             const Array<double> &w,
                             const Vector &j,
-                            Vector &_coeff,
+                            Vector &coeff_,
                             Vector &op)
 {
    const int NQ = Q1D*Q1D*Q1D;
    auto W = w.Read();
    auto J = Reshape(j.Read(), NQ, 3, 3, NE);
-   auto coeff = Reshape(_coeff.Read(), NQ, NE);
+   auto coeff = Reshape(coeff_.Read(), NQ, NE);
    auto y = Reshape(op.Write(), NQ, NE);
 
    MFEM_FORALL(e, NE,
@@ -602,31 +602,31 @@ static void PADivDivSetup3D(const int Q1D,
 static void PADivDivApply2D(const int D1D,
                             const int Q1D,
                             const int NE,
-                            const Array<double> &_Bo,
-                            const Array<double> &_Gc,
-                            const Array<double> &_Bot,
-                            const Array<double> &_Gct,
-                            const Vector &_op,
-                            const Vector &_x,
-                            Vector &_y)
+                            const Array<double> &Bo_,
+                            const Array<double> &Gc_,
+                            const Array<double> &Bot_,
+                            const Array<double> &Gct_,
+                            const Vector &op_,
+                            const Vector &x_,
+                            Vector &y_)
 {
    constexpr static int VDIM = 2;
    constexpr static int MAX_D1D = HDIV_MAX_D1D;
    constexpr static int MAX_Q1D = HDIV_MAX_Q1D;
 
-   auto Bo = Reshape(_Bo.Read(), Q1D, D1D-1);
-   auto Bot = Reshape(_Bot.Read(), D1D-1, Q1D);
-   auto Gc = Reshape(_Gc.Read(), Q1D, D1D);
-   auto Gct = Reshape(_Gct.Read(), D1D, Q1D);
-   auto op = Reshape(_op.Read(), Q1D, Q1D, NE);
-   auto x = Reshape(_x.Read(), 2*(D1D-1)*D1D, NE);
-   auto y = Reshape(_y.ReadWrite(), 2*(D1D-1)*D1D, NE);
+   auto Bo = Reshape(Bo_.Read(), Q1D, D1D-1);
+   auto Bot = Reshape(Bot_.Read(), D1D-1, Q1D);
+   auto Gc = Reshape(Gc_.Read(), Q1D, D1D);
+   auto Gct = Reshape(Gct_.Read(), D1D, Q1D);
+   auto op = Reshape(op_.Read(), Q1D, Q1D, NE);
+   auto x = Reshape(x_.Read(), 2*(D1D-1)*D1D, NE);
+   auto y = Reshape(y_.ReadWrite(), 2*(D1D-1)*D1D, NE);
 
    MFEM_FORALL(e, NE,
    {
       double div[MAX_Q1D][MAX_Q1D];
 
-      // div[qy][qx] will be computed as du_x/dx + du_y/dy
+      // div[qy][qx] will be computed as du_x/dx + duy_/dy
 
       for (int qy = 0; qy < Q1D; ++qy)
       {
@@ -721,25 +721,25 @@ static void PADivDivApply2D(const int D1D,
 static void PADivDivApply3D(const int D1D,
                             const int Q1D,
                             const int NE,
-                            const Array<double> &_Bo,
-                            const Array<double> &_Gc,
-                            const Array<double> &_Bot,
-                            const Array<double> &_Gct,
-                            const Vector &_op,
-                            const Vector &_x,
-                            Vector &_y)
+                            const Array<double> &Bo_,
+                            const Array<double> &Gc_,
+                            const Array<double> &Bot_,
+                            const Array<double> &Gct_,
+                            const Vector &op_,
+                            const Vector &x_,
+                            Vector &y_)
 {
    MFEM_VERIFY(D1D <= HDIV_MAX_D1D, "Error: D1D > HDIV_MAX_D1D");
    MFEM_VERIFY(Q1D <= HDIV_MAX_Q1D, "Error: Q1D > HDIV_MAX_Q1D");
    constexpr static int VDIM = 3;
 
-   auto Bo = Reshape(_Bo.Read(), Q1D, D1D-1);
-   auto Gc = Reshape(_Gc.Read(), Q1D, D1D);
-   auto Bot = Reshape(_Bot.Read(), D1D-1, Q1D);
-   auto Gct = Reshape(_Gct.Read(), D1D, Q1D);
-   auto op = Reshape(_op.Read(), Q1D, Q1D, Q1D, NE);
-   auto x = Reshape(_x.Read(), 3*(D1D-1)*(D1D-1)*D1D, NE);
-   auto y = Reshape(_y.ReadWrite(), 3*(D1D-1)*(D1D-1)*D1D, NE);
+   auto Bo = Reshape(Bo_.Read(), Q1D, D1D-1);
+   auto Gc = Reshape(Gc_.Read(), Q1D, D1D);
+   auto Bot = Reshape(Bot_.Read(), D1D-1, Q1D);
+   auto Gct = Reshape(Gct_.Read(), D1D, Q1D);
+   auto op = Reshape(op_.Read(), Q1D, Q1D, Q1D, NE);
+   auto x = Reshape(x_.Read(), 3*(D1D-1)*(D1D-1)*D1D, NE);
+   auto y = Reshape(y_.ReadWrite(), 3*(D1D-1)*(D1D-1)*D1D, NE);
 
    MFEM_FORALL(e, NE,
    {
@@ -970,18 +970,18 @@ void DivDivIntegrator::AddMultPA(const Vector &x, Vector &y) const
 static void PADivDivAssembleDiagonal2D(const int D1D,
                                        const int Q1D,
                                        const int NE,
-                                       const Array<double> &_Bo,
-                                       const Array<double> &_Gc,
-                                       const Vector &_op,
-                                       Vector &_diag)
+                                       const Array<double> &Bo_,
+                                       const Array<double> &Gc_,
+                                       const Vector &op_,
+                                       Vector &diag_)
 {
    constexpr static int VDIM = 2;
    constexpr static int MAX_Q1D = HDIV_MAX_Q1D;
 
-   auto Bo = Reshape(_Bo.Read(), Q1D, D1D-1);
-   auto Gc = Reshape(_Gc.Read(), Q1D, D1D);
-   auto op = Reshape(_op.Read(), Q1D, Q1D, NE);
-   auto diag = Reshape(_diag.ReadWrite(), 2*(D1D-1)*D1D, NE);
+   auto Bo = Reshape(Bo_.Read(), Q1D, D1D-1);
+   auto Gc = Reshape(Gc_.Read(), Q1D, D1D);
+   auto op = Reshape(op_.Read(), Q1D, Q1D, NE);
+   auto diag = Reshape(diag_.ReadWrite(), 2*(D1D-1)*D1D, NE);
 
    MFEM_FORALL(e, NE,
    {
@@ -1026,19 +1026,19 @@ static void PADivDivAssembleDiagonal2D(const int D1D,
 static void PADivDivAssembleDiagonal3D(const int D1D,
                                        const int Q1D,
                                        const int NE,
-                                       const Array<double> &_Bo,
-                                       const Array<double> &_Gc,
-                                       const Vector &_op,
-                                       Vector &_diag)
+                                       const Array<double> &Bo_,
+                                       const Array<double> &Gc_,
+                                       const Vector &op_,
+                                       Vector &diag_)
 {
    MFEM_VERIFY(D1D <= HDIV_MAX_D1D, "Error: D1D > HDIV_MAX_D1D");
    MFEM_VERIFY(Q1D <= HDIV_MAX_Q1D, "Error: Q1D > HDIV_MAX_Q1D");
    constexpr static int VDIM = 3;
 
-   auto Bo = Reshape(_Bo.Read(), Q1D, D1D-1);
-   auto Gc = Reshape(_Gc.Read(), Q1D, D1D);
-   auto op = Reshape(_op.Read(), Q1D, Q1D, Q1D, NE);
-   auto diag = Reshape(_diag.ReadWrite(), 3*(D1D-1)*(D1D-1)*D1D, NE);
+   auto Bo = Reshape(Bo_.Read(), Q1D, D1D-1);
+   auto Gc = Reshape(Gc_.Read(), Q1D, D1D);
+   auto op = Reshape(op_.Read(), Q1D, Q1D, Q1D, NE);
+   auto diag = Reshape(diag_.ReadWrite(), 3*(D1D-1)*(D1D-1)*D1D, NE);
 
    MFEM_FORALL(e, NE,
    {
@@ -1107,12 +1107,12 @@ void DivDivIntegrator::AssembleDiagonalPA(Vector& diag)
 static void PADivL2Setup2D(const int Q1D,
                            const int NE,
                            const Array<double> &w,
-                           Vector &_coeff,
+                           Vector &coeff_,
                            Vector &op)
 {
    const int NQ = Q1D*Q1D;
    auto W = w.Read();
-   auto coeff = Reshape(_coeff.Read(), NQ, NE);
+   auto coeff = Reshape(coeff_.Read(), NQ, NE);
    auto y = Reshape(op.Write(), NQ, NE);
    MFEM_FORALL(e, NE,
    {
@@ -1126,12 +1126,12 @@ static void PADivL2Setup2D(const int Q1D,
 static void PADivL2Setup3D(const int Q1D,
                            const int NE,
                            const Array<double> &w,
-                           Vector &_coeff,
+                           Vector &coeff_,
                            Vector &op)
 {
    const int NQ = Q1D*Q1D*Q1D;
    auto W = w.Read();
-   auto coeff = Reshape(_coeff.Read(), NQ, NE);
+   auto coeff = Reshape(coeff_.Read(), NQ, NE);
    auto y = Reshape(op.Write(), NQ, NE);
 
    MFEM_FORALL(e, NE,
@@ -1229,23 +1229,23 @@ static void PAHdivL2Apply3D(const int D1D,
                             const int Q1D,
                             const int L2D1D,
                             const int NE,
-                            const Array<double> &_Bo,
-                            const Array<double> &_Gc,
-                            const Array<double> &_L2Bot,
-                            const Vector &_op,
-                            const Vector &_x,
-                            Vector &_y)
+                            const Array<double> &Bo_,
+                            const Array<double> &Gc_,
+                            const Array<double> &L2Bot_,
+                            const Vector &op_,
+                            const Vector &x_,
+                            Vector &y_)
 {
    MFEM_VERIFY(D1D <= HDIV_MAX_D1D, "Error: D1D > HDIV_MAX_D1D");
    MFEM_VERIFY(Q1D <= HDIV_MAX_Q1D, "Error: Q1D > HDIV_MAX_Q1D");
    constexpr static int VDIM = 3;
 
-   auto Bo = Reshape(_Bo.Read(), Q1D, D1D-1);
-   auto Gc = Reshape(_Gc.Read(), Q1D, D1D);
-   auto L2Bot = Reshape(_L2Bot.Read(), L2D1D, Q1D);
-   auto op = Reshape(_op.Read(), Q1D, Q1D, Q1D, NE);
-   auto x = Reshape(_x.Read(), 3*(D1D-1)*(D1D-1)*D1D, NE);
-   auto y = Reshape(_y.ReadWrite(), L2D1D, L2D1D, L2D1D, NE);
+   auto Bo = Reshape(Bo_.Read(), Q1D, D1D-1);
+   auto Gc = Reshape(Gc_.Read(), Q1D, D1D);
+   auto L2Bot = Reshape(L2Bot_.Read(), L2D1D, Q1D);
+   auto op = Reshape(op_.Read(), Q1D, Q1D, Q1D, NE);
+   auto x = Reshape(x_.Read(), 3*(D1D-1)*(D1D-1)*D1D, NE);
+   auto y = Reshape(y_.ReadWrite(), L2D1D, L2D1D, L2D1D, NE);
 
    MFEM_FORALL(e, NE,
    {
@@ -1392,23 +1392,23 @@ static void PAHdivL2Apply2D(const int D1D,
                             const int Q1D,
                             const int L2D1D,
                             const int NE,
-                            const Array<double> &_Bo,
-                            const Array<double> &_Gc,
-                            const Array<double> &_L2Bot,
-                            const Vector &_op,
-                            const Vector &_x,
-                            Vector &_y)
+                            const Array<double> &Bo_,
+                            const Array<double> &Gc_,
+                            const Array<double> &L2Bot_,
+                            const Vector &op_,
+                            const Vector &x_,
+                            Vector &y_)
 {
    constexpr static int VDIM = 2;
    constexpr static int MAX_D1D = HDIV_MAX_D1D;
    constexpr static int MAX_Q1D = HDIV_MAX_Q1D;
 
-   auto Bo = Reshape(_Bo.Read(), Q1D, D1D-1);
-   auto Gc = Reshape(_Gc.Read(), Q1D, D1D);
-   auto L2Bot = Reshape(_L2Bot.Read(), L2D1D, Q1D);
-   auto op = Reshape(_op.Read(), Q1D, Q1D, NE);
-   auto x = Reshape(_x.Read(), 2*(D1D-1)*D1D, NE);
-   auto y = Reshape(_y.ReadWrite(), L2D1D, L2D1D, NE);
+   auto Bo = Reshape(Bo_.Read(), Q1D, D1D-1);
+   auto Gc = Reshape(Gc_.Read(), Q1D, D1D);
+   auto L2Bot = Reshape(L2Bot_.Read(), L2D1D, Q1D);
+   auto op = Reshape(op_.Read(), Q1D, Q1D, NE);
+   auto x = Reshape(x_.Read(), 2*(D1D-1)*D1D, NE);
+   auto y = Reshape(y_.ReadWrite(), L2D1D, L2D1D, NE);
 
    MFEM_FORALL(e, NE,
    {
@@ -1498,23 +1498,23 @@ static void PAHdivL2ApplyTranspose3D(const int D1D,
                                      const int Q1D,
                                      const int L2D1D,
                                      const int NE,
-                                     const Array<double> &_L2Bo,
-                                     const Array<double> &_Gct,
-                                     const Array<double> &_Bot,
-                                     const Vector &_op,
-                                     const Vector &_x,
-                                     Vector &_y)
+                                     const Array<double> &L2Bo_,
+                                     const Array<double> &Gct_,
+                                     const Array<double> &Bot_,
+                                     const Vector &op_,
+                                     const Vector &x_,
+                                     Vector &y_)
 {
    MFEM_VERIFY(D1D <= HDIV_MAX_D1D, "Error: D1D > HDIV_MAX_D1D");
    MFEM_VERIFY(Q1D <= HDIV_MAX_Q1D, "Error: Q1D > HDIV_MAX_Q1D");
    constexpr static int VDIM = 3;
 
-   auto L2Bo = Reshape(_L2Bo.Read(), Q1D, L2D1D);
-   auto Gct = Reshape(_Gct.Read(), D1D, Q1D);
-   auto Bot = Reshape(_Bot.Read(), D1D-1, Q1D);
-   auto op = Reshape(_op.Read(), Q1D, Q1D, Q1D, NE);
-   auto x = Reshape(_x.Read(), L2D1D, L2D1D, L2D1D, NE);
-   auto y = Reshape(_y.ReadWrite(), 3*(D1D-1)*(D1D-1)*D1D, NE);
+   auto L2Bo = Reshape(L2Bo_.Read(), Q1D, L2D1D);
+   auto Gct = Reshape(Gct_.Read(), D1D, Q1D);
+   auto Bot = Reshape(Bot_.Read(), D1D-1, Q1D);
+   auto op = Reshape(op_.Read(), Q1D, Q1D, Q1D, NE);
+   auto x = Reshape(x_.Read(), L2D1D, L2D1D, L2D1D, NE);
+   auto y = Reshape(y_.ReadWrite(), 3*(D1D-1)*(D1D-1)*D1D, NE);
 
    MFEM_FORALL(e, NE,
    {
@@ -1660,23 +1660,23 @@ static void PAHdivL2ApplyTranspose2D(const int D1D,
                                      const int Q1D,
                                      const int L2D1D,
                                      const int NE,
-                                     const Array<double> &_L2Bo,
-                                     const Array<double> &_Gct,
-                                     const Array<double> &_Bot,
-                                     const Vector &_op,
-                                     const Vector &_x,
-                                     Vector &_y)
+                                     const Array<double> &L2Bo_,
+                                     const Array<double> &Gct_,
+                                     const Array<double> &Bot_,
+                                     const Vector &op_,
+                                     const Vector &x_,
+                                     Vector &y_)
 {
    constexpr static int VDIM = 2;
    constexpr static int MAX_D1D = HDIV_MAX_D1D;
    constexpr static int MAX_Q1D = HDIV_MAX_Q1D;
 
-   auto L2Bo = Reshape(_L2Bo.Read(), Q1D, L2D1D);
-   auto Gct = Reshape(_Gct.Read(), D1D, Q1D);
-   auto Bot = Reshape(_Bot.Read(), D1D-1, Q1D);
-   auto op = Reshape(_op.Read(), Q1D, Q1D, NE);
-   auto x = Reshape(_x.Read(), L2D1D, L2D1D, NE);
-   auto y = Reshape(_y.ReadWrite(), 2*(D1D-1)*D1D, NE);
+   auto L2Bo = Reshape(L2Bo_.Read(), Q1D, L2D1D);
+   auto Gct = Reshape(Gct_.Read(), D1D, Q1D);
+   auto Bot = Reshape(Bot_.Read(), D1D-1, Q1D);
+   auto op = Reshape(op_.Read(), Q1D, Q1D, NE);
+   auto x = Reshape(x_.Read(), L2D1D, L2D1D, NE);
+   auto y = Reshape(y_.ReadWrite(), 2*(D1D-1)*D1D, NE);
 
    MFEM_FORALL(e, NE,
    {
@@ -1795,23 +1795,23 @@ static void PAHdivL2AssembleDiagonal_ADAt_3D(const int D1D,
                                              const int Q1D,
                                              const int L2D1D,
                                              const int NE,
-                                             const Array<double> &_L2Bo,
-                                             const Array<double> &_Gct,
-                                             const Array<double> &_Bot,
-                                             const Vector &_op,
-                                             const Vector &_D,
-                                             Vector &_diag)
+                                             const Array<double> &L2Bo_,
+                                             const Array<double> &Gct_,
+                                             const Array<double> &Bot_,
+                                             const Vector &op_,
+                                             const Vector &D_,
+                                             Vector &diag_)
 {
    MFEM_VERIFY(D1D <= HDIV_MAX_D1D, "Error: D1D > HDIV_MAX_D1D");
    MFEM_VERIFY(Q1D <= HDIV_MAX_Q1D, "Error: Q1D > HDIV_MAX_Q1D");
    constexpr static int VDIM = 3;
 
-   auto L2Bo = Reshape(_L2Bo.Read(), Q1D, L2D1D);
-   auto Gct = Reshape(_Gct.Read(), D1D, Q1D);
-   auto Bot = Reshape(_Bot.Read(), D1D-1, Q1D);
-   auto op = Reshape(_op.Read(), Q1D, Q1D, Q1D, NE);
-   auto D = Reshape(_D.Read(), 3*(D1D-1)*(D1D-1)*D1D, NE);
-   auto diag = Reshape(_diag.ReadWrite(), L2D1D, L2D1D, L2D1D, NE);
+   auto L2Bo = Reshape(L2Bo_.Read(), Q1D, L2D1D);
+   auto Gct = Reshape(Gct_.Read(), D1D, Q1D);
+   auto Bot = Reshape(Bot_.Read(), D1D-1, Q1D);
+   auto op = Reshape(op_.Read(), Q1D, Q1D, Q1D, NE);
+   auto D = Reshape(D_.Read(), 3*(D1D-1)*(D1D-1)*D1D, NE);
+   auto diag = Reshape(diag_.ReadWrite(), L2D1D, L2D1D, L2D1D, NE);
 
    MFEM_FORALL(e, NE,
    {
@@ -1920,21 +1920,21 @@ static void PAHdivL2AssembleDiagonal_ADAt_2D(const int D1D,
                                              const int Q1D,
                                              const int L2D1D,
                                              const int NE,
-                                             const Array<double> &_L2Bo,
-                                             const Array<double> &_Gct,
-                                             const Array<double> &_Bot,
-                                             const Vector &_op,
-                                             const Vector &_D,
-                                             Vector &_diag)
+                                             const Array<double> &L2Bo_,
+                                             const Array<double> &Gct_,
+                                             const Array<double> &Bot_,
+                                             const Vector &op_,
+                                             const Vector &D_,
+                                             Vector &diag_)
 {
    constexpr static int VDIM = 2;
 
-   auto L2Bo = Reshape(_L2Bo.Read(), Q1D, L2D1D);
-   auto Gct = Reshape(_Gct.Read(), D1D, Q1D);
-   auto Bot = Reshape(_Bot.Read(), D1D-1, Q1D);
-   auto op = Reshape(_op.Read(), Q1D, Q1D, NE);
-   auto D = Reshape(_D.Read(), 2*(D1D-1)*D1D, NE);
-   auto diag = Reshape(_diag.ReadWrite(), L2D1D, L2D1D, NE);
+   auto L2Bo = Reshape(L2Bo_.Read(), Q1D, L2D1D);
+   auto Gct = Reshape(Gct_.Read(), D1D, Q1D);
+   auto Bot = Reshape(Bot_.Read(), D1D-1, Q1D);
+   auto op = Reshape(op_.Read(), Q1D, Q1D, NE);
+   auto D = Reshape(D_.Read(), 2*(D1D-1)*D1D, NE);
+   auto diag = Reshape(diag_.ReadWrite(), L2D1D, L2D1D, NE);
 
    MFEM_FORALL(e, NE,
    {

--- a/fem/bilininteg_vecdiffusion.cpp
+++ b/fem/bilininteg_vecdiffusion.cpp
@@ -324,9 +324,9 @@ void PAVectorDiffusionApply3D(const int NE,
                               const Array<double> &g,
                               const Array<double> &bt,
                               const Array<double> &gt,
-                              const Vector &_op,
-                              const Vector &_x,
-                              Vector &_y,
+                              const Vector &op_,
+                              const Vector &x_,
+                              Vector &y_,
                               int d1d = 0, int q1d = 0)
 {
    const int D1D = T_D1D ? T_D1D : d1d;
@@ -338,9 +338,9 @@ void PAVectorDiffusionApply3D(const int NE,
    auto G = Reshape(g.Read(), Q1D, D1D);
    auto Bt = Reshape(bt.Read(), D1D, Q1D);
    auto Gt = Reshape(gt.Read(), D1D, Q1D);
-   auto op = Reshape(_op.Read(), Q1D*Q1D*Q1D, 6, NE);
-   auto x = Reshape(_x.Read(), D1D, D1D, D1D, VDIM, NE);
-   auto y = Reshape(_y.ReadWrite(), D1D, D1D, D1D, VDIM, NE);
+   auto op = Reshape(op_.Read(), Q1D*Q1D*Q1D, 6, NE);
+   auto x = Reshape(x_.Read(), D1D, D1D, D1D, VDIM, NE);
+   auto y = Reshape(y_.ReadWrite(), D1D, D1D, D1D, VDIM, NE);
    MFEM_FORALL(e, NE,
    {
       const int D1D = T_D1D ? T_D1D : d1d;

--- a/fem/bilininteg_vecmass.cpp
+++ b/fem/bilininteg_vecmass.cpp
@@ -106,10 +106,10 @@ template<const int T_D1D = 0,
          const int T_Q1D = 0>
 static void PAVectorMassApply2D(const int NE,
                                 const Array<double> &B_,
-                                const Array<double> &_Bt,
-                                const Vector &_op,
-                                const Vector &_x,
-                                Vector &_y,
+                                const Array<double> &Bt_,
+                                const Vector &op_,
+                                const Vector &x_,
+                                Vector &y_,
                                 const int d1d = 0,
                                 const int q1d = 0)
 {
@@ -119,10 +119,10 @@ static void PAVectorMassApply2D(const int NE,
    MFEM_VERIFY(D1D <= MAX_D1D, "");
    MFEM_VERIFY(Q1D <= MAX_Q1D, "");
    auto B = Reshape(B_.Read(), Q1D, D1D);
-   auto Bt = Reshape(_Bt.Read(), D1D, Q1D);
-   auto op = Reshape(_op.Read(), Q1D, Q1D, NE);
-   auto x = Reshape(_x.Read(), D1D, D1D, VDIM, NE);
-   auto y = Reshape(_y.ReadWrite(), D1D, D1D, VDIM, NE);
+   auto Bt = Reshape(Bt_.Read(), D1D, Q1D);
+   auto op = Reshape(op_.Read(), Q1D, Q1D, NE);
+   auto x = Reshape(x_.Read(), D1D, D1D, VDIM, NE);
+   auto y = Reshape(y_.ReadWrite(), D1D, D1D, VDIM, NE);
    MFEM_FORALL(e, NE,
    {
       const int D1D = T_D1D ? T_D1D : d1d; // nvcc workaround
@@ -203,10 +203,10 @@ template<const int T_D1D = 0,
          const int T_Q1D = 0>
 static void PAVectorMassApply3D(const int NE,
                                 const Array<double> &B_,
-                                const Array<double> &_Bt,
-                                const Vector &_op,
-                                const Vector &_x,
-                                Vector &_y,
+                                const Array<double> &Bt_,
+                                const Vector &op_,
+                                const Vector &x_,
+                                Vector &y_,
                                 const int d1d = 0,
                                 const int q1d = 0)
 {
@@ -216,10 +216,10 @@ static void PAVectorMassApply3D(const int NE,
    MFEM_VERIFY(D1D <= MAX_D1D, "");
    MFEM_VERIFY(Q1D <= MAX_Q1D, "");
    auto B = Reshape(B_.Read(), Q1D, D1D);
-   auto Bt = Reshape(_Bt.Read(), D1D, Q1D);
-   auto op = Reshape(_op.Read(), Q1D, Q1D, Q1D, NE);
-   auto x = Reshape(_x.Read(), D1D, D1D, D1D, VDIM, NE);
-   auto y = Reshape(_y.ReadWrite(), D1D, D1D, D1D, VDIM, NE);
+   auto Bt = Reshape(Bt_.Read(), D1D, Q1D);
+   auto op = Reshape(op_.Read(), Q1D, Q1D, Q1D, NE);
+   auto x = Reshape(x_.Read(), D1D, D1D, D1D, VDIM, NE);
+   auto y = Reshape(y_.ReadWrite(), D1D, D1D, D1D, VDIM, NE);
    MFEM_FORALL(e, NE,
    {
       const int D1D = T_D1D ? T_D1D : d1d;
@@ -381,9 +381,9 @@ void VectorMassIntegrator::AddMultPA(const Vector &x, Vector &y) const
 template<const int T_D1D = 0, const int T_Q1D = 0>
 static void PAVectorMassAssembleDiagonal2D(const int NE,
                                            const Array<double> &B_,
-                                           const Array<double> &_Bt,
-                                           const Vector &_op,
-                                           Vector &_diag,
+                                           const Array<double> &Bt_,
+                                           const Vector &op_,
+                                           Vector &diag_,
                                            const int d1d = 0,
                                            const int q1d = 0)
 {
@@ -393,8 +393,8 @@ static void PAVectorMassAssembleDiagonal2D(const int NE,
    MFEM_VERIFY(D1D <= MAX_D1D, "");
    MFEM_VERIFY(Q1D <= MAX_Q1D, "");
    auto B = Reshape(B_.Read(), Q1D, D1D);
-   auto op = Reshape(_op.Read(), Q1D, Q1D, NE);
-   auto y = Reshape(_diag.ReadWrite(), D1D, D1D, VDIM, NE);
+   auto op = Reshape(op_.Read(), Q1D, Q1D, NE);
+   auto y = Reshape(diag_.ReadWrite(), D1D, D1D, VDIM, NE);
    MFEM_FORALL(e, NE,
    {
       const int D1D = T_D1D ? T_D1D : d1d;
@@ -433,9 +433,9 @@ static void PAVectorMassAssembleDiagonal2D(const int NE,
 template<const int T_D1D = 0, const int T_Q1D = 0>
 static void PAVectorMassAssembleDiagonal3D(const int NE,
                                            const Array<double> &B_,
-                                           const Array<double> &_Bt,
-                                           const Vector &_op,
-                                           Vector &_diag,
+                                           const Array<double> &Bt_,
+                                           const Vector &op_,
+                                           Vector &diag_,
                                            const int d1d = 0,
                                            const int q1d = 0)
 {
@@ -445,8 +445,8 @@ static void PAVectorMassAssembleDiagonal3D(const int NE,
    MFEM_VERIFY(D1D <= MAX_D1D, "");
    MFEM_VERIFY(Q1D <= MAX_Q1D, "");
    auto B = Reshape(B_.Read(), Q1D, D1D);
-   auto op = Reshape(_op.Read(), Q1D, Q1D, Q1D, NE);
-   auto y = Reshape(_diag.ReadWrite(), D1D, D1D, D1D, VDIM, NE);
+   auto op = Reshape(op_.Read(), Q1D, Q1D, Q1D, NE);
+   auto y = Reshape(diag_.ReadWrite(), D1D, D1D, D1D, VDIM, NE);
    MFEM_FORALL(e, NE,
    {
       const int D1D = T_D1D ? T_D1D : d1d; // nvcc workaround

--- a/fem/bilininteg_vectorfe.cpp
+++ b/fem/bilininteg_vectorfe.cpp
@@ -20,7 +20,7 @@ void PADiffusionSetup3D(const int Q1D,
                         const int NE,
                         const Array<double> &w,
                         const Vector &j,
-                        const Vector &_coeff,
+                        const Vector &coeff_,
                         Vector &op);
 
 void PAHcurlMassAssembleDiagonal2D(const int D1D,
@@ -92,14 +92,14 @@ void PAHdivSetup2D(const int Q1D,
                    const int NE,
                    const Array<double> &w,
                    const Vector &j,
-                   Vector &_coeff,
+                   Vector &coeff_,
                    Vector &op);
 
 void PAHdivSetup3D(const int Q1D,
                    const int NE,
                    const Array<double> &w,
                    const Vector &j,
-                   Vector &_coeff,
+                   Vector &coeff_,
                    Vector &op);
 
 void PAHcurlH1Apply2D(const int D1D,
@@ -127,46 +127,46 @@ void PAHcurlH1Apply3D(const int D1D,
 void PAHdivMassAssembleDiagonal2D(const int D1D,
                                   const int Q1D,
                                   const int NE,
-                                  const Array<double> &_Bo,
-                                  const Array<double> &_Bc,
-                                  const Vector &_op,
-                                  Vector &_diag);
+                                  const Array<double> &Bo_,
+                                  const Array<double> &Bc_,
+                                  const Vector &op_,
+                                  Vector &diag_);
 
 void PAHdivMassAssembleDiagonal3D(const int D1D,
                                   const int Q1D,
                                   const int NE,
-                                  const Array<double> &_Bo,
-                                  const Array<double> &_Bc,
-                                  const Vector &_op,
-                                  Vector &_diag);
+                                  const Array<double> &Bo_,
+                                  const Array<double> &Bc_,
+                                  const Vector &op_,
+                                  Vector &diag_);
 
 void PAHdivMassApply2D(const int D1D,
                        const int Q1D,
                        const int NE,
-                       const Array<double> &_Bo,
-                       const Array<double> &_Bc,
-                       const Array<double> &_Bot,
-                       const Array<double> &_Bct,
-                       const Vector &_op,
-                       const Vector &_x,
-                       Vector &_y);
+                       const Array<double> &Bo_,
+                       const Array<double> &Bc_,
+                       const Array<double> &Bot_,
+                       const Array<double> &Bct_,
+                       const Vector &op_,
+                       const Vector &x_,
+                       Vector &y_);
 
 void PAHdivMassApply3D(const int D1D,
                        const int Q1D,
                        const int NE,
-                       const Array<double> &_Bo,
-                       const Array<double> &_Bc,
-                       const Array<double> &_Bot,
-                       const Array<double> &_Bct,
-                       const Vector &_op,
-                       const Vector &_x,
-                       Vector &_y);
+                       const Array<double> &Bo_,
+                       const Array<double> &Bc_,
+                       const Array<double> &Bot_,
+                       const Array<double> &Bct_,
+                       const Vector &op_,
+                       const Vector &x_,
+                       Vector &y_);
 
 void PAHcurlL2Setup(const int NQ,
                     const int coeffDim,
                     const int NE,
                     const Array<double> &w,
-                    Vector &_coeff,
+                    Vector &coeff_,
                     Vector &op);
 
 // PA H(curl) x H(div) mass assemble 3D kernel, with factor
@@ -176,15 +176,15 @@ void PAHcurlHdivSetup3D(const int Q1D,
                         const int coeffDim,
                         const int NE,
                         const bool transpose,
-                        const Array<double> &_w,
+                        const Array<double> &w_,
                         const Vector &j,
-                        Vector &_coeff,
+                        Vector &coeff_,
                         Vector &op)
 {
    const bool symmetric = (coeffDim != 9);
-   auto W = Reshape(_w.Read(), Q1D, Q1D, Q1D);
+   auto W = Reshape(w_.Read(), Q1D, Q1D, Q1D);
    auto J = Reshape(j.Read(), Q1D, Q1D, Q1D, 3, 3, NE);
-   auto coeff = Reshape(_coeff.Read(), coeffDim, Q1D, Q1D, Q1D, NE);
+   auto coeff = Reshape(coeff_.Read(), coeffDim, Q1D, Q1D, Q1D, NE);
    auto y = Reshape(op.Write(), 9, Q1D, Q1D, Q1D, NE);
 
    const int i11 = 0;
@@ -292,15 +292,15 @@ void PAHcurlHdivSetup2D(const int Q1D,
                         const int coeffDim,
                         const int NE,
                         const bool transpose,
-                        const Array<double> &_w,
+                        const Array<double> &w_,
                         const Vector &j,
-                        Vector &_coeff,
+                        Vector &coeff_,
                         Vector &op)
 {
    const bool symmetric = (coeffDim != 4);
-   auto W = Reshape(_w.Read(), Q1D, Q1D);
+   auto W = Reshape(w_.Read(), Q1D, Q1D);
    auto J = Reshape(j.Read(), Q1D, Q1D, 2, 2, NE);
-   auto coeff = Reshape(_coeff.Read(), coeffDim, Q1D, Q1D, NE);
+   auto coeff = Reshape(coeff_.Read(), coeffDim, Q1D, Q1D, NE);
    auto y = Reshape(op.Write(), 4, Q1D, Q1D, NE);
 
    const int i11 = 0;
@@ -365,13 +365,13 @@ void PAHcurlHdivMassApply3D(const int D1D,
                             const int NE,
                             const bool scalarCoeff,
                             const bool trialHcurl,
-                            const Array<double> &_Bo,
-                            const Array<double> &_Bc,
-                            const Array<double> &_Bot,
-                            const Array<double> &_Bct,
-                            const Vector &_op,
-                            const Vector &_x,
-                            Vector &_y)
+                            const Array<double> &Bo_,
+                            const Array<double> &Bc_,
+                            const Array<double> &Bot_,
+                            const Array<double> &Bct_,
+                            const Vector &op_,
+                            const Vector &x_,
+                            Vector &y_)
 {
    constexpr static int MAX_D1D = HCURL_MAX_D1D;
    constexpr static int MAX_Q1D = HCURL_MAX_Q1D;
@@ -380,13 +380,13 @@ void PAHcurlHdivMassApply3D(const int D1D,
    MFEM_VERIFY(Q1D <= MAX_Q1D, "Error: Q1D > MAX_Q1D");
    constexpr static int VDIM = 3;
 
-   auto Bo = Reshape(_Bo.Read(), Q1D, D1D-1);
-   auto Bc = Reshape(_Bc.Read(), Q1D, D1D);
-   auto Bot = Reshape(_Bot.Read(), D1Dtest-1, Q1D);
-   auto Bct = Reshape(_Bct.Read(), D1Dtest, Q1D);
-   auto op = Reshape(_op.Read(), scalarCoeff ? 1 : 9, Q1D, Q1D, Q1D, NE);
-   auto x = Reshape(_x.Read(), 3*(D1D-1)*D1D*(trialHcurl ? D1D : D1D-1), NE);
-   auto y = Reshape(_y.ReadWrite(), 3*(D1Dtest-1)*D1Dtest*
+   auto Bo = Reshape(Bo_.Read(), Q1D, D1D-1);
+   auto Bc = Reshape(Bc_.Read(), Q1D, D1D);
+   auto Bot = Reshape(Bot_.Read(), D1Dtest-1, Q1D);
+   auto Bct = Reshape(Bct_.Read(), D1Dtest, Q1D);
+   auto op = Reshape(op_.Read(), scalarCoeff ? 1 : 9, Q1D, Q1D, Q1D, NE);
+   auto x = Reshape(x_.Read(), 3*(D1D-1)*D1D*(trialHcurl ? D1D : D1D-1), NE);
+   auto y = Reshape(y_.ReadWrite(), 3*(D1Dtest-1)*D1Dtest*
                     (trialHcurl ? D1Dtest-1 : D1Dtest), NE);
 
    MFEM_FORALL(e, NE,
@@ -577,13 +577,13 @@ void PAHcurlHdivMassApply2D(const int D1D,
                             const int NE,
                             const bool scalarCoeff,
                             const bool trialHcurl,
-                            const Array<double> &_Bo,
-                            const Array<double> &_Bc,
-                            const Array<double> &_Bot,
-                            const Array<double> &_Bct,
-                            const Vector &_op,
-                            const Vector &_x,
-                            Vector &_y)
+                            const Array<double> &Bo_,
+                            const Array<double> &Bc_,
+                            const Array<double> &Bot_,
+                            const Array<double> &Bct_,
+                            const Vector &op_,
+                            const Vector &x_,
+                            Vector &y_)
 {
    constexpr static int MAX_D1D = HCURL_MAX_D1D;
    constexpr static int MAX_Q1D = HCURL_MAX_Q1D;
@@ -592,13 +592,13 @@ void PAHcurlHdivMassApply2D(const int D1D,
    MFEM_VERIFY(Q1D <= MAX_Q1D, "Error: Q1D > MAX_Q1D");
    constexpr static int VDIM = 2;
 
-   auto Bo = Reshape(_Bo.Read(), Q1D, D1D-1);
-   auto Bc = Reshape(_Bc.Read(), Q1D, D1D);
-   auto Bot = Reshape(_Bot.Read(), D1Dtest-1, Q1D);
-   auto Bct = Reshape(_Bct.Read(), D1Dtest, Q1D);
-   auto op = Reshape(_op.Read(), scalarCoeff ? 1 : 4, Q1D, Q1D, NE);
-   auto x = Reshape(_x.Read(), 2*(D1D-1)*D1D, NE);
-   auto y = Reshape(_y.ReadWrite(), 2*(D1Dtest-1)*D1Dtest, NE);
+   auto Bo = Reshape(Bo_.Read(), Q1D, D1D-1);
+   auto Bc = Reshape(Bc_.Read(), Q1D, D1D);
+   auto Bot = Reshape(Bot_.Read(), D1Dtest-1, Q1D);
+   auto Bct = Reshape(Bct_.Read(), D1Dtest, Q1D);
+   auto op = Reshape(op_.Read(), scalarCoeff ? 1 : 4, Q1D, Q1D, NE);
+   auto x = Reshape(x_.Read(), 2*(D1D-1)*D1D, NE);
+   auto y = Reshape(y_.ReadWrite(), 2*(D1Dtest-1)*D1Dtest, NE);
 
    MFEM_FORALL(e, NE,
    {

--- a/fem/coefficient.cpp
+++ b/fem/coefficient.cpp
@@ -247,9 +247,9 @@ double DivergenceGridFunctionCoefficient::Eval(ElementTransformation &T,
    return GridFunc->GetDivergence(T);
 }
 
-void VectorDeltaCoefficient::SetDirection(const Vector &_d)
+void VectorDeltaCoefficient::SetDirection(const Vector &d_)
 {
-   dir = _d;
+   dir = d_;
    (*this).vdim = dir.Size();
 }
 
@@ -514,33 +514,33 @@ VectorSumCoefficient::VectorSumCoefficient(int dim)
    A = 0.0; B = 0.0;
 }
 
-VectorSumCoefficient::VectorSumCoefficient(VectorCoefficient &_A,
+VectorSumCoefficient::VectorSumCoefficient(VectorCoefficient &A_,
                                            VectorCoefficient &B_,
-                                           double _alpha, double _beta)
-   : VectorCoefficient(_A.GetVDim()),
-     ACoef(&_A), BCoef(&B_),
-     A(_A.GetVDim()), B(_A.GetVDim()),
+                                           double alpha_, double beta_)
+   : VectorCoefficient(A_.GetVDim()),
+     ACoef(&A_), BCoef(&B_),
+     A(A_.GetVDim()), B(A_.GetVDim()),
      alphaCoef(NULL), betaCoef(NULL),
-     alpha(_alpha), beta(_beta)
+     alpha(alpha_), beta(beta_)
 {
-   MFEM_ASSERT(_A.GetVDim() == B_.GetVDim(),
+   MFEM_ASSERT(A_.GetVDim() == B_.GetVDim(),
                "VectorSumCoefficient:  "
                "Arguments must have the same dimension.");
 }
 
-VectorSumCoefficient::VectorSumCoefficient(VectorCoefficient &_A,
+VectorSumCoefficient::VectorSumCoefficient(VectorCoefficient &A_,
                                            VectorCoefficient &B_,
-                                           Coefficient &_alpha,
-                                           Coefficient &_beta)
-   : VectorCoefficient(_A.GetVDim()),
-     ACoef(&_A), BCoef(&B_),
-     A(_A.GetVDim()),
-     B(_A.GetVDim()),
-     alphaCoef(&_alpha),
-     betaCoef(&_beta),
+                                           Coefficient &alpha_,
+                                           Coefficient &beta_)
+   : VectorCoefficient(A_.GetVDim()),
+     ACoef(&A_), BCoef(&B_),
+     A(A_.GetVDim()),
+     B(A_.GetVDim()),
+     alphaCoef(&alpha_),
+     betaCoef(&beta_),
      alpha(0.0), beta(0.0)
 {
-   MFEM_ASSERT(_A.GetVDim() == B_.GetVDim(),
+   MFEM_ASSERT(A_.GetVDim() == B_.GetVDim(),
                "VectorSumCoefficient:  "
                "Arguments must have the same dimension.");
 }
@@ -577,8 +577,8 @@ void ScalarVectorProductCoefficient::Eval(Vector &V, ElementTransformation &T,
 }
 
 NormalizedVectorCoefficient::NormalizedVectorCoefficient(VectorCoefficient &A,
-                                                         double _tol)
-   : VectorCoefficient(A.GetVDim()), a(&A), tol(_tol)
+                                                         double tol_)
+   : VectorCoefficient(A.GetVDim()), a(&A), tol(tol_)
 {}
 
 void NormalizedVectorCoefficient::Eval(Vector &V, ElementTransformation &T,
@@ -639,9 +639,9 @@ void IdentityMatrixCoefficient::Eval(DenseMatrix &M, ElementTransformation &T,
 
 MatrixSumCoefficient::MatrixSumCoefficient(MatrixCoefficient &A,
                                            MatrixCoefficient &B,
-                                           double _alpha, double _beta)
+                                           double alpha_, double beta_)
    : MatrixCoefficient(A.GetHeight(), A.GetWidth()),
-     a(&A), b(&B), alpha(_alpha), beta(_beta),
+     a(&A), b(&B), alpha(alpha_), beta(beta_),
      ma(A.GetHeight(), A.GetWidth())
 {
    MFEM_ASSERT(A.GetHeight() == B.GetHeight() && A.GetWidth() == B.GetWidth(),
@@ -938,18 +938,18 @@ VectorQuadratureFunctionCoefficient::VectorQuadratureFunctionCoefficient(
    QuadratureFunction &qf)
    : VectorCoefficient(qf.GetVDim()), QuadF(qf), index(0) { }
 
-void VectorQuadratureFunctionCoefficient::SetComponent(int _index, int _length)
+void VectorQuadratureFunctionCoefficient::SetComponent(int index_, int length_)
 {
-   MFEM_VERIFY(_index >= 0, "Index must be >= 0");
-   MFEM_VERIFY(_index < QuadF.GetVDim(),
+   MFEM_VERIFY(index_ >= 0, "Index must be >= 0");
+   MFEM_VERIFY(index_ < QuadF.GetVDim(),
                "Index must be < QuadratureFunction length");
-   index = _index;
+   index = index_;
 
-   MFEM_VERIFY(_length > 0, "Length must be > 0");
-   MFEM_VERIFY(_length <= QuadF.GetVDim() - index,
+   MFEM_VERIFY(length_ > 0, "Length must be > 0");
+   MFEM_VERIFY(length_ <= QuadF.GetVDim() - index,
                "Length must be <= (QuadratureFunction length - index)");
 
-   vdim = _length;
+   vdim = length_;
 }
 
 void VectorQuadratureFunctionCoefficient::Eval(Vector &V,

--- a/fem/coefficient.hpp
+++ b/fem/coefficient.hpp
@@ -273,7 +273,7 @@ public:
    void SetDeltaCenter(const Vector& center);
 
    /// Set the scale value multiplying the delta function.
-   void SetScale(double _s) { scale = _s; }
+   void SetScale(double s_) { scale = s_; }
 
    /// Set a time-dependent function that multiplies the Scale().
    void SetFunction(double (*f)(double)) { tdf = f; }
@@ -281,7 +281,7 @@ public:
    /** @brief Set the tolerance used during projection onto GridFunction to
        identify the Mesh vertex where the Center() of the delta function
        lies. (default 1e-12)*/
-   void SetTol(double _tol) { tol = _tol; }
+   void SetTol(double tol_) { tol = tol_; }
 
    /// Set a weight Coefficient that multiplies the DeltaCoefficient.
    /** The weight Coefficient multiplies the value returned by EvalDelta() but
@@ -330,8 +330,8 @@ public:
    /** @brief Construct with a parent coefficient and an array with
        ones marking the attributes on which this coefficient should be
        active. */
-   RestrictedCoefficient(Coefficient &_c, Array<int> &attr)
-   { c = &_c; attr.Copy(active_attr); }
+   RestrictedCoefficient(Coefficient &c_, Array<int> &attr)
+   { c = &c_; attr.Copy(active_attr); }
 
    /// Evaluate the coefficient at @a ip.
    virtual double Eval(ElementTransformation &T, const IntegrationPoint &ip)
@@ -607,41 +607,41 @@ protected:
    DeltaCoefficient d;
 
 public:
-   /// Construct with a vector of dimension @a _vdim.
-   VectorDeltaCoefficient(int _vdim)
-      : VectorCoefficient(_vdim), dir(_vdim), d() { }
+   /// Construct with a vector of dimension @a vdim_.
+   VectorDeltaCoefficient(int vdim_)
+      : VectorCoefficient(vdim_), dir(vdim_), d() { }
 
    /** @brief Construct with a Vector object representing the direction and a
        unit delta function centered at (0.0,0.0,0.0) */
-   VectorDeltaCoefficient(const Vector& _dir)
-      : VectorCoefficient(_dir.Size()), dir(_dir), d() { }
+   VectorDeltaCoefficient(const Vector& dir_)
+      : VectorCoefficient(dir_.Size()), dir(dir_), d() { }
 
    /** @brief Construct with a Vector object representing the direction and a
        delta function scaled by @a s and centered at (x,0.0,0.0) */
-   VectorDeltaCoefficient(const Vector& _dir, double x, double s)
-      : VectorCoefficient(_dir.Size()), dir(_dir), d(x,s) { }
+   VectorDeltaCoefficient(const Vector& dir_, double x, double s)
+      : VectorCoefficient(dir_.Size()), dir(dir_), d(x,s) { }
 
    /** @brief Construct with a Vector object representing the direction and a
        delta function scaled by @a s and centered at (x,y,0.0) */
-   VectorDeltaCoefficient(const Vector& _dir, double x, double y, double s)
-      : VectorCoefficient(_dir.Size()), dir(_dir), d(x,y,s) { }
+   VectorDeltaCoefficient(const Vector& dir_, double x, double y, double s)
+      : VectorCoefficient(dir_.Size()), dir(dir_), d(x,y,s) { }
 
    /** @brief Construct with a Vector object representing the direction and a
        delta function scaled by @a s and centered at (x,y,z) */
-   VectorDeltaCoefficient(const Vector& _dir, double x, double y, double z,
+   VectorDeltaCoefficient(const Vector& dir_, double x, double y, double z,
                           double s)
-      : VectorCoefficient(_dir.Size()), dir(_dir), d(x,y,z,s) { }
+      : VectorCoefficient(dir_.Size()), dir(dir_), d(x,y,z,s) { }
 
    /// Replace the associated DeltaCoefficient with a new DeltaCoefficient.
    /** The new DeltaCoefficient cannot have a specified weight Coefficient, i.e.
        DeltaCoefficient::Weight() should return NULL. */
-   void SetDeltaCoefficient(const DeltaCoefficient& _d) { d = _d; }
+   void SetDeltaCoefficient(const DeltaCoefficient& d_) { d = d_; }
 
    /// Return the associated scalar DeltaCoefficient.
    DeltaCoefficient& GetDeltaCoefficient() { return d; }
 
    void SetScale(double s) { d.SetScale(s); }
-   void SetDirection(const Vector& _d);
+   void SetDirection(const Vector& d_);
 
    void SetDeltaCenter(const Vector& center) { d.SetDeltaCenter(center); }
    void GetDeltaCenter(Vector& center) { d.GetDeltaCenter(center); }
@@ -901,15 +901,15 @@ private:
    double beta;
 
 public:
-   /// Constructor with one coefficient.  Result is _alpha * A + _beta * B
+   /// Constructor with one coefficient.  Result is alpha_ * A + beta_ * B
    SumCoefficient(double A, Coefficient &B,
-                  double _alpha = 1.0, double _beta = 1.0)
-      : aConst(A), a(NULL), b(&B), alpha(_alpha), beta(_beta) { }
+                  double alpha_ = 1.0, double beta_ = 1.0)
+      : aConst(A), a(NULL), b(&B), alpha(alpha_), beta(beta_) { }
 
-   /// Constructor with two coefficients.  Result is _alpha * A + _beta * B.
+   /// Constructor with two coefficients.  Result is alpha_ * A + beta_ * B.
    SumCoefficient(Coefficient &A, Coefficient &B,
-                  double _alpha = 1.0, double _beta = 1.0)
-      : aConst(0.0), a(&A), b(&B), alpha(_alpha), beta(_beta) { }
+                  double alpha_ = 1.0, double beta_ = 1.0)
+      : aConst(0.0), a(&A), b(&B), alpha(alpha_), beta(beta_) { }
 
    /// Reset the first term in the linear combination as a constant
    void SetAConst(double A) { a = NULL; aConst = A; }
@@ -927,12 +927,12 @@ public:
    Coefficient * GetBCoef() const { return b; }
 
    /// Reset the factor in front of the first term in the linear combination
-   void SetAlpha(double _alpha) { alpha = _alpha; }
+   void SetAlpha(double alpha_) { alpha = alpha_; }
    /// Return the factor in front of the first term in the linear combination
    double GetAlpha() const { return alpha; }
 
    /// Reset the factor in front of the second term in the linear combination
-   void SetBeta(double _beta) { beta = _beta; }
+   void SetBeta(double beta_) { beta = beta_; }
    /// Return the factor in front of the second term in the linear combination
    double GetBeta() const { return beta; }
 
@@ -1147,9 +1147,9 @@ private:
    double p;
 
 public:
-   /// Construct with a coefficient and a constant power @a _p.  Result is A^p.
-   PowerCoefficient(Coefficient &A, double _p)
-      : a(&A), p(_p) { }
+   /// Construct with a coefficient and a constant power @a p_.  Result is A^p.
+   PowerCoefficient(Coefficient &A, double p_)
+      : a(&A), p(p_) { }
 
    /// Reset the base coefficient
    void SetACoef(Coefficient &A) { a = &A; }
@@ -1157,7 +1157,7 @@ public:
    Coefficient * GetACoef() const { return a; }
 
    /// Reset the exponent
-   void SetExponent(double _p) { p = _p; }
+   void SetExponent(double p_) { p = p_; }
    /// Return the exponent
    double GetExponent() const { return p; }
 
@@ -1271,14 +1271,14 @@ public:
    VectorSumCoefficient(int dim);
 
    /** Constructor with two vector coefficients.
-       Result is _alpha * A + _beta * B */
+       Result is alpha_ * A + beta_ * B */
    VectorSumCoefficient(VectorCoefficient &A, VectorCoefficient &B,
-                        double _alpha = 1.0, double _beta = 1.0);
+                        double alpha_ = 1.0, double beta_ = 1.0);
 
    /** Constructor with scalar coefficients.
-       Result is _alpha * _A + _beta * B_ */
-   VectorSumCoefficient(VectorCoefficient &_A, VectorCoefficient &B_,
-                        Coefficient &_alpha, Coefficient &_beta);
+       Result is alpha_ * A_ + beta_ * B_ */
+   VectorSumCoefficient(VectorCoefficient &A_, VectorCoefficient &B_,
+                        Coefficient &alpha_, Coefficient &beta_);
 
    /// Reset the first vector coefficient
    void SetACoef(VectorCoefficient &A) { ACoef = &A; }
@@ -1301,7 +1301,7 @@ public:
    Coefficient * GetBetaCoef() const { return betaCoef; }
 
    /// Reset the first vector as a constant
-   void SetA(const Vector &_A) { A = _A; ACoef = NULL; }
+   void SetA(const Vector &A_) { A = A_; ACoef = NULL; }
    /// Return the first vector constant
    const Vector & GetA() const { return A; }
 
@@ -1311,12 +1311,12 @@ public:
    const Vector & GetB() const { return B; }
 
    /// Reset the factor in front of the first vector coefficient as a constant
-   void SetAlpha(double _alpha) { alpha = _alpha; alphaCoef = NULL; }
+   void SetAlpha(double alpha_) { alpha = alpha_; alphaCoef = NULL; }
    /// Return the factor in front of the first vector coefficient
    double GetAlpha() const { return alpha; }
 
    /// Reset the factor in front of the second vector coefficient as a constant
-   void SetBeta(double _beta) { beta = _beta; betaCoef = NULL; }
+   void SetBeta(double beta_) { beta = beta_; betaCoef = NULL; }
    /// Return the factor in front of the second vector coefficient
    double GetBeta() const { return beta; }
 
@@ -1483,9 +1483,9 @@ private:
    mutable DenseMatrix ma;
 
 public:
-   /// Construct with the two coefficients.  Result is _alpha * A + _beta * B.
+   /// Construct with the two coefficients.  Result is alpha_ * A + beta_ * B.
    MatrixSumCoefficient(MatrixCoefficient &A, MatrixCoefficient &B,
-                        double _alpha = 1.0, double _beta = 1.0);
+                        double alpha_ = 1.0, double beta_ = 1.0);
 
    /// Reset the first matrix coefficient
    void SetACoef(MatrixCoefficient &A) { a = &A; }
@@ -1498,12 +1498,12 @@ public:
    MatrixCoefficient * GetBCoef() const { return b; }
 
    /// Reset the factor in front of the first matrix coefficient
-   void SetAlpha(double _alpha) { alpha = _alpha; }
+   void SetAlpha(double alpha_) { alpha = alpha_; }
    /// Return the factor in front of the first matrix coefficient
    double GetAlpha() const { return alpha; }
 
    /// Reset the factor in front of the second matrix coefficient
-   void SetBeta(double _beta) { beta = _beta; }
+   void SetBeta(double beta_) { beta = beta_; }
    /// Return the factor in front of the second matrix coefficient
    double GetBeta() const { return beta; }
 
@@ -1676,7 +1676,7 @@ public:
    /** Set the starting index within the QuadFunc that'll be used to project
        outwards as well as the corresponding length. The projected length should
        have the bounds of 1 <= length <= (length QuadFunc - index). */
-   void SetComponent(int _index, int _length);
+   void SetComponent(int index_, int length_);
 
    const QuadratureFunction& GetQuadFunction() const { return QuadF; }
 

--- a/fem/datacollection.hpp
+++ b/fem/datacollection.hpp
@@ -397,8 +397,8 @@ public:
    int num_components;
    int lod;
    VisItFieldInfo() { association = ""; num_components = 0; lod = 1;}
-   VisItFieldInfo(std::string _association, int _num_components, int _lod = 1)
-   { association = _association; num_components = _num_components; lod =_lod;}
+   VisItFieldInfo(std::string association_, int num_components_, int lod_ = 1)
+   { association = association_; num_components = num_components_; lod =lod_;}
 };
 
 /// Data collection with VisIt I/O routines

--- a/fem/fe_coll.hpp
+++ b/fem/fe_coll.hpp
@@ -1096,10 +1096,10 @@ public:
    Local_FECollection(const char *fe_name);
 
    virtual const FiniteElement *FiniteElementForGeometry(
-      Geometry::Type _GeomType) const
-   { return (GeomType == _GeomType) ? Local_Element : NULL; }
-   virtual int DofForGeometry(Geometry::Type _GeomType) const
-   { return (GeomType == _GeomType) ? Local_Element->GetDof() : 0; }
+      Geometry::Type GeomType_) const
+   { return (GeomType == GeomType_) ? Local_Element : NULL; }
+   virtual int DofForGeometry(Geometry::Type GeomType_) const
+   { return (GeomType == GeomType_) ? Local_Element->GetDof() : 0; }
    virtual const int *DofOrderForOrientation(Geometry::Type GeomType,
                                              int Or) const
    { return NULL; }

--- a/fem/gridfunc.cpp
+++ b/fem/gridfunc.cpp
@@ -1804,7 +1804,7 @@ void GridFunction::ProjectGridFunction(const GridFunction &src)
 }
 
 void GridFunction::ImposeBounds(int i, const Vector &weights,
-                                const Vector &_lo, const Vector &_hi)
+                                const Vector &lo_, const Vector &hi_)
 {
    Array<int> vdofs;
    fes->GetElementVDofs(i, vdofs);
@@ -1813,8 +1813,8 @@ void GridFunction::ImposeBounds(int i, const Vector &weights,
    GetSubVector(vdofs, vals);
 
    MFEM_ASSERT(weights.Size() == size, "Different # of weights and dofs.");
-   MFEM_ASSERT(_lo.Size() == size, "Different # of lower bounds and dofs.");
-   MFEM_ASSERT(_hi.Size() == size, "Different # of upper bounds and dofs.");
+   MFEM_ASSERT(lo_.Size() == size, "Different # of lower bounds and dofs.");
+   MFEM_ASSERT(hi_.Size() == size, "Different # of upper bounds and dofs.");
 
    int max_iter = 30;
    double tol = 1.e-12;
@@ -1822,7 +1822,7 @@ void GridFunction::ImposeBounds(int i, const Vector &weights,
    slbqp.SetMaxIter(max_iter);
    slbqp.SetAbsTol(1.0e-18);
    slbqp.SetRelTol(tol);
-   slbqp.SetBounds(_lo, _hi);
+   slbqp.SetBounds(lo_, hi_);
    slbqp.SetLinearConstraint(weights, weights * vals);
    slbqp.SetPrintLevel(0); // print messages only if not converged
    slbqp.Mult(vals, new_vals);
@@ -1831,7 +1831,7 @@ void GridFunction::ImposeBounds(int i, const Vector &weights,
 }
 
 void GridFunction::ImposeBounds(int i, const Vector &weights,
-                                double _min, double _max)
+                                double min_, double max_)
 {
    Array<int> vdofs;
    fes->GetElementVDofs(i, vdofs);
@@ -1842,21 +1842,21 @@ void GridFunction::ImposeBounds(int i, const Vector &weights,
    double max_val = vals.Max();
    double min_val = vals.Min();
 
-   if (max_val <= _min)
+   if (max_val <= min_)
    {
-      new_vals = _min;
+      new_vals = min_;
       SetSubVector(vdofs, new_vals);
       return;
    }
 
-   if (_min <= min_val && max_val <= _max)
+   if (min_ <= min_val && max_val <= max_)
    {
       return;
    }
 
    Vector minv(size), maxv(size);
-   minv = (_min > min_val) ? _min : min_val;
-   maxv = (_max < max_val) ? _max : max_val;
+   minv = (min_ > min_val) ? min_ : min_val;
+   maxv = (max_ < max_val) ? max_ : max_val;
 
    ImposeBounds(i, weights, minv, maxv);
 }

--- a/fem/gridfunc.hpp
+++ b/fem/gridfunc.hpp
@@ -113,9 +113,9 @@ public:
    { return operator=((const Vector &)rhs); }
 
    /// Make the GridFunction the owner of #fec and #fes.
-   /** If the new FiniteElementCollection, @a _fec, is NULL, ownership of #fec
+   /** If the new FiniteElementCollection, @a fec_, is NULL, ownership of #fec
        and #fes is taken away. */
-   void MakeOwner(FiniteElementCollection *_fec) { fec = _fec; }
+   void MakeOwner(FiniteElementCollection *fec_) { fec = fec_; }
 
    FiniteElementCollection *OwnFEC() { return fec; }
 
@@ -337,9 +337,9 @@ public:
     *  through SLBPQ optimization.
     *  Intended to be used for discontinuous FE functions. */
    void ImposeBounds(int i, const Vector &weights,
-                     const Vector &_lo, const Vector &_hi);
+                     const Vector &lo_, const Vector &hi_);
    void ImposeBounds(int i, const Vector &weights,
-                     double _min = 0.0, double _max = infinity());
+                     double min_ = 0.0, double max_ = infinity());
 
    /** On a non-conforming mesh, make sure the function lies in the conforming
        space by multiplying with R and then with P, the conforming restriction
@@ -909,8 +909,8 @@ private:
    Mesh *mesh_in;
    Coefficient &sol_in;
 public:
-   ExtrudeCoefficient(Mesh *m, Coefficient &s, int _n)
-      : n(_n), mesh_in(m), sol_in(s) { }
+   ExtrudeCoefficient(Mesh *m, Coefficient &s, int n_)
+      : n(n_), mesh_in(m), sol_in(s) { }
    virtual double Eval(ElementTransformation &T, const IntegrationPoint &ip);
    virtual ~ExtrudeCoefficient() { }
 };

--- a/fem/gslib.cpp
+++ b/fem/gslib.cpp
@@ -56,7 +56,7 @@ FindPointsGSLIB::~FindPointsGSLIB()
 }
 
 #ifdef MFEM_USE_MPI
-FindPointsGSLIB::FindPointsGSLIB(MPI_Comm _comm)
+FindPointsGSLIB::FindPointsGSLIB(MPI_Comm comm_)
    : mesh(NULL), meshsplit(NULL), ir_simplex(NULL),
      fdata2D(NULL), fdata3D(NULL), cr(NULL), gsl_comm(NULL),
      dim(-1), points_cnt(0), setupflag(false), default_interp_value(0),
@@ -64,7 +64,7 @@ FindPointsGSLIB::FindPointsGSLIB(MPI_Comm _comm)
 {
    gsl_comm = new comm;
    cr      = new crystal;
-   comm_init(gsl_comm, _comm);
+   comm_init(gsl_comm, comm_);
 }
 #endif
 

--- a/fem/gslib.hpp
+++ b/fem/gslib.hpp
@@ -85,7 +85,7 @@ public:
    FindPointsGSLIB();
 
 #ifdef MFEM_USE_MPI
-   FindPointsGSLIB(MPI_Comm _comm);
+   FindPointsGSLIB(MPI_Comm comm_);
 #endif
 
    virtual ~FindPointsGSLIB();
@@ -199,7 +199,7 @@ public:
       overset(true) { }
 
 #ifdef MFEM_USE_MPI
-   OversetFindPointsGSLIB(MPI_Comm _comm) : FindPointsGSLIB(_comm),
+   OversetFindPointsGSLIB(MPI_Comm comm_) : FindPointsGSLIB(comm_),
       overset(true) { }
 #endif
 

--- a/fem/intrules.cpp
+++ b/fem/intrules.cpp
@@ -878,8 +878,8 @@ IntegrationRules IntRules(0, Quadrature1D::GaussLegendre);
 
 IntegrationRules RefinedIntRules(1, Quadrature1D::GaussLegendre);
 
-IntegrationRules::IntegrationRules(int Ref, int _type):
-   quad_type(_type)
+IntegrationRules::IntegrationRules(int Ref, int type_):
+   quad_type(type_)
 {
    refined = Ref;
 

--- a/fem/lininteg.hpp
+++ b/fem/lininteg.hpp
@@ -406,13 +406,13 @@ private:
    Vector shape;
 
 public:
-   BoundaryFlowIntegrator(Coefficient &_f, VectorCoefficient &_u,
+   BoundaryFlowIntegrator(Coefficient &f_, VectorCoefficient &u_,
                           double a)
-   { f = &_f; u = &_u; alpha = a; beta = 0.5*a; }
+   { f = &f_; u = &u_; alpha = a; beta = 0.5*a; }
 
-   BoundaryFlowIntegrator(Coefficient &_f, VectorCoefficient &_u,
+   BoundaryFlowIntegrator(Coefficient &f_, VectorCoefficient &u_,
                           double a, double b)
-   { f = &_f; u = &_u; alpha = a; beta = b; }
+   { f = &f_; u = &u_; alpha = a; beta = b; }
 
    virtual void AssembleRHSElementVect(const FiniteElement &el,
                                        ElementTransformation &Tr,

--- a/fem/nonlininteg.hpp
+++ b/fem/nonlininteg.hpp
@@ -193,9 +193,9 @@ public:
 
    /// A reference-element to target-element transformation that can be used to
    /// evaluate Coefficient%s.
-   /** @note It is assumed that _Ttr.SetIntPoint() is already called for the
+   /** @note It is assumed that Ttr_.SetIntPoint() is already called for the
        point of interest. */
-   void SetTransformation(ElementTransformation &_Ttr) { Ttr = &_Ttr; }
+   void SetTransformation(ElementTransformation &Ttr_) { Ttr = &Ttr_; }
 
    /** @brief Evaluate the strain energy density function, W = W(Jpt).
        @param[in] Jpt  Represents the target->physical transformation
@@ -263,11 +263,11 @@ protected:
    inline void EvalCoeffs() const;
 
 public:
-   NeoHookeanModel(double _mu, double _K, double _g = 1.0)
-      : mu(_mu), K(_K), g(_g), have_coeffs(false) { c_mu = c_K = c_g = NULL; }
+   NeoHookeanModel(double mu_, double K_, double g_ = 1.0)
+      : mu(mu_), K(K_), g(g_), have_coeffs(false) { c_mu = c_K = c_g = NULL; }
 
-   NeoHookeanModel(Coefficient &_mu, Coefficient &_K, Coefficient *_g = NULL)
-      : mu(0.0), K(0.0), g(1.0), c_mu(&_mu), c_K(&_K), c_g(_g),
+   NeoHookeanModel(Coefficient &mu_, Coefficient &K_, Coefficient *g_ = NULL)
+      : mu(0.0), K(0.0), g(1.0), c_mu(&mu_), c_K(&K_), c_g(g_),
         have_coeffs(true) { }
 
    virtual double EvalW(const DenseMatrix &J) const;
@@ -336,7 +336,7 @@ private:
    Vector Sh_p;
 
 public:
-   IncompressibleNeoHookeanIntegrator(Coefficient &_mu) : c_mu(&_mu) { }
+   IncompressibleNeoHookeanIntegrator(Coefficient &mu_) : c_mu(&mu_) { }
 
    virtual double GetElementEnergy(const Array<const FiniteElement *>&el,
                                    ElementTransformation &Tr,

--- a/fem/pgridfunc.cpp
+++ b/fem/pgridfunc.cpp
@@ -275,8 +275,8 @@ const
       if (fes_vdim > 1)
       {
          int s = dofs.Size()/fes_vdim;
-         Array<int> _dofs(&dofs[(vdim-1)*s], s);
-         face_nbr_data.GetSubVector(_dofs, LocVec);
+         Array<int> dofs_(&dofs[(vdim-1)*s], s);
+         face_nbr_data.GetSubVector(dofs_, LocVec);
          DofVal.SetSize(s);
       }
       else

--- a/fem/tmop.hpp
+++ b/fem/tmop.hpp
@@ -40,7 +40,7 @@ public:
        The specified Jacobian matrix, #Jtr, can be used by metrics that cannot
        be written just as a function of the target->physical Jacobian matrix,
        Jpt. */
-   virtual void SetTargetJacobian(const DenseMatrix &_Jtr) { Jtr = &_Jtr; }
+   virtual void SetTargetJacobian(const DenseMatrix &Jtr_) { Jtr = &Jtr_; }
 
    /** @brief Evaluate the strain energy density function, W = W(Jpt).
        @param[in] Jpt  Represents the target->physical transformation
@@ -84,11 +84,11 @@ public:
       wt_arr.Append(wt);
    }
 
-   virtual void SetTargetJacobian(const DenseMatrix &_Jtr)
+   virtual void SetTargetJacobian(const DenseMatrix &Jtr_)
    {
       for (int i = 0; i < tmop_q_arr.Size(); i++)
       {
-         tmop_q_arr[i]->SetTargetJacobian(_Jtr);
+         tmop_q_arr[i]->SetTargetJacobian(Jtr_);
       }
    }
 
@@ -1311,7 +1311,7 @@ public:
    void EnableFiniteDifferences(const ParGridFunction &x);
 #endif
 
-   void   SetFDhScale(double _dxscale) { dxscale = _dxscale; }
+   void   SetFDhScale(double dxscale_) { dxscale = dxscale_; }
    bool   GetFDFlag() const { return fdflag; }
    double GetFDh()    const { return dx; }
 

--- a/general/array.hpp
+++ b/general/array.hpp
@@ -67,8 +67,8 @@ public:
    /** @brief Creates array using an existing c-array of asize elements;
        allocsize is set to -asize to indicate that the data will not
        be deleted. */
-   inline Array(T *_data, int asize)
-   { data.Wrap(_data, asize, false); size = asize; }
+   inline Array(T *data_, int asize)
+   { data.Wrap(data_, asize, false); size = asize; }
 
    /// Copy constructor: deep copy from @a src
    /** This method supports source arrays using any MemoryType. */

--- a/general/gecko.hpp
+++ b/general/gecko.hpp
@@ -600,10 +600,10 @@ public:
    class Comparator
    {
    public:
-      Comparator(ConstPtr node) : _node(node) {}
-      bool operator()(uint k, uint l) const { return _node[k].pos < _node[l].pos; }
+      Comparator(ConstPtr node_) : node(node_) {}
+      bool operator()(uint k, uint l) const { return node[k].pos < node[l].pos; }
    private:
-      const ConstPtr _node;
+      const ConstPtr node;
    };
 
    // constructor

--- a/general/optparser.hpp
+++ b/general/optparser.hpp
@@ -45,10 +45,10 @@ private:
 
       Option() = default;
 
-      Option(OptionType _type, void *_var_ptr, const char *_short_name,
-             const char *_long_name, const char *_description, bool req)
-         : type(_type), var_ptr(_var_ptr), short_name(_short_name),
-           long_name(_long_name), description(_description), required(req) { }
+      Option(OptionType type_, void *var_ptr_, const char *short_name_,
+             const char *long_name_, const char *description_, bool req)
+         : type(type_), var_ptr(var_ptr_), short_name(short_name_),
+           long_name(long_name_), description(description_), required(req) { }
    };
 
    int argc;
@@ -69,9 +69,9 @@ private:
 
 public:
 
-   /// Construct a command line option parser with '_argc' and '_argv'.
-   OptionsParser(int _argc, char *_argv[])
-      : argc(_argc), argv(_argv)
+   /// Construct a command line option parser with 'argc_' and 'argv_'.
+   OptionsParser(int argc_, char *argv_[])
+      : argc(argc_), argv(argv_)
    {
       error_type = error_idx = 0;
    }

--- a/general/socketstream.cpp
+++ b/general/socketstream.cpp
@@ -216,21 +216,21 @@ socketbuf::int_type socketbuf::overflow(int_type c)
    return c;
 }
 
-std::streamsize socketbuf::xsgetn(char_type *__s, std::streamsize __n)
+std::streamsize socketbuf::xsgetn(char_type *s__, std::streamsize n__)
 {
-   // mfem::out << "[socketbuf::xsgetn __n=" << __n << ']'
+   // mfem::out << "[socketbuf::xsgetn n__=" << n__ << ']'
    //           << std::endl;
    const std::streamsize bn = egptr() - gptr();
-   if (__n <= bn)
+   if (n__ <= bn)
    {
-      traits_type::copy(__s, gptr(), __n);
-      gbump(__n);
-      return __n;
+      traits_type::copy(s__, gptr(), n__);
+      gbump(n__);
+      return n__;
    }
-   traits_type::copy(__s, gptr(), bn);
+   traits_type::copy(s__, gptr(), bn);
    setg(NULL, NULL, NULL);
-   std::streamsize remain = __n - bn;
-   char_type *end = __s + __n;
+   std::streamsize remain = n__ - bn;
+   char_type *end = s__ + n__;
    ssize_t br;
    while (remain > 0)
    {
@@ -243,30 +243,30 @@ std::streamsize socketbuf::xsgetn(char_type *__s, std::streamsize __n)
             mfem::out << "Error in recv(): " << strerror(errno) << std::endl;
          }
 #endif
-         return (__n - remain);
+         return (n__ - remain);
       }
       remain -= br;
    }
-   return __n;
+   return n__;
 }
 
-std::streamsize socketbuf::xsputn(const char_type *__s, std::streamsize __n)
+std::streamsize socketbuf::xsputn(const char_type *s__, std::streamsize n__)
 {
-   // mfem::out << "[socketbuf::xsputn __n=" << __n << ']'
+   // mfem::out << "[socketbuf::xsputn n__=" << n__ << ']'
    //           << std::endl;
-   if (pptr() + __n <= epptr())
+   if (pptr() + n__ <= epptr())
    {
-      traits_type::copy(pptr(), __s, __n);
-      pbump(__n);
-      return __n;
+      traits_type::copy(pptr(), s__, n__);
+      pbump(n__);
+      return n__;
    }
    if (sync() < 0)
    {
       return 0;
    }
    ssize_t bw;
-   std::streamsize remain = __n;
-   const char_type *end = __s + __n;
+   std::streamsize remain = n__;
+   const char_type *end = s__ + n__;
    while (remain > buflen)
    {
 #ifdef MSG_NOSIGNAL
@@ -279,7 +279,7 @@ std::streamsize socketbuf::xsputn(const char_type *__s, std::streamsize __n)
 #ifdef MFEM_DEBUG
          mfem::out << "Error in send(): " << strerror(errno) << std::endl;
 #endif
-         return (__n - remain);
+         return (n__ - remain);
       }
       remain -= bw;
    }
@@ -288,7 +288,7 @@ std::streamsize socketbuf::xsputn(const char_type *__s, std::streamsize __n)
       traits_type::copy(pptr(), end - remain, remain);
       pbump(remain);
    }
-   return __n;
+   return n__;
 }
 
 
@@ -842,24 +842,24 @@ GnuTLS_socketbuf::int_type GnuTLS_socketbuf::underflow()
    return traits_type::to_int_type(*ibuf);
 }
 
-std::streamsize GnuTLS_socketbuf::xsgetn(char_type *__s, std::streamsize __n)
+std::streamsize GnuTLS_socketbuf::xsgetn(char_type *s__, std::streamsize n__)
 {
 #ifdef MFEM_USE_GNUTLS_DEBUG
-   mfem::out << "[GnuTLS_socketbuf::xsgetn __n=" << __n << ']' << std::endl;
+   mfem::out << "[GnuTLS_socketbuf::xsgetn n__=" << n__ << ']' << std::endl;
 #endif
    if (!session_started || !status.good()) { return 0; }
 
    const std::streamsize bn = egptr() - gptr();
-   if (__n <= bn)
+   if (n__ <= bn)
    {
-      traits_type::copy(__s, gptr(), __n);
-      gbump(__n);
-      return __n;
+      traits_type::copy(s__, gptr(), n__);
+      gbump(n__);
+      return n__;
    }
-   traits_type::copy(__s, gptr(), bn);
+   traits_type::copy(s__, gptr(), bn);
    setg(NULL, NULL, NULL);
-   std::streamsize remain = __n - bn;
-   char_type *end = __s + __n;
+   std::streamsize remain = n__ - bn;
+   char_type *end = s__ + n__;
    ssize_t br;
    while (remain > 0)
    {
@@ -881,34 +881,34 @@ std::streamsize GnuTLS_socketbuf::xsgetn(char_type *__s, std::streamsize __n)
             status.print_on_error("gnutls_record_recv");
 #endif
          }
-         return (__n - remain);
+         return (n__ - remain);
       }
       remain -= br;
    }
-   return __n;
+   return n__;
 }
 
-std::streamsize GnuTLS_socketbuf::xsputn(const char_type *__s,
-                                         std::streamsize __n)
+std::streamsize GnuTLS_socketbuf::xsputn(const char_type *s__,
+                                         std::streamsize n__)
 {
 #ifdef MFEM_USE_GNUTLS_DEBUG
-   mfem::out << "[GnuTLS_socketbuf::xsputn __n=" << __n << ']' << std::endl;
+   mfem::out << "[GnuTLS_socketbuf::xsputn n__=" << n__ << ']' << std::endl;
 #endif
    if (!session_started || !status.good()) { return 0; }
 
-   if (pptr() + __n <= epptr())
+   if (pptr() + n__ <= epptr())
    {
-      traits_type::copy(pptr(), __s, __n);
-      pbump(__n);
-      return __n;
+      traits_type::copy(pptr(), s__, n__);
+      pbump(n__);
+      return n__;
    }
    if (sync() < 0)
    {
       return 0;
    }
    ssize_t bw;
-   std::streamsize remain = __n;
-   const char_type *end = __s + __n;
+   std::streamsize remain = n__;
+   const char_type *end = s__ + n__;
    while (remain > buflen)
    {
       bw = gnutls_record_send(session, end - remain, remain);
@@ -922,7 +922,7 @@ std::streamsize GnuTLS_socketbuf::xsputn(const char_type *__s,
 #ifdef MFEM_DEBUG
          status.print_on_error("gnutls_record_send");
 #endif
-         return (__n - remain);
+         return (n__ - remain);
       }
       remain -= bw;
    }
@@ -931,7 +931,7 @@ std::streamsize GnuTLS_socketbuf::xsputn(const char_type *__s,
       traits_type::copy(pptr(), end - remain, remain);
       pbump(remain);
    }
-   return __n;
+   return n__;
 }
 
 

--- a/general/socketstream.hpp
+++ b/general/socketstream.hpp
@@ -83,9 +83,9 @@ protected:
 
    virtual int_type overflow(int_type c = traits_type::eof());
 
-   virtual std::streamsize xsgetn(char_type *__s, std::streamsize __n);
+   virtual std::streamsize xsgetn(char_type *s__, std::streamsize n__);
 
-   virtual std::streamsize xsputn(const char_type *__s, std::streamsize __n);
+   virtual std::streamsize xsputn(const char_type *s__, std::streamsize n__);
 };
 
 
@@ -200,9 +200,9 @@ protected:
    // Same as in the base class:
    // virtual int_type overflow(int_type c = traits_type::eof());
 
-   virtual std::streamsize xsgetn(char_type *__s, std::streamsize __n);
+   virtual std::streamsize xsgetn(char_type *s__, std::streamsize n__);
 
-   virtual std::streamsize xsputn(const char_type *__s, std::streamsize __n);
+   virtual std::streamsize xsputn(const char_type *s__, std::streamsize n__);
 };
 
 #endif // MFEM_USE_GNUTLS

--- a/general/table.cpp
+++ b/general/table.cpp
@@ -411,12 +411,12 @@ Table::~Table ()
    J.Delete();
 }
 
-void Transpose (const Table &A, Table &At, int _ncols_A)
+void Transpose (const Table &A, Table &At, int ncols_A_)
 {
    const int *i_A     = A.GetI();
    const int *j_A     = A.GetJ();
    const int  nrows_A = A.Size();
-   const int  ncols_A = (_ncols_A < 0) ? A.Width() : _ncols_A;
+   const int  ncols_A = (ncols_A_ < 0) ? A.Width() : ncols_A_;
    const int  nnz_A   = i_A[nrows_A];
 
    At.SetDims (ncols_A, nnz_A);
@@ -458,9 +458,9 @@ Table * Transpose(const Table &A)
    return At;
 }
 
-void Transpose(const Array<int> &A, Table &At, int _ncols_A)
+void Transpose(const Array<int> &A, Table &At, int ncols_A_)
 {
-   At.MakeI((_ncols_A < 0) ? (A.Max() + 1) : _ncols_A);
+   At.MakeI((ncols_A_ < 0) ? (A.Max() + 1) : ncols_A_);
    for (int i = 0; i < A.Size(); i++)
    {
       At.AddAColumnInRow(A[i]);

--- a/general/table.hpp
+++ b/general/table.hpp
@@ -178,11 +178,11 @@ template <> inline void Swap<Table>(Table &a, Table &b)
 }
 
 ///  Transpose a Table
-void Transpose (const Table &A, Table &At, int _ncols_A = -1);
+void Transpose (const Table &A, Table &At, int ncols_A_ = -1);
 Table * Transpose (const Table &A);
 
 ///  Transpose an Array<int>
-void Transpose(const Array<int> &A, Table &At, int _ncols_A = -1);
+void Transpose(const Array<int> &A, Table &At, int ncols_A_ = -1);
 
 ///  C = A * B  (as boolean matrices)
 void Mult (const Table &A, const Table &B, Table &C);

--- a/general/zstr.hpp
+++ b/general/zstr.hpp
@@ -268,32 +268,32 @@ class Exception
 {
 public:
    Exception(z_stream *zstrm_p, int ret)
-      : msg_("zlib: ")
+      : msg("zlib: ")
    {
       switch (ret)
       {
          case Z_STREAM_ERROR:
-            msg_ += "Z_STREAM_ERROR: ";
+            msg += "Z_STREAM_ERROR: ";
             break;
          case Z_DATA_ERROR:
-            msg_ += "Z_DATA_ERROR: ";
+            msg += "Z_DATA_ERROR: ";
             break;
          case Z_MEM_ERROR:
-            msg_ += "Z_MEM_ERROR: ";
+            msg += "Z_MEM_ERROR: ";
             break;
          case Z_VERSION_ERROR:
-            msg_ += "Z_VERSION_ERROR: ";
+            msg += "Z_VERSION_ERROR: ";
             break;
          case Z_BUF_ERROR:
-            msg_ += "Z_BUF_ERROR: ";
+            msg += "Z_BUF_ERROR: ";
             break;
          default:
             std::ostringstream oss;
             oss << ret;
-            msg_ += "[" + oss.str() + "]: ";
+            msg += "[" + oss.str() + "]: ";
             break;
       }
-      msg_ += zstrm_p->msg;
+      msg += zstrm_p->msg;
    }
    Exception(const std::string msg_) : msg(msg_) {}
    const char *what() const noexcept { return msg.c_str(); }

--- a/general/zstr.hpp
+++ b/general/zstr.hpp
@@ -92,10 +92,10 @@ class Exception
    : public std::exception
 {
 public:
-   Exception(const std::string& msg) : _msg(msg) {}
-   const char * what() const noexcept { return _msg.c_str(); }
+   Exception(const std::string& msg_) : msg(msg_) {}
+   const char * what() const noexcept { return msg.c_str(); }
 private:
-   std::string _msg;
+   std::string msg;
 }; // class Exception
 
 namespace detail
@@ -268,38 +268,38 @@ class Exception
 {
 public:
    Exception(z_stream *zstrm_p, int ret)
-      : _msg("zlib: ")
+      : msg_("zlib: ")
    {
       switch (ret)
       {
          case Z_STREAM_ERROR:
-            _msg += "Z_STREAM_ERROR: ";
+            msg_ += "Z_STREAM_ERROR: ";
             break;
          case Z_DATA_ERROR:
-            _msg += "Z_DATA_ERROR: ";
+            msg_ += "Z_DATA_ERROR: ";
             break;
          case Z_MEM_ERROR:
-            _msg += "Z_MEM_ERROR: ";
+            msg_ += "Z_MEM_ERROR: ";
             break;
          case Z_VERSION_ERROR:
-            _msg += "Z_VERSION_ERROR: ";
+            msg_ += "Z_VERSION_ERROR: ";
             break;
          case Z_BUF_ERROR:
-            _msg += "Z_BUF_ERROR: ";
+            msg_ += "Z_BUF_ERROR: ";
             break;
          default:
             std::ostringstream oss;
             oss << ret;
-            _msg += "[" + oss.str() + "]: ";
+            msg_ += "[" + oss.str() + "]: ";
             break;
       }
-      _msg += zstrm_p->msg;
+      msg_ += zstrm_p->msg;
    }
-   Exception(const std::string msg) : _msg(msg) {}
-   const char *what() const noexcept { return _msg.c_str(); }
+   Exception(const std::string msg_) : msg(msg_) {}
+   const char *what() const noexcept { return msg.c_str(); }
 
 private:
-   std::string _msg;
+   std::string msg;
 }; // class Exception
 #endif
 
@@ -310,8 +310,8 @@ class z_stream_wrapper
    : public z_stream
 {
 public:
-   z_stream_wrapper(bool _is_input = true, int _level = Z_DEFAULT_COMPRESSION)
-      : is_input(_is_input)
+   z_stream_wrapper(bool is_input_ = true, int level_ = Z_DEFAULT_COMPRESSION)
+      : is_input(is_input_)
    {
       this->zalloc = Z_NULL;
       this->zfree = Z_NULL;
@@ -325,7 +325,7 @@ public:
       }
       else
       {
-         ret = deflateInit2(this, _level, Z_DEFLATED, 15 + 16, 8, Z_DEFAULT_STRATEGY);
+         ret = deflateInit2(this, level_, Z_DEFLATED, 15 + 16, 8, Z_DEFAULT_STRATEGY);
       }
       if (ret != Z_OK)
       {
@@ -354,12 +354,12 @@ class istreambuf
    : public std::streambuf
 {
 public:
-   istreambuf(std::streambuf *_sbuf_p,
-              std::size_t _buff_size = default_buff_size, bool _auto_detect = true)
-      : sbuf_p(_sbuf_p),
+   istreambuf(std::streambuf *sbuf_p_,
+              std::size_t buff_size_ = default_buff_size, bool auto_detect_ = true)
+      : sbuf_p(sbuf_p_),
         zstrm_p(nullptr),
-        buff_size(_buff_size),
-        auto_detect(_auto_detect),
+        buff_size(buff_size_),
+        auto_detect(auto_detect_),
         auto_detect_run(false),
         is_text(false)
    {
@@ -491,11 +491,11 @@ class ostreambuf
    : public std::streambuf
 {
 public:
-   ostreambuf(std::streambuf *_sbuf_p,
-              std::size_t _buff_size = default_buff_size, int _level = Z_DEFAULT_COMPRESSION)
-      : sbuf_p(_sbuf_p),
-        zstrm_p(new detail::z_stream_wrapper(false, _level)),
-        buff_size(_buff_size)
+   ostreambuf(std::streambuf *sbuf_p_,
+              std::size_t buff_size_ = default_buff_size, int level_ = Z_DEFAULT_COMPRESSION)
+      : sbuf_p(sbuf_p_),
+        zstrm_p(new detail::z_stream_wrapper(false, level_)),
+        buff_size(buff_size_)
    {
       assert(sbuf_p);
       in_buff = new char[buff_size];
@@ -647,10 +647,10 @@ struct strict_fstream_holder
 {
    strict_fstream_holder(const std::string &filename,
                          std::ios_base::openmode mode = std::ios_base::in)
-      : _fs(filename, mode)
+      : fs_(filename, mode)
    {
    }
-   FStream_Type _fs;
+   FStream_Type fs_;
 }; // class strict_fstream_holder
 
 } // namespace detail
@@ -664,7 +664,7 @@ public:
    explicit ifstream(const std::string &filename,
                      std::ios_base::openmode mode = std::ios_base::in)
       : detail::strict_fstream_holder<strict_fstream::ifstream>(filename, mode),
-        std::istream(new istreambuf(_fs.rdbuf()))
+        std::istream(new istreambuf(fs_.rdbuf()))
    {
       exceptions(std::ios_base::badbit);
    }
@@ -686,7 +686,7 @@ public:
                      std::ios_base::openmode mode = std::ios_base::out)
       : detail::strict_fstream_holder<strict_fstream::ofstream>(filename,
                                                                 mode | std::ios_base::binary),
-        std::ostream(new ostreambuf(_fs.rdbuf()))
+        std::ostream(new ostreambuf(fs_.rdbuf()))
    {
       exceptions(std::ios_base::badbit);
    }
@@ -722,13 +722,13 @@ public:
 #ifdef MFEM_USE_ZLIB
       if (compression)
       {
-         strbuf = new zstr::ostreambuf(_fs.rdbuf());
+         strbuf = new zstr::ostreambuf(fs_.rdbuf());
          rdbuf(strbuf);
       }
       else
 #endif
       {
-         rdbuf(_fs.rdbuf());
+         rdbuf(fs_.rdbuf());
       }
       exceptions(std::ios_base::badbit);
    }
@@ -746,15 +746,15 @@ public:
       // level (it is always set to 6).
       if (std::string(open_mode_chars).find('z') != std::string::npos)
       {
-         strbuf = new zstr::ostreambuf(_fs.rdbuf());
+         strbuf = new zstr::ostreambuf(fs_.rdbuf());
          rdbuf(strbuf);
       }
       else
 #endif
       {
-         rdbuf(_fs.rdbuf());
+         rdbuf(fs_.rdbuf());
       }
-      setstate(_fs.rdstate());
+      setstate(fs_.rdstate());
       exceptions(std::ios_base::badbit);
    }
 
@@ -777,12 +777,12 @@ public:
         std::istream(nullptr)
    {
 #ifdef MFEM_USE_ZLIB
-      strbuf = new zstr::istreambuf(_fs.rdbuf());
+      strbuf = new zstr::istreambuf(fs_.rdbuf());
       rdbuf(strbuf);
 #else
-      rdbuf(_fs.rdbuf());
+      rdbuf(fs_.rdbuf());
 #endif
-      setstate(_fs.rdstate());
+      setstate(fs_.rdstate());
       exceptions(std::ios_base::badbit);
    }
 

--- a/linalg/complex_operator.hpp
+++ b/linalg/complex_operator.hpp
@@ -196,15 +196,15 @@ public:
    mutable double Info[UMFPACK_INFO];
 
    /** @brief For larger matrices, if the solver fails, set the parameter @a
-       _use_long_ints = true. */
-   ComplexUMFPackSolver(bool _use_long_ints = false, bool transa_ = false)
-      : use_long_ints(_use_long_ints), transa(transa_) { Init(); }
+       use_long_ints_ = true. */
+   ComplexUMFPackSolver(bool use_long_ints_ = false, bool transa_ = false)
+      : use_long_ints(use_long_ints_), transa(transa_) { Init(); }
    /** @brief Factorize the given ComplexSparseMatrix using the defaults.
        For larger matrices, if the solver fails, set the parameter
-       @a _use_long_ints = true. */
-   ComplexUMFPackSolver(ComplexSparseMatrix &A, bool _use_long_ints = false,
+       @a use_long_ints_ = true. */
+   ComplexUMFPackSolver(ComplexSparseMatrix &A, bool use_long_ints_ = false,
                         bool transa_ = false)
-      : use_long_ints(_use_long_ints), transa(transa_) { Init(); SetOperator(A); }
+      : use_long_ints(use_long_ints_), transa(transa_) { Init(); SetOperator(A); }
 
    /** @brief Factorize the given Operator @a op which must be
        a ComplexSparseMatrix.

--- a/linalg/dtensor.hpp
+++ b/linalg/dtensor.hpp
@@ -89,15 +89,15 @@ public:
    /// Default constructor
    DeviceTensor() = delete;
 
-   /// Constructor to initialize a tensor from the Scalar array _data
+   /// Constructor to initialize a tensor from the Scalar array data_
    template <typename... Args> MFEM_HOST_DEVICE
-   DeviceTensor(Scalar* _data, Args... args)
+   DeviceTensor(Scalar* data_, Args... args)
    {
       static_assert(sizeof...(args) == Dim, "Wrong number of arguments");
       // Initialize sizes, and compute the number of values
       const long int nb = Init<1, Dim, Args...>::result(sizes, args...);
       capacity = nb;
-      data = (capacity > 0) ? _data : NULL;
+      data = (capacity > 0) ? data_ : NULL;
    }
 
    /// Copy constructor

--- a/linalg/hiop.cpp
+++ b/linalg/hiop.cpp
@@ -169,11 +169,11 @@ bool HiopOptimizationProblem::get_vecdistrib_info(long long global_n,
 {
 #ifdef MFEM_USE_MPI
    int nranks;
-   MPI_Comm_size(comm_, &nranks);
+   MPI_Comm_size(comm, &nranks);
 
    long long *sizes = new long long[nranks];
    MPI_Allgather(&ntdofs_loc, 1, MPI_LONG_LONG_INT, sizes, 1,
-                 MPI_LONG_LONG_INT, comm_);
+                 MPI_LONG_LONG_INT, comm);
    cols[0] = 0;
    for (int r = 1; r <= nranks; r++)
    {
@@ -249,7 +249,7 @@ HiopNlpOptimizer::HiopNlpOptimizer() : OptimizationSolver(), hiop_problem(NULL)
 {
 #ifdef MFEM_USE_MPI
    // Set in case a serial driver uses a parallel MFEM build.
-   comm_ = MPI_COMM_WORLD;
+   comm = MPI_COMM_WORLD;
    int initialized, nret = MPI_Initialized(&initialized);
    MFEM_ASSERT(MPI_SUCCESS == nret, "Failure in calling MPI_Initialized!");
    if (!initialized)
@@ -261,8 +261,8 @@ HiopNlpOptimizer::HiopNlpOptimizer() : OptimizationSolver(), hiop_problem(NULL)
 }
 
 #ifdef MFEM_USE_MPI
-HiopNlpOptimizer::HiopNlpOptimizer(MPI_Comm _comm)
-   : OptimizationSolver(_comm), hiop_problem(NULL), comm_(_comm) { }
+HiopNlpOptimizer::HiopNlpOptimizer(MPI_Comm comm_)
+   : OptimizationSolver(comm_), hiop_problem(NULL), comm(comm_) { }
 #endif
 
 HiopNlpOptimizer::~HiopNlpOptimizer()
@@ -278,7 +278,7 @@ void HiopNlpOptimizer::SetOptimizationProblem(const OptimizationProblem &prob)
    if (hiop_problem) { delete hiop_problem; }
 
 #ifdef MFEM_USE_MPI
-   hiop_problem = new HiopOptimizationProblem(comm_, *problem);
+   hiop_problem = new HiopOptimizationProblem(comm, *problem);
 #else
    hiop_problem = new HiopOptimizationProblem(*problem);
 #endif

--- a/linalg/hiop.hpp
+++ b/linalg/hiop.hpp
@@ -34,7 +34,7 @@ class HiopOptimizationProblem : public hiop::hiopInterfaceDenseConstraints
 private:
 
 #ifdef MFEM_USE_MPI
-   MPI_Comm comm_;
+   MPI_Comm comm;
 #endif
 
    // Problem info.
@@ -63,14 +63,14 @@ public:
    {
 #ifdef MFEM_USE_MPI
       // Used when HiOp with MPI support is called by a serial driver.
-      comm_ = MPI_COMM_WORLD;
+      comm = MPI_COMM_WORLD;
 #endif
    }
 
 #ifdef MFEM_USE_MPI
-   HiopOptimizationProblem(const MPI_Comm& _comm,
+   HiopOptimizationProblem(const MPI_Comm& comm_,
                            const OptimizationProblem &prob)
-      : comm_(_comm),
+      : comm(comm_),
         problem(prob),
         ntdofs_loc(prob.input_size), m_total(prob.GetNumConstraints()),
         ntdofs_glob(0),
@@ -79,7 +79,7 @@ public:
         constr_info_is_current(false)
    {
       MPI_Allreduce(&ntdofs_loc, &ntdofs_glob, 1, MPI_LONG_LONG_INT,
-                    MPI_SUM, comm_);
+                    MPI_SUM, comm);
    }
 #endif
 
@@ -162,7 +162,7 @@ public:
 #ifdef MFEM_USE_MPI
    virtual bool get_MPI_comm(MPI_Comm &comm_out)
    {
-      comm_out = comm_;
+      comm_out = comm;
       return true;
    }
 #endif
@@ -175,13 +175,13 @@ protected:
    HiopOptimizationProblem *hiop_problem;
 
 #ifdef MFEM_USE_MPI
-   MPI_Comm comm_;
+   MPI_Comm comm;
 #endif
 
 public:
    HiopNlpOptimizer();
 #ifdef MFEM_USE_MPI
-   HiopNlpOptimizer(MPI_Comm _comm);
+   HiopNlpOptimizer(MPI_Comm comm_);
 #endif
    virtual ~HiopNlpOptimizer();
 

--- a/linalg/hypre.cpp
+++ b/linalg/hypre.cpp
@@ -64,7 +64,7 @@ HypreParVector::HypreParVector(MPI_Comm comm, HYPRE_BigInt glob_size,
 }
 
 HypreParVector::HypreParVector(MPI_Comm comm, HYPRE_BigInt glob_size,
-                               double *_data, HYPRE_BigInt *col) : Vector()
+                               double *data_, HYPRE_BigInt *col) : Vector()
 {
    x = hypre_ParVectorCreate(comm,glob_size,col);
    hypre_ParVectorSetDataOwner(x,1); // owns the seq vector
@@ -76,7 +76,7 @@ HypreParVector::HypreParVector(MPI_Comm comm, HYPRE_BigInt glob_size,
    // hypre_ParVectorInitialize(x) does not allocate memory!
    hypre_ParVectorInitialize(x);
    // Set the internal data array to the one passed in
-   hypre_VectorData(hypre_ParVectorLocalVector(x)) = _data;
+   hypre_VectorData(hypre_ParVectorLocalVector(x)) = data_;
    _SetDataAndSize_();
    own_ParVector = 1;
 }
@@ -166,10 +166,10 @@ HypreParVector& HypreParVector::operator=(const HypreParVector &y)
    return *this;
 }
 
-void HypreParVector::SetData(double *_data)
+void HypreParVector::SetData(double *data_)
 {
-   hypre_VectorData(hypre_ParVectorLocalVector(x)) = _data;
-   Vector::SetData(_data);
+   hypre_VectorData(hypre_ParVectorLocalVector(x)) = data_;
+   Vector::SetData(data_);
 }
 
 HYPRE_Int HypreParVector::Randomize(HYPRE_Int seed)
@@ -2376,17 +2376,17 @@ HypreSmoother::HypreSmoother() : Solver()
    A_is_symmetric = false;
 }
 
-HypreSmoother::HypreSmoother(const HypreParMatrix &_A, int _type,
-                             int _relax_times, double _relax_weight, double _omega,
-                             int _poly_order, double _poly_fraction, int _eig_est_cg_iter)
+HypreSmoother::HypreSmoother(const HypreParMatrix &A_, int type_,
+                             int relax_times_, double relax_weight_, double omega_,
+                             int poly_order_, double poly_fraction_, int eig_est_cg_iter_)
 {
-   type = _type;
-   relax_times = _relax_times;
-   relax_weight = _relax_weight;
-   omega = _omega;
-   poly_order = _poly_order;
-   poly_fraction = _poly_fraction;
-   eig_est_cg_iter = _eig_est_cg_iter;
+   type = type_;
+   relax_times = relax_times_;
+   relax_weight = relax_weight_;
+   omega = omega_;
+   poly_order = poly_order_;
+   poly_fraction = poly_fraction_;
+   eig_est_cg_iter = eig_est_cg_iter_;
 
    l1_norms = NULL;
    pos_l1_norms = false;
@@ -2395,35 +2395,35 @@ HypreSmoother::HypreSmoother(const HypreParMatrix &_A, int _type,
    fir_coeffs = NULL;
    A_is_symmetric = false;
 
-   SetOperator(_A);
+   SetOperator(A_);
 }
 
-void HypreSmoother::SetType(HypreSmoother::Type _type, int _relax_times)
+void HypreSmoother::SetType(HypreSmoother::Type type_, int relax_times_)
 {
-   type = static_cast<int>(_type);
-   relax_times = _relax_times;
+   type = static_cast<int>(type_);
+   relax_times = relax_times_;
 }
 
-void HypreSmoother::SetSOROptions(double _relax_weight, double _omega)
+void HypreSmoother::SetSOROptions(double relax_weight_, double omega_)
 {
-   relax_weight = _relax_weight;
-   omega = _omega;
+   relax_weight = relax_weight_;
+   omega = omega_;
 }
 
-void HypreSmoother::SetPolyOptions(int _poly_order, double _poly_fraction,
-                                   int _eig_est_cg_iter)
+void HypreSmoother::SetPolyOptions(int poly_order_, double poly_fraction_,
+                                   int eig_est_cg_iter_)
 {
-   poly_order = _poly_order;
-   poly_fraction = _poly_fraction;
-   eig_est_cg_iter = _eig_est_cg_iter;
+   poly_order = poly_order_;
+   poly_fraction = poly_fraction_;
+   eig_est_cg_iter = eig_est_cg_iter_;
 }
 
-void HypreSmoother::SetTaubinOptions(double _lambda, double _mu,
-                                     int _taubin_iter)
+void HypreSmoother::SetTaubinOptions(double lambda_, double mu_,
+                                     int taubin_iter_)
 {
-   lambda = _lambda;
-   mu = _mu;
-   taubin_iter = _taubin_iter;
+   lambda = lambda_;
+   mu = mu_;
+   taubin_iter = taubin_iter_;
 }
 
 void HypreSmoother::SetWindowByName(const char* name)
@@ -2718,10 +2718,10 @@ HypreSolver::HypreSolver()
    error_mode = ABORT_HYPRE_ERRORS;
 }
 
-HypreSolver::HypreSolver(const HypreParMatrix *_A)
-   : Solver(_A->Height(), _A->Width())
+HypreSolver::HypreSolver(const HypreParMatrix *A_)
+   : Solver(A_->Height(), A_->Width())
 {
-   A = _A;
+   A = A_;
    setup_called = 0;
    B = X = NULL;
    error_mode = ABORT_HYPRE_ERRORS;
@@ -2813,7 +2813,7 @@ HyprePCG::HyprePCG(MPI_Comm comm) : precond(NULL)
    HYPRE_ParCSRPCGCreate(comm, &pcg_solver);
 }
 
-HyprePCG::HyprePCG(const HypreParMatrix &_A) : HypreSolver(&_A), precond(NULL)
+HyprePCG::HyprePCG(const HypreParMatrix &A_) : HypreSolver(&A_), precond(NULL)
 {
    MPI_Comm comm;
 
@@ -2864,14 +2864,14 @@ void HyprePCG::SetPrintLevel(int print_lvl)
    HYPRE_ParCSRPCGSetPrintLevel(pcg_solver, print_lvl);
 }
 
-void HyprePCG::SetPreconditioner(HypreSolver &_precond)
+void HyprePCG::SetPreconditioner(HypreSolver &precond_)
 {
-   precond = &_precond;
+   precond = &precond_;
 
    HYPRE_ParCSRPCGSetPrecond(pcg_solver,
-                             _precond.SolveFcn(),
-                             _precond.SetupFcn(),
-                             _precond);
+                             precond_.SolveFcn(),
+                             precond_.SetupFcn(),
+                             precond_);
 }
 
 void HyprePCG::SetResidualConvergenceOptions(int res_frequency, double rtol)
@@ -2978,8 +2978,8 @@ HypreGMRES::HypreGMRES(MPI_Comm comm) : precond(NULL)
    SetDefaultOptions();
 }
 
-HypreGMRES::HypreGMRES(const HypreParMatrix &_A)
-   : HypreSolver(&_A), precond(NULL)
+HypreGMRES::HypreGMRES(const HypreParMatrix &A_)
+   : HypreSolver(&A_), precond(NULL)
 {
    MPI_Comm comm;
 
@@ -3052,14 +3052,14 @@ void HypreGMRES::SetPrintLevel(int print_lvl)
    HYPRE_GMRESSetPrintLevel(gmres_solver, print_lvl);
 }
 
-void HypreGMRES::SetPreconditioner(HypreSolver &_precond)
+void HypreGMRES::SetPreconditioner(HypreSolver &precond_)
 {
-   precond = &_precond;
+   precond = &precond_;
 
    HYPRE_ParCSRGMRESSetPrecond(gmres_solver,
-                               _precond.SolveFcn(),
-                               _precond.SetupFcn(),
-                               _precond);
+                               precond_.SolveFcn(),
+                               precond_.SetupFcn(),
+                               precond_);
 }
 
 void HypreGMRES::Mult(const HypreParVector &b, HypreParVector &x) const
@@ -3144,8 +3144,8 @@ HypreFGMRES::HypreFGMRES(MPI_Comm comm) : precond(NULL)
    SetDefaultOptions();
 }
 
-HypreFGMRES::HypreFGMRES(const HypreParMatrix &_A)
-   : HypreSolver(&_A), precond(NULL)
+HypreFGMRES::HypreFGMRES(const HypreParMatrix &A_)
+   : HypreSolver(&A_), precond(NULL)
 {
    MPI_Comm comm;
 
@@ -3213,13 +3213,13 @@ void HypreFGMRES::SetPrintLevel(int print_lvl)
    HYPRE_ParCSRFlexGMRESSetPrintLevel(fgmres_solver, print_lvl);
 }
 
-void HypreFGMRES::SetPreconditioner(HypreSolver &_precond)
+void HypreFGMRES::SetPreconditioner(HypreSolver &precond_)
 {
-   precond = &_precond;
+   precond = &precond_;
    HYPRE_ParCSRFlexGMRESSetPrecond(fgmres_solver,
-                                   _precond.SolveFcn(),
-                                   _precond.SetupFcn(),
-                                   _precond);
+                                   precond_.SolveFcn(),
+                                   precond_.SetupFcn(),
+                                   precond_);
 }
 
 void HypreFGMRES::Mult(const HypreParVector &b, HypreParVector &x) const

--- a/linalg/hypre.hpp
+++ b/linalg/hypre.hpp
@@ -104,10 +104,10 @@ public:
    HypreParVector(MPI_Comm comm, HYPRE_BigInt glob_size, HYPRE_BigInt *col);
    /** @brief Creates vector with given global size, partitioning of the
        columns, and data. */
-   /** The data must be allocated and destroyed outside. If @a _data is NULL, a
+   /** The data must be allocated and destroyed outside. If @a data_ is NULL, a
        dummy vector without a valid data array will be created. See @ref
        hypre_partitioning_descr "here" for a description of the @a col array. */
-   HypreParVector(MPI_Comm comm, HYPRE_BigInt glob_size, double *_data,
+   HypreParVector(MPI_Comm comm, HYPRE_BigInt glob_size, double *data_,
                   HYPRE_BigInt *col);
    /// Creates vector compatible with y
    HypreParVector(const HypreParVector &y);
@@ -161,11 +161,11 @@ public:
    /// Define '=' for hypre vectors.
    HypreParVector& operator= (const HypreParVector &y);
 
-   /// Sets the data of the Vector and the hypre_ParVector to @a _data.
+   /// Sets the data of the Vector and the hypre_ParVector to @a data_.
    /** Must be used only for HypreParVector%s that do not own the data,
        e.g. created with the constructor:
        HypreParVector(MPI_Comm, HYPRE_BigInt, double *, HYPRE_BigInt *). */
-   void SetData(double *_data);
+   void SetData(double *data_);
 
    /// Set random values
    HYPRE_Int Randomize(HYPRE_Int seed);
@@ -735,7 +735,7 @@ public:
 
    HypreSmoother();
 
-   HypreSmoother(const HypreParMatrix &_A, int type = l1GS,
+   HypreSmoother(const HypreParMatrix &A_, int type = l1GS,
                  int relax_times = 1, double relax_weight = 1.0,
                  double omega = 1.0, int poly_order = 2,
                  double poly_fraction = .3, int eig_est_cg_iter = 10);
@@ -813,7 +813,7 @@ protected:
 public:
    HypreSolver();
 
-   HypreSolver(const HypreParMatrix *_A);
+   HypreSolver(const HypreParMatrix *A_);
 
    /// Typecast to HYPRE_Solver -- return the solver
    virtual operator HYPRE_Solver() const = 0;
@@ -882,7 +882,7 @@ private:
 public:
    HyprePCG(MPI_Comm comm);
 
-   HyprePCG(const HypreParMatrix &_A);
+   HyprePCG(const HypreParMatrix &A_);
 
    virtual void SetOperator(const Operator &op);
 
@@ -943,7 +943,7 @@ private:
 public:
    HypreGMRES(MPI_Comm comm);
 
-   HypreGMRES(const HypreParMatrix &_A);
+   HypreGMRES(const HypreParMatrix &A_);
 
    virtual void SetOperator(const Operator &op);
 
@@ -994,7 +994,7 @@ private:
 public:
    HypreFGMRES(MPI_Comm comm);
 
-   HypreFGMRES(const HypreParMatrix &_A);
+   HypreFGMRES(const HypreParMatrix &A_);
 
    virtual void SetOperator(const Operator &op);
 

--- a/linalg/ode.cpp
+++ b/linalg/ode.cpp
@@ -15,15 +15,15 @@
 namespace mfem
 {
 
-void ODESolver::Init(TimeDependentOperator &f)
+void ODESolver::Init(TimeDependentOperator &f_)
 {
-   this->f = &f;
-   mem_type = GetMemoryType(f.GetMemoryClass());
+   this->f = &f_;
+   mem_type = GetMemoryType(f_.GetMemoryClass());
 }
 
-void ForwardEulerSolver::Init(TimeDependentOperator &_f)
+void ForwardEulerSolver::Init(TimeDependentOperator &f_)
 {
-   ODESolver::Init(_f);
+   ODESolver::Init(f_);
    dxdt.SetSize(f->Width(), mem_type);
 }
 
@@ -36,9 +36,9 @@ void ForwardEulerSolver::Step(Vector &x, double &t, double &dt)
 }
 
 
-void RK2Solver::Init(TimeDependentOperator &_f)
+void RK2Solver::Init(TimeDependentOperator &f_)
 {
-   ODESolver::Init(_f);
+   ODESolver::Init(f_);
    int n = f->Width();
    dxdt.SetSize(n, mem_type);
    x1.SetSize(n, mem_type);
@@ -65,9 +65,9 @@ void RK2Solver::Step(Vector &x, double &t, double &dt)
 }
 
 
-void RK3SSPSolver::Init(TimeDependentOperator &_f)
+void RK3SSPSolver::Init(TimeDependentOperator &f_)
 {
-   ODESolver::Init(_f);
+   ODESolver::Init(f_);
    int n = f->Width();
    y.SetSize(n, mem_type);
    k.SetSize(n, mem_type);
@@ -97,9 +97,9 @@ void RK3SSPSolver::Step(Vector &x, double &t, double &dt)
 }
 
 
-void RK4Solver::Init(TimeDependentOperator &_f)
+void RK4Solver::Init(TimeDependentOperator &f_)
 {
-   ODESolver::Init(_f);
+   ODESolver::Init(f_);
    int n = f->Width();
    y.SetSize(n, mem_type);
    k.SetSize(n, mem_type);
@@ -135,19 +135,19 @@ void RK4Solver::Step(Vector &x, double &t, double &dt)
    t += dt;
 }
 
-ExplicitRKSolver::ExplicitRKSolver(int _s, const double *_a, const double *_b,
-                                   const double *_c)
+ExplicitRKSolver::ExplicitRKSolver(int s_, const double *a_, const double *b_,
+                                   const double *c_)
 {
-   s = _s;
-   a = _a;
-   b = _b;
-   c = _c;
+   s = s_;
+   a = a_;
+   b = b_;
+   c = c_;
    k = new Vector[s];
 }
 
-void ExplicitRKSolver::Init(TimeDependentOperator &_f)
+void ExplicitRKSolver::Init(TimeDependentOperator &f_)
 {
-   ODESolver::Init(_f);
+   ODESolver::Init(f_);
    int n = f->Width();
    y.SetSize(n, mem_type);
    for (int i = 0; i < s; i++)
@@ -344,10 +344,10 @@ const double RK8Solver::c[] =
 };
 
 
-AdamsBashforthSolver::AdamsBashforthSolver(int _s, const double *_a)
+AdamsBashforthSolver::AdamsBashforthSolver(int s_, const double *a_)
 {
-   smax = std::min(_s,5);
-   a = _a;
+   smax = std::min(s_,5);
+   a = a_;
    k = new Vector[5];
 
    if (smax <= 2)
@@ -392,10 +392,10 @@ void AdamsBashforthSolver::SetStateVector(int i, Vector &state)
    s = std::max(i,s);
 }
 
-void AdamsBashforthSolver::Init(TimeDependentOperator &_f)
+void AdamsBashforthSolver::Init(TimeDependentOperator &f_)
 {
-   ODESolver::Init(_f);
-   RKsolver->Init(_f);
+   ODESolver::Init(f_);
+   RKsolver->Init(f_);
    idx.SetSize(smax);
    for (int i = 0; i < smax; i++)
    {
@@ -440,11 +440,11 @@ const double AB4Solver::a[] =
 const double AB5Solver::a[] =
 {1901.0/720.0,-2774.0/720.0, 2616.0/720.0,-1274.0/720.0, 251.0/720.0};
 
-AdamsMoultonSolver::AdamsMoultonSolver(int _s, const double *_a)
+AdamsMoultonSolver::AdamsMoultonSolver(int s_, const double *a_)
 {
    s = 0;
-   smax = std::min(_s+1,5);
-   a = _a;
+   smax = std::min(s_+1,5);
+   a = a_;
    k = new Vector[5];
 
    if (smax <= 3)
@@ -482,10 +482,10 @@ void AdamsMoultonSolver::SetStateVector(int i, Vector &state)
    s = std::max(i,s);
 }
 
-void AdamsMoultonSolver::Init(TimeDependentOperator &_f)
+void AdamsMoultonSolver::Init(TimeDependentOperator &f_)
 {
-   ODESolver::Init(_f);
-   RKsolver->Init(_f);
+   ODESolver::Init(f_);
+   RKsolver->Init(f_);
    int n = f->Width();
    idx.SetSize(smax);
    for (int i = 0; i < smax; i++)
@@ -538,9 +538,9 @@ const double AM4Solver::a[] =
 {251.0/720.0,646.0/720.0,-264.0/720.0, 106.0/720.0, -19.0/720.0};
 
 
-void BackwardEulerSolver::Init(TimeDependentOperator &_f)
+void BackwardEulerSolver::Init(TimeDependentOperator &f_)
 {
-   ODESolver::Init(_f);
+   ODESolver::Init(f_);
    k.SetSize(f->Width(), mem_type);
 }
 
@@ -553,9 +553,9 @@ void BackwardEulerSolver::Step(Vector &x, double &t, double &dt)
 }
 
 
-void ImplicitMidpointSolver::Init(TimeDependentOperator &_f)
+void ImplicitMidpointSolver::Init(TimeDependentOperator &f_)
 {
-   ODESolver::Init(_f);
+   ODESolver::Init(f_);
    k.SetSize(f->Width(), mem_type);
 }
 
@@ -588,9 +588,9 @@ SDIRK23Solver::SDIRK23Solver(int gamma_opt)
    }
 }
 
-void SDIRK23Solver::Init(TimeDependentOperator &_f)
+void SDIRK23Solver::Init(TimeDependentOperator &f_)
 {
-   ODESolver::Init(_f);
+   ODESolver::Init(f_);
    k.SetSize(f->Width(), mem_type);
    y.SetSize(f->Width(), mem_type);
 }
@@ -615,9 +615,9 @@ void SDIRK23Solver::Step(Vector &x, double &t, double &dt)
 }
 
 
-void SDIRK34Solver::Init(TimeDependentOperator &_f)
+void SDIRK34Solver::Init(TimeDependentOperator &f_)
 {
-   ODESolver::Init(_f);
+   ODESolver::Init(f_);
    k.SetSize(f->Width(), mem_type);
    y.SetSize(f->Width(), mem_type);
    z.SetSize(f->Width(), mem_type);
@@ -652,9 +652,9 @@ void SDIRK34Solver::Step(Vector &x, double &t, double &dt)
 }
 
 
-void SDIRK33Solver::Init(TimeDependentOperator &_f)
+void SDIRK33Solver::Init(TimeDependentOperator &f_)
 {
-   ODESolver::Init(_f);
+   ODESolver::Init(f_);
    k.SetSize(f->Width(), mem_type);
    y.SetSize(f->Width(), mem_type);
 }
@@ -685,9 +685,9 @@ void SDIRK33Solver::Step(Vector &x, double &t, double &dt)
    t += dt;
 }
 
-void TrapezoidalRuleSolver::Init(TimeDependentOperator &_f)
+void TrapezoidalRuleSolver::Init(TimeDependentOperator &f_)
 {
-   ODESolver::Init(_f);
+   ODESolver::Init(f_);
    k.SetSize(f->Width(), mem_type);
    y.SetSize(f->Width(), mem_type);
 }
@@ -709,9 +709,9 @@ void TrapezoidalRuleSolver::Step(Vector &x, double &t, double &dt)
    t += dt;
 }
 
-void ESDIRK32Solver::Init(TimeDependentOperator &_f)
+void ESDIRK32Solver::Init(TimeDependentOperator &f_)
 {
-   ODESolver::Init(_f);
+   ODESolver::Init(f_);
    k.SetSize(f->Width(), mem_type);
    y.SetSize(f->Width(), mem_type);
    z.SetSize(f->Width(), mem_type);
@@ -744,9 +744,9 @@ void ESDIRK32Solver::Step(Vector &x, double &t, double &dt)
    t += dt;
 }
 
-void ESDIRK33Solver::Init(TimeDependentOperator &_f)
+void ESDIRK33Solver::Init(TimeDependentOperator &f_)
 {
-   ODESolver::Init(_f);
+   ODESolver::Init(f_);
    k.SetSize(f->Width(), mem_type);
    y.SetSize(f->Width(), mem_type);
    z.SetSize(f->Width(), mem_type);
@@ -781,9 +781,9 @@ void ESDIRK33Solver::Step(Vector &x, double &t, double &dt)
    t += dt;
 }
 
-void GeneralizedAlphaSolver::Init(TimeDependentOperator &_f)
+void GeneralizedAlphaSolver::Init(TimeDependentOperator &f_)
 {
-   ODESolver::Init(_f);
+   ODESolver::Init(f_);
    k.SetSize(f->Width(), mem_type);
    y.SetSize(f->Width(), mem_type);
    xdot.SetSize(f->Width(), mem_type);
@@ -992,9 +992,9 @@ void SecondOrderODESolver::Init(SecondOrderTimeDependentOperator &f)
    mem_type = GetMemoryType(f.GetMemoryClass());
 }
 
-void NewmarkSolver::Init(SecondOrderTimeDependentOperator &_f)
+void NewmarkSolver::Init(SecondOrderTimeDependentOperator &f_)
 {
-   SecondOrderODESolver::Init(_f);
+   SecondOrderODESolver::Init(f_);
    d2xdt2.SetSize(f->Width());
    d2xdt2 = 0.0;
    first = true;
@@ -1056,9 +1056,9 @@ void NewmarkSolver::Step(Vector &x, Vector &dxdt, double &t, double &dt)
    t += dt;
 }
 
-void GeneralizedAlpha2Solver::Init(SecondOrderTimeDependentOperator &_f)
+void GeneralizedAlpha2Solver::Init(SecondOrderTimeDependentOperator &f_)
 {
-   SecondOrderODESolver::Init(_f);
+   SecondOrderODESolver::Init(f_);
    xa.SetSize(f->Width());
    va.SetSize(f->Width());
    aa.SetSize(f->Width());

--- a/linalg/ode.hpp
+++ b/linalg/ode.hpp
@@ -35,7 +35,7 @@ public:
        - When the dimensions of the associated TimeDependentOperator change.
        - When a time stepping sequence has to be restarted.
        - To change the associated TimeDependentOperator. */
-   virtual void Init(TimeDependentOperator &f);
+   virtual void Init(TimeDependentOperator &f_);
 
    /** @brief Perform a time step from time @a t [in] to time @a t [out] based
        on the requested step size @a dt [in]. */
@@ -119,7 +119,7 @@ private:
    Vector dxdt;
 
 public:
-   void Init(TimeDependentOperator &_f) override;
+   void Init(TimeDependentOperator &f_) override;
 
    void Step(Vector &x, double &t, double &dt) override;
 };
@@ -137,9 +137,9 @@ private:
    Vector dxdt, x1;
 
 public:
-   RK2Solver(const double _a = 2./3.) : a(_a) { }
+   RK2Solver(const double a_ = 2./3.) : a(a_) { }
 
-   void Init(TimeDependentOperator &_f) override;
+   void Init(TimeDependentOperator &f_) override;
 
    void Step(Vector &x, double &t, double &dt) override;
 };
@@ -152,7 +152,7 @@ private:
    Vector y, k;
 
 public:
-   void Init(TimeDependentOperator &_f) override;
+   void Init(TimeDependentOperator &f_) override;
 
    void Step(Vector &x, double &t, double &dt) override;
 };
@@ -165,7 +165,7 @@ private:
    Vector y, k, z;
 
 public:
-   void Init(TimeDependentOperator &_f) override;
+   void Init(TimeDependentOperator &f_) override;
 
    void Step(Vector &x, double &t, double &dt) override;
 };
@@ -188,10 +188,10 @@ private:
    Vector y, *k;
 
 public:
-   ExplicitRKSolver(int _s, const double *_a, const double *_b,
-                    const double *_c);
+   ExplicitRKSolver(int s_, const double *a_, const double *b_,
+                    const double *c_);
 
-   void Init(TimeDependentOperator &_f) override;
+   void Init(TimeDependentOperator &f_) override;
 
    void Step(Vector &x, double &t, double &dt) override;
 
@@ -234,9 +234,9 @@ private:
    ODESolver *RKsolver;
 
 public:
-   AdamsBashforthSolver(int _s, const double *_a);
+   AdamsBashforthSolver(int s_, const double *a_);
 
-   void Init(TimeDependentOperator &_f) override;
+   void Init(TimeDependentOperator &f_) override;
 
    void Step(Vector &x, double &t, double &dt) override;
 
@@ -315,9 +315,9 @@ private:
    ODESolver *RKsolver;
 
 public:
-   AdamsMoultonSolver(int _s, const double *_a);
+   AdamsMoultonSolver(int s_, const double *a_);
 
-   void Init(TimeDependentOperator &_f) override;
+   void Init(TimeDependentOperator &f_) override;
 
    void Step(Vector &x, double &t, double &dt) override;
 
@@ -392,7 +392,7 @@ protected:
    Vector k;
 
 public:
-   void Init(TimeDependentOperator &_f) override;
+   void Init(TimeDependentOperator &f_) override;
 
    void Step(Vector &x, double &t, double &dt) override;
 };
@@ -405,7 +405,7 @@ protected:
    Vector k;
 
 public:
-   void Init(TimeDependentOperator &_f) override;
+   void Init(TimeDependentOperator &f_) override;
 
    void Step(Vector &x, double &t, double &dt) override;
 };
@@ -426,7 +426,7 @@ protected:
 public:
    SDIRK23Solver(int gamma_opt = 1);
 
-   void Init(TimeDependentOperator &_f) override;
+   void Init(TimeDependentOperator &f_) override;
 
    void Step(Vector &x, double &t, double &dt) override;
 };
@@ -440,7 +440,7 @@ protected:
    Vector k, y, z;
 
 public:
-   void Init(TimeDependentOperator &_f) override;
+   void Init(TimeDependentOperator &f_) override;
 
    void Step(Vector &x, double &t, double &dt) override;
 };
@@ -454,7 +454,7 @@ protected:
    Vector k, y;
 
 public:
-   void Init(TimeDependentOperator &_f) override;
+   void Init(TimeDependentOperator &f_) override;
 
    void Step(Vector &x, double &t, double &dt) override;
 };
@@ -468,7 +468,7 @@ protected:
    Vector k, y;
 
 public:
-   virtual void Init(TimeDependentOperator &_f);
+   virtual void Init(TimeDependentOperator &f_);
 
    virtual void Step(Vector &x, double &t, double &dt);
 };
@@ -482,7 +482,7 @@ protected:
    Vector k, y, z;
 
 public:
-   virtual void Init(TimeDependentOperator &_f);
+   virtual void Init(TimeDependentOperator &f_);
 
    virtual void Step(Vector &x, double &t, double &dt);
 };
@@ -496,7 +496,7 @@ protected:
    Vector k, y, z;
 
 public:
-   virtual void Init(TimeDependentOperator &_f);
+   virtual void Init(TimeDependentOperator &f_);
 
    virtual void Step(Vector &x, double &t, double &dt);
 };
@@ -518,7 +518,7 @@ public:
 
    GeneralizedAlphaSolver(double rho = 1.0) { SetRhoInf(rho); };
 
-   void Init(TimeDependentOperator &_f) override;
+   void Init(TimeDependentOperator &f_) override;
 
    void Step(Vector &x, double &t, double &dt) override;
 
@@ -719,7 +719,7 @@ public:
 
    void PrintProperties(std::ostream &out = mfem::out);
 
-   void Init(SecondOrderTimeDependentOperator &_f) override;
+   void Init(SecondOrderTimeDependentOperator &f_) override;
 
    void Step(Vector &x, Vector &dxdt, double &t, double &dt) override;
 };
@@ -769,7 +769,7 @@ public:
 
    void PrintProperties(std::ostream &out = mfem::out);
 
-   void Init(SecondOrderTimeDependentOperator &_f) override;
+   void Init(SecondOrderTimeDependentOperator &f_) override;
 
    void Step(Vector &x, Vector &dxdt, double &t, double &dt) override;
 

--- a/linalg/operator.cpp
+++ b/linalg/operator.cpp
@@ -403,10 +403,10 @@ TripleProductOperator::~TripleProductOperator()
 
 
 ConstrainedOperator::ConstrainedOperator(Operator *A, const Array<int> &list,
-                                         bool _own_A,
-                                         DiagonalPolicy _diag_policy)
-   : Operator(A->Height(), A->Width()), A(A), own_A(_own_A),
-     diag_policy(_diag_policy)
+                                         bool own_A_,
+                                         DiagonalPolicy diag_policy_)
+   : Operator(A->Height(), A->Width()), A(A), own_A(own_A_),
+     diag_policy(diag_policy_)
 {
    // 'mem_class' should work with A->Mult() and MFEM_FORALL():
    mem_class = A->GetMemoryClass()*Device::GetDeviceMemoryClass();
@@ -527,8 +527,8 @@ RectangularConstrainedOperator::RectangularConstrainedOperator(
    Operator *A,
    const Array<int> &trial_list,
    const Array<int> &test_list,
-   bool _own_A)
-   : Operator(A->Height(), A->Width()), A(A), own_A(_own_A)
+   bool own_A_)
+   : Operator(A->Height(), A->Width()), A(A), own_A(own_A_)
 {
    // 'mem_class' should work with A->Mult() and MFEM_FORALL():
    mem_class = A->GetMemoryClass()*Device::GetMemoryClass();

--- a/linalg/operator.hpp
+++ b/linalg/operator.hpp
@@ -323,7 +323,7 @@ public:
    virtual double GetTime() const { return t; }
 
    /// Set the current time.
-   virtual void SetTime(const double _t) { t = _t; }
+   virtual void SetTime(const double t_) { t = t_; }
 
    /// True if #type is #EXPLICIT.
    bool isExplicit() const { return (type == EXPLICIT); }
@@ -857,8 +857,8 @@ public:
    virtual MemoryClass GetMemoryClass() const { return mem_class; }
 
    /// Set the diagonal policy for the constrained operator.
-   void SetDiagonalPolicy(const DiagonalPolicy _diag_policy)
-   { diag_policy = _diag_policy; }
+   void SetDiagonalPolicy(const DiagonalPolicy diag_policy_)
+   { diag_policy = diag_policy_; }
 
    /// Diagonal of A, modified according to the used DiagonalPolicy.
    virtual void AssembleDiagonal(Vector &diag) const;
@@ -959,7 +959,7 @@ public:
 #endif
 
 #ifdef MFEM_USE_MPI
-   PowerMethod(MPI_Comm _comm) : comm(_comm) {}
+   PowerMethod(MPI_Comm comm_) : comm(comm_) {}
 #endif
 
    /// @brief Returns an estimate of the largest eigenvalue of the operator \p opr

--- a/linalg/petsc.cpp
+++ b/linalg/petsc.cpp
@@ -2723,8 +2723,8 @@ void PetscSolver::FreePrivateContext()
 // PetscBCHandler methods
 
 PetscBCHandler::PetscBCHandler(Array<int>& ess_tdof_list,
-                               enum PetscBCHandler::Type _type)
-   : bctype(_type), setup(false), eval_t(0.0),
+                               enum PetscBCHandler::Type type_)
+   : bctype(type_), setup(false), eval_t(0.0),
      eval_t_cached(std::numeric_limits<double>::min())
 {
    SetTDofs(ess_tdof_list);

--- a/linalg/petsc.hpp
+++ b/linalg/petsc.hpp
@@ -96,25 +96,25 @@ public:
    void SetDeviceInvalid() const      { flags &= ~VALID_DEVICE; }
    inline bool IsAliasForSync() const { return base && (flags & ALIAS); }
 
-   inline void MakeAliasForSync(const Memory<double> &_base, int _offset,
-                                int _size, bool _usedev)
+   inline void MakeAliasForSync(const Memory<double> &base_, int offset_,
+                                int size_, bool usedev_)
    {
       MFEM_VERIFY(!IsAliasForSync(),"Already alias");
-      base = (Memory<double>*)&_base;
+      base = (Memory<double>*)&base_;
       read = true;
       write = false;
-      usedev = _usedev;
-      MakeAlias(_base,_offset,_size);
+      usedev = usedev_;
+      MakeAlias(base_,offset_,size_);
    }
-   inline void MakeAliasForSync(Memory<double> &_base, int _offset, int _size,
-                                bool _read, bool _write, bool _usedev)
+   inline void MakeAliasForSync(Memory<double> &base_, int offset_, int size_,
+                                bool read_, bool write_, bool usedev_)
    {
       MFEM_VERIFY(!IsAliasForSync(),"Already alias");
-      base = (Memory<double>*)&_base;
-      read = _read;
-      write = _write;
-      usedev = _usedev;
-      MakeAlias(_base,_offset,_size);
+      base = (Memory<double>*)&base_;
+      read = read_;
+      write = write_;
+      usedev = usedev_;
+      MakeAlias(base_,offset_,size_);
    }
    inline void SyncBase()
    {
@@ -183,9 +183,9 @@ public:
    /** @brief Creates vector with given global size, partitioning of the
        columns, and data.
 
-       The data must be allocated and destroyed outside. If @a _data is NULL, a
+       The data must be allocated and destroyed outside. If @a data_ is NULL, a
        dummy vector without a valid data array will be created. */
-   PetscParVector(MPI_Comm comm, PetscInt glob_size, PetscScalar *_data,
+   PetscParVector(MPI_Comm comm, PetscInt glob_size, PetscScalar *data_,
                   PetscInt *col);
 
    /// Creates vector compatible with @a y
@@ -193,9 +193,9 @@ public:
 
    /** @brief Creates a PetscParVector from a Vector
        @param[in] comm  MPI communicator on which the new object lives
-       @param[in] _x    The mfem Vector (data is not shared)
-       @param[in] copy  Whether to copy the data in _x or not */
-   PetscParVector(MPI_Comm comm, const Vector &_x, bool copy = false);
+       @param[in] x_    The mfem Vector (data is not shared)
+       @param[in] copy  Whether to copy the data in x_ or not */
+   PetscParVector(MPI_Comm comm, const Vector &x_, bool copy = false);
 
    /** @brief Creates vector compatible with the Operator (i.e. in the domain
        of) @a op or its adjoint. */
@@ -571,10 +571,10 @@ public:
       TIME_DEPENDENT
    };
 
-   PetscBCHandler(Type _type = ZERO) :
-      bctype(_type), setup(false), eval_t(0.0),
+   PetscBCHandler(Type type_ = ZERO) :
+      bctype(type_), setup(false), eval_t(0.0),
       eval_t_cached(std::numeric_limits<double>::min()) {}
-   PetscBCHandler(Array<int>& ess_tdof_list, Type _type = ZERO);
+   PetscBCHandler(Array<int>& ess_tdof_list, Type type_ = ZERO);
 
    virtual ~PetscBCHandler() {}
 
@@ -582,7 +582,7 @@ public:
    Type GetType() const { return bctype; }
 
    /// Sets the type of boundary conditions
-   void SetType(enum Type _type) { bctype = _type; setup = false; }
+   void SetType(enum Type type_) { bctype = type_; setup = false; }
 
    /// Boundary conditions evaluation
    /** In the result vector, @a g, only values at the essential dofs need to be
@@ -634,8 +634,8 @@ class PetscPreconditionerFactory
 private:
    std::string name;
 public:
-   PetscPreconditionerFactory(const std::string &_name = "MFEM Factory")
-      : name(_name) { }
+   PetscPreconditionerFactory(const std::string &name_ = "MFEM Factory")
+      : name(name_) { }
    const char* GetName() { return name.c_str(); }
    virtual Solver *NewPreconditioner(const OperatorHandle& oh) = 0;
    virtual ~PetscPreconditionerFactory() {}

--- a/linalg/solvers.cpp
+++ b/linalg/solvers.cpp
@@ -39,7 +39,7 @@ IterativeSolver::IterativeSolver()
 }
 
 #ifdef MFEM_USE_MPI
-IterativeSolver::IterativeSolver(MPI_Comm _comm)
+IterativeSolver::IterativeSolver(MPI_Comm comm_)
    : Solver(0, true)
 {
    oper = NULL;
@@ -48,7 +48,7 @@ IterativeSolver::IterativeSolver(MPI_Comm _comm)
    print_level = -1;
    rel_tol = abs_tol = 0.0;
    dot_prod_type = 1;
-   comm = _comm;
+   comm = comm_;
 }
 #endif
 
@@ -2139,16 +2139,16 @@ void SLBQPOptimizer::SetOptimizationProblem(const OptimizationProblem &prob)
    problem = &prob;
 }
 
-void SLBQPOptimizer::SetBounds(const Vector &_lo, const Vector &_hi)
+void SLBQPOptimizer::SetBounds(const Vector &lo_, const Vector &hi_)
 {
-   lo.SetDataAndSize(_lo.GetData(), _lo.Size());
-   hi.SetDataAndSize(_hi.GetData(), _hi.Size());
+   lo.SetDataAndSize(lo_.GetData(), lo_.Size());
+   hi.SetDataAndSize(hi_.GetData(), hi_.Size());
 }
 
-void SLBQPOptimizer::SetLinearConstraint(const Vector &_w, double _a)
+void SLBQPOptimizer::SetLinearConstraint(const Vector &w_, double a_)
 {
-   w.SetDataAndSize(_w.GetData(), _w.Size());
-   a = _a;
+   w.SetDataAndSize(w_.GetData(), w_.Size());
+   a = a_;
 }
 
 inline void SLBQPOptimizer::print_iteration(int it, double r, double l) const

--- a/linalg/solvers.hpp
+++ b/linalg/solvers.hpp
@@ -91,7 +91,7 @@ public:
    IterativeSolver();
 
 #ifdef MFEM_USE_MPI
-   IterativeSolver(MPI_Comm _comm);
+   IterativeSolver(MPI_Comm comm_);
 #endif
 
    void SetRelTol(double rtol) { rel_tol = rtol; }
@@ -270,7 +270,7 @@ public:
    SLISolver() { }
 
 #ifdef MFEM_USE_MPI
-   SLISolver(MPI_Comm _comm) : IterativeSolver(_comm) { }
+   SLISolver(MPI_Comm comm_) : IterativeSolver(comm_) { }
 #endif
 
    virtual void SetOperator(const Operator &op)
@@ -302,7 +302,7 @@ public:
    CGSolver() { }
 
 #ifdef MFEM_USE_MPI
-   CGSolver(MPI_Comm _comm) : IterativeSolver(_comm) { }
+   CGSolver(MPI_Comm comm_) : IterativeSolver(comm_) { }
 #endif
 
    virtual void SetOperator(const Operator &op)
@@ -332,7 +332,7 @@ public:
    GMRESSolver() { m = 50; }
 
 #ifdef MFEM_USE_MPI
-   GMRESSolver(MPI_Comm _comm) : IterativeSolver(_comm) { m = 50; }
+   GMRESSolver(MPI_Comm comm_) : IterativeSolver(comm_) { m = 50; }
 #endif
 
    /// Set the number of iteration to perform between restarts, default is 50.
@@ -351,7 +351,7 @@ public:
    FGMRESSolver() { m = 50; }
 
 #ifdef MFEM_USE_MPI
-   FGMRESSolver(MPI_Comm _comm) : IterativeSolver(_comm) { m = 50; }
+   FGMRESSolver(MPI_Comm comm_) : IterativeSolver(comm_) { m = 50; }
 #endif
 
    void SetKDim(int dim) { m = dim; }
@@ -381,7 +381,7 @@ public:
    BiCGSTABSolver() { }
 
 #ifdef MFEM_USE_MPI
-   BiCGSTABSolver(MPI_Comm _comm) : IterativeSolver(_comm) { }
+   BiCGSTABSolver(MPI_Comm comm_) : IterativeSolver(comm_) { }
 #endif
 
    virtual void SetOperator(const Operator &op)
@@ -411,7 +411,7 @@ public:
    MINRESSolver() { }
 
 #ifdef MFEM_USE_MPI
-   MINRESSolver(MPI_Comm _comm) : IterativeSolver(_comm) { }
+   MINRESSolver(MPI_Comm comm_) : IterativeSolver(comm_) { }
 #endif
 
    virtual void SetPreconditioner(Solver &pr)
@@ -481,7 +481,7 @@ public:
    NewtonSolver() { }
 
 #ifdef MFEM_USE_MPI
-   NewtonSolver(MPI_Comm _comm) : IterativeSolver(_comm) { }
+   NewtonSolver(MPI_Comm comm_) : IterativeSolver(comm_) { }
 #endif
    virtual void SetOperator(const Operator &op);
 
@@ -536,7 +536,7 @@ public:
    LBFGSSolver() : NewtonSolver() { }
 
 #ifdef MFEM_USE_MPI
-   LBFGSSolver(MPI_Comm _comm) : NewtonSolver(_comm) { }
+   LBFGSSolver(MPI_Comm comm_) : NewtonSolver(comm_) { }
 #endif
 
    void SetHistorySize(int dim) { m = dim; }
@@ -620,7 +620,7 @@ protected:
 public:
    OptimizationSolver(): IterativeSolver(), problem(NULL) { }
 #ifdef MFEM_USE_MPI
-   OptimizationSolver(MPI_Comm _comm): IterativeSolver(_comm), problem(NULL) { }
+   OptimizationSolver(MPI_Comm comm_): IterativeSolver(comm_), problem(NULL) { }
 #endif
    virtual ~OptimizationSolver() { }
 
@@ -678,7 +678,7 @@ public:
    SLBQPOptimizer() { }
 
 #ifdef MFEM_USE_MPI
-   SLBQPOptimizer(MPI_Comm _comm) : OptimizationSolver(_comm) { }
+   SLBQPOptimizer(MPI_Comm comm_) : OptimizationSolver(comm_) { }
 #endif
 
    /** Setting an OptimizationProblem will overwrite the Vectors given by
@@ -686,8 +686,8 @@ public:
     *  unchanged. */
    virtual void SetOptimizationProblem(const OptimizationProblem &prob);
 
-   void SetBounds(const Vector &_lo, const Vector &_hi);
-   void SetLinearConstraint(const Vector &_w, double _a);
+   void SetBounds(const Vector &lo_, const Vector &hi_);
+   void SetLinearConstraint(const Vector &w_, double a_);
 
    /** We let the target values play the role of the initial vector xt, from
     *  which the operator generates the optimal vector x. */
@@ -832,14 +832,14 @@ public:
    mutable double Info[UMFPACK_INFO];
 
    /** @brief For larger matrices, if the solver fails, set the parameter @a
-       _use_long_ints = true. */
-   UMFPackSolver(bool _use_long_ints = false)
-      : use_long_ints(_use_long_ints) { Init(); }
+       use_long_ints_ = true. */
+   UMFPackSolver(bool use_long_ints_ = false)
+      : use_long_ints(use_long_ints_) { Init(); }
    /** @brief Factorize the given SparseMatrix using the defaults. For larger
-       matrices, if the solver fails, set the parameter @a _use_long_ints =
+       matrices, if the solver fails, set the parameter @a use_long_ints_ =
        true. */
-   UMFPackSolver(SparseMatrix &A, bool _use_long_ints = false)
-      : use_long_ints(_use_long_ints) { Init(); SetOperator(A); }
+   UMFPackSolver(SparseMatrix &A, bool use_long_ints_ = false)
+      : use_long_ints(use_long_ints_) { Init(); SetOperator(A); }
 
    /** @brief Factorize the given Operator @a op which must be a SparseMatrix.
 

--- a/linalg/sparsemat.cpp
+++ b/linalg/sparsemat.cpp
@@ -3019,7 +3019,7 @@ SparseMatrix &SparseMatrix::operator*=(double a)
    return (*this);
 }
 
-void SparseMatrix::Print(std::ostream & out, int _width) const
+void SparseMatrix::Print(std::ostream & out, int width_) const
 {
    int i, j;
 
@@ -3032,12 +3032,12 @@ void SparseMatrix::Print(std::ostream & out, int _width) const
          for (nd = Rows[i], j = 0; nd != NULL; nd = nd->Prev, j++)
          {
             out << " (" << nd->Column << "," << nd->Value << ")";
-            if ( !((j+1) % _width) )
+            if ( !((j+1) % width_) )
             {
                out << '\n';
             }
          }
-         if (j % _width)
+         if (j % width_)
          {
             out << '\n';
          }
@@ -3055,12 +3055,12 @@ void SparseMatrix::Print(std::ostream & out, int _width) const
       for (j = I[i]; j < I[i+1]; j++)
       {
          out << " (" << J[j] << "," << A[j] << ")";
-         if ( !((j+1-I[i]) % _width) )
+         if ( !((j+1-I[i]) % width_) )
          {
             out << '\n';
          }
       }
-      if ((j-I[i]) % _width)
+      if ((j-I[i]) % width_)
       {
          out << '\n';
       }
@@ -3662,10 +3662,10 @@ DenseMatrix *RAP (const SparseMatrix &A, DenseMatrix &P)
 {
    DenseMatrix R (P, 't'); // R = P^T
    DenseMatrix *AP   = Mult (A, P);
-   DenseMatrix *_RAP = new DenseMatrix(R.Height(), AP->Width());
-   Mult (R, *AP, *_RAP);
+   DenseMatrix *RAP_ = new DenseMatrix(R.Height(), AP->Width());
+   Mult (R, *AP, *RAP_);
    delete AP;
-   return _RAP;
+   return RAP_;
 }
 
 DenseMatrix *RAP(DenseMatrix &A, const SparseMatrix &P)
@@ -3676,9 +3676,9 @@ DenseMatrix *RAP(DenseMatrix &A, const SparseMatrix &P)
    delete RA;
    DenseMatrix  *RAtP = Mult(*R, AtP);
    delete R;
-   DenseMatrix * _RAP = new DenseMatrix(*RAtP, 't');
+   DenseMatrix * RAP_ = new DenseMatrix(*RAtP, 't');
    delete RAtP;
-   return _RAP;
+   return RAP_;
 }
 
 SparseMatrix *RAP (const SparseMatrix &A, const SparseMatrix &R,
@@ -3687,9 +3687,9 @@ SparseMatrix *RAP (const SparseMatrix &A, const SparseMatrix &R,
    SparseMatrix *P  = Transpose (R);
    SparseMatrix *AP = Mult (A, *P);
    delete P;
-   SparseMatrix *_RAP = Mult (R, *AP, ORAP);
+   SparseMatrix *RAP_ = Mult (R, *AP, ORAP);
    delete AP;
-   return _RAP;
+   return RAP_;
 }
 
 SparseMatrix *RAP(const SparseMatrix &Rt, const SparseMatrix &A,

--- a/linalg/sparsemat.hpp
+++ b/linalg/sparsemat.hpp
@@ -152,7 +152,7 @@ public:
    SparseMatrix(const Vector & v);
 
    // Runtime option to use cuSPARSE. Only valid when using a CUDA backend.
-   void UseCuSparse(bool _useCuSparse = true) { useCuSparse = _useCuSparse;}
+   void UseCuSparse(bool useCuSparse_ = true) { useCuSparse = useCuSparse_;}
 
    /// Assignment operator: deep copy
    SparseMatrix& operator=(const SparseMatrix &rhs);

--- a/linalg/sundials.cpp
+++ b/linalg/sundials.cpp
@@ -280,8 +280,8 @@ SundialsNVector::SundialsNVector()
    own_NVector = 1;
 }
 
-SundialsNVector::SundialsNVector(double *_data, int _size)
-   : Vector(_data, _size)
+SundialsNVector::SundialsNVector(double *data_, int size_)
+   : Vector(data_, size_)
 {
    UseDevice(Device::IsAvailable());
    x = MakeNVector(UseDevice());
@@ -314,9 +314,9 @@ SundialsNVector::SundialsNVector(MPI_Comm comm, int loc_size, long glob_size)
    _SetNvecDataAndSize_(glob_size);
 }
 
-SundialsNVector::SundialsNVector(MPI_Comm comm, double *_data, int loc_size,
+SundialsNVector::SundialsNVector(MPI_Comm comm, double *data_, int loc_size,
                                  long glob_size)
-   : Vector(_data, loc_size)
+   : Vector(data_, loc_size)
 {
    UseDevice(Device::IsAvailable());
    x = MakeNVector(comm, UseDevice());

--- a/linalg/sundials.hpp
+++ b/linalg/sundials.hpp
@@ -69,9 +69,9 @@ public:
    SundialsNVector();
 
    /// Creates a SundialsNVector referencing an array of doubles, owned by someone else.
-   /** The pointer @a _data can be NULL. The data array can be replaced later
+   /** The pointer @a data_ can be NULL. The data array can be replaced later
        with SetData(). */
-   SundialsNVector(double *_data, int _size);
+   SundialsNVector(double *data_, int size_);
 
    /// Creates a SundialsNVector out of a SUNDIALS N_Vector object.
    /** The N_Vector @a nv must be destroyed outside. */
@@ -85,9 +85,9 @@ public:
    SundialsNVector(MPI_Comm comm, int loc_size, long glob_size);
 
    /// Creates a SundialsNVector referencing an array of doubles, owned by someone else.
-   /** The pointer @a _data can be NULL. The data array can be replaced later
+   /** The pointer @a data_ can be NULL. The data array can be replaced later
        with SetData(). */
-   SundialsNVector(MPI_Comm comm, double *_data, int loc_size, long glob_size);
+   SundialsNVector(MPI_Comm comm, double *data_, int loc_size, long glob_size);
 
    /// Creates a SundialsNVector from a HypreParVector.
    /** Ownership of the data will not change. */
@@ -100,8 +100,8 @@ public:
    /// Returns the N_Vector_ID for the internal N_Vector.
    inline N_Vector_ID GetNVectorID() const { return N_VGetVectorID(x); }
 
-   /// Returns the N_Vector_ID for the N_Vector @a _x.
-   inline N_Vector_ID GetNVectorID(N_Vector _x) const { return N_VGetVectorID(_x); }
+   /// Returns the N_Vector_ID for the N_Vector @a x_.
+   inline N_Vector_ID GetNVectorID(N_Vector x_) const { return N_VGetVectorID(x_); }
 
 #ifdef MFEM_USE_MPI
    /// Returns the MPI communicator for the internal N_Vector x.

--- a/linalg/vector.hpp
+++ b/linalg/vector.hpp
@@ -77,10 +77,10 @@ public:
    explicit Vector(int s);
 
    /// Creates a vector referencing an array of doubles, owned by someone else.
-   /** The pointer @a _data can be NULL. The data array can be replaced later
+   /** The pointer @a data_ can be NULL. The data array can be replaced later
        with SetData(). */
-   Vector(double *_data, int _size)
-   { data.Wrap(_data, _size, false); size = _size; }
+   Vector(double *data_, int size_)
+   { data.Wrap(data_, size_, false); size = size_; }
 
    /// Create a Vector of size @a size_ using MemoryType @a mt.
    Vector(int size_, MemoryType mt)

--- a/mesh/mesh.cpp
+++ b/mesh/mesh.cpp
@@ -1226,12 +1226,12 @@ void Mesh::SetAttributes()
    }
 }
 
-void Mesh::InitMesh(int _Dim, int _spaceDim, int NVert, int NElem, int NBdrElem)
+void Mesh::InitMesh(int Dim_, int spaceDim_, int NVert, int NElem, int NBdrElem)
 {
    SetEmpty();
 
-   Dim = _Dim;
-   spaceDim = _spaceDim;
+   Dim = Dim_;
+   spaceDim = spaceDim_;
 
    NumOfVertices = 0;
    vertices.SetSize(NVert);  // just allocate space for vertices
@@ -3359,7 +3359,7 @@ void Mesh::ChangeVertexDataOwnership(double *vertex_data, int len_vertex_data,
    vertices.MakeRef(reinterpret_cast<Vertex*>(vertex_data), NumOfVertices);
 }
 
-Mesh::Mesh(double *_vertices, int num_vertices,
+Mesh::Mesh(double *vertices_, int num_vertices,
            int *element_indices, Geometry::Type element_type,
            int *element_attributes, int num_elements,
            int *boundary_indices, Geometry::Type boundary_type,
@@ -3379,7 +3379,7 @@ Mesh::Mesh(double *_vertices, int num_vertices,
                                Geometry::NumVerts[boundary_type] : 0;
 
    // assuming Vertex is POD
-   vertices.MakeRef(reinterpret_cast<Vertex*>(_vertices), num_vertices);
+   vertices.MakeRef(reinterpret_cast<Vertex*>(vertices_), num_vertices);
    NumOfVertices = num_vertices;
 
    for (int i = 0; i < num_elements; i++)
@@ -6690,15 +6690,15 @@ void FindPartitioningComponents(Table &elem_elem,
    }
 }
 
-void Mesh::CheckPartitioning(int *partitioning)
+void Mesh::CheckPartitioning(int *partitioning_)
 {
    int i, n_empty, n_mcomp;
    Array<int> component, num_comp;
-   const Array<int> _partitioning(partitioning, GetNE());
+   const Array<int> partitioning(partitioning_, GetNE());
 
    ElementToElementTable();
 
-   FindPartitioningComponents(*el_to_el, _partitioning, component, num_comp);
+   FindPartitioningComponents(*el_to_el, partitioning, component, num_comp);
 
    n_empty = n_mcomp = 0;
    for (i = 0; i < num_comp.Size(); i++)
@@ -11326,9 +11326,9 @@ FaceGeometricFactors::FaceGeometricFactors(const Mesh *mesh,
    qi->Mult(Fnodes, eval_flags, X, J, detJ, normal);
 }
 
-NodeExtrudeCoefficient::NodeExtrudeCoefficient(const int dim, const int _n,
-                                               const double _s)
-   : VectorCoefficient(dim), n(_n), s(_s), tip(p, dim-1)
+NodeExtrudeCoefficient::NodeExtrudeCoefficient(const int dim, const int n_,
+                                               const double s_)
+   : VectorCoefficient(dim), n(n_), s(s_), tip(p, dim-1)
 {
 }
 

--- a/mesh/mesh.hpp
+++ b/mesh/mesh.hpp
@@ -433,7 +433,7 @@ protected:
    void GenerateNCFaceInfo();
 
    /// Begin construction of a mesh
-   void InitMesh(int _Dim, int _spaceDim, int NVert, int NElem, int NBdrElem);
+   void InitMesh(int Dim_, int spaceDim_, int NVert, int NElem, int NBdrElem);
 
    // Used in the methods FinalizeXXXMesh() and FinalizeTopology()
    void FinalizeCheck();
@@ -600,10 +600,10 @@ public:
 
    /** @anchor mfem_Mesh_init_ctor
        @brief _Init_ constructor: begin the construction of a Mesh object. */
-   Mesh(int _Dim, int NVert, int NElem, int NBdrElem = 0, int _spaceDim = -1)
+   Mesh(int Dim_, int NVert, int NElem, int NBdrElem = 0, int spaceDim_ = -1)
    {
-      if (_spaceDim == -1) { _spaceDim = _Dim; }
-      InitMesh(_Dim, _spaceDim, NVert, NElem, NBdrElem);
+      if (spaceDim_ == -1) { spaceDim_ = Dim_; }
+      InitMesh(Dim_, spaceDim_, NVert, NElem, NBdrElem);
    }
 
    /** @name Methods for Mesh construction.
@@ -1199,7 +1199,7 @@ public:
 
    int *CartesianPartitioning(int nxyz[]);
    int *GeneratePartitioning(int nparts, int part_method = 1);
-   void CheckPartitioning(int *partitioning);
+   void CheckPartitioning(int *partitioning_);
 
    void CheckDisplacements(const Vector &displacements, double &tmax);
 
@@ -1623,7 +1623,7 @@ private:
    double p[2], s;
    Vector tip;
 public:
-   NodeExtrudeCoefficient(const int dim, const int _n, const double _s);
+   NodeExtrudeCoefficient(const int dim, const int n_, const double s_);
    void SetLayer(const int l) { layer = l; }
    using VectorCoefficient::Eval;
    virtual void Eval(Vector &V, ElementTransformation &T,

--- a/mesh/nurbs.cpp
+++ b/mesh/nurbs.cpp
@@ -2570,9 +2570,9 @@ void NURBSExtension::Get2DBdrElementTopo(Array<Element *> &boundary) const
       {
          if (activeBdrElem[g_be])
          {
-            int _i = (okv[0] >= 0) ? i : (nx - 1 - i);
-            ind[0] = activeVert[p2g[_i  ]];
-            ind[1] = activeVert[p2g[_i+1]];
+            int i_ = (okv[0] >= 0) ? i : (nx - 1 - i);
+            ind[0] = activeVert[p2g[i_  ]];
+            ind[1] = activeVert[p2g[i_+1]];
 
             boundary[l_be] = new Segment(ind, bdr_patch_attr);
             l_be++;
@@ -2600,16 +2600,16 @@ void NURBSExtension::Get3DBdrElementTopo(Array<Element *> &boundary) const
 
       for (int j = 0; j < ny; j++)
       {
-         int _j = (okv[1] >= 0) ? j : (ny - 1 - j);
+         int j_ = (okv[1] >= 0) ? j : (ny - 1 - j);
          for (int i = 0; i < nx; i++)
          {
             if (activeBdrElem[g_be])
             {
-               int _i = (okv[0] >= 0) ? i : (nx - 1 - i);
-               ind[0] = activeVert[p2g(_i,  _j  )];
-               ind[1] = activeVert[p2g(_i+1,_j  )];
-               ind[2] = activeVert[p2g(_i+1,_j+1)];
-               ind[3] = activeVert[p2g(_i,  _j+1)];
+               int i_ = (okv[0] >= 0) ? i : (nx - 1 - i);
+               ind[0] = activeVert[p2g(i_,  j_  )];
+               ind[1] = activeVert[p2g(i_+1,j_  )];
+               ind[2] = activeVert[p2g(i_+1,j_+1)];
+               ind[3] = activeVert[p2g(i_,  j_+1)];
 
                boundary[l_be] = new Quadrilateral(ind, bdr_patch_attr);
                l_be++;
@@ -2867,11 +2867,11 @@ void NURBSExtension::Generate3DBdrElementDofTable()
                      Connection conn(lbe,0);
                      for (int jj = 0; jj <= ord1; jj++)
                      {
-                        const int _jj = (okv[1] >= 0) ? (j+jj) : (ny-j-jj);
+                        const int jj_ = (okv[1] >= 0) ? (j+jj) : (ny-j-jj);
                         for (int ii = 0; ii <= ord0; ii++)
                         {
-                           const int _ii = (okv[0] >= 0) ? (i+ii) : (nx-i-ii);
-                           conn.to = DofMap(p2g(_ii, _jj));
+                           const int ii_ = (okv[0] >= 0) ? (i+ii) : (nx-i-ii);
+                           conn.to = DofMap(p2g(ii_, jj_));
                            bel_dof_list.Append(conn);
                         }
                      }
@@ -3610,7 +3610,7 @@ Table *ParNURBSExtension::Get3DGlobalElementDofTable()
    return (new Table(GetGNE(), gel_dof_list));
 }
 
-void ParNURBSExtension::SetActive(const int *_partitioning,
+void ParNURBSExtension::SetActive(const int *partitioning_,
                                   const Array<bool> &active_bel)
 {
    activeElem.SetSize(GetGNE());
@@ -3618,7 +3618,7 @@ void ParNURBSExtension::SetActive(const int *_partitioning,
    NumOfActiveElems = 0;
    const int MyRank = gtopo.MyRank();
    for (int i = 0; i < GetGNE(); i++)
-      if (_partitioning[i] == MyRank)
+      if (partitioning_[i] == MyRank)
       {
          activeElem[i] = true;
          NumOfActiveElems++;
@@ -3633,7 +3633,7 @@ void ParNURBSExtension::SetActive(const int *_partitioning,
       }
 }
 
-void ParNURBSExtension::BuildGroups(const int *_partitioning,
+void ParNURBSExtension::BuildGroups(const int *partitioning_,
                                     const Table &elem_dof)
 {
    Table dof_proc;
@@ -3645,7 +3645,7 @@ void ParNURBSExtension::BuildGroups(const int *_partitioning,
    // convert elements to processors
    for (int i = 0; i < dof_proc.Size_of_connections(); i++)
    {
-      dof_proc.GetJ()[i] = _partitioning[dof_proc.GetJ()[i]];
+      dof_proc.GetJ()[i] = partitioning_[dof_proc.GetJ()[i]];
    }
 
    // the first group is the local one

--- a/miniapps/electromagnetics/joule_solver.cpp
+++ b/miniapps/electromagnetics/joule_solver.cpp
@@ -820,8 +820,8 @@ void MagneticDiffusionEOperator::GetJouleHeating(ParGridFunction &E_gf,
    w_gf.ProjectCoefficient(w_coeff);
 }
 
-void MagneticDiffusionEOperator::SetTime(const double _t)
-{ t = _t; }
+void MagneticDiffusionEOperator::SetTime(const double t_)
+{ t = t_; }
 
 MagneticDiffusionEOperator::~MagneticDiffusionEOperator()
 {

--- a/miniapps/electromagnetics/joule_solver.hpp
+++ b/miniapps/electromagnetics/joule_solver.hpp
@@ -214,7 +214,7 @@ public:
    // E is the input, w is the output which is L2 heating.
    void GetJouleHeating(ParGridFunction &E_gf, ParGridFunction &w_gf) const;
 
-   void SetTime(const double _t);
+   void SetTime(const double t_);
 
    // Write all the hypre matrices and vectors to disk.
    void Debug(const char *basefilename, double time);

--- a/tests/unit/miniapps/test_sedov.cpp
+++ b/tests/unit/miniapps/test_sedov.cpp
@@ -99,21 +99,21 @@ struct Tensors1D
 template<int DIM, int D1D, int Q1D, int L1D, int H1D, int NBZ =1> static
 void kSmemForceMult2D(const int NE,
                       const Array<double> &B_,
-                      const Array<double> &_Bt,
-                      const Array<double> &_Gt,
-                      const DenseTensor &_sJit,
-                      const Vector &_e,
-                      Vector &_v)
+                      const Array<double> &Bt_,
+                      const Array<double> &Gt_,
+                      const DenseTensor &sJit_,
+                      const Vector &e_,
+                      Vector &v_)
 {
    auto b = Reshape(B_.Read(), Q1D, L1D);
-   auto bt = Reshape(_Bt.Read(), H1D, Q1D);
-   auto gt = Reshape(_Gt.Read(), H1D, Q1D);
-   auto sJit = Reshape(Read(_sJit.GetMemory(), Q1D*Q1D*NE*2*2),
+   auto bt = Reshape(Bt_.Read(), H1D, Q1D);
+   auto gt = Reshape(Gt_.Read(), H1D, Q1D);
+   auto sJit = Reshape(Read(sJit_.GetMemory(), Q1D*Q1D*NE*2*2),
                        Q1D,Q1D,NE,2,2);
-   auto energy = Reshape(_e.Read(), L1D, L1D, NE);
+   auto energy = Reshape(e_.Read(), L1D, L1D, NE);
    const double eps1 = std::numeric_limits<double>::epsilon();
    const double eps2 = eps1*eps1;
-   auto velocity = Reshape(_v.Write(), D1D,D1D,2,NE);
+   auto velocity = Reshape(v_.Write(), D1D,D1D,2,NE);
    MFEM_FORALL_2D(e, NE, Q1D, Q1D, 1,
    {
       const int z = MFEM_THREAD_ID(z);
@@ -242,21 +242,21 @@ void kSmemForceMult2D(const int NE,
 template<int DIM, int D1D, int Q1D, int L1D, int H1D> static
 void kSmemForceMult3D(const int NE,
                       const Array<double> &B_,
-                      const Array<double> &_Bt,
-                      const Array<double> &_Gt,
-                      const DenseTensor &_sJit,
-                      const Vector &_e,
-                      Vector &_v)
+                      const Array<double> &Bt_,
+                      const Array<double> &Gt_,
+                      const DenseTensor &sJit_,
+                      const Vector &e_,
+                      Vector &v_)
 {
    auto b = Reshape(B_.Read(), Q1D, L1D);
-   auto bt = Reshape(_Bt.Read(), H1D, Q1D);
-   auto gt = Reshape(_Gt.Read(), H1D, Q1D);
-   auto sJit = Reshape(Read(_sJit.GetMemory(), Q1D*Q1D*Q1D*NE*3*3),
+   auto bt = Reshape(Bt_.Read(), H1D, Q1D);
+   auto gt = Reshape(Gt_.Read(), H1D, Q1D);
+   auto sJit = Reshape(Read(sJit_.GetMemory(), Q1D*Q1D*Q1D*NE*3*3),
                        Q1D,Q1D,Q1D,NE,3,3);
-   auto energy = Reshape(_e.Read(), L1D, L1D, L1D, NE);
+   auto energy = Reshape(e_.Read(), L1D, L1D, L1D, NE);
    const double eps1 = std::numeric_limits<double>::epsilon();
    const double eps2 = eps1*eps1;
-   auto velocity = Reshape(_v.Write(), D1D, D1D, D1D, 3, NE);
+   auto velocity = Reshape(v_.Write(), D1D, D1D, D1D, 3, NE);
    MFEM_FORALL_3D(e, NE, Q1D, Q1D, Q1D,
    {
       const int z = MFEM_THREAD_ID(z);
@@ -492,21 +492,21 @@ static void kForceMult(const int DIM,
 
 template<int DIM, int D1D, int Q1D, int L1D, int H1D, int NBZ =1> static
 void kSmemForceMultTranspose2D(const int NE,
-                               const Array<double> &_Bt,
+                               const Array<double> &Bt_,
                                const Array<double> &B_,
-                               const Array<double> &_G,
-                               const DenseTensor &_sJit,
-                               const Vector &_v,
-                               Vector &_e)
+                               const Array<double> &G_,
+                               const DenseTensor &sJit_,
+                               const Vector &v_,
+                               Vector &e_)
 {
    MFEM_VERIFY(D1D==H1D,"");
    auto b = Reshape(B_.Read(), Q1D,H1D);
-   auto g = Reshape(_G.Read(), Q1D,H1D);
-   auto bt = Reshape(_Bt.Read(), L1D,Q1D);
-   auto sJit = Reshape(Read(_sJit.GetMemory(), Q1D*Q1D*NE*2*2),
+   auto g = Reshape(G_.Read(), Q1D,H1D);
+   auto bt = Reshape(Bt_.Read(), L1D,Q1D);
+   auto sJit = Reshape(Read(sJit_.GetMemory(), Q1D*Q1D*NE*2*2),
                        Q1D, Q1D, NE, 2, 2);
-   auto velocity = Reshape(_v.Read(), D1D,D1D,2,NE);
-   auto energy = Reshape(_e.Write(), L1D, L1D, NE);
+   auto velocity = Reshape(v_.Read(), D1D,D1D,2,NE);
+   auto energy = Reshape(e_.Write(), L1D, L1D, NE);
    MFEM_FORALL_2D(e, NE, Q1D, Q1D, NBZ,
    {
       const int z = MFEM_THREAD_ID(z);
@@ -632,21 +632,21 @@ void kSmemForceMultTranspose2D(const int NE,
 
 template<int DIM, int D1D, int Q1D, int L1D, int H1D> static
 void kSmemForceMultTranspose3D(const int NE,
-                               const Array<double> &_Bt,
+                               const Array<double> &Bt_,
                                const Array<double> &B_,
-                               const Array<double> &_G,
-                               const DenseTensor &_sJit,
-                               const Vector &_v,
-                               Vector &_e)
+                               const Array<double> &G_,
+                               const DenseTensor &sJit_,
+                               const Vector &v_,
+                               Vector &e_)
 {
    MFEM_VERIFY(D1D==H1D,"");
    auto b = Reshape(B_.Read(), Q1D,H1D);
-   auto g = Reshape(_G.Read(), Q1D,H1D);
-   auto bt = Reshape(_Bt.Read(), L1D,Q1D);
-   auto sJit = Reshape(Read(_sJit.GetMemory(), Q1D*Q1D*Q1D*NE*3*3),
+   auto g = Reshape(G_.Read(), Q1D,H1D);
+   auto bt = Reshape(Bt_.Read(), L1D,Q1D);
+   auto sJit = Reshape(Read(sJit_.GetMemory(), Q1D*Q1D*Q1D*NE*3*3),
                        Q1D, Q1D, Q1D, NE, 3, 3);
-   auto velocity = Reshape(_v.Read(), D1D, D1D, D1D, 3, NE);
-   auto energy = Reshape(_e.Write(), L1D, L1D, L1D, NE);
+   auto velocity = Reshape(v_.Read(), D1D, D1D, D1D, 3, NE);
+   auto energy = Reshape(e_.Write(), L1D, L1D, L1D, NE);
    MFEM_FORALL_3D(e, NE, Q1D, Q1D, Q1D,
    {
       const int z = MFEM_THREAD_ID(z);


### PR DESCRIPTION
Removed nearly all leading underscores for variable names.  Every once in a while one of these will conflict with standard libraries in an oddball compiler and it's best to just avoid this problem alltogether.  In nearly all instances I just replaced the variable names with trailing underscore versions.  I also didn't make these changes to the examples and miniapps, but I am happy to do so if we like.
<!--GHEX{"id":2236,"author":"acfisher","editor":"tzanio","reviewers":["dylan-copeland","mlstowell"],"assignment":"2021-05-11T14:20:40-07:00","approval":"2021-05-16T21:20:30.261Z","merge":"2021-05-18T23:44:37.885Z"}XEHG--><!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge| 
 | --- | --- | --- | --- | --- | --- | --- | 
| [#2236](https://github.com/mfem/mfem/pull/2236) | @acfisher | @tzanio | @dylan-copeland + @mlstowell | 05/11/21 | 05/16/21 | 05/18/21 | |
<!--ELBATXEHG-->