### PR TITLE
Change the default constructor of `Memory<T>`

### DIFF
--- a/fem/staticcond.cpp
+++ b/fem/staticcond.cpp
@@ -40,8 +40,6 @@ StaticCondensation::StaticCondensation(FiniteElementSpace *fespace)
 #endif
    S = S_e = NULL;
    symm = false;
-   A_data.Reset();
-   A_ipiv.Reset();
 
    Array<int> vdofs;
    const int NE = fes->GetNE();

--- a/general/array.hpp
+++ b/general/array.hpp
@@ -626,7 +626,7 @@ inline void Swap(Array<T> &a, Array<T> &b)
 
 template <class T>
 inline Array<T>::Array(const Array &src)
-   : data(size, src.data.GetMemoryType()), size(src.Size())
+   : data(src.Size(), src.data.GetMemoryType()), size(src.Size())
 {
    data.CopyFrom(src.data, size);
    data.UseDevice(src.data.UseDevice());

--- a/general/array.hpp
+++ b/general/array.hpp
@@ -634,7 +634,7 @@ inline Array<T>::Array(const Array &src)
 
 template <typename T> template <typename CT>
 inline Array<T>::Array(const Array<CT> &src)
-   : data(size), size(src.Size())
+   : data(src.Size()), size(src.Size())
 {
    for (int i = 0; i < size; i++) { (*this)[i] = T(src[i]); }
 }

--- a/general/array.hpp
+++ b/general/array.hpp
@@ -61,14 +61,14 @@ public:
    friend void Swap<T>(Array<T> &, Array<T> &);
 
    /// Creates an empty array
-   inline Array() : size(0) { data.Reset(); }
+   inline Array() : size(0) { }
 
    /// Creates an empty array with a given MemoryType
    inline Array(MemoryType mt) : size(0) { data.Reset(mt); }
 
    /// Creates array of @a asize elements
    explicit inline Array(int asize)
-      : size(asize) { asize > 0 ? data.New(asize) : data.Reset(); }
+      : size(asize), data(asize) { }
 
    /** @brief Creates array using an existing c-array of asize elements;
        allocsize is set to -asize to indicate that the data will not
@@ -626,18 +626,16 @@ inline void Swap(Array<T> &a, Array<T> &b)
 
 template <class T>
 inline Array<T>::Array(const Array &src)
-   : size(src.Size())
+   : size(src.Size()), data(size, src.data.GetMemoryType())
 {
-   size > 0 ? data.New(size, src.data.GetMemoryType()) : data.Reset();
    data.CopyFrom(src.data, size);
    data.UseDevice(src.data.UseDevice());
 }
 
 template <typename T> template <typename CT>
 inline Array<T>::Array(const Array<CT> &src)
-   : size(src.Size())
+   : size(src.Size()), data(size)
 {
-   size > 0 ? data.New(size) : data.Reset();
    for (int i = 0; i < size; i++) { (*this)[i] = T(src[i]); }
 }
 
@@ -709,16 +707,8 @@ inline void Array<T>::SetSize(int nsize, MemoryType mt)
    }
    const bool use_dev = data.UseDevice();
    data.Delete();
-   if (nsize > 0)
-   {
-      data.New(nsize, mt);
-      size = nsize;
-   }
-   else
-   {
-      data.Reset();
-      size = 0;
-   }
+   data.New(nsize, mt);
+   size = nsize;
    data.UseDevice(use_dev);
 }
 

--- a/general/array.hpp
+++ b/general/array.hpp
@@ -68,7 +68,7 @@ public:
 
    /// Creates array of @a asize elements
    explicit inline Array(int asize)
-      : size(asize), data(asize) { }
+      : data(asize), size(asize) { }
 
    /** @brief Creates array using an existing c-array of asize elements;
        allocsize is set to -asize to indicate that the data will not
@@ -626,7 +626,7 @@ inline void Swap(Array<T> &a, Array<T> &b)
 
 template <class T>
 inline Array<T>::Array(const Array &src)
-   : size(src.Size()), data(size, src.data.GetMemoryType())
+   : data(size, src.data.GetMemoryType()), size(src.Size())
 {
    data.CopyFrom(src.data, size);
    data.UseDevice(src.data.UseDevice());
@@ -634,7 +634,7 @@ inline Array<T>::Array(const Array &src)
 
 template <typename T> template <typename CT>
 inline Array<T>::Array(const Array<CT> &src)
-   : size(src.Size()), data(size)
+   : data(size), size(src.Size())
 {
    for (int i = 0; i < size; i++) { (*this)[i] = T(src[i]); }
 }

--- a/general/mem_manager.hpp
+++ b/general/mem_manager.hpp
@@ -169,8 +169,13 @@ protected:
    // Copy{From,To}, {ReadWrite,Read,Write}.
 
 public:
-   /// Default constructor: no initialization.
-   Memory() { }
+   /// Default constructor.
+   Memory()
+      : h_ptr(nullptr),
+      capacity(0),
+      h_mt(MemoryManager::GetHostMemoryType()),
+      flags(0)
+   { }
 
    /// Copy constructor: default.
    Memory(const Memory &orig) = default;

--- a/general/mem_manager.hpp
+++ b/general/mem_manager.hpp
@@ -828,7 +828,7 @@ inline void Memory<T>::New(int size)
    if (size > 0)
    {
       h_ptr = (h_mt == MemoryType::HOST) ? NewHOST(size) :
-            (T*)MemoryManager::New_(nullptr, size*sizeof(T), h_mt, flags);
+              (T*)MemoryManager::New_(nullptr, size*sizeof(T), h_mt, flags);
    }
    else
    {

--- a/general/mem_manager.hpp
+++ b/general/mem_manager.hpp
@@ -825,8 +825,15 @@ inline void Memory<T>::New(int size)
    capacity = size;
    flags = OWNS_HOST | VALID_HOST;
    h_mt = MemoryManager::GetHostMemoryType();
-   h_ptr = (h_mt == MemoryType::HOST) ? NewHOST(size) :
-           (T*)MemoryManager::New_(nullptr, size*sizeof(T), h_mt, flags);
+   if (size > 0)
+   {
+      h_ptr = (h_mt == MemoryType::HOST) ? NewHOST(size) :
+            (T*)MemoryManager::New_(nullptr, size*sizeof(T), h_mt, flags);
+   }
+   else
+   {
+      h_ptr = nullptr;
+   }
 }
 
 template <typename T>
@@ -838,7 +845,16 @@ inline void Memory<T>::New(int size, MemoryType mt)
    if (mt_host) { flags = OWNS_HOST | VALID_HOST; }
    h_mt = IsHostMemory(mt) ? mt : MemoryManager::GetDualMemoryType(mt);
    T *h_tmp = (h_mt == MemoryType::HOST) ? NewHOST(size) : nullptr;
-   h_ptr = (mt_host) ? h_tmp : (T*)MemoryManager::New_(h_tmp, bytes, mt, flags);
+   if (size > 0)
+   {
+      h_ptr = (mt_host) ?
+              h_tmp :
+              (T*)MemoryManager::New_(h_tmp, bytes, mt, flags);
+   }
+   else
+   {
+      h_ptr = nullptr;
+   }
 }
 
 template <typename T>
@@ -847,8 +863,16 @@ inline void Memory<T>::New(int size, MemoryType h_mt, MemoryType d_mt)
    capacity = size;
    const size_t bytes = size*sizeof(T);
    this->h_mt = h_mt;
-   T *h_tmp = (h_mt == MemoryType::HOST) ? NewHOST(size) : nullptr;
-   h_ptr = (T*)MemoryManager::New_(h_tmp, bytes, h_mt, d_mt, VALID_HOST, flags);
+   if (size > 0)
+   {
+      T *h_tmp = (h_mt == MemoryType::HOST) ? NewHOST(size) : nullptr;
+      h_ptr = (T*)MemoryManager::New_(h_tmp, bytes, h_mt, d_mt, VALID_HOST,
+                                      flags);
+   }
+   else
+   {
+      h_ptr = nullptr;
+   }
 }
 
 template <typename T>

--- a/general/mem_manager.hpp
+++ b/general/mem_manager.hpp
@@ -170,7 +170,7 @@ protected:
 
 public:
    /// Default constructor.
-   Memory() { New(0); }
+   Memory() { Reset(); }
 
    /// Copy constructor: default.
    Memory(const Memory &orig) = default;

--- a/general/mem_manager.hpp
+++ b/general/mem_manager.hpp
@@ -170,12 +170,7 @@ protected:
 
 public:
    /// Default constructor.
-   Memory()
-      : h_ptr(nullptr),
-        capacity(0),
-        h_mt(MemoryManager::GetHostMemoryType()),
-        flags(0)
-   { }
+   Memory() { New(0); }
 
    /// Copy constructor: default.
    Memory(const Memory &orig) = default;

--- a/general/mem_manager.hpp
+++ b/general/mem_manager.hpp
@@ -172,9 +172,9 @@ public:
    /// Default constructor.
    Memory()
       : h_ptr(nullptr),
-      capacity(0),
-      h_mt(MemoryManager::GetHostMemoryType()),
-      flags(0)
+        capacity(0),
+        h_mt(MemoryManager::GetHostMemoryType()),
+        flags(0)
    { }
 
    /// Copy constructor: default.

--- a/general/mem_manager.hpp
+++ b/general/mem_manager.hpp
@@ -210,7 +210,7 @@ public:
        host memory type returned by MemoryManager::GetHostMemoryType(). */
    /** The parameter @a own determines whether @a ptr will be deleted when the
        method Delete() is called. */
-   explicit Memory(T *ptr, int size, bool own) { Wrap(ptr, size, own); }
+   Memory(T *ptr, int size, bool own) { Wrap(ptr, size, own); }
 
    /// Wrap an externally allocated pointer, @a ptr, of the given MemoryType.
    /** The new memory object will have the given MemoryType set as valid.

--- a/general/table.cpp
+++ b/general/table.cpp
@@ -27,7 +27,7 @@ using namespace std;
 Table::Table(const Table &table)
 {
    size = table.size;
-   if (size >=0)
+   if (size >= 0)
    {
       const int nnz = table.I[size];
       I.New(size+1, table.I.GetMemoryType());

--- a/general/table.cpp
+++ b/general/table.cpp
@@ -27,17 +27,13 @@ using namespace std;
 Table::Table(const Table &table)
 {
    size = table.size;
-   if (size >= 0)
+   if (size >=0)
    {
       const int nnz = table.I[size];
       I.New(size+1, table.I.GetMemoryType());
       J.New(nnz, table.J.GetMemoryType());
       I.CopyFrom(table.I, size+1);
       J.CopyFrom(table.J, nnz);
-   }
-   else
-   {
-      I.Reset(); J.Reset();
    }
 }
 

--- a/general/table.hpp
+++ b/general/table.hpp
@@ -53,7 +53,7 @@ protected:
 
 public:
    /// Creates an empty table
-   Table() { size = -1; I.Reset(); J.Reset(); }
+   Table() { size = -1; }
 
    /// Copy constructor
    Table(const Table &);
@@ -66,7 +66,7 @@ public:
 
    /** Create a table from a list of connections, see MakeFromList(). */
    Table(int nrows, Array<Connection> &list) : size(-1)
-   { I.Reset(); J.Reset(); MakeFromList(nrows, list); }
+   { MakeFromList(nrows, list); }
 
    /** Create a table with one entry per row with column indices given
        by 'partitioning'. */
@@ -151,7 +151,7 @@ public:
    int Width() const;
 
    /// Call this if data has been stolen.
-   void LoseData() { size = -1; I.Reset(); J.Reset(); }
+   void LoseData() { size = -1; }
 
    /// Prints the table to stream out.
    void Print(std::ostream & out = mfem::out, int width = 4) const;

--- a/linalg/densemat.cpp
+++ b/linalg/densemat.cpp
@@ -93,7 +93,6 @@ DenseMatrix::DenseMatrix(int m, int n) : Matrix(m, n), data(m*n)
 {
    MFEM_ASSERT(m >= 0 && n >= 0,
                "invalid DenseMatrix size: " << m << " x " << n);
-   const int capacity = m*n;
    *this = 0.0; // init with zeroes
 }
 

--- a/linalg/densemat.cpp
+++ b/linalg/densemat.cpp
@@ -70,65 +70,40 @@ namespace mfem
 
 using namespace std;
 
-DenseMatrix::DenseMatrix() : Matrix(0)
-{
-   data.Reset();
-}
+DenseMatrix::DenseMatrix() : Matrix(0) { }
 
-DenseMatrix::DenseMatrix(const DenseMatrix &m) : Matrix(m.height, m.width)
+DenseMatrix::DenseMatrix(const DenseMatrix &m)
+: Matrix(m.height, m.width), data(m.height * m.width)
 {
    const int hw = height * width;
    if (hw > 0)
    {
       MFEM_ASSERT(m.data, "invalid source matrix");
-      data.New(hw);
       std::memcpy(data, m.data, sizeof(double)*hw);
    }
-   else
-   {
-      data.Reset();
-   }
 }
 
-DenseMatrix::DenseMatrix(int s) : Matrix(s)
+DenseMatrix::DenseMatrix(int s) : Matrix(s), data(s*s)
 {
    MFEM_ASSERT(s >= 0, "invalid DenseMatrix size: " << s);
-   if (s > 0)
-   {
-      data.New(s*s);
-      *this = 0.0; // init with zeroes
-   }
-   else
-   {
-      data.Reset();
-   }
+   *this = 0.0; // init with zeroes
 }
 
-DenseMatrix::DenseMatrix(int m, int n) : Matrix(m, n)
+DenseMatrix::DenseMatrix(int m, int n) : Matrix(m, n), data(m*n)
 {
    MFEM_ASSERT(m >= 0 && n >= 0,
                "invalid DenseMatrix size: " << m << " x " << n);
    const int capacity = m*n;
-   if (capacity > 0)
-   {
-      data.New(capacity);
-      *this = 0.0; // init with zeroes
-   }
-   else
-   {
-      data.Reset();
-   }
+   *this = 0.0; // init with zeroes
 }
 
 DenseMatrix::DenseMatrix(const DenseMatrix &mat, char ch)
-   : Matrix(mat.width, mat.height)
+   : Matrix(mat.width, mat.height), data(height*width)
 {
    MFEM_CONTRACT_VAR(ch);
    const int capacity = height*width;
    if (capacity > 0)
    {
-      data.New(capacity);
-
       for (int i = 0; i < height; i++)
       {
          for (int j = 0; j < width; j++)
@@ -136,10 +111,6 @@ DenseMatrix::DenseMatrix(const DenseMatrix &mat, char ch)
             (*this)(i,j) = mat(j,i);
          }
       }
-   }
-   else
-   {
-      data.Reset();
    }
 }
 

