### PR TITLE
Push to autotest

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -40,11 +40,14 @@
 # Directory used to place artifacts.
 
 variables:
-  BUILD_ROOT: ${CI_BUILDS_DIR}/${CI_PROJECT_NAME}_${CI_COMMIT_REF_SLUG}_${CI_PIPELINE_ID}
+  BUILD_ROOT: ${CI_BUILDS_DIR}/MFEM/${CI_PROJECT_NAME}_${CI_COMMIT_REF_SLUG}_${CI_PIPELINE_ID}
+  AUTOTEST_ROOT: ${CI_BUILDS_DIR}/MFEM
   REBASELINE: "NO"
+  AUTOTEST: "NO"
   ALLOC_NAME: ${CI_PROJECT_NAME}_ci_${CI_PIPELINE_ID}
   TPLS_REPO: ssh://git@mybitbucket.llnl.gov:7999/mfem/tpls.git
   TESTS_REPO: ssh://git@mybitbucket.llnl.gov:7999/mfem/tests.git
+  AUTOTEST_REPO: ssh://git@mybitbucket.llnl.gov:7999/mfem/autotest.git
   ARTIFACTS_DIR: artifacts
 
 # The pipeline is divided into stages. Usually, these are also synchronization
@@ -64,6 +67,7 @@ stages:
   - c_build_and_test
   - setup
   - baseline_check
+  - baseline_to_autotest
   - baseline_publish
 
 # The setup job in setup stage don't rely on MFEM git repo. It prepares a
@@ -85,6 +89,9 @@ setup:
     - if [ ! -d "tests" ]; then git clone ${TESTS_REPO}; fi
     - cd tpls && git pull && cd ..
     - cd tests && git pull && cd ..
+    - cd ${AUTOTEST_ROOT}
+    - if [ ! -d "autotest" ]; then git clone ${AUTOTEST_REPO}; fi
+    - cd autotest && git pull && cd ..
   needs: []
 
 .build_toss_3_x86_64_ib_script:
@@ -130,6 +137,8 @@ setup:
   srun --nodes=1 -p pdebug ../runtest ../../mfem "${BASELINE_TEST} ${ADDITIONAL_DIR}"
   # post
   mkdir ${CI_PROJECT_DIR}/${ARTIFACTS_DIR}
+  # commit to autotest
+  cd .. && cp -r _${BASELINE_TEST} ${CI_PROJECT_DIR}/${ARTIFACTS_DIR} ; cd -
   if [[ -s ${_glob_err} ]]
   then
     echo "ERROR during ${BASELINE_TEST} execution";
@@ -195,7 +204,7 @@ setup:
       - ${ARTIFACTS_DIR}
   allow_failure: true
 
-# This job can only be manually triggers on a pipeline for master branch, or if
+# This job can only be manually triggered on a pipeline for master branch, or if
 # the pipeline was triggered with REBASELINE="YES"
 .rebaseline_mfem:
   stage: baseline_publish

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -118,16 +118,10 @@ setup:
 # differentiates between the two tests.
 .baseline_script: &baseline_script |
   # locals
-  _glob_out=${BASELINE_TEST}.out
   _glob_err=${BASELINE_TEST}.err
   _base_diff=${BASELINE_TEST}-${SYS_TYPE}.diff
   _base_patch=${BASELINE_TEST}-${SYS_TYPE}.patch
   _base_out=${BASELINE_TEST}-${SYS_TYPE}.out
-
-  _out=${BASELINE_TEST}-${SYS_TYPE}.out
-  _ref=../${BASELINE_TEST}-${SYS_TYPE}.saved
-  _out_txt=${BASELINE_TEST}.txt
-  _diff=${BASELINE_TEST}-diff.txt
   # prepare
   cd ${BUILD_ROOT}
   ln -snf ${CI_PROJECT_DIR} mfem
@@ -144,7 +138,7 @@ setup:
     echo "ERROR during ${BASELINE_TEST} execution";
     echo "Here is the ${_glob_err} file content";
     cat ${_glob_err}
-    cp ${_glob_err} ${CI_PROJECT_DIR}/${ARTIFACTS_DIR}/${_glob_err}.txt
+    cp ${_glob_err} ${CI_PROJECT_DIR}/${ARTIFACTS_DIR}/${_glob_err}
     exit 1;
   elif [[ ! -f ${_base_patch} && ! -f ${_base_out} ]]
   then
