### PR TITLE
Elasticity RB modes - NCMesh

### DIFF
--- a/linalg/hypre.cpp
+++ b/linalg/hypre.cpp
@@ -4590,7 +4590,8 @@ void HypreBoomerAMG::RecomputeRBMs()
 
       rbms.SetSize(nrbms);
       gf_rbms.SetSize(nrbms);
-      gf_rbms[0] = rbms_rxy.ParallelAverage();
+      gf_rbms[0] = fespace->NewTrueDofVector();
+      rbms_rxy.GetTrueDofs(*gf_rbms[0]);
    }
    else if (dim == 3)
    {
@@ -4609,9 +4610,12 @@ void HypreBoomerAMG::RecomputeRBMs()
 
       rbms.SetSize(nrbms);
       gf_rbms.SetSize(nrbms);
-      gf_rbms[0] = rbms_rxy.ParallelAverage();
-      gf_rbms[1] = rbms_ryz.ParallelAverage();
-      gf_rbms[2] = rbms_rzx.ParallelAverage();
+      gf_rbms[0] = fespace->NewTrueDofVector();
+      gf_rbms[1] = fespace->NewTrueDofVector();
+      gf_rbms[2] = fespace->NewTrueDofVector();
+      rbms_rxy.GetTrueDofs(*gf_rbms[0]);
+      rbms_ryz.GetTrueDofs(*gf_rbms[1]);
+      rbms_rzx.GetTrueDofs(*gf_rbms[2]);
    }
    else
    {


### PR DESCRIPTION
Small fix allowing RBM computation for NCMesh. The original implementation calls ParallelAverage() which is not defined for NCMesh. The RBMs are continuous so averaging between the parallel processes is not necessary. 
<!--GHEX{"id":2567,"author":"bslazarov","editor":"tzanio","reviewers":["tzanio","rcarson3","jamiebramwell"],"assignment":"2021-09-24T09:07:33-07:00","approval":"2021-09-27T19:41:35.293Z","merge":"2021-09-28T16:42:35.744Z"}XEHG--><!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge| 
 | --- | --- | --- | --- | --- | --- | --- | 
| [#2567](https://github.com/mfem/mfem/pull/2567) | @bslazarov | @tzanio | @tzanio + @rcarson3 + @jamiebramwell | 09/24/21 | 09/27/21 | 09/28/21 | |
<!--ELBATXEHG-->