### PR TITLE
cmake: install examples when enabled

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -550,7 +550,11 @@ add_custom_target(${MFEM_EXEC_PREREQUISITES_TARGET_NAME})
 # Create a target for all examples and, optionally, enable it.
 set(MFEM_ALL_EXAMPLES_TARGET_NAME examples)
 add_mfem_target(${MFEM_ALL_EXAMPLES_TARGET_NAME} ${MFEM_ENABLE_EXAMPLES})
-add_subdirectory(examples EXCLUDE_FROM_ALL)
+if (MFEM_ENABLE_EXAMPLES)
+  add_subdirectory(examples) #install examples if enabled
+else()
+  add_subdirectory(examples EXCLUDE_FROM_ALL)
+endif()
 
 # Create a target for all miniapps and, optionally, enable it.
 set(MFEM_ALL_MINIAPPS_TARGET_NAME miniapps)

--- a/config/cmake/modules/MfemCmakeUtilities.cmake
+++ b/config/cmake/modules/MfemCmakeUtilities.cmake
@@ -101,7 +101,7 @@ macro(add_mfem_examples EXE_SRCS)
     string(REPLACE ".cpp" "" EXE_NAME "${EXE_PREFIX}${SRC_FILENAME}")
     mfem_add_executable(${EXE_NAME} ${SRC_FILE})
     install(TARGETS ${EXE_NAME}
-            RUNTIME DESTINATION bin)
+            RUNTIME DESTINATION examples)
     add_dependencies(${MFEM_ALL_EXAMPLES_TARGET_NAME} ${EXE_NAME})
     if (EXE_NEEDED_BY)
       add_dependencies(${EXE_NEEDED_BY} ${EXE_NAME})

--- a/config/cmake/modules/MfemCmakeUtilities.cmake
+++ b/config/cmake/modules/MfemCmakeUtilities.cmake
@@ -101,7 +101,7 @@ macro(add_mfem_examples EXE_SRCS)
     string(REPLACE ".cpp" "" EXE_NAME "${EXE_PREFIX}${SRC_FILENAME}")
     mfem_add_executable(${EXE_NAME} ${SRC_FILE})
     install(TARGETS ${EXE_NAME}
-            DESTINATION ${CMAKE_INSTALL_PREFIX}/bin)
+            RUNTIME DESTINATION bin)
     add_dependencies(${MFEM_ALL_EXAMPLES_TARGET_NAME} ${EXE_NAME})
     if (EXE_NEEDED_BY)
       add_dependencies(${EXE_NEEDED_BY} ${EXE_NAME})

--- a/config/cmake/modules/MfemCmakeUtilities.cmake
+++ b/config/cmake/modules/MfemCmakeUtilities.cmake
@@ -100,6 +100,8 @@ macro(add_mfem_examples EXE_SRCS)
 
     string(REPLACE ".cpp" "" EXE_NAME "${EXE_PREFIX}${SRC_FILENAME}")
     mfem_add_executable(${EXE_NAME} ${SRC_FILE})
+    install(TARGETS ${EXE_NAME}
+            DESTINATION ${CMAKE_INSTALL_PREFIX}/bin)
     add_dependencies(${MFEM_ALL_EXAMPLES_TARGET_NAME} ${EXE_NAME})
     if (EXE_NEEDED_BY)
       add_dependencies(${EXE_NEEDED_BY} ${EXE_NAME})


### PR DESCRIPTION
This PR modifies the CMake build system to install examples when `MFEM_ENABLE_EXAMPLES` is on/true.
<!--GHEX{"id":2406,"author":"cwsmith","editor":"tzanio","reviewers":["v-dobrev","jandrej","jwang125"],"assignment":"2021-07-15T07:42:10-07:00","approval":"2021-10-31T21:31:35.700Z","merge":"2021-11-03T15:02:22.493Z"}XEHG--><!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge| 
 | --- | --- | --- | --- | --- | --- | --- | 
| [#2406](https://github.com/mfem/mfem/pull/2406) | @cwsmith | @tzanio | @v-dobrev + @jandrej + @jwang125 | 07/15/21 | 10/31/21 | 11/03/21 | |
<!--ELBATXEHG-->