### PR TITLE
DerivativeIntegrator for 1D embedded geometry

### DIFF
--- a/fem/bilininteg.cpp
+++ b/fem/bilininteg.cpp
@@ -1777,15 +1777,16 @@ void DerivativeIntegrator::AssembleElementMatrix2 (
    int dim = trial_fe.GetDim();
    int trial_nd = trial_fe.GetDof();
    int test_nd = test_fe.GetDof();
+   int spaceDim = Trans.GetSpaceDim();
 
    int i, l;
    double det;
 
    elmat.SetSize (test_nd,trial_nd);
    dshape.SetSize (trial_nd,dim);
-   dshapedxt.SetSize(trial_nd,dim);
+   dshapedxt.SetSize(trial_nd, spaceDim);
    dshapedxi.SetSize(trial_nd);
-   invdfdx.SetSize(dim);
+   invdfdx.SetSize(dim, spaceDim);
    shape.SetSize (test_nd);
 
    const IntegrationRule *ir = IntRule;


### PR DESCRIPTION
I think this minor change allows to address https://github.com/mfem/mfem/issues/2402.
A simple SS shows a diffusion problem (- d^2 u/ ds^2 = 1) solved along 3/4 arc, where s 
is a length along the path. The solution is u(s) = - s^2/2 + 2.776
u (right top panel) and -du_x*y + du_y *x (right bottom) seems correct to my eyes ;D

![image](https://user-images.githubusercontent.com/1929159/125353765-f7c8cf00-e330-11eb-9b06-65475da2fef6.png)

<!--GHEX{"id":2403,"author":"sshiraiwa","editor":"tzanio","reviewers":["mlstowell","psocratis"],"assignment":"2021-07-13T11:55:25-07:00","approval":"2021-07-13T19:33:01.495Z","merge":"2021-07-15T15:15:02.424Z"}XEHG--><!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge| 
 | --- | --- | --- | --- | --- | --- | --- | 
| [#2403](https://github.com/mfem/mfem/pull/2403) | @sshiraiwa | @tzanio | @mlstowell + @psocratis | 07/13/21 | 07/13/21 | 07/15/21 | |
<!--ELBATXEHG-->