### PR TITLE
Githooks: share checks with github actions

### DIFF
--- a/.github/workflows/repo-check.yml
+++ b/.github/workflows/repo-check.yml
@@ -32,49 +32,24 @@ jobs:
         access_token: ${{ github.token }}
     - name: checkout mfem
       uses: actions/checkout@v2
-      with:
-        path: mfem
 
     - name: copyright check
       id: copyright
       run: |
-        cd mfem
-        if git grep -l "^\(#\|//\).*\(\-2020\|\ 2010,\)" > matches.txt
-        then
-          echo "Please update the following files to Copyright (c) 2010-2021:"
-          cat matches.txt
-          exit 1
-        else
-          echo "No outdated copyright found."
-        fi
+        ./config/githooks/pre-push --copyright
+
       continue-on-error: true
 
     - name: license check
       id: license
       run: |
-        cd mfem
-        if git grep -li "^\(#\|//\).*GNU\ Lesser\ General\ Public\ License" > matches.txt
-        then
-          echo "Please update the following files to the BSD-3 license:"
-          cat matches.txt
-          exit 1
-        else
-          echo "No GNU GPL license found."
-        fi
+        ./config/githooks/pre-push --license
       continue-on-error: true
 
     - name: release check
       id: release
       run: |
-        cd mfem
-        if git grep -l "^\(#\|//\).*LLNL\-CODE\-443211" > matches.txt
-        then
-          echo "Please update the following files to LLNL-CODE-806117:"
-          cat matches.txt
-          exit 1
-        else
-          echo "No outdated release number found."
-        fi
+        ./config/githooks/pre-push --release
       continue-on-error: true
 
     - name: wrap-up
@@ -104,8 +79,7 @@ jobs:
 
     - name: style check
       run: |
-        cd tests/scripts
-        ./runtest code-style
+        ./config/githooks/pre-push --style
 
   documentation:
     runs-on: ubuntu-18.04
@@ -137,5 +111,4 @@ jobs:
       run: |
         git fetch origin master:master
         git checkout -b gh-actions-branch-history
-        cd tests/scripts
-        ./runtest branch-history
+        ./config/githooks/pre-push --history

--- a/config/githooks/pre-push
+++ b/config/githooks/pre-push
@@ -1,32 +1,65 @@
 #!/bin/bash
 
+# Copyright (c) 2010-2021, Lawrence Livermore National Security, LLC. Produced
+# at the Lawrence Livermore National Laboratory. All Rights reserved. See files
+# LICENSE and NOTICE for details. LLNL-CODE-806117.
+#
+# This file is part of the MFEM library. For more information and source code
+# availability visit https://mfem.org.
+#
+# MFEM is free software; you can redistribute it and/or modify it under the
+# terms of the BSD-3 license. We welcome feedback and contributions, see file
+# CONTRIBUTING.md for details.
+
+option=${1:-""}
+
+if [[ "${option}" == "--help" ]]; then
+  echo " This script runs checks on the repository."
+  echo " It has 2 modes: with and without option"
+  echo ""
+  echo " - options are use in GitHub Actions and can be:"
+  echo "   --copyright"
+  echo "   --license"
+  echo "   --release"
+  echo "   --style"
+  echo "   --history"
+  echo ""
+  echo " - as a githook, the script is used without options"
+  echo "   In that case, it will run all the checks except style."
+  echo ""
+  echo " - of course, --help is also option and prints this help."
+fi
+
 cd $(git rev-parse --show-toplevel)
 
 # copyright check
-copyright=true
-if git grep -l "^\(#\|//\).*\(\-2020\|\ 2010,\)" > matches.txt
-then
-  echo "Please update the following files to Copyright (c) 2010-2021:"
-  cat matches.txt
-  copyright=false
+if [[ "${option}" == "--copyright" || "${option}" == "" ]]; then
+  copyright=true
+  if git grep -l "^\(#\|//\).*\(\-2020\|\ 2010,\)" > matches.txt; then
+    echo "Please update the following files to Copyright (c) 2010-2021:"
+    cat matches.txt
+    copyright=false
+  fi
 fi
 
 # license check
 license=true
-if git grep -li "^\(#\|//\).*GNU\ Lesser\ General\ Public\ License" > matches.txt
-then
-  echo "Please update the following files to the BSD-3 license:"
-  cat matches.txt
-  license=false
+if [[ "${option}" == "--license" || "${option}" == "" ]]; then
+  if git grep -li "^\(#\|//\).*GNU\ Lesser\ General\ Public\ License" > matches.txt; then
+    echo "Please update the following files to the BSD-3 license:"
+    cat matches.txt
+    license=false
 fi
 
 # release check
 release=true
