### PR TITLE
Remove functions that are now duplicated from libCEED.

### DIFF
--- a/fem/ceed/solvers-atpmg.cpp
+++ b/fem/ceed/solvers-atpmg.cpp
@@ -692,54 +692,6 @@ int CeedATPMGOperator(CeedOperator oper, int order_reduction,
    return 0;
 }
 
-int CeedOperatorGetActiveBasis(CeedOperator oper, CeedBasis *basis)
-{
-   int ierr;
-   Ceed ceed;
-   ierr = CeedOperatorGetCeed(oper, &ceed); CeedChk(ierr);
-   CeedQFunction qf;
-   ierr = CeedOperatorGetQFunction(oper, &qf); CeedChk(ierr);
-   CeedInt numinputfields, numoutputfields;
-   ierr = CeedQFunctionGetNumArgs(qf, &numinputfields, &numoutputfields);
-   CeedOperatorField *inputfields, *outputfields;
-   ierr = CeedOperatorGetFields(oper, &inputfields, &outputfields); CeedChk(ierr);
-
-   *basis = NULL;
-   for (int i = 0; i < numinputfields; ++i)
-   {
-      CeedVector if_vector;
-      CeedBasis basis_in;
-      ierr = CeedOperatorFieldGetVector(inputfields[i], &if_vector); CeedChk(ierr);
-      ierr = CeedOperatorFieldGetBasis(inputfields[i], &basis_in); CeedChk(ierr);
-      if (if_vector == CEED_VECTOR_ACTIVE)
-      {
-         if (*basis == NULL)
-         {
-            *basis = basis_in;
-         }
-         else if (*basis != basis_in)
-         {
-            return CeedError(ceed, 1, "Two different active input basis!");
-         }
-      }
-   }
-   for (int i = 0; i < numoutputfields; ++i)
-   {
-      CeedVector of_vector;
-      CeedBasis basis_out;
-      ierr = CeedOperatorFieldGetVector(outputfields[i], &of_vector); CeedChk(ierr);
-      ierr = CeedOperatorFieldGetBasis(outputfields[i], &basis_out); CeedChk(ierr);
-      if (of_vector == CEED_VECTOR_ACTIVE)
-      {
-         if (*basis != basis_out)
-         {
-            return CeedError(ceed, 1, "Input and output basis do not match!");
-         }
-      }
-   }
-   return 0;
-}
-
 int CeedATPMGOperator(CeedOperator oper, int order_reduction,
                       CeedElemRestriction coarse_er,
                       CeedBasis *coarse_basis_out,

--- a/fem/ceed/util.cpp
+++ b/fem/ceed/util.cpp
@@ -374,20 +374,6 @@ int CeedOperatorGetActiveField(CeedOperator oper, CeedOperatorField *field)
    return 0;
 }
 
-int CeedOperatorGetActiveElemRestriction(CeedOperator oper,
-                                         CeedElemRestriction* restr_out)
-{
-   int ierr;
-
-   CeedOperatorField active_field;
-   ierr = CeedOperatorGetActiveField(oper, &active_field); CeedChk(ierr);
-   CeedElemRestriction er;
-   ierr = CeedOperatorFieldGetElemRestriction(active_field, &er); CeedChk(ierr);
-   *restr_out = er;
-
-   return 0;
-}
-
 std::string ceed_path;
 
 const std::string &GetCeedPath()

--- a/fem/ceed/util.hpp
+++ b/fem/ceed/util.hpp
@@ -79,9 +79,6 @@ void InitTensorRestriction(const FiniteElementSpace &fes,
 
 int CeedOperatorGetActiveField(CeedOperator oper, CeedOperatorField *field);
 
-int CeedOperatorGetActiveElemRestriction(CeedOperator oper,
-                                         CeedElemRestriction* restr_out);
-
 /// Return the path to the libCEED q-function headers.
 const std::string &GetCeedPath();
 


### PR DESCRIPTION
Remove `CeedOperatorGetActiveBasis` and `CeedOperatorGetActiveElemRestriction` from MFEM since they are now defined in libCEED.