### PR TITLE
Support reading VTK XML binary compressed data with multiple blocks [vtk-compressed-blocks]

### DIFF
--- a/general/binaryio.cpp
+++ b/general/binaryio.cpp
@@ -100,5 +100,7 @@ void DecodeBase64(const char *src, size_t len, std::vector<char> &buf)
    buf.resize(out - (unsigned char *)buf.data());
 }
 
+size_t NumBase64Chars(size_t nbytes) { return ((4*nbytes/3) + 3) & ~3; }
+
 } // namespace mfem::bin_io
 } // namespace mfem

--- a/general/binaryio.cpp
+++ b/general/binaryio.cpp
@@ -71,7 +71,7 @@ static const unsigned char b64table[] =
    255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255
 };
 
-void DecodeBase64(const char *src, size_t len, std::vector<unsigned char> &buf)
+void DecodeBase64(const char *src, size_t len, std::vector<char> &buf)
 {
    const unsigned char *in = (const unsigned char *)src;
    buf.clear();
@@ -79,7 +79,7 @@ void DecodeBase64(const char *src, size_t len, std::vector<unsigned char> &buf)
    for (size_t i=0; i<len; ++i) { if (b64table[in[i]] != 255) { ++count; } }
    if (count % 4 != 0) { return; }
    buf.resize(3*len/4);
-   unsigned char *out = buf.data();
+   unsigned char *out = (unsigned char *)buf.data();
    count = 0;
    int pad = 0;
    unsigned char c[4];
@@ -97,7 +97,7 @@ void DecodeBase64(const char *src, size_t len, std::vector<unsigned char> &buf)
          count = pad = 0;
       }
    }
-   buf.resize(out - buf.data());
+   buf.resize(out - (unsigned char *)buf.data());
 }
 
 } // namespace mfem::bin_io

--- a/general/binaryio.hpp
+++ b/general/binaryio.hpp
@@ -58,7 +58,7 @@ void AppendBytes(std::vector<char> &vec, const T &val)
    vec.insert(vec.end(), ptr, ptr + sizeof(T));
 }
 
-/// Encode the buffer of length @a nbytes give by pointer @a bytes in base-64
+/// Given a buffer @a buf of length @a nbytes, encode the data in base-64
 /// format, and write the encoded data to the output stream @a out.
 void WriteBase64(std::ostream &out, const void *bytes, size_t nbytes);
 

--- a/general/binaryio.hpp
+++ b/general/binaryio.hpp
@@ -59,7 +59,7 @@ void AppendBytes(std::vector<char> &vec, const T &val)
 
 void WriteBase64(std::ostream &out, const void *bytes, size_t length);
 
-void DecodeBase64(const char *src, size_t len, std::vector<unsigned char> &buf);
+void DecodeBase64(const char *src, size_t len, std::vector<char> &buf);
 
 } // namespace mfem::bin_io
 

--- a/general/binaryio.hpp
+++ b/general/binaryio.hpp
@@ -50,6 +50,7 @@ inline T read(const char *buf)
    return value;
 }
 
+/// Append the binary representation of @a val to the byte buffer @a vec.
 template <typename T>
 void AppendBytes(std::vector<char> &vec, const T &val)
 {
@@ -57,8 +58,12 @@ void AppendBytes(std::vector<char> &vec, const T &val)
    vec.insert(vec.end(), ptr, ptr + sizeof(T));
 }
 
-void WriteBase64(std::ostream &out, const void *bytes, size_t length);
+/// Encode the buffer of length @a nbytes give by pointer @a bytes in base-64
+/// format, and write the encoded data to the output stream @a out.
+void WriteBase64(std::ostream &out, const void *bytes, size_t nbytes);
 
+/// Decode @a len base-64 encoded characters in the buffer @a src, and store the
+/// resulting decoded data in @a buf. @a buf will be resized as needed.
 void DecodeBase64(const char *src, size_t len, std::vector<char> &buf);
 
 /// Return the number of characters needed to encode @a nbytes in base-64. This

