### PR TITLE
Testing/bernede1/actions interrupt

### DIFF
--- a/.github/workflows/builds-and-tests.yml
+++ b/.github/workflows/builds-and-tests.yml
@@ -71,7 +71,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-    # This external action allows to interrupt a workflow alrealy running on
+    # This external action allows to interrupt a workflow already running on
     # the same branch to save resource
     - name: Cancel Previous Runs
       uses: styfle/cancel-workflow-action@0.9.0

--- a/.github/workflows/builds-and-tests.yml
+++ b/.github/workflows/builds-and-tests.yml
@@ -62,6 +62,11 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
+    - name: Cancel Previous Runs
+      uses: styfle/cancel-workflow-action@0.9.0
+      with:
+        access_token: ${{ github.token }}
+
     # Checkout MFEM in "mfem" subdirectory. Final path:
     # /home/runner/work/mfem/mfem/mfem
     # Note: Done now to access "install-hypre" and "install-metis" actions.

--- a/.github/workflows/builds-and-tests.yml
+++ b/.github/workflows/builds-and-tests.yml
@@ -16,7 +16,7 @@ name: builds-and-tests
 # is set to have permissive access. However, this is not a good practice
 # security-wise. Here we use an external action, so we restrict the
 # permission to the minimum required.
-# When the 'permissions' is set, all the scoped not mentioned are set to the
+# When the 'permissions' is set, all the scopes not mentioned are set to the
 # most restrictive setting. So the following is enough.
 permissions:
   actions: write

--- a/.github/workflows/builds-and-tests.yml
+++ b/.github/workflows/builds-and-tests.yml
@@ -12,6 +12,12 @@
 # In this CI section, we build different variants of mfem and run test on them.
 name: builds-and-tests
 
+# Github actions can use the default "GITHUB_TOKEN". By default, this token
+# is set to have permissive access. However, this is not a good pracice
+# security-wise. Here we will use an external action, so we restrict the
+# permission to the minimum required.
+# When the 'permissions' is set, all the scoped not mentioned are set to the
+# most restrictive setting. So the following is enough.
 permissions:
   actions: write
 

--- a/.github/workflows/builds-and-tests.yml
+++ b/.github/workflows/builds-and-tests.yml
@@ -12,6 +12,9 @@
 # In this CI section, we build different variants of mfem and run test on them.
 name: builds-and-tests
 
+permissions:
+  actions: write
+
 on:
   push:
     branches:

--- a/.github/workflows/builds-and-tests.yml
+++ b/.github/workflows/builds-and-tests.yml
@@ -14,7 +14,7 @@ name: builds-and-tests
 
 # Github actions can use the default "GITHUB_TOKEN". By default, this token
 # is set to have permissive access. However, this is not a good practice
-# security-wise. Here we will use an external action, so we restrict the
+# security-wise. Here we use an external action, so we restrict the
 # permission to the minimum required.
 # When the 'permissions' is set, all the scoped not mentioned are set to the
 # most restrictive setting. So the following is enough.

--- a/.github/workflows/builds-and-tests.yml
+++ b/.github/workflows/builds-and-tests.yml
@@ -62,6 +62,8 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
+    # This external action allows to interrupt a workflow alrealy running on
+    # the same branch to same resource
     - name: Cancel Previous Runs
       uses: styfle/cancel-workflow-action@0.9.0
       with:

--- a/.github/workflows/builds-and-tests.yml
+++ b/.github/workflows/builds-and-tests.yml
@@ -72,7 +72,7 @@ jobs:
 
     steps:
     # This external action allows to interrupt a workflow alrealy running on
-    # the same branch to same resource
+    # the same branch to save resource
     - name: Cancel Previous Runs
       uses: styfle/cancel-workflow-action@0.9.0
       with:

--- a/.github/workflows/builds-and-tests.yml
+++ b/.github/workflows/builds-and-tests.yml
@@ -13,7 +13,7 @@
 name: builds-and-tests
 
 # Github actions can use the default "GITHUB_TOKEN". By default, this token
-# is set to have permissive access. However, this is not a good pracice
+# is set to have permissive access. However, this is not a good practice
 # security-wise. Here we will use an external action, so we restrict the
 # permission to the minimum required.
 # When the 'permissions' is set, all the scoped not mentioned are set to the

--- a/.github/workflows/mfem-analysis.yml
+++ b/.github/workflows/mfem-analysis.yml
@@ -11,6 +11,9 @@
 
 name: build-analysis
 
+permissions:
+  actions: write
+
 on:
   push:
     branches:
@@ -30,6 +33,11 @@ jobs:
     runs-on: ubuntu-18.04
 
     steps:
+    - name: Cancel Previous Runs
+      uses: styfle/cancel-workflow-action@0.9.0
+      with:
+        access_token: ${{ github.token }}
+
     - name: checkout MFEM
       uses: actions/checkout@v2
       with:

--- a/.github/workflows/repo-check.yml
+++ b/.github/workflows/repo-check.yml
@@ -11,6 +11,9 @@
 
 name: repo-check
 
+permissions:
+  actions: write
+
 on:
   push:
     branches:
@@ -23,6 +26,10 @@ jobs:
     runs-on: ubuntu-18.04 # needed for astyle 2.05.1
 
     steps:
+    - name: Cancel Previous Runs
+      uses: styfle/cancel-workflow-action@0.9.0
+      with:
+        access_token: ${{ github.token }}
     - name: checkout mfem
       uses: actions/checkout@v2
       with:


### PR DESCRIPTION
This short PR allows new commits to a PR to cancel the actions running for a previous commit in order to free Actions runners.

Important notes:

- In order not to re-invent the wheel, I used a popular external Github Action from the market place.
(https://github.com/marketplace/actions/cancel-workflow-action).

- The external Action is using the `GITHUB_TOKEN` which is a token automatically made available by github when actions are turned on. However, by default it has permissive access. This can be changed by admins in "settings/actions/workflow permissions", but to be safe, I restricted the permissions directly in the .yml file. This result in write access only to actions themselves. For more details: https://docs.github.com/en/actions/reference/authentication-in-a-workflow#permissions-for-the-github_token

- The cancelled jobs will make the make workflow show as error. The author will receive an email for it.
<!--GHEX{"id":2255,"author":"adrienbernede","editor":"tzanio","reviewers":["tzanio","pazner"],"assignment":"2021-05-19T11:12:31-07:00","approval":"2021-05-26T00:20:48.946Z","merge":"2021-05-26T19:56:19.521Z"}XEHG--><!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge| 
 | --- | --- | --- | --- | --- | --- | --- | 
| [#2255](https://github.com/mfem/mfem/pull/2255) | @adrienbernede | @tzanio | @tzanio + @pazner | 05/19/21 | 05/25/21 | 05/26/21 | |
<!--ELBATXEHG-->