@@ -154,11 +148,11 @@ setup:
   elif [[ -f ${_base_patch} ]]
   then
     echo "${BASELINE_TEST}: Differences found, patch generated"
-    cp ${_base_patch} ${CI_PROJECT_DIR}/${ARTIFACTS_DIR}/${_base_patch}.txt
+    cp ${_base_patch} ${CI_PROJECT_DIR}/${ARTIFACTS_DIR}/${_base_patch}
   elif [[ -f ${_base_out} ]]
   then
     echo "${BASELINE_TEST}: Differences found, replacement file generated"
-    cp ${_base_out} ${CI_PROJECT_DIR}/${ARTIFACTS_DIR}/${_base_out}.txt
+    cp ${_base_out} ${CI_PROJECT_DIR}/${ARTIFACTS_DIR}/${_base_out}
   fi
   # _base_diff won't even exist if there is no difference.
   if [[ -f ${_base_diff} ]]
@@ -166,6 +160,10 @@ setup:
     echo "${BASELINE_TEST}: Relevant differences (filtered diff) ..."
     cat ${_base_diff}
     cp ${_base_diff} ${CI_PROJECT_DIR}/${ARTIFACTS_DIR}/${_base_diff}.txt
+    # We create a .err file, because that's how we signal that there was a diff.
+    cp ${_base_diff} ${CI_PROJECT_DIR}/${ARTIFACTS_DIR}/${_base_diff}.err
+    # We create an autotest-email.html file, because that's how we signal that there was a diff (temporary).
+    cp ${_base_diff} ${CI_PROJECT_DIR}/${ARTIFACTS_DIR}/autotest-email.html
   fi
   if [[ ! -s ${_base_diff} ]]
   then
@@ -217,19 +215,18 @@ setup:
     - export DIFF_FILE=${CI_PROJECT_DIR}/${ARTIFACTS_DIR}/baseline-${SYS_TYPE}.diff
     - cd ${BUILD_ROOT}/tests
     - |
-      if [[ ! -f "${DIFF_FILE}.txt" ]]
+      if [[ ! -f "${DIFF_FILE}" ]]
       then
           echo "Nothing to be done: no relevant change in baseline"
           exit 0
-      elif [[ -f "${PATCH_FILE}.txt" ]]
+      elif [[ -f "${PATCH_FILE}" ]]
       then
-          mv ${PATCH_FILE}.txt ${PATCH_FILE}
           patch "./baseline-${SYS_TYPE}.saved" < "${PATCH_FILE}"
-      elif [[ -f "${FULL_FILE}.txt" ]]
+      elif [[ -f "${FULL_FILE}t" ]]
       then
-          cp "${FULL_FILE}.txt" "./baseline-${SYS_TYPE}.saved"
+          cp "${FULL_FILE}" "./baseline-${SYS_TYPE}.saved"
       else
-          echo "File missing: expected ${PATCH_FILE}.txt or ${FULL_FILE}.txt"
+          echo "File missing: expected ${PATCH_FILE} or ${FULL_FILE}"
           exit 1
       fi
     - git add baseline-${SYS_TYPE}.saved

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -131,8 +131,6 @@ setup:
   srun --nodes=1 -p pdebug ../runtest ../../mfem "${BASELINE_TEST} ${ADDITIONAL_DIR}"
   # post
   mkdir ${CI_PROJECT_DIR}/${ARTIFACTS_DIR}
-  # commit to autotest
-  cd .. && cp -r _${BASELINE_TEST} ${CI_PROJECT_DIR}/${ARTIFACTS_DIR} ; cd -
   if [[ -s ${_glob_err} ]]
   then
     echo "ERROR during ${BASELINE_TEST} execution";
@@ -161,9 +159,7 @@ setup:
     cat ${_base_diff}
     cp ${_base_diff} ${CI_PROJECT_DIR}/${ARTIFACTS_DIR}/${_base_diff}.txt
     # We create a .err file, because that's how we signal that there was a diff.
