### PR TITLE
Explicitly set the relative tolerance in the MFEM_Approx function

### DIFF
--- a/tests/unit/fem/test_calcshape.cpp
+++ b/tests/unit/fem/test_calcshape.cpp
@@ -75,7 +75,7 @@ void GetRelatedIntegrationPoints(const IntegrationPoint& ip, int dim,
  * of resolution res. Also tests at integration points
  * that are outside the element.
  */
-void TestCalcShape(FiniteElement* fe, int res)
+void TestCalcShape(FiniteElement* fe, int res, double tol=1e-12)
 {
    int dim = fe->GetDim();
 
@@ -102,7 +102,7 @@ void TestCalcShape(FiniteElement* fe, int res)
       {
          IntegrationPoint& ip = ipArr[j];
          fe->CalcShape(ip, weights);
-         REQUIRE( weights.Sum() == MFEM_Approx(1.) );
+         REQUIRE(weights.Sum() == MFEM_Approx(1., tol, tol));
       }
    }
 }
@@ -173,7 +173,7 @@ TEST_CASE("CalcShape for several H1 FiniteElement instances",
          std::cout << "Testing H1_SegmentElement::CalcShape() "
                    << "for order " << order << std::endl;
          H1_SegmentElement fe(order);
-         TestCalcShape(&fe, resolution);
+         TestCalcShape(&fe, resolution, 5e-12*std::pow(10, order));
       }
    }
 
@@ -184,7 +184,7 @@ TEST_CASE("CalcShape for several H1 FiniteElement instances",
          std::cout << "Testing H1_TriangleElement::CalcShape() "
                    << "for order " << order << std::endl;
          H1_TriangleElement fe(order);
-         TestCalcShape(&fe, resolution);
+         TestCalcShape(&fe, resolution, 5e-12*std::pow(10, order));
       }
    }
 
@@ -195,7 +195,7 @@ TEST_CASE("CalcShape for several H1 FiniteElement instances",
          std::cout << "Testing H1_QuadrilateralElement::CalcShape() "
                    << "for order " << order << std::endl;
          H1_QuadrilateralElement fe(order);
-         TestCalcShape(&fe, resolution);
+         TestCalcShape(&fe, resolution, 5e-12*std::pow(10, order));
       }
    }
 
@@ -206,7 +206,7 @@ TEST_CASE("CalcShape for several H1 FiniteElement instances",
          std::cout << "Testing H1_TetrahedronElement::CalcShape() "
                    << "for order " << order << std::endl;
          H1_TetrahedronElement fe(order);
-         TestCalcShape(&fe, resolution);
+         TestCalcShape(&fe, resolution, 5e-12*std::pow(10, order));
       }
    }
 
@@ -217,7 +217,7 @@ TEST_CASE("CalcShape for several H1 FiniteElement instances",
          std::cout << "Testing H1_HexahedronElement::CalcShape() "
                    << "for order " << order << std::endl;
          H1_HexahedronElement fe(order);
-         TestCalcShape(&fe, resolution);
+         TestCalcShape(&fe, resolution, 5e-12*std::pow(10, order));
       }
    }
 
@@ -228,7 +228,7 @@ TEST_CASE("CalcShape for several H1 FiniteElement instances",
          std::cout << "Testing H1_WedgeElement::CalcShape() "
                    << "for order " << order << std::endl;
          H1_WedgeElement fe(order);
-         TestCalcShape(&fe, resolution);
+         TestCalcShape(&fe, resolution, 5e-12*std::pow(10, order));
       }
    }
 

--- a/tests/unit/fem/test_calcshape.cpp
+++ b/tests/unit/fem/test_calcshape.cpp
@@ -173,7 +173,7 @@ TEST_CASE("CalcShape for several H1 FiniteElement instances",
          std::cout << "Testing H1_SegmentElement::CalcShape() "
                    << "for order " << order << std::endl;
          H1_SegmentElement fe(order);
-         TestCalcShape(&fe, resolution, 5e-12*std::pow(10, order));
+         TestCalcShape(&fe, resolution, 2e-11*std::pow(10, order));
       }
    }
 
