### PR TITLE
TMOP temp memory

### DIFF
--- a/fem/bilininteg_convection_pa.cpp
+++ b/fem/bilininteg_convection_pa.cpp
@@ -768,6 +768,8 @@ void SmemPAConvectionApply3D(const int ne,
 
 void ConvectionIntegrator::AssemblePA(const FiniteElementSpace &fes)
 {
+   const MemoryType mt = temp_mt == MemoryType::DEFAULT ?
+                         Device::GetDeviceMemoryType() : temp_mt;
    // Assumes tensor-product elements
    Mesh *mesh = fes.GetMesh();
    const FiniteElement &el = *fes.GetFE(0);
@@ -784,11 +786,11 @@ void ConvectionIntegrator::AssemblePA(const FiniteElementSpace &fes)
    const int nq = ir->GetNPoints();
    dim = mesh->Dimension();
    ne = fes.GetNE();
-   geom = mesh->GetGeometricFactors(*ir, GeometricFactors::JACOBIANS);
+   geom = mesh->GetGeometricFactors(*ir, GeometricFactors::JACOBIANS, temp_mt);
    maps = &el.GetDofToQuad(*ir, DofToQuad::TENSOR);
    dofs1D = maps->ndof;
    quad1D = maps->nqpt;
-   pa_data.SetSize(symmDims * nq * ne, Device::GetMemoryType());
+   pa_data.SetSize(symmDims * nq * ne, mt);
    Vector vel;
    if (VectorConstantCoefficient *cQ =
           dynamic_cast<VectorConstantCoefficient*>(Q))
@@ -798,7 +800,7 @@ void ConvectionIntegrator::AssemblePA(const FiniteElementSpace &fes)
    else if (VectorGridFunctionCoefficient *vgfQ =
                dynamic_cast<VectorGridFunctionCoefficient*>(Q))
    {
-      vel.SetSize(dim * nq * ne);
+      vel.SetSize(dim * nq * ne, mt);
 
       const GridFunction *gf = vgfQ->GetGridFunction();
       const FiniteElementSpace &gf_fes = *gf->FESpace();
@@ -809,7 +811,7 @@ void ConvectionIntegrator::AssemblePA(const FiniteElementSpace &fes)
                                           ElementDofOrdering::NATIVE;
       const Operator *R = gf_fes.GetElementRestriction(ordering);
 
-      Vector xe(R->Height(), Device::GetMemoryType());
+      Vector xe(R->Height(), mt);
       xe.UseDevice(true);
 
       R->Mult(*gf, xe);

--- a/fem/bilininteg_convection_pa.cpp
+++ b/fem/bilininteg_convection_pa.cpp
@@ -768,8 +768,8 @@ void SmemPAConvectionApply3D(const int ne,
 
 void ConvectionIntegrator::AssemblePA(const FiniteElementSpace &fes)
 {
-   const MemoryType mt = temp_mt == MemoryType::DEFAULT ?
-                         Device::GetDeviceMemoryType() : temp_mt;
+   const MemoryType mt = (pa_mt == MemoryType::DEFAULT) ?
+                         Device::GetDeviceMemoryType() : pa_mt;
    // Assumes tensor-product elements
    Mesh *mesh = fes.GetMesh();
    const FiniteElement &el = *fes.GetFE(0);

--- a/fem/bilininteg_convection_pa.cpp
+++ b/fem/bilininteg_convection_pa.cpp
@@ -786,7 +786,7 @@ void ConvectionIntegrator::AssemblePA(const FiniteElementSpace &fes)
    const int nq = ir->GetNPoints();
    dim = mesh->Dimension();
    ne = fes.GetNE();
-   geom = mesh->GetGeometricFactors(*ir, GeometricFactors::JACOBIANS, temp_mt);
+   geom = mesh->GetGeometricFactors(*ir, GeometricFactors::JACOBIANS, mt);
    maps = &el.GetDofToQuad(*ir, DofToQuad::TENSOR);
    dofs1D = maps->ndof;
    quad1D = maps->nqpt;

--- a/fem/bilininteg_diffusion_pa.cpp
+++ b/fem/bilininteg_diffusion_pa.cpp
@@ -351,8 +351,8 @@ static void PADiffusionSetup(const int dim,
 
 void DiffusionIntegrator::AssemblePA(const FiniteElementSpace &fes)
 {
-   const MemoryType mt = (temp_mt == MemoryType::DEFAULT) ?
-                         Device::GetDeviceMemoryType() : temp_mt;
+   const MemoryType mt = (pa_mt == MemoryType::DEFAULT) ?
+                         Device::GetDeviceMemoryType() : pa_mt;
    // Assuming the same element type
    fespace = &fes;
    Mesh *mesh = fes.GetMesh();

--- a/fem/bilininteg_diffusion_pa.cpp
+++ b/fem/bilininteg_diffusion_pa.cpp
@@ -351,6 +351,8 @@ static void PADiffusionSetup(const int dim,
 
 void DiffusionIntegrator::AssemblePA(const FiniteElementSpace &fes)
 {
+   const MemoryType mt = (temp_mt == MemoryType::DEFAULT) ?
+                         Device::GetDeviceMemoryType() : temp_mt;
    // Assuming the same element type
    fespace = &fes;
    Mesh *mesh = fes.GetMesh();
@@ -371,7 +373,7 @@ void DiffusionIntegrator::AssemblePA(const FiniteElementSpace &fes)
    const int nq = ir->GetNPoints();
    dim = mesh->Dimension();
    ne = fes.GetNE();
-   geom = mesh->GetGeometricFactors(*ir, GeometricFactors::JACOBIANS, temp_mt);
+   geom = mesh->GetGeometricFactors(*ir, GeometricFactors::JACOBIANS, mt);
    const int sdim = mesh->SpaceDimension();
    maps = &el.GetDofToQuad(*ir, DofToQuad::TENSOR);
    dofs1D = maps->ndof;
@@ -488,8 +490,7 @@ void DiffusionIntegrator::AssemblePA(const FiniteElementSpace &fes)
          }
       }
    }
-   pa_data.SetSize((symmetric ? symmDims : MQfullDim) * nq * ne,
-                   temp_mt == MemoryType::DEFAULT ? Device::GetDeviceMemoryType() : temp_mt);
+   pa_data.SetSize((symmetric ? symmDims : MQfullDim) * nq * ne, mt);
    PADiffusionSetup(dim, sdim, dofs1D, quad1D, coeffDim, ne, ir->GetWeights(),
                     geom->J, coeff, pa_data);
 }

--- a/fem/bilininteg_diffusion_pa.cpp
+++ b/fem/bilininteg_diffusion_pa.cpp
@@ -371,7 +371,7 @@ void DiffusionIntegrator::AssemblePA(const FiniteElementSpace &fes)
    const int nq = ir->GetNPoints();
    dim = mesh->Dimension();
    ne = fes.GetNE();
-   geom = mesh->GetGeometricFactors(*ir, GeometricFactors::JACOBIANS);
+   geom = mesh->GetGeometricFactors(*ir, GeometricFactors::JACOBIANS, temp_mt);
    const int sdim = mesh->SpaceDimension();
    maps = &el.GetDofToQuad(*ir, DofToQuad::TENSOR);
    dofs1D = maps->ndof;
@@ -489,7 +489,7 @@ void DiffusionIntegrator::AssemblePA(const FiniteElementSpace &fes)
       }
    }
    pa_data.SetSize((symmetric ? symmDims : MQfullDim) * nq * ne,
-                   Device::GetDeviceMemoryType());
+                   temp_mt == MemoryType::DEFAULT ? Device::GetDeviceMemoryType() : temp_mt);
    PADiffusionSetup(dim, sdim, dofs1D, quad1D, coeffDim, ne, ir->GetWeights(),
                     geom->J, coeff, pa_data);
 }

--- a/fem/bilininteg_mass_pa.cpp
+++ b/fem/bilininteg_mass_pa.cpp
@@ -25,6 +25,9 @@ namespace mfem
 
 void MassIntegrator::AssemblePA(const FiniteElementSpace &fes)
 {
+   const MemoryType mt = (temp_mt == MemoryType::DEFAULT) ?
+                         Device::GetDeviceMemoryType() : temp_mt;
+
    // Assuming the same element type
    fespace = &fes;
    Mesh *mesh = fes.GetMesh();
@@ -42,12 +45,11 @@ void MassIntegrator::AssemblePA(const FiniteElementSpace &fes)
    ne = fes.GetMesh()->GetNE();
    nq = ir->GetNPoints();
    geom = mesh->GetGeometricFactors(*ir, GeometricFactors::COORDINATES |
-                                    GeometricFactors::JACOBIANS, temp_mt);
+                                    GeometricFactors::JACOBIANS, mt);
    maps = &el.GetDofToQuad(*ir, DofToQuad::TENSOR);
    dofs1D = maps->ndof;
    quad1D = maps->nqpt;
-   pa_data.SetSize(ne*nq, temp_mt == MemoryType::DEFAULT ?
-                   Device::GetDeviceMemoryType() : temp_mt);
+   pa_data.SetSize(ne*nq, mt);
    Vector coeff;
    if (Q == nullptr)
    {

--- a/fem/bilininteg_mass_pa.cpp
+++ b/fem/bilininteg_mass_pa.cpp
@@ -42,11 +42,12 @@ void MassIntegrator::AssemblePA(const FiniteElementSpace &fes)
    ne = fes.GetMesh()->GetNE();
    nq = ir->GetNPoints();
    geom = mesh->GetGeometricFactors(*ir, GeometricFactors::COORDINATES |
-                                    GeometricFactors::JACOBIANS);
+                                    GeometricFactors::JACOBIANS, temp_mt);
    maps = &el.GetDofToQuad(*ir, DofToQuad::TENSOR);
    dofs1D = maps->ndof;
    quad1D = maps->nqpt;
-   pa_data.SetSize(ne*nq, Device::GetDeviceMemoryType());
+   pa_data.SetSize(ne*nq, temp_mt == MemoryType::DEFAULT ?
+                   Device::GetDeviceMemoryType() : temp_mt);
    Vector coeff;
    if (Q == nullptr)
    {

--- a/fem/bilininteg_mass_pa.cpp
+++ b/fem/bilininteg_mass_pa.cpp
@@ -25,8 +25,8 @@ namespace mfem
 
 void MassIntegrator::AssemblePA(const FiniteElementSpace &fes)
 {
-   const MemoryType mt = (temp_mt == MemoryType::DEFAULT) ?
-                         Device::GetDeviceMemoryType() : temp_mt;
+   const MemoryType mt = (pa_mt == MemoryType::DEFAULT) ?
+                         Device::GetDeviceMemoryType() : pa_mt;
 
    // Assuming the same element type
    fespace = &fes;

--- a/fem/nonlininteg.hpp
+++ b/fem/nonlininteg.hpp
@@ -45,8 +45,8 @@ public:
    /// Prescribe a fixed IntegrationRule to use.
    void SetIntegrationRule(const IntegrationRule &irule) { IntRule = &irule; }
 
-   /// Set the memory type used for GeometricFactors and other large
-   /// allocations in PA extensions.
+   /// Set the memory type used for GeometricFactors and other large allocations
+   /// in PA extensions.
    void SetPAMemoryType(MemoryType mt) { pa_mt = mt; }
 
    /// Get the integration rule of the integrator (possibly NULL).

--- a/fem/nonlininteg.hpp
+++ b/fem/nonlininteg.hpp
@@ -32,7 +32,7 @@ protected:
    // CEED extension
    ceed::Operator* ceedOp;
 
-   MemoryType temp_mt = MemoryType::DEFAULT;
+   MemoryType pa_mt = MemoryType::DEFAULT;
 
    NonlinearFormIntegrator(const IntegrationRule *ir = NULL)
       : IntRule(ir), ceedOp(NULL) { }
@@ -45,7 +45,9 @@ public:
    /// Prescribe a fixed IntegrationRule to use.
    void SetIntegrationRule(const IntegrationRule &irule) { IntRule = &irule; }
 
-   void SetTempMemoryType(MemoryType mt) { temp_mt = mt; }
+   /// Set the memory type used for GeometricFactors and other large
+   /// allocations in PA extensions.
+   void SetPAMemoryType(MemoryType mt) { pa_mt = mt; }
 
    /// Get the integration rule of the integrator (possibly NULL).
    const IntegrationRule *GetIntegrationRule() const { return IntRule; }

--- a/fem/nonlininteg.hpp
+++ b/fem/nonlininteg.hpp
@@ -32,6 +32,8 @@ protected:
    // CEED extension
    ceed::Operator* ceedOp;
 
+   MemoryType temp_mt = MemoryType::DEFAULT;
+
    NonlinearFormIntegrator(const IntegrationRule *ir = NULL)
       : IntRule(ir), ceedOp(NULL) { }
 
@@ -42,6 +44,8 @@ public:
 
    /// Prescribe a fixed IntegrationRule to use.
    void SetIntegrationRule(const IntegrationRule &irule) { IntRule = &irule; }
+
+   void SetTempMemoryType(MemoryType mt) { temp_mt = mt; }
 
    /// Get the integration rule of the integrator (possibly NULL).
    const IntegrationRule *GetIntegrationRule() const { return IntRule; }

--- a/fem/tmop.cpp
+++ b/fem/tmop.cpp
@@ -2195,7 +2195,6 @@ void TMOP_Integrator::ReleasePAMemory()
       PA.H.GetMemory().DeleteDevice();
       PA.H0.GetMemory().DeleteDevice();
       PA.Jtr.GetMemory().DeleteDevice();
-      PA.Jtr_needs_update = true;
    }
 }
 

--- a/fem/tmop.cpp
+++ b/fem/tmop.cpp
@@ -2188,7 +2188,7 @@ AdaptivityEvaluator::~AdaptivityEvaluator()
 #endif
 }
 
