### PR TITLE
Fix total error definition in KellyErrorEstimator

### DIFF
--- a/fem/estimators.cpp
+++ b/fem/estimators.cpp
@@ -329,7 +329,7 @@ void KellyErrorEstimator::ComputeEstimates()
          error_estimates(e) = sqrt(factor * error_estimates(e));
       }
 
-      total_error = error_estimates.Sum();
+      total_error = error_estimates.Norml2();
       delete flux;
       return;
    }
@@ -452,9 +452,10 @@ void KellyErrorEstimator::ComputeEstimates()
    auto pfes = dynamic_cast<ParFiniteElementSpace*>(xfes);
    MFEM_VERIFY(pfes, "xfes is not a ParFiniteElementSpace pointer");
 
-   double process_local_error = error_estimates.Sum();
+   double process_local_error = pow(error_estimates.Norml2(),2.0);
    MPI_Allreduce(&process_local_error, &total_error, 1, MPI_DOUBLE,
                  MPI_SUM, pfes->GetComm());
+   total_error = sqrt(total_error);
 #endif // MFEM_USE_MPI
 }
 


### PR DESCRIPTION
Small bug fix. Total error should be defined as the sum of the squares of the local errors.