### PR TITLE
Expanding copyright statement checks [repo-check-dev]

### DIFF
--- a/.github/workflows/repo-check.yml
+++ b/.github/workflows/repo-check.yml
@@ -31,7 +31,7 @@ jobs:
     - name: copyright check
       run: |
         cd mfem
-        if git grep -l "^#.*\-2020" > matches.txt
+        if git grep -l "^\(#\|//\).*\(\-2020\|\ 2010,\)" > matches.txt
         then
           echo "Please update the following files to Copyright (c) 2010-2021:"
           cat matches.txt

--- a/.github/workflows/repo-check.yml
+++ b/.github/workflows/repo-check.yml
@@ -19,7 +19,7 @@ on:
   pull_request:
 
 jobs:
-  repo-check:
+  file-headers-check:
     runs-on: ubuntu-18.04
 
     steps:

--- a/.github/workflows/repo-check.yml
+++ b/.github/workflows/repo-check.yml
@@ -40,6 +40,48 @@ jobs:
           echo "No outdated copyright found."
         fi
 
+  license-check:
+    runs-on: ubuntu-18.04 # needed for astyle 2.05.1
+
+    steps:
+    - name: checkout mfem
+      uses: actions/checkout@v2
+      with:
+        path: mfem
+
+    - name: license check
+      run: |
+        cd mfem
+        if git grep -li "^\(#\|//\).*GNU\ Lesser\ General\ Public\ License" > matches.txt
+        then
+          echo "Please update the following files to the BSD-3 license:"
+          cat matches.txt
+          exit 1
+        else
+          echo "No GNU GPL license found."
+        fi
+
+  release-check:
+    runs-on: ubuntu-18.04 # needed for astyle 2.05.1
+
+    steps:
+    - name: checkout mfem
+      uses: actions/checkout@v2
+      with:
+        path: mfem
+
+    - name: relsease check
+      run: |
+        cd mfem
+        if git grep -l "^\(#\|//\).*LLNL\-CODE\-443211" > matches.txt
+        then
+          echo "Please update the following files to LLNL-CODE-806117:"
+          cat matches.txt
+          exit 1
+        else
+          echo "No outdated release number found."
+        fi
+
   code-style:
     runs-on: ubuntu-16.04 # needed for astyle 2.05.1
 

--- a/.github/workflows/repo-check.yml
+++ b/.github/workflows/repo-check.yml
@@ -20,7 +20,7 @@ on:
 
 jobs:
   copyright-check:
-    runs-on: ubuntu-18.04 # needed for astyle 2.05.1
+    runs-on: ubuntu-18.04
 
     steps:
     - name: checkout mfem
@@ -41,7 +41,7 @@ jobs:
         fi
 
   license-check:
-    runs-on: ubuntu-18.04 # needed for astyle 2.05.1
+    runs-on: ubuntu-18.04
 
     steps:
     - name: checkout mfem
@@ -62,7 +62,7 @@ jobs:
         fi
 
   release-check:
-    runs-on: ubuntu-18.04 # needed for astyle 2.05.1
+    runs-on: ubuntu-18.04
 
     steps:
     - name: checkout mfem


### PR DESCRIPTION
This PR expands the checks done in `repo-check.yml` to include the outdated release number and GPL license type. It also appeared that the check was only looking at lines starting with '#' i.e. comments in shell scripts so I expanded this to include "//" i.e. comments in C++ files.

Addresses issue #2265. 

<!--GHEX{"id":2267,"author":"mlstowell","editor":"tzanio","reviewers":["tzanio","adrienbernede","v-dobrev"],"assignment":"2021-05-23T15:54:58-07:00","approval":"2021-05-26T19:54:05.585Z","merge":"2021-05-26T19:57:00.674Z"}XEHG--><!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge| 
 | --- | --- | --- | --- | --- | --- | --- | 
| [#2267](https://github.com/mfem/mfem/pull/2267) | @mlstowell | @tzanio | @tzanio + @adrienbernede + @v-dobrev | 05/23/21 | 05/26/21 | 05/26/21 | |
<!--ELBATXEHG-->