### PR TITLE
Feature: Jacobi2/3 device

### DIFF
--- a/linalg/sparsemat.cpp
+++ b/linalg/sparsemat.cpp
@@ -2498,7 +2498,14 @@ static void JacobiDispatch(const Vector &b, const Vector &x0, Vector &x1,
       }
       else
       {
-         MFEM_ABORT_KERNEL("L1 norm of row is zero.");
+	 if (useFabs)
+         {
+	    MFEM_ABORT_KERNEL("L1 norm of row is zero.");
+	 }
+	 else
+         {
+	    MFEM_ABORT_KERNEL("sum of row is zero.");
+	 }
       }
    });
 }

--- a/linalg/sparsemat.cpp
+++ b/linalg/sparsemat.cpp
@@ -2463,9 +2463,9 @@ void SparseMatrix::DiagScale(const Vector &b, Vector &x, double sc) const
 
 template <bool useFabs>
 static void JacobiDispatch(const Vector &b, const Vector &x0, Vector &x1,
-			   const Memory<int> &I, const Memory<int> &J,
-			   const Memory<double> &A, const int height,
-			   const double sc)
+                           const Memory<int> &I, const Memory<int> &J,
+                           const Memory<double> &A, const int height,
+                           const double sc)
 {
    const bool useDevice = b.UseDevice() || x0.UseDevice() || x1.UseDevice();
 
@@ -2483,14 +2483,14 @@ static void JacobiDispatch(const Vector &b, const Vector &x0, Vector &x1,
       for (int j = Ip[i]; j < Ip[i+1]; j++)
       {
          resi -= Ap[j] * x0p[Jp[j]];
-	 if (useFabs)
+         if (useFabs)
          {
-	    norm += fabs(Ap[j]);
-	 }
-	 else
+            norm += fabs(Ap[j]);
+         }
+         else
          {
-	    norm += Ap[j];
-	 }
+            norm += Ap[j];
+         }
       }
       if (norm > 0.0)
       {
@@ -2498,7 +2498,7 @@ static void JacobiDispatch(const Vector &b, const Vector &x0, Vector &x1,
       }
       else
       {
-	MFEM_ABORT_KERNEL("L1 norm of row is zero.");
+         MFEM_ABORT_KERNEL("L1 norm of row is zero.");
       }
    });
 }

--- a/linalg/sparsemat.cpp
+++ b/linalg/sparsemat.cpp
@@ -2461,52 +2461,60 @@ void SparseMatrix::DiagScale(const Vector &b, Vector &x, double sc) const
    });
 }
 
+template <bool useFabs>
+static void JacobiDispatch(const Vector &b, const Vector &x0, Vector &x1,
+			   const Memory<int> &I, const Memory<int> &J,
+			   const Memory<double> &A, const int height,
+			   const double sc)
+{
+   const bool useDevice = b.UseDevice() || x0.UseDevice() || x1.UseDevice();
+
+   const auto bp  = b.Read(useDevice);
+   const auto x0p = x0.Read(useDevice);
+   auto       x1p = x1.Write(useDevice);
+
+   const auto Ip = Read(I, height+1, useDevice);
+   const auto Jp = Read(J, J.Capacity(), useDevice);
+   const auto Ap = Read(A, J.Capacity(), useDevice);
+
+   MFEM_FORALL_SWITCH(useDevice, i, height,
+   {
+      double resi = bp[i], norm = 0.0;
+      for (int j = Ip[i]; j < Ip[i+1]; j++)
+      {
+         resi -= Ap[j] * x0p[Jp[j]];
+	 if (useFabs)
+         {
+	    norm += fabs(Ap[j]);
+	 }
+	 else
+         {
+	    norm += Ap[j];
+	 }
+      }
+      if (norm > 0.0)
+      {
+         x1p[i] = x0p[i] + sc * resi / norm;
+      }
+      else
+      {
+	MFEM_ABORT_KERNEL("L1 norm of row is zero.");
+      }
+   });
+}
+
 void SparseMatrix::Jacobi2(const Vector &b, const Vector &x0, Vector &x1,
                            double sc) const
 {
    MFEM_VERIFY(Finalized(), "Matrix must be finalized.");
-
-   for (int i = 0; i < height; i++)
-   {
-      double resi = b(i), norm = 0.0;
-      for (int j = I[i]; j < I[i+1]; j++)
-      {
-         resi -= A[j] * x0(J[j]);
-         norm += fabs(A[j]);
-      }
-      if (norm > 0.0)
-      {
-         x1(i) = x0(i) + sc * resi / norm;
-      }
-      else
-      {
-         MFEM_ABORT("L1 norm of row " << i << " is zero.");
-      }
-   }
+   JacobiDispatch<true>(b,x0,x1,I,J,A,height,sc);
 }
 
 void SparseMatrix::Jacobi3(const Vector &b, const Vector &x0, Vector &x1,
                            double sc) const
 {
    MFEM_VERIFY(Finalized(), "Matrix must be finalized.");
-
-   for (int i = 0; i < height; i++)
-   {
-      double resi = b(i), sum = 0.0;
-      for (int j = I[i]; j < I[i+1]; j++)
-      {
-         resi -= A[j] * x0(J[j]);
-         sum  += A[j];
-      }
-      if (sum > 0.0)
-      {
-         x1(i) = x0(i) + sc * resi / sum;
-      }
-      else
-      {
-         MFEM_ABORT("sum of row " << i << " is zero.");
-      }
-   }
+   JacobiDispatch<false>(b,x0,x1,I,J,A,height,sc);
 }
 
 void SparseMatrix::AddSubMatrix(const Array<int> &rows, const Array<int> &cols,

--- a/linalg/sparsemat.cpp
+++ b/linalg/sparsemat.cpp
@@ -2498,14 +2498,14 @@ static void JacobiDispatch(const Vector &b, const Vector &x0, Vector &x1,
       }
       else
       {
-	 if (useFabs)
+         if (useFabs)
          {
-	    MFEM_ABORT_KERNEL("L1 norm of row is zero.");
-	 }
-	 else
+            MFEM_ABORT_KERNEL("L1 norm of row is zero.");
+         }
+         else
          {
-	    MFEM_ABORT_KERNEL("sum of row is zero.");
-	 }
+            MFEM_ABORT_KERNEL("sum of row is zero.");
+         }
       }
    });
 }


### PR DESCRIPTION
Ported over `SparseMat::Jacobi2` and `SparseMat::Jacobi3` to device via `MFEM_FORALL`.

cc @psocratis 
<!--GHEX{"id":2446,"author":"Jacobfaib","editor":"tzanio","reviewers":["psocratis","YohannDudouit"],"assignment":"2021-08-03T19:11:30-07:00","approval":"2021-09-03T01:30:11.379Z","merge":"2021-09-10T03:29:18.531Z"}XEHG--><!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge| 
 | --- | --- | --- | --- | --- | --- | --- | 
| [#2446](https://github.com/mfem/mfem/pull/2446) | @Jacobfaib | @tzanio | @psocratis + @YohannDudouit | 08/03/21 | 09/02/21 | 09/09/21 | |
<!--ELBATXEHG-->