### PR TITLE
Fix print in the shifted diffusion miniapp

### DIFF
--- a/miniapps/shifted/diffusion.cpp
+++ b/miniapps/shifted/diffusion.cpp
@@ -109,15 +109,19 @@ int main(int argc, char *argv[])
    args.Parse();
    if (!args.Good())
    {
-      args.PrintUsage(cout);
+      if (myid == 0)
+      {
+         args.PrintUsage(cout);
+      }
+      MPI_Finalize();
       return 1;
    }
-   args.PrintOptions(cout);
+   if (myid == 0) { args.PrintOptions(cout); }
 
    // Enable hardware devices such as GPUs, and programming models such as CUDA,
    // OCCA, RAJA and OpenMP based on command line options.
    Device device("cpu");
-   device.Print();
+   if (myid == 0) { device.Print(); }
 
    // Refine the mesh.
    Mesh mesh(mesh_file, 1, 1);


### PR DESCRIPTION
Minor fix to the print statements in the diffusion miniapp.
<!--GHEX{"id":2394,"author":"kmittal2","editor":"tzanio","reviewers":["tzanio","v-dobrev"],"assignment":"2021-07-07T13:34:42-07:00","approval":"2021-07-09T23:00:10.246Z","merge":"2021-07-12T15:28:48.847Z"}XEHG--><!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge| 
 | --- | --- | --- | --- | --- | --- | --- | 
| [#2394](https://github.com/mfem/mfem/pull/2394) | @kmittal2 | @tzanio | @tzanio + @v-dobrev | 07/07/21 | 07/09/21 | 07/12/21 | |
<!--ELBATXEHG-->