### PR TITLE
Fix oversight: rules override

### DIFF
--- a/.gitlab/quartz.yml
+++ b/.gitlab/quartz.yml
@@ -25,6 +25,12 @@
     # Don’t run autotest update if...
     - if: '$CI_JOB_NAME =~ /q_report/ && $AUTOTEST != "YES"'
       when: never
+    # Report success on success status
+    - if: '$CI_JOB_NAME =~ /q_report_success/ && $AUTOTEST == "YES"'
+      when: on_success
+    # Report failure on failure status
+    - if: '$CI_JOB_NAME =~ /q_report_failure/ && $AUTOTEST == "YES"'
+      when: on_failure
     # Always release resources
     - if: '$CI_JOB_NAME =~ /release_resources/'
       when: always
@@ -66,8 +72,6 @@ q_report_success:
     - git add ${rundir}
     - git commit -am "Gitlab CI log for baseline on quartz with intel ($(date +%Y-%m-%d))"
     - git push origin master
-  rules:
-    - when: on_success
 
 q_report_failure:
   variables:
@@ -84,8 +88,6 @@ q_report_failure:
     - git add ${rundir}
     - git commit -am "Gitlab CI log for baseline on quartz with intel ($(date +%Y-%m-%d))"
     - git push origin master
-  rules:
-    - when: on_failure
 
 # Spack helped builds
 # Generic quartz build job, extending build script


### PR DESCRIPTION
### Fix:

In Gitlab CI yaml syntax, rules use a list of constraints, and lists cannot be merged.
Defining `rules` in a job, while there is already a `rules` section in the "template" `on_quartz` lead to an override of `on_quartz` rules. This is annoying, but that’s how it is. 
<!--GHEX{"id":2332,"author":"adrienbernede","editor":"tzanio","reviewers":["tzanio","pazner"],"assignment":"2021-06-14T13:43:19-07:00","approval":"2021-06-14T21:45:41.797Z","merge":"2021-06-14T21:46:06.715Z"}XEHG--><!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge| 
 | --- | --- | --- | --- | --- | --- | --- | 
| [#2332](https://github.com/mfem/mfem/pull/2332) | @adrienbernede | @tzanio | @tzanio + @pazner | 06/14/21 | 06/14/21 | 06/14/21 | |
<!--ELBATXEHG-->