### PR TITLE
Serial KellyErrorEstimator

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -129,7 +129,8 @@ Version 4.2.1 (development)
 
 - Changed the interface for the error estimator.
 
-- Implemented the parallel Kelly error indicator for scalar-valued problems.
+- Implemented the Kelly error indicator for scalar-valued problems, supported
+  in serial and parallel builds.
 
 - Added new classes DenseSymmetricMatrix and SymmetricMatrixCoefficient for
   efficient evaluation of symmetric matrix coefficients. This replaces the now

--- a/examples/ex15.cpp
+++ b/examples/ex15.cpp
@@ -19,6 +19,14 @@
 //               ex15 -m ../data/square-disc.mesh
 //               ex15 -m ../data/escher.mesh -r 2 -tf 0.3
 //
+//               Kelly estimator:
+//
+//               ex15 -est 1
+//               ex15 -est 1 -o 1 -y 0.4
+//               ex15 -est 1 -o 4 -y 0.1
+//               ex15 -est 1 -n 5
+//               ex15 -est 1 -p 1 -n 3
+//
 // Description:  Building on Example 6, this example demonstrates dynamic AMR.
 //               The mesh is adapted to a time-dependent solution by refinement
 //               as well as by derefinement. For simplicity, the solution is
@@ -28,10 +36,10 @@
 //               At each outer iteration the right hand side function is changed
 //               to mimic a time dependent problem.  Within each inner iteration
 //               the problem is solved on a sequence of meshes which are locally
-//               refined according to a simple ZZ error estimator.  At the end
-//               of the inner iteration the error estimates are also used to
-//               identify any elements which may be over-refined and a single
-//               derefinement step is performed.
+//               refined according to a simple ZZ or Kelly error estimator.  At
+//               the end of the inner iteration the error estimates are also
+//               used to identify any elements which may be over-refined and a
+//               single derefinement step is performed.
 //
 //               The example demonstrates MFEM's capability to refine and
 //               derefine nonconforming meshes, in 2D and 3D, and on linear,

--- a/examples/ex15.cpp
+++ b/examples/ex15.cpp
@@ -21,7 +21,7 @@
 //
 //               Kelly estimator:
 //
-//               ex15 -est 1
+//               ex15 -est 1 -e 0.0001
 //               ex15 -est 1 -o 1 -y 0.4
 //               ex15 -est 1 -o 4 -y 0.1
 //               ex15 -est 1 -n 5

--- a/examples/ex15p.cpp
+++ b/examples/ex15p.cpp
@@ -223,13 +223,14 @@ int main(int argc, char *argv[])
    visit_dc.RegisterField("solution", &x);
    int vis_cycle = 0;
 
-   // 10. As in Example 6p, we set up a Zienkiewicz-Zhu estimator that will be
-   //     used to obtain element error indicators. The integrator needs to
-   //     provide the method ComputeElementFlux. We supply an L2 space for the
-   //     discontinuous flux and an H(div) space for the smoothed flux.
+   // 10. As in Example 6p, we set up an estimator that will be used to obtain
+   //     element error indicators. The integrator needs to provide the method
+   //     ComputeElementFlux. We supply an L2 space for the discontinuous flux
+   //     and an H(div) space for the smoothed flux.
    L2_FECollection flux_fec(order, dim);
    RT_FECollection smooth_flux_fec(order-1, dim);