--- a/general/binaryio.hpp
+++ b/general/binaryio.hpp
@@ -61,6 +61,10 @@ void WriteBase64(std::ostream &out, const void *bytes, size_t length);
 
 void DecodeBase64(const char *src, size_t len, std::vector<char> &buf);
 
+/// Return the number of characters needed to encode @a nbytes in base-64. This
+/// is equal to 4*nbytes/3, rounded up to the nearest multiple of 4.
+size_t NumBase64Chars(size_t nbytes);
+
 } // namespace mfem::bin_io
 
 } // namespace mfem

--- a/mesh/mesh_readers.cpp
+++ b/mesh/mesh_readers.cpp
@@ -819,15 +819,15 @@ struct BufferReader : BufferReaderBase
          // Decode the first entry of the header, which we need to determine
          // how long the rest of the header is.
          std::vector<char> nblocks_buf;
-         int nblocks_b64 = ((4*HeaderEntrySize()/3) + 3) & ~3;
+         int nblocks_b64 = bin_io::NumBase64Chars(HeaderEntrySize());
          bin_io::DecodeBase64(txt, nblocks_b64, nblocks_buf);
          std::vector<char> data, header;
          // Compute number of characters needed to encode header in base 64,
          // then round to nearest multiple of 4 to take padding into account.
-         int b64_header = ((4*NumHeaderBytes(nblocks_buf.data())/3) + 3) & ~3;
+         int header_b64 = bin_io::NumBase64Chars(NumHeaderBytes(nblocks_buf.data()));
          // If data is compressed, header is encoded separately
-         bin_io::DecodeBase64(txt, b64_header, header);
-         bin_io::DecodeBase64(txt + b64_header, strlen(txt)-b64_header, data);
+         bin_io::DecodeBase64(txt, header_b64, header);
+         bin_io::DecodeBase64(txt + header_b64, strlen(txt)-header_b64, data);
          ReadBinaryWithHeader(header.data(), data.data(), dest, n);
       }
       else

--- a/mesh/mesh_readers.cpp
+++ b/mesh/mesh_readers.cpp
@@ -737,10 +737,10 @@ struct BufferReader : BufferReaderBase
          //    header_t uncompressed_block_size;
          //    header_t uncompressed_last_block_size;
          //    header_t compressed_size[number_of_blocks];
-         size_t header_entry_size = HeaderEntrySize();
-         uint64_t nblocks = ReadHeaderEntry(header_buf);
+         int header_entry_size = HeaderEntrySize();
+         int nblocks = ReadHeaderEntry(header_buf);
          header_buf += header_entry_size;
-         std::vector<uint64_t> header(nblocks + 2);
+         std::vector<int> header(nblocks + 2);
          for (int i=0; i<nblocks+2; ++i)
          {
             header[i] = ReadHeaderEntry(header_buf);
@@ -759,7 +759,7 @@ struct BufferReader : BufferReaderBase
             dest_ptr += dest_len;
             source_ptr += source_len;
          }
