### PR TITLE
Makefile rule to generate TAGS table

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -223,6 +223,8 @@ Version 4.2.1 (development)
   non body-fitted meshes. This is illustrated in the new Shifted Diffusion
   miniapp, see miniapps/shifted/diffusion.cpp.
 
+- Added makefile rule to generate TAGS table for vi or Emacs users.
+
 libCEED integration improvements
 --------------------------------
 - Refactor the libCEED integration

--- a/config/defaults.mk
+++ b/config/defaults.mk
@@ -18,6 +18,9 @@
 # Some choices below are based on the OS type:
 NOTMAC := $(subst Darwin,,$(shell uname -s))
 
+ETAGS_BIN = $(shell command -v etags 2> /dev/null)
+EGREP_BIN = $(shell command -v egrep 2> /dev/null)
+
 CXX = g++
 MPICXX = mpicxx
 

--- a/makefile
+++ b/makefile
@@ -95,7 +95,7 @@ make style
    Format the MFEM C++ source files using Artistic Style (astyle).
 make tags
    Generate a vi or Emacs compatible TAGS file in ${MFEM_DIR}/TAGS. Requires functional
-   "etags" and "egrep" in the users ${PATH}.
+   "etags" and "egrep" in the user ${PATH}.
 endef
 
 # Save the MAKEOVERRIDES for cases where we explicitly want to pass the command

--- a/makefile
+++ b/makefile
@@ -36,6 +36,7 @@ MFEM makefile targets:
    make clean
    make distclean
    make style
+   make tags
 
 Examples:
 
@@ -92,7 +93,9 @@ make distclean
    installation directory.
 make style
    Format the MFEM C++ source files using Artistic Style (astyle).
-
+make tags
+   Generate a vi or Emacs compatible TAGS file in ${MFEM_DIR}/TAGS. Requires functional
+   "etags" and "egrep" in the users ${PATH}.
 endef
 
 # Save the MAKEOVERRIDES for cases where we explicitly want to pass the command
@@ -741,6 +744,20 @@ style:
 	   "No use of std::cerr found", "Use mfem::err instead of std::cerr");\
 	exit $$err_code
 
+# Generate a TAGS table in $MFEM_DIR from all the tracked files
+tags:
+ifndef ETAGS_BIN
+	$(error Error could not find suitable 'etags', please install one \
+	using your package manager)
+else ifndef EGREP_BIN
+	$(error Error could not find suitable 'egrep', please install one \
+	using your package manager)
+endif
+	$(eval MFEM_TRACKED_SOURCE = $(shell git -C $(MFEM_REAL_DIR) \
+	ls-files | $(EGREP_BIN) -v \(^\(data/\)\|\.\(png\|pdf\|ps\|ppt\|jpg\|txt\|mesh\|yml\|md\)\$\)))
+	@cd $(MFEM_REAL_DIR) && $(ETAGS_BIN) --class-qualify \
+	--declarations -o $(MFEM_REAL_DIR)/TAGS $(MFEM_TRACKED_SOURCE)
+
 # Print the contents of a makefile variable, e.g.: 'make print-MFEM_LIBS'.
 print-%:
 	$(info [ variable name]: $*)
@@ -751,6 +768,6 @@ print-%:
 	@true
 
 # Print the contents of all makefile variables.
-.PHONY: printall
+.PHONY: printall tags
 printall: $(subst :,\:,$(foreach var,$(.VARIABLES),print-$(var)))
 	@true

--- a/makefile
+++ b/makefile
@@ -94,8 +94,8 @@ make distclean
 make style
    Format the MFEM C++ source files using Artistic Style (astyle).
 make tags
-   Generate a vi or Emacs compatible TAGS file in ${MFEM_DIR}/TAGS. Requires functional
-   "etags" and "egrep" in the user ${PATH}.
+   Generate a vi or Emacs compatible TAGS file in ${MFEM_DIR}/TAGS. Requires
+   functional "etags" and "egrep" in the user ${PATH}.
 endef
 
 # Save the MAKEOVERRIDES for cases where we explicitly want to pass the command
@@ -745,6 +745,7 @@ style:
 	exit $$err_code
 
 # Generate a TAGS table in $MFEM_DIR from all the tracked files
+.PHONY: tags
 tags:
 ifndef ETAGS_BIN
 	$(error Error could not find suitable 'etags', please install one \
@@ -753,8 +754,8 @@ else ifndef EGREP_BIN
 	$(error Error could not find suitable 'egrep', please install one \
 	using your package manager)
 endif
-	$(eval MFEM_TRACKED_SOURCE = $(shell git -C $(MFEM_REAL_DIR) \
-	ls-files | $(EGREP_BIN) -v \(^\(data/\)\|\.\(png\|pdf\|ps\|ppt\|jpg\|txt\|mesh\|yml\|md\)\$\)))
+	$(eval MFEM_TRACKED_SOURCE = $(shell git -C $(MFEM_REAL_DIR) ls-files |\
+	$(EGREP_BIN) '(\.[hc](pp)?)$$'))
 	@cd $(MFEM_REAL_DIR) && $(ETAGS_BIN) --class-qualify \
 	--declarations -o $(MFEM_REAL_DIR)/TAGS $(MFEM_TRACKED_SOURCE)
 
@@ -768,6 +769,6 @@ print-%:
 	@true
 
 # Print the contents of all makefile variables.
-.PHONY: printall tags
+.PHONY: printall
 printall: $(subst :,\:,$(foreach var,$(.VARIABLES),print-$(var)))
 	@true


### PR DESCRIPTION
Rule to generate a TAGS table in the main `makefile` and place it in `$MFEM_DIR/TAGS`. Works from anywhere that `include`'s the main `makefile`. Requires the user to have both `egrep`, and `etags` in their $PATH. `config/defaults.mk` does the bare minimum effort to find both.
<!--GHEX{"id":2305,"author":"Jacobfaib","editor":"tzanio","reviewers":["tzanio","v-dobrev"],"assignment":"2021-06-08T12:14:05-07:00","approval":"2021-06-09T19:03:21.833Z","merge":"2021-06-10T23:22:26.145Z"}XEHG--><!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge| 
 | --- | --- | --- | --- | --- | --- | --- | 
| [#2305](https://github.com/mfem/mfem/pull/2305) | @Jacobfaib | @tzanio | @tzanio + @v-dobrev | 06/08/21 | 06/09/21 | 06/10/21 | |
<!--ELBATXEHG-->