-    cp ${_base_diff} ${CI_PROJECT_DIR}/${ARTIFACTS_DIR}/${_base_diff}.err
-    # We create an autotest-email.html file, because that's how we signal that there was a diff (temporary).
-    cp ${_base_diff} ${CI_PROJECT_DIR}/${ARTIFACTS_DIR}/autotest-email.html
+    cp ${_base_diff} ${CI_PROJECT_DIR}/${ARTIFACTS_DIR}/gitlab-${BASELINE_TEST}-${SYS_TYPE}.err
   fi
   if [[ ! -s ${_base_diff} ]]
   then

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -43,7 +43,7 @@ variables:
   BUILD_ROOT: ${CI_BUILDS_DIR}/MFEM/${CI_PROJECT_NAME}_${CI_COMMIT_REF_SLUG}_${CI_PIPELINE_ID}
   AUTOTEST_ROOT: ${CI_BUILDS_DIR}/MFEM
   REBASELINE: "NO"
-  AUTOTEST: "YES"
+  AUTOTEST: "NO"
   ALLOC_NAME: ${CI_PROJECT_NAME}_ci_${CI_PIPELINE_ID}
   TPLS_REPO: ssh://git@mybitbucket.llnl.gov:7999/mfem/tpls.git
   TESTS_REPO: ssh://git@mybitbucket.llnl.gov:7999/mfem/tests.git

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -43,7 +43,7 @@ variables:
   BUILD_ROOT: ${CI_BUILDS_DIR}/MFEM/${CI_PROJECT_NAME}_${CI_COMMIT_REF_SLUG}_${CI_PIPELINE_ID}
   AUTOTEST_ROOT: ${CI_BUILDS_DIR}/MFEM
   REBASELINE: "NO"
-  AUTOTEST: "NO"
+  AUTOTEST: "YES"
   ALLOC_NAME: ${CI_PROJECT_NAME}_ci_${CI_PIPELINE_ID}
   TPLS_REPO: ssh://git@mybitbucket.llnl.gov:7999/mfem/tpls.git
   TESTS_REPO: ssh://git@mybitbucket.llnl.gov:7999/mfem/tests.git

--- a/.gitlab/quartz.yml
+++ b/.gitlab/quartz.yml
@@ -48,6 +48,40 @@ q_release_resources:
     - export JOBID=$(squeue -h --name=${ALLOC_NAME} --format=%A)
     - ([[ -n "${JOBID}" ]] && scancel ${JOBID})
 
+# Release
+q_report_success:
+  variables:
+    GIT_STRATEGY: none
+  extends: .on_quartz
+  stage: q_release_resources
+  script:
+    - echo "Can only run if all the quartz jobs passed"
+    - rundir="gitlab-ci/$(date +%Y-%m-%d)-github-${CI_COMMIT_REF_SLUG}"
+    - cd ${AUTOTEST_ROOT}/autotest
+    - mkdir -p ${rundir}
+    - echo "The Quartz jobs were successful" > ${rundir}/gitlab-ci.out
+    - git add ${rundir}
+    - git commit -am "Gitlab CI log for baseline on quartz with intel ($(date +%Y-%m-%d))"
+  rules:
+    - when: on_success
+
+q_report_failure:
+  variables:
+    GIT_STRATEGY: none
+  extends: .on_quartz
+  stage: q_release_resources
+  script:
+    - echo "Runs if there was at least one failure on quartz"
+    - rundir="gitlab-ci/$(date +%Y-%m-%d)-github-${CI_COMMIT_REF_SLUG}"
+    - cd ${AUTOTEST_ROOT}/autotest
+    - mkdir -p ${rundir}
+    - echo "There was an error while running CI on Quartz" > ${rundir}/gitlab-ci.err
+    - cp ${rundir}/gitlab-ci.err ${rundir}/autotest-email.html
+    - git add ${rundir}
+    - git commit -am "Gitlab CI log for baseline on quartz with intel ($(date +%Y-%m-%d))"
+  rules:
+    - when: on_failure
+
 # Spack helped builds
 # Generic quartz build job, extending build script
 .build_and_test_on_quartz:
@@ -105,9 +139,16 @@ update_autotest:
   needs: [baselinecheck_mfem_intel_quartz]
   stage: baseline_to_autotest
   script:
-    - rundir="$(date +%Y-%m-%d)-github-${CI_COMMIT_REF_SLUG}"
+    - rundir="quartz-baseline/$(date +%Y-%m-%d)-github-${CI_COMMIT_REF_SLUG}"
     - cd ${AUTOTEST_ROOT}/autotest
