### PR TITLE
fix GetElementSize for surface meshes

### DIFF
--- a/mesh/mesh.cpp
+++ b/mesh/mesh.cpp
@@ -75,7 +75,7 @@ void Mesh::GetElementCenter(int i, Vector &center)
 
 double Mesh::GetElementSize(ElementTransformation *T, int type)
 {
-   DenseMatrix J(Dim);
+   DenseMatrix J(spaceDim,Dim);
 
    Geometry::Type geom = T->GetGeometryType();
    T->SetIntPoint(&Geometries.GetCenter(geom));
@@ -83,7 +83,7 @@ double Mesh::GetElementSize(ElementTransformation *T, int type)
 
    if (type == 0)
    {
-      return pow(fabs(J.Det()), 1./Dim);
+      return pow(fabs(J.Weight()), 1./Dim);
    }
    else if (type == 1)
    {
@@ -102,7 +102,7 @@ double Mesh::GetElementSize(int i, int type)
 
 double Mesh::GetElementSize(int i, const Vector &dir)
 {
-   DenseMatrix J(Dim);
+   DenseMatrix J(spaceDim,Dim);
    Vector d_hat(Dim);
    GetElementJacobian(i, J);
    J.MultTranspose(dir, d_hat);


### PR DESCRIPTION
Small bug fix to support embedded meshes
<!--GHEX{"id":2441,"author":"brendankeith","editor":"tzanio","reviewers":["mlstowell","kmittal2"],"assignment":"2021-08-01T14:34:40-07:00","approval":"2021-08-04T13:21:49.419Z","merge":"2021-08-05T19:16:53.833Z"}XEHG--><!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge| 
 | --- | --- | --- | --- | --- | --- | --- | 
| [#2441](https://github.com/mfem/mfem/pull/2441) | @brendankeith | @tzanio | @mlstowell + @kmittal2 | 08/01/21 | 08/04/21 | 08/05/21 | |
<!--ELBATXEHG-->