### PR TITLE
Change copy constructor and assignment operator for `Memory<T>`.

### DIFF
--- a/general/array.hpp
+++ b/general/array.hpp
@@ -863,7 +863,7 @@ template <class T>
 inline void Array<T>::MakeRef(const Array &master)
 {
    data.Delete();
-   data = master.data; // note: copies the device flag
+   data = master.data;
    size = master.size;
    data.ClearOwnerFlags();
 }

--- a/general/mem_manager.hpp
+++ b/general/mem_manager.hpp
@@ -175,7 +175,7 @@ public:
    /// Copy constructor, does not take ownership.
    Memory(const Memory &orig)
       : h_ptr(orig.h_ptr), capacity(orig.capacity), h_mt(orig.h_mt),
-      flags(orig.flags)
+        flags(orig.flags)
    {
       flags = flags & ~(OWNS_HOST | OWNS_DEVICE | OWNS_INTERNAL);
    }

--- a/general/mem_manager.hpp
+++ b/general/mem_manager.hpp
@@ -172,14 +172,26 @@ public:
    /// Default constructor: no initialization.
    Memory() { }
 
-   /// Copy constructor: default.
-   Memory(const Memory &orig) = default;
+   /// Copy constructor, does not take ownership.
+   Memory(const Memory &orig)
+      : h_ptr(orig.h_ptr), capacity(orig.capacity), h_mt(orig.h_mt),
+      flags(orig.flags)
+   {
+      flags = flags & ~(OWNS_HOST | OWNS_DEVICE | OWNS_INTERNAL);
+   }
 
    /// Move constructor: default.
    Memory(Memory &&orig) = default;
 
-   /// Copy-assignment operator: default.
-   Memory &operator=(const Memory &orig) = default;
+   /// Copy-assignment operator, does not take ownership.
+   Memory &operator=(const Memory &orig)
+   {
+      h_ptr = orig.h_ptr;
+      capacity = orig.capacity;
+      h_mt = orig.h_mt;
+      flags = orig.flags & ~(OWNS_HOST | OWNS_DEVICE | OWNS_INTERNAL);
+      return *this;
+   }
 
    /// Move-assignment operator: default.
    Memory &operator=(Memory &&orig) = default;

--- a/general/mem_manager.hpp
+++ b/general/mem_manager.hpp
@@ -174,10 +174,8 @@ public:
 
    /// Copy constructor, does not take ownership.
    Memory(const Memory &orig)
-      : h_ptr(orig.h_ptr), capacity(orig.capacity), h_mt(orig.h_mt),
-        flags(orig.flags)
    {
-      flags = flags & ~(OWNS_HOST | OWNS_DEVICE | OWNS_INTERNAL);
+      MakesAlias(orig, 0, orig.capacity);
    }
 
    /// Move constructor: default.
@@ -186,10 +184,7 @@ public:
    /// Copy-assignment operator, does not take ownership.
    Memory &operator=(const Memory &orig)
    {
-      h_ptr = orig.h_ptr;
-      capacity = orig.capacity;
-      h_mt = orig.h_mt;
-      flags = orig.flags & ~(OWNS_HOST | OWNS_DEVICE | OWNS_INTERNAL);
+      MakesAlias(orig, 0, orig.capacity);
       return *this;
    }
 

--- a/general/mem_manager.hpp
+++ b/general/mem_manager.hpp
@@ -175,7 +175,7 @@ public:
    /// Copy constructor, does not take ownership.
    Memory(const Memory &orig)
    {
-      MakesAlias(orig, 0, orig.capacity);
+      MakeAlias(orig, 0, orig.capacity);
    }
 
    /// Move constructor: default.
@@ -184,7 +184,7 @@ public:
    /// Copy-assignment operator, does not take ownership.
    Memory &operator=(const Memory &orig)
    {
-      MakesAlias(orig, 0, orig.capacity);
+      MakeAlias(orig, 0, orig.capacity);
       return *this;
    }
 


### PR DESCRIPTION
The default copy constructor and assignment operator copy the ownership flags, I think this is only bug prone, this PR changes this behavior to never take ownership.