### PR TITLE
Adjust true add mult to use MFEM's GetProlongationMatrix()

### DIFF
--- a/fem/pbilinearform.cpp
+++ b/fem/pbilinearform.cpp
@@ -321,11 +321,7 @@ const
    {
       X.SetSpace(pfes);
       Y.SetSpace(pfes);
-   }
-
-   if (Ytmp.ParFESpace() != pfes)
-   {
-      Ytmp.SetSpace(pfes);
+      Ytmp.SetSize(pfes->GetTrueVSize());
    }
 
    X.Distribute(&x);

--- a/fem/pbilinearform.cpp
+++ b/fem/pbilinearform.cpp
@@ -325,7 +325,7 @@ const
 
    if (Ytmp.ParFESpace() != pfes)
    {
-     Ytmp.SetSpace(pfes);
+      Ytmp.SetSpace(pfes);
    }
 
    X.Distribute(&x);

--- a/fem/pbilinearform.cpp
+++ b/fem/pbilinearform.cpp
@@ -323,6 +323,11 @@ const
       Y.SetSpace(pfes);
    }
 
+   if (Ytmp.ParFESpace() != pfes)
+   {
+     Ytmp.SetSpace(pfes);
+   }
+
    X.Distribute(&x);
    if (ext)
    {
@@ -335,7 +340,8 @@ const
                   " implemented");
       mat->Mult(X, Y);
    }
-   pfes->Dof_TrueDof_Matrix()->MultTranspose(a, Y, 1.0, y);
+   pfes->GetProlongationMatrix()->MultTranspose(Y, Ytmp);
+   y.Add(a,Ytmp);
 }
 
 void ParBilinearForm::FormLinearSystem(

--- a/fem/pbilinearform.hpp
+++ b/fem/pbilinearform.hpp
@@ -32,7 +32,7 @@ protected:
    ParFiniteElementSpace *pfes; ///< Points to the same object as #fes
 
    /// Auxiliary objects used in TrueAddMult().
-   mutable ParGridFunction X, Y;
+   mutable ParGridFunction X, Y, Ytmp;
 
    OperatorHandle p_mat, p_mat_e;
 

--- a/fem/pbilinearform.hpp
+++ b/fem/pbilinearform.hpp
@@ -32,7 +32,8 @@ protected:
    ParFiniteElementSpace *pfes; ///< Points to the same object as #fes
 
    /// Auxiliary objects used in TrueAddMult().
-   mutable ParGridFunction X, Y, Ytmp;
+   mutable ParGridFunction X, Y;
+   Vector Ytmp;
 
    OperatorHandle p_mat, p_mat_e;
 

--- a/fem/pbilinearform.hpp
+++ b/fem/pbilinearform.hpp
@@ -33,7 +33,7 @@ protected:
 
    /// Auxiliary objects used in TrueAddMult().
    mutable ParGridFunction X, Y;
-   Vector Ytmp;
+   mutable Vector Ytmp;
 
    OperatorHandle p_mat, p_mat_e;
 


### PR DESCRIPTION
This removes the reliance on Hypre's parallel sparse matrix. Enables GPU action when not building Hypre on the GPU but MFEM is GPU built. 
<!--GHEX{"id":2468,"author":"artv3","editor":"tzanio","reviewers":["tzanio","v-dobrev"],"assignment":"2021-08-17T10:13:26-07:00","approval":"2021-08-18T00:05:19.954Z","merge":"2021-08-19T01:32:59.540Z"}XEHG--><!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge| 
 | --- | --- | --- | --- | --- | --- | --- | 
| [#2468](https://github.com/mfem/mfem/pull/2468) | @artv3 | @tzanio | @tzanio + @v-dobrev | 08/17/21 | 08/17/21 | 08/18/21 | |
<!--ELBATXEHG-->