### PR TITLE
Compare PRs from forks with mfem/mfem:master

### DIFF
--- a/.github/workflows/repo-check.yml
+++ b/.github/workflows/repo-check.yml
@@ -105,6 +105,7 @@ jobs:
 
     - name: branch-history
       run: |
-        git fetch origin master:master
+        git remote add reference https://github.com/mfem/mfem.git
+        git fetch reference master:master
         git checkout -b gh-actions-branch-history
         ./config/githooks/pre-push --history

--- a/.github/workflows/repo-check.yml
+++ b/.github/workflows/repo-check.yml
@@ -105,13 +105,9 @@ jobs:
 
     - name: branch-history
       run: |
-        git remote add reference https://github.com/mfem/mfem.git
-        git fetch reference master:master
+        # We override origin to make sure we point to the main repo.
+        # This is to have consistent test results on PRs from forks.
+        git remote remove origin
+        git remote add origin https://github.com/mfem/mfem.git
         git checkout -b gh-actions-branch-history
-        # Note: the script below will run `git fetch origin master:master.
-        # This may fail on forks because the forked master may be far behind.
-        # This is OK because we are sure to be up-to-date with the fetch from
-        # "reference" we do here.
-        # An alternative would be to change origin here, so that it points to
-        # the main repo (like reference).
         ./config/githooks/pre-push --history

--- a/.github/workflows/repo-check.yml
+++ b/.github/workflows/repo-check.yml
@@ -108,4 +108,10 @@ jobs:
         git remote add reference https://github.com/mfem/mfem.git
         git fetch reference master:master
         git checkout -b gh-actions-branch-history
+        # Note: the script below will run `git fetch origin master:master.
+        # This may fail on forks because the forked master may be far behind.
+        # This is OK because we are sure to be up-to-date with the fetch from
+        # "reference" we do here.
+        # An alternative would be to change origin here, so that it points to
+        # the main repo (like reference).
         ./config/githooks/pre-push --history


### PR DESCRIPTION
1. I first created this PR to test if running GitHub Action "repo-checks" on the fork reports to the PR in the main repo.
Answer is NO.

2. I changed `branch-history` GitHub Action to make it works on forks, comparing with master in mfem/mfem.
Status is DONE.

Details:
Before this, when running the repo-checks on MFEM forks (rare I guess), the GitHub Action would use the state of "master" in the fork as a point of comparison for `branch-history`.

Because the `repo-checks` are not run on PRs coming from forks, I was thinking that we could ask developers working with forks to run repo-checks locally on their fork repo. I was hoping that this would report in the PR in the end, but it doesn't.

In the end, the changes here just make sure that when there is a PR from a fork, if the fork has Github Action activated, then we can see if the `repo-checks` pass on the fork, while before it was not a reliable source of info.
<!--GHEX{"id":2505,"author":"adrienbernede","editor":"tzanio","reviewers":["tzanio","v-dobrev"],"assignment":"2021-09-09T20:31:18-07:00","approval":"2021-09-27T19:11:55.820Z","merge":"2021-09-28T16:42:04.583Z"}XEHG--><!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge| 
 | --- | --- | --- | --- | --- | --- | --- | 
| [#2505](https://github.com/mfem/mfem/pull/2505) | @adrienbernede | @tzanio | @tzanio + @v-dobrev | 09/09/21 | 09/27/21 | 09/28/21 | |
<!--ELBATXEHG-->