--- a/linalg/densemat.cpp
+++ b/linalg/densemat.cpp
@@ -73,7 +73,7 @@ using namespace std;
 DenseMatrix::DenseMatrix() : Matrix(0) { }
 
 DenseMatrix::DenseMatrix(const DenseMatrix &m)
-: Matrix(m.height, m.width), data(m.height * m.width)
+   : Matrix(m.height, m.width), data(m.height * m.width)
 {
    const int hw = height * width;
    if (hw > 0)

--- a/linalg/densemat.hpp
+++ b/linalg/densemat.hpp
@@ -771,8 +771,9 @@ public:
 
    /// Copy constructor: deep copy
    DenseTensor(const DenseTensor &other)
-      : Mk(NULL, other.Mk.height, other.Mk.width), nk(other.nk),
-        tdata(Mk.Height()*Mk.Width()*nk, other.tdata.GetMemoryType())
+      : Mk(NULL, other.Mk.height, other.Mk.width),
+        tdata(Mk.Height()*Mk.Width()*nk, other.tdata.GetMemoryType()),
+        nk(other.nk)
    {
       const int size = Mk.Height()*Mk.Width()*nk;
       if (size > 0)

--- a/linalg/densemat.hpp
+++ b/linalg/densemat.hpp
@@ -772,7 +772,7 @@ public:
    /// Copy constructor: deep copy
    DenseTensor(const DenseTensor &other)
       : Mk(NULL, other.Mk.height, other.Mk.width),
-        tdata(Mk.Height()*Mk.Width()*nk, other.tdata.GetMemoryType()),
+        tdata(Mk.Height()*Mk.Width()*other.nk, other.tdata.GetMemoryType()),
         nk(other.nk)
    {
       const int size = Mk.Height()*Mk.Width()*nk;

--- a/linalg/densemat.hpp
+++ b/linalg/densemat.hpp
@@ -772,7 +772,7 @@ public:
    /// Copy constructor: deep copy
    DenseTensor(const DenseTensor &other)
       : Mk(NULL, other.Mk.height, other.Mk.width), nk(other.nk),
-      tdata(Mk.Height()*Mk.Width()*nk, other.tdata.GetMemoryType())
+        tdata(Mk.Height()*Mk.Width()*nk, other.tdata.GetMemoryType())
    {
       const int size = Mk.Height()*Mk.Width()*nk;
       if (size > 0)

--- a/linalg/densemat.hpp
+++ b/linalg/densemat.hpp
@@ -753,7 +753,6 @@ public:
    DenseTensor()
    {
       nk = 0;
-      tdata.Reset();
    }
 
    DenseTensor(int i, int j, int k)
@@ -772,17 +771,13 @@ public:
 
    /// Copy constructor: deep copy
    DenseTensor(const DenseTensor &other)
-      : Mk(NULL, other.Mk.height, other.Mk.width), nk(other.nk)
+      : Mk(NULL, other.Mk.height, other.Mk.width), nk(other.nk),
+      tdata(Mk.Height()*Mk.Width()*nk, other.tdata.GetMemoryType())
    {
       const int size = Mk.Height()*Mk.Width()*nk;
       if (size > 0)
       {
-         tdata.New(size, other.tdata.GetMemoryType());
          tdata.CopyFrom(other.tdata, size);
-      }
-      else
-      {
-         tdata.Reset();
       }
    }
 

--- a/linalg/sparsemat.cpp
+++ b/linalg/sparsemat.cpp
@@ -78,11 +78,6 @@ SparseMatrix::SparseMatrix(int nrows, int ncols)
      At(NULL),
      isSorted(false)
 {
-   // We probably do not need to set the ownership flags here.
-   I.Reset(); I.SetHostPtrOwner(true);
-   J.Reset(); J.SetHostPtrOwner(true);
-   A.Reset(); A.SetHostPtrOwner(true);
-
    for (int i = 0; i < nrows; i++)
    {
       Rows[i] = NULL;
@@ -222,11 +217,6 @@ SparseMatrix::SparseMatrix(const SparseMatrix &mat, bool copy_graph,
          }
          *node_pp = NULL;
       }
-
-      // We probably do not need to set the ownership flags here.
-      I.Reset(); I.SetHostPtrOwner(true);
-      J.Reset(); J.SetHostPtrOwner(true);
-      A.Reset(); A.SetHostPtrOwner(true);
    }
 
    current_row = -1;

--- a/linalg/symmat.cpp
+++ b/linalg/symmat.cpp
@@ -23,7 +23,7 @@ DenseSymmetricMatrix::DenseSymmetricMatrix() : Matrix(0)
 }
 
 DenseSymmetricMatrix::DenseSymmetricMatrix(int s)
-: Matrix(s), data((s*(s+1))/2)
+   : Matrix(s), data((s*(s+1))/2)
 {
    MFEM_ASSERT(s >= 0, "invalid DenseSymmetricMatrix size: " << s);
    *this = 0.0; // init with zeroes

--- a/linalg/symmat.cpp
+++ b/linalg/symmat.cpp
@@ -22,18 +22,11 @@ DenseSymmetricMatrix::DenseSymmetricMatrix() : Matrix(0)
    data.Reset();
 }
 
-DenseSymmetricMatrix::DenseSymmetricMatrix(int s) : Matrix(s)
+DenseSymmetricMatrix::DenseSymmetricMatrix(int s)
+: Matrix(s), data((s*(s+1))/2)
 {
    MFEM_ASSERT(s >= 0, "invalid DenseSymmetricMatrix size: " << s);
-   if (s > 0)
-   {
-      data.New((s*(s+1))/2);
-      *this = 0.0; // init with zeroes
-   }
-   else
-   {
-      data.Reset();
-   }
+   *this = 0.0; // init with zeroes
 }
 
 void DenseSymmetricMatrix::SetSize(int s)

--- a/linalg/vector.cpp
+++ b/linalg/vector.cpp
@@ -37,19 +37,13 @@ namespace mfem
 {
 
 Vector::Vector(const Vector &v)
+: size(v.Size()), data(v.Size(), v.data.GetMemoryType())
 {
    const int s = v.Size();
+   MFEM_ASSERT(!v.data.Empty(), "invalid source vector");
    if (s > 0)
    {
-      MFEM_ASSERT(!v.data.Empty(), "invalid source vector");
-      size = s;
-      data.New(s, v.data.GetMemoryType());
       data.CopyFrom(v.data, s);
-   }
-   else
-   {
-      size = 0;
-      data.Reset();
    }
    UseDevice(v.UseDevice());
 }

--- a/linalg/vector.cpp
+++ b/linalg/vector.cpp
@@ -37,7 +37,7 @@ namespace mfem
 {
 
 Vector::Vector(const Vector &v)
-   : size(v.Size()), data(v.Size(), v.data.GetMemoryType())
+   : data(v.Size(), v.data.GetMemoryType()), size(v.Size())
 {
    const int s = v.Size();
    MFEM_ASSERT(!v.data.Empty(), "invalid source vector");

--- a/linalg/vector.cpp
+++ b/linalg/vector.cpp
@@ -37,7 +37,7 @@ namespace mfem
 {
 
 Vector::Vector(const Vector &v)
-: size(v.Size()), data(v.Size(), v.data.GetMemoryType())
+   : size(v.Size()), data(v.Size(), v.data.GetMemoryType())
 {
    const int s = v.Size();
    MFEM_ASSERT(!v.data.Empty(), "invalid source vector");

--- a/linalg/vector.hpp
+++ b/linalg/vector.hpp
@@ -491,7 +491,7 @@ inline int CheckFinite(const double *v, const int n)
    return bad;
 }
 
-inline Vector::Vector(int s): size(s), data(s) { }
+inline Vector::Vector(int s): data(s), size(s) { }
 
 inline void Vector::SetSize(int s)
 {

--- a/linalg/vector.hpp
+++ b/linalg/vector.hpp
@@ -67,7 +67,7 @@ protected:
 public:
 
    /// Default constructor for Vector. Sets size = 0 and data = NULL.
-   Vector() { data.Reset(); size = 0; }
+   Vector(): size(0) { }
 
    /// Copy constructor. Allocates a new data array and copies the data.
    Vector(const Vector &);
@@ -491,19 +491,7 @@ inline int CheckFinite(const double *v, const int n)
    return bad;
 }
 
-inline Vector::Vector(int s)
-{
-   if (s > 0)
-   {
-      size = s;
-      data.New(s);
-   }
-   else
-   {
-      size = 0;
-      data.Reset();
-   }
-}
+inline Vector::Vector(int s): size(s), data(s) { }
 
 inline void Vector::SetSize(int s)
 {
@@ -541,16 +529,8 @@ inline void Vector::SetSize(int s, MemoryType mt)
    }
    const bool use_dev = data.UseDevice();
    data.Delete();
-   if (s > 0)
-   {
-      data.New(s, mt);
-      size = s;
-   }
-   else
-   {
-      data.Reset();
-      size = 0;
-   }
+   data.New(s, mt);
+   size = s;
    data.UseDevice(use_dev);
 }
 


### PR DESCRIPTION
This PR proposes a change to the default constructor of the `Memory<T>` class, this prevents users from having to call `Memory<T>::Reset()` a bit everywhere, and also prevents bugs with uninitialized fields.
The PR also makes the `Memory<T>::New` method handle size `0` internally instead of externalizing the reasoning.