### PR TITLE
Example 20 broken

### DIFF
--- a/examples/ex20.cpp
+++ b/examples/ex20.cpp
@@ -231,6 +231,7 @@ int main(int argc, char *argv[])
    // 9. Finalize the GLVis output
    if (visualization)
    {
+      mesh.FinalizeQuadMesh(1);
       H1_FECollection fec(order = 1, 2);
       FiniteElementSpace fespace(&mesh, &fec);
       GridFunction energy(&fespace);

--- a/examples/ex20p.cpp
+++ b/examples/ex20p.cpp
@@ -168,7 +168,7 @@ int main(int argc, char *argv[])
    }
 
    // 6. Create a Mesh for visualization in phase space
-   int nverts = (visualization) ? (num_procs+1)*(nsteps+1) : 0;
+   int nverts = (visualization) ? 2*num_procs*(nsteps+1) : 0;
    int nelems = (visualization) ? (nsteps * num_procs) : 0;
    Mesh mesh(2, nverts, nelems, 0, 3);
 
@@ -190,9 +190,9 @@ int main(int argc, char *argv[])
 
          if (visualization)
          {
-            mesh.AddVertex(x0);
             for (int j = 0; j < num_procs; j++)
             {
+               mesh.AddVertex(x0);
                x1[0] = q(0);
                x1[1] = p(0);
                x1[2] = 0.0;
@@ -216,17 +216,17 @@ int main(int argc, char *argv[])
       if (visualization)
       {
          x0[2] = t;
-         mesh.AddVertex(x0);
          for (int j = 0; j < num_procs; j++)
          {
+            mesh.AddVertex(x0);
             x1[0] = q(0);
             x1[1] = p(0);
             x1[2] = t;
             mesh.AddVertex(x1);
-            v[0] = (num_procs + 1) * i;
-            v[1] = (num_procs + 1) * (i + 1);
-            v[2] = (num_procs + 1) * (i + 1) + j + 1;
-            v[3] = (num_procs + 1) * i + j + 1;
+            v[0] = 2 * num_procs * i + 2 * j;
+            v[1] = 2 * num_procs * (i + 1) + 2 * j;
+            v[2] = 2 * num_procs * (i + 1) + 2 * j + 1;
+            v[3] = 2 * num_procs * i + 2 * j + 1;
             mesh.AddQuad(v);
             part[num_procs * i + j] = j;
          }


### PR DESCRIPTION
I'm randomly using ex20(p) to compile and run mfem codes, and noticed that it breaks with the current master branch due to meshing issues. Not really my area of expertise but apparently my addition in the serial version did the trick. Maybe someone can take a look at the parallel one?
<!--GHEX{"id":2288,"author":"HennesHajduk","editor":"tzanio","reviewers":["tzanio","mlstowell"],"assignment":"2021-06-04T11:30:58-07:00","approval":"2021-06-04T21:04:12.921Z","merge":"2021-06-07T02:43:57.104Z"}XEHG--><!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge| 
 | --- | --- | --- | --- | --- | --- | --- | 
| [#2288](https://github.com/mfem/mfem/pull/2288) | @HennesHajduk | @tzanio | @tzanio + @mlstowell | 06/04/21 | 06/04/21 | 06/06/21 | |
<!--ELBATXEHG-->