### PR TITLE
GitLab CI using mfem/data [mfem-data-unit-tests]

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -48,39 +48,57 @@ variables:
   TPLS_REPO: ssh://git@mybitbucket.llnl.gov:7999/mfem/tpls.git
   TESTS_REPO: ssh://git@mybitbucket.llnl.gov:7999/mfem/tests.git
   AUTOTEST_REPO: ssh://git@mybitbucket.llnl.gov:7999/mfem/autotest.git
+  MFEM_DATA_REPO: https://github.com/mfem/data.git
   ARTIFACTS_DIR: artifacts
 
 # The pipeline is divided into stages. Usually, these are also synchronization
 # points, however, we use "needs" keyword to express the DAG of jobs for more
 # efficiency.
-# - We use setup phase to download content outside of mfem directory.
+# - We use setup and setup_baseline phases to download content outside of mfem
+#   directory.
 # - Allocate/Release is where quartz resources are allocated/released once for all.
 # - Build and Test is where we build and MFEM for multiple toolchains.
 # - Baseline_checks gathers baseline-type test suites execution
 # - Baseline_publish, only available on master, allows to update baseline
 #   results
 stages:
+  - setup
   - q_allocate_resources
   - q_build_and_test
   - q_release_resources
   - l_build_and_test
   - c_build_and_test
-  - setup
+  - setup_baseline
   - baseline_check
   - baseline_to_autotest
   - baseline_publish
 
-# The setup job in setup stage don't rely on MFEM git repo. It prepares a
-# pipeline-wide working directory downloading/updating external repos.
-# TODO: updating tests and tpls is not necessary anymore since pipelines are
-# now using unique directories so repo are never shared with another pipeline.
-# This is not memory efficient (we keep a lot of data), hence this reminder.
-# Setup
+# setup clones the mfem/data repo in ${BUILD_ROOT}. The build_and_test script
+# then symlinks the repo to the parent directory of the MFEM source directory.
+# Unit tests that depend on the mfem/data repo will then detect that this
+# directory is present and be enabled.
 setup:
   tags:
     - shell
-    - quartz
   stage: setup
+  variables:
+    GIT_STRATEGY: none
+  script:
+    - mkdir -p ${BUILD_ROOT} && cd ${BUILD_ROOT}
+    - if [ ! -d data ]; then git clone ${MFEM_DATA_REPO}; fi
+  needs: []
+
+# The setup_baseline job in setup stage_baseline doesn't rely on MFEM git repo.
+# It prepares a pipeline-wide working directory downloading/updating external
+# repos. TODO: updating tests and tpls is not necessary anymore since pipelines
+# are now using unique directories so repo are never shared with another
+# pipeline. This is not memory efficient (we keep a lot of data), hence this
+# reminder.
+setup_baseline:
+  tags:
+    - shell
+    - quartz
+  stage: setup_baseline
   variables:
     GIT_STRATEGY: none
   script:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -80,6 +80,7 @@ stages:
 setup:
   tags:
     - shell
+    - quartz
   stage: setup
   variables:
     GIT_STRATEGY: none

--- a/.gitlab/lassen.yml
+++ b/.gitlab/lassen.yml
@@ -25,7 +25,7 @@
 .build_and_test_on_lassen:
   extends: [.build_blueos_3_ppc64le_ib_script, .on_lassen]
   stage: l_build_and_test
-  needs: []
+  needs: [setup]
 
 opt_mpi_cuda_xl_16_1_1_8:
   variables:

--- a/.gitlab/quartz.yml
+++ b/.gitlab/quartz.yml
@@ -94,6 +94,7 @@ q_report_failure:
 .build_and_test_on_quartz:
   extends: [.build_toss_3_x86_64_ib_script, .on_quartz]
   stage: q_build_and_test
+  needs: [setup]
 
 # Build MFEM
 debug_ser_gcc_4_9_3:
@@ -139,7 +140,7 @@ opt_par_gcc_6_1_0_pumi:
 # Baseline
 baselinecheck_mfem_intel_quartz:
   extends: [.baselinecheck_mfem, .on_quartz]
-  needs: [setup]
+  needs: [setup_baseline]
 
 update_autotest:
   extends: [.on_quartz]

