### PR TITLE
TMOP kernels for metrics 80 and 332.

### DIFF
--- a/fem/tmop.cpp
+++ b/fem/tmop.cpp
@@ -34,6 +34,7 @@ void TMOP_Combo_QualityMetric::EvalP(const DenseMatrix &Jpt,
                                      DenseMatrix &P) const
 {
    DenseMatrix Pt(P.Size());
+   P = 0.0;
    for (int i = 0; i < tmop_q_arr.Size(); i++)
    {
       tmop_q_arr[i]->EvalP(Jpt, Pt);
@@ -50,6 +51,7 @@ void TMOP_Combo_QualityMetric::AssembleH(const DenseMatrix &Jpt,
    DenseMatrix At(A.Size());
    for (int i = 0; i < tmop_q_arr.Size(); i++)
    {
+      At = 0.0;
       tmop_q_arr[i]->AssembleH(Jpt, DS, weight, At);
       At *= wt_arr[i];
       A += At;

--- a/fem/tmop.hpp
+++ b/fem/tmop.hpp
@@ -371,6 +371,8 @@ public:
       AddQualityMetric(sh_metric, 1.-gamma_);
       AddQualityMetric(sz_metric, gamma_);
    }
+   virtual int Id() const { return 80; }
+   double GetGamma() const { return gamma; }
 
    virtual ~TMOP_Metric_080() { delete sh_metric; delete sz_metric; }
 };
@@ -588,6 +590,29 @@ public:
                           const double weight, DenseMatrix &A) const;
 
    virtual int Id() const { return 321; }
+};
+
+/// 3D barrier Shape+Size (VS) metric (polyconvex).
+class TMOP_Metric_333 : public TMOP_Combo_QualityMetric
+{
+protected:
+   double gamma;
+   TMOP_QualityMetric *sh_metric, *sz_metric;
+
+public:
+   TMOP_Metric_333(double gamma_) : gamma(gamma_),
+      sh_metric(new TMOP_Metric_302),
+      sz_metric(new TMOP_Metric_316)
+   {
+      // (1-gamma) mu_302 + gamma mu_316
+      AddQualityMetric(sh_metric, 1.-gamma_);
+      AddQualityMetric(sz_metric, gamma_);
+   }
+
+   virtual int Id() const { return 333; }
+   double GetGamma() const { return gamma; }
+
+   virtual ~TMOP_Metric_333() { delete sh_metric; delete sz_metric; }
 };
 
 /// Shifted barrier form of 3D metric 16 (volume, ideal barrier metric), 3D

--- a/fem/tmop.hpp
+++ b/fem/tmop.hpp
@@ -593,6 +593,29 @@ public:
 };
 
 /// 3D barrier Shape+Size (VS) metric (polyconvex).
+class TMOP_Metric_332 : public TMOP_Combo_QualityMetric
+{
+protected:
+   double gamma;
+   TMOP_QualityMetric *sh_metric, *sz_metric;
+
+public:
+   TMOP_Metric_332(double gamma_) : gamma(gamma_),
+      sh_metric(new TMOP_Metric_302),
+      sz_metric(new TMOP_Metric_315)
+   {
+      // (1-gamma) mu_302 + gamma mu_315
+      AddQualityMetric(sh_metric, 1.-gamma_);
+      AddQualityMetric(sz_metric, gamma_);
+   }
+
+   virtual int Id() const { return 332; }
+   double GetGamma() const { return gamma; }
+
+   virtual ~TMOP_Metric_332() { delete sh_metric; delete sz_metric; }
+};
+
+/// 3D barrier Shape+Size (VS) metric (polyconvex).
 class TMOP_Metric_333 : public TMOP_Combo_QualityMetric
 {
 protected:

--- a/fem/tmop/tmop_pa_w2.cpp
+++ b/fem/tmop/tmop_pa_w2.cpp
@@ -149,7 +149,7 @@ double TMOP_Integrator::GetLocalStateEnergyPA_2D(const Vector &X) const
    const int D1D = PA.maps->ndof;
    const int Q1D = PA.maps->nqpt;
    const int id = (D1D << 4 ) | Q1D;
-   const double m = metric_normal;
+   const double mn = metric_normal;
    const DenseTensor &J = PA.Jtr;
    const Array<double> &W = PA.ir->GetWeights();
    const Array<double> &B = PA.maps->B;
@@ -160,7 +160,7 @@ double TMOP_Integrator::GetLocalStateEnergyPA_2D(const Vector &X) const
    double mp = 0.0;
    if (auto m = dynamic_cast<TMOP_Metric_080 *>(metric)) { mp = m->GetGamma(); }
 
-   MFEM_LAUNCH_TMOP_KERNEL(EnergyPA_2D,id,m,mp,M,N,J,W,B,G,X,O,E);
+   MFEM_LAUNCH_TMOP_KERNEL(EnergyPA_2D,id,mn,mp,M,N,J,W,B,G,X,O,E);
 }
 
 } // namespace mfem

