### PR TITLE
Add copy assignment operator for DenseTensor [copy-dense-tensor]

### DIFF
--- a/linalg/densemat.cpp
+++ b/linalg/densemat.cpp
@@ -3509,6 +3509,13 @@ DenseTensor &DenseTensor::operator=(double c)
    return *this;
 }
 
+DenseTensor &DenseTensor::operator=(const DenseTensor &other)
+{
+   DenseTensor new_tensor(other);
+   Swap(new_tensor);
+   return *this;
+}
+
 void BatchLUFactor(DenseTensor &Mlu, Array<int> &P, const double TOL)
 {
    const int m = Mlu.SizeI();

--- a/linalg/densemat.hpp
+++ b/linalg/densemat.hpp
@@ -812,6 +812,9 @@ public:
    /// Sets the tensor elements equal to constant c
    DenseTensor &operator=(double c);
 
+   /// Copy assignment operator (performs a deep copy)
+   DenseTensor &operator=(const DenseTensor &other);
+
    DenseMatrix &operator()(int k)
    {
       MFEM_ASSERT_INDEX_IN_RANGE(k, 0, SizeK());

--- a/tests/unit/linalg/test_matrix_dense.cpp
+++ b/tests/unit/linalg/test_matrix_dense.cpp
@@ -313,3 +313,31 @@ TEST_CASE("DenseTensor LinearSolve methods",
       }
    }
 }
+
+TEST_CASE("DenseTensor copy", "[DenseMatrix][DenseTensor]")
+{
+   DenseTensor t1(2,2,2);
+   for (int i=0; i<t1.TotalSize(); ++i)
+   {
+      t1.Data()[i] = i;
+   }
+   DenseTensor t2(t1);
+   DenseTensor t3;
+   t3 = t1;
+   REQUIRE(t2.SizeI() == t1.SizeI());
+   REQUIRE(t2.SizeJ() == t1.SizeJ());
+   REQUIRE(t2.SizeK() == t1.SizeK());
+
+   REQUIRE(t3.SizeI() == t1.SizeI());
+   REQUIRE(t3.SizeJ() == t1.SizeJ());
+   REQUIRE(t3.SizeK() == t1.SizeK());
+
+   REQUIRE(t2.Data() != t1.Data());
+   REQUIRE(t3.Data() != t1.Data());
+
+   for (int i=0; i<t1.TotalSize(); ++i)
+   {
+      REQUIRE(t2.Data()[i] == t1.Data()[i]);
+      REQUIRE(t3.Data()[i] == t1.Data()[i]);
+   }
+}

--- a/tests/unit/linalg/test_matrix_dense.cpp
+++ b/tests/unit/linalg/test_matrix_dense.cpp
@@ -316,7 +316,7 @@ TEST_CASE("DenseTensor LinearSolve methods",
 
 TEST_CASE("DenseTensor copy", "[DenseMatrix][DenseTensor]")
 {
-   DenseTensor t1(2,2,2);
+   DenseTensor t1(2,3,4);
    for (int i=0; i<t1.TotalSize(); ++i)
    {
       t1.Data()[i] = i;


### PR DESCRIPTION
Adds `DenseTensor::operator=(const DenseTensor&)`, which is particularly useful for performing a deep copy on data structures containing instances of `DenseTensor` (e.g. `CoarseFineTransformations`).
<!--GHEX{"id":2318,"author":"pazner","editor":"tzanio","reviewers":["rcarson3","artv3"],"assignment":"2021-06-09T15:23:10-07:00","approval":"2021-06-10T17:12:14.827Z","merge":"2021-06-11T15:35:10.567Z"}XEHG--><!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge| 
 | --- | --- | --- | --- | --- | --- | --- | 
| [#2318](https://github.com/mfem/mfem/pull/2318) | @pazner | @tzanio | @rcarson3 + @artv3 | 06/09/21 | 06/10/21 | 06/11/21 | |
<!--ELBATXEHG-->