### PR TITLE
Adding more sample runs to ex20 and ex20p [ex20-sample-runs-dev]

### DIFF
--- a/examples/ex20.cpp
+++ b/examples/ex20.cpp
@@ -3,6 +3,10 @@
 // Compile with: make ex20
 //
 // Sample runs:  ex20
+//               ex20 -p 1 -o 1 -n 120 -dt 0.1
+//               ex20 -p 1 -o 2 -n 60 -dt 0.2
+//               ex20 -p 1 -o 3 -n 40 -dt 0.3
+//               ex20 -p 1 -o 4 -n 30 -dt 0.4
 //
 // Description: This example demonstrates the use of the variable order,
 //              symplectic ODE integration algorithm.  Symplectic integration

--- a/examples/ex20p.cpp
+++ b/examples/ex20p.cpp
@@ -3,6 +3,10 @@
 // Compile with: make ex20p
 //
 // Sample runs:  mpirun -np 4 ex20p
+//               mpirun -np 4 ex20p -p 1 -o 1 -n 120 -dt 0.1
+//               mpirun -np 4 ex20p -p 1 -o 2 -n 60 -dt 0.2
+//               mpirun -np 4 ex20p -p 1 -o 3 -n 40 -dt 0.3
+//               mpirun -np 4 ex20p -p 1 -o 4 -n 30 -dt 0.4
 //
 // Description: This example demonstrates the use of the variable order,
 //              symplectic ODE integration algorithm.  Symplectic integration


### PR DESCRIPTION
These new sample runs were chosen to demonstrate the drop in energy fluctuations when higher order symplectic methods are used.

Interestingly the 4th order method does not perform better than the 3rd order method for most of the sample Hamiltonians in the range of time steps that I tested. It does show good convergence on its own so choosing a smaller time step may produce better results but I didn't want the sample runs to take too long.

This PR depends on PR #2288 which should be merged first
<!--GHEX{"id":2293,"author":"mlstowell","editor":"tzanio","reviewers":["tzanio","cjvogl"],"assignment":"2021-06-07T09:46:08-07:00","approval":"2021-06-08T21:55:37.827Z","merge":"2021-06-09T22:22:39.242Z"}XEHG--><!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge| 
 | --- | --- | --- | --- | --- | --- | --- | 
| [#2293](https://github.com/mfem/mfem/pull/2293) | @mlstowell | @tzanio | @tzanio + @cjvogl | 06/07/21 | 06/08/21 | 06/09/21 | |
<!--ELBATXEHG-->