### PR TITLE
Fix for `make test` on macOS Big Sur

### DIFF
--- a/config/test.mk
+++ b/config/test.mk
@@ -39,7 +39,7 @@ set -- $$($(1) $(SHELL) -c "$(2)" 2>&1); while [ "$$#" -gt 3 ]; do shift; done
 endef
 define TIMECMD.NOTGNU
 set -- $$($(1) -l $(SHELL) -c "{ $(2); } > /dev/null 2>&1" 2>&1; echo $$?); \
-set -- "$$1"s "$$(($$7/1024))"kB "$${60}"
+set -- "$$1"s "$$(($$7/1024))"kB "$${!#}"
 endef
 define TIMECMD.BASH
 TIMEFORMAT=$$'%3Rs'; \


### PR DESCRIPTION
The `make test` and `make check` targets were failing on macOS Big Sur, because `/usr/bin/time -l` returns 3 additional rows compared to Catalina.

(The fix is to replace the previously hard-coded argument for the number of outputs of `/usr/bin/time -l` with the last entry of the Bash Array)

Resolves #2171.

<!--GHEX{"id":2276,"author":"tzanio","editor":"tzanio","reviewers":["v-dobrev","camierjs"],"assignment":"2021-05-26T18:38:35-07:00","approval":"2021-05-27T15:25:15.216Z","merge":"2021-05-28T15:59:35.760Z"}XEHG--><!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge| 
 | --- | --- | --- | --- | --- | --- | --- | 
| [#2276](https://github.com/mfem/mfem/pull/2276) | @tzanio | @tzanio | @v-dobrev + @camierjs | 05/26/21 | 05/27/21 | 05/28/21 | |
<!--ELBATXEHG-->