### PR TITLE
Update ParaViewDataCollection::Save() method to preserve metadata for previous timesteps

### DIFF
--- a/fem/datacollection.cpp
+++ b/fem/datacollection.cpp
@@ -867,16 +867,16 @@ void ParaViewDataCollection::Save()
          std::smatch match;
          while (getline(pvd_stream,line))
          {
-            if(regex_search(line,match,regexp))
+            if (regex_search(line,match,regexp))
             {
                MFEM_ASSERT(match.size() == 2,
-			   "Unable to ascertain time value from existing pvd file: " << pvdname);
+                           "Unable to ascertain time value from existing pvd file: " << pvdname);
                double tvalue = std::stod(match[1]);
                if (tvalue < GetTime())
                {
                   pos = pvd_stream.tellg();
                }
-             }
+            }
          }
          pvd_stream.clear();
          pvd_stream.seekp(pos);

--- a/fem/datacollection.cpp
+++ b/fem/datacollection.cpp
@@ -869,7 +869,7 @@ void ParaViewDataCollection::Save()
          {
             if(regex_search(line,match,regexp))
             {
-               MFEM_ASSERT(match.size == 2,
+               MFEM_ASSERT(match.size() == 2,
 			   "Unable to ascertain time value from existing pvd file: " << pvdname);
                double tvalue = std::stod(match[1]);
                if (tvalue < GetTime())

--- a/fem/datacollection.cpp
+++ b/fem/datacollection.cpp
@@ -892,8 +892,10 @@ void ParaViewDataCollection::Save()
             // remove timesteps newer than current time
             pvd_stream.close();
             int status = truncate(pvdname.c_str(), pos);
-            MFEM_ASSERT(status == 0,
-                        "Unable to truncate newer time values from pvd file: " << pvdname);
+            if (status != 0)
+            {
+               MFEM_ABORT("Unable to truncate newer time values from pvd file:: " << pvdname);
+            }
             pvd_stream.open(pvdname.c_str(),std::ios::in|std::ios::out);
          }
 #endif

--- a/fem/datacollection.cpp
+++ b/fem/datacollection.cpp
@@ -854,7 +854,7 @@ void ParaViewDataCollection::Save()
       std::string pvdname=dpath+"/"+GeneratePVDFileName();
 
       std::ifstream pvd_in;
-      if (restart_mode && (pvd_in.open(pvdname), pvd_in.good()))
+      if (restart_mode && (pvd_in.open(pvdname,std::ios::binary),pvd_in.good()))
       {
          // PVD file exists and restart mode enabled: preserve existing time
          // steps less than the current time.

--- a/fem/datacollection.cpp
+++ b/fem/datacollection.cpp
@@ -847,12 +847,36 @@ void ParaViewDataCollection::Save()
    {
       std::string dpath=GenerateCollectionPath();
       std::string pvdname=dpath+"/"+GeneratePVDFileName();
-      pvd_stream.open(pvdname.c_str(),std::ios::out);
-      // initialize the file
-      pvd_stream << "<?xml version=\"1.0\"?>\n";
-      pvd_stream << "<VTKFile type=\"Collection\" version=\"0.1\"";
-      pvd_stream << " byte_order=\"" << VTKByteOrder() << "\">\n";
-      pvd_stream << "<Collection>" << std::endl;
+
+      std::ifstream fileTest(pvdname);
+
+      if (fileTest.good())
+      {
+         // pvd file exists, open and update output pos so we retain any previously existing timesteps
+         pvd_stream.open(pvdname.c_str(),std::ios::in|std::ios::out);
+
+         std::string line;
+         std::fstream::pos_type pos = pvd_stream.tellp();
+         while (getline(pvd_stream,line))
+         {
+            if (line.find("<DataSet timestep=") != std::string::npos)
+            {
+               pos = pvd_stream.tellg();
+            }
+         }
+         pvd_stream.clear();
+         pvd_stream.seekp(pos);
+      }
+      else
+      {
+         // file does not exist - initialize new pvd file
+         pvd_stream.open(pvdname.c_str(),std::ios::out);
+         // initialize the file
+         pvd_stream << "<?xml version=\"1.0\"?>\n";
+         pvd_stream << "<VTKFile type=\"Collection\" version=\"0.1\"";
+         pvd_stream << " byte_order=\"" << VTKByteOrder() << "\">\n";
+         pvd_stream << "<Collection>" << std::endl;
+      }
    }
 
    // define the vtu file

--- a/fem/datacollection.cpp
+++ b/fem/datacollection.cpp
@@ -1151,17 +1151,10 @@ void ParaViewDataCollection::SetCompression(bool compression_)
    }
 }
 
-#ifndef _WIN32
-void ParaViewDataCollection::SetRestartMode(bool restart_mode_)
+void ParaViewDataCollection::UseRestartMode(bool restart_mode_)
 {
    restart_mode = restart_mode_;
 }
-#else
-void ParaViewDataCollection::SetRestartMode(bool restart_mode_)
-{
-   MFEM_ABORT("this method is not implemented for windows");
-}
-#endif
 
 const char *ParaViewDataCollection::GetDataFormatString() const
 {

--- a/fem/datacollection.hpp
+++ b/fem/datacollection.hpp
@@ -488,6 +488,7 @@ private:
    std::fstream pvd_stream;
    VTKFormat pv_data_format;
    bool high_order_output;
+   bool restart_mode;
 
 protected:
    void SaveDataVTU(std::ostream &out, int ref);
@@ -544,6 +545,10 @@ public:
    /// Sets whether or not to output the data as high-order elements (false
    /// by default). Reading high-order data requires ParaView 5.5 or later.
    void SetHighOrderOutput(bool high_order_output_);
+
+   /// Enable or disable restart mode. If restart is enabled, new writes will
+   /// preserve timestep metadata for any solutions prior to the currently defined time.
+   void SetRestartMode(bool restart_mode_);
 
    /// Load the collection - not implemented in the ParaView writer
    virtual void Load(int cycle_ = 0) override;

--- a/fem/datacollection.hpp
+++ b/fem/datacollection.hpp
@@ -547,8 +547,9 @@ public:
    void SetHighOrderOutput(bool high_order_output_);
 
    /// Enable or disable restart mode. If restart is enabled, new writes will
-   /// preserve timestep metadata for any solutions prior to the currently defined time.
-   void SetRestartMode(bool restart_mode_);
+   /// preserve timestep metadata for any solutions prior to the currently
+   /// defined time.
+   void UseRestartMode(bool restart_mode_);
 
    /// Load the collection - not implemented in the ParaView writer
    virtual void Load(int cycle_ = 0) override;

--- a/tests/unit/fem/test_datacollection.cpp
+++ b/tests/unit/fem/test_datacollection.cpp
@@ -11,6 +11,7 @@
 
 #include "mfem.hpp"
 #include "unit_tests.hpp"
+#include "general/tinyxml2.h"
 #include <stdio.h>
 
 #ifndef _WIN32
@@ -234,4 +235,87 @@ TEST_CASE("Save and load from collections", "[DataCollection]")
 #endif
    }
 
+}
+
+void SaveDataCollection(DataCollection &dc, int cycle, double t)
+{
+   dc.SetCycle(cycle);
+   dc.SetTime(t);
+   dc.Save();
+}
+
+TEST_CASE("ParaView restart mode", "[ParaView]")
+{
+   Mesh mesh = Mesh::MakeCartesian2D(2, 3, Element::QUADRILATERAL);
+   H1_FECollection fec(1, mesh.Dimension());
+   FiniteElementSpace fes(&mesh, &fec);
+   GridFunction u(&fes);
+   u = 0.0;
+
+   // Write initial dataset with three timesteps: 0, 1, 2.
+   {
+      ParaViewDataCollection dc("ParaView", &mesh);
+      dc.RegisterField("u", &u);
+      SaveDataCollection(dc, 0, 0);
+      SaveDataCollection(dc, 1, 1);
+      SaveDataCollection(dc, 2, 2);
+   }
+
+   // Using restart mode, append to the existing dataset, overwriting timesteps
+   // 1 and 2 with 1 and 1.5.
+   {
+      ParaViewDataCollection dc("ParaView", &mesh);
+      dc.UseRestartMode(true);
+      dc.RegisterField("u", &u);
+      SaveDataCollection(dc, 1, 1.0);
+      SaveDataCollection(dc, 2, 1.5);
+   }
+
+   // Parse the resulting PVD file, and verify that the structure is correct,
+   // and that it contains three timesteps: 0, 1, and 1.5.
+   using namespace tinyxml2;
+   auto StringCompare = [](const char *s1, const char *s2)
+   {
+      if (s1 == NULL || s2 == NULL) { return false; }
+      return strcmp(s1, s2) == 0;
+   };
+   auto VerifyDataset = [StringCompare](const XMLElement *ds, double t_ref)
+   {
+      REQUIRE(ds);
+      REQUIRE(StringCompare(ds->Name(), "DataSet"));
+      const char *timestep = ds->Attribute("timestep");
+      REQUIRE(timestep);
+      double t = std::stod(timestep);
+      REQUIRE(t == MFEM_Approx(t_ref));
+   };
+
+   XMLDocument xml;
+   xml.LoadFile("ParaView/ParaView.pvd");
+   REQUIRE(xml.ErrorID() == XML_SUCCESS);
+
+   const XMLElement *vtkfile = xml.FirstChildElement();
+   REQUIRE(vtkfile);
+   REQUIRE(StringCompare(vtkfile->Name(), "VTKFile"));
+   const XMLElement *collection = vtkfile->FirstChildElement();
+   REQUIRE(collection);
+   REQUIRE(StringCompare(collection->Name(), "Collection"));
+
+   const XMLElement *dataset = collection->FirstChildElement();
+   VerifyDataset(dataset, 0.0);
+   dataset = dataset->NextSiblingElement();
+   VerifyDataset(dataset, 1.0);
+   dataset = dataset->NextSiblingElement();
+   VerifyDataset(dataset, 1.5);
+   REQUIRE(dataset->NextSiblingElement() == NULL);
+
+   // Clean up
+   for (int c=0; c<=2; ++c)
+   {
+      std::string prefix = "ParaView/Cycle00000" + std::to_string(c);
+      REQUIRE(remove((prefix + "/data.pvtu").c_str()) == 0);
+      REQUIRE(remove((prefix + "/proc000000.vtu").c_str()) == 0);
+      REQUIRE(rmdir(prefix.c_str()) == 0);
+   }
+   REQUIRE(remove("ParaView/ParaView.pvd") == 0);
+   REQUIRE(rmdir("ParaView") == 0);
 }


