### PR TITLE
Implement HyprePCG::SetAbsTol

### DIFF
--- a/linalg/hypre.cpp
+++ b/linalg/hypre.cpp
@@ -2864,7 +2864,7 @@ void HyprePCG::SetTol(double tol)
 
 void HyprePCG::SetAbsTol(double atol)
 {
-  HYPRE_PCGSetAbsoluteTol(pcg_solver, atol);
+   HYPRE_PCGSetAbsoluteTol(pcg_solver, atol);
 }
 
 void HyprePCG::SetMaxIter(int max_iter)

--- a/linalg/hypre.cpp
+++ b/linalg/hypre.cpp
@@ -2862,6 +2862,11 @@ void HyprePCG::SetTol(double tol)
    HYPRE_PCGSetTol(pcg_solver, tol);
 }
 
+void HyprePCG::SetAbsTol(double atol)
+{
+  HYPRE_PCGSetAbsoluteTol(pcg_solver, atol);
+}
+
 void HyprePCG::SetMaxIter(int max_iter)
 {
    HYPRE_PCGSetMaxIter(pcg_solver, max_iter);

--- a/linalg/hypre.hpp
+++ b/linalg/hypre.hpp
@@ -887,6 +887,7 @@ public:
    virtual void SetOperator(const Operator &op);
 
    void SetTol(double tol);
+   void SetAbsTol(double atol);
    void SetMaxIter(int max_iter);
    void SetLogging(int logging);
    void SetPrintLevel(int print_lvl);


### PR DESCRIPTION
For consistency with other solver classes, this implements a `HyprePCG::SetAbsTol` function. It is simply a wrapper to `HYPRE_PCGSetAbsoluteTol()`.

Mostly, I've used this in comparing different solvers when I want to make sure I'm running with the same tolerances for all solvers.
<!--GHEX{"id":2285,"author":"wcdawn","editor":"tzanio","reviewers":["tzanio","mlstowell"],"assignment":"2021-06-02T10:53:09-07:00","approval":"2021-06-04T18:09:24.153Z","merge":"2021-06-07T02:45:17.174Z"}XEHG--><!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge| 
 | --- | --- | --- | --- | --- | --- | --- | 
| [#2285](https://github.com/mfem/mfem/pull/2285) | @wcdawn | @tzanio | @tzanio + @mlstowell | 06/02/21 | 06/04/21 | 06/06/21 | |
<!--ELBATXEHG-->