### PR TITLE
Apply the repo check workflow to all push events

### DIFF
--- a/.github/workflows/repo-check.yml
+++ b/.github/workflows/repo-check.yml
@@ -16,9 +16,6 @@ permissions:
 
 on:
   push:
-    branches:
-      - master
-      - next
   pull_request:
 
 jobs:


### PR DESCRIPTION
This allows to check for formatting and big change in history as early as someone pushes to the repo.

If we encourage developers to test earlier, with a push hook, then we could change the repo check so that it emails the author of the push?

What we could do anyway is to log the branches that do not pass the test.
<!--GHEX{"id":2282,"author":"adrienbernede","editor":"tzanio","reviewers":["tzanio","pazner"],"assignment":"2021-06-02T11:02:09-07:00","approval":"2021-06-03T22:30:29.432Z","merge":"2021-06-04T15:06:23.315Z"}XEHG--><!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge| 
 | --- | --- | --- | --- | --- | --- | --- | 
| [#2282](https://github.com/mfem/mfem/pull/2282) | @adrienbernede | @tzanio | @tzanio + @pazner | 06/02/21 | 06/03/21 | 06/04/21 | |
<!--ELBATXEHG-->