### PR TITLE
Small fix for petsc vectors

### DIFF
--- a/linalg/petsc.cpp
+++ b/linalg/petsc.cpp
@@ -732,8 +732,8 @@ void PetscParVector::PlaceMemory(Memory<double>& mem, bool rw)
    PetscInt n;
 
    ierr = VecGetLocalSize(x,&n); PCHKERRQ(x,ierr);
-   MFEM_VERIFY(n == mem.Capacity(),
-               "Memory size " << mem.Capacity() << " != " << n << " vector size!");
+   MFEM_VERIFY(n <= mem.Capacity(),
+               "Memory size " << mem.Capacity() << " < " << n << " vector size!");
    MFEM_VERIFY(pdata.Empty(),"Vector data is not empty");
    MFEM_VERIFY(data.Empty(),"Vector data is not empty");
 #if defined(_USE_DEVICE)
@@ -774,8 +774,8 @@ void PetscParVector::PlaceMemory(const Memory<double>& mem)
    PetscInt n;
 
    ierr = VecGetLocalSize(x,&n); PCHKERRQ(x,ierr);
-   MFEM_VERIFY(n == mem.Capacity(),
-               "Memory size " << mem.Capacity() << " != " << n << " vector size!");
+   MFEM_VERIFY(n <= mem.Capacity(),
+               "Memory size " << mem.Capacity() << " < " << n << " vector size!");
    MFEM_VERIFY(pdata.Empty(),"Vector data is not empty");
    MFEM_VERIFY(data.Empty(),"Vector data is not empty");
 #if defined(_USE_DEVICE)


### PR DESCRIPTION
Fix for a check in petsc.cpp lines 735 and 777. In general, the vector capacity should be larger or equal to the vector size. 
<!--GHEX{"id":2561,"author":"bslazarov","editor":"tzanio","reviewers":["stefanozampini","v-dobrev"],"assignment":"2021-09-22T16:28:46-07:00","approval":"2021-09-27T19:09:08.348Z","merge":"2021-09-28T16:43:14.872Z"}XEHG--><!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge| 
 | --- | --- | --- | --- | --- | --- | --- | 
| [#2561](https://github.com/mfem/mfem/pull/2561) | @bslazarov | @tzanio | @stefanozampini + @v-dobrev | 09/22/21 | 09/27/21 | 09/28/21 | |
<!--ELBATXEHG-->