### PR TITLE
Changing OperatorChebyshevSmoother to pass-by-reference [op-by-ref-dev]

### DIFF
--- a/examples/ex26.cpp
+++ b/examples/ex26.cpp
@@ -105,7 +105,7 @@ private:
       Vector diag(fespace.GetTrueVSize());
       bfs.Last()->AssembleDiagonal(diag);
 
-      Solver* smoother = new OperatorChebyshevSmoother(opr.Ptr(), diag,
+      Solver* smoother = new OperatorChebyshevSmoother(*opr, diag,
                                                        *essentialTrueDofs.Last(), 2);
       AddLevel(opr.Ptr(), smoother, true, true);
    }

--- a/examples/ex26p.cpp
+++ b/examples/ex26p.cpp
@@ -115,7 +115,7 @@ private:
       Vector diag(fespace.GetTrueVSize());
       bfs.Last()->AssembleDiagonal(diag);
 
-      Solver* smoother = new OperatorChebyshevSmoother(opr.Ptr(), diag,
+      Solver* smoother = new OperatorChebyshevSmoother(*opr, diag,
                                                        *essentialTrueDofs.Last(), 2, fespace.GetParMesh()->GetComm());
 
       AddLevel(opr.Ptr(), smoother, true, true);

--- a/fem/ceed/algebraic.cpp
+++ b/fem/ceed/algebraic.cpp
@@ -143,7 +143,7 @@ Solver *BuildSmootherFromCeed(ConstrainedOperator &op, bool chebyshev)
    if (chebyshev)
    {
       const int cheb_order = 3;
-      out = new OperatorChebyshevSmoother(&op, t_diag, ess_tdofs, cheb_order);
+      out = new OperatorChebyshevSmoother(op, t_diag, ess_tdofs, cheb_order);
    }
    else
    {

--- a/linalg/solvers.cpp
+++ b/linalg/solvers.cpp
@@ -248,58 +248,6 @@ OperatorChebyshevSmoother::OperatorChebyshevSmoother(const Operator &oper_,
    residual(N),
    oper(&oper_) { Setup(); }
 
-OperatorChebyshevSmoother::OperatorChebyshevSmoother(const Operator* oper_,
-                                                     const Vector &d,
-                                                     const Array<int>& ess_tdofs,
-                                                     int order_, double max_eig_estimate_)
-   :
-   Solver(d.Size()),
-   order(order_),
-   max_eig_estimate(max_eig_estimate_),
-   N(d.Size()),
-   dinv(N),
-   diag(d),
-   coeffs(order),
-   ess_tdof_list(ess_tdofs),
-   residual(N),
-   oper(oper_) { Setup(); }
-
-#ifdef MFEM_USE_MPI
-OperatorChebyshevSmoother::OperatorChebyshevSmoother(const Operator* oper_,
-                                                     const Vector &d,
-                                                     const Array<int>& ess_tdofs,
-                                                     int order_, MPI_Comm comm, int power_iterations, double power_tolerance)
-#else
-OperatorChebyshevSmoother::OperatorChebyshevSmoother(const Operator* oper_,
-                                                     const Vector &d,
-                                                     const Array<int>& ess_tdofs,
-                                                     int order_, int power_iterations, double power_tolerance)
-#endif
-   : Solver(d.Size()),
-     order(order_),
-     N(d.Size()),
-     dinv(N),
-     diag(d),
-     coeffs(order),
-     ess_tdof_list(ess_tdofs),
-     residual(N),
-     oper(oper_)
-{
-   OperatorJacobiSmoother invDiagOperator(diag, ess_tdofs, 1.0);
-   ProductOperator diagPrecond(&invDiagOperator, oper, false, false);
-
-#ifdef MFEM_USE_MPI
-   PowerMethod powerMethod(comm);
-#else
-   PowerMethod powerMethod;
-#endif
-   Vector ev(oper->Width());
-   max_eig_estimate = powerMethod.EstimateLargestEigenvalue(diagPrecond, ev,
-                                                            power_iterations, power_tolerance);
-
-   Setup();
-}
-
 #ifdef MFEM_USE_MPI
 OperatorChebyshevSmoother::OperatorChebyshevSmoother(const Operator &oper_,
                                                      const Vector &d,
@@ -335,6 +283,28 @@ OperatorChebyshevSmoother::OperatorChebyshevSmoother(const Operator &oper_,
 
    Setup();
 }
+
+OperatorChebyshevSmoother::OperatorChebyshevSmoother(const Operator* oper_,
+                                                     const Vector &d,
+                                                     const Array<int>& ess_tdofs,
+                                                     int order_, double max_eig_estimate_)
+   : OperatorChebyshevSmoother(*oper_, d, ess_tdofs, order_, max_eig_estimate_) { }
+
+#ifdef MFEM_USE_MPI
+OperatorChebyshevSmoother::OperatorChebyshevSmoother(const Operator* oper_,
+                                                     const Vector &d,
+                                                     const Array<int>& ess_tdofs,
+                                                     int order_, MPI_Comm comm, int power_iterations, double power_tolerance)
+   : OperatorChebyshevSmoother(*oper_, d, ess_tdofs, order_, comm,
+                               power_iterations, power_tolerance) { }
+#else
+OperatorChebyshevSmoother::OperatorChebyshevSmoother(const Operator* oper_,
+                                                     const Vector &d,
+                                                     const Array<int>& ess_tdofs,
+                                                     int order_, int power_iterations, double power_tolerance)
+   : OperatorChebyshevSmoother(*oper_, d, ess_tdofs, order_, power_iterations,
+                               power_tolerance) { }
+#endif
 
 void OperatorChebyshevSmoother::Setup()
 {

--- a/linalg/solvers.hpp
+++ b/linalg/solvers.hpp
@@ -208,6 +208,12 @@ public:
        the matrix-free setting. The estimated largest eigenvalue of the
        diagonally preconditoned operator must be provided via
        max_eig_estimate. */
+   OperatorChebyshevSmoother(const Operator &oper_, const Vector &d,
+                             const Array<int>& ess_tdof_list,
+                             int order, double max_eig_estimate);
+
+   /// Deprecated: see pass-by-reference version above
+   MFEM_DEPRECATED
    OperatorChebyshevSmoother(const Operator* oper_, const Vector &d,
                              const Array<int>& ess_tdof_list,
                              int order, double max_eig_estimate);
@@ -220,12 +226,27 @@ public:
        accuracy of the estimated eigenvalue may be controlled via
        power_iterations and power_tolerance. */
 #ifdef MFEM_USE_MPI
+   OperatorChebyshevSmoother(const Operator &oper_, const Vector &d,
+                             const Array<int>& ess_tdof_list,
+                             int order, MPI_Comm comm = MPI_COMM_NULL,
+                             int power_iterations = 10,
+                             double power_tolerance = 1e-8);
+
+   /// Deprecated: see pass-by-reference version above
+   MFEM_DEPRECATED
    OperatorChebyshevSmoother(const Operator* oper_, const Vector &d,
                              const Array<int>& ess_tdof_list,
                              int order, MPI_Comm comm = MPI_COMM_NULL,
                              int power_iterations = 10,
                              double power_tolerance = 1e-8);
 #else
+   OperatorChebyshevSmoother(const Operator &oper_, const Vector &d,
+                             const Array<int>& ess_tdof_list,
+                             int order, int power_iterations = 10,
+                             double power_tolerance = 1e-8);
+
+   /// Deprecated: see pass-by-reference version above
+   MFEM_DEPRECATED
    OperatorChebyshevSmoother(const Operator* oper_, const Vector &d,
                              const Array<int>& ess_tdof_list,
                              int order, int power_iterations = 10,

--- a/tests/unit/linalg/test_chebyshev.cpp
+++ b/tests/unit/linalg/test_chebyshev.cpp
@@ -38,7 +38,7 @@ TEST_CASE("OperatorChebyshevSmoother", "[Chebyshev symmetry]")
       Vector diag(fespace.GetTrueVSize());
       aform.AssembleDiagonal(diag);
 
-      Solver* smoother = new OperatorChebyshevSmoother(opr.Ptr(), diag, ess_tdof_list,
+      Solver* smoother = new OperatorChebyshevSmoother(*opr, diag, ess_tdof_list,
                                                        cheb_order);
 
       int n = smoother->Width();


### PR DESCRIPTION
The reason for this change in two-fold. First, all other classes declared in `solvers.hpp` use pass-by-reference for their operators so `OperatorChebyshevSmoother` may cause confusion. Second, this class will abort if the operator is NULL so pass-by-reference will ensure that a valid operator object has been passed.

Note: this PR includes deprecation warnings on the original constructors, however, these don't seem to work. I'm not sure why...
<!--GHEX{"id":2370,"author":"mlstowell","editor":"tzanio","reviewers":["pazner","barker29"],"assignment":"2021-06-30T13:59:46-07:00","approval":"2021-07-06T20:06:18.991Z","merge":"2021-07-09T23:02:02.943Z"}XEHG--><!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge| 
 | --- | --- | --- | --- | --- | --- | --- | 
| [#2370](https://github.com/mfem/mfem/pull/2370) | @mlstowell | @tzanio | @pazner + @barker29 | 06/30/21 | 07/06/21 | 07/09/21 | |
<!--ELBATXEHG-->