### PR TITLE
Parallel implementation of GridFunction::GetDerivative()

### DIFF
--- a/examples/ex1p.cpp
+++ b/examples/ex1p.cpp
@@ -203,7 +203,29 @@ int main(int argc, char *argv[])
    //     function corresponding to fespace. Initialize x with initial guess of
    //     zero, which satisfies the boundary conditions.
    ParGridFunction x(&fespace);
-   x = 0.0;
+
+   auto func = [&](Vector coord) { return std::sin(coord(0)*coord(1)); };
+   FunctionCoefficient x_coeff(func);
+
+   x.ProjectCoefficient(x_coeff);
+   ParGridFunction grad_x(&fespace);
+   ConstantCoefficient zero(0.0);
+   for (int i = 0; i < dim; i++)
+   {
+      x.GetDerivative(1, i, grad_x);
+      //x.GridFunction::GetDerivative(1, i, grad_x); // old behavior.
+      double error = grad_x.ComputeL2Error(zero);
+      if (myid == 0) { cout << setprecision(14) << error << endl; }
+   }
+
+   char vishost[] = "localhost";
+   int  visport   = 19916;
+   socketstream sol_sock(vishost, visport);
+   sol_sock << "parallel " << num_procs << " " << myid << "\n";
+   sol_sock.precision(8);
+   sol_sock << "solution\n" << pmesh << x << flush;
+
+   MFEM_ABORT("test getderiv");
 
    // 11. Set up the parallel bilinear form a(.,.) on the finite element space
    //     corresponding to the Laplacian operator -Delta, by adding the

--- a/fem/gridfunc.cpp
+++ b/fem/gridfunc.cpp
@@ -1341,21 +1341,20 @@ void GridFunction::ProjectVectorFieldOn(GridFunction &vec_field, int comp)
    }
 }
 
-void GridFunction::GetDerivative(int comp, int der_comp, GridFunction &der)
+void GridFunction::AccumulateAndCountDerivativeValues(int comp, int der_comp,
+                                                      GridFunction &der,
+                                                      Array<int> &zones_per_dof)
 {
    FiniteElementSpace * der_fes = der.FESpace();
    ElementTransformation * transf;
-   Array<int> overlap(der_fes->GetVSize());
+   zones_per_dof.SetSize(der_fes->GetVSize());
    Array<int> der_dofs, vdofs;
    DenseMatrix dshape, inv_jac;
    Vector pt_grad, loc_func;
    int i, j, k, dim, dof, der_dof, ind;
    double a;
 
-   for (i = 0; i < overlap.Size(); i++)
-   {
-      overlap[i] = 0;
-   }
+   zones_per_dof = 0;
    der = 0.0;
 
    comp--;
@@ -1390,11 +1389,17 @@ void GridFunction::GetDerivative(int comp, int der_comp, GridFunction &der)
             a += inv_jac(j, der_comp) * pt_grad(j);
          }
          der(der_dofs[k]) += a;
-         overlap[der_dofs[k]]++;
+         zones_per_dof[der_dofs[k]]++;
       }
    }
+}
 
-   for (i = 0; i < overlap.Size(); i++)
+void GridFunction::GetDerivative(int comp, int der_comp, GridFunction &der)
+{
+   Array<int> overlap;
+   AccumulateAndCountDerivativeValues(comp, der_comp, der, overlap);
+
+   for (int i = 0; i < overlap.Size(); i++)
    {
       der(i) /= overlap[i];
    }

--- a/fem/gridfunc.hpp
+++ b/fem/gridfunc.hpp
@@ -310,6 +310,16 @@ public:
 
    void ProjectVectorFieldOn(GridFunction &vec_field, int comp = 0);
 
+   /** @brief Compute a certain derivative of a function's component.
+       Derivatives of the function are computed at the DOF locations of @a der,
+       and averaged over overlapping DOFs. Thus this function projects the
+       derivative to the FiniteElementSpace of @a der.
+       @param[in]  comp  Index of the function's component to be differentiated.
+                         The index is 1-based, i.e., use 1 for scalar functions.
+       @param[in]  der_comp  Use 0/1/2 for derivatives in x/y/z directions.
+       @param[out] der       The resulting derivative (scalar function). The
+                             FiniteElementSpace of this function must be set
+                             before the call. */
    void GetDerivative(int comp, int der_comp, GridFunction &der);
 
    double GetDivergence(ElementTransformation &tr) const;
@@ -410,6 +420,12 @@ protected:
        shared vdofs and counts in how many zones each vdof appears. */
    void AccumulateAndCountZones(VectorCoefficient &vcoeff, AvgType type,
                                 Array<int> &zones_per_vdof);
+
+   /** @brief Used for the serial and parallel implementations of the
+       GetDerivative() method; see its documentation. */
+   void AccumulateAndCountDerivativeValues(int comp, int der_comp,
+                                           GridFunction &der,
+                                           Array<int> &zones_per_dof);
 
    void AccumulateAndCountBdrValues(Coefficient *coeff[],
                                     VectorCoefficient *vcoeff, Array<int> &attr,

--- a/fem/pgridfunc.cpp
+++ b/fem/pgridfunc.cpp
@@ -481,6 +481,27 @@ void ParGridFunction::GetVectorValue(ElementTransformation &T,
    }
 }
 
+void ParGridFunction::GetDerivative(int comp, int der_comp,
+                                    ParGridFunction &der)
+{
+   Array<int> overlap;
+   AccumulateAndCountDerivativeValues(comp, der_comp, der, overlap);
+
+   // Count the zones globally.
+   GroupCommunicator &gcomm = der.ParFESpace()->GroupComm();
+   gcomm.Reduce<int>(overlap, GroupCommunicator::Sum);
+   gcomm.Bcast(overlap);
+
+   // Accumulate for all dofs.
+   gcomm.Reduce<double>(der.GetData(), GroupCommunicator::Sum);
+   gcomm.Bcast<double>(der.GetData());
+
+   for (int i = 0; i < overlap.Size(); i++)
+   {
+      der(i) /= overlap[i];
+   }
+}
+
 void ParGridFunction::GetElementDofValues(int el, Vector &dof_vals) const
 {
    int ne = fes->GetNE();

--- a/fem/pgridfunc.hpp
+++ b/fem/pgridfunc.hpp
@@ -226,6 +226,9 @@ public:
                                const IntegrationPoint &ip,
                                Vector &val, Vector *tr = NULL) const;
 
+   /// Parallel version of GridFunction::GetDerivative(); see its documentation.
+   void GetDerivative(int comp, int der_comp, ParGridFunction &der);
+
    /** Sets the output vector @a dof_vals to the values of the degrees of
        freedom of element @a el. If @a el is greater than or equal to the number
        of local elements, it will be interpreted as a shifted index of a face


### PR DESCRIPTION
This came up in tracking small diffs between a serial and a parallel run. We were calling `ParGridFunction::GetDerivative()`, when this function was implemented only in serial. This PR fixes the accumulation of overlapping DOFs for the parallel case.

I left a small reproducer in `ex1p` that should be removed before the merge.