### PR TITLE
Fix `make test` in examples/hiop

### DIFF
--- a/examples/hiop/ex9.cpp
+++ b/examples/hiop/ex9.cpp
@@ -216,7 +216,7 @@ int main(int argc, char *argv[])
 {
    // 1. Parse command-line options.
    problem = 0;
-   optimizer_type = 1;
+   optimizer_type = 2;
    const char *mesh_file = "../../data/periodic-hexagon.mesh";
    int ref_levels = 2;
    int order = 3;

--- a/examples/hiop/ex9p.cpp
+++ b/examples/hiop/ex9p.cpp
@@ -247,7 +247,7 @@ int main(int argc, char *argv[])
 
    // 2. Parse command-line options.
    problem = 0;
-   optimizer_type = 1;
+   optimizer_type = 2;
    const char *mesh_file = "../../data/periodic-hexagon.mesh";
    int ser_ref_levels = 2;
    int par_ref_levels = 0;

--- a/examples/hiop/makefile
+++ b/examples/hiop/makefile
@@ -50,6 +50,13 @@ endif
 MFEM_TESTS = EXAMPLES
 include $(MFEM_TEST_MK)
 
+# Testing: Parallel vs. serial runs
+RUN_MPI = $(MFEM_MPIEXEC) $(MFEM_MPIEXEC_NP) $(MFEM_MPI_NP)
+%-test-par: %
+	@$(call mfem-test,$<, $(RUN_MPI), Parallel example)
+%-test-seq: %
+	@$(call mfem-test,$<,, Serial example)
+
 # Testing: "test" target and mfem-test* variables are defined in config/test.mk
 
 # Generate an error message if the MFEM library is not built and exit


### PR DESCRIPTION
Fix `make test` in examples/hiop
<!--GHEX{"id":2290,"author":"vladotomov","editor":"tzanio","reviewers":["tzanio","kmittal2"],"assignment":"2021-06-02T22:18:38-07:00","approval":"2021-06-03T22:44:18.349Z","merge":"2021-06-04T15:06:52.013Z"}XEHG--><!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge| 
 | --- | --- | --- | --- | --- | --- | --- | 
| [#2290](https://github.com/mfem/mfem/pull/2290) | @vladotomov | @tzanio | @tzanio + @kmittal2 | 06/02/21 | 06/03/21 | 06/04/21 | |
<!--ELBATXEHG-->