### PR TITLE
Add a check to prevent bad parallel results on Nedelec NC tets of order >= 2 [nedelec-nc-tet-warning]

### DIFF
--- a/fem/pfespace.cpp
+++ b/fem/pfespace.cpp
@@ -2294,6 +2294,12 @@ int ParFiniteElementSpace
                                        Array<int> *dof_tdof,
                                        bool partial) const
 {
+   // TODO: general face DOF transformations in NeighborRowMessage::Decode()
+   MFEM_VERIFY(!(fec->GetOrder() >= 2
+                 && pmesh->HasGeometry(Geometry::TETRAHEDRON)
+                 && fec->GetContType() == FiniteElementCollection::TANGENTIAL),
+               "Nedelec NC tets of order >= 2 are not supported yet.");
+
    bool dg = (nvdofs == 0 && nedofs == 0 && nfdofs == 0);
 
 #ifdef MFEM_PMATRIX_STATS


### PR DESCRIPTION
As a result of #1046, triangular shared faces are broken in Nedelec spaces on NC meshes. This PR adds a check that warns the user of this, until the problem is fixed.

The fix will require looping over ranges of DOFs in `NeighborRowMessage::Decode` (those with the same `id.index`), so that internal face DOFs are processed together, if necessary. The problem only occurs on conforming shared triangles, whose DOFs should all be present in a message from the owner.

We will need to have access to a face-only DOF transformation, specifically one that only works with the internal face DOFs only (i.e. no edges).

<!--GHEX{"id":2526,"author":"jakubcerveny","editor":"tzanio","reviewers":["mlstowell","tzanio"],"assignment":"2021-09-10T11:05:04-07:00","approval":"2021-09-17T17:29:43.699Z","merge":"2021-09-19T01:58:21.699Z"}XEHG--><!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge| 
 | --- | --- | --- | --- | --- | --- | --- | 
| [#2526](https://github.com/mfem/mfem/pull/2526) | @jakubcerveny | @tzanio | @mlstowell + @tzanio | 09/10/21 | 09/17/21 | 09/18/21 | |
<!--ELBATXEHG-->