### PR TITLE
fixed MatrixArrayCoefficient::Eval bug

### DIFF
--- a/fem/coefficient.cpp
+++ b/fem/coefficient.cpp
@@ -431,6 +431,7 @@ MatrixArrayCoefficient::~MatrixArrayCoefficient ()
 void MatrixArrayCoefficient::Eval(DenseMatrix &K, ElementTransformation &T,
                                   const IntegrationPoint &ip)
 {
+   K.SetSize(height, width);
    for (int i = 0; i < height; i++)
    {
       for (int j = 0; j < width; j++)


### PR DESCRIPTION
This PR fixes the bug adressed in https://github.com/mfem/mfem/issues/2500
<!--GHEX{"id":2501,"author":"Andr00dz","editor":"tzanio","reviewers":["psocratis","tzanio"],"assignment":"2021-09-02T08:11:34-07:00","approval":"2021-09-02T15:34:48.884Z","merge":"2021-09-05T23:45:00.675Z"}XEHG--><!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge| 
 | --- | --- | --- | --- | --- | --- | --- | 
| [#2501](https://github.com/mfem/mfem/pull/2501) | @Andr00dz | @tzanio | @psocratis + @tzanio | 09/02/21 | 09/02/21 | 09/05/21 | |
<!--ELBATXEHG-->