### PR TITLE
Adding meshes of the reference elements [ref-meshes-dev]

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -200,6 +200,11 @@ Version 4.2.1 (development)
   H(curl) and H(div) spaces is introduced to give spectral equivalence. This
   functionality is illustrated in the LOR solvers miniapp in miniapps/solvers.
 
+- Added sample meshes in the `data` subdirectory showing the reference elements
+  of the six currently supported element types; ref-segment.mesh,
+  ref-triangle.mesh, ref-square.mesh, ref-tetrahedron.mesh, ref-cube.mesh, and
+  ref-prism.mesh.
+
 libCEED integration improvements
 --------------------------------
 - Refactor the libCEED integration

--- a/data/ref-cube.mesh
+++ b/data/ref-cube.mesh
@@ -1,0 +1,41 @@
+MFEM mesh v1.0
+
+#
+# MFEM Geometry Types (see mesh/geom.hpp):
+#
+# POINT       = 0
+# SEGMENT     = 1
+# TRIANGLE    = 2
+# SQUARE      = 3
+# TETRAHEDRON = 4
+# CUBE        = 5
+# PRISM       = 6
+#
+
+dimension
+3
+
+elements
+1
+1 5 0 1 2 3 4 5 6 7
+
+boundary
+6
+1 3 3 2 1 0
+2 3 0 1 5 4
+3 3 1 2 6 5
+4 3 2 3 7 6
+5 3 3 0 4 7
+6 3 4 5 6 7
+
+vertices
+8
+3
+0 0 0
+1 0 0
+1 1 0
+0 1 0
+0 0 1
+1 0 1
+1 1 1
+0 1 1

--- a/data/ref-prism.mesh
+++ b/data/ref-prism.mesh
@@ -1,0 +1,38 @@
+MFEM mesh v1.0
+
+#
+# MFEM Geometry Types (see mesh/geom.hpp):
+#
+# POINT       = 0
+# SEGMENT     = 1
+# TRIANGLE    = 2
+# SQUARE      = 3
+# TETRAHEDRON = 4
+# CUBE        = 5
+# PRISM       = 6
+#
+
+dimension
+3
+
+elements
+1
+1 6 0 1 2 3 4 5
+
+boundary
+5
+1 2 0 2 1
+2 2 3 4 5
+3 3 0 1 4 3
+4 3 1 2 5 4
+5 3 2 0 3 5
+
+vertices
+6
+3
+0 0 0
+1 0 0
+0 1 0
+0 0 1
+1 0 1
+0 1 1

--- a/data/ref-segment.mesh
+++ b/data/ref-segment.mesh
@@ -1,0 +1,31 @@
+MFEM mesh v1.0
+
+#
+# MFEM Geometry Types (see mesh/geom.hpp):
+#
+# POINT       = 0
+# SEGMENT     = 1
+# TRIANGLE    = 2
+# SQUARE      = 3
+# TETRAHEDRON = 4
+# CUBE        = 5
+# PRISM       = 6
+#
+
+dimension
+1
+
+elements
+1
+1 1 0 1
+
+boundary
+2
+1 0 0
+2 0 1
+
+vertices
+2
+1
+0
+1

--- a/data/ref-square.mesh
+++ b/data/ref-square.mesh
@@ -1,0 +1,35 @@
+MFEM mesh v1.0
+
+#
+# MFEM Geometry Types (see mesh/geom.hpp):
+#
+# POINT       = 0
+# SEGMENT     = 1
+# TRIANGLE    = 2
+# SQUARE      = 3
+# TETRAHEDRON = 4
+# CUBE        = 5
+# PRISM       = 6
+#
+
+dimension
+2
+
+elements
+1
+1 3 0 1 2 3
+
+boundary
+4
+1 1 0 1
+2 1 1 2
+3 1 2 3
+4 1 3 0
+
+vertices
+4
+2
+0 0
+1 0
+1 1
+0 1

--- a/data/ref-tetrahedron.mesh
+++ b/data/ref-tetrahedron.mesh
@@ -1,0 +1,35 @@
+MFEM mesh v1.0
+
+#
+# MFEM Geometry Types (see mesh/geom.hpp):
+#
+# POINT       = 0
+# SEGMENT     = 1
+# TRIANGLE    = 2
+# SQUARE      = 3
+# TETRAHEDRON = 4
+# CUBE        = 5
+# PRISM       = 6
+#
+
+dimension
+3
+
+elements
+1
+1 4 0 1 2 3
+
+boundary
+4
+1 2 1 2 3
+2 2 0 3 2
+3 2 0 1 3
+4 2 0 2 1
+
+vertices
+4
+3
+0 0 0
+1 0 0
+0 1 0
+0 0 1

--- a/data/ref-triangle.mesh
+++ b/data/ref-triangle.mesh
@@ -1,0 +1,33 @@
+MFEM mesh v1.0
+
+#
+# MFEM Geometry Types (see mesh/geom.hpp):
+#
+# POINT       = 0
+# SEGMENT     = 1
+# TRIANGLE    = 2
+# SQUARE      = 3
+# TETRAHEDRON = 4
+# CUBE        = 5
+# PRISM       = 6
+#
+
+dimension
+2
+
+elements
+1
+1 2 0 1 2
+
+boundary
+3
+1 1 0 1
+2 1 1 2
+3 1 2 0
+
+vertices
+3
+2
+0 0
+1 0
+0 1


### PR DESCRIPTION
These meshes pull together information about the reference elements to make it more readily available to the users. Specifically, it combines the vertices of the reference elements (currently encoded in the 1st order H1 basis functions) and the numbering convention for the faces (also available in `fem/geom.cpp`).
<!--GHEX{"id":2264,"author":"mlstowell","editor":"tzanio","reviewers":["acfisher","cjvogl"],"assignment":"2021-05-23T16:09:11-07:00","approval":"2021-05-26T22:17:58.001Z","merge":"2021-05-28T19:32:20.499Z"}XEHG--><!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge| 
 | --- | --- | --- | --- | --- | --- | --- | 
| [#2264](https://github.com/mfem/mfem/pull/2264) | @mlstowell | @tzanio | @acfisher + @cjvogl | 05/23/21 | 05/26/21 | 05/28/21 | |
<!--ELBATXEHG-->