### PR TITLE
Use hypre_IntArray

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -292,6 +292,8 @@ miniapps/solvers/sol.*
 tests/unit/output_meshes
 tests/unit/unit_tests
 tests/unit/punit_tests
+tests/unit/cunit_tests
+tests/unit/pcunit_tests
 tests/unit/sedov_tests_*
 tests/unit/psedov_tests_*
 tests/unit/tmop_pa_tests_*

--- a/linalg/hypre.cpp
+++ b/linalg/hypre.cpp
@@ -26,8 +26,6 @@
 #include <nvector/nvector_parallel.h>
 #endif
 
-#define MFEM_HYPRE_INTARRAY 1
-
 using namespace std;
 
 namespace mfem
@@ -1534,7 +1532,7 @@ HypreParMatrix *HypreParMatrix::ExtractSubmatrix(const Array<int> &indices,
    int local_num_vars = hypre_CSRMatrixNumRows(hypre_ParCSRMatrixDiag(A));
 
    // Form hypre CF-splitting array designating submatrix as F-points (-1)
-#if MFEM_HYPRE_INTARRAY
+#ifdef hypre_IntArrayData
    hypre_IntArray *CF_marker;
 
    CF_marker = hypre_IntArrayCreate(local_num_vars);
@@ -1559,7 +1557,7 @@ HypreParMatrix *HypreParMatrix::ExtractSubmatrix(const Array<int> &indices,
                               CF_marker, NULL, &cpts_global);
 
    // Extract submatrix into *submat
-#if MFEM_HYPRE_INTARRAY
+#ifdef hypre_IntArrayData
    hypre_ParCSRMatrixExtractSubmatrixFC(A, hypre_IntArrayData(CF_marker), cpts_global,
                                         "FF", &submat, threshold);
 #else
@@ -1568,7 +1566,7 @@ HypreParMatrix *HypreParMatrix::ExtractSubmatrix(const Array<int> &indices,
 #endif
 
    mfem_hypre_TFree(cpts_global);
-#if MFEM_HYPRE_INTARRAY
+#ifdef hypre_IntArrayData
    hypre_IntArrayDestroy(CF_marker);
 #endif
    return new HypreParMatrix(submat);

--- a/linalg/hypre.cpp
+++ b/linalg/hypre.cpp
@@ -1521,6 +1521,11 @@ HypreParMatrix * HypreParMatrix::Transpose() const
 HypreParMatrix *HypreParMatrix::ExtractSubmatrix(const Array<int> &indices,
                                                  double threshold) const
 {
+#if defined(HYPRE_USING_CUDA) && !defined(HYPRE_USING_UNIFIED_MEMORY)
+   MFEM_ABORT("This method requires HYPRE built with UVM when"
+              " HYPRE is using CUDA!");
+#endif
+
    if (!(A->comm))
    {
       hypre_MatvecCommPkgCreate(A);

--- a/linalg/hypre.cpp
+++ b/linalg/hypre.cpp
@@ -1541,15 +1541,19 @@ HypreParMatrix *HypreParMatrix::ExtractSubmatrix(const Array<int> &indices,
 #else
    Array<HYPRE_Int> CF_marker(local_num_vars);
    CF_marker = 1;
+#endif
    for (int j=0; j<indices.Size(); j++)
    {
       if (indices[j] > local_num_vars)
       {
          MFEM_WARNING("WARNING : " << indices[j] << " > " << local_num_vars);
       }
+#ifdef hypre_IntArrayData
+      hypre_IntArrayData(CF_marker)[indices[j]] = -1;
+#else
       CF_marker[indices[j]] = -1;
-   }
 #endif
+   }
 
    // Construct cpts_global array on hypre matrix structure
    HYPRE_BigInt *cpts_global;

--- a/linalg/hypre.cpp
+++ b/linalg/hypre.cpp
@@ -4578,7 +4578,7 @@ void HypreBoomerAMG::SetSystemsOptions(int dim, bool order_bynodes)
       // After the addition of hypre_IntArray, mapping is assumed
       // to be a device pointer. Previously, it was assumed to be
       // a host pointer.
-#ifdef hypre_IntArrayData
+#if defined(hypre_IntArrayData) && defined(HYPRE_USING_GPU)
       HYPRE_Int *mapping = mfem_hypre_CTAlloc(HYPRE_Int, height);
       hypre_TMemcpy(mapping, h_mapping, HYPRE_Int, height,
                     HYPRE_MEMORY_DEVICE, HYPRE_MEMORY_HOST);

--- a/linalg/hypre.cpp
+++ b/linalg/hypre.cpp
@@ -1538,6 +1538,7 @@ HypreParMatrix *HypreParMatrix::ExtractSubmatrix(const Array<int> &indices,
 
    // Form hypre CF-splitting array designating submatrix as F-points (-1)
 #ifdef hypre_IntArrayData
+   // hypre_BoomerAMGCoarseParms needs CF_marker to be hypre_IntArray *
    hypre_IntArray *CF_marker;
 
    CF_marker = hypre_IntArrayCreate(local_num_vars);
@@ -1554,6 +1555,7 @@ HypreParMatrix *HypreParMatrix::ExtractSubmatrix(const Array<int> &indices,
          MFEM_WARNING("WARNING : " << indices[j] << " > " << local_num_vars);
       }
 #ifdef hypre_IntArrayData
+      // Note: CF_marker is host or UVM memory, so we can modify it on host:
       hypre_IntArrayData(CF_marker)[indices[j]] = -1;
 #else
       CF_marker[indices[j]] = -1;

--- a/linalg/hypre.cpp
+++ b/linalg/hypre.cpp
@@ -1558,8 +1558,9 @@ HypreParMatrix *HypreParMatrix::ExtractSubmatrix(const Array<int> &indices,
 
    // Extract submatrix into *submat
 #ifdef hypre_IntArrayData
-   hypre_ParCSRMatrixExtractSubmatrixFC(A, hypre_IntArrayData(CF_marker), cpts_global,
-                                        "FF", &submat, threshold);
+   hypre_ParCSRMatrixExtractSubmatrixFC(A, hypre_IntArrayData(CF_marker),
+                                        cpts_global, "FF", &submat,
+                                        threshold);
 #else
    hypre_ParCSRMatrixExtractSubmatrixFC(A, CF_marker, cpts_global,
                                         "FF", &submat, threshold);


### PR DESCRIPTION
This PR provides a temporary fix to issue #2551, and thus it compiles with `hypre-master`. It is temporary since it relies on a preprocessor variable (`hypre_IntArrayData`) to switch behavior from an old state (as in `mfem-master`) to a new state (in line with `hypre-master`). It would be nice to replace this variable with the new `HYPRE_DEVELOP` variables discussed in https://github.com/hypre-space/hypre/pull/472
<!--GHEX{"id":2553,"author":"victorapm","editor":"tzanio","reviewers":["tzanio","dylan-copeland","v-dobrev"],"assignment":"2021-09-20T08:05:06-07:00","approval":"2021-09-22T23:28:37.886Z","merge":"2021-09-27T00:43:39.009Z"}XEHG--><!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge| 
 | --- | --- | --- | --- | --- | --- | --- | 
| [#2553](https://github.com/mfem/mfem/pull/2553) | @victorapm | @tzanio | @tzanio + @dylan-copeland + @v-dobrev | 09/20/21 | 09/22/21 | 09/26/21 | |
<!--ELBATXEHG-->