### PR TITLE
Add a pull to make sure autotest is up-to-date

### DIFF
--- a/.gitlab/quartz.yml
+++ b/.gitlab/quartz.yml
@@ -60,7 +60,7 @@ q_report_success:
   script:
     - echo "Can only run if all the quartz jobs passed"
     - rundir="gitlab/$(date +%Y-%m-%d)-github-${CI_COMMIT_REF_SLUG}"
-    - cd ${AUTOTEST_ROOT}/autotest
+    - cd ${AUTOTEST_ROOT}/autotest && git pull
     - mkdir -p ${rundir}
     - echo "The Quartz jobs were successful" > ${rundir}/gitlab.out
     - git add ${rundir}
@@ -77,7 +77,7 @@ q_report_failure:
   script:
     - echo "Runs if there was at least one failure on quartz"
     - rundir="gitlab/$(date +%Y-%m-%d)-github-${CI_COMMIT_REF_SLUG}"
-    - cd ${AUTOTEST_ROOT}/autotest
+    - cd ${AUTOTEST_ROOT}/autotest && git pull
     - mkdir -p ${rundir}
     - echo "There was an error while running CI on Quartz" > ${rundir}/gitlab.err
     - cp ${rundir}/gitlab.err ${rundir}/autotest-email.html
@@ -145,7 +145,7 @@ update_autotest:
   stage: baseline_to_autotest
   script:
     - rundir="quartz/$(date +%Y-%m-%d)-github-${CI_COMMIT_REF_SLUG}"
-    - cd ${AUTOTEST_ROOT}/autotest
+    - cd ${AUTOTEST_ROOT}/autotest && git pull
     - mkdir -p ${rundir}
     - cp ${CI_PROJECT_DIR}/${ARTIFACTS_DIR}/* ${rundir}
     # We create an autotest-email.html file, because that's how we signal that there was a diff (temporary).


### PR DESCRIPTION
This is a quick fix to make the use of a single autotest clone less error-prone in CI.
<!--GHEX{"id":2323,"author":"adrienbernede","editor":"tzanio","reviewers":["tzanio","mlstowell"],"assignment":"2021-06-10T18:12:20-07:00","approval":"2021-06-11T01:27:29.327Z","merge":"2021-06-11T01:28:15.533Z"}XEHG--><!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge| 
 | --- | --- | --- | --- | --- | --- | --- | 
| [#2323](https://github.com/mfem/mfem/pull/2323) | @adrienbernede | @tzanio | @tzanio + @mlstowell | 06/10/21 | 06/10/21 | 06/10/21 | |
<!--ELBATXEHG-->