@@ -184,7 +184,7 @@ TEST_CASE("CalcShape for several H1 FiniteElement instances",
          std::cout << "Testing H1_TriangleElement::CalcShape() "
                    << "for order " << order << std::endl;
          H1_TriangleElement fe(order);
-         TestCalcShape(&fe, resolution, 5e-12*std::pow(10, order));
+         TestCalcShape(&fe, resolution, 2e-11*std::pow(10, order));
       }
    }
 
@@ -195,7 +195,7 @@ TEST_CASE("CalcShape for several H1 FiniteElement instances",
          std::cout << "Testing H1_QuadrilateralElement::CalcShape() "
                    << "for order " << order << std::endl;
          H1_QuadrilateralElement fe(order);
-         TestCalcShape(&fe, resolution, 5e-12*std::pow(10, order));
+         TestCalcShape(&fe, resolution, 2e-11*std::pow(10, order));
       }
    }
 
@@ -206,7 +206,7 @@ TEST_CASE("CalcShape for several H1 FiniteElement instances",
          std::cout << "Testing H1_TetrahedronElement::CalcShape() "
                    << "for order " << order << std::endl;
          H1_TetrahedronElement fe(order);
-         TestCalcShape(&fe, resolution, 5e-12*std::pow(10, order));
+         TestCalcShape(&fe, resolution, 2e-11*std::pow(10, order));
       }
    }
 
@@ -217,7 +217,7 @@ TEST_CASE("CalcShape for several H1 FiniteElement instances",
          std::cout << "Testing H1_HexahedronElement::CalcShape() "
                    << "for order " << order << std::endl;
          H1_HexahedronElement fe(order);
-         TestCalcShape(&fe, resolution, 5e-12*std::pow(10, order));
+         TestCalcShape(&fe, resolution, 2e-11*std::pow(10, order));
       }
    }
 
@@ -228,7 +228,7 @@ TEST_CASE("CalcShape for several H1 FiniteElement instances",
          std::cout << "Testing H1_WedgeElement::CalcShape() "
                    << "for order " << order << std::endl;
          H1_WedgeElement fe(order);
-         TestCalcShape(&fe, resolution, 5e-12*std::pow(10, order));
+         TestCalcShape(&fe, resolution, 2e-11*std::pow(10, order));
       }
    }
 

--- a/tests/unit/unit_tests.hpp
+++ b/tests/unit/unit_tests.hpp
@@ -14,11 +14,14 @@
 
 #include "catch.hpp"
 
-/// MFEM_Approx can be used to compare floating point values within an absolute
-/// tolerance of `margin` (default value 1e-12).
-inline Approx MFEM_Approx(double val, double margin = 1e-12)
+/** @brief MFEM_Approx can be used to compare floating point values within an
+    absolute tolerance of @a abs_tol (default value 1e-12) and relative
+    tolerance of @a rel_tol (default value 1e-12). */
+inline Approx MFEM_Approx(double val,
+                          double abs_tol = 1e-12,
+                          double rel_tol = 1e-12)
 {
-   return Approx(val).margin(margin);
+   return Approx(val).margin(abs_tol).epsilon(rel_tol);
 }
 
 #endif


### PR DESCRIPTION
The default value defined by Catch2's `Approx` is too high -- `std::numeric_limits<float>::epsilon()*100` ~ `1.192092895507812500e-05`.

<!--GHEX{"id":2256,"author":"v-dobrev","editor":"tzanio","reviewers":["tzanio","pazner","mlstowell"],"assignment":"2021-05-18T14:47:29-07:00","approval":"2021-05-19T00:47:19.050Z","merge":"2021-05-19T20:28:19.214Z"}XEHG--><!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge| 
 | --- | --- | --- | --- | --- | --- | --- | 
| [#2256](https://github.com/mfem/mfem/pull/2256) | @v-dobrev | @tzanio | @tzanio + @pazner + @mlstowell | 05/18/21 | 05/18/21 | 05/19/21 | |
<!--ELBATXEHG-->