-    - cp -r ${CI_PROJECT_DIR}/${ARTIFACTS_DIR}/_baseline ${rundir}
+    - mkdir -p ${rundir}
+    - cp ${CI_PROJECT_DIR}/${ARTIFACTS_DIR}/* ${rundir}
+    # We create an autotest-email.html file, because that's how we signal that there was a diff (temporary).
+    - |
+      if [[ -f ${rundir}/*.err ]]
+      then
+        cp ${rundir}/*.err ${rundir}/autotest-email.html
+      fi
     - git add ${rundir}
     - git commit -am "Gitlab CI log for baseline on quartz with intel ($(date +%Y-%m-%d))"
 

--- a/.gitlab/quartz.yml
+++ b/.gitlab/quartz.yml
@@ -16,10 +16,16 @@
     - shell
     - quartz
   rules:
-    - if: '$CI_COMMIT_BRANCH =~ /_qnone/ || $ON_QUARTZ == "OFF"' #run except if ...
+    # Don’t run quartz jobs if...
+    - if: '$CI_COMMIT_BRANCH =~ /_qnone/ || $ON_QUARTZ == "OFF"'
       when: never
+    # Don’t run autotest update if...
+    - if: '$CI_JOB_NAME =~ /update_autotest/ && ( $CI_COMMIT_BRANCH != "master" && $CI_COMMIT_BRANCH != "next" && $AUTOTEST != "YES" )'
+      when: never
+    # Always release resources
     - if: '$CI_JOB_NAME =~ /release_resources/'
       when: always
+    # Default is to run if previous stage succeeded
     - when: on_success
 
 # Allocate
@@ -93,6 +99,17 @@ opt_par_gcc_6_1_0_pumi:
 baselinecheck_mfem_intel_quartz:
   extends: [.baselinecheck_mfem, .on_quartz]
   needs: [setup]
+
+update_autotest:
+  extends: [.on_quartz]
+  needs: [baselinecheck_mfem_intel_quartz]
+  stage: baseline_to_autotest
+  script:
+    - rundir="$(date +%Y-%m-%d)-github-${CI_COMMIT_REF_SLUG}"
+    - cd ${AUTOTEST_ROOT}/autotest
+    - cp -r ${CI_PROJECT_DIR}/${ARTIFACTS_DIR}/_baseline ${rundir}
+    - git add ${rundir}
+    - git commit -am "Gitlab CI log for baseline on quartz with intel ($(date +%Y-%m-%d))"
 
 baselinepublish_mfem_quartz:
   extends: [.on_quartz, .rebaseline_mfem]

--- a/.gitlab/quartz.yml
+++ b/.gitlab/quartz.yml
@@ -22,6 +22,9 @@
     # Don’t run autotest update if...
     - if: '$CI_JOB_NAME =~ /update_autotest/ && ( $CI_COMMIT_BRANCH != "master" && $CI_COMMIT_BRANCH != "next" && $AUTOTEST != "YES" )'
       when: never
+    # Don’t run autotest update if...
+    - if: '$CI_JOB_NAME =~ /q_report/ && ( $CI_COMMIT_BRANCH != "master" && $CI_COMMIT_BRANCH != "next" && $AUTOTEST != "YES" )'
+      when: never
     # Always release resources
     - if: '$CI_JOB_NAME =~ /release_resources/'
       when: always

--- a/.gitlab/quartz.yml
+++ b/.gitlab/quartz.yml
@@ -59,10 +59,10 @@ q_report_success:
   stage: q_release_resources
   script:
     - echo "Can only run if all the quartz jobs passed"
-    - rundir="gitlab-ci/$(date +%Y-%m-%d)-github-${CI_COMMIT_REF_SLUG}"
+    - rundir="gitlab/$(date +%Y-%m-%d)-github-${CI_COMMIT_REF_SLUG}"
     - cd ${AUTOTEST_ROOT}/autotest
     - mkdir -p ${rundir}
-    - echo "The Quartz jobs were successful" > ${rundir}/gitlab-ci.out
+    - echo "The Quartz jobs were successful" > ${rundir}/gitlab.out
     - git add ${rundir}
     - git commit -am "Gitlab CI log for baseline on quartz with intel ($(date +%Y-%m-%d))"
     - git push origin master
@@ -76,11 +76,11 @@ q_report_failure:
   stage: q_release_resources
   script:
     - echo "Runs if there was at least one failure on quartz"
-    - rundir="gitlab-ci/$(date +%Y-%m-%d)-github-${CI_COMMIT_REF_SLUG}"
+    - rundir="gitlab/$(date +%Y-%m-%d)-github-${CI_COMMIT_REF_SLUG}"
     - cd ${AUTOTEST_ROOT}/autotest
     - mkdir -p ${rundir}
-    - echo "There was an error while running CI on Quartz" > ${rundir}/gitlab-ci.err
-    - cp ${rundir}/gitlab-ci.err ${rundir}/autotest-email.html
+    - echo "There was an error while running CI on Quartz" > ${rundir}/gitlab.err
+    - cp ${rundir}/gitlab.err ${rundir}/autotest-email.html
     - git add ${rundir}
     - git commit -am "Gitlab CI log for baseline on quartz with intel ($(date +%Y-%m-%d))"
     - git push origin master
@@ -144,7 +144,7 @@ update_autotest:
   needs: [baselinecheck_mfem_intel_quartz]
   stage: baseline_to_autotest
   script:
-    - rundir="quartz-baseline/$(date +%Y-%m-%d)-github-${CI_COMMIT_REF_SLUG}"
+    - rundir="quartz/$(date +%Y-%m-%d)-github-${CI_COMMIT_REF_SLUG}"
     - cd ${AUTOTEST_ROOT}/autotest
     - mkdir -p ${rundir}
     - cp ${CI_PROJECT_DIR}/${ARTIFACTS_DIR}/* ${rundir}

--- a/.gitlab/quartz.yml
+++ b/.gitlab/quartz.yml
@@ -62,6 +62,7 @@ q_report_success:
     - echo "The Quartz jobs were successful" > ${rundir}/gitlab-ci.out
     - git add ${rundir}
     - git commit -am "Gitlab CI log for baseline on quartz with intel ($(date +%Y-%m-%d))"
+    - git push origin master
   rules:
     - when: on_success
 
@@ -79,6 +80,7 @@ q_report_failure:
     - cp ${rundir}/gitlab-ci.err ${rundir}/autotest-email.html
     - git add ${rundir}
     - git commit -am "Gitlab CI log for baseline on quartz with intel ($(date +%Y-%m-%d))"
+    - git push origin master
   rules:
     - when: on_failure
 
@@ -151,6 +153,7 @@ update_autotest:
       fi
     - git add ${rundir}
     - git commit -am "Gitlab CI log for baseline on quartz with intel ($(date +%Y-%m-%d))"
+    - git push origin master
 
 baselinepublish_mfem_quartz:
   extends: [.on_quartz, .rebaseline_mfem]


### PR DESCRIPTION
This PR allows Gitlab CI to push in autotest in a way that will make the Autotest App report for the CI status.
This is meant to run only on `master` or `next` or when the variable "AUTOTEST" is set to "YES" like done in a commit here for demonstration.

- Add jobs after runs on quartz to do a basic commit in a dedicated dir in autotest.
  - Creates .out file with a status message (passing, failed)
  - Creates a dummy autotest-email.html if failing CI (temporary to match App criteria).
  - Commit to autotest (will push eventually).
- Add a job after the baseline (specific to master and next) to commit the diff and other files.
  - Creates .err file with the diff inside if there was one.
  - Creates a dummy autotest-email.html if there is a .err file (temporary to match App criteria).
  - Commit to autotest (will push eventually).
<!--GHEX{"id":2303,"author":"adrienbernede","editor":"tzanio","reviewers":["tzanio","jandrej"],"assignment":"2021-06-07T17:57:14-07:00","approval":"2021-06-21T17:57:14-07:00","merge":"2021-06-08T16:45:11.093Z"}XEHG--><!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge| 
 | --- | --- | --- | --- | --- | --- | --- | 
| [#2303](https://github.com/mfem/mfem/pull/2303) | @adrienbernede | @tzanio | @tzanio + @jandrej | 06/07/21 | 06/21/21 | 06/08/21 | |
<!--ELBATXEHG-->