-void TMOP_Integrator::ReleasePAMemory()
+void TMOP_Integrator::ReleasePADeviceMemory()
 {
    if (PA.enabled)
    {

--- a/fem/tmop.cpp
+++ b/fem/tmop.cpp
@@ -2169,6 +2169,15 @@ void AdaptivityEvaluator::SetParMetaInfo(const ParMesh &m,
 }
 #endif
 
+void AdaptivityEvaluator::ClearGeometricFactors()
+{
+#ifdef MFEM_USE_MPI
+   if (pmesh) { pmesh->DeleteGeometricFactors(); }
+#else
+   if (mesh) { mesh->DeleteGeometricFactors(); }
+#endif
+}
+
 AdaptivityEvaluator::~AdaptivityEvaluator()
 {
    delete fes;
@@ -2177,6 +2186,17 @@ AdaptivityEvaluator::~AdaptivityEvaluator()
    delete pfes;
    delete pmesh;
 #endif
+}
+
+void TMOP_Integrator::ReleasePAMemory()
+{
+   if (PA.enabled)
+   {
+      PA.H.GetMemory().DeleteDevice();
+      PA.H0.GetMemory().DeleteDevice();
+      PA.Jtr.GetMemory().DeleteDevice();
+      PA.Jtr_needs_update = true;
+   }
 }
 
 TMOP_Integrator::~TMOP_Integrator()

--- a/fem/tmop.hpp
+++ b/fem/tmop.hpp
@@ -1185,7 +1185,7 @@ protected:
 
    DiscreteAdaptTC *discr_tc;
 
-   MemoryType temp_mt = MemoryType::DEFAULT;
+   MemoryType pa_mt = MemoryType::DEFAULT;
 
    // Parameters for FD-based Gradient & Hessian calculation.
    bool fdflag;
@@ -1363,8 +1363,13 @@ public:
 
    ~TMOP_Integrator();
 
-   void ReleasePAMemory();
-   void SetTempMemoryType(MemoryType mt) { temp_mt = mt; }
+   /// Set the memory type of large PA allocations.
+   void SetPAMemoryType(MemoryType mt) { pa_mt = mt; }
+
+   /// Release the device memory of large PA allocations.
+   /// This will copy device memory back to the host before
+   /// releasing.
+   void ReleasePADeviceMemory();
 
    /// Prescribe a set of integration rules; relevant for mixed meshes.
    /** This function has priority over SetIntRule(), if both are called. */

--- a/fem/tmop.hpp
+++ b/fem/tmop.hpp
@@ -1366,9 +1366,8 @@ public:
    /// Set the memory type of large PA allocations.
    void SetPAMemoryType(MemoryType mt) { pa_mt = mt; }
 
-   /// Release the device memory of large PA allocations.
-   /// This will copy device memory back to the host before
-   /// releasing.
+   /// Release the device memory of large PA allocations. This will copy device
+   /// memory back to the host before releasing.
    void ReleasePADeviceMemory();
 
    /// Prescribe a set of integration rules; relevant for mixed meshes.

--- a/fem/tmop.hpp
+++ b/fem/tmop.hpp
@@ -1185,8 +1185,6 @@ protected:
 
    DiscreteAdaptTC *discr_tc;
 
-   MemoryType pa_mt = MemoryType::DEFAULT;
-
    // Parameters for FD-based Gradient & Hessian calculation.
    bool fdflag;
    double dx;
@@ -1362,9 +1360,6 @@ public:
    { PA.enabled = false; }
 
    ~TMOP_Integrator();
-
-   /// Set the memory type of large PA allocations.
-   void SetPAMemoryType(MemoryType mt) { pa_mt = mt; }
 
    /// Release the device memory of large PA allocations. This will copy device
    /// memory back to the host before releasing.

--- a/fem/tmop.hpp
+++ b/fem/tmop.hpp
@@ -804,6 +804,8 @@ public:
 
    virtual void ComputeAtNewPosition(const Vector &new_nodes,
                                      Vector &new_field) = 0;
+
+   void ClearGeometricFactors();
 };
 
 /** @brief Base class representing target-matrix construction algorithms for
@@ -1183,6 +1185,8 @@ protected:
 
    DiscreteAdaptTC *discr_tc;
 
+   MemoryType temp_mt = MemoryType::DEFAULT;
+
    // Parameters for FD-based Gradient & Hessian calculation.
    bool fdflag;
    double dx;
@@ -1358,6 +1362,9 @@ public:
    { PA.enabled = false; }
 
    ~TMOP_Integrator();
+
+   void ReleasePAMemory();
+   void SetTempMemoryType(MemoryType mt) { temp_mt = mt; }
 
    /// Prescribe a set of integration rules; relevant for mixed meshes.
    /** This function has priority over SetIntRule(), if both are called. */

--- a/fem/tmop/tmop_pa.cpp
+++ b/fem/tmop/tmop_pa.cpp
@@ -50,8 +50,8 @@ void TMOP_Integrator::AssembleGradPA(const Vector &xe,
 
 void TMOP_Integrator::AssemblePA_Limiting()
 {
-   const MemoryType mt = (temp_mt == MemoryType::DEFAULT) ?
-                         Device::GetDeviceMemoryType() : temp_mt;
+   const MemoryType mt = (pa_mt == MemoryType::DEFAULT) ?
+                         Device::GetDeviceMemoryType() : pa_mt;
    // Return immediately if limiting is not enabled
    if (coeff0 == nullptr) { return; }
    MFEM_VERIFY(nodes0, "internal error");
@@ -177,8 +177,8 @@ void TMOP_Integrator::ComputeAllElementTargets(const Vector &xe) const
 
 void TMOP_Integrator::AssemblePA(const FiniteElementSpace &fes)
 {
-   const MemoryType mt = (temp_mt == MemoryType::DEFAULT) ?
-                         Device::GetDeviceMemoryType() : temp_mt;
+   const MemoryType mt = (pa_mt == MemoryType::DEFAULT) ?
+                         Device::GetDeviceMemoryType() : pa_mt;
    PA.enabled = true;
    PA.fes = &fes;
    Mesh *mesh = fes.GetMesh();

--- a/fem/tmop/tmop_pa.cpp
+++ b/fem/tmop/tmop_pa.cpp
@@ -50,6 +50,8 @@ void TMOP_Integrator::AssembleGradPA(const Vector &xe,
 
 void TMOP_Integrator::AssemblePA_Limiting()
 {
+   const MemoryType mt = temp_mt == MemoryType::DEFAULT ?
+                         Device::GetDeviceMemoryType() : temp_mt;
    // Return immediately if limiting is not enabled
    if (coeff0 == nullptr) { return; }
    MFEM_VERIFY(nodes0, "internal error");
@@ -68,7 +70,7 @@ void TMOP_Integrator::AssemblePA_Limiting()
 
    // H0 for coeff0, (dim x dim) Q-vector
    PA.H0.UseDevice(true);
-   PA.H0.SetSize(PA.dim * PA.dim * PA.nq * NE, Device::GetDeviceMemoryType());
+   PA.H0.SetSize(PA.dim * PA.dim * PA.nq * NE, mt);
 
    // coeff0 -> PA.C0 (Q-vector)
    PA.C0.UseDevice(true);
@@ -175,6 +177,8 @@ void TMOP_Integrator::ComputeAllElementTargets(const Vector &xe) const
 
 void TMOP_Integrator::AssemblePA(const FiniteElementSpace &fes)
 {
+   const MemoryType mt = temp_mt == MemoryType::DEFAULT ?
+                         Device::GetDeviceMemoryType() : temp_mt;
    PA.enabled = true;
    PA.fes = &fes;
    Mesh *mesh = fes.GetMesh();
@@ -202,14 +206,14 @@ void TMOP_Integrator::AssemblePA(const FiniteElementSpace &fes)
 
    // H for Grad, (dim x dim) Q-vector
    PA.H.UseDevice(true);
-   PA.H.SetSize(dim*dim * dim*dim * nq*ne, Device::GetDeviceMemoryType());
+   PA.H.SetSize(dim*dim * dim*dim * nq*ne, mt);
 
    // Scalar Q-vector of '1', used to compute sums via dot product
    PA.O.SetSize(ne*nq, Device::GetDeviceMemoryType());
    PA.O = 1.0;
 
    // Setup ref->target Jacobians, PA.Jtr, (dim x dim) Q-vector, DenseTensor
-   PA.Jtr.SetSize(dim, dim, PA.ne*PA.nq);
+   PA.Jtr.SetSize(dim, dim, PA.ne*PA.nq, mt);
    PA.Jtr_needs_update = true;
    PA.Jtr_debug_grad = false;
 

--- a/fem/tmop/tmop_pa.cpp
+++ b/fem/tmop/tmop_pa.cpp
@@ -50,7 +50,7 @@ void TMOP_Integrator::AssembleGradPA(const Vector &xe,
 
 void TMOP_Integrator::AssemblePA_Limiting()
 {
-   const MemoryType mt = temp_mt == MemoryType::DEFAULT ?
+   const MemoryType mt = (temp_mt == MemoryType::DEFAULT) ?
                          Device::GetDeviceMemoryType() : temp_mt;
    // Return immediately if limiting is not enabled
    if (coeff0 == nullptr) { return; }
@@ -177,7 +177,7 @@ void TMOP_Integrator::ComputeAllElementTargets(const Vector &xe) const
 
 void TMOP_Integrator::AssemblePA(const FiniteElementSpace &fes)
 {
-   const MemoryType mt = temp_mt == MemoryType::DEFAULT ?
+   const MemoryType mt = (temp_mt == MemoryType::DEFAULT) ?
                          Device::GetDeviceMemoryType() : temp_mt;
    PA.enabled = true;
    PA.fes = &fes;

--- a/fem/tmop_tools.cpp
+++ b/fem/tmop_tools.cpp
@@ -232,7 +232,7 @@ ParAdvectorCGOper::ParAdvectorCGOper(const Vector &x_start,
                                      GridFunction &vel,
                                      ParFiniteElementSpace &pfes,
                                      AssemblyLevel al,
-                                     MemoryType temp_mt)
+                                     MemoryType mt)
    : TimeDependentOperator(pfes.GetVSize()),
      x0(x_start), x_now(*pfes.GetMesh()->GetNodes()),
      u(vel), u_coeff(&u), M(&pfes), K(&pfes), al(al)
@@ -240,7 +240,7 @@ ParAdvectorCGOper::ParAdvectorCGOper(const Vector &x_start,
    ConvectionIntegrator *Kinteg = new ConvectionIntegrator(u_coeff);
    if (al == AssemblyLevel::PARTIAL)
    {
-      Kinteg->SetPAMemoryType(temp_mt);
+      Kinteg->SetPAMemoryType(mt);
    }
    K.AddDomainIntegrator(Kinteg);
    K.SetAssemblyLevel(al);
@@ -250,7 +250,7 @@ ParAdvectorCGOper::ParAdvectorCGOper(const Vector &x_start,
    MassIntegrator *Minteg = new MassIntegrator;
    if (al == AssemblyLevel::PARTIAL)
    {
-      Minteg->SetPAMemoryType(temp_mt);
+      Minteg->SetPAMemoryType(mt);
    }
    M.AddDomainIntegrator(Minteg);
    M.SetAssemblyLevel(al);
@@ -384,7 +384,7 @@ double TMOPNewtonSolver::ComputeScalingFactor(const Vector &x,
 
    // Get the local prolongation of the solution vector.
    Vector x_out_loc(fes->GetVSize(),
-                    temp_mt == MemoryType::DEFAULT ? Device::GetDeviceMemoryType() : temp_mt);
+                    (temp_mt == MemoryType::DEFAULT) ? Device::GetDeviceMemoryType() : temp_mt);
    if (serial)
    {
       const SparseMatrix *cP = fes->GetConformingProlongation();

--- a/fem/tmop_tools.cpp
+++ b/fem/tmop_tools.cpp
@@ -78,7 +78,7 @@ void AdvectorCG::ComputeAtNewPositionScalar(const Vector &new_nodes,
    else if (pfes)
    {
       pfess = new ParFiniteElementSpace(pfes->GetParMesh(), pfes->FEColl(), 1);
-      oper  = new ParAdvectorCGOper(nodes0, u, *pfess, al, temp_mt);
+      oper  = new ParAdvectorCGOper(nodes0, u, *pfess, al, opt_mt);
    }
 #endif
    MFEM_VERIFY(oper != NULL,
@@ -238,14 +238,20 @@ ParAdvectorCGOper::ParAdvectorCGOper(const Vector &x_start,
      u(vel), u_coeff(&u), M(&pfes), K(&pfes), al(al)
 {
    ConvectionIntegrator *Kinteg = new ConvectionIntegrator(u_coeff);
-   Kinteg->SetTempMemoryType(temp_mt);
+   if (al == AssemblyLevel::PARTIAL)
+   {
+      Kinteg->SetPAMemoryType(temp_mt);
+   }
    K.AddDomainIntegrator(Kinteg);
    K.SetAssemblyLevel(al);
    K.Assemble(0);
    K.Finalize(0);
 
    MassIntegrator *Minteg = new MassIntegrator;
-   Minteg->SetTempMemoryType(temp_mt);
+   if (al == AssemblyLevel::PARTIAL)
+   {
+      Minteg->SetPAMemoryType(temp_mt);
+   }
    M.AddDomainIntegrator(Minteg);
    M.SetAssemblyLevel(al);
    M.Assemble(0);

--- a/fem/tmop_tools.hpp
+++ b/fem/tmop_tools.hpp
@@ -29,6 +29,7 @@ private:
    Vector field0;
    const double dt_scale;
    const AssemblyLevel al;
+   MemoryType temp_mt = MemoryType::DEFAULT;
 
    void ComputeAtNewPositionScalar(const Vector &new_nodes, Vector &new_field);
 public:
@@ -42,6 +43,8 @@ public:
 
    virtual void ComputeAtNewPosition(const Vector &new_nodes,
                                      Vector &new_field);
+
+   void SetTempMemoryType(MemoryType mt) { temp_mt = mt; }
 };
 
 #ifdef MFEM_USE_GSLIB
@@ -107,7 +110,8 @@ public:
        that Mult() moves the nodes of the mesh corresponding to @a pfes. */
    ParAdvectorCGOper(const Vector &x_start, GridFunction &vel,
                      ParFiniteElementSpace &pfes,
-                     AssemblyLevel al = AssemblyLevel::LEGACY);
+                     AssemblyLevel al = AssemblyLevel::LEGACY,
+                     MemoryType mt = MemoryType::DEFAULT);
 
    virtual void Mult(const Vector &ind, Vector &di_dt) const;
 };
@@ -128,6 +132,8 @@ protected:
    // These fields are relevant for mixed meshes.
    IntegrationRules *IntegRules;
    int integ_order;
+
+   MemoryType temp_mt = MemoryType::DEFAULT;
 
    const IntegrationRule &GetIntegrationRule(const FiniteElement &el) const
    {
@@ -166,6 +172,8 @@ public:
    }
 
    void SetMinDetPtr(double *md_ptr) { min_det_ptr = md_ptr; }
+
+   void SetTempMemoryType(MemoryType mt) { temp_mt = mt; }
 
    virtual double ComputeScalingFactor(const Vector &x, const Vector &b) const;
 

--- a/fem/tmop_tools.hpp
+++ b/fem/tmop_tools.hpp
@@ -29,7 +29,7 @@ private:
    Vector field0;
    const double dt_scale;
    const AssemblyLevel al;
-   MemoryType temp_mt = MemoryType::DEFAULT;
+   MemoryType opt_mt = MemoryType::DEFAULT;
 
    void ComputeAtNewPositionScalar(const Vector &new_nodes, Vector &new_field);
 public:
@@ -44,7 +44,10 @@ public:
    virtual void ComputeAtNewPosition(const Vector &new_nodes,
                                      Vector &new_field);
 
-   void SetTempMemoryType(MemoryType mt) { temp_mt = mt; }
+   /// Set the memory type used for large memory allocations. This memory type
+   /// is used when constructing the AdvectorCGOper but currently only for the
+   /// parallel variant.
+   void SetMemoryType(MemoryType mt) { opt_mt = mt; }
 };
 
 #ifdef MFEM_USE_GSLIB
@@ -107,7 +110,8 @@ protected:
 
 public:
    /** Here @a pfes is the ParFESpace of the function that will be moved. Note
-       that Mult() moves the nodes of the mesh corresponding to @a pfes. */
+       that Mult() moves the nodes of the mesh corresponding to @a pfes.
+       @a mt is used to set the memory type of the integrators. */
    ParAdvectorCGOper(const Vector &x_start, GridFunction &vel,
                      ParFiniteElementSpace &pfes,
                      AssemblyLevel al = AssemblyLevel::LEGACY,
@@ -173,6 +177,7 @@ public:
 
    void SetMinDetPtr(double *md_ptr) { min_det_ptr = md_ptr; }
 
+   // Set the memory type for temporary memory allocations.
    void SetTempMemoryType(MemoryType mt) { temp_mt = mt; }
 
    virtual double ComputeScalingFactor(const Vector &x, const Vector &b) const;


### PR DESCRIPTION
Add `SetTempMemoryType` methods to make it easier to use a custom memory type for large allocations in TMOP, specifically with PA. These changes should be no-ops unless they are explicitly used.

Note: not all allocations are setup to use the temporary memory type because I just went after the largest ones for now (based on results from recording `cudaMallocs`).
<!--GHEX{"id":2284,"author":"tomstitt","editor":"tzanio","reviewers":["artv3","camierjs","v-dobrev","vladotomov"],"assignment":"2021-06-02T08:08:32-07:00","approval":"2021-06-04T19:30:08.668Z","merge":"2021-06-15T21:40:41.971Z"}XEHG--><!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge| 
 | --- | --- | --- | --- | --- | --- | --- | 
| [#2284](https://github.com/mfem/mfem/pull/2284) | @tomstitt | @tzanio | @artv3 + @camierjs + @v-dobrev + @vladotomov | 06/02/21 | 06/04/21 | 06/15/21 | |
<!--ELBATXEHG-->