### PR TITLE
Do not re-install all the dependencies when CI is running on master

### DIFF
--- a/tests/gitlab/build_and_test
+++ b/tests/gitlab/build_and_test
@@ -123,7 +123,7 @@ then
     fi
 
     upstream_opt=""
-    if [[ ${CI_COMMIT_BRANCH:-"master"} != "master" && ${sys_type} != "" ]]
+    if [[ ${sys_type} != "" ]]
     then
         upstream_opt="--upstream=/usr/workspace/mfem/mfem-dependencies/install"
     fi


### PR DESCRIPTION
Short fix that should workaround random failures when spack tries to fetch petsc.
We are not building dependencies for master branch anymore.
Instead, we use the dependencies already installed in the upstream mfem-spack instance.
<!--GHEX{"id":2580,"author":"adrienbernede","editor":"tzanio","reviewers":["tzanio","jandrej"],"assignment":"2021-09-29T10:51:05-07:00","approval":"2021-09-29T22:18:09.172Z","merge":"2021-09-29T22:19:34.854Z"}XEHG--><!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge| 
 | --- | --- | --- | --- | --- | --- | --- | 
| [#2580](https://github.com/mfem/mfem/pull/2580) | @adrienbernede | @tzanio | @tzanio + @jandrej | 09/29/21 | 09/29/21 | 09/29/21 | |
<!--ELBATXEHG-->