-if git grep -l "^\(#\|//\).*LLNL\-CODE\-443211" > matches.txt
-then
-  echo "Please update the following files to LLNL-CODE-806117:"
-  cat matches.txt
-  release=false
+if [[ "${option}" == "--release" || "${option}" == "" ]]; then
+  if git grep -l "^\(#\|//\).*LLNL\-CODE\-443211" > matches.txt
+  then
+    echo "Please update the following files to LLNL-CODE-806117:"
+    cat matches.txt
+    release=false
+  fi
 fi
 
 # wrap-up
@@ -52,18 +85,23 @@ fi
 # directory and uncomment only then. (See README.md)
 #
 ## style check
-#if which astyle && [[ "$(astyle --version)" == "Artistic Style Version 2.05.1" ]]; then
-#  cd tests/scripts
-#  if ! ./runtest code-style; then code=1; fi
-#  cd -
-#else
-#  echo "Warning: astyle not found or version is not 2.05.1"
-#fi
+#if [[ "${option}" == "--style" || "${option}" == "" ]]; then
+if [[ "${option}" == "--style" ]]; then
+  if which astyle && [[ "$(astyle --version)" == "Artistic Style Version 2.05.1" ]]; then
+    cd tests/scripts
+    if ! ./runtest code-style; then code=1; fi
+    cd -
+  else
+    echo "Warning: astyle not found or version is not 2.05.1"
+  fi
+fi
 
 # branch-history
-git fetch origin master:master
-cd tests/scripts
-if ! ./runtest branch-history; then code=1; fi
-cd -
+if [[ "${option}" == "--history" || "${option}" == "" ]]; then
+  git fetch origin master:master
+  cd tests/scripts
+  if ! ./runtest branch-history; then code=1; fi
+  cd -
+fi
 
 exit $code

--- a/config/githooks/pre-push
+++ b/config/githooks/pre-push
@@ -15,9 +15,9 @@ option=${1:-""}
 
 if [[ "${option}" == "--help" ]]; then
   echo " This script runs checks on the repository."
-  echo " It has 2 modes: with and without option"
+  echo " It has 2 modes: with and without an option"
   echo ""
-  echo " - options are use in GitHub Actions and can be:"
+  echo " - options are used in GitHub Actions and can be:"
   echo "   --copyright"
   echo "   --license"
   echo "   --release"

--- a/config/githooks/pre-push
+++ b/config/githooks/pre-push
@@ -49,6 +49,7 @@ if [[ "${option}" == "--license" || "${option}" == "" ]]; then
     echo "Please update the following files to the BSD-3 license:"
     cat matches.txt
     license=false
+  fi
 fi
 
 # release check

--- a/config/githooks/pre-push
+++ b/config/githooks/pre-push
@@ -33,8 +33,8 @@ fi
 cd $(git rev-parse --show-toplevel)
 
 # copyright check
+copyright=true
 if [[ "${option}" == "--copyright" || "${option}" == "" ]]; then
-  copyright=true
   if git grep -l "^\(#\|//\).*\(\-2020\|\ 2010,\)" > matches.txt; then
     echo "Please update the following files to Copyright (c) 2010-2021:"
     cat matches.txt

--- a/config/githooks/pre-push
+++ b/config/githooks/pre-push
@@ -44,6 +44,13 @@ if ! $release ; then
   code=1
 fi
 
+# `code-style` is not just a check, it will actually reformat the code if
+# necessary. This means that if one pushes while the repo is in dirty state
+# (changes not staged), those changes may be mixed with format changes, which
+# can be annoying.
+# To activate this, you will need to hard-copy this hook script in the hook
+# directory and uncomment only then. (See README.md)
+#
 ## style check
 #if which astyle && [[ "$(astyle --version)" == "Artistic Style Version 2.05.1" ]]; then
 #  cd tests/scripts


### PR DESCRIPTION
@tzanio @pazner 

Per Tzanio request this is a suggestion about how to have the checks coded in only one place.

This is true for "copyright", "license", "release". For "style" and "history" this is an extra layer on top of "runtest".

That's why it is a suggestion. Advantage: Github Actions really run the the same script as the pre-push githook. (documentation check is separate). 