--- a/general/binaryio.cpp
+++ b/general/binaryio.cpp
@@ -100,5 +100,7 @@ void DecodeBase64(const char *src, size_t len, std::vector<char> &buf)
    buf.resize(out - (unsigned char *)buf.data());
 }
 
+size_t NumBase64Chars(size_t nbytes) { return ((4*nbytes/3) + 3) & ~3; }
+
 } // namespace mfem::bin_io
 } // namespace mfem

--- a/general/binaryio.cpp
+++ b/general/binaryio.cpp
@@ -71,7 +71,7 @@ static const unsigned char b64table[] =
    255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255
 };
 
-void DecodeBase64(const char *src, size_t len, std::vector<unsigned char> &buf)
+void DecodeBase64(const char *src, size_t len, std::vector<char> &buf)
 {
    const unsigned char *in = (const unsigned char *)src;
    buf.clear();
@@ -79,7 +79,7 @@ void DecodeBase64(const char *src, size_t len, std::vector<unsigned char> &buf)
    for (size_t i=0; i<len; ++i) { if (b64table[in[i]] != 255) { ++count; } }
    if (count % 4 != 0) { return; }
    buf.resize(3*len/4);
-   unsigned char *out = buf.data();
+   unsigned char *out = (unsigned char *)buf.data();
    count = 0;
    int pad = 0;
    unsigned char c[4];
@@ -97,7 +97,7 @@ void DecodeBase64(const char *src, size_t len, std::vector<unsigned char> &buf)
          count = pad = 0;
       }
    }
-   buf.resize(out - buf.data());
+   buf.resize(out - (unsigned char *)buf.data());
 }
 
 } // namespace mfem::bin_io

--- a/general/binaryio.hpp
+++ b/general/binaryio.hpp
@@ -58,7 +58,7 @@ void AppendBytes(std::vector<char> &vec, const T &val)
    vec.insert(vec.end(), ptr, ptr + sizeof(T));
 }
 
-/// Encode the buffer of length @a nbytes give by pointer @a bytes in base-64
+/// Given a buffer @a buf of length @a nbytes, encode the data in base-64
 /// format, and write the encoded data to the output stream @a out.
 void WriteBase64(std::ostream &out, const void *bytes, size_t nbytes);
 

--- a/general/binaryio.hpp
+++ b/general/binaryio.hpp
@@ -59,7 +59,7 @@ void AppendBytes(std::vector<char> &vec, const T &val)
 
 void WriteBase64(std::ostream &out, const void *bytes, size_t length);
 
-void DecodeBase64(const char *src, size_t len, std::vector<unsigned char> &buf);
+void DecodeBase64(const char *src, size_t len, std::vector<char> &buf);
 
 } // namespace mfem::bin_io
 

--- a/general/binaryio.hpp
+++ b/general/binaryio.hpp
@@ -50,6 +50,7 @@ inline T read(const char *buf)
    return value;
 }
 
+/// Append the binary representation of @a val to the byte buffer @a vec.
 template <typename T>
 void AppendBytes(std::vector<char> &vec, const T &val)
 {
@@ -57,8 +58,12 @@ void AppendBytes(std::vector<char> &vec, const T &val)
    vec.insert(vec.end(), ptr, ptr + sizeof(T));
 }
 
-void WriteBase64(std::ostream &out, const void *bytes, size_t length);
+/// Encode the buffer of length @a nbytes give by pointer @a bytes in base-64
+/// format, and write the encoded data to the output stream @a out.
+void WriteBase64(std::ostream &out, const void *bytes, size_t nbytes);
 
+/// Decode @a len base-64 encoded characters in the buffer @a src, and store the
+/// resulting decoded data in @a buf. @a buf will be resized as needed.
 void DecodeBase64(const char *src, size_t len, std::vector<char> &buf);
 
 /// Return the number of characters needed to encode @a nbytes in base-64. This

--- a/general/binaryio.hpp
+++ b/general/binaryio.hpp
@@ -61,6 +61,10 @@ void WriteBase64(std::ostream &out, const void *bytes, size_t length);
 
 void DecodeBase64(const char *src, size_t len, std::vector<char> &buf);
 
