### PR TITLE
Bug in the assembly  for BlockNonlinearForm

### DIFF
--- a/fem/nonlinearform.cpp
+++ b/fem/nonlinearform.cpp
@@ -979,6 +979,8 @@ void BlockNonlinearForm::ComputeGradientBlocked(const BlockVector &bx) const
 
             for (int k = 0; k < bfnfi.Size(); ++k)
             {
+	       if (bfnfi_marker[k] &&
+                   (*bfnfi_marker[k])[bdr_attr-1] == 0) { continue; }	    
                bfnfi[k]->AssembleFaceGrad(fe, fe2, *tr, el_x_const, elmats);
                for (int l=0; l<fes.Size(); ++l)
                {

--- a/fem/nonlinearform.cpp
+++ b/fem/nonlinearform.cpp
@@ -979,8 +979,8 @@ void BlockNonlinearForm::ComputeGradientBlocked(const BlockVector &bx) const
 
             for (int k = 0; k < bfnfi.Size(); ++k)
             {
-	       if (bfnfi_marker[k] &&
-                   (*bfnfi_marker[k])[bdr_attr-1] == 0) { continue; }	    
+               if (bfnfi_marker[k] &&
+                   (*bfnfi_marker[k])[bdr_attr-1] == 0) { continue; }
                bfnfi[k]->AssembleFaceGrad(fe, fe2, *tr, el_x_const, elmats);
                for (int l=0; l<fes.Size(); ++l)
                {


### PR DESCRIPTION
For multiple face integrators the gradient assembly process  does not account for the assigned markers and assemble all of them. 
<!--GHEX{"id":2396,"author":"bslazarov","editor":"tzanio","reviewers":["jandrej","jamiebramwell"],"assignment":"2021-07-08T09:51:28-07:00","approval":"2021-07-09T22:59:06.829Z","merge":"2021-07-12T15:28:24.434Z"}XEHG--><!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge| 
 | --- | --- | --- | --- | --- | --- | --- | 
| [#2396](https://github.com/mfem/mfem/pull/2396) | @bslazarov | @tzanio | @jandrej + @jamiebramwell | 07/08/21 | 07/09/21 | 07/12/21 | |
<!--ELBATXEHG-->