### PR TITLE
Fix bug in CEED integration

### DIFF
--- a/fem/ceed/util.cpp
+++ b/fem/ceed/util.cpp
@@ -186,14 +186,18 @@ static void InitTensorBasis(const mfem::FiniteElementSpace &fes,
    const int ndofs = maps.ndof;
    const int nqpts = maps.nqpt;
    mfem::Vector qX(nqpts), qW(nqpts);
-   const mfem::IntegrationRule &ir1d =
-      IntRules.Get(Geometry::SEGMENT, ir.GetOrder());
+   // The x-coordinates of the first `nqpts` points of the integration rule are
+   // the points of the corresponding 1D rule. We also scale the weights
+   // accordingly.
+   double w_sum = 0.0;
    for (int i = 0; i < nqpts; i++)
    {
-      const mfem::IntegrationPoint &ip = ir1d.IntPoint(i);
+      const mfem::IntegrationPoint &ip = ir.IntPoint(i);
       qX(i) = ip.x;
       qW(i) = ip.weight;
+      w_sum += ip.weight;
    }
+   qW *= 1.0/w_sum;
    CeedBasisCreateTensorH1(ceed, mesh->Dimension(), fes.GetVDim(), ndofs,
                            nqpts, maps.Bt.GetData(),
                            maps.Gt.GetData(), qX.GetData(),

--- a/tests/unit/ceed/test_ceed.cpp
+++ b/tests/unit/ceed/test_ceed.cpp
@@ -393,7 +393,7 @@ void test_ceed_convection(const char* input, int order,
    ConvectionIntegrator *conv_integ = new ConvectionIntegrator(velocity_coeff, 1);
    conv_integ->SetIntRule(&ir);
    conv_op.AddDomainIntegrator(conv_integ);
-   conv_op.SetAssemblyLevel(AssemblyLevel::PARTIAL);
+   conv_op.SetAssemblyLevel(assembly);
    conv_op.Assemble();
 
    GridFunction q(&fes), r(&fes), ex(&fes);


### PR DESCRIPTION
The requested integration rule was assumed to be `GaussLegendre` (because it uses the `IntRules` global object), but this is not always the case (if the user passes in an integration rule of a different type).

<!--GHEX{"id":2598,"author":"pazner","editor":"v-dobrev","reviewers":["YohannDudouit","jandrej"],"assignment":"2021-10-14T16:52:59-07:00","approval":"2021-10-15T00:06:45.113Z","merge":"2021-10-29T23:03:43.003Z"}XEHG--><!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge| 
 | --- | --- | --- | --- | --- | --- | --- | 
| [#2598](https://github.com/mfem/mfem/pull/2598) | @pazner | @v-dobrev | @YohannDudouit + @jandrej | 10/14/21 | 10/14/21 | 10/29/21 | |
<!--ELBATXEHG-->