### PR DESCRIPTION
#### Background

The current `ParaViewDataCollection::Save` method looks to nicely save time-series data as a collection so that multiple time steps can be interrogated after loading in Paraview.  Metadata for the timestep values is included in an XML file  with a suffix of `.pvd`. There are no issues encountered for a single run of a transient analysis. However, if a user considers using this funcionality in conjunction with a restart method for their application, one has to be careful to save the `.pvd` file in advance as it is overwritten every run and the exact timestep values associate with a given iteration will be lost; however, the raw solution files (`.vtu`) will still exist from previous time steps.

This PR proposes an update to enable preserving previous timesteps (if the `.pvd` file exists) so that end users can more easily maintain a single output directory with Paraview output in longer-running simulations that require restart capability.

#### Example of current behavior

Consider a time-stepping CFD example that is run for 20 timesteps that calls  the `ParaViewDataCollection::Save()` method every 5th timestep.  In that case, we have four solutions saved with the timestep values and a `.pvd` file as follows:

```
$ ls output
Cycle000005  Cycle000010  Cycle000015  Cycle000020   output.pvd

$ cat output/output.pvd
<?xml version="1.0"?>
<VTKFile type="Collection" version="0.1" byte_order="LittleEndian">
<Collection>
<DataSet timestep="1.22855e-05" group="" part="0" file="Cycle000005/data.pvtu"/>
<DataSet timestep="2.40118e-05" group="" part="0" file="Cycle000010/data.pvtu"/>
<DataSet timestep="3.5577e-05" group="" part="0" file="Cycle000015/data.pvtu"/>
<DataSet timestep="4.70662e-05" group="" part="0" file="Cycle000020/data.pvtu"/>
</Collection>
</VTKFile>
```
If we restart this case and run another 10 iterations, we will add two additional solutions to the output directory, but because the `.pvd` file is currently overwritten every time, we lose the time values associated with the previous outputs.

