### PR TITLE
Improved device compilation.

### DIFF
--- a/general/forall.hpp
+++ b/general/forall.hpp
@@ -190,7 +190,7 @@ template <>
 struct RajaCuWrap<1>
 {
    template <const int BLCK = MFEM_CUDA_BLOCKS, typename DBODY>
-   void operator()(const int N, DBODY &&d_body,
+   static void run(const int N, DBODY &&d_body,
                    const int X, const int Y, const int Z, const int G)
    {
       RajaCuWrap1D<BLCK>(N, d_body);
@@ -201,7 +201,7 @@ template <>
 struct RajaCuWrap<2>
 {
    template <const int BLCK = MFEM_CUDA_BLOCKS, typename DBODY>
-   void operator()(const int N, DBODY &&d_body,
+   static void run(const int N, DBODY &&d_body,
                    const int X, const int Y, const int Z, const int G)
    {
       RajaCuWrap2D(N, d_body, X, Y, Z);
@@ -212,7 +212,7 @@ template <>
 struct RajaCuWrap<3>
 {
    template <const int BLCK = MFEM_CUDA_BLOCKS, typename DBODY>
-   void operator()(const int N, DBODY &&d_body,
+   static void run(const int N, DBODY &&d_body,
                    const int X, const int Y, const int Z, const int G)
    {
       RajaCuWrap3D(N, d_body, X, Y, Z, G);
@@ -292,7 +292,7 @@ template <>
 struct RajaHipWrap<1>
 {
    template <const int BLCK = MFEM_CUDA_BLOCKS, typename DBODY>
-   void operator()(const int N, DBODY &&d_body,
+   static void run(const int N, DBODY &&d_body,
                    const int X, const int Y, const int Z, const int G)
    {
       RajaHipWrap1D<BLCK>(N, d_body);
@@ -303,7 +303,7 @@ template <>
 struct RajaHipWrap<2>
 {
    template <const int BLCK = MFEM_CUDA_BLOCKS, typename DBODY>
-   void operator()(const int N, DBODY &&d_body,
+   static void run(const int N, DBODY &&d_body,
                    const int X, const int Y, const int Z, const int G)
    {
       RajaHipWrap2D(N, d_body, X, Y, Z);
@@ -314,7 +314,7 @@ template <>
 struct RajaHipWrap<3>
 {
    template <const int BLCK = MFEM_CUDA_BLOCKS, typename DBODY>
-   void operator()(const int N, DBODY &&d_body,
+   static void run(const int N, DBODY &&d_body,
                    const int X, const int Y, const int Z, const int G)
    {
       RajaHipWrap3D(N, d_body, X, Y, Z, G);
@@ -413,7 +413,7 @@ template <>
 struct CuWrap<1>
 {
    template <const int BLCK = MFEM_CUDA_BLOCKS, typename DBODY>
-   void operator()(const int N, DBODY &&d_body,
+   static void run(const int N, DBODY &&d_body,
                    const int X, const int Y, const int Z, const int G)
    {
       CuWrap1D<BLCK>(N, d_body);
@@ -424,7 +424,7 @@ template <>
 struct CuWrap<2>
 {
    template <const int BLCK = MFEM_CUDA_BLOCKS, typename DBODY>
-   void operator()(const int N, DBODY &&d_body,
+   static void run(const int N, DBODY &&d_body,
                    const int X, const int Y, const int Z, const int G)
    {
       CuWrap2D(N, d_body, X, Y, Z);
@@ -435,7 +435,7 @@ template <>
 struct CuWrap<3>
 {
    template <const int BLCK = MFEM_CUDA_BLOCKS, typename DBODY>
-   void operator()(const int N, DBODY &&d_body,
+   static void run(const int N, DBODY &&d_body,
                    const int X, const int Y, const int Z, const int G)
    {
       CuWrap3D(N, d_body, X, Y, Z, G);
@@ -508,7 +508,7 @@ template <>
 struct HipWrap<1>
 {
    template <const int BLCK = MFEM_CUDA_BLOCKS, typename DBODY>
-   void operator()(const int N, DBODY &&d_body,
+   static void run(const int N, DBODY &&d_body,
                    const int X, const int Y, const int Z, const int G)
    {
       HipWrap1D<BLCK>(N, d_body);
@@ -519,7 +519,7 @@ template <>
 struct HipWrap<2>
 {
    template <const int BLCK = MFEM_CUDA_BLOCKS, typename DBODY>
-   void operator()(const int N, DBODY &&d_body,
+   static void run(const int N, DBODY &&d_body,
                    const int X, const int Y, const int Z, const int G)
    {
       HipWrap2D(N, d_body, X, Y, Z);
@@ -530,7 +530,7 @@ template <>
 struct HipWrap<3>
 {
    template <const int BLCK = MFEM_CUDA_BLOCKS, typename DBODY>
-   void operator()(const int N, DBODY &&d_body,
+   static void run(const int N, DBODY &&d_body,
                    const int X, const int Y, const int Z, const int G)
    {
       HipWrap3D(N, d_body, X, Y, Z, G);
@@ -558,7 +558,7 @@ inline void ForallWrap(const bool use_dev, const int N,
    // If Backend::RAJA_CUDA is allowed, use it
    if (Device::Allows(Backend::RAJA_CUDA))
    {
-      return RajaCuWrap<DIM>(N, d_body, X, Y, Z, G);
+      return RajaCuWrap<DIM>::run(N, d_body, X, Y, Z, G);
    }
 #endif
 
@@ -566,7 +566,7 @@ inline void ForallWrap(const bool use_dev, const int N,
    // If Backend::RAJA_HIP is allowed, use it
    if (Device::Allows(Backend::RAJA_HIP))
    {
-      return RajaHipWrap<DIM>(N, d_body, X, Y, Z, G);
+      return RajaHipWrap<DIM>::run(N, d_body, X, Y, Z, G);
    }
 #endif
 
@@ -574,7 +574,7 @@ inline void ForallWrap(const bool use_dev, const int N,
    // If Backend::CUDA is allowed, use it
    if (Device::Allows(Backend::CUDA))
    {
-      return CuWrap<DIM>(N, d_body, X, Y, Z, G);
+      return CuWrap<DIM>::run(N, d_body, X, Y, Z, G);
    }
 #endif
 
@@ -582,7 +582,7 @@ inline void ForallWrap(const bool use_dev, const int N,
    // If Backend::HIP is allowed, use it
    if (Device::Allows(Backend::HIP))
    {
-      return HipWrap<DIM>(N, d_body, X, Y, Z, G);
+      return HipWrap<DIM>::run(N, d_body, X, Y, Z, G);
    }
 #endif
 


### PR DESCRIPTION
It appears that the compiler is not optimizing some `if(false)` resulting in 3 kernels (for all kernels) being compiled instead of just 1. This PR wraps the execution policies to avoid this compilation pitfall.

Using `make clean; time make pcuda CUDA_ARCH=sm_70 MFEM_USE_BENCHMARK=YES MFEM_USE_CEED=YES -j32` on Lassen:
From:
```
real	3m5.816s
user	49m39.718s
sys	1m48.213s
```
To:
```
real	1m53.853s
user	41m45.493s
sys	1m50.766s
```
<!--GHEX{"id":2612,"author":"YohannDudouit","editor":"tzanio","reviewers":["artv3","camierjs","jandrej"],"assignment":"2021-10-16T18:48:31-07:00","approval":"2021-10-26T20:34:41.591Z","merge":"2021-10-29T15:00:21.708Z"}XEHG--><!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge| 
 | --- | --- | --- | --- | --- | --- | --- | 
| [#2612](https://github.com/mfem/mfem/pull/2612) | @YohannDudouit | @tzanio | @artv3 + @camierjs + @jandrej | 10/16/21 | 10/26/21 | 10/29/21 | |
<!--ELBATXEHG-->