### PR TITLE
Rename hypre_ParcsrAdd -> hypre_ParCSRMatrixAdd

### DIFF
--- a/linalg/hypre.cpp
+++ b/linalg/hypre.cpp
@@ -1813,7 +1813,7 @@ HypreParMatrix *Add(double alpha, const HypreParMatrix &A,
                     double beta,  const HypreParMatrix &B)
 {
    hypre_ParCSRMatrix *C;
-   hypre_ParcsrAdd(alpha, A, beta, B, &C);
+   hypre_ParCSRMatrixAdd(alpha, A, beta, B, &C);
 
    return new HypreParMatrix(C);
 }
@@ -1821,7 +1821,7 @@ HypreParMatrix *Add(double alpha, const HypreParMatrix &A,
 HypreParMatrix * ParAdd(const HypreParMatrix *A, const HypreParMatrix *B)
 {
    hypre_ParCSRMatrix *C;
-   hypre_ParcsrAdd(1.0, *A, 1.0, *B, &C);
+   hypre_ParCSRMatrixAdd(1.0, *A, 1.0, *B, &C);
 
    return new HypreParMatrix(C);
 }


### PR DESCRIPTION
The name of the function `hypre_ParcsrAdd` was changed in hypre. This PR updates the name.
<!--GHEX{"id":2245,"author":"dylan-copeland","editor":"tzanio","reviewers":["tzanio","v-dobrev"],"assignment":"2021-05-23T16:10:07-07:00","approval":"2021-05-27T00:49:08.813Z","merge":"2021-05-28T16:14:41.809Z"}XEHG--><!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge| 
 | --- | --- | --- | --- | --- | --- | --- | 
| [#2245](https://github.com/mfem/mfem/pull/2245) | @dylan-copeland | @tzanio | @tzanio + @v-dobrev | 05/23/21 | 05/26/21 | 05/28/21 | |
<!--ELBATXEHG-->