```
$ ls output/
Cycle000005  Cycle000010  Cycle000015  Cycle000020  Cycle000025  Cycle000030  output.pvd

$ cat output/output.pvd 
<?xml version="1.0"?>
<VTKFile type="Collection" version="0.1" byte_order="LittleEndian">
<Collection>
<DataSet timestep="5.85358e-05" group="" part="0" file="Cycle000025/data.pvtu"/>
<DataSet timestep="6.99925e-05" group="" part="0" file="Cycle000030/data.pvtu"/>
</Collection>
</VTKFile>
```

#### Example of proposed behavior

With this PR, the `Save` method is updated slightly to check if the `.pvd` file exists, and if so, it is scanned for any previous timesteps and the stream `pos` is updated accordingly so subsequent timesteps are appended.  The resulting file after completing the same restart process highlighted above is then:

```
 $ ls output/
Cycle000005  Cycle000010  Cycle000015  Cycle000020  Cycle000025  Cycle000030  output.pvd

$ cat output/output.pvd 
<?xml version="1.0"?>
<VTKFile type="Collection" version="0.1" byte_order="LittleEndian">
<Collection>
<DataSet timestep="1.22855e-05" group="" part="0" file="Cycle000005/data.pvtu"/>
<DataSet timestep="2.40118e-05" group="" part="0" file="Cycle000010/data.pvtu"/>
<DataSet timestep="3.5577e-05" group="" part="0" file="Cycle000015/data.pvtu"/>
<DataSet timestep="4.70662e-05" group="" part="0" file="Cycle000020/data.pvtu"/>
<DataSet timestep="5.85358e-05" group="" part="0" file="Cycle000025/data.pvtu"/>
<DataSet timestep="6.99925e-05" group="" part="0" file="Cycle000030/data.pvtu"/>
</Collection>
</VTKFile>
```


Note: regardless of the current implementation or proposed update in this PR, the end application will need to take care of what to do when a simulation is starting from scratch in the same directory where they may have saved previous solution data.  In the case of this PR, a user can additional logic to remove an existing `.pvd` file if they do not want to preserve any previous data, but would gain the benefit of being able to do restarts and have their Paraview output all in one directory.
<!--GHEX{"id":2339,"author":"koomie","editor":"tzanio","reviewers":["pazner","jandrej"],"assignment":"2021-06-18T09:55:45-07:00","approval":"2021-06-28T20:56:56.621Z","merge":"2021-06-29T15:44:04.535Z"}XEHG--><!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge| 
 | --- | --- | --- | --- | --- | --- | --- | 
| [#2339](https://github.com/mfem/mfem/pull/2339) | @koomie | @tzanio | @pazner + @jandrej | 06/18/21 | 06/28/21 | 06/29/21 | |
<!--ELBATXEHG-->