### PR TITLE
Fix method declaration introduced in PR #2043

### DIFF
--- a/fem/lininteg.hpp
+++ b/fem/lininteg.hpp
@@ -170,6 +170,8 @@ public:
    virtual void AssembleRHSElementVect(const FiniteElement &el,
                                        FaceElementTransformations &Tr,
                                        Vector &elvect);
+
+   using LinearFormIntegrator::AssembleRHSElementVect;
 };
 
 /// Class for boundary integration \f$ L(v) = (g \cdot n, v) \f$
@@ -424,6 +426,8 @@ public:
    virtual void AssembleRHSElementVect(const FiniteElement &el,
                                        FaceElementTransformations &Tr,
                                        Vector &elvect);
+
+   using LinearFormIntegrator::AssembleRHSElementVect;
 };
 
 
@@ -464,6 +468,8 @@ public:
    virtual void AssembleRHSElementVect(const FiniteElement &el,
                                        FaceElementTransformations &Tr,
                                        Vector &elvect);
+
+   using LinearFormIntegrator::AssembleRHSElementVect;
 };
 
 
@@ -507,6 +513,8 @@ public:
    virtual void AssembleRHSElementVect(const FiniteElement &el,
                                        FaceElementTransformations &Tr,
                                        Vector &elvect);
+
+   using LinearFormIntegrator::AssembleRHSElementVect;
 };
 
 /** Class for domain integration of L(v) := (f, v), where


### PR DESCRIPTION
This PR resolves the issue mentioned [here](https://github.com/mfem/mfem/pull/2043#discussion_r646984969):
```
.../fem/lininteg.hpp(154): warning: overloaded virtual function "mfem::LinearFormIntegrator::AssembleRHSElementVect" is only partially overridden in class "mfem::BoundaryLFIntegrator"

.../fem/lininteg.hpp(403): warning: overloaded virtual function "mfem::LinearFormIntegrator::AssembleRHSElementVect" is only partially overridden in class "mfem::BoundaryFlowIntegrator"

.../fem/lininteg.hpp(440): warning: overloaded virtual function "mfem::LinearFormIntegrator::AssembleRHSElementVect" is only partially overridden in class "mfem::DGDirichletLFIntegrator"

.../fem/lininteg.hpp(480): warning: overloaded virtual function "mfem::LinearFormIntegrator::AssembleRHSElementVect" is only partially overridden in class "mfem::DGElasticityDirichletLFIntegrator"
```

<!--GHEX{"id":2304,"author":"kmittal2","editor":"tzanio","reviewers":["tzanio","v-dobrev"],"assignment":"2021-06-08T08:55:46-07:00","approval":"2021-06-08T16:13:25.546Z","merge":"2021-06-09T14:38:06.477Z"}XEHG--><!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge| 
 | --- | --- | --- | --- | --- | --- | --- | 
| [#2304](https://github.com/mfem/mfem/pull/2304) | @kmittal2 | @tzanio | @tzanio + @v-dobrev | 06/08/21 | 06/08/21 | 06/09/21 | |
<!--ELBATXEHG-->