### PR TITLE
libCEED 0.9.0

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -720,7 +720,7 @@ The specific libraries and their options are:
   URL: https://github.com/CEED/libCEED
        https://ceed.exascaleproject.org/libceed
   Options: CEED_DIR, CEED_OPT, CEED_LIB.
-  Versions: libCEED >= 0.8.
+  Versions: libCEED >= 0.9.0.
 
 - RAJA (optional), used when MFEM_USE_RAJA = YES.
   Beginning with MFEM v4.3, only RAJA v0.13.0+ is supported.


### PR DESCRIPTION
libCEED has released v0.9.0 - this is a minor change, so there shouldn't be any issues here. This has the update to silence those pedantic warnings from Clang.