### PR TITLE
Apply repo-check only on branch, not PR

### DIFF
--- a/.github/workflows/repo-check.yml
+++ b/.github/workflows/repo-check.yml
@@ -16,7 +16,6 @@ permissions:
 
 on:
   push:
-  pull_request:
 
 jobs:
   file-headers-check:


### PR DESCRIPTION
Following #2282 

Per @v-dobrev comment (https://github.com/mfem/mfem/pull/2282#issuecomment-855158719)
The repo-check where running twice, which was sort of expected.

In fact, the difference between a `push` check and a `PR` check is that the former will run on the current state of the branch, while the latter will run on the merge result with the target branch. (Of course `push` test will run even if no branch was created, which was the point of #2282).

In this PR, I remove the run on the PR because repo check does not have to run on the merge result, so the `push` test should be enough. 
<!--GHEX{"id":2300,"author":"adrienbernede","editor":"tzanio","reviewers":["tzanio","v-dobrev"],"assignment":"2021-06-07T17:59:23-07:00","approval":"2021-06-08T14:52:42.599Z","merge":"2021-06-08T14:55:27.516Z"}XEHG--><!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge| 
 | --- | --- | --- | --- | --- | --- | --- | 
| [#2300](https://github.com/mfem/mfem/pull/2300) | @adrienbernede | @tzanio | @tzanio + @v-dobrev | 06/07/21 | 06/08/21 | 06/08/21 | |
<!--ELBATXEHG-->