### PR TITLE
Fix deprecation warnings for IterativeSolver::print_level

### DIFF
--- a/fem/tmop_tools.cpp
+++ b/fem/tmop_tools.cpp
@@ -444,14 +444,14 @@ double TMOPNewtonSolver::ComputeScalingFactor(const Vector &x,
       if (untangling == false && min_detT_out < 0.0)
       {
          // No untangling, and detJ got negative -- no good.
-         if (print_level >= 0)
+         if (print_options & PrintLevel::WARNINGS)
          { mfem::out << "Scale = " << scale << " Neg det(J) found.\n"; }
          scale *= detJ_factor; continue;
       }
       if (untangling == true && min_detT_out < *min_det_ptr)
       {
          // Untangling, and detJ got even more negative -- no good.
-         if (print_level >= 0)
+         if (print_options & PrintLevel::WARNINGS)
          { mfem::out << "Scale = " << scale << " Neg det(J) decreased.\n"; }
          scale *= detJ_factor; continue;
       }
@@ -477,7 +477,7 @@ double TMOPNewtonSolver::ComputeScalingFactor(const Vector &x,
       if (energy_out > energy_in + 0.2*fabs(energy_in) ||
           std::isnan(energy_out) != 0)
       {
-         if (print_level >= 0)
+         if (print_options & PrintLevel::ITERATION_DETAILS)
          {
             mfem::out << "Scale = " << scale << " Increasing energy: "
                       << energy_in << " --> " << energy_out << '\n';
@@ -492,7 +492,7 @@ double TMOPNewtonSolver::ComputeScalingFactor(const Vector &x,
 
       if (norm_out > 1.2*norm_in)
       {
-         if (print_level >= 0)
+         if (print_options & PrintLevel::ITERATION_DETAILS)
          {
             mfem::out << "Scale = " << scale << " Norm increased: "
                       << norm_in << " --> " << norm_out << '\n';
@@ -508,13 +508,13 @@ double TMOPNewtonSolver::ComputeScalingFactor(const Vector &x,
       if (min_detT_out > 0.0)
       {
          *min_det_ptr = 0.0;
-         if (print_level >= 0)
+         if (print_options & PrintLevel::SUMMARY)
          { mfem::out << "The mesh has been untangled at the used points!\n"; }
       }
       else { *min_det_ptr = untangle_factor * min_detT_out; }
    }
 
-   if (print_level >= 0)
+   if (print_options & PrintLevel::SUMMARY)
    {
       if (untangling)
       {

--- a/linalg/constraints.cpp
+++ b/linalg/constraints.cpp
@@ -327,7 +327,7 @@ void EliminationSolver::Mult(const Vector& rhs, Vector& sol) const
    krylov->SetMaxIter(max_iter);
    krylov->SetRelTol(rel_tol);
    krylov->SetAbsTol(abs_tol);
-   krylov->SetPrintLevel(print_level);
+   krylov->SetPrintLevel(print_options);
 
    Vector rtilde(rhs.Size());
    if (constraint_rhs.Size() > 0)
@@ -447,7 +447,7 @@ void PenaltyConstrainedSolver::Mult(const Vector& b, Vector& x) const
    krylov->SetRelTol(rel_tol);
    krylov->SetAbsTol(abs_tol);
    krylov->SetMaxIter(max_iter);
-   krylov->SetPrintLevel(print_level);
+   krylov->SetPrintLevel(print_options);
    krylov->Mult(penalized_rhs, x);
    final_iter = krylov->GetNumIterations();
    final_norm = krylov->GetFinalNorm();
@@ -574,7 +574,7 @@ void SchurConstrainedSolver::LagrangeSystemMult(const Vector& x,
    gmres->SetRelTol(rel_tol);
    gmres->SetAbsTol(abs_tol);
    gmres->SetMaxIter(max_iter);
-   gmres->SetPrintLevel(print_level);
+   gmres->SetPrintLevel(print_options);
    gmres->SetPreconditioner(
       const_cast<BlockDiagonalPreconditioner&>(*block_pc));
 

--- a/linalg/solvers.cpp
+++ b/linalg/solvers.cpp
@@ -25,6 +25,9 @@ namespace mfem
 
 using namespace std;
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+
 IterativeSolver::IterativeSolver()
    : Solver(0, true)
 {
@@ -49,6 +52,8 @@ IterativeSolver::IterativeSolver(MPI_Comm comm_)
    comm = comm_;
 }
 #endif
+
+#pragma GCC diagnostic pop
 
 double IterativeSolver::Dot(const Vector &x, const Vector &y) const
 {

--- a/linalg/solvers.cpp
+++ b/linalg/solvers.cpp
@@ -26,7 +26,7 @@ namespace mfem
 using namespace std;
 
 IterativeSolver::IterativeSolver()
-   : Solver(0, true), print_level(-1)
+   : Solver(0, true)
 {
    oper = NULL;
    prec = NULL;
@@ -39,7 +39,7 @@ IterativeSolver::IterativeSolver()
 
 #ifdef MFEM_USE_MPI
 IterativeSolver::IterativeSolver(MPI_Comm comm_)
-   : Solver(0, true), print_level(-1)
+   : Solver(0, true)
 {
    oper = NULL;
    prec = NULL;
@@ -91,7 +91,7 @@ void IterativeSolver::SetPrintLevel(int print_lvl)
       else // Suppress output.
       {
          print_level = 0;
-         print_options = static_cast<PrintLevel>(0);
+         print_options = PrintLevel::NONE;
       }
    }
 #endif
@@ -138,23 +138,14 @@ IterativeSolver::PrintLevel IterativeSolver::ConvertFromLegacyPrintLevel(
    switch (print_level)
    {
       case -1:
-         return static_cast<PrintLevel>(0);
-         break;
-
+         return PrintLevel::NONE;
       case 0:
-         return static_cast<PrintLevel>(PrintLevel::ERRORS | PrintLevel::WARNINGS);
-         break;
-
+         return PrintLevel::ERRORS | PrintLevel::WARNINGS;
       case 1:
-         return static_cast<PrintLevel>(PrintLevel::ERRORS | PrintLevel::WARNINGS |
-                                        PrintLevel::ITERATION_DETAILS);
-         break;
-
+         return PrintLevel::ERRORS | PrintLevel::WARNINGS |
+                PrintLevel::ITERATION_DETAILS;
       case 2:
-         return static_cast<PrintLevel>(PrintLevel::ERRORS | PrintLevel::WARNINGS |
-                                        PrintLevel::SUMMARY);
-         break;
-
+         return PrintLevel::ERRORS | PrintLevel::WARNINGS | PrintLevel::SUMMARY;
       default:
 #ifdef MFEM_USE_MPI
          if (rank == 0)
@@ -162,8 +153,7 @@ IterativeSolver::PrintLevel IterativeSolver::ConvertFromLegacyPrintLevel(
             MFEM_WARNING("Unknown print level " << print_level <<
                          ". Defaulting to level 0.");
 
-         return static_cast<PrintLevel>(PrintLevel::ERRORS | PrintLevel::WARNINGS);
-         break;
+         return PrintLevel::ERRORS | PrintLevel::WARNINGS;
    }
 }
 

--- a/linalg/solvers.cpp
+++ b/linalg/solvers.cpp
@@ -26,12 +26,11 @@ namespace mfem
 using namespace std;
 
 IterativeSolver::IterativeSolver()
-   : Solver(0, true)
+   : Solver(0, true), print_level(-1)
 {
    oper = NULL;
    prec = NULL;
    max_iter = 10;
-   print_level = -1;
    rel_tol = abs_tol = 0.0;
 #ifdef MFEM_USE_MPI
    dot_prod_type = 0;
@@ -40,12 +39,11 @@ IterativeSolver::IterativeSolver()
 
 #ifdef MFEM_USE_MPI
 IterativeSolver::IterativeSolver(MPI_Comm comm_)
-   : Solver(0, true)
+   : Solver(0, true), print_level(-1)
 {
    oper = NULL;
    prec = NULL;
    max_iter = 10;
-   print_level = -1;
    rel_tol = abs_tol = 0.0;
    dot_prod_type = 1;
    comm = comm_;
@@ -67,6 +65,9 @@ double IterativeSolver::Dot(const Vector &x, const Vector &y) const
    }
 #endif
 }
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 
 void IterativeSolver::SetPrintLevel(int print_lvl)
 {
@@ -120,6 +121,8 @@ void IterativeSolver::SetPrintLevel(PrintLevel options)
    }
 #endif
 }
+
+#pragma GCC diagnostic pop
 
 IterativeSolver::PrintLevel IterativeSolver::ConvertFromLegacyPrintLevel(
    int print_level)

--- a/linalg/solvers.hpp
+++ b/linalg/solvers.hpp
@@ -71,6 +71,8 @@ public:
      */
    enum PrintLevel
    {
+      /// Don't print any output
+      NONE = 0,
       /** If a fatal problem has been detected some context-specific
           information will be reported
         */
@@ -109,7 +111,7 @@ protected:
 
        See #print_options for more information.
      */
-   MFEM_DEPRECATED int print_level;
+   MFEM_DEPRECATED int print_level = -1;
 
    /** @brief Output behavior for the iterative solver.
 
@@ -118,7 +120,7 @@ protected:
        #print_level to ensure compatibility with custom iterative solvers.
        See PR2519 for some discussion.
      */
-   PrintLevel print_options;
+   PrintLevel print_options = PrintLevel::NONE;
 
    ///@}
 
@@ -233,6 +235,12 @@ public:
 #endif
 };
 
+inline IterativeSolver::PrintLevel operator|(IterativeSolver::PrintLevel a,
+                                             IterativeSolver::PrintLevel b)
+{
+   return static_cast<IterativeSolver::PrintLevel>(
+             static_cast<int>(a) | static_cast<int>(b));
+}
 
 /// Jacobi smoothing for a given bilinear form (no matrix necessary).
 /** Useful with tensorized, partially assembled operators. Can also be defined


### PR DESCRIPTION
I think it's better to deprecate `print_level` rather than just the setter, so that custom solvers that depend on this member variable can change to use `print_options`, and then we will be able to remove the legacy one altogether.