### PR TITLE
pumi: update adaptation input object apis

### DIFF
--- a/examples/pumi/ex1p.cpp
+++ b/examples/pumi/ex1p.cpp
@@ -145,7 +145,7 @@ int main(int argc, char *argv[])
    // Perform Uniform refinement
    if (ref_levels > 1)
    {
-      ma::Input* uniInput = ma::configureUniformRefine(pumi_mesh, ref_levels);
+      const ma::Input* uniInput = ma::configureUniformRefine(pumi_mesh, ref_levels);
 
       if (geom_order > 1)
       {

--- a/examples/pumi/ex6p.cpp
+++ b/examples/pumi/ex6p.cpp
@@ -150,7 +150,7 @@ int main(int argc, char *argv[])
 
    if (ref_levels > 1)
    {
-      ma::Input* uniInput = ma::configureUniformRefine(pumi_mesh, ref_levels);
+      const ma::Input* uniInput = ma::configureUniformRefine(pumi_mesh, ref_levels);
 
       if ( geom_order > 1)
       {
@@ -345,9 +345,7 @@ int main(int argc, char *argv[])
       apf::destroyField(ipfield);
 
       // 18. Perform MesAdapt.
-      ma::Input* erinput = ma::configure(pumi_mesh, sizefield);
-      erinput->shouldFixShape = true;
-      erinput->maximumIterations = 2;
+      const ma::Input* erinput = ma::configure(pumi_mesh, sizefield);
       if ( geom_order > 1)
       {
          crv::adapt(erinput);


### PR DESCRIPTION
This PR updates the pumi examples to use the modified apis for constructing mesh adaptation input objects that exists in pumi master(@b07bec1).  Note, these changes to pumi will be included in the v2.2.7 release (date TBD).

The following cmake command was used to build mfem:

```
cmake ../mfem \
-DCMAKE_BUILD_TYPE=Debug \
-DMFEM_USE_MPI=YES \
-DMFEM_USE_METIS_5=YES \
-DMFEM_DEBUG=YES \
-DMFEM_ENABLE_EXAMPLES=YES \
-DMFEM_ENABLE_MINIAPPS=YES \
-DMFEM_USE_PUMI=YES \
-DPUMI_DIR=/path/to/pumi/install \
-DHYPRE_DIR=$hypre \
-DMETIS_DIR=$metis \
-DCMAKE_INSTALL_PREFIX=$PWD/install
```

Then, in the build directory a symlink was made to the pumi data:

```
d=$PWD
git clone git@github.com:mfem/data mfemData
cd /path/to/mfem/buildDir/data
ln -s $d/mfemData/pumi .
```

With this setup, all but the following `ctest`s passed:

```
The following tests FAILED:
          1 - unit_tests (Not Run)
          2 - sedov_tests_cpu (Not Run)
          3 - sedov_tests_debug (Not Run)
          4 - tmop_pa_tests_cpu (Not Run)
          5 - tmop_pa_tests_debug (Not Run)
          6 - punit_tests_np=1 (Failed)
          7 - punit_tests_np=4 (Failed)
          8 - psedov_tests_cpu_np=1 (Failed)
          9 - psedov_tests_cpu_np=4 (Failed)
         10 - psedov_tests_debug_np=1 (Failed)
         11 - psedov_tests_debug_np=4 (Failed)
         12 - ptmop_pa_tests_cpu_np=1 (Failed)
         13 - ptmop_pa_tests_cpu_np=4 (Failed)
         14 - debug_device_tests (Not Run)
```