### PR TITLE
Allow reading Gmsh meshes where all elements have attribute zero [gmsh-zero-attributes]

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -20,6 +20,9 @@ Version 4.3.1 (development)
   functions on wedges and pyramids which are not amenable to reordering. The
   ReorientTetMesh method of the Mesh and ParMesh classes has been deprecated.
 
+- Gmsh meshes where all elements have zero physical tag (the default Gmsh
+  output format if no physical groups are defined) are now successfully loaded,
+  and elements are reassigned attribute number 1.
 
 Version 4.3, released on July 29, 2021
 ======================================

--- a/mesh/mesh_readers.cpp
+++ b/mesh/mesh_readers.cpp
@@ -2374,6 +2374,12 @@ void Mesh::ReadGmshMesh(std::istream &input, int &curved, int &read_gf)
                        " for all curves, surfaces, or volumes in your"
                        " Gmsh geometry to values which are >= 1.");
          }
+         else if (has_nonpositive_phys_domain)
+         {
+            mfem::out << "\nGmsh reader: all element attributes were zero.\n"
+                      << "MFEM only supports positive element attributes.\n"
+                      << "Setting element attributes to 1.\n\n";
+         }
 
          if (!elements_3D.empty())
          {

--- a/mesh/mesh_readers.cpp
+++ b/mesh/mesh_readers.cpp
@@ -1884,6 +1884,9 @@ void Mesh::ReadGmshMesh(std::istream &input, int &curved, int &read_gf)
          ho_wdg[2] = wdg18; ho_wdg[3] = wdg40;
          ho_pyr[2] = pyr14; ho_pyr[3] = pyr30;
 
+         bool has_nonpositive_phys_domain = false;
+         bool has_positive_phys_domain = false;
+
          if (binary)
          {
             int n_elem_part = 0; // partial sum of elements that are read
@@ -1934,17 +1937,19 @@ void Mesh::ReadGmshMesh(std::istream &input, int &curved, int &read_gf)
                      vert_indices[vi] = it->second;
                   }
 
-                  // non-positive attributes are not allowed in MFEM
+                  // Non-positive attributes are not allowed in MFEM. However,
+                  // by default, Gmsh sets the physical domain of all elements
+                  // to zero. In the case that all elements have physical domain
+                  // zero, we will given them attribute 1. If only some elements
+                  // have physical domain zero, we will throw an error.
                   if (phys_domain <= 0)
                   {
-                     MFEM_ABORT("Non-positive element attribute in Gmsh mesh!\n"
-                                "By default Gmsh sets element tags (attributes)"
-                                " to '0' but MFEM requires that they be"
-                                " positive integers.\n"
-                                "Use \"Physical Curve\", \"Physical Surface\","
-                                " or \"Physical Volume\" to set tags/attributes"
-                                " for all curves, surfaces, or volumes in your"
-                                " Gmsh geometry to values which are >= 1.");
+                     has_nonpositive_phys_domain = true;
+                     phys_domain = 1;
+                  }
+                  else
+                  {
+                     has_positive_phys_domain = true;
                   }
 
                   // initialize the mesh element
@@ -2161,17 +2166,19 @@ void Mesh::ReadGmshMesh(std::istream &input, int &curved, int &read_gf)
                   vert_indices[vi] = it->second;
                }
 
-               // non-positive attributes are not allowed in MFEM
+               // Non-positive attributes are not allowed in MFEM. However,
+               // by default, Gmsh sets the physical domain of all elements
+               // to zero. In the case that all elements have physical domain
+               // zero, we will given them attribute 1. If only some elements
+               // have physical domain zero, we will throw an error.
                if (phys_domain <= 0)
                {
-                  MFEM_ABORT("Non-positive element attribute in Gmsh mesh!\n"
-                             "By default Gmsh sets element tags (attributes)"
-                             " to '0' but MFEM requires that they be"
-                             " positive integers.\n"
-                             "Use \"Physical Curve\", \"Physical Surface\","
-                             " or \"Physical Volume\" to set tags/attributes"
-                             " for all curves, surfaces, or volumes in your"
-                             " Gmsh geometry to values which are >= 1.");
+                  has_nonpositive_phys_domain = true;
+                  phys_domain = 1;
+               }
+               else
+               {
+                  has_positive_phys_domain = true;
                }
 
                // initialize the mesh element
@@ -2355,6 +2362,18 @@ void Mesh::ReadGmshMesh(std::istream &input, int &curved, int &read_gf)
                } // switch (type_of_element)
             } // el (all elements)
          } // if ASCII
+
+         if (has_positive_phys_domain && has_nonpositive_phys_domain)
+         {
+            MFEM_ABORT("Non-positive element attribute in Gmsh mesh!\n"
+                       "By default Gmsh sets element tags (attributes)"
+                       " to '0' but MFEM requires that they be"
+                       " positive integers.\n"
+                       "Use \"Physical Curve\", \"Physical Surface\","
+                       " or \"Physical Volume\" to set tags/attributes"
+                       " for all curves, surfaces, or volumes in your"
+                       " Gmsh geometry to values which are >= 1.");
+         }
 
          if (!elements_3D.empty())
          {


### PR DESCRIPTION
We [commonly encounter](https://github.com/mfem/mfem/issues?q=is%3Aissue+gmsh+attribute+physical) the issue where users try to load Gmsh meshes where all the elements have physical tag zero (since if no physical groups are explicitly created in the geometry file, this is what Gmsh will do by default). However, MFEM requires strictly positive element attributes.

This is a small change to the Gmsh reader that will check to see if **all** elements of the Gmsh mesh have physical tag zero. If so, then it will load the mesh and give the elements attribute 1. If there are some elements with attribute zero, and others with positive attributes, it will throw an error, since in this case it is not clear what attribute we would want to assign to the zero elements.

I suspect that this will resolve the vast majority of user issues loading Gmsh meshes with non-positive physical tags.
<!--GHEX{"id":2489,"author":"pazner","editor":"tzanio","reviewers":["tzanio","mlstowell","bslazarov"],"assignment":"2021-08-25T16:15:05-07:00","approval":"2021-08-30T20:12:40.904Z","merge":"2021-09-02T15:47:41.696Z"}XEHG--><!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge| 
 | --- | --- | --- | --- | --- | --- | --- | 
| [#2489](https://github.com/mfem/mfem/pull/2489) | @pazner | @tzanio | @tzanio + @mlstowell + @bslazarov | 08/25/21 | 08/30/21 | 09/02/21 | |
<!--ELBATXEHG-->