+/// Return the number of characters needed to encode @a nbytes in base-64. This
+/// is equal to 4*nbytes/3, rounded up to the nearest multiple of 4.
+size_t NumBase64Chars(size_t nbytes);
+
 } // namespace mfem::bin_io
 
 } // namespace mfem

--- a/mesh/mesh_readers.cpp
+++ b/mesh/mesh_readers.cpp
@@ -819,15 +819,15 @@ struct BufferReader : BufferReaderBase
          // Decode the first entry of the header, which we need to determine
          // how long the rest of the header is.
          std::vector<char> nblocks_buf;
-         int nblocks_b64 = ((4*HeaderEntrySize()/3) + 3) & ~3;
+         int nblocks_b64 = bin_io::NumBase64Chars(HeaderEntrySize());
          bin_io::DecodeBase64(txt, nblocks_b64, nblocks_buf);
          std::vector<char> data, header;
          // Compute number of characters needed to encode header in base 64,
          // then round to nearest multiple of 4 to take padding into account.
-         int b64_header = ((4*NumHeaderBytes(nblocks_buf.data())/3) + 3) & ~3;
+         int header_b64 = bin_io::NumBase64Chars(NumHeaderBytes(nblocks_buf.data()));
          // If data is compressed, header is encoded separately
-         bin_io::DecodeBase64(txt, b64_header, header);
-         bin_io::DecodeBase64(txt + b64_header, strlen(txt)-b64_header, data);
+         bin_io::DecodeBase64(txt, header_b64, header);
+         bin_io::DecodeBase64(txt + header_b64, strlen(txt)-header_b64, data);
          ReadBinaryWithHeader(header.data(), data.data(), dest, n);
       }
       else

--- a/mesh/mesh_readers.cpp
+++ b/mesh/mesh_readers.cpp
@@ -737,10 +737,10 @@ struct BufferReader : BufferReaderBase
          //    header_t uncompressed_block_size;
          //    header_t uncompressed_last_block_size;
          //    header_t compressed_size[number_of_blocks];
-         size_t header_entry_size = HeaderEntrySize();
-         uint64_t nblocks = ReadHeaderEntry(header_buf);
+         int header_entry_size = HeaderEntrySize();
+         int nblocks = ReadHeaderEntry(header_buf);
          header_buf += header_entry_size;
-         std::vector<uint64_t> header(nblocks + 2);
+         std::vector<int> header(nblocks + 2);
          for (int i=0; i<nblocks+2; ++i)
          {
             header[i] = ReadHeaderEntry(header_buf);
@@ -759,7 +759,7 @@ struct BufferReader : BufferReaderBase
             dest_ptr += dest_len;
             source_ptr += source_len;
          }
