### PR TITLE
HyperParVector Erase{X,Y}

### DIFF
--- a/linalg/hypre.cpp
+++ b/linalg/hypre.cpp
@@ -1541,12 +1541,15 @@ void HypreParMatrix::Mult(double a, const Vector &x, double b, Vector &y) const
    MFEM_ASSERT(y.Size() == Height(), "invalid y.Size() = " << y.Size()
                << ", expected size = " << Height());
 
-   if (X == NULL)
+   if (X == nullptr)
    {
       X = new HypreParVector(A->comm,
                              GetGlobalNumCols(),
                              nullptr,
                              GetColStarts());
+   }
+   if (Y == nullptr)
+   {
       Y = new HypreParVector(A->comm,
                              GetGlobalNumRows(),
                              nullptr,
@@ -1601,12 +1604,15 @@ void HypreParMatrix::MultTranspose(double a, const Vector &x,
 
    // Note: x has the dimensions of Y (height), and
    //       y has the dimensions of X (width)
-   if (X == NULL)
+   if (X == nullptr)
    {
       X = new HypreParVector(A->comm,
                              GetGlobalNumCols(),
                              nullptr,
                              GetColStarts());
+   }
+   if (Y == nullptr)
+   {
       Y = new HypreParVector(A->comm,
                              GetGlobalNumRows(),
                              nullptr,

--- a/linalg/hypre.hpp
+++ b/linalg/hypre.hpp
@@ -281,7 +281,7 @@ private:
    hypre_ParCSRMatrix *A;
 
    /// Auxiliary vectors for typecasting
-   mutable HypreParVector *X, *Y;
+   mutable HypreParVector *X = nullptr, *Y = nullptr;
    /** @brief Auxiliary buffers for the case when the input or output arrays in
        methods like Mult(double, const Vector &, double, Vector &) need to be
        deep copied in order to be used by hypre. */
@@ -775,6 +775,10 @@ public:
 
    /// Calls hypre's destroy function
    virtual ~HypreParMatrix() { Destroy(); }
+
+   /// Erase X or Y and set the deleted value to nullptr
+   inline void EraseX() { delete X; X = nullptr; }
+   inline void EraseY() { delete Y; Y = nullptr; }
 
    Type GetType() const { return Hypre_ParCSR; }
 };


### PR DESCRIPTION
- add `EraseX` and `EraseY` methods to `HyperParVector`
- check for `nullptr` and ctor `X` and `Y` separately

This is needed for an app that uses temporary memory for the `Y` argument in `HyperParVector::Mult`. `Mult` makes an alias to `Y` (and `X`) and when we release the temporary memory that `Y` is aliased to we get a runtime error; we need a way to explicitly tell the `HyperParVector` to erase its reference.