-   ErrorEstimator* estimator;
+   ErrorEstimator* estimator{nullptr};
+
    switch (which_estimator)
    {
       case 1:
@@ -248,7 +249,7 @@ int main(int argc, char *argv[])
       default:
          if (myid == 0)
          {
-            std::cout << "Unkown estimator. Falling back to L2ZZ." << std::endl;
+            std::cout << "Unknown estimator. Falling back to L2ZZ." << std::endl;
          }
       case 0:
       {

--- a/fem/estimators.cpp
+++ b/fem/estimators.cpp
@@ -48,29 +48,31 @@ void L2ZienkiewiczZhuEstimator::ComputeEstimates()
    current_sequence = solution->FESpace()->GetMesh()->GetSequence();
 }
 
-
+// TODO: put this outside #ifdef MFEM_USE_MPI
 KellyErrorEstimator::KellyErrorEstimator(BilinearFormIntegrator& di_,
-                                         ParGridFunction& sol_,
-                                         ParFiniteElementSpace& flux_fespace_,
+                                         GridFunction& sol_,
+                                         FiniteElementSpace& flux_fespace_,
                                          const Array<int> &attributes_)
    : attributes(attributes_)
    , flux_integrator(&di_)
    , solution(&sol_)
    , flux_space(&flux_fespace_)
    , own_flux_fespace(false)
+   , isParallel(dynamic_cast<ParFiniteElementSpace*>(sol_.FESpace()))
 {
    ResetCoefficientFunctions();
 }
 
 KellyErrorEstimator::KellyErrorEstimator(BilinearFormIntegrator& di_,
-                                         ParGridFunction& sol_,
-                                         ParFiniteElementSpace* flux_fespace_,
+                                         GridFunction& sol_,
+                                         FiniteElementSpace* flux_fespace_,
                                          const Array<int> &attributes_)
    : attributes(attributes_)
    , flux_integrator(&di_)
    , solution(&sol_)
    , flux_space(flux_fespace_)
    , own_flux_fespace(true)
+   , isParallel(dynamic_cast<ParFiniteElementSpace*>(sol_.FESpace()))
 {
    ResetCoefficientFunctions();
 }
@@ -85,29 +87,29 @@ KellyErrorEstimator::~KellyErrorEstimator()
 
 void KellyErrorEstimator::ResetCoefficientFunctions()
 {
-   compute_element_coefficient = [](ParMesh* pmesh, const int e)
+   compute_element_coefficient = [](Mesh* mesh, const int e)
    {
       return 1.0;
    };
 
-   compute_face_coefficient = [](ParMesh* pmesh, const int f,
+   compute_face_coefficient = [](Mesh* mesh, const int f,
                                  const bool shared_face)
    {
       auto FT = [&]()
       {
          if (shared_face)
          {
-            return pmesh->GetSharedFaceTransformations(f);
+            return dynamic_cast<ParMesh*>(mesh)->GetSharedFaceTransformations(f);
          }
-         return pmesh->GetFaceElementTransformations(f);
+         return mesh->GetFaceElementTransformations(f);
       }();
       const auto order = FT->GetFE()->GetOrder();
 
       // Poor man's face diameter.
       double diameter = 0.0;
 
-      Vector p1(pmesh->SpaceDimension());
-      Vector p2(pmesh->SpaceDimension());
+      Vector p1(mesh->SpaceDimension());
+      Vector p2(mesh->SpaceDimension());
       // NOTE: We have no direct access to vertices for shared faces,
       // so we fall back to compute the positions from the element.
       // This can also be modified to compute the diameter for non-linear
@@ -148,17 +150,21 @@ void KellyErrorEstimator::ComputeEstimates()
 
    flux_space->Update(false);
 
-   auto xfes      = solution->ParFESpace();
+   auto xfes = solution->FESpace();
    MFEM_ASSERT(xfes->GetVDim() == 1,
                "Estimation for vector-valued problems not implemented yet.");
-   auto pmesh     = xfes->GetParMesh();
+   auto mesh = xfes->GetMesh();
 
    this->error_estimates.SetSize(xfes->GetNE());
    this->error_estimates = 0.0;
 
    // 1. Compute fluxes in discontinuous space
-   ParGridFunction flux(flux_space);
-   flux = 0.0;
+   GridFunction *flux =
+      isParallel ? new ParGridFunction(dynamic_cast<ParFiniteElementSpace*>
+                                       (flux_space)) :
+      new GridFunction(flux_space);
+
+   *flux = 0.0;
 
    // We pre-sort the array to speed up the search in the following loops.
    if (attributes.Size())
@@ -184,21 +190,21 @@ void KellyErrorEstimator::ComputeEstimates()
                                           *flux_space->GetFE(e), el_f, true);
 
       flux_space->GetElementVDofs(e, fdofs);
-      flux.AddElementVector(fdofs, el_f);
+      flux->AddElementVector(fdofs, el_f);
    }
 
    // 2. Add error contribution from local interior faces
-   for (int f = 0; f < pmesh->GetNumFaces(); f++)
+   for (int f = 0; f < mesh->GetNumFaces(); f++)
    {
-      auto FT = pmesh->GetFaceElementTransformations(f);
+      auto FT = mesh->GetFaceElementTransformations(f);
 
       auto &int_rule = IntRules.Get(FT->FaceGeom, 2 * xfes->GetFaceOrder(f));
       const auto nip = int_rule.GetNPoints();
 
-      if (pmesh->FaceIsInterior(f))
+      if (mesh->FaceIsInterior(f))
       {
          int Inf1, Inf2, NCFace;
-         pmesh->GetFaceInfos(f, &Inf1, &Inf2, &NCFace);
+         mesh->GetFaceInfos(f, &Inf1, &Inf2, &NCFace);
 
          // Convention
          // * Conforming face: Face side with smaller element id handles
@@ -229,18 +235,18 @@ void KellyErrorEstimator::ComputeEstimates()
                FT->Loc1.Transform(fip, ip);
 
                Vector val(flux_space->GetVDim());
-               flux.GetVectorValue(FT->Elem1No, ip, val);
+               flux->GetVectorValue(FT->Elem1No, ip, val);
 
                // And build scalar product with normal
-               Vector normal(pmesh->SpaceDimension());
+               Vector normal(mesh->SpaceDimension());
                FT->Face->SetIntPoint(&fip);
-               if (pmesh->Dimension() == pmesh->SpaceDimension())
+               if (mesh->Dimension() == mesh->SpaceDimension())
                {
                   CalcOrtho(FT->Face->Jacobian(), normal);
                }
                else
                {
-                  Vector ref_normal(pmesh->Dimension());
+                  Vector ref_normal(mesh->Dimension());
                   FT->Loc1.Transf.SetIntPoint(&fip);
                   CalcOrtho(FT->Loc1.Transf.Jacobian(), ref_normal);
                   auto &e1 = FT->GetElement1Transformation();
@@ -260,18 +266,18 @@ void KellyErrorEstimator::ComputeEstimates()
                FT->Loc2.Transform(fip, ip);
 
                Vector val(flux_space->GetVDim());
-               flux.GetVectorValue(FT->Elem2No, ip, val);
+               flux->GetVectorValue(FT->Elem2No, ip, val);
 
                // And build scalar product with normal
-               Vector normal(pmesh->SpaceDimension());
+               Vector normal(mesh->SpaceDimension());
                FT->Face->SetIntPoint(&fip);
-               if (pmesh->Dimension() == pmesh->SpaceDimension())
+               if (mesh->Dimension() == mesh->SpaceDimension())
                {
                   CalcOrtho(FT->Face->Jacobian(), normal);
                }
                else
                {
-                  Vector ref_normal(pmesh->Dimension());
+                  Vector ref_normal(mesh->Dimension());
                   FT->Loc1.Transf.SetIntPoint(&fip);
                   CalcOrtho(FT->Loc1.Transf.Jacobian(), ref_normal);
                   auto &e1 = FT->GetElement1Transformation();
@@ -287,7 +293,7 @@ void KellyErrorEstimator::ComputeEstimates()
             {
                jumps(i) *= jumps(i);
             }
-            auto h_k_face = compute_face_coefficient(pmesh, f, false);
+            auto h_k_face = compute_face_coefficient(mesh, f, false);
             double jump_integral = h_k_face*jumps.Sum();
 
             // A local face is shared between two local elements, so we
@@ -300,9 +306,31 @@ void KellyErrorEstimator::ComputeEstimates()
       }
    }
 
+   current_sequence = solution->FESpace()->GetMesh()->GetSequence();
+
    // 3. Add error contribution from shared interior faces
    // Synchronize face data.
-   flux.ExchangeFaceNbrData();
+   if (!isParallel)
+   {
+      // Finalize element errors
+      for (int e = 0; e < xfes->GetNE(); e++)
+      {
+         auto factor = compute_element_coefficient(mesh, e);
+         // The sqrt belongs to the norm and hₑ to the indicator.
+         error_estimates(e) = sqrt(factor * error_estimates(e));
+      }
+
+      total_error = error_estimates.Sum();
+      return;
+   }
+
+   ParGridFunction *pflux = dynamic_cast<ParGridFunction*>(flux);
+   MFEM_VERIFY(pflux, "flux is not a ParGridFunction pointer");
+
+   ParMesh *pmesh = dynamic_cast<ParMesh*>(mesh);
+   MFEM_VERIFY(pmesh, "mesh is not a ParMesh pointer");
+
+   pflux->ExchangeFaceNbrData();
 
    for (int sf = 0; sf < pmesh->GetNSharedFaces(); sf++)
    {
@@ -330,17 +358,17 @@ void KellyErrorEstimator::ComputeEstimates()
          FT->Loc1.Transform(fip, ip);
 
          Vector val(flux_space->GetVDim());
-         flux.GetVectorValue(FT->Elem1No, ip, val);
+         flux->GetVectorValue(FT->Elem1No, ip, val);
 
-         Vector normal(pmesh->SpaceDimension());
+         Vector normal(mesh->SpaceDimension());
          FT->Face->SetIntPoint(&fip);
-         if (pmesh->Dimension() == pmesh->SpaceDimension())
+         if (mesh->Dimension() == mesh->SpaceDimension())
          {
             CalcOrtho(FT->Face->Jacobian(), normal);
          }
          else
          {
-            Vector ref_normal(pmesh->Dimension());
+            Vector ref_normal(mesh->Dimension());
             FT->Loc1.Transf.SetIntPoint(&fip);
             CalcOrtho(FT->Loc1.Transf.Jacobian(), ref_normal);
             auto &e1 = FT->GetElement1Transformation();
@@ -361,18 +389,18 @@ void KellyErrorEstimator::ComputeEstimates()
          FT->Loc2.Transform(fip, ip);
 
          Vector val(flux_space->GetVDim());
-         flux.GetVectorValue(FT->Elem2No, ip, val);
+         flux->GetVectorValue(FT->Elem2No, ip, val);
 
          // Evaluate gauss point
-         Vector normal(pmesh->SpaceDimension());
+         Vector normal(mesh->SpaceDimension());
          FT->Face->SetIntPoint(&fip);
-         if (pmesh->Dimension() == pmesh->SpaceDimension())
+         if (mesh->Dimension() == mesh->SpaceDimension())
          {
             CalcOrtho(FT->Face->Jacobian(), normal);
          }
          else
          {
-            Vector ref_normal(pmesh->Dimension());
+            Vector ref_normal(mesh->Dimension());
             CalcOrtho(FT->Loc1.Transf.Jacobian(), ref_normal);
             auto &e1 = FT->GetElement1Transformation();
             e1.AdjugateJacobian().MultTranspose(ref_normal, normal);
@@ -387,7 +415,7 @@ void KellyErrorEstimator::ComputeEstimates()
       {
          jumps(i) *= jumps(i);
       }
-      auto h_k_face = compute_face_coefficient(pmesh, sf, true);
+      auto h_k_face = compute_face_coefficient(mesh, sf, true);
       double jump_integral = h_k_face*jumps.Sum();
 
       error_estimates(FT->Elem1No) += jump_integral;
@@ -399,17 +427,18 @@ void KellyErrorEstimator::ComputeEstimates()
    // Finalize element errors
    for (int e = 0; e < xfes->GetNE(); e++)
    {
-      auto factor = compute_element_coefficient(pmesh, e);
+      auto factor = compute_element_coefficient(mesh, e);
       // The sqrt belongs to the norm and hₑ to the indicator.
       error_estimates(e) = sqrt(factor * error_estimates(e));
    }
 
-   current_sequence = solution->FESpace()->GetMesh()->GetSequence();
-
    // Finish by computing the global error.
+   auto pfes = dynamic_cast<ParFiniteElementSpace*>(xfes);
+   MFEM_VERIFY(pfes, "xfes is not a ParFiniteElementSpace pointer");
+
    double process_local_error = error_estimates.Sum();
    MPI_Allreduce(&process_local_error, &total_error, 1, MPI_DOUBLE,
-                 MPI_SUM, xfes->GetComm());
+                 MPI_SUM, pfes->GetComm());
 }
 
 #endif // MFEM_USE_MPI

--- a/fem/estimators.cpp
+++ b/fem/estimators.cpp
@@ -330,6 +330,7 @@ void KellyErrorEstimator::ComputeEstimates()
       }
 
       total_error = error_estimates.Sum();
+      delete flux;
       return;
    }
 
@@ -437,6 +438,7 @@ void KellyErrorEstimator::ComputeEstimates()
       // because the error is stored on the remote process and
       // recomputed there.
    }
+   delete flux;
 
    // Finalize element errors
    for (int e = 0; e < xfes->GetNE(); e++)

--- a/fem/estimators.hpp
+++ b/fem/estimators.hpp
@@ -443,11 +443,11 @@ class KellyErrorEstimator final : public ErrorEstimator
 public:
    /// Function type to compute the local coefficient hₑ of an element.
    using ElementCoefficientFunction =
-      std::function<double(ParMesh*, const int)>;
+      std::function<double(Mesh*, const int)>;
    /** @brief Function type to compute the local coefficient hₖ of a face. The
        third argument is true for shared faces and false for local faces. */
    using FaceCoefficientFunction =
-      std::function<double(ParMesh*, const int, const bool)>;
+      std::function<double(Mesh*, const int, const bool)>;
 
 private:
    int current_sequence = -1;
@@ -478,11 +478,15 @@ private:
    FaceCoefficientFunction compute_face_coefficient;
 
    BilinearFormIntegrator* flux_integrator; ///< Not owned.
-   ParGridFunction* solution;               ///< Not owned.
+   GridFunction* solution;               ///< Not owned.
 
-   ParFiniteElementSpace*
+   FiniteElementSpace*
    flux_space; /**< @brief Ownership based on own_flux_fes. */
    bool own_flux_fespace; ///< Ownership flag for flux_space.
+
+#ifdef MFEM_USE_MPI
+   const bool isParallel;
+#endif
 
    /// Check if the mesh of the solution was modified.
    bool MeshIsModified()
@@ -512,8 +516,8 @@ public:
                           error should be estimated. An empty array results in
                           estimating the error over the complete domain.
    */
-   KellyErrorEstimator(BilinearFormIntegrator& di_, ParGridFunction& sol_,
-                       ParFiniteElementSpace& flux_fes_,
+   KellyErrorEstimator(BilinearFormIntegrator& di_, GridFunction& sol_,
+                       FiniteElementSpace& flux_fes_,
                        const Array<int> &attributes_ = Array<int>());
 
    /** @brief Construct a new KellyErrorEstimator object for a scalar field.
@@ -524,8 +528,8 @@ public:
                           error should be estimated. An empty array results in
                           estimating the error over the complete domain.
    */
-   KellyErrorEstimator(BilinearFormIntegrator& di_, ParGridFunction& sol_,
-                       ParFiniteElementSpace* flux_fes_,
+   KellyErrorEstimator(BilinearFormIntegrator& di_, GridFunction& sol_,
+                       FiniteElementSpace* flux_fes_,
                        const Array<int> &attributes_ = Array<int>());
 
    ~KellyErrorEstimator();

--- a/fem/estimators.hpp
+++ b/fem/estimators.hpp
@@ -412,11 +412,11 @@ public:
 
     The Kelly error indicator is based on the following papers:
 
-    Kelly, D. W., et al. "A posteriori error analysis and adaptive processes in
-    the finite element method: Part I—Error analysis." International journal for
-    numerical methods in engineering 19.11 (1983): 1593-1619.
+    [1] Kelly, D. W., et al. "A posteriori error analysis and adaptive processes
+    in the finite element method: Part I—Error analysis." International journal
+    for numerical methods in engineering 19.11 (1983): 1593-1619.
 
-    De SR Gago, J. P., et al. "A posteriori error analysis and adaptive
+    [2] De SR Gago, J. P., et al. "A posteriori error analysis and adaptive
     processes in the finite element method: Part II—Adaptive mesh refinement."
     International journal for numerical methods in engineering 19.11 (1983):
     1621-1656.
@@ -434,11 +434,11 @@ public:
     @note This algorithm is appropriate only for problems with scalar diffusion
     coefficients (e.g. Poisson problems), because it measures only the flux of
     the gradient of the discrete solution. The current implementation also does
-    not include the volume term present in Equation 75 of Kelly et al. Instead,
-    it includes only the flux term recommended in Equation 82.  The current
-    implementation also does not include the constant factor "C". It furthermore
-    assumes that the approximation error at the boundary is small enough, as the
-    implementation ignores boundary faces.
+    not include the volume term present in Equation 75 of Kelly et al [1].
+    Instead, it includes only the flux term recommended in Equation 82. The
+    current implementation also does not include the constant factor "C". It
+    furthermore assumes that the approximation error at the boundary is small
+    enough, as the implementation ignores boundary faces.
 */
 class KellyErrorEstimator final : public ErrorEstimator
 {

--- a/fem/estimators.hpp
+++ b/fem/estimators.hpp
@@ -422,7 +422,7 @@ public:
     1621-1656.
 
     It can be roughly described by:
-        ||∇(u-uₕ)||ₑ ≦ √( C hₑ ∑ₖ (hₖ ∫ |J[∇uₕ]|²) dS )
+        ||∇(u-uₕ)||ₑ ≅ √( C hₑ ∑ₖ (hₖ ∫ |J[∇uₕ]|²) dS )
     where "e" denotes an element, ||⋅||ₑ the corresponding local norm and k the
     corresponding faces. u is the analytic solution and uₕ the discretized
     solution. hₖ and hₑ are factors dependent on the face and element geometry.
@@ -431,11 +431,14 @@ public:
     is also possible to estimate the error only on a subspace by feeding this
     class an attribute array describing the subspace.
 
-    @note This algorithm is a proper error esimator only for Poisson problems.
-    The current implementation does not reflect this, because the "C" factor is
-    not included.
-    It further assumes that the approximation error at the boundary is small
-    enough, as the implementation ignores boundary faces.
+    @note This algorithm is appropriate only for problems with scalar diffusion
+    coefficients (e.g. Poisson problems), because it measures only the flux of
+    the gradient of the discrete solution. The current implementation also does
+    not include the volume term present in Equation 75 of Kelly et al. Instead,
+    it includes only the flux term recommended in Equation 82.  The current
+    implementation also does not include the constant factor "C". It furthermore
+    assumes that the approximation error at the boundary is small enough, as the
+    implementation ignores boundary faces.
 */
 class KellyErrorEstimator final : public ErrorEstimator
 {

--- a/fem/estimators.hpp
+++ b/fem/estimators.hpp
@@ -407,7 +407,6 @@ public:
 };
 
 
-#ifdef MFEM_USE_MPI
 /** @brief The KellyErrorEstimator class provides a fast error indication
     strategy for smooth scalar parallel problems.
 
@@ -426,13 +425,13 @@ public:
         ||∇(u-uₕ)||ₑ ≦ √( C hₑ ∑ₖ (hₖ ∫ |J[∇uₕ]|²) dS )
     where "e" denotes an element, ||⋅||ₑ the corresponding local norm and k the
     corresponding faces. u is the analytic solution and uₕ the discretized
-    solution. hₖ and hₑ are factors dependend on the face and element geometry.
+    solution. hₖ and hₑ are factors dependent on the face and element geometry.
     J is the jump function, i.e. the difference between the limits at each point
     for each side of the face. A custom method to compute hₖ can be provided. It
     is also possible to estimate the error only on a subspace by feeding this
     class an attribute array describing the subspace.
 
-    @note This algorithm is only for Poisson problems a proper error esimator.
+    @note This algorithm is a proper error esimator only for Poisson problems.
     The current implementation does not reflect this, because the "C" factor is
     not included.
     It further assumes that the approximation error at the boundary is small
@@ -575,8 +574,6 @@ public:
    /// Change the coefficients back to default as described above.
    void ResetCoefficientFunctions();
 };
-
-#endif // MFEM_USE_MPI
 
 } // namespace mfem
 


### PR DESCRIPTION
This PR adds the option to use the Kelly error estimator in the serial example ex15, meaning that `KellyErrorEstimator` can now generally be constructed and used for serial or parallel `{Par}FiniteElementSpace`, `{Par}GridFunction`, `{Par}Mesh`. Also, `ex15` works with a serial or parallel build of MFEM.

The parallel unit tests in `tests/unit/fem/test_estimator.cpp` could easily be copied to make serial unit tests, but I don't think it is necessary to test the serial case, as the code differences between serial and parallel are insignificant. The sample runs in `ex15` should be adequate for testing.

There has been some discussion (@YohannDudouit) about unifying the serial and parallel classes in MFEM. There may be pros and cons to this, but this PR is an example of the problems caused by having them separate.
<!--GHEX{"id":2260,"author":"dylan-copeland","editor":"tzanio","reviewers":["brendankeith","jandrej"],"assignment":"2021-05-23T16:10:29-07:00","approval":"2021-06-08T21:55:17.365Z","merge":"2021-06-10T23:28:42.279Z"}XEHG--><!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge| 
 | --- | --- | --- | --- | --- | --- | --- | 
| [#2260](https://github.com/mfem/mfem/pull/2260) | @dylan-copeland | @tzanio | @brendankeith + @jandrej | 05/23/21 | 06/08/21 | 06/10/21 | |
<!--ELBATXEHG-->