### PR TITLE
Replace template ND values by 1D values.

### DIFF
--- a/fem/quadinterpolator_face.cpp
+++ b/fem/quadinterpolator_face.cpp
@@ -384,22 +384,22 @@ void FaceQuadratureInterpolator::Mult(
          {
             // Q0
             case 101: eval_func = &Eval2D<1,1,1>; break;
-            case 104: eval_func = &Eval2D<1,1,4>; break;
+            case 102: eval_func = &Eval2D<1,1,2>; break;
             // Q1
-            case 404: eval_func = &Eval2D<1,4,4>; break;
-            case 409: eval_func = &Eval2D<1,4,9>; break;
+            case 202: eval_func = &Eval2D<1,2,2>; break;
+            case 203: eval_func = &Eval2D<1,2,3>; break;
             // Q2
-            case 909: eval_func = &Eval2D<1,9,9>; break;
-            case 916: eval_func = &Eval2D<1,9,16>; break;
+            case 303: eval_func = &Eval2D<1,3,3>; break;
+            case 304: eval_func = &Eval2D<1,3,4>; break;
             // Q3
-            case 1616: eval_func = &Eval2D<1,16,16>; break;
-            case 1625: eval_func = &Eval2D<1,16,25>; break;
-            case 1636: eval_func = &Eval2D<1,16,36>; break;
+            case 404: eval_func = &Eval2D<1,4,4>; break;
+            case 405: eval_func = &Eval2D<1,4,5>; break;
+            case 406: eval_func = &Eval2D<1,4,6>; break;
             // Q4
-            case 2525: eval_func = &Eval2D<1,25,25>; break;
-            case 2536: eval_func = &Eval2D<1,25,36>; break;
-            case 2549: eval_func = &Eval2D<1,25,49>; break;
-            case 2564: eval_func = &Eval2D<1,25,64>; break;
+            case 505: eval_func = &Eval2D<1,5,5>; break;
+            case 506: eval_func = &Eval2D<1,5,6>; break;
+            case 507: eval_func = &Eval2D<1,5,7>; break;
+            case 508: eval_func = &Eval2D<1,5,8>; break;
          }
          if (nq >= 100 || !eval_func)
          {
@@ -412,20 +412,20 @@ void FaceQuadratureInterpolator::Mult(
          {
             // Q0
             case 1001: eval_func = &Eval3D<1,1,1>; break;
-            case 1008: eval_func = &Eval3D<1,1,8>; break;
+            case 1002: eval_func = &Eval3D<1,1,2>; break;
             // Q1
-            case 8008: eval_func = &Eval3D<1,8,8>; break;
-            case 8027: eval_func = &Eval3D<1,8,27>; break;
+            case 2002: eval_func = &Eval3D<1,2,2>; break;
+            case 2003: eval_func = &Eval3D<1,2,3>; break;
             // Q2
-            case 27027: eval_func = &Eval3D<1,27,27>; break;
-            case 27064: eval_func = &Eval3D<1,27,64>; break;
+            case 3003: eval_func = &Eval3D<1,3,3>; break;
+            case 3004: eval_func = &Eval3D<1,3,4>; break;
             // Q3
-            case 64064: eval_func = &Eval3D<1,64,64>; break;
-            case 64125: eval_func = &Eval3D<1,64,125>; break;
-            case 64216: eval_func = &Eval3D<1,64,216>; break;
+            case 4004: eval_func = &Eval3D<1,4,4>; break;
+            case 4005: eval_func = &Eval3D<1,4,5>; break;
+            case 4006: eval_func = &Eval3D<1,4,6>; break;
             // Q4
-            case 125125: eval_func = &Eval3D<1,125,125>; break;
-            case 125216: eval_func = &Eval3D<1,125,216>; break;
+            case 5005: eval_func = &Eval3D<1,5,5>; break;
+            case 5006: eval_func = &Eval3D<1,5,6>; break;
          }
          if (nq >= 1000 || !eval_func)
          {
@@ -440,20 +440,20 @@ void FaceQuadratureInterpolator::Mult(
          switch (100*nd + nq)
          {
             // Q1
-            case 404: eval_func = &Eval2D<2,4,4>; break;
-            case 409: eval_func = &Eval2D<2,4,9>; break;
+            case 202: eval_func = &Eval2D<2,2,2>; break;
+            case 203: eval_func = &Eval2D<2,2,3>; break;
             // Q2
-            case 909: eval_func = &Eval2D<2,9,9>; break;
-            case 916: eval_func = &Eval2D<2,9,16>; break;
+            case 303: eval_func = &Eval2D<2,3,3>; break;
+            case 304: eval_func = &Eval2D<2,3,4>; break;
             // Q3
-            case 1616: eval_func = &Eval2D<2,16,16>; break;
-            case 1625: eval_func = &Eval2D<2,16,25>; break;
-            case 1636: eval_func = &Eval2D<2,16,36>; break;
+            case 404: eval_func = &Eval2D<2,4,4>; break;
+            case 405: eval_func = &Eval2D<2,4,5>; break;
+            case 406: eval_func = &Eval2D<2,4,6>; break;
             // Q4
-            case 2525: eval_func = &Eval2D<2,25,25>; break;
-            case 2536: eval_func = &Eval2D<2,25,36>; break;
-            case 2549: eval_func = &Eval2D<2,25,49>; break;
-            case 2564: eval_func = &Eval2D<2,25,64>; break;
+            case 505: eval_func = &Eval2D<2,5,5>; break;
+            case 506: eval_func = &Eval2D<2,5,6>; break;
+            case 507: eval_func = &Eval2D<2,5,7>; break;
+            case 508: eval_func = &Eval2D<2,5,8>; break;
          }
          if (nq >= 100 || !eval_func)
          {
@@ -465,18 +465,18 @@ void FaceQuadratureInterpolator::Mult(
          switch (1000*nd + nq)
          {
             // Q1
-            case 8008: eval_func = &Eval3D<3,8,8>; break;
-            case 8027: eval_func = &Eval3D<3,8,27>; break;
+            case 2002: eval_func = &Eval3D<3,2,2>; break;
+            case 2003: eval_func = &Eval3D<3,2,3>; break;
             // Q2
-            case 27027: eval_func = &Eval3D<3,27,27>; break;
-            case 27064: eval_func = &Eval3D<3,27,64>; break;
+            case 3003: eval_func = &Eval3D<3,3,3>; break;
+            case 3004: eval_func = &Eval3D<3,3,4>; break;
             // Q3
-            case 64064: eval_func = &Eval3D<3,64,64>; break;
-            case 64125: eval_func = &Eval3D<3,64,125>; break;
-            case 64216: eval_func = &Eval3D<3,64,216>; break;
+            case 4004: eval_func = &Eval3D<3,4,4>; break;
+            case 4005: eval_func = &Eval3D<3,4,5>; break;
+            case 4006: eval_func = &Eval3D<3,4,6>; break;
             // Q4
-            case 125125: eval_func = &Eval3D<3,125,125>; break;
-            case 125216: eval_func = &Eval3D<3,125,216>; break;
+            case 5005: eval_func = &Eval3D<3,5,5>; break;
+            case 5006: eval_func = &Eval3D<3,5,6>; break;
          }
          if (nq >= 1000 || !eval_func)
          {

--- a/fem/quadinterpolator_face.cpp
+++ b/fem/quadinterpolator_face.cpp
@@ -98,10 +98,10 @@ void FaceQuadratureInterpolator::Eval2D(
    Vector &q_nor,
    const int eval_flags)
 {
-   const int nd = maps.ndof;
-   const int nq = maps.nqpt;
-   const int ND1D = T_ND1D ? T_ND1D : nd;
-   const int NQ1D = T_NQ1D ? T_NQ1D : nq;
+   const int nd1d = maps.ndof;
+   const int nq1d = maps.nqpt;
+   const int ND1D = T_ND1D ? T_ND1D : nd1d;
+   const int NQ1D = T_NQ1D ? T_NQ1D : nq1d;
    const int VDIM = T_VDIM ? T_VDIM : vdim;
    MFEM_VERIFY(ND1D <= MAX_ND1D, "");
    MFEM_VERIFY(NQ1D <= MAX_NQ1D, "");
@@ -119,8 +119,8 @@ void FaceQuadratureInterpolator::Eval2D(
    // If Gauss-Lobatto
    MFEM_FORALL(f, NF,
    {
-      const int ND1D = T_ND1D ? T_ND1D : nd;
-      const int NQ1D = T_NQ1D ? T_NQ1D : nq;
+      const int ND1D = T_ND1D ? T_ND1D : nd1d;
+      const int NQ1D = T_NQ1D ? T_NQ1D : nq1d;
       const int VDIM = T_VDIM ? T_VDIM : vdim;
       constexpr int max_ND1D = T_ND1D ? T_ND1D : MAX_ND1D;
       constexpr int max_VDIM = T_VDIM ? T_VDIM : MAX_VDIM2D;
@@ -194,10 +194,10 @@ void FaceQuadratureInterpolator::Eval3D(
    Vector &q_nor,
    const int eval_flags)
 {
-   const int nd = maps.ndof;
-   const int nq = maps.nqpt;
-   const int ND1D = T_ND1D ? T_ND1D : nd;
-   const int NQ1D = T_NQ1D ? T_NQ1D : nq;
+   const int nd1d = maps.ndof;
+   const int nq1d = maps.nqpt;
+   const int ND1D = T_ND1D ? T_ND1D : nd1d;
+   const int NQ1D = T_NQ1D ? T_NQ1D : nq1d;
    const int VDIM = T_VDIM ? T_VDIM : vdim;
    MFEM_VERIFY(ND1D <= MAX_ND1D, "");
    MFEM_VERIFY(NQ1D <= MAX_NQ1D, "");
@@ -214,8 +214,8 @@ void FaceQuadratureInterpolator::Eval3D(
                "Derivatives on the faces are not yet supported.");
    MFEM_FORALL(f, NF,
    {
-      const int ND1D = T_ND1D ? T_ND1D : nd;
-      const int NQ1D = T_NQ1D ? T_NQ1D : nq;
+      const int ND1D = T_ND1D ? T_ND1D : nd1d;
+      const int NQ1D = T_NQ1D ? T_NQ1D : nq1d;
       const int VDIM = T_VDIM ? T_VDIM : vdim;
       constexpr int max_ND1D = T_ND1D ? T_ND1D : MAX_ND1D;
       constexpr int max_NQ1D = T_NQ1D ? T_NQ1D : MAX_NQ1D;
@@ -363,8 +363,8 @@ void FaceQuadratureInterpolator::Mult(
       fespace->GetTraceElement(0, fespace->GetMesh()->GetFaceBaseGeometry(0));
    const IntegrationRule *ir = IntRule;
    const DofToQuad &maps = fe->GetDofToQuad(*ir, DofToQuad::TENSOR);
-   const int nd = maps.ndof;
-   const int nq = maps.nqpt;
+   const int nd1d = maps.ndof;
+   const int nq1d = maps.nqpt;
    void (*eval_func)(
       const int NF,
       const int vdim,
@@ -380,54 +380,54 @@ void FaceQuadratureInterpolator::Mult(
    {
       if (dim == 2)
       {
-         switch (100*nd + nq)
+         switch (10*nd1d + nq1d)
          {
             // Q0
-            case 101: eval_func = &Eval2D<1,1,1>; break;
-            case 102: eval_func = &Eval2D<1,1,2>; break;
+            case 11: eval_func = &Eval2D<1,1,1>; break;
+            case 12: eval_func = &Eval2D<1,1,2>; break;
             // Q1
-            case 202: eval_func = &Eval2D<1,2,2>; break;
-            case 203: eval_func = &Eval2D<1,2,3>; break;
+            case 22: eval_func = &Eval2D<1,2,2>; break;
+            case 23: eval_func = &Eval2D<1,2,3>; break;
             // Q2
-            case 303: eval_func = &Eval2D<1,3,3>; break;
-            case 304: eval_func = &Eval2D<1,3,4>; break;
+            case 33: eval_func = &Eval2D<1,3,3>; break;
+            case 34: eval_func = &Eval2D<1,3,4>; break;
             // Q3
-            case 404: eval_func = &Eval2D<1,4,4>; break;
-            case 405: eval_func = &Eval2D<1,4,5>; break;
-            case 406: eval_func = &Eval2D<1,4,6>; break;
+            case 44: eval_func = &Eval2D<1,4,4>; break;
+            case 45: eval_func = &Eval2D<1,4,5>; break;
+            case 46: eval_func = &Eval2D<1,4,6>; break;
             // Q4
-            case 505: eval_func = &Eval2D<1,5,5>; break;
-            case 506: eval_func = &Eval2D<1,5,6>; break;
-            case 507: eval_func = &Eval2D<1,5,7>; break;
-            case 508: eval_func = &Eval2D<1,5,8>; break;
+            case 55: eval_func = &Eval2D<1,5,5>; break;
+            case 56: eval_func = &Eval2D<1,5,6>; break;
+            case 57: eval_func = &Eval2D<1,5,7>; break;
+            case 58: eval_func = &Eval2D<1,5,8>; break;
          }
-         if (nq >= 100 || !eval_func)
+         if (nq1d >= 10 || !eval_func)
          {
             eval_func = &Eval2D<1>;
          }
       }
       else if (dim == 3)
       {
-         switch (1000*nd + nq)
+         switch (10*nd1d + nq1d)
          {
             // Q0
-            case 1001: eval_func = &Eval3D<1,1,1>; break;
-            case 1002: eval_func = &Eval3D<1,1,2>; break;
+            case 11: eval_func = &Eval3D<1,1,1>; break;
+            case 12: eval_func = &Eval3D<1,1,2>; break;
             // Q1
-            case 2002: eval_func = &Eval3D<1,2,2>; break;
-            case 2003: eval_func = &Eval3D<1,2,3>; break;
+            case 22: eval_func = &Eval3D<1,2,2>; break;
+            case 23: eval_func = &Eval3D<1,2,3>; break;
             // Q2
-            case 3003: eval_func = &Eval3D<1,3,3>; break;
-            case 3004: eval_func = &Eval3D<1,3,4>; break;
+            case 33: eval_func = &Eval3D<1,3,3>; break;
+            case 34: eval_func = &Eval3D<1,3,4>; break;
             // Q3
-            case 4004: eval_func = &Eval3D<1,4,4>; break;
-            case 4005: eval_func = &Eval3D<1,4,5>; break;
-            case 4006: eval_func = &Eval3D<1,4,6>; break;
+            case 44: eval_func = &Eval3D<1,4,4>; break;
+            case 45: eval_func = &Eval3D<1,4,5>; break;
+            case 46: eval_func = &Eval3D<1,4,6>; break;
             // Q4
-            case 5005: eval_func = &Eval3D<1,5,5>; break;
-            case 5006: eval_func = &Eval3D<1,5,6>; break;
+            case 55: eval_func = &Eval3D<1,5,5>; break;
+            case 56: eval_func = &Eval3D<1,5,6>; break;
          }
-         if (nq >= 1000 || !eval_func)
+         if (nq1d >= 10 || !eval_func)
          {
             eval_func = &Eval3D<1>;
          }
@@ -437,48 +437,48 @@ void FaceQuadratureInterpolator::Mult(
    {
       if (dim == 2)
       {
-         switch (100*nd + nq)
+         switch (10*nd1d + nq1d)
          {
             // Q1
-            case 202: eval_func = &Eval2D<2,2,2>; break;
-            case 203: eval_func = &Eval2D<2,2,3>; break;
+            case 22: eval_func = &Eval2D<2,2,2>; break;
+            case 23: eval_func = &Eval2D<2,2,3>; break;
             // Q2
-            case 303: eval_func = &Eval2D<2,3,3>; break;
-            case 304: eval_func = &Eval2D<2,3,4>; break;
+            case 33: eval_func = &Eval2D<2,3,3>; break;
+            case 34: eval_func = &Eval2D<2,3,4>; break;
             // Q3
-            case 404: eval_func = &Eval2D<2,4,4>; break;
-            case 405: eval_func = &Eval2D<2,4,5>; break;
-            case 406: eval_func = &Eval2D<2,4,6>; break;
+            case 44: eval_func = &Eval2D<2,4,4>; break;
+            case 45: eval_func = &Eval2D<2,4,5>; break;
+            case 46: eval_func = &Eval2D<2,4,6>; break;
             // Q4
-            case 505: eval_func = &Eval2D<2,5,5>; break;
-            case 506: eval_func = &Eval2D<2,5,6>; break;
-            case 507: eval_func = &Eval2D<2,5,7>; break;
-            case 508: eval_func = &Eval2D<2,5,8>; break;
+            case 55: eval_func = &Eval2D<2,5,5>; break;
+            case 56: eval_func = &Eval2D<2,5,6>; break;
+            case 57: eval_func = &Eval2D<2,5,7>; break;
+            case 58: eval_func = &Eval2D<2,5,8>; break;
          }
-         if (nq >= 100 || !eval_func)
+         if (nq1d >= 10 || !eval_func)
          {
             eval_func = &Eval2D<2>;
          }
       }
       else if (dim == 3)
       {
-         switch (1000*nd + nq)
+         switch (10*nd1d + nq1d)
          {
             // Q1
-            case 2002: eval_func = &Eval3D<3,2,2>; break;
-            case 2003: eval_func = &Eval3D<3,2,3>; break;
+            case 22: eval_func = &Eval3D<3,2,2>; break;
+            case 23: eval_func = &Eval3D<3,2,3>; break;
             // Q2
-            case 3003: eval_func = &Eval3D<3,3,3>; break;
-            case 3004: eval_func = &Eval3D<3,3,4>; break;
+            case 33: eval_func = &Eval3D<3,3,3>; break;
+            case 34: eval_func = &Eval3D<3,3,4>; break;
             // Q3
-            case 4004: eval_func = &Eval3D<3,4,4>; break;
-            case 4005: eval_func = &Eval3D<3,4,5>; break;
-            case 4006: eval_func = &Eval3D<3,4,6>; break;
+            case 44: eval_func = &Eval3D<3,4,4>; break;
+            case 45: eval_func = &Eval3D<3,4,5>; break;
+            case 46: eval_func = &Eval3D<3,4,6>; break;
             // Q4
-            case 5005: eval_func = &Eval3D<3,5,5>; break;
-            case 5006: eval_func = &Eval3D<3,5,6>; break;
+            case 55: eval_func = &Eval3D<3,5,5>; break;
+            case 56: eval_func = &Eval3D<3,5,6>; break;
          }
-         if (nq >= 1000 || !eval_func)
+         if (nq1d >= 10 || !eval_func)
          {
             eval_func = &Eval3D<3>;
          }


### PR DESCRIPTION
It appears that we haven't been using the optimized kernels for the `FaceQuadratureInterpolator` due to the instantiation of the kernels with ND template values instead of 1D template values.
<!--GHEX{"id":2301,"author":"YohannDudouit","editor":"tzanio","reviewers":["artv3","camierjs"],"assignment":"2021-06-07T17:57:56-07:00","approval":"2021-06-08T23:17:40.319Z","merge":"2021-06-09T14:39:50.261Z"}XEHG--><!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge| 
 | --- | --- | --- | --- | --- | --- | --- | 
| [#2301](https://github.com/mfem/mfem/pull/2301) | @YohannDudouit | @tzanio | @artv3 + @camierjs | 06/07/21 | 06/08/21 | 06/09/21 | |
<!--ELBATXEHG-->