### PR TITLE
Fix for BR2 integrator [br2-fix]

### DIFF
--- a/fem/bilininteg_br2.cpp
+++ b/fem/bilininteg_br2.cpp
@@ -162,10 +162,6 @@ void DGDiffusionBR2Integrator::AssembleFaceMatrix(
       }
 
       double w = factor*sqrt(eta)*ip.weight*Trans.Face->Weight();
-      if (ndof2)
-      {
-         w /= 2;
-      }
 
       for (int i = 0; i < ndof1; i++)
       {


### PR DESCRIPTION
Removes an unnecessary factor of 0.5 in the BR2 integrator penalty term for DG diffusion. BR2 should always work with `kappa = 0`, `eta = 1`, but it was failing (the operator was indefinite) for highly distorted meshes.

Thanks for @smsolivier for bringing this to my attention. 