### PR TITLE
Fixing special cases in RT pyramids [bugfix/lin-penta-dev]

### DIFF
--- a/fem/fe.cpp
+++ b/fem/fe.cpp
@@ -8034,6 +8034,15 @@ void RT0PyrFiniteElement::CalcVShape(const IntegrationPoint &ip,
       shape(4,1) = - 0.5;
       shape(4,2) =   1.0;
 
+      if (!rt0)
+      {
+         for (int i=1; i<5; i++)
+            for (int j=0; j<3; j++)
+            {
+               shape(i, j) *= 0.5;
+            }
+      }
+
       return;
    }
 

--- a/tests/unit/fem/test_get_value.cpp
+++ b/tests/unit/fem/test_get_value.cpp
@@ -2495,6 +2495,12 @@ TEST_CASE("3D GetVectorValue",
          Vector dgv_gvv_val(dim); dgv_gvv_val = 0.0;
          Vector dgi_gvv_val(dim); dgi_gvv_val = 0.0;
 
+         Vector  nd_gvf_val(dim);  nd_gvf_val = 0.0;
+         Vector  rt_gvf_val(dim);  rt_gvf_val = 0.0;
+         DenseMatrix nd_gvf_vals;
+         DenseMatrix rt_gvf_vals;
+         DenseMatrix tr;
+
          SECTION("Domain Evaluation 3D")
          {
             std::cout << "Domain Evaluation 3D" << std::endl;
@@ -2519,6 +2525,12 @@ TEST_CASE("3D GetVectorValue",
                double dgv_gvv_err = 0.0;
                double dgi_gvv_err = 0.0;
 
+               double  nd_gvf_err = 0.0;
+               double  rt_gvf_err = 0.0;
+
+               nd_x.GetVectorFieldValues(e, ir, nd_gvf_vals, tr);
+               rt_x.GetVectorFieldValues(e, ir, rt_gvf_vals, tr);
+
                for (int j=0; j<ir.GetNPoints(); j++)
                {
                   npts++;
@@ -2541,6 +2553,9 @@ TEST_CASE("3D GetVectorValue",
                   dgv_x.GetVectorValue(e, ip, dgv_gvv_val);
                   dgi_x.GetVectorValue(e, ip, dgi_gvv_val);
 
+                  nd_gvf_vals.GetRow(j, nd_gvf_val);
+                  rt_gvf_vals.GetRow(j, rt_gvf_val);
+
                   double  h1_gfc_dist = Distance(f_val,  h1_gfc_val, dim);
                   double  nd_gfc_dist = Distance(f_val,  nd_gfc_val, dim);
                   double  rt_gfc_dist = Distance(f_val,  rt_gfc_val, dim);
@@ -2555,6 +2570,9 @@ TEST_CASE("3D GetVectorValue",
                   double dgv_gvv_dist = Distance(f_val, dgv_gvv_val, dim);
                   double dgi_gvv_dist = Distance(f_val, dgi_gvv_val, dim);
 
+                  double  nd_gvf_dist = Distance(f_val,  nd_gvf_val, dim);
+                  double  rt_gvf_dist = Distance(f_val,  rt_gvf_val, dim);
+
                   h1_gfc_err  +=  h1_gfc_dist;
                   nd_gfc_err  +=  nd_gfc_dist;
                   rt_gfc_err  +=  rt_gfc_dist;
@@ -2568,6 +2586,9 @@ TEST_CASE("3D GetVectorValue",
                   l2_gvv_err  +=  l2_gvv_dist;
                   dgv_gvv_err += dgv_gvv_dist;
                   dgi_gvv_err += dgi_gvv_dist;
+
+                  nd_gvf_err  +=  nd_gvf_dist;
+                  rt_gvf_err  +=  rt_gvf_dist;
 
                   if (log > 0 && h1_gfc_dist > tol)
                   {
@@ -2681,6 +2702,26 @@ TEST_CASE("3D GetVectorValue",
                                << dgi_gvv_val[2] << ") "
                                << dgi_gvv_dist << std::endl;
                   }
+                  if (log > 0 && nd_gvf_dist > tol)
+                  {
+                     std::cout << e << ":" << j << " nd  gvf ("
+                               << f_val[0] << "," << f_val[1] << ","
+                               << f_val[2] << ") vs. ("
+                               << nd_gvf_val[0] << ","
+                               << nd_gvf_val[1] << ","
+                               << nd_gvf_val[2] << ") "
+                               << nd_gvf_dist << std::endl;
+                  }
+                  if (log > 0 && rt_gvf_dist > tol)
+                  {
+                     std::cout << e << ":" << j << " rt  gvf ("
+                               << f_val[0] << "," << f_val[1] << ","
+                               << f_val[2] << ") vs. ("
+                               << rt_gvf_val[0] << ","
+                               << rt_gvf_val[1] << ","
+                               << rt_gvf_val[2] << ") "
+                               << rt_gvf_dist << std::endl;
+                  }
                }
 
                h1_gfc_err  /= ir.GetNPoints();
@@ -2697,6 +2738,9 @@ TEST_CASE("3D GetVectorValue",
                dgv_gvv_err /= ir.GetNPoints();
                dgi_gvv_err /= ir.GetNPoints();
 
+               nd_gvf_err  /= ir.GetNPoints();
+               rt_gvf_err  /= ir.GetNPoints();
+
                REQUIRE( h1_gfc_err == MFEM_Approx(0.0));
                REQUIRE( nd_gfc_err == MFEM_Approx(0.0));
                REQUIRE( rt_gfc_err == MFEM_Approx(0.0));
@@ -2710,6 +2754,9 @@ TEST_CASE("3D GetVectorValue",
                REQUIRE( l2_gvv_err == MFEM_Approx(0.0));
                REQUIRE(dgv_gvv_err == MFEM_Approx(0.0));
                REQUIRE(dgi_gvv_err == MFEM_Approx(0.0));
+
+               REQUIRE( nd_gvf_err == MFEM_Approx(0.0));
+               REQUIRE( rt_gvf_err == MFEM_Approx(0.0));
             }
          }
 


### PR DESCRIPTION
When evaluating Raviart-Thomas basis functions in a pyramid there are two special cases that must be addressed.

1. The basis functions for the triangular faces contain a division by zero at the apex. However, the numerator also approaches zero so when evaluating very near the apex we need to return the limiting values which remain well behaved.
2. The `RT0TetFiniteElement` and the `RT_TetrahedronElement` for order 0 differ by a factor of 2. Since we are currently using the `RT0PyrFiniteElement` with each of these tetrahedral elements we need to also scale our triangular face basis functions so that they match the appropriate tetrahedral element.

The second special case (the factor of 2) was not being taken into account when addressing the first special case (evaluation at the apex).

This PR also adds unit test coverage of the `GridFunction::GetVectorFieldValues` member function. This function works correctly but this unit test helped to rule out a possible failure during the debugging process.