### PR TITLE
WIP: 1d ncmesh dev

### DIFF
--- a/mesh/mesh.cpp
+++ b/mesh/mesh.cpp
@@ -3495,8 +3495,6 @@ void Mesh::SetMeshGen()
             mesh_geoms |= (1 << Geometry::TETRAHEDRON);
          case Element::TRIANGLE:
             mesh_geoms |= (1 << Geometry::TRIANGLE);
-         case Element::SEGMENT:
-            mesh_geoms |= (1 << Geometry::SEGMENT);
          case Element::POINT:
             mesh_geoms |= (1 << Geometry::POINT);
             meshgen |= 1;
@@ -3508,6 +3506,8 @@ void Mesh::SetMeshGen()
             mesh_geoms |= (1 << Geometry::SQUARE);
             mesh_geoms |= (1 << Geometry::SEGMENT);
             mesh_geoms |= (1 << Geometry::POINT);
+         case Element::SEGMENT:
+            mesh_geoms |= (1 << Geometry::SEGMENT);
             meshgen |= 2;
             break;
 

--- a/mesh/ncmesh.cpp
+++ b/mesh/ncmesh.cpp
@@ -4253,6 +4253,19 @@ void NCMesh::GetPointMatrix(Geometry::Type geom, const char* ref_path,
             pm = PointMatrix(mid12, mid20, mid01);
          }
       }
+      else if (geom == Geometry::SEGMENT)
+      {
+         Point mid01(pm(0), pm(1));
+
+         if (child == 0)
+         {
+            pm = PointMatrix(pm(0), mid01);
+         }
+         else if (child == 1)
+         {
+            pm = PointMatrix(mid01, pm(1));
+         }
+      }
    }
 
    // write the points to the matrix


### PR DESCRIPTION
The idea behind this is to allow "ncmesh" refinement of 1D meshes, even though 1D is a degenerate case that has no hanging nodes. The advantage of this is that derefinement is only supported in non-conforming refinement, and we have a desire to do 1D refinement/derefinement in an ML project for the cheap evaluation. 

Also, it seems so far like the modifications/additions needed to support this are small.

I'd like to add a 1D run of example 15 to test this, but haven't added that yet.

@jakubcerveny I thought you might have some thoughts about viability of this path and whether these changes make sense so far.
