### PR TITLE
Fixing HiOp int types

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -692,7 +692,7 @@ The specific libraries and their options are:
 - HiOp (optional), used when MFEM_USE_HIOP = YES.
   URL: https://github.com/LLNL/hiop
   Options: HIOP_OPT, HIOP_LIB.
-  Versions: HIOP >= 0.4.
+  Versions: HIOP >= 0.4.6.
 
 - GSLIB (optional), used when MFEM_USE_GSLIB = YES. The gslib library must be
   built prior to the MFEM build, as follows: download gslib-1.0.7, untar it at

--- a/linalg/hiop.cpp
+++ b/linalg/hiop.cpp
@@ -303,7 +303,7 @@ void HiopNlpOptimizer::Mult(const Vector &xt, Vector &x) const
    hiopInstance.options->SetNumericValue("fixed_var_perturb", 1e-9);
 
    hiopInstance.options->SetNumericValue("mu0", 1e-1);
-   
+
    // 0: no output; 3: not too much
    hiopInstance.options->SetIntegerValue("verbosity_level", print_level);
 

--- a/linalg/hiop.cpp
+++ b/linalg/hiop.cpp
@@ -22,7 +22,7 @@ using namespace hiop;
 namespace mfem
 {
 
-bool HiopOptimizationProblem::get_prob_sizes(long long &n, long long &m)
+bool HiopOptimizationProblem::get_prob_sizes(size_type &n, size_type &m)
 {
    n = ntdofs_glob;
    m = problem.GetNumConstraints();
@@ -30,7 +30,7 @@ bool HiopOptimizationProblem::get_prob_sizes(long long &n, long long &m)
    return true;
 }
 
-bool HiopOptimizationProblem::get_starting_point(const long long &n, double *x0)
+bool HiopOptimizationProblem::get_starting_point(const size_type &n, double *x0)
 {
    MFEM_ASSERT(x_start != NULL && ntdofs_loc == x_start->Size(),
                "Starting point is not set properly.");
@@ -40,7 +40,7 @@ bool HiopOptimizationProblem::get_starting_point(const long long &n, double *x0)
    return true;
 }
 
-bool HiopOptimizationProblem::get_vars_info(const long long &n,
+bool HiopOptimizationProblem::get_vars_info(const size_type &n,
                                             double *xlow, double *xupp,
                                             NonlinearityType *type)
 {
@@ -55,7 +55,7 @@ bool HiopOptimizationProblem::get_vars_info(const long long &n,
    return true;
 }
 
-bool HiopOptimizationProblem::get_cons_info(const long long &m,
+bool HiopOptimizationProblem::get_cons_info(const size_type &m,
                                             double *clow, double *cupp,
                                             NonlinearityType *type)
 {
@@ -79,7 +79,7 @@ bool HiopOptimizationProblem::get_cons_info(const long long &m,
    return true;
 }
 
-bool HiopOptimizationProblem::eval_f(const long long &n, const double *x,
+bool HiopOptimizationProblem::eval_f(const size_type &n, const double *x,
                                      bool new_x, double &obj_value)
 {
    MFEM_ASSERT(n == ntdofs_glob, "Global input mismatch.");
@@ -93,7 +93,7 @@ bool HiopOptimizationProblem::eval_f(const long long &n, const double *x,
    return true;
 }
 
-bool HiopOptimizationProblem::eval_grad_f(const long long &n, const double *x,
+bool HiopOptimizationProblem::eval_grad_f(const size_type &n, const double *x,
                                           bool new_x, double *gradf)
 {
    MFEM_ASSERT(n == ntdofs_glob, "Global input mismatch.");
@@ -108,9 +108,9 @@ bool HiopOptimizationProblem::eval_grad_f(const long long &n, const double *x,
    return true;
 }
 
-bool HiopOptimizationProblem::eval_cons(const long long &n, const long long &m,
-                                        const long long &num_cons,
-                                        const long long *idx_cons,
+bool HiopOptimizationProblem::eval_cons(const size_type &n, const size_type &m,
+                                        const size_type &num_cons,
+                                        const index_type *idx_cons,
                                         const double *x, bool new_x,
                                         double *cons)
 {
@@ -134,10 +134,10 @@ bool HiopOptimizationProblem::eval_cons(const long long &n, const long long &m,
    return true;
 }
 
-bool HiopOptimizationProblem::eval_Jac_cons(const long long &n,
-                                            const long long &m,
-                                            const long long &num_cons,
-                                            const long long *idx_cons,
+bool HiopOptimizationProblem::eval_Jac_cons(const size_type &n,
+                                            const size_type &m,
+                                            const size_type &num_cons,
+                                            const index_type *idx_cons,
                                             const double *x, bool new_x,
                                             double *Jac)
 {
@@ -165,16 +165,16 @@ bool HiopOptimizationProblem::eval_Jac_cons(const long long &n,
    return true;
 }
 
-bool HiopOptimizationProblem::get_vecdistrib_info(long long global_n,
-                                                  long long *cols)
+bool HiopOptimizationProblem::get_vecdistrib_info(size_type global_n,
+                                                  index_type *cols)
 {
 #ifdef MFEM_USE_MPI
    int nranks;
    MPI_Comm_size(comm, &nranks);
 
-   long long *sizes = new long long[nranks];
-   MPI_Allgather(&ntdofs_loc, 1, MPI_LONG_LONG_INT, sizes, 1,
-                 MPI_LONG_LONG_INT, comm);
+   size_type *sizes = new size_type[nranks];
+   MPI_Allgather(&ntdofs_loc, 1, MPI_HIOP_SIZE_TYPE, sizes, 1,
+                 MPI_HIOP_SIZE_TYPE, comm);
    cols[0] = 0;
    for (int r = 1; r <= nranks; r++)
    {
@@ -302,6 +302,8 @@ void HiopNlpOptimizer::Mult(const Vector &xt, Vector &x) const
    hiopInstance.options->SetNumericValue("fixed_var_tolerance", 1e-20);
    hiopInstance.options->SetNumericValue("fixed_var_perturb", 1e-9);
 
+   hiopInstance.options->SetNumericValue("mu0", 1e-1);
+   
    // 0: no output; 3: not too much
    hiopInstance.options->SetIntegerValue("verbosity_level", print_level);
 

--- a/linalg/hiop.hpp
+++ b/linalg/hiop.hpp
@@ -41,8 +41,8 @@ private:
    const OptimizationProblem &problem;
 
    // Local and global number of variables and constraints.
-   const long long ntdofs_loc, m_total;
-   long long ntdofs_glob;
+   const hiop::size_type ntdofs_loc, m_total;
+   hiop::size_type ntdofs_glob;
 
    // Initial guess.
    const Vector *x_start;
@@ -78,8 +78,7 @@ public:
         constr_vals(m_total), constr_grads(m_total, ntdofs_loc),
         constr_info_is_current(false)
    {
-      MPI_Allreduce(&ntdofs_loc, &ntdofs_glob, 1, MPI_LONG_LONG_INT,
-                    MPI_SUM, comm);
+     MPI_Allreduce(&ntdofs_loc, &ntdofs_glob, 1, MPI_HIOP_SIZE_TYPE, MPI_SUM, comm);
    }
 #endif
 
@@ -87,27 +86,27 @@ public:
 
    /** Extraction of problem dimensions:
     *  n is the number of variables, m is the number of constraints. */
-   virtual bool get_prob_sizes(long long int& n, long long int& m);
+   virtual bool get_prob_sizes(hiop::size_type& n, hiop::size_type& m);
 
    /** Provide an primal starting point. This point is subject to adjustments
     *  internally in HiOp. */
-   virtual bool get_starting_point(const long long &n, double *x0);
+   virtual bool get_starting_point(const hiop::size_type &n, double *x0);
 
-   virtual bool get_vars_info(const long long& n, double *xlow, double* xupp,
+   virtual bool get_vars_info(const hiop::size_type &n, double *xlow, double* xupp,
                               NonlinearityType* type);
 
    /** bounds on the constraints
     *  (clow<=-1e20 means no lower bound, cupp>=1e20 means no upper bound) */
-   virtual bool get_cons_info(const long long &m, double *clow, double *cupp,
+   virtual bool get_cons_info(const hiop::size_type &m, double *clow, double *cupp,
                               NonlinearityType* type);
 
    /** Objective function evaluation.
     *  Each rank returns the global objective value. */
-   virtual bool eval_f(const long long& n, const double *x, bool new_x,
+   virtual bool eval_f(const hiop::size_type &n, const double *x, bool new_x,
                        double& obj_value);
 
    /** Gradient of the objective function (local chunk). */
-   virtual bool eval_grad_f(const long long &n, const double *x, bool new_x,
+   virtual bool eval_grad_f(const hiop::size_type &n, const double *x, bool new_x,
                             double *gradf);
 
    /** Evaluates a subset of the constraints cons(x). The subset is of size
@@ -132,9 +131,12 @@ public:
     *  When MPI enabled, every rank populates cons, since the constraints are
     *  not distributed.
     */
-   virtual bool eval_cons(const long long &n, const long long &m,
-                          const long long &num_cons, const long long *idx_cons,
-                          const double *x, bool new_x, double *cons);
+   virtual bool eval_cons(const hiop::size_type &n,
+			  const hiop::size_type &m,
+                          const hiop::size_type &num_cons,
+			  const hiop::index_type *idx_cons,
+                          const double *x,
+			  bool new_x, double *cons);
 
    /** Evaluates the Jacobian of the subset of constraints indicated by
     *  idx_cons. The idx_cons is assumed to be of size num_cons.
@@ -147,9 +149,9 @@ public:
     *  When MPI enabled, each rank computes only the local columns of the
     *  Jacobian, that is the partials with respect to local variables.
     */
-   virtual bool eval_Jac_cons(const long long &n, const long long &m,
-                              const long long &num_cons,
-                              const long long *idx_cons,
+   virtual bool eval_Jac_cons(const hiop::size_type &n, const hiop::size_type &m,
+                              const hiop::size_type &num_cons,
+                              const hiop::index_type *idx_cons,
                               const double *x, bool new_x, double *Jac);
 
    /** Specifies column partitioning for distributed memory vectors.
@@ -158,7 +160,7 @@ public:
     *  Example: for a vector x of 6 entries (globally) on 3 ranks, the uniform
     *  column partitioning is cols=[0,2,4,6].
     */
-   virtual bool get_vecdistrib_info(long long global_n, long long *cols);
+   virtual bool get_vecdistrib_info(hiop::size_type global_n, hiop::index_type *cols);
 
 #ifdef MFEM_USE_MPI
    virtual bool get_MPI_comm(MPI_Comm &comm_out)

--- a/linalg/hiop.hpp
+++ b/linalg/hiop.hpp
@@ -131,12 +131,10 @@ public:
     *  When MPI enabled, every rank populates cons, since the constraints are
     *  not distributed.
     */
-   virtual bool eval_cons(const hiop::size_type &n,
-			  const hiop::size_type &m,
+   virtual bool eval_cons(const hiop::size_type &n, const hiop::size_type &m,
                           const hiop::size_type &num_cons,
-			  const hiop::index_type *idx_cons,
-                          const double *x,
-			  bool new_x, double *cons);
+                          const hiop::index_type *idx_cons,
+                          const double *x, bool new_x, double *cons);
 
    /** Evaluates the Jacobian of the subset of constraints indicated by
     *  idx_cons. The idx_cons is assumed to be of size num_cons.

--- a/linalg/hiop.hpp
+++ b/linalg/hiop.hpp
@@ -78,7 +78,7 @@ public:
         constr_vals(m_total), constr_grads(m_total, ntdofs_loc),
         constr_info_is_current(false)
    {
-     MPI_Allreduce(&ntdofs_loc, &ntdofs_glob, 1, MPI_HIOP_SIZE_TYPE, MPI_SUM, comm);
+      MPI_Allreduce(&ntdofs_loc, &ntdofs_glob, 1, MPI_HIOP_SIZE_TYPE, MPI_SUM, comm);
    }
 #endif
 
@@ -158,7 +158,8 @@ public:
     *  Example: for a vector x of 6 entries (globally) on 3 ranks, the uniform
     *  column partitioning is cols=[0,2,4,6].
     */
-   virtual bool get_vecdistrib_info(hiop::size_type global_n, hiop::index_type *cols);
+   virtual bool get_vecdistrib_info(hiop::size_type global_n,
+                                    hiop::index_type *cols);
 
 #ifdef MFEM_USE_MPI
    virtual bool get_MPI_comm(MPI_Comm &comm_out)


### PR DESCRIPTION
Updates mfem's HiOp interface and closes issue #2503 

The PR replaces the `long long int` with `hiop::size_type` and `hiop::index_type` . The MPI calls are also updated to match the new types. 
<!--GHEX{"id":2517,"author":"cnpetra","editor":"tzanio","reviewers":["tzanio","vladotomov"],"assignment":"2021-09-10T11:07:47-07:00","approval":"2021-09-15T17:33:02.229Z","merge":"2021-09-16T15:28:38.953Z"}XEHG--><!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge| 
 | --- | --- | --- | --- | --- | --- | --- | 
| [#2517](https://github.com/mfem/mfem/pull/2517) | @cnpetra | @tzanio | @tzanio + @vladotomov | 09/10/21 | 09/15/21 | 09/16/21 | |
<!--ELBATXEHG-->