-         MFEM_VERIFY(sizeof(F)*n == (dest_ptr - dest_start),
+         MFEM_VERIFY(int(sizeof(F)*n) == (dest_ptr - dest_start),
                      "AppendedData: wrong data size");
          buf = uncompressed_data.data();
 #else

--- a/mesh/mesh_readers.cpp
+++ b/mesh/mesh_readers.cpp
@@ -732,6 +732,11 @@ struct BufferReader : BufferReaderBase
       if (compressed)
       {
 #ifdef MFEM_USE_ZLIB
+         // The header has format (where header_t is uint32_t or uint64_t):
+         //    header_t number_of_blocks;
+         //    header_t uncompressed_block_size;
+         //    header_t uncompressed_last_block_size;
+         //    header_t compressed_size[number_of_blocks];
          size_t header_entry_size = HeaderEntrySize();
          uint64_t nblocks = ReadHeaderEntry(header_buf);
          header_buf += header_entry_size;

--- a/mesh/mesh_readers.cpp
+++ b/mesh/mesh_readers.cpp
@@ -691,16 +691,31 @@ struct BufferReader : BufferReaderBase
    BufferReader(bool compressed_, HeaderType header_type_)
       : compressed(compressed_), header_type(header_type_) { }
 
-   /// Return the number of bytes in the header. The header consists of one
-   /// integer if the data is uncompressed, and four integers if the data is
-   /// compressed. The integers are either 32 or 64 bytes depending on the value
-   /// of @a header_type.
-   int NumHeaderBytes() const
+   /// Return the number of bytes of each header entry.
+   size_t HeaderEntrySize() const
    {
-      int num_entries = compressed ? 4 : 1;
-      int entry_size = (header_type == UINT64_HEADER)
-                       ? sizeof(uint64_t) : sizeof(uint32_t);
-      return num_entries*entry_size;
+      return header_type == UINT64_HEADER ? sizeof(uint64_t) : sizeof(uint32_t);
+   }
+
+   /// Return the value of the header entry pointer to by @a header_buf. The
+   /// value is stored as either uint32_t or uint64_t, according to the @a
+   /// header_type, and is returned as uint64_t.
+   uint64_t ReadHeaderEntry(const char *header_buf) const
+   {
+      return (header_type == UINT64_HEADER) ? bin_io::read<uint64_t>(header_buf)
+             : bin_io::read<uint32_t>(header_buf);
+   }
+
+   /// Return the number of bytes in the header. The header consists of one
+   /// integer if the data is uncompressed, and @a N + 3 integers if the data is
+   /// compressed, where @a N is the number of blocks. The integers are either
+   /// 32 or 64 bytes depending on the value of @a header_type. The number of
+   /// blocks is determined by reading the first integer (of type @a
+   /// header_type) pointed to by @a header_buf.
+   int NumHeaderBytes(const char *header_buf) const
+   {
+      if (!compressed) { return HeaderEntrySize(); }
+      return (3 + ReadHeaderEntry(header_buf))*HeaderEntrySize();
    }
 
    /// Read @a n elements of type @a F from the source buffer @a buf into the
@@ -711,32 +726,37 @@ struct BufferReader : BufferReaderBase
    void ReadBinaryWithHeader(const char *header_buf, const char *buf,
                              void *dest_void, int n) const
    {
-      std::vector<unsigned char> uncompressed_data;
+      std::vector<char> uncompressed_data;
       T *dest = static_cast<T*>(dest_void);
 
       if (compressed)
       {
 #ifdef MFEM_USE_ZLIB
-         uint64_t header[4];
-         if (header_type == UINT32_HEADER)
+         size_t header_entry_size = HeaderEntrySize();
+         uint64_t nblocks = ReadHeaderEntry(header_buf);
+         header_buf += header_entry_size;
+         std::vector<uint64_t> header(nblocks + 2);
+         for (int i=0; i<nblocks+2; ++i)
          {
-            uint32_t *header_32 = (uint32_t *)header_buf;
-            for (int i=0; i<4; ++i) { header[i] = header_32[i]; }
+            header[i] = ReadHeaderEntry(header_buf);
+            header_buf += header_entry_size;
          }
-         else
+         uncompressed_data.resize((nblocks-1)*header[0] + header[1]);
+         Bytef *dest_ptr = (Bytef *)uncompressed_data.data();
+         Bytef *dest_start = dest_ptr;
+         const Bytef *source_ptr = (const Bytef *)buf;
+         for (int i=0; i<nblocks; ++i)
          {
-            uint64_t *header_64 = (uint64_t *)header_buf;
-            for (int i=0; i<4; ++i) { header[i] = header_64[i]; }
+            uLongf source_len = header[i+2];
+            uLong dest_len = (i == nblocks-1) ? header[1] : header[0];
+            int res = uncompress(dest_ptr, &dest_len, source_ptr, source_len);
+            MFEM_VERIFY(res == Z_OK, "Error uncompressing");
+            dest_ptr += dest_len;
+            source_ptr += source_len;
          }
-
-         MFEM_VERIFY(header[0] == 1, "Multiple compressed blocks not supported");
-         uLongf dest_len = header[1];
-         uncompressed_data.resize(dest_len);
-         int res = uncompress(uncompressed_data.data(), &dest_len,
-                              (const Bytef *)buf, header[3]);
-         MFEM_VERIFY(res == Z_OK, "Error uncompressing");
-         MFEM_VERIFY(sizeof(F)*n == dest_len, "AppendedData: wrong data size");
-         buf = (const char *)uncompressed_data.data();
+         MFEM_VERIFY(sizeof(F)*n == (dest_ptr - dest_start),
+                     "AppendedData: wrong data size");
+         buf = uncompressed_data.data();
 #else
          MFEM_ABORT("MFEM must be compiled with zlib enabled to uncompress.")
 #endif
@@ -779,7 +799,7 @@ struct BufferReader : BufferReaderBase
    /// buffer @a dest. The input buffer contains both the header and the data.
    void ReadBinary(const char *buf, void *dest, int n) const override
    {
-      ReadBinaryWithHeader(buf, buf + NumHeaderBytes(), dest, n);
+      ReadBinaryWithHeader(buf, buf + NumHeaderBytes(buf), dest, n);
    }
 
    /// Read @a n elements of type @a F from base-64 encoded source buffer into
@@ -796,21 +816,25 @@ struct BufferReader : BufferReaderBase
       }
       if (compressed)
       {
-         std::vector<unsigned char> data, header;
+         // Decode the first entry of the header, which we need to determine
+         // how long the rest of the header is.
+         std::vector<char> nblocks_buf;
+         int nblocks_b64 = ((4*HeaderEntrySize()/3) + 3) & ~3;
+         bin_io::DecodeBase64(txt, nblocks_b64, nblocks_buf);
+         std::vector<char> data, header;
          // Compute number of characters needed to encode header in base 64,
          // then round to nearest multiple of 4 to take padding into account.
-         int b64_header = ((4*NumHeaderBytes()/3) + 3) & ~3;
+         int b64_header = ((4*NumHeaderBytes(nblocks_buf.data())/3) + 3) & ~3;
          // If data is compressed, header is encoded separately
          bin_io::DecodeBase64(txt, b64_header, header);
          bin_io::DecodeBase64(txt + b64_header, strlen(txt)-b64_header, data);
-         ReadBinaryWithHeader((const char *)header.data(),
-                              (const char *)data.data(), dest, n);
+         ReadBinaryWithHeader(header.data(), data.data(), dest, n);
       }
       else
       {
-         std::vector<unsigned char> data;
+         std::vector<char> data;
          bin_io::DecodeBase64(txt, strlen(txt), data);
-         ReadBinary((const char *)data.data(), dest, n);
+         ReadBinary(data.data(), dest, n);
       }
    }
 };


### PR DESCRIPTION
Both raw binary data and base-64 encoded are supported. ParaView can sometimes output multiple blocks when compression is enabled, so it is good to support this case.

We previously only supported reading a single "block" of compressed data. VTK format supports multiple blocks for semi-random access. Each block is compressed separately, and the blocks are concatenated.

The header format is as follows (where `header_t` is either `uint32_t` or `uint64_t` according to the VTK file metadata):

```c++
header_t number_of_blocks;
header_t uncompressed_block_size;
header_t uncompressed_last_block_size;
header_t compressed_size[number_of_blocks];
```

The total uncompressed data size is bounded by `(number_of_blocks - 1)*uncompressed_block_size + uncompressed_last_block_size`.

The main complication is that the header contains a variable number of integers (depending on the number of blocks, `number_of_blocks + 3`), rather than a fixed number of 4 integers as is the case when we are restricted to one block only.

Also adds some documentation to `bin_io` functions along the way.
<!--GHEX{"id":2378,"author":"pazner","editor":"v-dobrev","reviewers":["jandrej","bslazarov"],"assignment":"2021-07-01T11:25:36-07:00","approval":"2021-07-15T11:25:36-07:00","merge":"2021-07-22T11:25:36-07:00"}XEHG--><!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge| 
 | --- | --- | --- | --- | --- | --- | --- | 
| [#2378](https://github.com/mfem/mfem/pull/2378) | @pazner | @v-dobrev | @jandrej + @bslazarov | 07/01/21 | ⌛due 07/15/21 | ⌛due 07/22/21 | |
<!--ELBATXEHG-->