-         MFEM_VERIFY(sizeof(F)*n == (dest_ptr - dest_start),
+         MFEM_VERIFY(int(sizeof(F)*n) == (dest_ptr - dest_start),
                      "AppendedData: wrong data size");
          buf = uncompressed_data.data();
 #else

--- a/mesh/mesh_readers.cpp
+++ b/mesh/mesh_readers.cpp
@@ -732,6 +732,11 @@ struct BufferReader : BufferReaderBase
       if (compressed)
       {
 #ifdef MFEM_USE_ZLIB
+         // The header has format (where header_t is uint32_t or uint64_t):
+         //    header_t number_of_blocks;
+         //    header_t uncompressed_block_size;
+         //    header_t uncompressed_last_block_size;
+         //    header_t compressed_size[number_of_blocks];
          size_t header_entry_size = HeaderEntrySize();
          uint64_t nblocks = ReadHeaderEntry(header_buf);
          header_buf += header_entry_size;

--- a/mesh/mesh_readers.cpp
+++ b/mesh/mesh_readers.cpp
@@ -691,16 +691,31 @@ struct BufferReader : BufferReaderBase
    BufferReader(bool compressed_, HeaderType header_type_)
       : compressed(compressed_), header_type(header_type_) { }
 
-   /// Return the number of bytes in the header. The header consists of one
-   /// integer if the data is uncompressed, and four integers if the data is
-   /// compressed. The integers are either 32 or 64 bytes depending on the value
-   /// of @a header_type.
-   int NumHeaderBytes() const
+   /// Return the number of bytes of each header entry.
+   size_t HeaderEntrySize() const
    {
-      int num_entries = compressed ? 4 : 1;
-      int entry_size = (header_type == UINT64_HEADER)
-                       ? sizeof(uint64_t) : sizeof(uint32_t);
-      return num_entries*entry_size;
+      return header_type == UINT64_HEADER ? sizeof(uint64_t) : sizeof(uint32_t);
+   }
+
+   /// Return the value of the header entry pointer to by @a header_buf. The
+   /// value is stored as either uint32_t or uint64_t, according to the @a
+   /// header_type, and is returned as uint64_t.
+   uint64_t ReadHeaderEntry(const char *header_buf) const
+   {
+      return (header_type == UINT64_HEADER) ? bin_io::read<uint64_t>(header_buf)
+             : bin_io::read<uint32_t>(header_buf);
+   }
+
+   /// Return the number of bytes in the header. The header consists of one
+   /// integer if the data is uncompressed, and @a N + 3 integers if the data is
+   /// compressed, where @a N is the number of blocks. The integers are either
+   /// 32 or 64 bytes depending on the value of @a header_type. The number of
+   /// blocks is determined by reading the first integer (of type @a
+   /// header_type) pointed to by @a header_buf.
+   int NumHeaderBytes(const char *header_buf) const
+   {
+      if (!compressed) { return HeaderEntrySize(); }
+      return (3 + ReadHeaderEntry(header_buf))*HeaderEntrySize();
    }
 
    /// Read @a n elements of type @a F from the source buffer @a buf into the
@@ -711,32 +726,37 @@ struct BufferReader : BufferReaderBase
    void ReadBinaryWithHeader(const char *header_buf, const char *buf,
                              void *dest_void, int n) const
    {
-      std::vector<unsigned char> uncompressed_data;
+      std::vector<char> uncompressed_data;
       T *dest = static_cast<T*>(dest_void);
 
       if (compressed)
       {
 #ifdef MFEM_USE_ZLIB
-         uint64_t header[4];
-         if (header_type == UINT32_HEADER)
+         size_t header_entry_size = HeaderEntrySize();
+         uint64_t nblocks = ReadHeaderEntry(header_buf);
+         header_buf += header_entry_size;
+         std::vector<uint64_t> header(nblocks + 2);
+         for (int i=0; i<nblocks+2; ++i)
          {
-            uint32_t *header_32 = (uint32_t *)header_buf;
-            for (int i=0; i<4; ++i) { header[i] = header_32[i]; }
+            header[i] = ReadHeaderEntry(header_buf);
+            header_buf += header_entry_size;
          }
-         else
+         uncompressed_data.resize((nblocks-1)*header[0] + header[1]);
+         Bytef *dest_ptr = (Bytef *)uncompressed_data.data();
+         Bytef *dest_start = dest_ptr;
+         const Bytef *source_ptr = (const Bytef *)buf;
+         for (int i=0; i<nblocks; ++i)
          {
-            uint64_t *header_64 = (uint64_t *)header_buf;
-            for (int i=0; i<4; ++i) { header[i] = header_64[i]; }
+            uLongf source_len = header[i+2];
+            uLong dest_len = (i == nblocks-1) ? header[1] : header[0];
+            int res = uncompress(dest_ptr, &dest_len, source_ptr, source_len);
+            MFEM_VERIFY(res == Z_OK, "Error uncompressing");
+            dest_ptr += dest_len;
+            source_ptr += source_len;
          }
-
-         MFEM_VERIFY(header[0] == 1, "Multiple compressed blocks not supported");
-         uLongf dest_len = header[1];
-         uncompressed_data.resize(dest_len);
-         int res = uncompress(uncompressed_data.data(), &dest_len,
-                              (const Bytef *)buf, header[3]);
-         MFEM_VERIFY(res == Z_OK, "Error uncompressing");
-         MFEM_VERIFY(sizeof(F)*n == dest_len, "AppendedData: wrong data size");
-         buf = (const char *)uncompressed_data.data();
+         MFEM_VERIFY(sizeof(F)*n == (dest_ptr - dest_start),
+                     "AppendedData: wrong data size");
+         buf = uncompressed_data.data();
 #else
          MFEM_ABORT("MFEM must be compiled with zlib enabled to uncompress.")
 #endif
@@ -779,7 +799,7 @@ struct BufferReader : BufferReaderBase
    /// buffer @a dest. The input buffer contains both the header and the data.
    void ReadBinary(const char *buf, void *dest, int n) const override
    {
-      ReadBinaryWithHeader(buf, buf + NumHeaderBytes(), dest, n);
+      ReadBinaryWithHeader(buf, buf + NumHeaderBytes(buf), dest, n);
    }
 
    /// Read @a n elements of type @a F from base-64 encoded source buffer into
@@ -796,21 +816,25 @@ struct BufferReader : BufferReaderBase
       }
       if (compressed)
       {
-         std::vector<unsigned char> data, header;
+         // Decode the first entry of the header, which we need to determine
+         // how long the rest of the header is.
+         std::vector<char> nblocks_buf;
+         int nblocks_b64 = ((4*HeaderEntrySize()/3) + 3) & ~3;
+         bin_io::DecodeBase64(txt, nblocks_b64, nblocks_buf);
+         std::vector<char> data, header;
          // Compute number of characters needed to encode header in base 64,
          // then round to nearest multiple of 4 to take padding into account.
-         int b64_header = ((4*NumHeaderBytes()/3) + 3) & ~3;
+         int b64_header = ((4*NumHeaderBytes(nblocks_buf.data())/3) + 3) & ~3;
          // If data is compressed, header is encoded separately
          bin_io::DecodeBase64(txt, b64_header, header);
          bin_io::DecodeBase64(txt + b64_header, strlen(txt)-b64_header, data);
-         ReadBinaryWithHeader((const char *)header.data(),
-                              (const char *)data.data(), dest, n);
+         ReadBinaryWithHeader(header.data(), data.data(), dest, n);
       }
       else
       {
-         std::vector<unsigned char> data;
+         std::vector<char> data;
          bin_io::DecodeBase64(txt, strlen(txt), data);
-         ReadBinary((const char *)data.data(), dest, n);
+         ReadBinary(data.data(), dest, n);
       }
    }
 };

--- a/tests/gitlab/build_and_test
+++ b/tests/gitlab/build_and_test
@@ -110,7 +110,7 @@ then
     echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
 
     cp ${hostconfig_path} ${project_dir}/config/
-    ln -sf ${build_root}/data ${project_dir}/../data
+    ln -sf ${build_root}/data ${project_dir}/../
 
     make all -j ${threads}
 fi

--- a/tests/gitlab/build_and_test
+++ b/tests/gitlab/build_and_test
@@ -110,6 +110,7 @@ then
     echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
 
     cp ${hostconfig_path} ${project_dir}/config/
+    ln -sf ${build_root}/data ${project_dir}/../data
 
     make all -j ${threads}
 fi

--- a/tests/unit/makefile
+++ b/tests/unit/makefile
@@ -214,21 +214,27 @@ $(DATA_DIR):
 MFEM_TESTS = UNIT_TESTS
 include $(MFEM_TEST_MK)
 
+ifeq (,$(wildcard $(MFEM_DIR)/../data))
+   MFEM_DATA_FLAG =
+else
+   MFEM_DATA_FLAG = --data $(MFEM_DIR)/../data
+endif
+
 %-test-seq: %
-	@$(call mfem-test,$<,, Unit tests,,SKIP-NO-VIS)
+	@$(call mfem-test,$<,, Unit tests,$(MFEM_DATA_FLAG),SKIP-NO-VIS)
 
 ceed_tests-test-seq: ceed_tests
-	@$(call mfem-test,$<,, CEED Unit tests (cpu),--device ceed-cpu,SKIP-NO-VIS)
+	@$(call mfem-test,$<,, CEED Unit tests (cpu),--device ceed-cpu $(MFEM_DATA_FLAG),SKIP-NO-VIS)
 ifeq ($(MFEM_USE_CUDA),YES)
-	@$(call mfem-test,$<,, CEED Unit tests (cuda-ref),--device ceed-cuda:/gpu/cuda/ref,SKIP-NO-VIS)
-	@$(call mfem-test,$<,, CEED Unit tests (cuda-shared),--device ceed-cuda:/gpu/cuda/shared,SKIP-NO-VIS)
-	@$(call mfem-test,$<,, CEED Unit tests (cuda-gen),--device ceed-cuda:/gpu/cuda/gen,SKIP-NO-VIS)
+	@$(call mfem-test,$<,, CEED Unit tests (cuda-ref),--device ceed-cuda:/gpu/cuda/ref $(MFEM_DATA_FLAG),SKIP-NO-VIS)
+	@$(call mfem-test,$<,, CEED Unit tests (cuda-shared),--device ceed-cuda:/gpu/cuda/shared $(MFEM_DATA_FLAG),SKIP-NO-VIS)
+	@$(call mfem-test,$<,, CEED Unit tests (cuda-gen),--device ceed-cuda:/gpu/cuda/gen $(MFEM_DATA_FLAG),SKIP-NO-VIS)
 endif
 
 RUN_MPI = $(MFEM_MPIEXEC) $(MFEM_MPIEXEC_NP)
 %-test-par: %
-	@$(call mfem-test,$<, $(RUN_MPI) 1, Parallel unit tests,,SKIP-NO-VIS)
-	@$(call mfem-test,$<, $(RUN_MPI) $(MFEM_MPI_NP), Parallel unit tests,,SKIP-NO-VIS)
+	@$(call mfem-test,$<, $(RUN_MPI) 1, Parallel unit tests,$(MFEM_DATA_FLAG),SKIP-NO-VIS)
+	@$(call mfem-test,$<, $(RUN_MPI) $(MFEM_MPI_NP), Parallel unit tests,$(MFEM_DATA_FLAG),SKIP-NO-VIS)
 
 # Generate an error message if the MFEM library is not built and exit
 $(MFEM_LIB_FILE):
@@ -237,4 +243,3 @@ $(MFEM_LIB_FILE):
 clean:
 	rm -f $(SEQ_UNIT_TESTS) $(PAR_UNIT_TESTS) *.o */*.o */*~ *~
 	rm -rf *.dSYM output_meshes
-

--- a/tests/unit/mesh/test_vtu.cpp
+++ b/tests/unit/mesh/test_vtu.cpp
@@ -41,3 +41,21 @@ TEST_CASE("VTU XML Reader", "[Mesh][VTU][XML]")
       REQUIRE(mesh.GetNumGeometries(2) == 1);
    }
 }
