### PR TITLE
[WIP] LOR solvers: device and p-refinement [lor-solvers-p-ref]

### DIFF
--- a/fem/bilinearform.cpp
+++ b/fem/bilinearform.cpp
@@ -953,6 +953,7 @@ void BilinearForm::EliminateVDofs(const Array<int> &vdofs,
                                   const Vector &sol, Vector &rhs,
                                   DiagonalPolicy dpolicy)
 {
+   vdofs.HostRead();
    for (int i = 0; i < vdofs.Size(); i++)
    {
       int vdof = vdofs[i];

--- a/fem/fespace.cpp
+++ b/fem/fespace.cpp
@@ -123,10 +123,21 @@ void FiniteElementSpace::CopyProlongationAndRestriction(
       else { cP = new SparseMatrix(*fes.GetConformingProlongation()); }
       cP_is_set = true;
    }
+   else if (perm != NULL)
+   {
+      cP = perm_mat;
+      cP_is_set = true;
+      perm_mat = NULL;
+   }
    if (fes.GetConformingRestriction() != NULL)
    {
       if (perm) { cR = Mult(*fes.GetConformingRestriction(), *perm_mat_tr); }
       else { cR = new SparseMatrix(*fes.GetConformingRestriction()); }
+   }
+   else if (perm != NULL)
+   {
+      cR = perm_mat_tr;
+      perm_mat_tr = NULL;
    }
 
    delete perm_mat;

--- a/fem/fespace.cpp
+++ b/fem/fespace.cpp
@@ -102,8 +102,11 @@ void FiniteElementSpace::CopyProlongationAndRestriction(
    SparseMatrix *perm_mat = NULL, *perm_mat_tr = NULL;
    if (perm)
    {
+      // Note: although n and fes.GetVSize() are typically equal, in
+      // variable-order spaces they may differ, since nonconforming edges/faces
+      // my have fictitious DOFs.
       int n = perm->Size();
-      perm_mat = new SparseMatrix(n, n);
+      perm_mat = new SparseMatrix(n, fes.GetVSize());
       for (int i=0; i<n; ++i)
       {
          double s;

--- a/fem/lor.cpp
+++ b/fem/lor.cpp
@@ -241,10 +241,15 @@ const Array<int> &LORBase::GetDofPermutation() const
    return perm;
 }
 
-bool LORBase::RequiresDofPermutation() const
+bool LORBase::HasSameDofNumbering() const
 {
    FESpaceType type = GetFESpaceType();
-   return (type == H1 || type == L2 || nonconforming) ? false : true;
+   return type == H1 || type == L2;
+}
+
+bool LORBase::RequiresDofPermutation() const
+{
+   return (HasSameDofNumbering() || nonconforming) ? false : true;
 }
 
 const OperatorHandle &LORBase::GetAssembledSystem() const
@@ -295,7 +300,7 @@ void LORBase::AssembleSystem_(BilinearForm &a_ho, const Array<int> &ess_dofs)
 
 void LORBase::SetupNonconforming()
 {
-   if (RequiresDofPermutation())
+   if (!HasSameDofNumbering())
    {
       Array<int> p;
       ConstructLocalDofPermutation(p);
@@ -305,7 +310,7 @@ void LORBase::SetupNonconforming()
    {
       fes->CopyProlongationAndRestriction(fes_ho, NULL);
    }
-   nonconforming = true;
+   nonconforming = fes->Nonconforming();
 }
 
 template <typename FEC>

--- a/fem/lor.hpp
+++ b/fem/lor.hpp
@@ -79,6 +79,10 @@ protected:
    /// GetDofPermutation.
    void ConstructDofPermutation() const;
 
+   /// Returns true if the LOR space and HO space have the same DOF numbering
+   /// (H1 or L2 spaces), false otherwise (ND or RT spaces).
+   bool HasSameDofNumbering() const;
+
    /// Sets up the prolongation and restriction operators required for
    /// nonconforming spaces.
    void SetupNonconforming();
@@ -113,11 +117,19 @@ public:
    /// LOR dof, @a perm[i] is the index of the corresponding HO dof.
    const Array<int> &GetDofPermutation() const;
 
-   /// Returns true if the LOR spaces requires a DOF permutation (if the
-   /// corresponding LOR and HO DOFs are numbered differently), false
-   /// otherwise. Note: permutations are not required in the case of
-   /// nonconforming spaces, since the DOF numbering is incorporated into the
-   /// prolongation operators.
+   /// @brief Returns true if the LOR space requires a DOF permutation, false
+   /// otherwise.
+   ///
+   /// DOF permutations are required if all of the following conditions are
+   /// true:
+   ///  * The spaces have different DOF numberings (which occurs for ND and RT
+   ///    spaces, in this case @ref HasSameDofNumbering returns false).
+   ///  * The mesh is conforming.
+   ///  * The space is not variable degree.
+   ///
+   /// Note: permutations are not required in the case of nonconforming meshes
+   /// or variable polynomial degrees, since in these cases the DOF numbering is
+   /// incorporated into the prolongation operators.
    bool RequiresDofPermutation() const;
 
    /// Returns the low-order refined finite element space.

--- a/fem/lor.hpp
+++ b/fem/lor.hpp
@@ -286,6 +286,9 @@ public:
    /// Access the underlying solver.
    const SolverType &GetSolver() const { return solver; }
 
+   /// Access the LOR discretization object.
+   const LORBase &GetLOR() const { return *lor; }
+
    ~LORSolver() { if (own_lor) { delete lor; } }
 };
 

--- a/fem/lor.hpp
+++ b/fem/lor.hpp
@@ -89,14 +89,16 @@ protected:
    /// Returns the order of the LOR space. 1 for H1 or ND, 0 for L2 or RT.
    int GetLOROrder() const;
 
+   /// Assembles the LOR system (used internally by
+   /// LORDiscretization::AssembleSystem and
+   /// ParLORDiscretization::AssembleSystem).
+   void AssembleSystem_(BilinearForm &a_ho, const Array<int> &ess_dofs);
+
    LORBase(FiniteElementSpace &fes_ho_);
 
 public:
    /// Returns the assembled LOR system.
    const OperatorHandle &GetAssembledSystem() const;
-
-   /// Assembles the %LOR system.
-   void AssembleSystem(BilinearForm &a_ho, const Array<int> &ess_dofs);
 
    /// @brief Returns the permutation that maps LOR DOFs to high-order DOFs.
    ///
@@ -144,6 +146,9 @@ public:
    LORDiscretization(FiniteElementSpace &fes_ho,
                      int ref_type=BasisType::GaussLobatto);
 
+   /// Assembles the LOR system corresponding to @a a_ho.
+   void AssembleSystem(BilinearForm &a_ho, const Array<int> &ess_dofs);
+
    /// Return the assembled LOR operator as a SparseMatrix.
    SparseMatrix &GetAssembledMatrix() const;
 };
@@ -169,6 +174,9 @@ public:
    /// (see ParMesh::MakeRefined).
    ParLORDiscretization(ParFiniteElementSpace &fes_ho,
                         int ref_type=BasisType::GaussLobatto);
+
+   /// Assembles the LOR system corresponding to @a a_ho.
+   void AssembleSystem(ParBilinearForm &a_ho, const Array<int> &ess_dofs);
 
    /// Return the assembled LOR operator as a HypreParMatrix.
    HypreParMatrix &GetAssembledMatrix() const;

--- a/fem/lor.hpp
+++ b/fem/lor.hpp
@@ -35,7 +35,7 @@ private:
    /// Adds all the integrators from the BilinearForm @a a_from to @a a_to. If
    /// the mesh consists of tensor product elements, temporarily changes the
    /// integration rules of the integrators to use collocated quadrature for
-   /// better conditioning of the %LOR system.
+   /// better conditioning of the LOR system.
    void AddIntegrators(BilinearForm &a_from,
                        BilinearForm &a_to,
                        GetIntegratorsFn get_integrators,
@@ -53,7 +53,7 @@ private:
                                  const IntegrationRule *ir);
 
    /// Resets the integration rules of the integrators of @a a to their original
-   /// values (after temporarily changing them for %LOR assembly).
+   /// values (after temporarily changing them for LOR assembly).
    void ResetIntegrationRules(GetIntegratorsFn get_integrators);
 
    static inline int absdof(int i) { return i < 0 ? -1-i : i; }
@@ -75,7 +75,7 @@ protected:
    /// ConstructDofPermutation and GetDofPermutation).
    void ConstructLocalDofPermutation(Array<int> &perm_) const;
 
-   /// Construct the permutation that maps %LOR DOFs to high-order DOFs. See
+   /// Construct the permutation that maps LOR DOFs to high-order DOFs. See
    /// GetDofPermutation.
    void ConstructDofPermutation() const;
 
@@ -86,19 +86,19 @@ protected:
    /// Returns the type of finite element space: H1, ND, RT or L2.
    FESpaceType GetFESpaceType() const;
 
-   /// Returns the order of the %LOR space. 1 for H1 or ND, 0 for L2 or RT.
+   /// Returns the order of the LOR space. 1 for H1 or ND, 0 for L2 or RT.
    int GetLOROrder() const;
 
    LORBase(FiniteElementSpace &fes_ho_);
 
 public:
-   /// Returns the assembled %LOR system.
+   /// Returns the assembled LOR system.
    const OperatorHandle &GetAssembledSystem() const;
 
    /// Assembles the %LOR system.
    void AssembleSystem(BilinearForm &a_ho, const Array<int> &ess_dofs);
 
-   /// @brief Returns the permutation that maps %LOR DOFs to high-order DOFs.
+   /// @brief Returns the permutation that maps LOR DOFs to high-order DOFs.
    ///
    /// This permutation is constructed the first time it is requested, and then
    /// is cached. For H1 and L2 finite element spaces (or for nonconforming
@@ -108,11 +108,11 @@ public:
    ///
    /// For vector finite element spaces (ND and RT), the DOF permutation is
    /// nontrivial. Returns an array @a perm such that, given an index @a i of a
-   /// %LOR dof, @a perm[i] is the index of the corresponding HO dof.
+   /// LOR dof, @a perm[i] is the index of the corresponding HO dof.
    const Array<int> &GetDofPermutation() const;
 
-   /// Returns true if the %LOR spaces requires a DOF permutation (if the
-   /// corresponding %LOR and HO DOFs are numbered differently), false
+   /// Returns true if the LOR spaces requires a DOF permutation (if the
+   /// corresponding LOR and HO DOFs are numbered differently), false
    /// otherwise. Note: permutations are not required in the case of
    /// nonconforming spaces, since the DOF numbering is incorporated into the
    /// prolongation operators.
@@ -144,7 +144,7 @@ public:
    LORDiscretization(FiniteElementSpace &fes_ho,
                      int ref_type=BasisType::GaussLobatto);
 
-   /// Return the assembled %LOR operator as a SparseMatrix.
+   /// Return the assembled LOR operator as a SparseMatrix.
    SparseMatrix &GetAssembledMatrix() const;
 };
 
@@ -170,10 +170,10 @@ public:
    ParLORDiscretization(ParFiniteElementSpace &fes_ho,
                         int ref_type=BasisType::GaussLobatto);
 
-   /// Return the assembled %LOR operator as a HypreParMatrix.
+   /// Return the assembled LOR operator as a HypreParMatrix.
    HypreParMatrix &GetAssembledMatrix() const;
 
-   /// Return the %LOR ParFiniteElementSpace.
+   /// Return the LOR ParFiniteElementSpace.
    ParFiniteElementSpace &GetParFESpace() const;
 };
 
@@ -197,7 +197,7 @@ protected:
    mutable Vector px, py;
 public:
    /// @brief Create a solver of type @a SolverType, formed using the assembled
-   /// SparseMatrix of the %LOR version of @a a_ho. @see LORDiscretization
+   /// SparseMatrix of the LOR version of @a a_ho. @see LORDiscretization
    LORSolver(BilinearForm &a_ho, const Array<int> &ess_tdof_list,
              int ref_type=BasisType::GaussLobatto)
    {
@@ -207,7 +207,7 @@ public:
 
 #ifdef MFEM_USE_MPI
    /// @brief Create a solver of type @a SolverType, formed using the assembled
-   /// HypreParMatrix of the %LOR version of @a a_ho. @see ParLORDiscretization
+   /// HypreParMatrix of the LOR version of @a a_ho. @see ParLORDiscretization
    LORSolver(ParBilinearForm &a_ho, const Array<int> &ess_tdof_list,
              int ref_type=BasisType::GaussLobatto)
    {
@@ -228,7 +228,7 @@ public:
       SetOperator(op);
    }
 
-   /// @brief Create a solver of type @a SolverType using the assembled %LOR
+   /// @brief Create a solver of type @a SolverType using the assembled LOR
    /// operator represented by @a lor_.
    ///
    /// The given @a args will be used as arguments to the solver constructor.
@@ -270,9 +270,9 @@ public:
 
    /// @brief Enable or disable the DOF permutation (enabled by default).
    ///
-   /// The corresponding %LOR and high-order DOFs may not have the same
+   /// The corresponding LOR and high-order DOFs may not have the same
    /// numbering (for example, when using ND or RT spaces), and so a permutation
-   /// is required when applying the %LOR solver as a preconditioner for the
+   /// is required when applying the LOR solver as a preconditioner for the
    /// high-order problem. This permutation can be disabled (for example, in
    /// order to precondition the low-order problem directly).
    void UsePermutation(bool use_permutation_)

--- a/fem/pfespace.cpp
+++ b/fem/pfespace.cpp
@@ -2939,8 +2939,11 @@ void ParFiniteElementSpace::CopyProlongationAndRestriction(
    SparseMatrix *perm_mat = NULL, *perm_mat_tr = NULL;
    if (perm)
    {
+      // Note: although n and fes.GetVSize() are typically equal, in
+      // variable-order spaces they may differ, since nonconforming edges/faces
+      // my have fictitious DOFs.
       int n = perm->Size();
-      perm_mat = new SparseMatrix(n, n);
+      perm_mat = new SparseMatrix(n, fes.GetVSize());
       for (int i=0; i<n; ++i)
       {
          double s;

--- a/fem/pfespace.cpp
+++ b/fem/pfespace.cpp
@@ -2960,10 +2960,25 @@ void ParFiniteElementSpace::CopyProlongationAndRestriction(
       else { P = new HypreParMatrix(*pfes->P); }
       nonconf_P = true;
    }
+   else if (perm != NULL)
+   {
+      HYPRE_BigInt glob_nrows = GlobalVSize();
+      HYPRE_BigInt glob_ncols = GlobalTrueVSize();
+      HYPRE_BigInt *col_starts = GetTrueDofOffsets();
+      HYPRE_BigInt *row_starts = GetDofOffsets();
+      P = new HypreParMatrix(MyComm, glob_nrows, glob_ncols, row_starts,
+                             col_starts, perm_mat);
+      nonconf_P = true;
+   }
    if (pfes->R != NULL)
    {
       if (perm) { R = Mult(*pfes->R, *perm_mat_tr); }
       else { R = new SparseMatrix(*pfes->R); }
+   }
+   else if (perm != NULL)
+   {
+      R = perm_mat_tr;
+      perm_mat_tr = NULL;
    }
 
    delete perm_mat;


### PR DESCRIPTION
Extends the `LORDiscretization` and `LORSolver` functionality:

* Works with *p*-refined finite element spaces (including *hp*-refinement).
* Compatibility with hypre's GPU solvers

The main difference is that the DOF permutation (required for Nédélec and Raviart-Thomas spaces since the LOR and HO DOFs have different numberings) is built into to the `P` and `R` matrices of the finite element space (even for conforming meshes), so the `LORSolver` class does not need to perform any permutations.

Preliminary testing looks good using hypre's GPU solvers with #1492.