### PR TITLE
HYPRE v2.22 API update

### DIFF
--- a/linalg/hypre.hpp
+++ b/linalg/hypre.hpp
@@ -517,7 +517,7 @@ public:
    /// Initialize all entries with value.
    HypreParMatrix &operator=(double value)
    {
-#if MFEM_HYPRE_VERSION < 22000
+#if MFEM_HYPRE_VERSION < 22200
       internal::hypre_ParCSRMatrixSetConstantValues(A, value);
 #else
       hypre_ParCSRMatrixSetConstantValues(A, value);

--- a/linalg/hypre.hpp
+++ b/linalg/hypre.hpp
@@ -516,7 +516,14 @@ public:
 
    /// Initialize all entries with value.
    HypreParMatrix &operator=(double value)
-   { internal::hypre_ParCSRMatrixSetConstantValues(A, value); return *this; }
+   {
+#if MFEM_HYPRE_VERSION < 22000
+      internal::hypre_ParCSRMatrixSetConstantValues(A, value);
+#else
+      hypre_ParCSRMatrixSetConstantValues(A, value);
+#endif
+      return *this;
+   }
 
    /** Perform the operation `*this += B`, assuming that both matrices use the
        same row and column partitions and the same col_map_offd arrays, or B has

--- a/linalg/hypre_parcsr.cpp
+++ b/linalg/hypre_parcsr.cpp
@@ -1765,6 +1765,7 @@ hypre_ParCSRMatrix *
 hypre_ParCSRMatrixAdd(hypre_ParCSRMatrix *A,
                       hypre_ParCSRMatrix *B)
 {
+#if MFEM_HYPRE_VERSION < 22000
    MPI_Comm            comm   = hypre_ParCSRMatrixComm(A);
    hypre_CSRMatrix    *A_diag = hypre_ParCSRMatrixDiag(A);
    hypre_CSRMatrix    *A_offd = hypre_ParCSRMatrixOffd(A);
@@ -1899,7 +1900,25 @@ hypre_ParCSRMatrixAdd(hypre_ParCSRMatrix *A,
    hypre_ParCSRMatrixSetColStartsOwner(C, 0);
 
    return C;
+
+#else
+
+   hypre_ParCSRMatrix *C;
+   hypre_ParCSRMatrixAdd(1.0, A, 1.0, B, &C);
+   return C;
+
+#endif
+
 }
+
+#if MFEM_HYPRE_VERSION >= 22000
+hypre_CSRMatrix *
+hypre_CSRMatrixAdd(hypre_CSRMatrix *A,
+                   hypre_CSRMatrix *B)
+{
+   return hypre_CSRMatrixAdd(1.0, A, 1.0, B);
+}
+#endif
 
 HYPRE_Int
 hypre_ParCSRMatrixSum(hypre_ParCSRMatrix *A,
@@ -1921,6 +1940,8 @@ hypre_ParCSRMatrixSum(hypre_ParCSRMatrix *A,
 
    return error;
 }
+
+#if MFEM_HYPRE_VERSION < 22000
 
 HYPRE_Int
 hypre_CSRMatrixSetConstantValues(hypre_CSRMatrix *A,
@@ -1947,6 +1968,8 @@ hypre_ParCSRMatrixSetConstantValues(hypre_ParCSRMatrix *A,
 
    return 0;
 }
+
+#endif
 
 } // namespace mfem::internal
 

--- a/linalg/hypre_parcsr.cpp
+++ b/linalg/hypre_parcsr.cpp
@@ -1765,7 +1765,6 @@ hypre_ParCSRMatrix *
 hypre_ParCSRMatrixAdd(hypre_ParCSRMatrix *A,
                       hypre_ParCSRMatrix *B)
 {
-#if MFEM_HYPRE_VERSION < 22200
    MPI_Comm            comm   = hypre_ParCSRMatrixComm(A);
    hypre_CSRMatrix    *A_diag = hypre_ParCSRMatrixDiag(A);
    hypre_CSRMatrix    *A_offd = hypre_ParCSRMatrixOffd(A);
@@ -1900,25 +1899,7 @@ hypre_ParCSRMatrixAdd(hypre_ParCSRMatrix *A,
    hypre_ParCSRMatrixSetColStartsOwner(C, 0);
 
    return C;
-
-#else
-
-   hypre_ParCSRMatrix *C;
-   hypre_ParCSRMatrixAdd(1.0, A, 1.0, B, &C);
-   return C;
-
-#endif
-
 }
-
-#if MFEM_HYPRE_VERSION >= 22200
-hypre_CSRMatrix *
-hypre_CSRMatrixAdd(hypre_CSRMatrix *A,
-                   hypre_CSRMatrix *B)
-{
-   return hypre_CSRMatrixAdd(1.0, A, 1.0, B);
-}
-#endif
 
 HYPRE_Int
 hypre_ParCSRMatrixSum(hypre_ParCSRMatrix *A,
@@ -1941,8 +1922,6 @@ hypre_ParCSRMatrixSum(hypre_ParCSRMatrix *A,
    return error;
 }
 
-#if MFEM_HYPRE_VERSION < 22200
-
 HYPRE_Int
 hypre_CSRMatrixSetConstantValues(hypre_CSRMatrix *A,
                                  HYPRE_Complex    value)
@@ -1963,13 +1942,11 @@ HYPRE_Int
 hypre_ParCSRMatrixSetConstantValues(hypre_ParCSRMatrix *A,
                                     HYPRE_Complex       value)
 {
-   hypre_CSRMatrixSetConstantValues(hypre_ParCSRMatrixDiag(A), value);
-   hypre_CSRMatrixSetConstantValues(hypre_ParCSRMatrixOffd(A), value);
+   internal::hypre_CSRMatrixSetConstantValues(hypre_ParCSRMatrixDiag(A), value);
+   internal::hypre_CSRMatrixSetConstantValues(hypre_ParCSRMatrixOffd(A), value);
 
    return 0;
 }
-
-#endif
 
 } // namespace mfem::internal
 

--- a/linalg/hypre_parcsr.cpp
+++ b/linalg/hypre_parcsr.cpp
@@ -1765,7 +1765,7 @@ hypre_ParCSRMatrix *
 hypre_ParCSRMatrixAdd(hypre_ParCSRMatrix *A,
                       hypre_ParCSRMatrix *B)
 {
-#if MFEM_HYPRE_VERSION < 22000
+#if MFEM_HYPRE_VERSION < 22200
    MPI_Comm            comm   = hypre_ParCSRMatrixComm(A);
    hypre_CSRMatrix    *A_diag = hypre_ParCSRMatrixDiag(A);
    hypre_CSRMatrix    *A_offd = hypre_ParCSRMatrixOffd(A);
@@ -1911,7 +1911,7 @@ hypre_ParCSRMatrixAdd(hypre_ParCSRMatrix *A,
 
 }
 
-#if MFEM_HYPRE_VERSION >= 22000
+#if MFEM_HYPRE_VERSION >= 22200
 hypre_CSRMatrix *
 hypre_CSRMatrixAdd(hypre_CSRMatrix *A,
                    hypre_CSRMatrix *B)
@@ -1941,7 +1941,7 @@ hypre_ParCSRMatrixSum(hypre_ParCSRMatrix *A,
    return error;
 }
 
-#if MFEM_HYPRE_VERSION < 22000
+#if MFEM_HYPRE_VERSION < 22200
 
 HYPRE_Int
 hypre_CSRMatrixSetConstantValues(hypre_CSRMatrix *A,

--- a/linalg/hypre_parcsr.hpp
+++ b/linalg/hypre_parcsr.hpp
@@ -198,6 +198,16 @@ hypre_CSRMatrixSum(hypre_CSRMatrix *A,
                    HYPRE_Complex    beta,
                    hypre_CSRMatrix *B);
 
+#if MFEM_HYPRE_VERSION >= 22200
+/** Provide an overloaded function for code consistency between HYPRE API
+    versions. */
+inline hypre_CSRMatrix *hypre_CSRMatrixAdd(hypre_CSRMatrix *A,
+                                           hypre_CSRMatrix *B)
+{
+   return ::hypre_CSRMatrixAdd(1.0, A, 1.0, B);
+}
+#endif
+
 /** Return a new matrix containing the sum of A and B, assuming that both
     matrices use the same row and column partitions. The col_map_offd do not
     need to be the same, but a more efficient algorithm is used if that's the
@@ -205,14 +215,6 @@ hypre_CSRMatrixSum(hypre_CSRMatrix *A,
 hypre_ParCSRMatrix *
 hypre_ParCSRMatrixAdd(hypre_ParCSRMatrix *A,
                       hypre_ParCSRMatrix *B);
-
-#if MFEM_HYPRE_VERSION >= 22200
-/** Provide an overloaded function for code consistency between HYPRE API
-    versions. */
-hypre_CSRMatrix *
-hypre_CSRMatrixAdd(hypre_CSRMatrix *A,
-                   hypre_CSRMatrix *B);
-#endif
 
 /** Perform the operation A += beta*B, assuming that both matrices use the same
     row and column partitions and the same col_map_offd arrays, or B has an empty
@@ -223,8 +225,6 @@ hypre_ParCSRMatrixSum(hypre_ParCSRMatrix *A,
                       HYPRE_Complex       beta,
                       hypre_ParCSRMatrix *B);
 
-#if MFEM_HYPRE_VERSION < 22200
-
 /** Initialize all entries of A with value. */
 HYPRE_Int
 hypre_CSRMatrixSetConstantValues(hypre_CSRMatrix *A,
@@ -234,8 +234,6 @@ hypre_CSRMatrixSetConstantValues(hypre_CSRMatrix *A,
 HYPRE_Int
 hypre_ParCSRMatrixSetConstantValues(hypre_ParCSRMatrix *A,
                                     HYPRE_Complex       value);
-
-#endif
 
 } // namespace mfem::internal
 

--- a/linalg/hypre_parcsr.hpp
+++ b/linalg/hypre_parcsr.hpp
@@ -206,7 +206,7 @@ hypre_ParCSRMatrix *
 hypre_ParCSRMatrixAdd(hypre_ParCSRMatrix *A,
                       hypre_ParCSRMatrix *B);
 
-#if MFEM_HYPRE_VERSION >= 22000
+#if MFEM_HYPRE_VERSION >= 22200
 /** Provide an overloaded function for code consistency between HYPRE API
     versions. */
 hypre_CSRMatrix *
@@ -223,7 +223,7 @@ hypre_ParCSRMatrixSum(hypre_ParCSRMatrix *A,
                       HYPRE_Complex       beta,
                       hypre_ParCSRMatrix *B);
 
-#if MFEM_HYPRE_VERSION < 22000
+#if MFEM_HYPRE_VERSION < 22200
 
 /** Initialize all entries of A with value. */
 HYPRE_Int

--- a/linalg/hypre_parcsr.hpp
+++ b/linalg/hypre_parcsr.hpp
@@ -206,6 +206,14 @@ hypre_ParCSRMatrix *
 hypre_ParCSRMatrixAdd(hypre_ParCSRMatrix *A,
                       hypre_ParCSRMatrix *B);
 
+#if MFEM_HYPRE_VERSION >= 22000
+/** Provide an overloaded function for code consistency between HYPRE API
+    versions. */
+hypre_CSRMatrix *
+hypre_CSRMatrixAdd(hypre_CSRMatrix *A,
+                   hypre_CSRMatrix *B);
+#endif
+
 /** Perform the operation A += beta*B, assuming that both matrices use the same
     row and column partitions and the same col_map_offd arrays, or B has an empty
     off-diagonal block. We also assume that the sparsity pattern of A contains
@@ -214,6 +222,8 @@ HYPRE_Int
 hypre_ParCSRMatrixSum(hypre_ParCSRMatrix *A,
                       HYPRE_Complex       beta,
                       hypre_ParCSRMatrix *B);
+
+#if MFEM_HYPRE_VERSION < 22000
 
 /** Initialize all entries of A with value. */
 HYPRE_Int
@@ -224,6 +234,8 @@ hypre_CSRMatrixSetConstantValues(hypre_CSRMatrix *A,
 HYPRE_Int
 hypre_ParCSRMatrixSetConstantValues(hypre_ParCSRMatrix *A,
                                     HYPRE_Complex       value);
+
+#endif
 
 } // namespace mfem::internal
 


### PR DESCRIPTION
HYRPE changed the API for some of the functions in v2.22. Notably for MFEM:
* Changed function signature of `hypre_CSRMatrixAdd`
* Added function `hypre_ParCSRMatrixAdd` (previously in `mfem::internal`).
* Added function `hypre_CSRMatrixSetConstantValues` (previously in `mfem::internal`).
* Added function `hypre_ParCSRMatrixSetConstantValues` (previously in `mfem::internal`).

I've introduced an overloaded function to address the function signature change and some preprocessor conditionals to only define the internal functions if `MFEM_HYPRE_VERSION < 22200`.

Resolves #2346 
Thanks!
<!--GHEX{"id":2348,"author":"wcdawn","editor":"v-dobrev","reviewers":["dylan-copeland","v-dobrev"],"assignment":"2021-06-23T13:11:10-07:00","approval":"2021-06-24T22:56:30.665Z","merge":"2021-06-25T19:34:33.394Z"}XEHG--><!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge| 
 | --- | --- | --- | --- | --- | --- | --- | 
| [#2348](https://github.com/mfem/mfem/pull/2348) | @wcdawn | @v-dobrev | @dylan-copeland + @v-dobrev | 06/23/21 | 06/24/21 | 06/25/21 | |
<!--ELBATXEHG-->