+
+TEST_CASE("VTU XML Compressed Blocks", "[VTU][XML][MFEMData]")
+{
+   auto filename = GENERATE(
+                      "bracket_appended_compressed.vtu",
+                      "bracket_appended_encoded_compressed.vtu",
+                      "bracket_inline_compressed.vtu"
+                   );
+
+   std::string mesh_path = mfem_data_dir + "/vtk/" + filename;
+   Mesh mesh = Mesh::LoadFromFile(mesh_path.c_str());
+
+   REQUIRE(mesh.Dimension() == 3);
+   REQUIRE(mesh.GetNE() == 206208);
+   REQUIRE(mesh.GetNV() == 50000);
+   REQUIRE(mesh.HasGeometry(Geometry::TETRAHEDRON));
+   REQUIRE(mesh.GetNumGeometries(3) == 1);
+}

--- a/tests/unit/punit_test_main.cpp
+++ b/tests/unit/punit_test_main.cpp
@@ -11,7 +11,7 @@
 
 #define CATCH_CONFIG_RUNNER
 #include "mfem.hpp"
-#include "unit_tests.hpp"
+#include "run_unit_tests.hpp"
 
 bool launch_all_non_regression_tests = false;
 std::string mfem_data_dir;
@@ -24,25 +24,6 @@ mfem::MPI_Session *GlobalMPISession;
 
 int main(int argc, char *argv[])
 {
-   // There must be exactly one instance.
-   Catch::Session session;
-
-   // Build a new command line parser on top of Catch's
-   using namespace Catch::clara;
-   auto cli = session.cli()
-              | Opt(launch_all_non_regression_tests) ["--all"] ("all tests")
-              | Opt(mfem_data_dir, "") ["--data"] ("mfem/data repository");
-   session.cli(cli);
-
-   // For floating point comparisons, print 8 digits for single precision
-   // values, and 16 digits for double precision values.
-   Catch::StringMaker<float>::precision = 8;
-   Catch::StringMaker<double>::precision = 16;
-
-   // Apply provided command line arguments.
-   int r = session.applyCommandLine(argc, argv);
-   if (r != 0) { return r; }
-
 #ifdef MFEM_USE_MPI
    mfem::MPI_Session mpi;
    GlobalMPISession = &mpi;
@@ -51,25 +32,6 @@ int main(int argc, char *argv[])
    bool root = true;
 #endif
 
-   auto cfg = session.configData();
-   // Exclude all tests that are not labeled with Parallel.
-   cfg.testsOrTags.push_back("[Parallel]");
-   if (mfem_data_dir == "") { cfg.testsOrTags.push_back("~[MFEMData]"); }
-   session.useConfigData(cfg);
-
-   // NOTE: tests marked with "[CUDA]" (in addition to "[Parallel]") are still
-   //       run with the default device.
-   if (root)
-   {
-      std::cout << "INFO: Test filter: ";
-      for (std::string &filter : cfg.testsOrTags)
-      {
-         std::cout << filter << " ";
-      }
-      std::cout << std::endl;
-   }
-
-   int result = session.run();
-
-   return result;
+   // Only run tests that are labeled with Parallel.
+   return RunCatchSession(argc, argv, {"[Parallel]"}, root);
 }

