### PR TITLE
Detect renames in branch-history [branch-history-detect-renames]

### DIFF
--- a/tests/scripts/branch-history
+++ b/tests/scripts/branch-history
@@ -103,7 +103,7 @@ sub formatSize {
 # Loop over each commit in this branch, and check for large diffs
 my $total_size = 0;
 foreach my $sha (@commits) {
-  my @blobs = `git diff-tree -r -c --root --no-commit-id $sha`;
+  my @blobs = `git diff-tree -r -c --root --no-commit-id --find-renames $sha`;
   my $nfiles_changed = scalar @blobs;
   if ($nfiles_changed > $commit_max_files_changed) {
     printf STDERR
@@ -133,7 +133,8 @@ foreach my $sha (@commits) {
       elsif ($mode eq "D") { }
       # File was modified, use the gzip'ed diff as a proxy of the required git storage
       elsif ($mode =~ m/M\d*/) { $blob_size += int(`git diff -U0 --binary $src $dst | gzip -c | wc -c`); }
-      elsif ($mode =~ m/R\d*/) { }
+      # File was renamed (at least 50% similarity)
+      elsif ($mode =~ m/R\d*/) { $blob_size += int(`git diff -U0 --binary $src $dst | gzip -c | wc -c`); }
       elsif ($mode eq "T") { }
       elsif ($mode eq "U") { }
       else { die "Unknown git status letter." }


### PR DESCRIPTION
This PR changes the `branch-history` script to detect renames, so that we reduce false positives when renaming large files.

For example, #2335 has the following `branch-history` failure:
```
Large commit of size 513.26 KB.
    ^---> SHA: 2cffb578e264d349759225b6f101911dcca8f7eb
Large commit of size 576.39 KB.
    ^---> SHA: 06dcdb75acdef34c39a40f75ca82d083e30fd915
Large total branch size: 1.08 MB.
Branch HEAD has errors.
```

<details>
<summary>However, <code>git show 2cffb578e264d349759225b6f101911dcca8f7eb</code> gives the following result (click to expand):</summary>

```
commit 2cffb578e264d349759225b6f101911dcca8f7eb
Author: Stowell, Mark L <stowell1@llnl.gov>
Date:   Wed Jul 7 20:33:19 2021 -0700

    Moving fe* files into subdirectory

diff --git a/fem/CMakeLists.txt b/fem/CMakeLists.txt
index 7de5e9dbe..3e22aacb9 100644
--- a/fem/CMakeLists.txt
+++ b/fem/CMakeLists.txt
@@ -42,15 +42,15 @@ set(SRCS
   eltrans.cpp
   estimators.cpp
   fe.cpp
-  fe_base.cpp
-  fe_fixed_order.cpp
-  fe_h1.cpp
-  fe_l2.cpp
-  fe_nd.cpp
-  fe_nurbs.cpp
-  fe_pos.cpp
-  fe_rt.cpp
-  fe_ser.cpp
+  fe/fe_base.cpp
+  fe/fe_fixed_order.cpp
+  fe/fe_h1.cpp
+  fe/fe_l2.cpp
+  fe/fe_nd.cpp
+  fe/fe_nurbs.cpp
+  fe/fe_pos.cpp
+  fe/fe_rt.cpp
+  fe/fe_ser.cpp
   fe_coll.cpp
   fespace.cpp
   geom.cpp
@@ -130,15 +130,15 @@ set(HDRS
   eltrans.hpp
   estimators.hpp
   fe.hpp
-  fe_base.hpp
-  fe_fixed_order.hpp
-  fe_h1.hpp
-  fe_l2.hpp
-  fe_nd.hpp
-  fe_nurbs.hpp
-  fe_pos.hpp
-  fe_rt.hpp
-  fe_ser.hpp
+  fe/fe_base.hpp
+  fe/fe_fixed_order.hpp
+  fe/fe_h1.hpp
+  fe/fe_l2.hpp
+  fe/fe_nd.hpp
+  fe/fe_nurbs.hpp
+  fe/fe_pos.hpp
+  fe/fe_rt.hpp
+  fe/fe_ser.hpp
   fe_coll.hpp
   fem.hpp
   fespace.hpp
diff --git a/fem/fe.hpp b/fem/fe.hpp
index 551ba8de1..488073cb7 100644
--- a/fem/fe.hpp
+++ b/fem/fe.hpp
@@ -17,14 +17,14 @@
 #include "../linalg/linalg.hpp"
 
 // Base and derived classes for finite elements
-#include "fe_base.hpp"
-#include "fe_fixed_order.hpp"
-#include "fe_h1.hpp"
-#include "fe_nd.hpp"
-#include "fe_rt.hpp"
-#include "fe_l2.hpp"
-#include "fe_nurbs.hpp"
-#include "fe_pos.hpp"
-#include "fe_ser.hpp"
+#include "fe/fe_base.hpp"
+#include "fe/fe_fixed_order.hpp"
+#include "fe/fe_h1.hpp"
+#include "fe/fe_nd.hpp"
+#include "fe/fe_rt.hpp"
+#include "fe/fe_l2.hpp"
+#include "fe/fe_nurbs.hpp"
+#include "fe/fe_pos.hpp"
+#include "fe/fe_ser.hpp"
 
 #endif
diff --git a/fem/fe_base.cpp b/fem/fe/fe_base.cpp
similarity index 99%
rename from fem/fe_base.cpp
rename to fem/fe/fe_base.cpp
index 4778f2164..00c23f89d 100644
--- a/fem/fe_base.cpp
+++ b/fem/fe/fe_base.cpp
@@ -12,7 +12,7 @@
 // Finite Element Base classes
 
 #include "fe_base.hpp"
-#include "coefficient.hpp"
+#include "../coefficient.hpp"
 
 namespace mfem
 {
diff --git a/fem/fe_base.hpp b/fem/fe/fe_base.hpp
similarity index 99%
rename from fem/fe_base.hpp
rename to fem/fe/fe_base.hpp
index 4e2110cc8..d6dc72006 100644
--- a/fem/fe_base.hpp
+++ b/fem/fe/fe_base.hpp
@@ -12,8 +12,8 @@
 #ifndef MFEM_FE_BASE
 #define MFEM_FE_BASE
 
-#include "intrules.hpp"
-#include "geom.hpp"
+#include "../intrules.hpp"
+#include "../geom.hpp"
 
 #include <map>
 
diff --git a/fem/fe_fixed_order.cpp b/fem/fe/fe_fixed_order.cpp
similarity index 99%
rename from fem/fe_fixed_order.cpp
rename to fem/fe/fe_fixed_order.cpp
index 633620f79..64af73fe7 100644
--- a/fem/fe_fixed_order.cpp
+++ b/fem/fe/fe_fixed_order.cpp
@@ -12,7 +12,7 @@
 // Fixed Order Finite Element classes
 
 #include "fe_fixed_order.hpp"
-#include "coefficient.hpp"
+#include "../coefficient.hpp"
 
 namespace mfem
 {
diff --git a/fem/fe_fixed_order.hpp b/fem/fe/fe_fixed_order.hpp
similarity index 100%
rename from fem/fe_fixed_order.hpp
rename to fem/fe/fe_fixed_order.hpp
diff --git a/fem/fe_h1.cpp b/fem/fe/fe_h1.cpp
similarity index 100%
rename from fem/fe_h1.cpp
rename to fem/fe/fe_h1.cpp
diff --git a/fem/fe_h1.hpp b/fem/fe/fe_h1.hpp
similarity index 100%
rename from fem/fe_h1.hpp
rename to fem/fe/fe_h1.hpp
diff --git a/fem/fe_l2.cpp b/fem/fe/fe_l2.cpp
similarity index 100%
rename from fem/fe_l2.cpp
rename to fem/fe/fe_l2.cpp
diff --git a/fem/fe_l2.hpp b/fem/fe/fe_l2.hpp
similarity index 100%
rename from fem/fe_l2.hpp
rename to fem/fe/fe_l2.hpp
diff --git a/fem/fe_nd.cpp b/fem/fe/fe_nd.cpp
similarity index 99%
rename from fem/fe_nd.cpp
rename to fem/fe/fe_nd.cpp
index 5e975d17c..cc1d03287 100644
--- a/fem/fe_nd.cpp
+++ b/fem/fe/fe_nd.cpp
@@ -12,7 +12,7 @@
 // Nedelec Finite Element classes
 
 #include "fe_nd.hpp"
-#include "coefficient.hpp"
+#include "../coefficient.hpp"
 
 namespace mfem
 {
diff --git a/fem/fe_nd.hpp b/fem/fe/fe_nd.hpp
similarity index 100%
rename from fem/fe_nd.hpp
rename to fem/fe/fe_nd.hpp
diff --git a/fem/fe_nurbs.cpp b/fem/fe/fe_nurbs.cpp
similarity index 99%
rename from fem/fe_nurbs.cpp
rename to fem/fe/fe_nurbs.cpp
index 5cd86943f..c810bd38e 100644
--- a/fem/fe_nurbs.cpp
+++ b/fem/fe/fe_nurbs.cpp
@@ -12,7 +12,7 @@
 // H1 Finite Element classes utilizing the Bernstein basis
 
 #include "fe_nurbs.hpp"
-#include "../mesh/nurbs.hpp"
+#include "../../mesh/nurbs.hpp"
 
 namespace mfem
 {
diff --git a/fem/fe_nurbs.hpp b/fem/fe/fe_nurbs.hpp
similarity index 100%
rename from fem/fe_nurbs.hpp
rename to fem/fe/fe_nurbs.hpp
diff --git a/fem/fe_pos.cpp b/fem/fe/fe_pos.cpp
similarity index 99%
rename from fem/fe_pos.cpp
rename to fem/fe/fe_pos.cpp
index 4c3e30331..f192b301e 100644
--- a/fem/fe_pos.cpp
+++ b/fem/fe/fe_pos.cpp
@@ -12,8 +12,8 @@
 // H1 Finite Element classes utilizing the Bernstein basis
 
 #include "fe_pos.hpp"
-#include "bilininteg.hpp"
-#include "coefficient.hpp"
+#include "../bilininteg.hpp"
+#include "../coefficient.hpp"
 
 namespace mfem
 {
diff --git a/fem/fe_pos.hpp b/fem/fe/fe_pos.hpp
similarity index 100%
rename from fem/fe_pos.hpp
rename to fem/fe/fe_pos.hpp
diff --git a/fem/fe_rt.cpp b/fem/fe/fe_rt.cpp
similarity index 99%
rename from fem/fe_rt.cpp
rename to fem/fe/fe_rt.cpp
index fd9136833..d08f6fac0 100644
--- a/fem/fe_rt.cpp
+++ b/fem/fe/fe_rt.cpp
@@ -12,7 +12,7 @@
 // Raviart-Thomas Finite Element classes
 
 #include "fe_rt.hpp"
-#include "coefficient.hpp"
+#include "../coefficient.hpp"
 
 namespace mfem
 {
diff --git a/fem/fe_rt.hpp b/fem/fe/fe_rt.hpp
similarity index 100%
rename from fem/fe_rt.hpp
rename to fem/fe/fe_rt.hpp
diff --git a/fem/fe_ser.cpp b/fem/fe/fe_ser.cpp
similarity index 100%
rename from fem/fe_ser.cpp
rename to fem/fe/fe_ser.cpp
diff --git a/fem/fe_ser.hpp b/fem/fe/fe_ser.hpp
similarity index 100%
rename from fem/fe_ser.hpp
rename to fem/fe/fe_ser.hpp
diff --git a/makefile b/makefile
index 4dc997fbd..16d9e9907 100644
--- a/makefile
+++ b/makefile
@@ -404,7 +404,7 @@ ifneq (,$(filter install,$(MAKECMDGOALS)))
 endif
 
 # Source dirs in logical order
-DIRS = general linalg linalg/simd mesh fem fem/ceed fem/qinterp fem/tmop
+DIRS = general linalg linalg/simd mesh fem fem/fe fem/ceed fem/qinterp fem/tmop
 SOURCE_FILES = $(foreach dir,$(DIRS),$(wildcard $(SRC)$(dir)/*.cpp))
 RELSRC_FILES = $(patsubst $(SRC)%,%,$(SOURCE_FILES))
 OBJECT_FILES = $(patsubst $(SRC)%,$(BLD)%,$(SOURCE_FILES:.cpp=.o))
```
</details>

So this is not really a big commit (false positive), it's just renaming many large files.

The new `branch-history` should not flag that commit:
```
Large commit of size 576.39 KB.
    ^---> SHA: 06dcdb75acdef34c39a40f75ca82d083e30fd915
Branch HEAD has errors.
```