### PR TITLE
Reduce several constants to avoid exceeding stack size limits when using newer `hipcc` versions

### DIFF
--- a/fem/bilininteg.hpp
+++ b/fem/bilininteg.hpp
@@ -21,7 +21,11 @@ namespace mfem
 
 // Local maximum size of dofs and quads in 1D
 constexpr int HCURL_MAX_D1D = 5;
+#ifdef MFEM_USE_HIP
+constexpr int HCURL_MAX_Q1D = 5;
+#else
 constexpr int HCURL_MAX_Q1D = 6;
+#endif
 
 constexpr int HDIV_MAX_D1D = 5;
 constexpr int HDIV_MAX_Q1D = 6;

--- a/general/forall.hpp
+++ b/general/forall.hpp
@@ -23,8 +23,13 @@ namespace mfem
 {
 
 // Maximum size of dofs and quads in 1D.
+#ifdef MFEM_USE_HIP
+const int MAX_D1D = 11;
+const int MAX_Q1D = 11;
+#else
 const int MAX_D1D = 14;
 const int MAX_Q1D = 14;
+#endif
 
 // MFEM pragma macros that can be used inside MFEM_FORALL macros.
 #define MFEM_PRAGMA(X) _Pragma(#X)


### PR DESCRIPTION
Reducing the constants in this patch allowed building on a gfx803 AMD gpu with HIP version `4.2.21155-37cb3a34`.  

`make test` passed locally with this particular GPU.   Based on discussion in #2307.
<!--GHEX{"id":2319,"author":"koomie","editor":"tzanio","reviewers":["artv3","YohannDudouit","camierjs"],"assignment":"2021-06-09T17:19:36-07:00","approval":"2021-06-15T15:08:09.853Z","merge":"2021-06-15T21:37:51.055Z"}XEHG--><!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge| 
 | --- | --- | --- | --- | --- | --- | --- | 
| [#2319](https://github.com/mfem/mfem/pull/2319) | @koomie | @tzanio | @artv3 + @YohannDudouit + @camierjs | 06/09/21 | 06/15/21 | 06/15/21 | |
<!--ELBATXEHG-->