--- a/tests/unit/run_unit_tests.hpp
+++ b/tests/unit/run_unit_tests.hpp
@@ -1,0 +1,60 @@
+// Copyright (c) 2010-2021, Lawrence Livermore National Security, LLC. Produced
+// at the Lawrence Livermore National Laboratory. All Rights reserved. See files
+// LICENSE and NOTICE for details. LLNL-CODE-806117.
+//
+// This file is part of the MFEM library. For more information and source code
+// availability visit https://mfem.org.
+//
+// MFEM is free software; you can redistribute it and/or modify it under the
+// terms of the BSD-3 license. We welcome feedback and contributions, see file
+// CONTRIBUTING.md for details.
+
+#ifndef MFEM_RUN_UNIT_TEST
+#define MFEM_RUN_UNIT_TEST
+
+#include "unit_tests.hpp"
+
+static int RunCatchSession(int argc, char *argv[],
+                           const std::vector<std::string> &testsOrTags,
+                           bool root=true)
+{
+   // There must be exactly one instance.
+   Catch::Session session;
+
+   // Build a new command line parser on top of Catch's
+   using namespace Catch::clara;
+   auto cli = session.cli()
+              | Opt(launch_all_non_regression_tests) ["--all"] ("all tests")
+              | Opt(mfem_data_dir, "") ["--data"] ("mfem/data repository");
+   session.cli(cli);
+
+   // For floating point comparisons, print 8 digits for single precision
+   // values, and 16 digits for double precision values.
+   Catch::StringMaker<float>::precision = 8;
+   Catch::StringMaker<double>::precision = 16;
+
+   // Apply provided command line arguments.
+   int r = session.applyCommandLine(argc, argv);
+   if (r != 0) { return r; }
+
+   auto cfg = session.configData();
+   cfg.testsOrTags.insert(cfg.testsOrTags.end(), testsOrTags.begin(), testsOrTags.end());
+   if (mfem_data_dir == "") { cfg.testsOrTags.push_back("~[MFEMData]"); }
+   session.useConfigData(cfg);
+
+   if (root)
+   {
+    std::cout << "INFO: Test filter: ";
+    for (std::string &filter : cfg.testsOrTags)
+    {
+        std::cout << filter << " ";
+    }
+    std::cout << std::endl;
+   }
+
+   int result = session.run();
+
+   return result;
+}
+
+#endif

