### PR TITLE
Optionally skip Randomize call in EstimateLargestEigenvalue

### DIFF
--- a/linalg/operator.cpp
+++ b/linalg/operator.cpp
@@ -628,7 +628,10 @@ double PowerMethod::EstimateLargestEigenvalue(Operator& opr, Vector& v0,
                                               int numSteps, double tolerance, int seed)
 {
    v1.SetSize(v0.Size());
-   v0.Randomize(seed);
+   if (seed != -1)
+   {
+      v0.Randomize(seed);
+   }
 
    double eigenvalue = 1.0;
 

--- a/linalg/operator.cpp
+++ b/linalg/operator.cpp
@@ -628,7 +628,7 @@ double PowerMethod::EstimateLargestEigenvalue(Operator& opr, Vector& v0,
                                               int numSteps, double tolerance, int seed)
 {
    v1.SetSize(v0.Size());
-   if (seed != -1)
+   if (seed != 0)
    {
       v0.Randomize(seed);
    }

--- a/linalg/operator.hpp
+++ b/linalg/operator.hpp
@@ -968,7 +968,7 @@ public:
        the eigenvector corresponding to the largest eigenvalue after convergence.
        The maximum number of iterations may set with \p numSteps, the relative
        tolerance with \p tolerance and the seed of the random initialization of
-       \p v0 with \p seed. */
+       \p v0 with \p seed. If \p seed is -1 \p v0 will not be random-initialized. */
    double EstimateLargestEigenvalue(Operator& opr, Vector& v0,
                                     int numSteps = 10, double tolerance = 1e-8,
                                     int seed = 12345);

--- a/linalg/operator.hpp
+++ b/linalg/operator.hpp
@@ -968,7 +968,7 @@ public:
        the eigenvector corresponding to the largest eigenvalue after convergence.
        The maximum number of iterations may set with \p numSteps, the relative
        tolerance with \p tolerance and the seed of the random initialization of
-       \p v0 with \p seed. If \p seed is -1 \p v0 will not be random-initialized. */
+       \p v0 with \p seed. If \p seed is 0 \p v0 will not be random-initialized. */
    double EstimateLargestEigenvalue(Operator& opr, Vector& v0,
                                     int numSteps = 10, double tolerance = 1e-8,
                                     int seed = 12345);


### PR DESCRIPTION
Skip input vector randomizing in `EstimateLargestEigenvalue` if the seed is `-1`; useful when `v0` is already random initialized.

`Randomize` can be real slow.
<!--GHEX{"id":2274,"author":"tomstitt","editor":"tzanio","reviewers":["tzanio","vladotomov"],"assignment":"2021-05-26T14:02:33-07:00","approval":"2021-05-27T15:34:36.070Z","merge":"2021-05-28T16:15:31.477Z"}XEHG--><!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge| 
 | --- | --- | --- | --- | --- | --- | --- | 
| [#2274](https://github.com/mfem/mfem/pull/2274) | @tomstitt | @tzanio | @tzanio + @vladotomov | 05/26/21 | 05/27/21 | 05/28/21 | |
<!--ELBATXEHG-->