### PR TITLE
Allows partial assembly with nonconstant scalar coefficients for Gradient and VectorDiffusion integrators [pa-coeffs-nonconstant]

### DIFF
--- a/fem/bilininteg_gradient.cpp
+++ b/fem/bilininteg_gradient.cpp
@@ -25,7 +25,7 @@ namespace mfem
    \b Q1D number of quadrature points in one dimension.
    \b w quadrature weights.
    \b j element Jacobians.
-   \b COEFF coefficient at quadrature points.
+   \b c coefficient at quadrature points.
 
    The function is used precompute data needed at quadrature points during
    the action. */

--- a/fem/bilininteg_gradient.cpp
+++ b/fem/bilininteg_gradient.cpp
@@ -117,6 +117,7 @@ static void PAGradientSetup3D(const int Q1D,
    auto J = Reshape(j.Read(), NQ, 3, 3, NE);
    auto y = Reshape(op.Write(), NQ, 3, 3, NE);
 
+   const bool const_c = c.Size() == 1;
    const auto C = const_c ? Reshape(c.Read(), 1,1) :
                   Reshape(c.Read(), Q1D,NE);
 

--- a/fem/bilininteg_gradient.cpp
+++ b/fem/bilininteg_gradient.cpp
@@ -84,7 +84,7 @@ static void PAGradientSetup2D(const int Q1D,
 
    const bool const_c = c.Size() == 1;
    const auto C = const_c ? Reshape(c.Read(), 1,1) :
-                  Reshape(c.Read(), Q1D, NE);
+                  Reshape(c.Read(), NQ, NE);
 
    MFEM_FORALL(e, NE,
    {
@@ -119,7 +119,7 @@ static void PAGradientSetup3D(const int Q1D,
 
    const bool const_c = c.Size() == 1;
    const auto C = const_c ? Reshape(c.Read(), 1,1) :
-                  Reshape(c.Read(), Q1D,NE);
+                  Reshape(c.Read(), NQ,NE);
 
    MFEM_FORALL(e, NE,
    {

--- a/fem/bilininteg_vecdiffusion.cpp
+++ b/fem/bilininteg_vecdiffusion.cpp
@@ -37,7 +37,7 @@ static void PAVectorDiffusionSetup2D(const int Q1D,
 
    const bool const_c = c.Size() == 1;
    const auto C = const_c ? Reshape(c.Read(), 1,1) :
-                  Reshape(c.Read(), Q1D, NE);
+                  Reshape(c.Read(), NQ, NE);
 
 
    MFEM_FORALL(e, NE,
@@ -73,7 +73,7 @@ static void PAVectorDiffusionSetup3D(const int Q1D,
 
    const bool const_c = c.Size() == 1;
    const auto C = const_c ? Reshape(c.Read(), 1,1) :
-                  Reshape(c.Read(), Q1D,NE);
+                  Reshape(c.Read(), NQ,NE);
 
 
    MFEM_FORALL(e, NE,
@@ -217,7 +217,7 @@ void VectorDiffusionIntegrator::AssemblePA(const FiniteElementSpace &fes)
       auto J = Reshape(j.Read(), NQ, SDIM, DIM, ne);
       auto D = Reshape(d.Write(), NQ, SDIM, ne);
 
-      auto C = Reshape(coeff.HostWrite(), nq, ne);
+      auto C = Reshape(coeff.HostWrite(), NQ, ne);
 
       MFEM_FORALL(e, ne,
       {

--- a/fem/bilininteg_vecdiffusion.cpp
+++ b/fem/bilininteg_vecdiffusion.cpp
@@ -217,7 +217,9 @@ void VectorDiffusionIntegrator::AssemblePA(const FiniteElementSpace &fes)
       auto J = Reshape(j.Read(), NQ, SDIM, DIM, ne);
       auto D = Reshape(d.Write(), NQ, SDIM, ne);
 
-      auto C = Reshape(coeff.HostWrite(), NQ, ne);
+      const bool const_c = coeff.Size() == 1;
+      const auto C = const_c ? Reshape(coeff.Read(), 1,1) :
+                     Reshape(coeff.Read(), NQ,ne);
 
       MFEM_FORALL(e, ne,
       {
@@ -234,7 +236,8 @@ void VectorDiffusionIntegrator::AssemblePA(const FiniteElementSpace &fes)
             const double G = J12*J12 + J22*J22 + J32*J32;
             const double F = J11*J12 + J21*J22 + J31*J32;
             const double iw = 1.0 / sqrt(E*G - F*F);
-            const double alpha = wq * C(q, e) * iw;
+            const double C1 = const_c ? C(0,0) : C(q,e);
+            const double alpha = wq * C1 * iw;
             D(q,0,e) =  alpha * G; // 1,1
             D(q,1,e) = -alpha * F; // 1,2
             D(q,2,e) =  alpha * E; // 2,2


### PR DESCRIPTION
Currently `GradientIntegrator` and `VectorDiffusionIntegrator` only allow for constant scalar coefficients for partial assembly.  This PR adds the ability to use nonconstant scalar coefficients for partial assembly with these integrators. It does this in a similar way as is implemented for `DiffusionIntegrator` in `bilininteg_diffusion_pa.cpp`. A vector is used to store the coefficient values. The vectors are reshaped into 2d arrays. For constant coefficients, it is a 1x1 array. For nonconstant coefficients, it uses an nq x ne array where nq is the number of quadrature points and ne is the number of elements. It includes checks to verify that the coefficient input can be used.
<!--GHEX{"id":2270,"author":"smattis-nnl","editor":"tzanio","reviewers":["jandrej","pazner"],"assignment":"2021-05-27T19:11:26-07:00","approval":"2021-06-11T14:54:05.309Z","merge":"2021-06-14T15:35:13.927Z"}XEHG--><!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge| 
 | --- | --- | --- | --- | --- | --- | --- | 
| [#2270](https://github.com/mfem/mfem/pull/2270) | @smattis-nnl | @tzanio | @jandrej + @pazner | 05/27/21 | 06/11/21 | 06/14/21 | |
<!--ELBATXEHG-->