--- a/tests/unit/unit_test_main.cpp
+++ b/tests/unit/unit_test_main.cpp
@@ -11,45 +11,13 @@
 
 #define CATCH_CONFIG_RUNNER
 #include "mfem.hpp"
-#include "unit_tests.hpp"
+#include "run_unit_tests.hpp"
 
 bool launch_all_non_regression_tests = false;
 std::string mfem_data_dir;
 
 int main(int argc, char *argv[])
 {
-   // There must be exactly one instance.
-   Catch::Session session;
-
-   // Build a new command line parser on top of Catch's
-   using namespace Catch::clara;
-   auto cli = session.cli()
-              | Opt(launch_all_non_regression_tests) ["--all"] ("all tests")
-              | Opt(mfem_data_dir, "") ["--data"] ("mfem/data repository");
-   session.cli(cli);
-
-   // For floating point comparisons, print 8 digits for single precision
-   // values, and 16 digits for double precision values.
-   Catch::StringMaker<float>::precision = 8;
-   Catch::StringMaker<double>::precision = 16;
-
-   // Apply provided command line arguments.
-   int r = session.applyCommandLine(argc, argv);
-   if (r != 0) { return r; }
-
-   auto cfg = session.configData();
-   // Exclude tests marked as Parallel in a serial run, even when compiled with
-   // MPI. This is done because there is no MPI session initialized.
-   cfg.testsOrTags.push_back("~[Parallel]");
-   if (mfem_data_dir == "") { cfg.testsOrTags.push_back("~[MFEMData]"); }
-   session.useConfigData(cfg);
-
-   // NOTE: tests marked with "[CUDA]" are still run using the default device.
-   std::cout << "INFO: Test filter: ";
-   for (std::string &filter : cfg.testsOrTags) { std::cout << filter << " "; }
-   std::cout << std::endl;
-
-   int result = session.run();
-
-   return result;
+   // Exclude parallel tests.
+   return RunCatchSession(argc, argv, {"~[Parallel]"});
 }