--- a/fem/tmop/tmop_pa_w2.cpp
+++ b/fem/tmop/tmop_pa_w2.cpp
@@ -50,8 +50,15 @@ double EvalW_077(const double *Jpt)
    return 0.5*(I2b*I2b + 1./(I2b*I2b) - 2.);
 }
 
+static MFEM_HOST_DEVICE inline
+double EvalW_080(const double *Jpt, double gamma)
+{
+   return (1.0 - gamma) * EvalW_002(Jpt) + gamma * EvalW_077(Jpt);
+}
+
 MFEM_REGISTER_TMOP_KERNELS(double, EnergyPA_2D,
                            const double metric_normal,
+                           const double metric_param,
                            const int mid,
                            const int NE,
                            const DenseTensor &j_,
@@ -64,7 +71,7 @@ MFEM_REGISTER_TMOP_KERNELS(double, EnergyPA_2D,
                            const int d1d,
                            const int q1d)
 {
-   MFEM_VERIFY(mid == 1 || mid == 2 || mid == 7 || mid == 77,
+   MFEM_VERIFY(mid == 1 || mid == 2 || mid == 7 || mid == 77 || mid == 80,
                "2D metric not yet implemented!");
 
    constexpr int DIM = 2;
@@ -125,7 +132,8 @@ MFEM_REGISTER_TMOP_KERNELS(double, EnergyPA_2D,
             mid ==  1 ? EvalW_001(Jpt) :
             mid ==  2 ? EvalW_002(Jpt) :
             mid ==  7 ? EvalW_007(Jpt) :
-            mid == 77 ? EvalW_077(Jpt) : 0.0;
+            mid == 77 ? EvalW_077(Jpt) :
+            mid == 80 ? EvalW_080(Jpt, metric_param) : 0.0;
 
             E(qx,qy,e) = weight * EvalW;
          }
@@ -149,7 +157,10 @@ double TMOP_Integrator::GetLocalStateEnergyPA_2D(const Vector &X) const
    const Vector &O = PA.O;
    Vector &E = PA.E;
 
-   MFEM_LAUNCH_TMOP_KERNEL(EnergyPA_2D,id,m,M,N,J,W,B,G,X,O,E);
+   double mp = 0.0;
+   if (auto m = dynamic_cast<TMOP_Metric_080 *>(metric)) { mp = m->GetGamma(); }
+
+   MFEM_LAUNCH_TMOP_KERNEL(EnergyPA_2D,id,m,mp,M,N,J,W,B,G,X,O,E);
 }
 
 } // namespace mfem

--- a/linalg/kernels.hpp
+++ b/linalg/kernels.hpp
@@ -276,6 +276,20 @@ void Add(const int height, const int width, const TA *Adata, TB *Bdata)
    }
 }
 
+/** @brief Compute B +=alpha*A, where the matrices A and B are of size
+    @a height x @a width with data @a Adata and @a Bdata. */
+template<typename TA, typename TB>
+MFEM_HOST_DEVICE inline
+void Add(const int height, const int width,
+         const double alpha, const TA *Adata, TB *Bdata)
+{
+   const int m = height * width;
+   for (int i = 0; i < m; i++)
+   {
+      Bdata[i] += alpha * Adata[i];
+   }
+}
+
 /** @brief Compute B = alpha*A, where the matrices A and B are of size
     @a height x @a width with data @a Adata and @a Bdata. */
 template<typename TA, typename TB>
@@ -289,7 +303,6 @@ void Set(const int height, const int width,
       Bdata[i] = alpha * Adata[i];
    }
 }
