### PR TITLE
Const parameter for mesh copy assignment

### DIFF
--- a/mesh/mesh.hpp
+++ b/mesh/mesh.hpp
@@ -503,7 +503,7 @@ public:
    Mesh& operator=(Mesh &&mesh);
 
    /// Explicitly delete the copy assignment operator.
-   Mesh& operator=(Mesh &mesh) = delete;
+   Mesh& operator=(const Mesh &mesh) = delete;
 
    /** @name Named mesh constructors.
 


### PR DESCRIPTION
The use of a non-const reference parameter to the explicitly deleted copy assignment operator (where the implicitly declared copy assignment operator would have had a const ref) interferes with the ability to inherit from `mfem::Mesh`.  See core language defect reports [1331](http://www.open-std.org/jtc1/sc22/wg21/docs/cwg_defects.html#1331) and [1426](http://www.open-std.org/jtc1/sc22/wg21/docs/cwg_defects.html#1426).  These will be fixed in C++20 by [P0641R2](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2017/p0641r2.html).

An example error is as follows (when trying to declare a `std::optional<mfem::Mesh>`):
```
#14 34.58 /usr/bin/../lib/gcc/x86_64-linux-gnu/9/../../../../include/c++/9/optional:155:7: error: the parameter for this explicitly-defaulted copy assignment operator is const, but a member or base requires it to be non-const
#14 34.58       operator=(const _Optional_payload_base&) = default;
#14 34.58       ^
#14 34.58 /usr/bin/../lib/gcc/x86_64-linux-gnu/9/../../../../include/c++/9/optional:354:7: note: in instantiation of template class 'std::_Optional_payload_base<mfem::Mesh>' requested here
#14 34.58     : _Optional_payload_base<_Tp>
#14 34.58       ^
#14 34.58 /usr/bin/../lib/gcc/x86_64-linux-gnu/9/../../../../include/c++/9/optional:387:7: note: in instantiation of template class 'std::_Optional_payload<mfem::Mesh, true, false, false>' requested here
#14 34.58     : _Optional_payload<_Tp, true, false, false>
#14 34.58       ^
#14 34.58 /usr/bin/../lib/gcc/x86_64-linux-gnu/9/../../../../include/c++/9/optional:511:30: note: in instantiation of template class 'std::_Optional_payload<mfem::Mesh, false, false, false>' requested here
#14 34.58       _Optional_payload<_Tp> _M_payload;
#14 34.58                              ^
#14 34.58 /usr/bin/../lib/gcc/x86_64-linux-gnu/9/../../../../include/c++/9/optional:657:15: note: in instantiation of template class 'std::_Optional_base<mfem::Mesh, false, false>' requested here
#14 34.58     : private _Optional_base<_Tp>,
#14 34.58               ^
#14 34.58 /home/serac/serac/src/serac/numerics/mesh_utils.cpp:392:29: note: in instantiation of template class 'std::optional<mfem::Mesh>' requested here
#14 34.58   std::optional<mfem::Mesh> serial_mesh;
```
<!--GHEX{"id":2456,"author":"joshessman-llnl","editor":"tzanio","reviewers":["jakubcerveny","pazner"],"assignment":"2021-08-06T09:33:30-07:00","approval":"2021-08-12T19:05:34.980Z","merge":"2021-08-16T01:16:21.782Z"}XEHG--><!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge| 
 | --- | --- | --- | --- | --- | --- | --- | 
| [#2456](https://github.com/mfem/mfem/pull/2456) | @joshessman-llnl | @tzanio | @jakubcerveny + @pazner | 08/06/21 | 08/12/21 | 08/15/21 | |
<!--ELBATXEHG-->