--- a/tests/unit/unit_tests.hpp
+++ b/tests/unit/unit_tests.hpp
@@ -17,6 +17,11 @@
 /// Command line '--all' option to launch all non-regression tests.
 extern bool launch_all_non_regression_tests;
 
+/// Command line '--data' argument for path to mfem/data repo.
+/** If no --data path is provided, then mfem_data_dir will be the empty string,
+    and tests tagged with [MFEMData] will be skipped. */
+extern std::string mfem_data_dir;
+
 /** @brief MFEM_Approx can be used to compare floating point values within an
     absolute tolerance of @a abs_tol (default value 1e-12) and relative
     tolerance of @a rel_tol (default value 1e-12). */


### PR DESCRIPTION
(Note that this PR includes commits from #2378, since that PR introduces the need for testing with mfem/data)

This PR makes some changes to MFEM's unit testing:
* Refactors the unit tests main files (`cunit_test_main.cpp`, `pcunit_test_main.cpp`, `punit_test_main.cpp`, `unit_test_main.cpp`) so that they use a common function (`RunCatchSession` in `run_unit_tests.hpp`) rather than duplicate essentially the same command line argument processing, etc.
* Adds a command line argument `--data` to the unit tests. If `--data` is *not* provided, no tests tagged with `[MFEMData]` will be run. If `--data` *is* provided, it should be a path to the mfem/data repository. Tests tagged with `[MFEMData]` will be run, and can use the `mfem_data_dir` variable to access data files from mfem/data.
* `make test` checks for a `data` directory in the parent of the MFEM source directory, and if it exists, will pass `--data` with the appropriate path to the unit test executables. If it doesn't exist, `--data` will not be provided, and those tests will be skipped.
* Adds a unit test for #2378 that depends on mesh files in mfem/data. The test is tagged with `[MFEMData]` and uses `mfem_data_dir`.

Additionally, the new testing is integrated into the GitLab CI:
* Adds a `setup` phase, run before any of the tests, which clones mfem/data into the `BUILD_ROOT` directory.
* When MFEM is built, the cloned data repository is symlinked into the parent of the MFEM source directory, so the unit tests makefile will find it.
<!--GHEX{"id":2392,"author":"pazner","editor":"tzanio","reviewers":["adrienbernede","jandrej"],"assignment":"2021-07-07T13:35:30-07:00","approval":"2021-07-14T18:28:02.316Z","merge":"2021-07-19T01:49:14.923Z"}XEHG--><!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge| 
 | --- | --- | --- | --- | --- | --- | --- | 
| [#2392](https://github.com/mfem/mfem/pull/2392) | @pazner | @tzanio | @adrienbernede + @jandrej | 07/07/21 | 07/14/21 | 07/18/21 | |
<!--ELBATXEHG-->