### PR TITLE
Two fixes to improve autotest CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -157,7 +157,7 @@ setup:
   then
     echo "${BASELINE_TEST}: Relevant differences (filtered diff) ..."
     cat ${_base_diff}
-    cp ${_base_diff} ${CI_PROJECT_DIR}/${ARTIFACTS_DIR}/${_base_diff}.txt
+    cp ${_base_diff} ${CI_PROJECT_DIR}/${ARTIFACTS_DIR}/${_base_diff}
     # We create a .err file, because that's how we signal that there was a diff.
     cp ${_base_diff} ${CI_PROJECT_DIR}/${ARTIFACTS_DIR}/gitlab-${BASELINE_TEST}-${SYS_TYPE}.err
   fi

--- a/.gitlab/quartz.yml
+++ b/.gitlab/quartz.yml
@@ -20,10 +20,10 @@
     - if: '$CI_COMMIT_BRANCH =~ /_qnone/ || $ON_QUARTZ == "OFF"'
       when: never
     # Don’t run autotest update if...
-    - if: '$CI_JOB_NAME =~ /update_autotest/ && ( $AUTOTEST != "YES" )'
+    - if: '$CI_JOB_NAME =~ /update_autotest/ && $AUTOTEST != "YES"'
       when: never
     # Don’t run autotest update if...
-    - if: '$CI_JOB_NAME =~ /q_report/ && ( $AUTOTEST != "YES" )'
+    - if: '$CI_JOB_NAME =~ /q_report/ && $AUTOTEST != "YES"'
       when: never
     # Always release resources
     - if: '$CI_JOB_NAME =~ /release_resources/'

--- a/.gitlab/quartz.yml
+++ b/.gitlab/quartz.yml
@@ -20,10 +20,10 @@
     - if: '$CI_COMMIT_BRANCH =~ /_qnone/ || $ON_QUARTZ == "OFF"'
       when: never
     # Don’t run autotest update if...
-    - if: '$CI_JOB_NAME =~ /update_autotest/ && ( $CI_COMMIT_BRANCH != "master" && $CI_COMMIT_BRANCH != "next" && $AUTOTEST != "YES" )'
+    - if: '$CI_JOB_NAME =~ /update_autotest/ && ( $AUTOTEST != "YES" )'
       when: never
     # Don’t run autotest update if...
-    - if: '$CI_JOB_NAME =~ /q_report/ && ( $CI_COMMIT_BRANCH != "master" && $CI_COMMIT_BRANCH != "next" && $AUTOTEST != "YES" )'
+    - if: '$CI_JOB_NAME =~ /q_report/ && ( $AUTOTEST != "YES" )'
       when: never
     # Always release resources
     - if: '$CI_JOB_NAME =~ /release_resources/'


### PR DESCRIPTION
This PR fixes two things:

- Remove a remaining ".txt" extension that prevented the diffs to appear correctly.
- Simplify the rules under which the autotest report jobs run.

For the autotest rules, the choice is to run the reports only if `AUTOTEST` variable is set to `YES` in CI. In practice, this is done in the settings of the `scheduled pipeline`. No other pipeline, even for `master` or `next` will commit to autotest without this variable set.
<!--GHEX{"id":2325,"author":"adrienbernede","editor":"tzanio","reviewers":["tzanio","jandrej"],"assignment":"2021-06-11T09:09:50-07:00","approval":"2021-06-11T16:41:22.781Z","merge":"2021-06-11T17:58:43.087Z"}XEHG--><!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge| 
 | --- | --- | --- | --- | --- | --- | --- | 
| [#2325](https://github.com/mfem/mfem/pull/2325) | @adrienbernede | @tzanio | @tzanio + @jandrej | 06/11/21 | 06/11/21 | 06/11/21 | |
<!--ELBATXEHG-->