### PR TITLE
Bug fix for DiffusionIntegrator

### DIFF
--- a/fem/bilininteg.cpp
+++ b/fem/bilininteg.cpp
@@ -1129,7 +1129,7 @@ double DiffusionIntegrator::ComputeFluxEnergy
          {
             (*d_energy)[k] += w * vec[k] * vec[k];
          }
-         // TODO: Q, MQ
+         // TODO: Q, VQ, MQ
       }
    }
 


### PR DESCRIPTION
This PR fixes a bug in `DiffusionIntegrator` in the case of a vector (diagonal matrix) coefficient. There does not appear to be a ZZ unit test yet, but this small bug fix can be verified in ex6(p) by replacing the coefficient of `DiffusionIntegrator` with 
`VectorConstantCoefficient oneVec(ones);`
where `ones` is a vector of ones.
Also, note that building fails after this small change in `bilininteg.cpp`, and it is necessary to do `make clean` and rebuild from scratch, so something is not right in the build system (not fixed in this PR).
<!--GHEX{"id":2493,"author":"dylan-copeland","editor":"tzanio","reviewers":["mlstowell","v-dobrev"],"assignment":"2021-08-29T18:44:59-07:00","approval":"2021-10-26T18:59:45.923Z","merge":"2021-10-29T15:17:35.609Z"}XEHG--><!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge| 
 | --- | --- | --- | --- | --- | --- | --- | 
| [#2493](https://github.com/mfem/mfem/pull/2493) | @dylan-copeland | @tzanio | @mlstowell + @v-dobrev | 08/29/21 | 10/26/21 | 10/29/21 | |
<!--ELBATXEHG-->