### PR TITLE
Improvements to PrintMatlab [print-matlab]

### DIFF
--- a/linalg/blockmatrix.cpp
+++ b/linalg/blockmatrix.cpp
@@ -571,6 +571,7 @@ void BlockMatrix::PrintMatlab(std::ostream & os) const
          os << i+1 << " " << row_ind[j]+1 << " " << row_data[j] << std::endl;
       }
    }
+   // Write a zero entry at (m,n) to make sure MATLAB doesn't shrink the matrix
    os << row_offsets.Last() << " " << col_offsets.Last () << " 0.0\n";
 
    os.precision(old_prec);

--- a/linalg/blockmatrix.cpp
+++ b/linalg/blockmatrix.cpp
@@ -571,6 +571,7 @@ void BlockMatrix::PrintMatlab(std::ostream & os) const
          os << i+1 << " " << row_ind[j]+1 << " " << row_data[j] << std::endl;
       }
    }
+   os << row_offsets.Last() << " " << col_offsets.Last () << " 0.0\n";
 
    os.precision(old_prec);
    os.flags(old_fmt);

--- a/linalg/blockmatrix.hpp
+++ b/linalg/blockmatrix.hpp
@@ -89,7 +89,7 @@ public:
    //! Returns a monolithic CSR matrix that represents this operator.
    SparseMatrix * CreateMonolithic() const;
    //! Export the monolithic matrix to file.
-   void PrintMatlab(std::ostream & os = mfem::out) const;
+   virtual void PrintMatlab(std::ostream & os = mfem::out) const;
 
    /// @name Matrix interface
    ///@{

--- a/linalg/operator.cpp
+++ b/linalg/operator.cpp
@@ -210,6 +210,11 @@ void Operator::PrintMatlab(std::ostream & out, int n, int m) const
    }
 }
 
+void Operator::PrintMatlab(std::ostream &out) const
+{
+   PrintMatlab(out, width, height);
+}
+
 
 void TimeDependentOperator::ExplicitMult(const Vector &, Vector &) const
 {

--- a/linalg/operator.hpp
+++ b/linalg/operator.hpp
@@ -244,6 +244,9 @@ public:
    /// Prints operator with input size n and output size m in Matlab format.
    void PrintMatlab(std::ostream & out, int n = 0, int m = 0) const;
 
+   /// Prints operator in Matlab format.
+   virtual void PrintMatlab(std::ostream & out) const;
+
    /// Virtual destructor.
    virtual ~Operator() { }
 

--- a/linalg/sparsemat.cpp
+++ b/linalg/sparsemat.cpp
@@ -3098,6 +3098,7 @@ void SparseMatrix::PrintMatlab(std::ostream & out) const
          out << i+1 << " " << J[j]+1 << " " << A[j] << '\n';
       }
    }
+   // Write a zero entry at (m,n) to make sure MATLAB doesn't shrink the matrix
    out << height << " " << width << " 0.0\n";
    out.precision(old_prec);
    out.flags(old_fmt);

--- a/linalg/sparsemat.cpp
+++ b/linalg/sparsemat.cpp
@@ -3098,6 +3098,7 @@ void SparseMatrix::PrintMatlab(std::ostream & out) const
          out << i+1 << " " << J[j]+1 << " " << A[j] << '\n';
       }
    }
+   out << height << " " << width << " 0.0\n";
    out.precision(old_prec);
    out.flags(old_fmt);
 }

--- a/linalg/sparsemat.hpp
+++ b/linalg/sparsemat.hpp
@@ -574,7 +574,7 @@ public:
    void Print(std::ostream &out = mfem::out, int width_ = 4) const;
 
    /// Prints matrix in matlab format.
-   void PrintMatlab(std::ostream &out = mfem::out) const;
+   virtual void PrintMatlab(std::ostream &out = mfem::out) const;
 
    /// Prints matrix in Matrix Market sparse format.
    void PrintMM(std::ostream &out = mfem::out) const;


### PR DESCRIPTION
Make `Operator::PrintMatlab` virtual, and output zero entry in last row and column to preserve matrix size.

Resolves #2515.
<!--GHEX{"id":2578,"author":"pazner","editor":"tzanio","reviewers":["tzanio","bslazarov"],"assignment":"2021-09-28T13:52:37-07:00","approval":"2021-09-28T21:44:45.619Z","merge":"2021-09-30T03:57:55.152Z"}XEHG--><!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge| 
 | --- | --- | --- | --- | --- | --- | --- | 
| [#2578](https://github.com/mfem/mfem/pull/2578) | @pazner | @tzanio | @tzanio + @bslazarov | 09/28/21 | 09/28/21 | 09/29/21 | |
<!--ELBATXEHG-->