### PR TITLE
Allow changing the integration rule of TransposeIntegrator

### DIFF
--- a/fem/bilininteg.cpp
+++ b/fem/bilininteg.cpp
@@ -175,6 +175,11 @@ void BilinearFormIntegrator::AssembleFaceVector(
    elmat.Mult(elfun, elvect);
 }
 
+void TransposeIntegrator::SetIntRule(const IntegrationRule *ir)
+{
+   IntRule = ir;
+   bfi->SetIntRule(ir);
+}
 
 void TransposeIntegrator::AssembleElementMatrix (
    const FiniteElement &el, ElementTransformation &Trans, DenseMatrix &elmat)

--- a/fem/bilininteg.cpp
+++ b/fem/bilininteg.cpp
@@ -207,6 +207,12 @@ void TransposeIntegrator::AssembleFaceMatrix (
    elmat.Transpose (bfi_elmat);
 }
 
+void LumpedIntegrator::SetIntRule(const IntegrationRule *ir)
+{
+   IntRule = ir;
+   bfi->SetIntRule(ir);
+}
+
 void LumpedIntegrator::AssembleElementMatrix (
    const FiniteElement &el, ElementTransformation &Trans, DenseMatrix &elmat)
 {
@@ -214,11 +220,26 @@ void LumpedIntegrator::AssembleElementMatrix (
    elmat.Lump();
 }
 
+void InverseIntegrator::SetIntRule(const IntegrationRule *ir)
+{
+   IntRule = ir;
+   integrator->SetIntRule(ir);
+}
+
 void InverseIntegrator::AssembleElementMatrix(
    const FiniteElement &el, ElementTransformation &Trans, DenseMatrix &elmat)
 {
    integrator->AssembleElementMatrix(el, Trans, elmat);
    elmat.Invert();
+}
+
+void SumIntegrator::SetIntRule(const IntegrationRule *ir)
+{
+   IntRule = ir;
+   for (int i = 0; i < integrators.Size(); i++)
+   {
+      integrators[i]->SetIntRule(ir);
+   }
 }
 
 void SumIntegrator::AssembleElementMatrix(

--- a/fem/bilininteg.hpp
+++ b/fem/bilininteg.hpp
@@ -326,6 +326,8 @@ public:
    LumpedIntegrator (BilinearFormIntegrator *bfi_, int own_bfi_ = 1)
    { bfi = bfi_; own_bfi = own_bfi_; }
 
+   virtual void SetIntRule(const IntegrationRule *ir);
+
    virtual void AssembleElementMatrix(const FiniteElement &el,
                                       ElementTransformation &Trans,
                                       DenseMatrix &elmat);
@@ -344,6 +346,8 @@ public:
    InverseIntegrator(BilinearFormIntegrator *integ, int own_integ = 1)
    { integrator = integ; own_integrator = own_integ; }
 
+   virtual void SetIntRule(const IntegrationRule *ir);
+
    virtual void AssembleElementMatrix(const FiniteElement &el,
                                       ElementTransformation &Trans,
                                       DenseMatrix &elmat);
@@ -361,6 +365,8 @@ private:
 
 public:
    SumIntegrator(int own_integs = 1) { own_integrators = own_integs; }
+
+   virtual void SetIntRule(const IntegrationRule *ir);
 
    void AddIntegrator(BilinearFormIntegrator *integ)
    { integrators.Append(integ); }

--- a/fem/bilininteg.hpp
+++ b/fem/bilininteg.hpp
@@ -257,6 +257,8 @@ public:
    TransposeIntegrator (BilinearFormIntegrator *bfi_, int own_bfi_ = 1)
    { bfi = bfi_; own_bfi = own_bfi_; }
 
+   virtual void SetIntRule(const IntegrationRule *ir);
+
    virtual void AssembleElementMatrix(const FiniteElement &el,
                                       ElementTransformation &Trans,
                                       DenseMatrix &elmat);

--- a/fem/nonlininteg.hpp
+++ b/fem/nonlininteg.hpp
@@ -38,10 +38,10 @@ protected:
 public:
    /** @brief Prescribe a fixed IntegrationRule to use (when @a ir != NULL) or
        let the integrator choose (when @a ir == NULL). */
-   void SetIntRule(const IntegrationRule *ir) { IntRule = ir; }
+   virtual void SetIntRule(const IntegrationRule *ir) { IntRule = ir; }
 
    /// Prescribe a fixed IntegrationRule to use.
-   void SetIntegrationRule(const IntegrationRule &irule) { IntRule = &irule; }
+   void SetIntegrationRule(const IntegrationRule &ir) { SetIntRule(&ir); }
 
    /// Get the integration rule of the integrator (possibly NULL).
    const IntegrationRule *GetIntegrationRule() const { return IntRule; }


### PR DESCRIPTION
If the user changes the integration rule of a `TransposeIntegrator`, that change will now propagate to the underlying "wrapped" integrator.

* Changed `NonlinearFormIntegrator::SetIntRule` to be virtual, so derived classes (like `TransposeIntegrator`) can implement custom behavior.
* Changed `NonlinearFormIntegrator::SetIntegrationRule` to call `SetIntRule`.
* Added `TransposeIntegrator::SetIntRule` which in turn calls `SetIntRule` on the wrapped `BilinearFormIntegrator`.
* [x] ~~If we want, we could extend this behavior to some of the other "wrapper integrators" (`LumpedIntegrator`, `InverseIntegrator`, `SumIntegrator`)~~ **Done.**

<!--GHEX{"id":2334,"author":"pazner","editor":"tzanio","reviewers":["homijan","YohannDudouit"],"assignment":"2021-06-15T11:30:31-07:00","approval":"2021-06-17T17:24:48.015Z","merge":"2021-06-25T14:58:39.992Z"}XEHG--><!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge| 
 | --- | --- | --- | --- | --- | --- | --- | 
| [#2334](https://github.com/mfem/mfem/pull/2334) | @pazner | @tzanio | @homijan + @YohannDudouit | 06/15/21 | 06/17/21 | 06/25/21 | |
<!--ELBATXEHG-->