### PR TITLE
Solver const correctness [solver-const-correctness]

### DIFF
--- a/linalg/solvers.cpp
+++ b/linalg/solvers.cpp
@@ -232,7 +232,7 @@ void OperatorJacobiSmoother::Mult(const Vector &x, Vector &y) const
    MFEM_FORALL(i, height, Y[i] += DI[i] * R[i]; );
 }
 
-OperatorChebyshevSmoother::OperatorChebyshevSmoother(Operator* oper_,
+OperatorChebyshevSmoother::OperatorChebyshevSmoother(const Operator* oper_,
                                                      const Vector &d,
                                                      const Array<int>& ess_tdofs,
                                                      int order_, double max_eig_estimate_)
@@ -249,12 +249,12 @@ OperatorChebyshevSmoother::OperatorChebyshevSmoother(Operator* oper_,
    oper(oper_) { Setup(); }
 
 #ifdef MFEM_USE_MPI
-OperatorChebyshevSmoother::OperatorChebyshevSmoother(Operator* oper_,
+OperatorChebyshevSmoother::OperatorChebyshevSmoother(const Operator* oper_,
                                                      const Vector &d,
                                                      const Array<int>& ess_tdofs,
                                                      int order_, MPI_Comm comm, int power_iterations, double power_tolerance)
 #else
-OperatorChebyshevSmoother::OperatorChebyshevSmoother(Operator* oper_,
+OperatorChebyshevSmoother::OperatorChebyshevSmoother(const Operator* oper_,
                                                      const Vector &d,
                                                      const Array<int>& ess_tdofs,
                                                      int order_, int power_iterations, double power_tolerance)
@@ -2533,7 +2533,7 @@ BlockILU::BlockILU(int block_size_,
      reordering(reordering_)
 { }
 
-BlockILU::BlockILU(Operator &op,
+BlockILU::BlockILU(const Operator &op,
                    int block_size_,
                    Reordering reordering_,
                    int k_fill_)

--- a/linalg/solvers.hpp
+++ b/linalg/solvers.hpp
@@ -208,7 +208,7 @@ public:
        the matrix-free setting. The estimated largest eigenvalue of the
        diagonally preconditoned operator must be provided via
        max_eig_estimate. */
-   OperatorChebyshevSmoother(Operator* oper_, const Vector &d,
+   OperatorChebyshevSmoother(const Operator* oper_, const Vector &d,
                              const Array<int>& ess_tdof_list,
                              int order, double max_eig_estimate);
 
@@ -220,13 +220,13 @@ public:
        accuracy of the estimated eigenvalue may be controlled via
        power_iterations and power_tolerance. */
 #ifdef MFEM_USE_MPI
-   OperatorChebyshevSmoother(Operator* oper_, const Vector &d,
+   OperatorChebyshevSmoother(const Operator* oper_, const Vector &d,
                              const Array<int>& ess_tdof_list,
                              int order, MPI_Comm comm = MPI_COMM_NULL,
                              int power_iterations = 10,
                              double power_tolerance = 1e-8);
 #else
-   OperatorChebyshevSmoother(Operator* oper_, const Vector &d,
+   OperatorChebyshevSmoother(const Operator* oper_, const Vector &d,
                              const Array<int>& ess_tdof_list,
                              int order, int power_iterations = 10,
                              double power_tolerance = 1e-8);
@@ -731,7 +731,7 @@ public:
     *  case that @a op is a HypreParMatrix, the ILU factorization is performed
     *  on the diagonal blocks of the parallel decomposition.
     */
-   BlockILU(Operator &op, int block_size_ = 1,
+   BlockILU(const Operator &op, int block_size_ = 1,
             Reordering reordering_ = Reordering::MINIMUM_DISCARDED_FILL,
             int k_fill_ = 0);
 


### PR DESCRIPTION
Some simple const correctness fixes for `OperatorChebyshevSmoother` and `BlockILU`.
<!--GHEX{"id":2360,"author":"pazner","editor":"tzanio","reviewers":["mlstowell","tzanio"],"assignment":"2021-06-26T19:31:18-07:00","approval":"2021-06-28T20:54:45.119Z","merge":"2021-06-29T15:41:09.607Z"}XEHG--><!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge| 
 | --- | --- | --- | --- | --- | --- | --- | 
| [#2360](https://github.com/mfem/mfem/pull/2360) | @pazner | @tzanio | @mlstowell + @tzanio | 06/26/21 | 06/28/21 | 06/29/21 | |
<!--ELBATXEHG-->