### PR TITLE
Make sure to call SetPointIndices when constructing IntegrationRules [int-rule-set-point-idx]

### DIFF
--- a/fem/intrules.cpp
+++ b/fem/intrules.cpp
@@ -374,6 +374,7 @@ public:
 void QuadratureFunctions1D::GaussLegendre(const int np, IntegrationRule* ir)
 {
    ir->SetSize(np);
+   ir->SetPointIndices();
 
    switch (np)
    {

--- a/fem/intrules.cpp
+++ b/fem/intrules.cpp
@@ -34,6 +34,7 @@ IntegrationRule::IntegrationRule(IntegrationRule &irx, IntegrationRule &iry)
    nx = irx.GetNPoints();
    ny = iry.GetNPoints();
    SetSize(nx * ny);
+   SetPointIndices();
 
    for (j = 0; j < ny; j++)
    {
@@ -48,8 +49,6 @@ IntegrationRule::IntegrationRule(IntegrationRule &irx, IntegrationRule &iry)
          ip.weight = ipx.weight * ipy.weight;
       }
    }
-
-   SetPointIndices();
 }
 
 IntegrationRule::IntegrationRule(IntegrationRule &irx, IntegrationRule &iry,
@@ -59,6 +58,7 @@ IntegrationRule::IntegrationRule(IntegrationRule &irx, IntegrationRule &iry,
    const int ny = iry.GetNPoints();
    const int nz = irz.GetNPoints();
    SetSize(nx*ny*nz);
+   SetPointIndices();
 
    for (int iz = 0; iz < nz; ++iz)
    {
@@ -78,8 +78,6 @@ IntegrationRule::IntegrationRule(IntegrationRule &irx, IntegrationRule &iry,
          }
       }
    }
-
-   SetPointIndices();
 }
 
 const Array<double> &IntegrationRule::GetWeights() const
@@ -125,6 +123,7 @@ void IntegrationRule::GrundmannMollerSimplexRule(int s, int n)
    }
    np /= f;
    SetSize(np);
+   SetPointIndices();
 
    int pt = 0;
    for (int i = 0; i <= s; i++)
@@ -477,6 +476,7 @@ void QuadratureFunctions1D::GaussLobatto(const int np, IntegrationRule* ir)
    */
 
    ir->SetSize(np);
+   ir->SetPointIndices();
    if ( np == 1 )
    {
       ir->IntPoint(0).Set1w(0.5, 1.0);
@@ -576,6 +576,7 @@ void QuadratureFunctions1D::GaussLobatto(const int np, IntegrationRule* ir)
 void QuadratureFunctions1D::OpenUniform(const int np, IntegrationRule* ir)
 {
    ir->SetSize(np);
+   ir->SetPointIndices();
 
    // The Newton-Cotes quadrature is based on weights that integrate exactly the
    // interpolatory polynomial through the equally spaced quadrature points.
@@ -591,6 +592,7 @@ void QuadratureFunctions1D::ClosedUniform(const int np,
                                           IntegrationRule* ir)
 {
    ir->SetSize(np);
+   ir->SetPointIndices();
    if ( np == 1 ) // allow this case as "closed"
    {
       ir->IntPoint(0).Set1w(0.5, 1.0);
@@ -608,6 +610,7 @@ void QuadratureFunctions1D::ClosedUniform(const int np,
 void QuadratureFunctions1D::OpenHalfUniform(const int np, IntegrationRule* ir)
 {
    ir->SetSize(np);
+   ir->SetPointIndices();
 
    // Open half points: the centers of np uniform intervals
    for (int i = 0; i < np ; ++i)
@@ -621,6 +624,7 @@ void QuadratureFunctions1D::OpenHalfUniform(const int np, IntegrationRule* ir)
 void QuadratureFunctions1D::ClosedGL(const int np, IntegrationRule* ir)
 {
    ir->SetSize(np);
+   ir->SetPointIndices();
    ir->IntPoint(0).x = 0.0;
    ir->IntPoint(np-1).x = 1.0;
 

--- a/fem/intrules.hpp
+++ b/fem/intrules.hpp
@@ -222,7 +222,6 @@ public:
       {
          (*this)[i].Init(i);
       }
-      SetPointIndices();
    }
 
    /// Sets the indices of each quadrature point on initialization.

--- a/fem/intrules.hpp
+++ b/fem/intrules.hpp
@@ -96,9 +96,6 @@ private:
        by request with the method GetWeights(). */
    mutable Array<double> weights;
 
-   /// Sets the indices of each quadrature point on initialization.
-   void SetPointIndices();
-
    /// Define n-simplex rule (triangle/tetrahedron for n=2/3) of order (2s+1)
    void GrundmannMollerSimplexRule(int s, int n = 3);
 
@@ -225,7 +222,13 @@ public:
       {
          (*this)[i].Init(i);
       }
+      SetPointIndices();
    }
+
+   /// Sets the indices of each quadrature point on initialization.
+   /** Note that most calls to IntegrationRule::SetSize should be paired with a
+       call to SetPointIndices in order for the indices to be set correctly. */
+   void SetPointIndices();
 
    /// Tensor product of two 1D integration rules
    IntegrationRule(IntegrationRule &irx, IntegrationRule &iry);


### PR DESCRIPTION
Fixes #2333. Also makes `SetPointIndices` public. Every call to `IntegrationRule::SetSize` should be paired with a corresponding call to `SetPointIndices`.
<!--GHEX{"id":2338,"author":"pazner","editor":"tzanio","reviewers":["v-dobrev","tzanio"],"assignment":"2021-06-17T15:33:15-07:00","approval":"2021-06-18T18:09:55.762Z","merge":"2021-06-25T15:01:14.476Z"}XEHG--><!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge| 
 | --- | --- | --- | --- | --- | --- | --- | 
| [#2338](https://github.com/mfem/mfem/pull/2338) | @pazner | @tzanio | @v-dobrev + @tzanio | 06/17/21 | 06/18/21 | 06/25/21 | |
<!--ELBATXEHG-->