### PR TITLE
Change the destructor of `Memory<T>` to delete.

### DIFF
--- a/general/mem_manager.hpp
+++ b/general/mem_manager.hpp
@@ -224,9 +224,11 @@ public:
    Memory(const Memory &base, int offset, int size)
    { MakeAlias(base, offset, size); }
 
-   /// Destructor: default.
-   /** @note The destructor will NOT delete the current memory. */
-   ~Memory() = default;
+   /// Destructor.
+   ~Memory()
+   {
+      Delete();
+   }
 
    /** @brief Return true if the host pointer is owned. Ownership indicates
        whether the pointer will be deleted by the method Delete(). */

--- a/general/mem_manager.hpp
+++ b/general/mem_manager.hpp
@@ -942,6 +942,7 @@ inline void Memory<T>::Delete()
    {
       if (flags & OWNS_HOST) { delete [] h_ptr; }
    }
+   Reset();
 }
 
 template <typename T>


### PR DESCRIPTION
The current destructor of the `Memory<T>` class currently doesn't delete the memory, even when owned, this PR proposes to change this behavior. This should also help catching issues by enforcing a more strict memory ownership.