### PR TITLE
Specify a custom directory to be used by the Gitlab CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -27,6 +27,9 @@
 stages:
   - sub-pipelines
 
+variables:
+  CUSTOM_CI_BUILDS_DIR: "/usr/workspace/mfem/gitlab-runner"
+
 # Trigger subpipelines:
 quartz-build-and-test:
   stage: sub-pipelines


### PR DESCRIPTION
This should fix an issue with the new version of the Gitlab CI.
<!--GHEX{"id":2594,"author":"v-dobrev","editor":"v-dobrev","reviewers":["v-dobrev","jandrej","pazner"],"assignment":"2021-10-06T16:49:26-07:00","approval":"2021-10-07T03:38:50.753Z","merge":"2021-10-07T03:48:20.151Z"}XEHG--><!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge| 
 | --- | --- | --- | --- | --- | --- | --- | 
| [#2594](https://github.com/mfem/mfem/pull/2594) | @v-dobrev | @v-dobrev | @v-dobrev + @jandrej + @pazner | 10/06/21 | 10/06/21 | 10/06/21 | |
<!--ELBATXEHG-->