### PR TITLE
Use l1-Jacobi smoother for ADS with CUDA [ads-cuda-use-jacobi]

### DIFF
--- a/linalg/hypre.cpp
+++ b/linalg/hypre.cpp
@@ -4997,11 +4997,11 @@ HypreADS::HypreADS(const HypreParMatrix &A, ParFiniteElementSpace *face_fespace)
 void HypreADS::Init(ParFiniteElementSpace *face_fespace)
 {
    int cycle_type       = 11;
-   int rlx_type         = 2;
    int rlx_sweeps       = 1;
    double rlx_weight    = 1.0;
    double rlx_omega     = 1.0;
 #ifndef HYPRE_USING_CUDA
+   int rlx_type         = 2;
    int amg_coarsen_type = 10;
    int amg_agg_levels   = 1;
    int amg_rlx_type     = 8;
@@ -5009,6 +5009,7 @@ void HypreADS::Init(ParFiniteElementSpace *face_fespace)
    int amg_interp_type  = 6;
    int amg_Pmax         = 4;
 #else
+   int rlx_type         = 1;
    int amg_coarsen_type = 8;
    int amg_agg_levels   = 0;
    int amg_rlx_type     = 18;


### PR DESCRIPTION
We were accidentally not setting the ADS smoother to Jacobi (instead of Gauss-Seidel) when running on the GPU. This gives ~10x speedup on the following ex4 test:

Before:
```
==88537== Profiling application: ./ex4p -d cuda -m ../data/fichera.mesh
==88537== Profiling result:
            Type  Time(%)      Time     Calls       Avg       Min       Max  Name
 GPU activities:   48.09%  2.97751s       192  15.508ms  5.2480us  46.981ms  void csrsv2_solve_lower_nontranspose_byLevel_kernel<double, int=5, int=3>(int, int, double const *, int const *, int const *, double const *, double*, int*, int*, double const *, double, int, int*, double*, int*, int)
                   41.89%  2.59369s       192  13.509ms  5.3440us  40.086ms  void csrsv2_solve_upper_nontranspose_byLevel_kernel<double, int=5, int=3>(int, int, double const *, int const *, int const *, double const *, double*, int*, int*, double const *, double, int, int*, double*, int*, int)
                    1.55%  95.800ms      9796  9.7790us  3.9040us  73.376us  void sortI32_by_key_merge_core<int=256, int=4>(int, unsigned int*, int*, int*, int*, unsigned int*, int*)
                    1.39%  85.760ms      9796  8.7540us  4.0960us  60.928us  void sortI32_by_key_local_core<int=256, int=4, bool=1>(int, int, unsigned int*, int*, int*, int*)
⁞
```
After:
```
==102851== Profiling application: ./ex4p -d cuda -m ../data/fichera.mesh
==102851== Profiling result:
            Type  Time(%)      Time     Calls       Avg       Min       Max  Name
 GPU activities:   16.17%  92.186ms      9796  9.4100us  4.0320us  72.095us  void sortI32_by_key_merge_core<int=256, int=4>(int, unsigned int*, int*, int*, int*, unsigned int*, int*)
                   14.64%  83.453ms      9796  8.5190us  4.1270us  61.248us  void sortI32_by_key_local_core<int=256, int=4, bool=1>(int, int, unsigned int*, int*, int*, int*)
⁞
```
<!--GHEX{"id":2479,"author":"pazner","editor":"tzanio","reviewers":["tzanio","v-dobrev"],"assignment":"2021-08-19T14:53:45-07:00","approval":"2021-08-19T21:56:54.115Z","merge":"2021-08-20T21:07:00.163Z"}XEHG--><!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge| 
 | --- | --- | --- | --- | --- | --- | --- | 
| [#2479](https://github.com/mfem/mfem/pull/2479) | @pazner | @tzanio | @tzanio + @v-dobrev | 08/19/21 | 08/19/21 | 08/20/21 | |
<!--ELBATXEHG-->