### PR TITLE
Parallel GradientGridFunctionCoefficient 

### DIFF
--- a/fem/coefficient.cpp
+++ b/fem/coefficient.cpp
@@ -8,7 +8,6 @@
 // MFEM is free software; you can redistribute it and/or modify it under the
 // terms of the BSD-3 license. We welcome feedback and contributions, see file
 // CONTRIBUTING.md for details.
-
 // Implementation of Coefficient class
 
 #include "fem.hpp"
@@ -200,12 +199,12 @@ void GradientGridFunctionCoefficient::SetGridFunction(const GridFunction *gf)
 void GradientGridFunctionCoefficient::Eval(Vector &V, ElementTransformation &T,
                                            const IntegrationPoint &ip)
 {
-#ifdef MFEM_USE_MPI 
-   const ParGridFunction *pgf = dynamic_cast<const ParGridFunction*>(GridFunc); 
-   if (pgf) pgf->GetGradient(T, V); 
-   else GridFunc->GetGradient(T, V);
-#else 
-   GridFunc->GetGradient(T,V); 
+#ifdef MFEM_USE_MPI
+   const ParGridFunction *pgf = dynamic_cast<const ParGridFunction*>(GridFunc);
+   if (pgf) { pgf->GetGradient(T, V); }
+   else { GridFunc->GetGradient(T, V); }
+#else
+   GridFunc->GetGradient(T,V);
 #endif
 }
 
@@ -213,10 +212,10 @@ void GradientGridFunctionCoefficient::Eval(
    DenseMatrix &M, ElementTransformation &T, const IntegrationRule &ir)
 {
 #ifdef MFEM_USE_MPI
-   const ParGridFunction *pgf = dynamic_cast<const ParGridFunction*>(GridFunc); 
-   if (pgf) pgf->GetGradients(T, ir, M); 
-   else GridFunc->GetGradients(T, ir, M);
-#else 
+   const ParGridFunction *pgf = dynamic_cast<const ParGridFunction*>(GridFunc);
+   if (pgf) { pgf->GetGradients(T, ir, M); }
+   else { GridFunc->GetGradients(T, ir, M); }
+#else
    GridFunc->GetGradients(T, ir, M);
 #endif
 }

--- a/fem/coefficient.cpp
+++ b/fem/coefficient.cpp
@@ -200,13 +200,25 @@ void GradientGridFunctionCoefficient::SetGridFunction(const GridFunction *gf)
 void GradientGridFunctionCoefficient::Eval(Vector &V, ElementTransformation &T,
                                            const IntegrationPoint &ip)
 {
-   GridFunc->GetGradient(T, V);
+#ifdef MFEM_USE_MPI 
+   const ParGridFunction *pgf = dynamic_cast<const ParGridFunction*>(GridFunc); 
+   if (pgf) pgf->GetGradient(T, V); 
+   else GridFunc->GetGradient(T, V);
+#else 
+   GridFunc->GetGradient(T,V); 
+#endif
 }
 
 void GradientGridFunctionCoefficient::Eval(
    DenseMatrix &M, ElementTransformation &T, const IntegrationRule &ir)
 {
+#ifdef MFEM_USE_MPI
+   const ParGridFunction *pgf = dynamic_cast<const ParGridFunction*>(GridFunc); 
+   if (pgf) pgf->GetGradients(T, ir, M); 
+   else GridFunc->GetGradients(T, ir, M);
+#else 
    GridFunc->GetGradients(T, ir, M);
+#endif
 }
 
 CurlGridFunctionCoefficient::CurlGridFunctionCoefficient(


### PR DESCRIPTION
The current implementation of `GradientGridFunctionCoefficient` does not work on a parallel shared face (it causes an out of range access when `GetFE` is called). It calls `GridFunction::GetGradient` and not `ParGridFunction::GetGradient` which has logic to handle evaluating a grid function on a shared face. I added a `dynamic_cast` to a `ParGridFunction*` in `GradientGridFunctionCoefficient::Eval` so that `ParGridFunction::GetGradient` is called instead. 

I'm guessing all of the `GridFunction` based coefficients will have this issue too? I found this problem while trying to assemble a DG diffusion operator where the coefficients are computed from the solution of another PDE on the same mesh.  