### PR TITLE
Fix compilation errors on Visual Studio 2019 with CUDA support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -175,6 +175,10 @@ else()
   set(MFEM_DEBUG OFF)
 endif()
 
+if (WIN32)
+	add_definitions(-D_USE_MATH_DEFINES)
+endif()
+
 # MPI -> hypre; PETSc (optional)
 if (MFEM_USE_MPI)
   find_package(MPI REQUIRED)

--- a/fem/bilininteg_convection_ea.cpp
+++ b/fem/bilininteg_convection_ea.cpp
@@ -17,7 +17,7 @@ namespace mfem
 {
 
 template<int T_D1D = 0, int T_Q1D = 0>
-static void EAConvectionAssemble1D(const int NE,
+void EAConvectionAssemble1D(const int NE,
                                    const Array<double> &b,
                                    const Array<double> &g,
                                    const Vector &padata,
@@ -69,7 +69,7 @@ static void EAConvectionAssemble1D(const int NE,
 }
 
 template<int T_D1D = 0, int T_Q1D = 0>
-static void EAConvectionAssemble2D(const int NE,
+void EAConvectionAssemble2D(const int NE,
                                    const Array<double> &b,
                                    const Array<double> &g,
                                    const Vector &padata,
@@ -146,7 +146,7 @@ static void EAConvectionAssemble2D(const int NE,
 }
 
 template<int T_D1D = 0, int T_Q1D = 0>
-static void EAConvectionAssemble3D(const int NE,
+void EAConvectionAssemble3D(const int NE,
                                    const Array<double> &b,
                                    const Array<double> &g,
                                    const Vector &padata,

--- a/fem/bilininteg_convection_pa.cpp
+++ b/fem/bilininteg_convection_pa.cpp
@@ -21,7 +21,7 @@ namespace mfem
 // PA Convection Integrator
 
 // PA Convection Assemble 2D kernel
-static void PAConvectionSetup2D(const int NQ,
+void PAConvectionSetup2D(const int NQ,
                                 const int NE,
                                 const Array<double> &w,
                                 const Vector &j,
@@ -60,7 +60,7 @@ static void PAConvectionSetup2D(const int NQ,
 }
 
 // PA Convection Assemble 3D kernel
-static void PAConvectionSetup3D(const int NQ,
+void PAConvectionSetup3D(const int NQ,
                                 const int NE,
                                 const Array<double> &w,
                                 const Vector &j,
@@ -135,7 +135,7 @@ static void PAConvectionSetup(const int dim,
 }
 
 // PA Convection Apply 2D kernel
-template<int T_D1D = 0, int T_Q1D = 0> static
+template<int T_D1D = 0, int T_Q1D = 0>
 void PAConvectionApply2D(const int ne,
                          const Array<double> &b,
                          const Array<double> &g,
@@ -254,7 +254,7 @@ void PAConvectionApply2D(const int ne,
 }
 
 // Optimized PA Convection Apply 2D kernel
-template<int T_D1D = 0, int T_Q1D = 0, int T_NBZ = 0> static
+template<int T_D1D = 0, int T_Q1D = 0, int T_NBZ = 0>
 void SmemPAConvectionApply2D(const int ne,
                              const Array<double> &b,
                              const Array<double> &g,
@@ -382,7 +382,7 @@ void SmemPAConvectionApply2D(const int ne,
 }
 
 // PA Convection Apply 3D kernel
-template<int T_D1D = 0, int T_Q1D = 0> static
+template<int T_D1D = 0, int T_Q1D = 0>
 void PAConvectionApply3D(const int ne,
                          const Array<double> &b,
                          const Array<double> &g,
@@ -563,7 +563,7 @@ void PAConvectionApply3D(const int ne,
 }
 
 // Optimized PA Convection Apply 3D kernel
-template<int T_D1D = 0, int T_Q1D = 0> static
+template<int T_D1D = 0, int T_Q1D = 0>
 void SmemPAConvectionApply3D(const int ne,
                              const Array<double> &b,
                              const Array<double> &g,

--- a/fem/bilininteg_dgtrace_ea.cpp
+++ b/fem/bilininteg_dgtrace_ea.cpp
@@ -16,7 +16,7 @@
 namespace mfem
 {
 
-static void EADGTraceAssemble1DInt(const int NF,
+void EADGTraceAssemble1DInt(const int NF,
                                    const Array<double> &basis,
                                    const Vector &padata,
                                    Vector &eadata_int,
@@ -50,7 +50,7 @@ static void EADGTraceAssemble1DInt(const int NF,
    });
 }
 
-static void EADGTraceAssemble1DBdr(const int NF,
+void EADGTraceAssemble1DBdr(const int NF,
                                    const Array<double> &basis,
                                    const Vector &padata,
                                    Vector &eadata_bdr,
@@ -72,7 +72,7 @@ static void EADGTraceAssemble1DBdr(const int NF,
 }
 
 template<int T_D1D = 0, int T_Q1D = 0>
-static void EADGTraceAssemble2DInt(const int NF,
+void EADGTraceAssemble2DInt(const int NF,
                                    const Array<double> &basis,
                                    const Vector &padata,
                                    Vector &eadata_int,
@@ -128,7 +128,7 @@ static void EADGTraceAssemble2DInt(const int NF,
 }
 
 template<int T_D1D = 0, int T_Q1D = 0>
-static void EADGTraceAssemble2DBdr(const int NF,
+void EADGTraceAssemble2DBdr(const int NF,
                                    const Array<double> &basis,
                                    const Vector &padata,
                                    Vector &eadata_bdr,
@@ -170,7 +170,7 @@ static void EADGTraceAssemble2DBdr(const int NF,
 }
 
 template<int T_D1D = 0, int T_Q1D = 0>
-static void EADGTraceAssemble3DInt(const int NF,
+void EADGTraceAssemble3DInt(const int NF,
                                    const Array<double> &basis,
                                    const Vector &padata,
                                    Vector &eadata_int,
@@ -268,7 +268,7 @@ static void EADGTraceAssemble3DInt(const int NF,
 }
 
 template<int T_D1D = 0, int T_Q1D = 0>
-static void EADGTraceAssemble3DBdr(const int NF,
+void EADGTraceAssemble3DBdr(const int NF,
                                    const Array<double> &basis,
                                    const Vector &padata,
                                    Vector &eadata_bdr,

--- a/fem/bilininteg_dgtrace_pa.cpp
+++ b/fem/bilininteg_dgtrace_pa.cpp
@@ -19,7 +19,7 @@ using namespace std;
 namespace mfem
 {
 // PA DG Trace Integrator
-static void PADGTraceSetup2D(const int Q1D,
+void PADGTraceSetup2D(const int Q1D,
                              const int NF,
                              const Array<double> &w,
                              const Vector &det,
@@ -61,7 +61,7 @@ static void PADGTraceSetup2D(const int Q1D,
    });
 }
 
-static void PADGTraceSetup3D(const int Q1D,
+void PADGTraceSetup3D(const int Q1D,
                              const int NF,
                              const Array<double> &w,
                              const Vector &det,
@@ -301,7 +301,7 @@ void DGTraceIntegrator::AssemblePABoundaryFaces(const FiniteElementSpace& fes)
 }
 
 // PA DGTrace Apply 2D kernel for Gauss-Lobatto/Bernstein
-template<int T_D1D = 0, int T_Q1D = 0> static
+template<int T_D1D = 0, int T_Q1D = 0>
 void PADGTraceApply2D(const int NF,
                       const Array<double> &b,
                       const Array<double> &bt,
@@ -392,7 +392,7 @@ void PADGTraceApply2D(const int NF,
 }
 
 // PA DGTrace Apply 3D kernel for Gauss-Lobatto/Bernstein
-template<int T_D1D = 0, int T_Q1D = 0> static
+template<int T_D1D = 0, int T_Q1D = 0>
 void PADGTraceApply3D(const int NF,
                       const Array<double> &b,
                       const Array<double> &bt,
@@ -537,7 +537,7 @@ void PADGTraceApply3D(const int NF,
 }
 
 // Optimized PA DGTrace Apply 3D kernel for Gauss-Lobatto/Bernstein
-template<int T_D1D = 0, int T_Q1D = 0, int T_NBZ = 0> static
+template<int T_D1D = 0, int T_Q1D = 0, int T_NBZ = 0>
 void SmemPADGTraceApply3D(const int NF,
                           const Array<double> &b,
                           const Array<double> &bt,
@@ -701,7 +701,7 @@ static void PADGTraceApply(const int dim,
 }
 
 // PA DGTrace Apply 2D kernel for Gauss-Lobatto/Bernstein
-template<int T_D1D = 0, int T_Q1D = 0> static
+template<int T_D1D = 0, int T_Q1D = 0>
 void PADGTraceApplyTranspose2D(const int NF,
                                const Array<double> &b,
                                const Array<double> &bt,
@@ -797,7 +797,7 @@ void PADGTraceApplyTranspose2D(const int NF,
 }
 
 // PA DGTrace Apply Transpose 3D kernel for Gauss-Lobatto/Bernstein
-template<int T_D1D = 0, int T_Q1D = 0> static
+template<int T_D1D = 0, int T_Q1D = 0>
 void PADGTraceApplyTranspose3D(const int NF,
                                const Array<double> &b,
                                const Array<double> &bt,
@@ -953,7 +953,7 @@ void PADGTraceApplyTranspose3D(const int NF,
 }
 
 // Optimized PA DGTrace Apply Transpose 3D kernel for Gauss-Lobatto/Bernstein
-template<int T_D1D = 0, int T_Q1D = 0, int T_NBZ = 0> static
+template<int T_D1D = 0, int T_Q1D = 0, int T_NBZ = 0>
 void SmemPADGTraceApplyTranspose3D(const int NF,
                                    const Array<double> &b,
                                    const Array<double> &bt,

--- a/fem/bilininteg_diffusion_ea.cpp
+++ b/fem/bilininteg_diffusion_ea.cpp
@@ -17,7 +17,7 @@ namespace mfem
 {
 
 template<int T_D1D = 0, int T_Q1D = 0>
-static void EADiffusionAssemble1D(const int NE,
+void EADiffusionAssemble1D(const int NE,
                                   const Array<double> &b,
                                   const Array<double> &g,
                                   const Vector &padata,
@@ -68,7 +68,7 @@ static void EADiffusionAssemble1D(const int NE,
 }
 
 template<int T_D1D = 0, int T_Q1D = 0>
-static void EADiffusionAssemble2D(const int NE,
+void EADiffusionAssemble2D(const int NE,
                                   const Array<double> &b,
                                   const Array<double> &g,
                                   const Vector &padata,
@@ -145,7 +145,7 @@ static void EADiffusionAssemble2D(const int NE,
 }
 
 template<int T_D1D = 0, int T_Q1D = 0>
-static void EADiffusionAssemble3D(const int NE,
+void EADiffusionAssemble3D(const int NE,
                                   const Array<double> &b,
                                   const Array<double> &g,
                                   const Vector &padata,

--- a/fem/bilininteg_diffusion_pa.cpp
+++ b/fem/bilininteg_diffusion_pa.cpp
@@ -496,7 +496,7 @@ void DiffusionIntegrator::AssemblePA(const FiniteElementSpace &fes)
 }
 
 template<int T_D1D = 0, int T_Q1D = 0>
-static void PADiffusionDiagonal2D(const int NE,
+void PADiffusionDiagonal2D(const int NE,
                                   const bool symmetric,
                                   const Array<double> &b,
                                   const Array<double> &g,
@@ -562,7 +562,7 @@ static void PADiffusionDiagonal2D(const int NE,
 
 // Shared memory PA Diffusion Diagonal 2D kernel
 template<int T_D1D = 0, int T_Q1D = 0, int T_NBZ = 0>
-static void SmemPADiffusionDiagonal2D(const int NE,
+void SmemPADiffusionDiagonal2D(const int NE,
                                       const bool symmetric,
                                       const Array<double> &b_,
                                       const Array<double> &g_,
@@ -656,7 +656,7 @@ static void SmemPADiffusionDiagonal2D(const int NE,
 }
 
 template<int T_D1D = 0, int T_Q1D = 0>
-static void PADiffusionDiagonal3D(const int NE,
+void PADiffusionDiagonal3D(const int NE,
                                   const bool symmetric,
                                   const Array<double> &b,
                                   const Array<double> &g,
@@ -757,7 +757,7 @@ static void PADiffusionDiagonal3D(const int NE,
 
 // Shared memory PA Diffusion Diagonal 3D kernel
 template<int T_D1D = 0, int T_Q1D = 0>
-static void SmemPADiffusionDiagonal3D(const int NE,
+void SmemPADiffusionDiagonal3D(const int NE,
                                       const bool symmetric,
                                       const Array<double> &b_,
                                       const Array<double> &g_,
@@ -1034,7 +1034,7 @@ static void OccaPADiffusionApply3D(const int D1D,
 
 // PA Diffusion Apply 2D kernel
 template<int T_D1D = 0, int T_Q1D = 0>
-static void PADiffusionApply2D(const int NE,
+void PADiffusionApply2D(const int NE,
                                const bool symmetric,
                                const Array<double> &b_,
                                const Array<double> &g_,
@@ -1156,7 +1156,7 @@ static void PADiffusionApply2D(const int NE,
 
 // Shared memory PA Diffusion Apply 2D kernel
 template<int T_D1D = 0, int T_Q1D = 0, int T_NBZ = 0>
-static void SmemPADiffusionApply2D(const int NE,
+void SmemPADiffusionApply2D(const int NE,
                                    const bool symmetric,
                                    const Array<double> &b_,
                                    const Array<double> &g_,
@@ -1314,7 +1314,7 @@ static void SmemPADiffusionApply2D(const int NE,
 
 // PA Diffusion Apply 3D kernel
 template<int T_D1D = 0, int T_Q1D = 0>
-static void PADiffusionApply3D(const int NE,
+void PADiffusionApply3D(const int NE,
                                const bool symmetric,
                                const Array<double> &b,
                                const Array<double> &g,
@@ -1533,7 +1533,7 @@ static MFEM_HOST_DEVICE inline double sign(const int q, const int d)
 }
 
 template<int T_D1D = 0, int T_Q1D = 0>
-static void SmemPADiffusionApply3D(const int NE,
+void SmemPADiffusionApply3D(const int NE,
                                    const bool symmetric,
                                    const Array<double> &b_,
                                    const Array<double> &g_,

--- a/fem/bilininteg_divergence.cpp
+++ b/fem/bilininteg_divergence.cpp
@@ -21,7 +21,7 @@ namespace mfem
 // PA Divergence Integrator
 
 // PA Divergence Assemble 2D kernel
-static void PADivergenceSetup2D(const int Q1D,
+void PADivergenceSetup2D(const int Q1D,
                                 const int NE,
                                 const Array<double> &w,
                                 const Vector &j,
@@ -51,7 +51,7 @@ static void PADivergenceSetup2D(const int Q1D,
 }
 
 // PA Divergence Assemble 3D kernel
-static void PADivergenceSetup3D(const int Q1D,
+void PADivergenceSetup3D(const int Q1D,
                                 const int NE,
                                 const Array<double> &w,
                                 const Vector &j,
@@ -160,7 +160,7 @@ void VectorDivergenceIntegrator::AssemblePA(const FiniteElementSpace &trial_fes,
 
 // PA Divergence Apply 2D kernel
 template<const int T_TR_D1D = 0, const int T_TE_D1D = 0, const int T_Q1D = 0>
-static void PADivergenceApply2D(const int NE,
+void PADivergenceApply2D(const int NE,
                                 const Array<double> &b,
                                 const Array<double> &g,
                                 const Array<double> &bt,
@@ -281,7 +281,7 @@ static void PADivergenceApply2D(const int NE,
 // Shared memory PA Divergence Apply 2D kernel
 template<const int T_TR_D1D = 0, const int T_TE_D1D = 0, const int T_Q1D = 0,
          const int T_NBZ = 0>
-static void SmemPADivergenceApply2D(const int NE,
+void SmemPADivergenceApply2D(const int NE,
                                     const Array<double> &b_,
                                     const Array<double> &g_,
                                     const Array<double> &bt_,
@@ -298,7 +298,7 @@ static void SmemPADivergenceApply2D(const int NE,
 
 // PA Divergence Apply 2D kernel transpose
 template<const int T_TR_D1D = 0, const int T_TE_D1D = 0, const int T_Q1D = 0>
-static void PADivergenceApplyTranspose2D(const int NE,
+void PADivergenceApplyTranspose2D(const int NE,
                                          const Array<double> &bt,
                                          const Array<double> &gt,
                                          const Array<double> &b,
@@ -414,7 +414,7 @@ static void PADivergenceApplyTranspose2D(const int NE,
 
 // PA Vector Divergence Apply 3D kernel
 template<const int T_TR_D1D = 0, const int T_TE_D1D = 0, const int T_Q1D = 0>
-static void PADivergenceApply3D(const int NE,
+void PADivergenceApply3D(const int NE,
                                 const Array<double> &b,
                                 const Array<double> &g,
                                 const Array<double> &bt,
@@ -597,7 +597,7 @@ static void PADivergenceApply3D(const int NE,
 
 // PA Vector Divergence Apply 3D kernel
 template<const int T_TR_D1D = 0, const int T_TE_D1D = 0, const int T_Q1D = 0>
-static void PADivergenceApplyTranspose3D(const int NE,
+void PADivergenceApplyTranspose3D(const int NE,
                                          const Array<double> &bt,
                                          const Array<double> &gt,
                                          const Array<double> &b,
@@ -775,7 +775,7 @@ static void PADivergenceApplyTranspose3D(const int NE,
 
 // Shared memory PA Vector Divergence Apply 3D kernel
 template<const int T_TR_D1D = 0, const int T_TE_D1D = 0, const int T_Q1D = 0>
-static void SmemPADivergenceApply3D(const int NE,
+void SmemPADivergenceApply3D(const int NE,
                                     const Array<double> &b_,
                                     const Array<double> &g_,
                                     const Array<double> &bt_,

--- a/fem/bilininteg_gradient.cpp
+++ b/fem/bilininteg_gradient.cpp
@@ -70,7 +70,7 @@ namespace mfem
    the \b MFEM_SHARED keyword for local arrays. */
 
 // PA Gradient Assemble 2D kernel
-static void PAGradientSetup2D(const int Q1D,
+void PAGradientSetup2D(const int Q1D,
                               const int NE,
                               const Array<double> &w,
                               const Vector &j,
@@ -105,7 +105,7 @@ static void PAGradientSetup2D(const int Q1D,
 }
 
 // PA Gradient Assemble 3D kernel
-static void PAGradientSetup3D(const int Q1D,
+void PAGradientSetup3D(const int Q1D,
                               const int NE,
                               const Array<double> &w,
                               const Vector &j,
@@ -254,7 +254,7 @@ void GradientIntegrator::AssemblePA(const FiniteElementSpace &trial_fes,
 
 // PA Gradient Apply 2D kernel
 template<int T_TR_D1D = 0, int T_TE_D1D = 0, int T_Q1D = 0>
-static void PAGradientApply2D(const int NE,
+void PAGradientApply2D(const int NE,
                               const Array<double> &b,
                               const Array<double> &g,
                               const Array<double> &bt,
@@ -384,7 +384,7 @@ static void PAGradientApplyTranspose2D(const int NE,
 
 // PA Gradient Apply 3D kernel
 template<const int T_TR_D1D = 0, const int T_TE_D1D = 0, const int T_Q1D = 0>
-static void PAGradientApply3D(const int NE,
+void PAGradientApply3D(const int NE,
                               const Array<double> &b,
                               const Array<double> &g,
                               const Array<double> &bt,
@@ -579,7 +579,7 @@ static void PAGradientApplyTranspose3D(const int NE,
 
 // Shared memory PA Gradient Apply 3D kernel
 template<const int T_TR_D1D = 0, const int T_TE_D1D = 0, const int T_Q1D = 0>
-static void SmemPAGradientApply3D(const int NE,
+void SmemPAGradientApply3D(const int NE,
                                   const Array<double> &b_,
                                   const Array<double> &g_,
                                   const Array<double> &bt_,

--- a/fem/bilininteg_hcurl.cpp
+++ b/fem/bilininteg_hcurl.cpp
@@ -791,7 +791,7 @@ void SmemPAHcurlMassApply3D(const int D1D,
 }
 
 // PA H(curl) curl-curl assemble 2D kernel
-static void PACurlCurlSetup2D(const int Q1D,
+void PACurlCurlSetup2D(const int Q1D,
                               const int NE,
                               const Array<double> &w,
                               const Vector &j,
@@ -818,7 +818,7 @@ static void PACurlCurlSetup2D(const int Q1D,
 }
 
 // PA H(curl) curl-curl assemble 3D kernel
-static void PACurlCurlSetup3D(const int Q1D,
+void PACurlCurlSetup3D(const int Q1D,
                               const int coeffDim,
                               const int NE,
                               const Array<double> &w,
@@ -1045,7 +1045,7 @@ void CurlCurlIntegrator::AssemblePA(const FiniteElementSpace &fes)
    }
 }
 
-static void PACurlCurlApply2D(const int D1D,
+void PACurlCurlApply2D(const int D1D,
                               const int Q1D,
                               const int NE,
                               const Array<double> &bo,
@@ -1166,7 +1166,7 @@ static void PACurlCurlApply2D(const int D1D,
 }
 
 template<int MAX_D1D = HCURL_MAX_D1D, int MAX_Q1D = HCURL_MAX_Q1D>
-static void PACurlCurlApply3D(const int D1D,
+void PACurlCurlApply3D(const int D1D,
                               const int Q1D,
                               const bool symmetric,
                               const int NE,
@@ -1677,7 +1677,7 @@ static void PACurlCurlApply3D(const int D1D,
 }
 
 template<int MAX_D1D = HCURL_MAX_D1D, int MAX_Q1D = HCURL_MAX_Q1D>
-static void SmemPACurlCurlApply3D(const int D1D,
+void SmemPACurlCurlApply3D(const int D1D,
                                   const int Q1D,
                                   const bool symmetric,
                                   const int NE,
@@ -2032,7 +2032,7 @@ void CurlCurlIntegrator::AddMultPA(const Vector &x, Vector &y) const
    }
 }
 
-static void PACurlCurlAssembleDiagonal2D(const int D1D,
+void PACurlCurlAssembleDiagonal2D(const int D1D,
                                          const int Q1D,
                                          const int NE,
                                          const Array<double> &bo,
@@ -2087,7 +2087,7 @@ static void PACurlCurlAssembleDiagonal2D(const int D1D,
 }
 
 template<int MAX_D1D = HCURL_MAX_D1D, int MAX_Q1D = HCURL_MAX_Q1D>
-static void PACurlCurlAssembleDiagonal3D(const int D1D,
+void PACurlCurlAssembleDiagonal3D(const int D1D,
                                          const int Q1D,
                                          const bool symmetric,
                                          const int NE,
@@ -2273,7 +2273,7 @@ static void PACurlCurlAssembleDiagonal3D(const int D1D,
 }
 
 template<int MAX_D1D = HCURL_MAX_D1D, int MAX_Q1D = HCURL_MAX_Q1D>
-static void SmemPACurlCurlAssembleDiagonal3D(const int D1D,
+void SmemPACurlCurlAssembleDiagonal3D(const int D1D,
                                              const int Q1D,
                                              const bool symmetric,
                                              const int NE,
@@ -2955,7 +2955,7 @@ void MixedVectorCurlIntegrator::AssemblePA(const FiniteElementSpace &trial_fes,
 // Apply to x corresponding to DOF's in H(curl) (trial), whose curl is
 // integrated against H(curl) test functions corresponding to y.
 template<int MAX_D1D = HCURL_MAX_D1D, int MAX_Q1D = HCURL_MAX_Q1D>
-static void PAHcurlL2Apply3D(const int D1D,
+void PAHcurlL2Apply3D(const int D1D,
                              const int Q1D,
                              const int coeffDim,
                              const int NE,
@@ -3297,7 +3297,7 @@ static void PAHcurlL2Apply3D(const int D1D,
 // Apply to x corresponding to DOF's in H(curl) (trial), whose curl is
 // integrated against H(curl) test functions corresponding to y.
 template<int MAX_D1D = HCURL_MAX_D1D, int MAX_Q1D = HCURL_MAX_Q1D>
-static void SmemPAHcurlL2Apply3D(const int D1D,
+void SmemPAHcurlL2Apply3D(const int D1D,
                                  const int Q1D,
                                  const int coeffDim,
                                  const int NE,
@@ -3585,7 +3585,7 @@ static void SmemPAHcurlL2Apply3D(const int D1D,
 // Apply to x corresponding to DOF's in H(curl) (trial), whose curl is
 // integrated against H(div) test functions corresponding to y.
 template<int MAX_D1D = HCURL_MAX_D1D, int MAX_Q1D = HCURL_MAX_Q1D>
-static void PAHcurlHdivApply3D(const int D1D,
+void PAHcurlHdivApply3D(const int D1D,
                                const int D1Dtest,
                                const int Q1D,
                                const int NE,
@@ -4071,7 +4071,7 @@ void MixedVectorWeakCurlIntegrator::AssemblePA(const FiniteElementSpace
 // Apply to x corresponding to DOF's in H(curl) (trial), integrated against curl
 // of H(curl) test functions corresponding to y.
 template<int MAX_D1D = HCURL_MAX_D1D, int MAX_Q1D = HCURL_MAX_Q1D>
-static void PAHcurlL2Apply3DTranspose(const int D1D,
+void PAHcurlL2Apply3DTranspose(const int D1D,
                                       const int Q1D,
                                       const int coeffDim,
                                       const int NE,
@@ -4413,7 +4413,7 @@ static void PAHcurlL2Apply3DTranspose(const int D1D,
 }
 
 template<int MAX_D1D = HCURL_MAX_D1D, int MAX_Q1D = HCURL_MAX_Q1D>
-static void SmemPAHcurlL2Apply3DTranspose(const int D1D,
+void SmemPAHcurlL2Apply3DTranspose(const int D1D,
                                           const int Q1D,
                                           const int coeffDim,
                                           const int NE,
@@ -4675,7 +4675,7 @@ void MixedVectorWeakCurlIntegrator::AddMultPA(const Vector &x, Vector &y) const
 // Apply to x corresponding to DOFs in H^1 (domain) the (topological) gradient
 // to get a dof in H(curl) (range). You can think of the range as the "test" space
 // and the domain as the "trial" space, but there's no integration.
-static void PAHcurlApplyGradient2D(const int c_dofs1D,
+void PAHcurlApplyGradient2D(const int c_dofs1D,
                                    const int o_dofs1D,
                                    const int NE,
                                    const Array<double> &B_,
@@ -4753,7 +4753,7 @@ static void PAHcurlApplyGradient2D(const int c_dofs1D,
 }
 
 // Specialization of PAHcurlApplyGradient2D to the case where B is identity
-static void PAHcurlApplyGradient2DBId(const int c_dofs1D,
+void PAHcurlApplyGradient2DBId(const int c_dofs1D,
                                       const int o_dofs1D,
                                       const int NE,
                                       const Array<double> &G_,
@@ -4822,7 +4822,7 @@ static void PAHcurlApplyGradient2DBId(const int c_dofs1D,
    });
 }
 
-static void PAHcurlApplyGradientTranspose2D(
+void PAHcurlApplyGradientTranspose2D(
    const int c_dofs1D, const int o_dofs1D, const int NE,
    const Array<double> &B_, const Array<double> &G_,
    const Vector &x_, Vector &y_)
@@ -4898,7 +4898,7 @@ static void PAHcurlApplyGradientTranspose2D(
 
 // Specialization of PAHcurlApplyGradientTranspose2D to the case where
 // B is identity
-static void PAHcurlApplyGradientTranspose2DBId(
+void PAHcurlApplyGradientTranspose2DBId(
    const int c_dofs1D, const int o_dofs1D, const int NE,
    const Array<double> &G_,
    const Vector &x_, Vector &y_)
@@ -4965,7 +4965,7 @@ static void PAHcurlApplyGradientTranspose2DBId(
    });
 }
 
-static void PAHcurlApplyGradient3D(const int c_dofs1D,
+void PAHcurlApplyGradient3D(const int c_dofs1D,
                                    const int o_dofs1D,
                                    const int NE,
                                    const Array<double> &B_,
@@ -5154,7 +5154,7 @@ static void PAHcurlApplyGradient3D(const int c_dofs1D,
 }
 
 // Specialization of PAHcurlApplyGradient3D to the case where
-static void PAHcurlApplyGradient3DBId(const int c_dofs1D,
+void PAHcurlApplyGradient3DBId(const int c_dofs1D,
                                       const int o_dofs1D,
                                       const int NE,
                                       const Array<double> &G_,
@@ -5322,7 +5322,7 @@ static void PAHcurlApplyGradient3DBId(const int c_dofs1D,
    });
 }
 
-static void PAHcurlApplyGradientTranspose3D(
+void PAHcurlApplyGradientTranspose3D(
    const int c_dofs1D, const int o_dofs1D, const int NE,
    const Array<double> &B_, const Array<double> &G_,
    const Vector &x_, Vector &y_)
@@ -5507,7 +5507,7 @@ static void PAHcurlApplyGradientTranspose3D(
 }
 
 // Specialization of PAHcurlApplyGradientTranspose3D to the case where
-static void PAHcurlApplyGradientTranspose3DBId(
+void PAHcurlApplyGradientTranspose3DBId(
    const int c_dofs1D, const int o_dofs1D, const int NE,
    const Array<double> &G_,
    const Vector &x_, Vector &y_)
@@ -5789,7 +5789,7 @@ void GradientInterpolator::AddMultTransposePA(const Vector &x, Vector &y) const
    }
 }
 
-static void PAHcurlVecH1IdentityApply3D(const int c_dofs1D,
+void PAHcurlVecH1IdentityApply3D(const int c_dofs1D,
                                         const int o_dofs1D,
                                         const int NE,
                                         const Array<double> &Bclosed,
@@ -6002,7 +6002,7 @@ static void PAHcurlVecH1IdentityApply3D(const int c_dofs1D,
    });
 }
 
-static void PAHcurlVecH1IdentityApplyTranspose3D(const int c_dofs1D,
+void PAHcurlVecH1IdentityApplyTranspose3D(const int c_dofs1D,
                                                  const int o_dofs1D,
                                                  const int NE,
                                                  const Array<double> &Bclosed,
@@ -6228,7 +6228,7 @@ static void PAHcurlVecH1IdentityApplyTranspose3D(const int c_dofs1D,
    });
 }
 
-static void PAHcurlVecH1IdentityApply2D(const int c_dofs1D,
+void PAHcurlVecH1IdentityApply2D(const int c_dofs1D,
                                         const int o_dofs1D,
                                         const int NE,
                                         const Array<double> &Bclosed,
@@ -6327,7 +6327,7 @@ static void PAHcurlVecH1IdentityApply2D(const int c_dofs1D,
    });
 }
 
-static void PAHcurlVecH1IdentityApplyTranspose2D(const int c_dofs1D,
+void PAHcurlVecH1IdentityApplyTranspose2D(const int c_dofs1D,
                                                  const int o_dofs1D,
                                                  const int NE,
                                                  const Array<double> &Bclosed,

--- a/fem/bilininteg_hdiv.cpp
+++ b/fem/bilininteg_hdiv.cpp
@@ -539,7 +539,7 @@ void PAHdivMassApply3D(const int D1D,
 
 // PA H(div) div-div assemble 2D kernel
 // NOTE: this is identical to PACurlCurlSetup3D
-static void PADivDivSetup2D(const int Q1D,
+void PADivDivSetup2D(const int Q1D,
                             const int NE,
                             const Array<double> &w,
                             const Vector &j,
@@ -565,7 +565,7 @@ static void PADivDivSetup2D(const int Q1D,
    });
 }
 
-static void PADivDivSetup3D(const int Q1D,
+void PADivDivSetup3D(const int Q1D,
                             const int NE,
                             const Array<double> &w,
                             const Vector &j,
@@ -599,7 +599,7 @@ static void PADivDivSetup3D(const int Q1D,
    });
 }
 
-static void PADivDivApply2D(const int D1D,
+void PADivDivApply2D(const int D1D,
                             const int Q1D,
                             const int NE,
                             const Array<double> &Bo_,
@@ -718,7 +718,7 @@ static void PADivDivApply2D(const int D1D,
    }); // end of element loop
 }
 
-static void PADivDivApply3D(const int D1D,
+void PADivDivApply3D(const int D1D,
                             const int Q1D,
                             const int NE,
                             const Array<double> &Bo_,
@@ -967,7 +967,7 @@ void DivDivIntegrator::AddMultPA(const Vector &x, Vector &y) const
    }
 }
 
-static void PADivDivAssembleDiagonal2D(const int D1D,
+void PADivDivAssembleDiagonal2D(const int D1D,
                                        const int Q1D,
                                        const int NE,
                                        const Array<double> &Bo_,
@@ -1023,7 +1023,7 @@ static void PADivDivAssembleDiagonal2D(const int D1D,
    });
 }
 
-static void PADivDivAssembleDiagonal3D(const int D1D,
+void PADivDivAssembleDiagonal3D(const int D1D,
                                        const int Q1D,
                                        const int NE,
                                        const Array<double> &Bo_,
@@ -1104,7 +1104,7 @@ void DivDivIntegrator::AssembleDiagonalPA(Vector& diag)
 }
 
 // PA H(div)-L2 (div u, p) assemble 2D kernel
-static void PADivL2Setup2D(const int Q1D,
+void PADivL2Setup2D(const int Q1D,
                            const int NE,
                            const Array<double> &w,
                            Vector &coeff_,
@@ -1123,7 +1123,7 @@ static void PADivL2Setup2D(const int Q1D,
    });
 }
 
-static void PADivL2Setup3D(const int Q1D,
+void PADivL2Setup3D(const int Q1D,
                            const int NE,
                            const Array<double> &w,
                            Vector &coeff_,
@@ -1225,7 +1225,7 @@ VectorFEDivergenceIntegrator::AssemblePA(const FiniteElementSpace &trial_fes,
 
 // Apply to x corresponding to DOF's in H(div) (trial), whose divergence is
 // integrated against L_2 test functions corresponding to y.
-static void PAHdivL2Apply3D(const int D1D,
+void PAHdivL2Apply3D(const int D1D,
                             const int Q1D,
                             const int L2D1D,
                             const int NE,
@@ -1388,7 +1388,7 @@ static void PAHdivL2Apply3D(const int D1D,
 
 // Apply to x corresponding to DOF's in H(div) (trial), whose divergence is
 // integrated against L_2 test functions corresponding to y.
-static void PAHdivL2Apply2D(const int D1D,
+void PAHdivL2Apply2D(const int D1D,
                             const int Q1D,
                             const int L2D1D,
                             const int NE,
@@ -1494,7 +1494,7 @@ static void PAHdivL2Apply2D(const int D1D,
    }); // end of element loop
 }
 
-static void PAHdivL2ApplyTranspose3D(const int D1D,
+void PAHdivL2ApplyTranspose3D(const int D1D,
                                      const int Q1D,
                                      const int L2D1D,
                                      const int NE,
@@ -1656,7 +1656,7 @@ static void PAHdivL2ApplyTranspose3D(const int D1D,
    }); // end of element loop
 }
 
-static void PAHdivL2ApplyTranspose2D(const int D1D,
+void PAHdivL2ApplyTranspose2D(const int D1D,
                                      const int Q1D,
                                      const int L2D1D,
                                      const int NE,
@@ -1791,7 +1791,7 @@ void VectorFEDivergenceIntegrator::AddMultTransposePA(const Vector &x,
    }
 }
 
-static void PAHdivL2AssembleDiagonal_ADAt_3D(const int D1D,
+void PAHdivL2AssembleDiagonal_ADAt_3D(const int D1D,
                                              const int Q1D,
                                              const int L2D1D,
                                              const int NE,
@@ -1916,7 +1916,7 @@ static void PAHdivL2AssembleDiagonal_ADAt_3D(const int D1D,
    }); // end of element loop
 }
 
-static void PAHdivL2AssembleDiagonal_ADAt_2D(const int D1D,
+void PAHdivL2AssembleDiagonal_ADAt_2D(const int D1D,
                                              const int Q1D,
                                              const int L2D1D,
                                              const int NE,

--- a/fem/bilininteg_mass_ea.cpp
+++ b/fem/bilininteg_mass_ea.cpp
@@ -17,7 +17,7 @@ namespace mfem
 {
 
 template<int T_D1D = 0, int T_Q1D = 0>
-static void EAMassAssemble1D(const int NE,
+void EAMassAssemble1D(const int NE,
                              const Array<double> &basis,
                              const Vector &padata,
                              Vector &eadata,
@@ -67,7 +67,7 @@ static void EAMassAssemble1D(const int NE,
 }
 
 template<int T_D1D = 0, int T_Q1D = 0>
-static void EAMassAssemble2D(const int NE,
+void EAMassAssemble2D(const int NE,
                              const Array<double> &basis,
                              const Vector &padata,
                              Vector &eadata,
@@ -139,7 +139,7 @@ static void EAMassAssemble2D(const int NE,
 }
 
 template<int T_D1D = 0, int T_Q1D = 0>
-static void EAMassAssemble3D(const int NE,
+void EAMassAssemble3D(const int NE,
                              const Array<double> &basis,
                              const Vector &padata,
                              Vector &eadata,

--- a/fem/bilininteg_mass_pa.cpp
+++ b/fem/bilininteg_mass_pa.cpp
@@ -155,7 +155,7 @@ void MassIntegrator::AssemblePA(const FiniteElementSpace &fes)
 }
 
 template<int T_D1D = 0, int T_Q1D = 0>
-static void PAMassAssembleDiagonal2D(const int NE,
+void PAMassAssembleDiagonal2D(const int NE,
                                      const Array<double> &b,
                                      const Vector &d,
                                      Vector &y,
@@ -201,7 +201,7 @@ static void PAMassAssembleDiagonal2D(const int NE,
 }
 
 template<int T_D1D = 0, int T_Q1D = 0, int T_NBZ = 0>
-static void SmemPAMassAssembleDiagonal2D(const int NE,
+void SmemPAMassAssembleDiagonal2D(const int NE,
                                          const Array<double> &b_,
                                          const Vector &d_,
                                          Vector &y_,
@@ -267,7 +267,7 @@ static void SmemPAMassAssembleDiagonal2D(const int NE,
 }
 
 template<int T_D1D = 0, int T_Q1D = 0>
-static void PAMassAssembleDiagonal3D(const int NE,
+void PAMassAssembleDiagonal3D(const int NE,
                                      const Array<double> &b,
                                      const Vector &d,
                                      Vector &y,
@@ -336,7 +336,7 @@ static void PAMassAssembleDiagonal3D(const int NE,
 }
 
 template<int T_D1D = 0, int T_Q1D = 0>
-static void SmemPAMassAssembleDiagonal3D(const int NE,
+void SmemPAMassAssembleDiagonal3D(const int NE,
                                          const Array<double> &b_,
                                          const Vector &d_,
                                          Vector &y_,
@@ -569,7 +569,7 @@ static void OccaPAMassApply3D(const int D1D,
 #endif // MFEM_USE_OCCA
 
 template<int T_D1D = 0, int T_Q1D = 0>
-static void PAMassApply2D(const int NE,
+void PAMassApply2D(const int NE,
                           const Array<double> &b_,
                           const Array<double> &bt_,
                           const Vector &d_,
@@ -661,7 +661,7 @@ static void PAMassApply2D(const int NE,
 }
 
 template<int T_D1D = 0, int T_Q1D = 0, int T_NBZ = 0>
-static void SmemPAMassApply2D(const int NE,
+void SmemPAMassApply2D(const int NE,
                               const Array<double> &b_,
                               const Array<double> &bt_,
                               const Vector &d_,
@@ -784,7 +784,7 @@ static void SmemPAMassApply2D(const int NE,
 }
 
 template<int T_D1D = 0, int T_Q1D = 0>
-static void PAMassApply3D(const int NE,
+void PAMassApply3D(const int NE,
                           const Array<double> &b_,
                           const Array<double> &bt_,
                           const Vector &d_,
@@ -925,7 +925,7 @@ static void PAMassApply3D(const int NE,
 }
 
 template<int T_D1D = 0, int T_Q1D = 0>
-static void SmemPAMassApply3D(const int NE,
+void SmemPAMassApply3D(const int NE,
                               const Array<double> &b_,
                               const Array<double> &bt_,
                               const Vector &d_,

--- a/fem/bilininteg_vecdiffusion.cpp
+++ b/fem/bilininteg_vecdiffusion.cpp
@@ -22,7 +22,7 @@ namespace mfem
 // PA Vector Diffusion Integrator
 
 // PA Diffusion Assemble 2D kernel
-static void PAVectorDiffusionSetup2D(const int Q1D,
+void PAVectorDiffusionSetup2D(const int Q1D,
                                      const int NE,
                                      const Array<double> &w,
                                      const Vector &j,
@@ -59,7 +59,7 @@ static void PAVectorDiffusionSetup2D(const int Q1D,
 }
 
 // PA Diffusion Assemble 3D kernel
-static void PAVectorDiffusionSetup3D(const int Q1D,
+void PAVectorDiffusionSetup3D(const int Q1D,
                                      const int NE,
                                      const Array<double> &w,
                                      const Vector &j,
@@ -251,7 +251,7 @@ void VectorDiffusionIntegrator::AssemblePA(const FiniteElementSpace &fes)
 }
 
 // PA Diffusion Apply 2D kernel
-template<int T_D1D = 0, int T_Q1D = 0, int T_VDIM = 0> static
+template<int T_D1D = 0, int T_Q1D = 0, int T_VDIM = 0>
 void PAVectorDiffusionApply2D(const int NE,
                               const Array<double> &b,
                               const Array<double> &g,
@@ -374,7 +374,7 @@ void PAVectorDiffusionApply2D(const int NE,
 
 // PA Diffusion Apply 3D kernel
 template<const int T_D1D = 0,
-         const int T_Q1D = 0> static
+         const int T_Q1D = 0>
 void PAVectorDiffusionApply3D(const int NE,
                               const Array<double> &b,
                               const Array<double> &g,
@@ -606,7 +606,7 @@ void VectorDiffusionIntegrator::AddMultPA(const Vector &x, Vector &y) const
 }
 
 template<int T_D1D = 0, int T_Q1D = 0>
-static void PAVectorDiffusionDiagonal2D(const int NE,
+void PAVectorDiffusionDiagonal2D(const int NE,
                                         const Array<double> &b,
                                         const Array<double> &g,
                                         const Vector &d,
@@ -673,7 +673,7 @@ static void PAVectorDiffusionDiagonal2D(const int NE,
 }
 
 template<int T_D1D = 0, int T_Q1D = 0>
-static void PAVectorDiffusionDiagonal3D(const int NE,
+void PAVectorDiffusionDiagonal3D(const int NE,
                                         const Array<double> &b,
                                         const Array<double> &g,
                                         const Vector &d,

--- a/fem/bilininteg_vecmass.cpp
+++ b/fem/bilininteg_vecmass.cpp
@@ -104,7 +104,7 @@ void VectorMassIntegrator::AssemblePA(const FiniteElementSpace &fes)
 
 template<const int T_D1D = 0,
          const int T_Q1D = 0>
-static void PAVectorMassApply2D(const int NE,
+void PAVectorMassApply2D(const int NE,
                                 const Array<double> &B_,
                                 const Array<double> &Bt_,
                                 const Vector &op_,
@@ -201,7 +201,7 @@ static void PAVectorMassApply2D(const int NE,
 
 template<const int T_D1D = 0,
          const int T_Q1D = 0>
-static void PAVectorMassApply3D(const int NE,
+void PAVectorMassApply3D(const int NE,
                                 const Array<double> &B_,
                                 const Array<double> &Bt_,
                                 const Vector &op_,
@@ -379,7 +379,7 @@ void VectorMassIntegrator::AddMultPA(const Vector &x, Vector &y) const
 }
 
 template<const int T_D1D = 0, const int T_Q1D = 0>
-static void PAVectorMassAssembleDiagonal2D(const int NE,
+void PAVectorMassAssembleDiagonal2D(const int NE,
                                            const Array<double> &B_,
                                            const Array<double> &Bt_,
                                            const Vector &op_,
@@ -431,7 +431,7 @@ static void PAVectorMassAssembleDiagonal2D(const int NE,
 }
 
 template<const int T_D1D = 0, const int T_Q1D = 0>
-static void PAVectorMassAssembleDiagonal3D(const int NE,
+void PAVectorMassAssembleDiagonal3D(const int NE,
                                            const Array<double> &B_,
                                            const Array<double> &Bt_,
                                            const Vector &op_,

--- a/fem/nonlininteg_vectorconvection.cpp
+++ b/fem/nonlininteg_vectorconvection.cpp
@@ -116,7 +116,7 @@ void VectorConvectionNLFIntegrator::AssemblePA(const FiniteElementSpace &fes)
 
 // PA Convection NL 2D kernel
 template<int T_D1D = 0, int T_Q1D = 0>
-static void PAConvectionNLApply2D(const int NE,
+void PAConvectionNLApply2D(const int NE,
                                   const Array<double> &b,
                                   const Array<double> &g,
                                   const Array<double> &bt,
@@ -252,7 +252,7 @@ static void PAConvectionNLApply2D(const int NE,
 
 // PA Convection NL 3D kernel
 template<int T_D1D = 0, int T_Q1D = 0>
-static void PAConvectionNLApply3D(const int NE,
+void PAConvectionNLApply3D(const int NE,
                                   const Array<double> &b,
                                   const Array<double> &g,
                                   const Array<double> &bt,
@@ -558,7 +558,7 @@ static void PAConvectionNLApply3D(const int NE,
 }
 
 template<int T_D1D = 0, int T_Q1D = 0, int T_MAX_D1D =0, int T_MAX_Q1D =0>
-static void SmemPAConvectionNLApply3D(const int NE,
+void SmemPAConvectionNLApply3D(const int NE,
                                       const Array<double> &b_,
                                       const Array<double> &g_,
                                       const Vector &d_,

--- a/fem/qinterp/det.cpp
+++ b/fem/qinterp/det.cpp
@@ -27,7 +27,7 @@ namespace quadrature_interpolator
 {
 
 template<int T_D1D = 0, int T_Q1D = 0, int MAX_D1D = 0, int MAX_Q1D = 0>
-static void Det2D(const int NE,
+void Det2D(const int NE,
                   const double *b,
                   const double *g,
                   const double *x,
@@ -79,7 +79,7 @@ static void Det2D(const int NE,
 
 template<int T_D1D = 0, int T_Q1D = 0, int MAX_D1D = 0, int MAX_Q1D = 0,
          bool SMEM = true>
-static void Det3D(const int NE,
+void Det3D(const int NE,
                   const double *b,
                   const double *g,
                   const double *x,

--- a/fem/qinterp/eval.hpp
+++ b/fem/qinterp/eval.hpp
@@ -31,7 +31,7 @@ namespace quadrature_interpolator
 template<QVectorLayout Q_LAYOUT,
          int T_VDIM = 0, int T_D1D = 0, int T_Q1D = 0,
          int T_NBZ = 1, int MAX_D1D = 0, int MAX_Q1D = 0>
-static void Values2D(const int NE,
+void Values2D(const int NE,
                      const double *b_,
                      const double *x_,
                      double *y_,
@@ -95,7 +95,7 @@ static void Values2D(const int NE,
 template<QVectorLayout Q_LAYOUT,
          int T_VDIM = 0, int T_D1D = 0, int T_Q1D = 0,
          int MAX_D1D = 0, int MAX_Q1D = 0>
-static void Values3D(const int NE,
+void Values3D(const int NE,
                      const double *b_,
                      const double *x_,
                      double *y_,

--- a/fem/qinterp/grad.hpp
+++ b/fem/qinterp/grad.hpp
@@ -31,7 +31,7 @@ namespace quadrature_interpolator
 template<QVectorLayout Q_LAYOUT, bool GRAD_PHYS,
          int T_VDIM = 0, int T_D1D = 0, int T_Q1D = 0,
          int T_NBZ = 1, int MAX_D1D = 0, int MAX_Q1D = 0>
-static void Derivatives2D(const int NE,
+void Derivatives2D(const int NE,
                           const double *b_,
                           const double *g_,
                           const double *j_,
@@ -139,7 +139,7 @@ static void Derivatives2D(const int NE,
 template<QVectorLayout Q_LAYOUT, bool GRAD_PHYS,
          int T_VDIM = 0, int T_D1D = 0, int T_Q1D = 0,
          int MAX_D1D = 0, int MAX_Q1D = 0>
-static void Derivatives3D(const int NE,
+void Derivatives3D(const int NE,
                           const double *b_,
                           const double *g_,
                           const double *j_,

--- a/fem/quadinterpolator.cpp
+++ b/fem/quadinterpolator.cpp
@@ -61,7 +61,7 @@ namespace quadrature_interpolator
 // * assumes 'e_vec' is using ElementDofOrdering::NATIVE,
 // * assumes 'maps.mode == FULL'.
 template<const int T_VDIM, const int T_ND, const int T_NQ>
-static void Eval2D(const int NE,
+void Eval2D(const int NE,
                    const int vdim,
                    const QVectorLayout q_layout,
                    const GeometricFactors *geom,
@@ -209,7 +209,7 @@ static void Eval2D(const int NE,
 // * assumes 'e_vec' is using ElementDofOrdering::NATIVE,
 // * assumes 'maps.mode == FULL'.
 template<const int T_VDIM, const int T_ND, const int T_NQ>
-static void Eval3D(const int NE,
+void Eval3D(const int NE,
                    const int vdim,
                    const QVectorLayout q_layout,
                    const GeometricFactors *geom,

--- a/fem/tmop.cpp
+++ b/fem/tmop.cpp
@@ -1306,7 +1306,7 @@ namespace internal
 // MFEM_FORALL-based copy kernel -- used by protected methods below.
 // Needed as a workaround for the nvcc restriction that methods with MFEM_FORALL
 // in them must to be public.
-static inline void device_copy(double *d_dest, const double *d_src, int size)
+inline void device_copy(double *d_dest, const double *d_src, int size)
 {
    MFEM_FORALL(i, size, d_dest[i] = d_src[i];);
 }

--- a/general/error.hpp
+++ b/general/error.hpp
@@ -164,7 +164,13 @@ __device__ void abort_msg(T & msg)
 #endif
 
 // Abort inside a device kernel
-#if defined(__CUDA_ARCH__)
+#if defined(__CUDA_ARCH__) && defined(_WIN32)
+#define MFEM_ABORT_KERNEL(msg) \
+   {                           \
+      printf(msg);             \
+      __debugbreak();          \
+   }
+#elif defined(__CUDA_ARCH__)
 #define MFEM_ABORT_KERNEL(msg) \
    {                           \
       printf(msg);             \

--- a/general/isockstream.cpp
+++ b/general/isockstream.cpp
@@ -79,7 +79,7 @@ int isockstream::establish()
    int on=1;
    setsockopt(port, SOL_SOCKET, SO_REUSEADDR, (char *)(&on), sizeof(on));
 
-   if (bind(port,(const sockaddr*)&sa,(socklen_t)sizeof(struct sockaddr_in)) < 0)
+   if (bind((SOCKET)port,(const sockaddr*)&sa,(socklen_t)sizeof(struct sockaddr_in)) < 0)
    {
       mfem::err << "isockstream::establish(): bind() failed!" << endl;
       close(port);

--- a/linalg/kernels.hpp
+++ b/linalg/kernels.hpp
@@ -378,7 +378,7 @@ void Swap(T &a, T &b)
    b = tmp;
 }
 
-const double Epsilon = std::numeric_limits<double>::epsilon();
+constexpr double Epsilon = std::numeric_limits<double>::epsilon();
 
 /// Utility function used in CalcSingularvalue<3>.
 MFEM_HOST_DEVICE static inline

--- a/miniapps/meshing/minimal-surface.cpp
+++ b/miniapps/meshing/minimal-surface.cpp
@@ -1159,7 +1159,7 @@ static double u0(const Vector &x) { return sin(3.0 * PI * (x[1] + x[0])); }
 
 enum {NORM, AREA};
 
-static double qf(const int order, const int ker, Mesh &m,
+double qf(const int order, const int ker, Mesh &m,
                  FiniteElementSpace &fes, GridFunction &u)
 {
    const Geometry::Type type = m.GetElementBaseGeometry(0);


### PR DESCRIPTION
1. Remove "static" keyword from functions used as lambdas on "device"
2. Add _USE_MATH_DEFINES to CmakeLists.txt (without this change VS doesn't "see" this preprocessor in config.hpp)
3. Remove asm definition - asm is not allowed in VS anymore
4. Convert "const double Epsilon" to constexpr (fixes CUDA compilation error)