### PR TITLE
Fix reading VTK surface meshes [vtk-surface-fix]

### DIFF
--- a/mesh/mesh_readers.cpp
+++ b/mesh/mesh_readers.cpp
@@ -426,6 +426,28 @@ void Mesh::CreateVTKMesh(const Vector &points, const Array<int> &cell_data,
       j = cell_offsets[i];
    }
 
+   // determine spaceDim based on min/max differences detected each dimension
+   spaceDim = 0;
+   if (np > 0)
+   {
+      double min_value, max_value;
+      for (int d = 3; d > 0; --d)
+      {
+         min_value = max_value = points(3*0 + d-1);
+         for (int i = 1; i < np; i++)
+         {
+            min_value = std::min(min_value, points(3*i + d-1));
+            max_value = std::max(max_value, points(3*i + d-1));
+            if (min_value != max_value)
+            {
+               spaceDim = d;
+               break;
+            }
+         }
+         if (spaceDim > 0) { break; }
+      }
+   }
+
    if (order == 1 && !lagrange_elem)
    {
       NumOfVertices = np;
@@ -500,25 +522,6 @@ void Mesh::CreateVTKMesh(const Vector &points, const Array<int> &cell_data,
       // No boundary is defined in a VTK mesh
       NumOfBdrElements = 0;
 
-      // determine spaceDim based on min/max differences detected each dimension
-      if (vertices.Size() > 0)
-      {
-         double min_value, max_value;
-         for (int d=0; d<3; ++d)
-         {
-            min_value = max_value = vertices[0](d);
-            for (int i = 1; i < vertices.Size(); i++)
-            {
-               min_value = std::min(min_value,vertices[i](d));
-               max_value = std::max(max_value,vertices[i](d));
-               if (min_value != max_value)
-               {
-                  spaceDim++;
-                  break;
-               }
-            }
-         }
-      }
       // Generate faces and edges so that we can define FE space on the mesh
       FinalizeTopology();
 


### PR DESCRIPTION
The mesh space dimension was not set correctly in the VTK mesh reader when reading straight sided surface meshes.

Resolves #2547 and #2563.
<!--GHEX{"id":2566,"author":"pazner","editor":"tzanio","reviewers":["tzanio","bslazarov","mlstowell"],"assignment":"2021-09-23T10:49:37-07:00","approval":"2021-09-27T00:17:43.326Z","merge":"2021-09-27T19:51:43.346Z"}XEHG--><!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge| 
 | --- | --- | --- | --- | --- | --- | --- | 
| [#2566](https://github.com/mfem/mfem/pull/2566) | @pazner | @tzanio | @tzanio + @bslazarov + @mlstowell | 09/23/21 | 09/26/21 | 09/27/21 | |
<!--ELBATXEHG-->