### PR TITLE
Adding missing variables when MFEM_THREAD_SAFE is ON [bugfix/thread-safe-dev]

### DIFF
--- a/fem/bilininteg.cpp
+++ b/fem/bilininteg.cpp
@@ -747,6 +747,7 @@ void DiffusionIntegrator::AssembleElementMatrix
 #ifdef MFEM_THREAD_SAFE
    DenseMatrix dshape(nd, dim), dshapedxt(nd, spaceDim);
    DenseMatrix dshapedxt_m(nd, MQ ? spaceDim : 0);
+   DenseMatrix M(MQ ? spaceDim : 0);
    Vector D(VQ ? VQ->GetVDim() : 0);
 #else
    dshape.SetSize(nd, dim);

--- a/fem/fe.cpp
+++ b/fem/fe.cpp
@@ -10947,6 +10947,7 @@ void RT_QuadrilateralElement::CalcVShape(const IntegrationPoint &ip,
 
 #ifdef MFEM_THREAD_SAFE
    Vector shape_cx(pp1 + 1), shape_ox(pp1), shape_cy(pp1 + 1), shape_oy(pp1);
+   Vector dshape_cx, dshape_cy;
 #endif
 
    if (obasis1d.IsIntegratedType())
@@ -11272,6 +11273,7 @@ void RT_HexahedronElement::CalcVShape(const IntegrationPoint &ip,
 #ifdef MFEM_THREAD_SAFE
    Vector shape_cx(pp1 + 1), shape_ox(pp1), shape_cy(pp1 + 1), shape_oy(pp1);
    Vector shape_cz(pp1 + 1), shape_oz(pp1);
+   Vector dshape_cx, dshape_cy, dshape_cz;
 #endif
 
    if (obasis1d.IsIntegratedType())
@@ -12113,6 +12115,7 @@ void ND_HexahedronElement::CalcVShape(const IntegrationPoint &ip,
 #ifdef MFEM_THREAD_SAFE
    Vector shape_cx(p + 1), shape_ox(p), shape_cy(p + 1), shape_oy(p);
    Vector shape_cz(p + 1), shape_oz(p);
+   Vector dshape_cx, dshape_cy, dshape_cz;
 #endif
 
    if (obasis1d.IsIntegratedType())
@@ -12539,6 +12542,7 @@ void ND_QuadrilateralElement::CalcVShape(const IntegrationPoint &ip,
 
 #ifdef MFEM_THREAD_SAFE
    Vector shape_cx(p + 1), shape_ox(p), shape_cy(p + 1), shape_oy(p);
+   Vector dshape_cx, dshape_cy;
 #endif
 
    if (obasis1d.IsIntegratedType())


### PR DESCRIPTION
Adding missing variables when MFEM_THREAD_SAFE is ON
<!--GHEX{"id":2472,"author":"mlstowell","editor":"tzanio","reviewers":["tzanio","dylan-copeland"],"assignment":"2021-09-13T16:55:35-07:00","approval":"2021-09-15T17:01:43.670Z","merge":"2021-09-16T15:28:23.799Z"}XEHG--><!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge| 
 | --- | --- | --- | --- | --- | --- | --- | 
| [#2472](https://github.com/mfem/mfem/pull/2472) | @mlstowell | @tzanio | @tzanio + @dylan-copeland | 09/13/21 | 09/15/21 | 09/16/21 | |
<!--ELBATXEHG-->