### PR TITLE
Bug fix in FindPointsGSLIB::Interpolate when using L2_FECollection in parallel

### DIFF
--- a/fem/gslib.cpp
+++ b/fem/gslib.cpp
@@ -606,7 +606,12 @@ void FindPointsGSLIB::Interpolate(const GridFunction &field_in,
       {
          if (gsl_code[i] == 1) { indl2.Append(i); }
       }
-      if (indl2.Size() == 0) { return; } // no points on element borders
+      int borderPts = indl2.Size();
+#ifdef MFEM_USE_MPI
+      MPI_Allreduce(MPI_IN_PLACE, &borderPts, 1, MPI_INT, MPI_SUM, gsl_comm->c);
+#endif
+      if (borderPts == 0) { return; } // no points on element borders
+
 
       Vector field_out_l2(field_out.Size());
       VectorGridFunctionCoefficient field_in_dg(&field_in);

--- a/miniapps/gslib/schwarz_ex1p.cpp
+++ b/miniapps/gslib/schwarz_ex1p.cpp
@@ -327,7 +327,7 @@ int main(int argc, char *argv[])
       {
          bnd(i+d*number_boundary) = vxyz(idx + d*number_true);
       }
-      n      colorv[i] = (unsigned int)color;
+      colorv[i] = (unsigned int)color;
    }
    Vector interp_vals1(number_boundary);
    finder.Interpolate(bnd, colorv, x, interp_vals1);


### PR DESCRIPTION
This is intended to fix a problem observed when using the gslib-based interpolator (`FindPointsGSLIB::Interpolate`) with `L2_FECollection` in parallel.

Specifically, with the existing code, it is possible for a call to `FindPointsGSLIB::Interpolate` to hang indefinitely.  This happens when using `L2_FECollection` and some MPI tasks find border points while others do not.  In this case, the tasks that do not find border points exit `FindPointsGSLIB::Interpolate` "early"---i.e., before the subsequent call to either `InterpolateH1` or `InterpolateGeneral`.  These calls though have communication calls, which leads to the hang.

The changes in 7859c93 are intended to expose this behavior using the `pfindpts` miniapp, by allowing the user to force different MPI tasks to search for different points.  In particular, it is sufficient to have only task 0 own any points to search for, while the other tasks have none.  This is implemented with the option `--search-on-r0`, which defaults to false such that the default behavior reproduces the current behavior where all MPI tasks have the same points.  If this option is used with `L2_FECollection`, i.e., `-ft 1`, in parallel, the miniapp will hang without the modification in 9148a1d.


The changes in 9148a1d are intended to fix this problem, simply by checking that no process found border points before the return in `FindPointsGSLIB::Interpolate`.
<!--GHEX{"id":2422,"author":"trevilo","editor":"tzanio","reviewers":["kmittal2","vladotomov"],"assignment":"2021-07-22T09:53:06-07:00","approval":"2021-08-04T02:14:56.131Z","merge":"2021-08-05T19:16:07.976Z"}XEHG--><!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge| 
 | --- | --- | --- | --- | --- | --- | --- | 
| [#2422](https://github.com/mfem/mfem/pull/2422) | @trevilo | @tzanio | @kmittal2 + @vladotomov | 07/22/21 | 08/03/21 | 08/05/21 | |
<!--ELBATXEHG-->