-
 
 /** @brief Matrix-matrix multiplication: A = B * C, where the matrices A, B and
     C are of sizes @a Aheight x @a Awidth, @a Aheight x @a Bwidth and @a Bwidth

--- a/tests/unit/miniapps/test_tmop_pa.cpp
+++ b/tests/unit/miniapps/test_tmop_pa.cpp
@@ -746,6 +746,7 @@ static void tmop_tests(int id = 0, bool all = false)
           MESH("../../miniapps/meshing/square01.mesh").REFINE(1).
           NORMALIZATION(true).
           POR({1,2}).QOR({4,6}).
+          LINEAR_ITERATIONS(150).
           TID({5}).MID({80}).LS({3})).Run(id,all);
 
    Launch(Launch::Args("Blade").

--- a/tests/unit/miniapps/test_tmop_pa.cpp
+++ b/tests/unit/miniapps/test_tmop_pa.cpp
@@ -191,6 +191,7 @@ int tmop(int id, Req &res, int argc, char *argv[])
       case 303: metric = new TMOP_Metric_303; break;
       case 315: metric = new TMOP_Metric_315; break;
       case 321: metric = new TMOP_Metric_321; break;
+      case 332: metric = new TMOP_Metric_332(0.5); break;
       default:
       {
          if (id == 0) { cout << "Unknown metric_id: " << metric_id << endl; }
@@ -774,6 +775,12 @@ static void tmop_tests(int id = 0, bool all = false)
           NORMALIZATION(true).LIMITING(M_PI).
           POR({1,2}).QOR({4,2}).
           TID({7}).MID({302,321})).Run(id,all);
+
+   Launch(Launch::Args("Cube + Discrete size + normalization").
+          MESH("../../miniapps/meshing/cube.mesh").
+          NORMALIZATION(true).
+          POR({1,2}).QOR({4,2}).
+          TID({5}).MID({332})).Run(id,all);
 
    // Note: order 1 has no interior nodes, so all residuals are zero and the
    // Newton iteration exits immediately.

--- a/tests/unit/miniapps/test_tmop_pa.cpp
+++ b/tests/unit/miniapps/test_tmop_pa.cpp
@@ -186,6 +186,7 @@ int tmop(int id, Req &res, int argc, char *argv[])
       case   2: metric = new TMOP_Metric_002; break;
       case   7: metric = new TMOP_Metric_007; break;
       case  77: metric = new TMOP_Metric_077; break;
+      case  80: metric = new TMOP_Metric_080(0.5); break;
       case 302: metric = new TMOP_Metric_302; break;
       case 303: metric = new TMOP_Metric_303; break;
       case 315: metric = new TMOP_Metric_315; break;
@@ -739,6 +740,12 @@ static void tmop_tests(int id = 0, bool all = false)
           MESH("../../miniapps/meshing/square01.mesh").REFINE(1).
           POR({1,2}).QOR({2,4}).
           TID({4}).MID({1,2})).Run(id,all);
+
+   Launch(Launch::Args("Square01 + Adapted discrete size").
+          MESH("../../miniapps/meshing/square01.mesh").REFINE(1).
+          NORMALIZATION(true).
+          POR({1,2}).QOR({4,6}).
+          TID({5}).MID({80}).LS({3})).Run(id,all);
 
    Launch(Launch::Args("Blade").
           MESH("../../miniapps/meshing/blade.mesh").


### PR DESCRIPTION
Kernels and unit tests for metrics 80 and 332. These are polyconvex shape+size explicit combinations on the metric level (opposed to integral level).
<!--GHEX{"id":2351,"author":"vladotomov","editor":"v-dobrev","reviewers":["camierjs","kmittal2"],"assignment":"2021-06-23T13:18:26-07:00","approval":"2021-06-28T21:30:11.653Z","merge":"2021-06-28T21:38:11.188Z"}XEHG--><!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge| 
 | --- | --- | --- | --- | --- | --- | --- | 
| [#2351](https://github.com/mfem/mfem/pull/2351) | @vladotomov | @v-dobrev | @camierjs + @kmittal2 | 06/23/21 | 06/28/21 | 06/28/21 | |
<!--ELBATXEHG-->