### PR TITLE
Gitlab CI updates

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -29,36 +29,34 @@ stages:
 
 variables:
   CUSTOM_CI_BUILDS_DIR: "/usr/workspace/mfem/gitlab-runner"
+  USER_CI_TOP_DIR: "${CUSTOM_CI_BUILDS_DIR}/${GITLAB_USER_LOGIN}"
+  SHARED_REPOS_DIR: "${USER_CI_TOP_DIR}/repos"
+  AUTOTEST_ROOT: "${SHARED_REPOS_DIR}"
+  # MFEM_DATA_DIR is setup in '.gitlab/configs/setup-build-and-test.yml' and
+  # used in '.gitlab/configs/<machine>-config.yml':
+  MFEM_DATA_DIR: "${SHARED_REPOS_DIR}/mfem-data"
 
 # Trigger subpipelines:
 quartz-build-and-test:
   stage: sub-pipelines
-  variables:
-    _AUTOTEST: $AUTOTEST
   trigger:
     include: .gitlab/quartz-build-and-test.yml
     strategy: depend
 
 quartz-baseline:
   stage: sub-pipelines
-  variables:
-    _AUTOTEST: $AUTOTEST
   trigger:
     include: .gitlab/quartz-baseline.yml
     strategy: depend
 
 lassen-build-and-test:
   stage: sub-pipelines
-  variables:
-    _AUTOTEST: $AUTOTEST
   trigger:
     include: .gitlab/lassen-build-and-test.yml
     strategy: depend
 
 corona-build-and-test:
   stage: sub-pipelines
-  variables:
-    _AUTOTEST: $AUTOTEST
   trigger:
     include: .gitlab/corona-build-and-test.yml
     strategy: depend

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -52,32 +52,36 @@ variables:
 # Trigger subpipelines:
 quartz-build-and-test:
   stage: sub-pipelines
-  inherit:
-    variables: true
+  variables:
+    AUTOTEST: "${AUTOTEST}"
+    AUTOTEST_COMMIT: "${AUTOTEST_COMMIT}"
   trigger:
     include: .gitlab/quartz-build-and-test.yml
     strategy: depend
 
 quartz-baseline:
   stage: sub-pipelines
-  inherit:
-    variables: true
+  variables:
+    AUTOTEST: "${AUTOTEST}"
+    AUTOTEST_COMMIT: "${AUTOTEST_COMMIT}"
   trigger:
     include: .gitlab/quartz-baseline.yml
     strategy: depend
 
 lassen-build-and-test:
   stage: sub-pipelines
-  inherit:
-    variables: true
+  variables:
+    AUTOTEST: "${AUTOTEST}"
+    AUTOTEST_COMMIT: "${AUTOTEST_COMMIT}"
   trigger:
     include: .gitlab/lassen-build-and-test.yml
     strategy: depend
 
 corona-build-and-test:
   stage: sub-pipelines
-  inherit:
-    variables: true
+  variables:
+    AUTOTEST: "${AUTOTEST}"
+    AUTOTEST_COMMIT: "${AUTOTEST_COMMIT}"
   trigger:
     include: .gitlab/corona-build-and-test.yml
     strategy: depend

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -39,22 +39,22 @@ variables:
 # Defines the default choice for updating the saved baseline results. By default
 # the baseline can only be updated from the master branch. This variable offers
 # the option to manually ask for rebaselining from another branch if necessary.
-  REBASELINE: "NO"
-  AUTOTEST: "NO"
+  # REBASELINE: "NO"  # keep commented out
+  # AUTOTEST: "NO"    # keep commented out
   # AUTOTEST_COMMIT: used only when AUTOTEST is set to YES.
-  # * If AUTOTEST_COMMIT is set to YES (default), reporting jobs will commit
-  #   their files to the MFEM/autotest repo.
-  # * If AUTOTEST_COMMIT is set to NO, reporting jobs will NOT commit their
+  # * If AUTOTEST_COMMIT is set to YES, reporting jobs will commit their files
+  #   to the MFEM/autotest repo.
+  # * If AUTOTEST_COMMIT is NOT set to YES, reporting jobs will NOT commit their
   #   files to the MFEM/autotest repo. Instead they will just show the contents
   #   of the report files and remove them.
-  AUTOTEST_COMMIT: "YES"
+  # AUTOTEST_COMMIT: "NO"   # keep commented out
 
 # Trigger subpipelines:
 quartz-build-and-test:
   stage: sub-pipelines
-  variables:
-    AUTOTEST: "${AUTOTEST}"
-    AUTOTEST_COMMIT: "${AUTOTEST_COMMIT}"
+  # variables:
+  #   AUTOTEST: "${AUTOTEST}"
+  #   AUTOTEST_COMMIT: "${AUTOTEST_COMMIT}"
   trigger:
     include: .gitlab/quartz-build-and-test.yml
     strategy: depend
@@ -62,6 +62,7 @@ quartz-build-and-test:
 quartz-baseline:
   stage: sub-pipelines
   variables:
+    REBASELINE: "${REBASELINE}"
     AUTOTEST: "${AUTOTEST}"
     AUTOTEST_COMMIT: "${AUTOTEST_COMMIT}"
   trigger:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -36,6 +36,19 @@ variables:
   # used in '.gitlab/configs/<machine>-config.yml':
   MFEM_DATA_DIR: "${SHARED_REPOS_DIR}/mfem-data"
 
+# Defines the default choice for updating the saved baseline results. By default
+# the baseline can only be updated from the master branch. This variable offers
+# the option to manually ask for rebaselining from another branch if necessary.
+  REBASELINE: "NO"
+  AUTOTEST: "NO"
+  # AUTOTEST_COMMIT: used only when AUTOTEST is set to YES.
+  # * If AUTOTEST_COMMIT is set to YES (default), reporting jobs will commit
+  #   their files to the MFEM/autotest repo.
+  # * If AUTOTEST_COMMIT is set to NO, reporting jobs will NOT commit their
+  #   files to the MFEM/autotest repo. Instead they will just show the contents
+  #   of the report files and remove them.
+  AUTOTEST_COMMIT: "YES"
+
 # Trigger subpipelines:
 quartz-build-and-test:
   stage: sub-pipelines

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -52,24 +52,32 @@ variables:
 # Trigger subpipelines:
 quartz-build-and-test:
   stage: sub-pipelines
+  inherit:
+    variables: true
   trigger:
     include: .gitlab/quartz-build-and-test.yml
     strategy: depend
 
 quartz-baseline:
   stage: sub-pipelines
+  inherit:
+    variables: true
   trigger:
     include: .gitlab/quartz-baseline.yml
     strategy: depend
 
 lassen-build-and-test:
   stage: sub-pipelines
+  inherit:
+    variables: true
   trigger:
     include: .gitlab/lassen-build-and-test.yml
     strategy: depend
 
 corona-build-and-test:
   stage: sub-pipelines
+  inherit:
+    variables: true
   trigger:
     include: .gitlab/corona-build-and-test.yml
     strategy: depend

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -39,22 +39,24 @@ variables:
 # Defines the default choice for updating the saved baseline results. By default
 # the baseline can only be updated from the master branch. This variable offers
 # the option to manually ask for rebaselining from another branch if necessary.
-  # REBASELINE: "NO"  # keep commented out
-  # AUTOTEST: "NO"    # keep commented out
+  REBASELINE: "NO"
+  AUTOTEST: "NO"
   # AUTOTEST_COMMIT: used only when AUTOTEST is set to YES.
-  # * If AUTOTEST_COMMIT is set to YES, reporting jobs will commit their files
-  #   to the MFEM/autotest repo.
-  # * If AUTOTEST_COMMIT is NOT set to YES, reporting jobs will NOT commit their
+  # * If AUTOTEST_COMMIT is NOT set to NO, reporting jobs will commit their
+  #   files to the MFEM/autotest repo.
+  # * If AUTOTEST_COMMIT is set to NO, reporting jobs will NOT commit their
   #   files to the MFEM/autotest repo. Instead they will just show the contents
   #   of the report files and remove them.
-  # AUTOTEST_COMMIT: "NO"   # keep commented out
+  AUTOTEST_COMMIT: "YES"
 
 # Trigger subpipelines:
 quartz-build-and-test:
   stage: sub-pipelines
-  # variables:
-  #   AUTOTEST: "${AUTOTEST}"
-  #   AUTOTEST_COMMIT: "${AUTOTEST_COMMIT}"
+  variables:
+    # Explicitly pass down values that we want to be able to set when triggering
+    # pipelines manually or using scheduling
+    AUTOTEST: "${AUTOTEST}"
+    AUTOTEST_COMMIT: "${AUTOTEST_COMMIT}"
   trigger:
     include: .gitlab/quartz-build-and-test.yml
     strategy: depend
@@ -62,6 +64,8 @@ quartz-build-and-test:
 quartz-baseline:
   stage: sub-pipelines
   variables:
+    # Explicitly pass down values that we want to be able to set when triggering
+    # pipelines manually or using scheduling
     REBASELINE: "${REBASELINE}"
     AUTOTEST: "${AUTOTEST}"
     AUTOTEST_COMMIT: "${AUTOTEST_COMMIT}"
@@ -72,6 +76,8 @@ quartz-baseline:
 lassen-build-and-test:
   stage: sub-pipelines
   variables:
+    # Explicitly pass down values that we want to be able to set when triggering
+    # pipelines manually or using scheduling
     AUTOTEST: "${AUTOTEST}"
     AUTOTEST_COMMIT: "${AUTOTEST_COMMIT}"
   trigger:
@@ -81,6 +87,8 @@ lassen-build-and-test:
 corona-build-and-test:
   stage: sub-pipelines
   variables:
+    # Explicitly pass down values that we want to be able to set when triggering
+    # pipelines manually or using scheduling
     AUTOTEST: "${AUTOTEST}"
     AUTOTEST_COMMIT: "${AUTOTEST_COMMIT}"
   trigger:

--- a/.gitlab/configs/common.yml
+++ b/.gitlab/configs/common.yml
@@ -25,19 +25,6 @@ variables:
 # are sure to retrieve it.
   ALLOC_NAME: ${CI_PROJECT_NAME}_ci_${CI_PIPELINE_ID}
 
-# Defines the default choice for updating the saved baseline results. By default
-# the baseline can only be updated from the master branch. This variable offers
-# the option to manually ask for rebaselining from another branch if necessary.
-  REBASELINE: "NO"
-  AUTOTEST: "NO"
-  # AUTOTEST_COMMIT: used only when AUTOTEST is set to YES.
-  # * If AUTOTEST_COMMIT is set to YES (default), reporting jobs will commit
-  #   their files to the MFEM/autotest repo.
-  # * If AUTOTEST_COMMIT is set to NO, reporting jobs will NOT commit their
-  #   files to the MFEM/autotest repo. Instead they will just show the contents
-  #   of the report files and remove them.
-  AUTOTEST_COMMIT: "YES"
-
 # Git repositories used in the pipeline
   TPLS_REPO: ssh://git@mybitbucket.llnl.gov:7999/mfem/tpls.git
   TESTS_REPO: ssh://git@mybitbucket.llnl.gov:7999/mfem/tests.git

--- a/.gitlab/configs/common.yml
+++ b/.gitlab/configs/common.yml
@@ -18,7 +18,7 @@ variables:
 # the pipeline, preventing any form of concurrency with other pipelines. This
 # also means that the BUILD_ROOT directory will never be cleaned.
 # TODO: add a clean-up mechanism
-  BUILD_ROOT: ${CI_BUILDS_DIR}/MFEM_${MACHINE_NAME}/${CI_PROJECT_NAME}_${CI_COMMIT_REF_SLUG}_${CI_PIPELINE_ID}
+  BUILD_ROOT: ${USER_CI_TOP_DIR}/${CI_PROJECT_NAME}-${MACHINE_NAME}-pipeline-${CI_PIPELINE_ID}
 
 # On LLNL's quartz, there is only one allocation shared among jobs in order to
 # save time and resource. This allocation has to be uniquely named so that we
@@ -28,8 +28,15 @@ variables:
 # Defines the default choice for updating the saved baseline results. By default
 # the baseline can only be updated from the master branch. This variable offers
 # the option to manually ask for rebaselining from another branch if necessary.
-  _REBASELINE: "NO"
-  _AUTOTEST: "NO"
+  REBASELINE: "NO"
+  AUTOTEST: "NO"
+  # AUTOTEST_COMMIT: used only when AUTOTEST is set to YES.
+  # * If AUTOTEST_COMMIT is set to YES (default), reporting jobs will commit
+  #   their files to the MFEM/autotest repo.
+  # * If AUTOTEST_COMMIT is set to NO, reporting jobs will NOT commit their
+  #   files to the MFEM/autotest repo. Instead they will just show the contents
+  #   of the report files and remove them.
+  AUTOTEST_COMMIT: "YES"
 
 # Git repositories used in the pipeline
   TPLS_REPO: ssh://git@mybitbucket.llnl.gov:7999/mfem/tpls.git
@@ -40,5 +47,3 @@ variables:
 # Directory used to place artifacts.
   ARTIFACTS_DIR: artifacts
   SLURM_OVERLAP: 1
-
-

--- a/.gitlab/configs/corona-config.yml
+++ b/.gitlab/configs/corona-config.yml
@@ -26,16 +26,19 @@ variables:
     - if: '$CI_COMMIT_BRANCH =~ /_cnone/ || $ON_CORONA != "ON"'
       when: never
     # Don’t run autotest update if...
-    - if: '$CI_JOB_NAME =~ /report/ && $_AUTOTEST != "YES"'
+    - if: '$CI_JOB_NAME =~ /report/ && $AUTOTEST != "YES"'
       when: never
     # Report success on success status
-    - if: '$CI_JOB_NAME =~ /report_job_success/ && $_AUTOTEST == "YES"'
+    - if: '$CI_JOB_NAME =~ /report_job_success/ && $AUTOTEST == "YES"'
       when: on_success
     # Report failure on failure status
-    - if: '$CI_JOB_NAME =~ /report_job_failure/ && $_AUTOTEST == "YES"'
+    - if: '$CI_JOB_NAME =~ /report_job_failure/ && $AUTOTEST == "YES"'
       when: on_failure
     # Always release resource
     - if: '$CI_JOB_NAME =~ /release_resource/'
+      when: always
+    # Always cleanup
+    - if: '$CI_JOB_NAME =~ /cleanup/'
       when: always
     # Default is to run if previous stage succeeded
     - when: on_success
@@ -46,9 +49,11 @@ variables:
   extends: [.on_corona]
   stage: build_and_test
   script:
+    # THREADS is used by 'tests/gitlab/build_and_test', run below
     - export THREADS=12
     - echo ${ALLOC_NAME}
     - export JOBID=$(squeue -h --name=${ALLOC_NAME} --format=%A)
     - echo ${JOBID}
-    - srun $( [[ -n "${JOBID}" ]] && echo "--jobid=${JOBID}" ) -t 15 -N 1 tests/gitlab/build_and_test --spec "${SPEC}" --build-root "${BUILD_ROOT}" --data
-
+    - echo ${MFEM_DATA_DIR}
+    - echo ${SPEC}
+    - srun $( [[ -n "${JOBID}" ]] && echo "--jobid=${JOBID}" ) -t 15 -N 1 tests/gitlab/build_and_test --spec "${SPEC}" --data-dir "${MFEM_DATA_DIR}" --data

--- a/.gitlab/configs/lassen-config.yml
+++ b/.gitlab/configs/lassen-config.yml
@@ -21,14 +21,17 @@ variables:
     - if: '$CI_COMMIT_BRANCH =~ /_lnone/ || $ON_LASSEN == "OFF"' #run except if ...
       when: never
     # Don't run autotest update if...
-    - if: '$CI_JOB_NAME =~ /report/ && $_AUTOTEST != "YES"'
+    - if: '$CI_JOB_NAME =~ /report/ && $AUTOTEST != "YES"'
       when: never
     # Report success on success status
-    - if: '$CI_JOB_NAME =~ /report_job_success/ && $_AUTOTEST == "YES"'
+    - if: '$CI_JOB_NAME =~ /report_job_success/ && $AUTOTEST == "YES"'
       when: on_success
     # Report failure on failure status
-    - if: '$CI_JOB_NAME =~ /report_job_failure/ && $_AUTOTEST == "YES"'
+    - if: '$CI_JOB_NAME =~ /report_job_failure/ && $AUTOTEST == "YES"'
       when: on_failure
+    # Always cleanup
+    - if: '$CI_JOB_NAME =~ /cleanup/'
+      when: always
     - when: on_success
 
 # Lassen uses a different job scheduler (spectrum lsf) that does not allow
@@ -39,5 +42,8 @@ variables:
   extends: [.on_lassen]
   stage: build_and_test
   script:
-    - lalloc 1 -W 30 -q pdebug tests/gitlab/build_and_test --spec "${SPEC}" --build-root "${BUILD_ROOT}" --data
+    - echo ${MFEM_DATA_DIR}
+    - echo ${SPEC}
+    # Next script uses 'THREADS': leaving it empty --> it uses 'make all -j'
+    - lalloc 1 -W 30 -q pdebug tests/gitlab/build_and_test --spec "${SPEC}" --data-dir "${MFEM_DATA_DIR}" --data
   needs: [setup]

--- a/.gitlab/configs/quartz-config.yml
+++ b/.gitlab/configs/quartz-config.yml
@@ -22,16 +22,19 @@ variables:
     - if: '$CI_COMMIT_BRANCH =~ /_qnone/ || $ON_QUARTZ == "OFF"'
       when: never
     # Don't run autotest update if...
-    - if: '$CI_JOB_NAME =~ /report/ && $_AUTOTEST != "YES"'
+    - if: '$CI_JOB_NAME =~ /report/ && $AUTOTEST != "YES"'
       when: never
     # Report success on success status
-    - if: '$CI_JOB_NAME =~ /report_job_success/ && $_AUTOTEST == "YES"'
+    - if: '$CI_JOB_NAME =~ /report_job_success/ && $AUTOTEST == "YES"'
       when: on_success
     # Report failure on failure status
-    - if: '$CI_JOB_NAME =~ /report_job_failure/ && $_AUTOTEST == "YES"'
+    - if: '$CI_JOB_NAME =~ /report_job_failure/ && $AUTOTEST == "YES"'
       when: on_failure
     # Always release resource
     - if: '$CI_JOB_NAME =~ /release_resource/'
+      when: always
+    # Always cleanup
+    - if: '$CI_JOB_NAME =~ /cleanup/'
       when: always
     # Default is to run if previous stage succeeded
     - when: on_success
@@ -42,9 +45,11 @@ variables:
   extends: [.on_quartz]
   stage: build_and_test
   script:
+    # THREADS is used by 'tests/gitlab/build_and_test', run below
     - export THREADS=12
     - echo ${ALLOC_NAME}
     - export JOBID=$(squeue -h --name=${ALLOC_NAME} --format=%A)
     - echo ${JOBID}
-    - srun $( [[ -n "${JOBID}" ]] && echo "--jobid=${JOBID}" ) -t 30 -N 1 tests/gitlab/build_and_test --spec "${SPEC}" --build-root "${BUILD_ROOT}" --data
-
+    - echo ${MFEM_DATA_DIR}
+    - echo ${SPEC}
+    - srun $( [[ -n "${JOBID}" ]] && echo "--jobid=${JOBID}" ) -t 30 -N 1 tests/gitlab/build_and_test --spec "${SPEC}" --data-dir "${MFEM_DATA_DIR}" --data

--- a/.gitlab/configs/report-build-and-test.yml
+++ b/.gitlab/configs/report-build-and-test.yml
@@ -1,0 +1,79 @@
+# Copyright (c) 2010-2021, Lawrence Livermore National Security, LLC. Produced
+# at the Lawrence Livermore National Laboratory. All Rights reserved. See files
+# LICENSE and NOTICE for details. LLNL-CODE-806117.
+#
+# This file is part of the MFEM library. For more information and source code
+# availability visit https://mfem.org.
+#
+# MFEM is free software; you can redistribute it and/or modify it under the
+# terms of the BSD-3 license. We welcome feedback and contributions, see file
+# CONTRIBUTING.md for details.
+
+# Jobs report
+.report_job_success:
+  script:
+    # DEBUG
+    - export
+    - echo "AUTOTEST_ROOT ${AUTOTEST_ROOT}"
+    - cd ${AUTOTEST_ROOT}
+    - |
+      (
+        date
+        echo "Waiting to aquire lock on '$PWD/autotest.lock' ..."
+        # try to get an excusive lock on fd 9 (autotest.lock) repeating the try
+        # every 5 seconds; simply using no timeout, i.e. 'flock 9', causes the
+        # command to hang indefinitely sometimes, so we use the timeout & retry
+        # as a workaround; we may want to add a counter for the number of
+        # retries to interrupt a potential infinite loop
+        while ! flock -w 5 9; do
+          true
+        done
+        echo "Aquired lock on '$PWD/autotest.lock'"
+        date
+        # Report SUCCESS while holding the file lock on 'autotest.lock'.
+        # The next script uses the following environment variables:
+        # - MACHINE_NAME, AUTOTEST_ROOT, AUTOTEST_COMMIT
+        # - CI_COMMIT_REF_SLUG, CI_PROJECT_DIR, CI_PIPELINE_URL
+        # It also calls the script '.gitlab/scripts/safe_create_rundir'.
+        ${CI_PROJECT_DIR}/.gitlab/scripts/report_build_and_test_success
+        err=$?
+        # sleep for a period to allow NFS to propagate the above changes;
+        # clearly, there is no guarantee that other NFS clients will see the
+        # changes even after the timeout
+        sleep 10
+        exit $err
+      ) 9> autotest.lock
+
+.report_job_failure:
+  script:
+    # DEBUG
+    - export
+    - echo "AUTOTEST_ROOT ${AUTOTEST_ROOT}"
+    - cd ${AUTOTEST_ROOT}
+    - |
+      (
+        date
+        echo "Waiting to aquire lock on '$PWD/autotest.lock' ..."
+        # try to get an excusive lock on fd 9 (autotest.lock) repeating the try
+        # every 5 seconds; simply using no timeout, i.e. 'flock 9', causes the
+        # command to hang indefinitely sometimes, so we use the timeout & retry
+        # as a workaround; we may want to add a counter for the number of
+        # retries to interrupt a potential infinite loop
+        while ! flock -w 5 9; do
+          true
+        done
+        echo "Aquired lock on '$PWD/autotest.lock'"
+        date
+        # Report FAILURE while holding the file lock on 'autotest.lock'.
+        # The next script uses the following environment variables:
+        # - MACHINE_NAME, AUTOTEST_ROOT, AUTOTEST_COMMIT
+        # - CI_COMMIT_REF_SLUG, CI_PROJECT_DIR, CI_PIPELINE_URL
+        # It also calls the script '.gitlab/scripts/safe_create_rundir'.
+        ${CI_PROJECT_DIR}/.gitlab/scripts/report_build_and_test_failure
+        err=$?
+        # sleep for a period to allow NFS to propagate the above changes;
+        # clearly, there is no guarantee that other NFS clients will see the
+        # changes even after the timeout
+        sleep 10
+        exit $err
+      ) 9> autotest.lock

--- a/.gitlab/configs/report-build-and-test.yml
+++ b/.gitlab/configs/report-build-and-test.yml
@@ -12,8 +12,9 @@
 # Jobs report
 .report_job_success:
   script:
-    # DEBUG
-    - export
+    - echo ${MACHINE_NAME}
+    - echo ${AUTOTEST}
+    - echo ${AUTOTEST_COMMIT}
     - echo "AUTOTEST_ROOT ${AUTOTEST_ROOT}"
     - cd ${AUTOTEST_ROOT}
     - |
@@ -46,8 +47,9 @@
 
 .report_job_failure:
   script:
-    # DEBUG
-    - export
+    - echo ${MACHINE_NAME}
+    - echo ${AUTOTEST}
+    - echo ${AUTOTEST_COMMIT}
     - echo "AUTOTEST_ROOT ${AUTOTEST_ROOT}"
     - cd ${AUTOTEST_ROOT}
     - |

--- a/.gitlab/configs/setup-baseline.yml
+++ b/.gitlab/configs/setup-baseline.yml
@@ -26,6 +26,8 @@ setup_baseline:
     #
     # Setup ${BUILD_ROOT}/tpls and ${BUILD_ROOT}/tests:
     #
+    - echo "AUTOTEST = ${AUTOTEST}"
+    - echo "AUTOTEST_COMMIT = ${AUTOTEST_COMMIT}"
     - echo "BUILD_ROOT ${BUILD_ROOT}"
     - mkdir -p ${BUILD_ROOT} && cd ${BUILD_ROOT}
     - if [ ! -d "tpls" ]; then git clone ${TPLS_REPO}; fi

--- a/.gitlab/configs/setup-baseline.yml
+++ b/.gitlab/configs/setup-baseline.yml
@@ -26,6 +26,8 @@ setup_baseline:
     #
     # Setup ${BUILD_ROOT}/tpls and ${BUILD_ROOT}/tests:
     #
+    - echo "MACHINE_NAME = ${MACHINE_NAME}"
+    - echo "REBASELINE = ${REBASELINE}"
     - echo "AUTOTEST = ${AUTOTEST}"
     - echo "AUTOTEST_COMMIT = ${AUTOTEST_COMMIT}"
     - echo "BUILD_ROOT ${BUILD_ROOT}"

--- a/.gitlab/configs/setup-baseline.yml
+++ b/.gitlab/configs/setup-baseline.yml
@@ -9,13 +9,6 @@
 # terms of the BSD-3 license. We welcome feedback and contributions, see file
 # CONTRIBUTING.md for details.
 
-# TPLS_DIR is used in .gitlab/scripts/baseline to provide the tpls location
-# when call the runtest script in MFEM test repo.
-# Note: the value must be consistent with what setup_baseline does.
-variables:
-  TPLS_DIR: ${BUILD_ROOT}/tpls
-  AUTOTEST_ROOT: ${CI_BUILDS_DIR}/MFEM_${MACHINE_NAME}_baseline
-
 # The setup_baseline job doesn't rely on MFEM git repo. It prepares a
 # pipeline-wide working directory downloading/updating external repos.
 # TODO:
@@ -30,13 +23,46 @@ setup_baseline:
   variables:
     GIT_STRATEGY: none
   script:
+    #
+    # Setup ${BUILD_ROOT}/tpls and ${BUILD_ROOT}/tests:
+    #
     - echo "BUILD_ROOT ${BUILD_ROOT}"
     - mkdir -p ${BUILD_ROOT} && cd ${BUILD_ROOT}
     - if [ ! -d "tpls" ]; then git clone ${TPLS_REPO}; fi
     - if [ ! -d "tests" ]; then git clone ${TESTS_REPO}; fi
     - cd tpls && git pull && cd ..
     - cd tests && git pull origin && cd ..
+    #
+    # Setup ${AUTOTEST_ROOT}/autotest:
+    #
     - echo "AUTOTEST_ROOT ${AUTOTEST_ROOT}"
     - mkdir -p ${AUTOTEST_ROOT} && cd ${AUTOTEST_ROOT}
-    - if [ ! -d "autotest" ]; then git clone ${AUTOTEST_REPO}; fi
-    - cd autotest && git pull && cd ..
+    - command -v flock || echo "Required command 'flock' not found"
+    - |
+      (
+        date
+        echo "Waiting to aquire lock on '$PWD/autotest.lock' ..."
+        # try to get an excusive lock on fd 9 (autotest.lock) repeating the try
+        # every 5 seconds; simply using no timeout, i.e. 'flock 9', causes the
+        # command to hang indefinitely sometimes, so we use the timeout & retry
+        # as a workaround; we may want to add a counter for the number of
+        # retries to interrupt a potential infinite loop
+        while ! flock -w 5 9; do
+          true
+        done
+        echo "Aquired lock on '$PWD/autotest.lock'"
+        date
+        # clone/update the autotest repo while holding the file lock on
+        # 'autotest.lock'
+        err=0
+        if [[ ! -d "autotest" ]]; then
+          git clone ${AUTOTEST_REPO}
+        else
+          cd autotest && git pull && cd ..
+        fi || err=1
+        # sleep for a period to allow NFS to propagate the above changes;
+        # clearly, there is no guarantee that other NFS clients will see the
+        # changes even after the timeout
+        sleep 10
+        exit $err
+      ) 9> autotest.lock

--- a/.gitlab/configs/setup-build-and-test.yml
+++ b/.gitlab/configs/setup-build-and-test.yml
@@ -25,6 +25,8 @@ setup:
     # Setup MFEM_DATA_DIR=${SHARED_REPOS_DIR}/mfem-data, see '.gitlab-ci.yml'
     # and '.gitlab/configs/<machine>-config.yml'
     #
+    - echo "AUTOTEST = ${AUTOTEST}"
+    - echo "AUTOTEST_COMMIT = ${AUTOTEST_COMMIT}"
     - echo "SHARED_REPOS_DIR ${SHARED_REPOS_DIR}"
     - mkdir -p ${SHARED_REPOS_DIR} && cd ${SHARED_REPOS_DIR}
     - command -v flock || echo "Required command 'flock' not found"

--- a/.gitlab/configs/setup-build-and-test.yml
+++ b/.gitlab/configs/setup-build-and-test.yml
@@ -9,13 +9,10 @@
 # terms of the BSD-3 license. We welcome feedback and contributions, see file
 # CONTRIBUTING.md for details.
 
-variables:
-  AUTOTEST_ROOT: ${CI_BUILDS_DIR}/MFEM_${MACHINE_NAME}_build_and_test
-
-# setup clones the mfem/data repo in ${BUILD_ROOT}. The build_and_test script
-# then symlinks the repo to the parent directory of the MFEM source directory.
-# Unit tests that depend on the mfem/data repo will then detect that this
-# directory is present and be enabled.
+# Setup clones the mfem/data repo in ${SHARED_REPOS_DIR}. The build_and_test
+# script then symlinks the repo to the parent directory of the MFEM source
+# directory. Unit tests that depend on the mfem/data repo will then detect that
+# this directory is present and be enabled.
 setup:
   tags:
     - shell
@@ -24,11 +21,71 @@ setup:
   variables:
     GIT_STRATEGY: none
   script:
-    - echo "BUILD_ROOT ${BUILD_ROOT}"
-    - mkdir -p ${BUILD_ROOT} && cd ${BUILD_ROOT}
-    - if [ ! -d data ]; then git clone ${MFEM_DATA_REPO}; fi
+    #
+    # Setup MFEM_DATA_DIR=${SHARED_REPOS_DIR}/mfem-data, see '.gitlab-ci.yml'
+    # and '.gitlab/configs/<machine>-config.yml'
+    #
+    - echo "SHARED_REPOS_DIR ${SHARED_REPOS_DIR}"
+    - mkdir -p ${SHARED_REPOS_DIR} && cd ${SHARED_REPOS_DIR}
+    - command -v flock || echo "Required command 'flock' not found"
+    - |
+      (
+        date
+        echo "Waiting to aquire lock on '$PWD/mfem-data.lock' ..."
+        # try to get an excusive lock on fd 9 (mfem-data.lock) repeating the try
+        # every 5 seconds; simply using no timeout, i.e. 'flock 9', causes the
+        # command to hang indefinitely sometimes, so we use the timeout & retry
+        # as a workaround; we may want to add a counter for the number of
+        # retries to interrupt a potential infinite loop
+        while ! flock -w 5 9; do
+          true
+        done
+        echo "Aquired lock on '$PWD/mfem-data.lock'"
+        date
+        # clone/update the mfem/data repo while holding the file lock on
+        # 'mfem-data.lock'
+        err=0
+        if [[ ! -d "mfem-data" ]]; then
+          git clone ${MFEM_DATA_REPO} "mfem-data"
+        else
+          cd "mfem-data" && git pull && cd ..
+        fi || err=1
+        # sleep for a period to allow NFS to propagate the above changes;
+        # clearly, there is no guarantee that other NFS clients will see the
+        # changes even after the timeout
+        sleep 10
+        exit $err
+      ) 9> mfem-data.lock
+    #
+    # Setup ${AUTOTEST_ROOT}/autotest:
+    #
     - echo "AUTOTEST_ROOT ${AUTOTEST_ROOT}"
     - mkdir -p ${AUTOTEST_ROOT} && cd ${AUTOTEST_ROOT}
-    - if [ ! -d "autotest" ]; then git clone ${AUTOTEST_REPO}; fi
-    - cd autotest && git pull && cd ..
-
+    - |
+      (
+        date
+        echo "Waiting to aquire lock on '$PWD/autotest.lock' ..."
+        # try to get an excusive lock on fd 9 (autotest.lock) repeating the try
+        # every 5 seconds; simply using no timeout, i.e. 'flock 9', causes the
+        # command to hang indefinitely sometimes, so we use the timeout & retry
+        # as a workaround; we may want to add a counter for the number of
+        # retries to interrupt a potential infinite loop
+        while ! flock -w 5 9; do
+          true
+        done
+        echo "Aquired lock on '$PWD/autotest.lock'"
+        date
+        # clone/update the autotest repo while holding the file lock on
+        # 'autotest.lock'
+        err=0
+        if [[ ! -d "autotest" ]]; then
+          git clone ${AUTOTEST_REPO}
+        else
+          cd autotest && git pull && cd ..
+        fi || err=1
+        # sleep for a period to allow NFS to propagate the above changes;
+        # clearly, there is no guarantee that other NFS clients will see the
+        # changes even after the timeout
+        sleep 10
+        exit $err
+      ) 9> autotest.lock

--- a/.gitlab/configs/setup-build-and-test.yml
+++ b/.gitlab/configs/setup-build-and-test.yml
@@ -25,6 +25,7 @@ setup:
     # Setup MFEM_DATA_DIR=${SHARED_REPOS_DIR}/mfem-data, see '.gitlab-ci.yml'
     # and '.gitlab/configs/<machine>-config.yml'
     #
+    - echo "MACHINE_NAME = ${MACHINE_NAME}"
     - echo "AUTOTEST = ${AUTOTEST}"
     - echo "AUTOTEST_COMMIT = ${AUTOTEST_COMMIT}"
     - echo "SHARED_REPOS_DIR ${SHARED_REPOS_DIR}"

--- a/.gitlab/corona-build-and-test.yml
+++ b/.gitlab/corona-build-and-test.yml
@@ -22,6 +22,7 @@ allocate_resource:
   extends: .on_corona
   stage: allocate_resource
   script:
+    - echo ${ALLOC_NAME}
     - salloc --exclusive --nodes=1 --partition=mi60 --time=30 --no-shell --job-name=${ALLOC_NAME}
   timeout: 6h
   needs: [setup]
@@ -40,24 +41,27 @@ release_resource:
   extends: .on_corona
   stage: release_resource_and_report
   script:
+    - echo ${ALLOC_NAME}
     - export JOBID=$(squeue -h --name=${ALLOC_NAME} --format=%A)
+    - echo ${JOBID}
     - ([[ -n "${JOBID}" ]] && scancel ${JOBID})
   needs: [rocm_gcc_8.3.1]
 
 # Jobs report
 report_job_success:
-  extends: .on_corona
   stage: release_resource_and_report
-  script:
-    - .gitlab/scripts/report_build_and_test_success
+  extends:
+    - .on_corona
+    - .report_job_success
 
 report_job_failure:
-  extends: .on_corona
   stage: release_resource_and_report
-  script:
-    - .gitlab/scripts/report_build_and_test_failure
+  extends:
+    - .on_corona
+    - .report_job_failure
 
 include:
   - local: .gitlab/configs/common.yml
   - local: .gitlab/configs/corona-config.yml
   - local: .gitlab/configs/setup-build-and-test.yml
+  - local: .gitlab/configs/report-build-and-test.yml

--- a/.gitlab/lassen-build-and-test.yml
+++ b/.gitlab/lassen-build-and-test.yml
@@ -21,18 +21,19 @@ opt_mpi_cuda_xl_16_1_1_8:
 
 # Jobs report
 report_job_success:
-  extends: .on_lassen
   stage: report
-  script:
-    - .gitlab/scripts/report_build_and_test_success
+  extends:
+    - .on_lassen
+    - .report_job_success
 
 report_job_failure:
-  extends: .on_lassen
   stage: report
-  script:
-    - .gitlab/scripts/report_build_and_test_failure
+  extends:
+    - .on_lassen
+    - .report_job_failure
 
 include:
   - local: .gitlab/configs/common.yml
   - local: .gitlab/configs/lassen-config.yml
   - local: .gitlab/configs/setup-build-and-test.yml
+  - local: .gitlab/configs/report-build-and-test.yml

--- a/.gitlab/quartz-baseline.yml
+++ b/.gitlab/quartz-baseline.yml
@@ -16,12 +16,26 @@ stages:
   - setup
   - baseline_check
   - baseline_report
+  - cleanup
   - baseline_publish
 
 baselinecheck_mfem_intel_quartz:
   extends: [.on_quartz]
   stage: baseline_check
+  variables:
+    # TPLS_DIR is used in .gitlab/scripts/baseline to provide the tpls location
+    # when call the runtest script in MFEM test repo.
+    # Note: the value must be consistent with the setup performed in
+    #       .gitlab/configs/setup-baseline.yml.
+    TPLS_DIR: ${BUILD_ROOT}/tpls
   script:
+    - echo ${BUILD_ROOT}
+    - echo ${TPLS_DIR}
+    # Used by the tests in MFEM/tests:
+    - export MFEM_TEST_NP=32
+    # The next script uses the following environment variables:
+    # * BASELINE_TEST, SYS_TYPE, CI_PROJECT_DIR, ARTIFACTS_DIR,
+    # * BUILD_ROOT, TPLS_DIR, MACHINE_NAME
     - .gitlab/scripts/baseline
   artifacts:
     when: always
@@ -29,25 +43,74 @@ baselinecheck_mfem_intel_quartz:
       - ${ARTIFACTS_DIR}
   allow_failure: true
 
+cleanup:
+  extends: .on_quartz
+  stage: cleanup
+  variables:
+    GIT_STRATEGY: none
+  script:
+    - echo "BUILD_ROOT=${BUILD_ROOT}"
+    - rm -rf "${BUILD_ROOT}" || true
+
 report_baseline:
   extends: [.on_quartz]
   stage: baseline_report
   script:
-    - cd ${AUTOTEST_ROOT}/autotest && git pull
-    - mkdir -p ${MACHINE_NAME}
-    - rundir="${MACHINE_NAME}/$(date +%Y-%m-%d)-gitlab-${BASELINE_TEST}-${CI_COMMIT_REF_SLUG}"
-    - rundir=$(${CI_PROJECT_DIR}/.gitlab/scripts/safe_create_rundir ${rundir})
-    - cp ${CI_PROJECT_DIR}/${ARTIFACTS_DIR}/* ${rundir}
-    # We create an autotest-email.html file, because that's how we signal that there was a diff (temporary).
+    - echo ${AUTOTEST}
+    - echo ${AUTOTEST_COMMIT}
+    - echo "AUTOTEST_ROOT ${AUTOTEST_ROOT}"
+    - cd ${AUTOTEST_ROOT}
     - |
-      if [[ -f ${rundir}/*.err ]]
-      then
-        echo "See the pipeline here -> $CI_PIPELINE_URL" >> ${rundir}/*.err
-        cp ${rundir}/*.err ${rundir}/autotest-email.html
-      fi
-    - git add ${rundir}
-    - git commit -am "GitLab CI log for ${BASELINE_TEST} on ${MACHINE_NAME} with intel ($(date +%Y-%m-%d))"
-    - git push origin master
+      (
+        date
+        echo "Waiting to aquire lock on '$PWD/autotest.lock' ..."
+        # try to get an excusive lock on fd 9 (autotest.lock) repeating the try
+        # every 5 seconds; simply using no timeout, i.e. 'flock 9', causes the
+        # command to hang indefinitely sometimes, so we use the timeout & retry
+        # as a workaround; we may want to add a counter for the number of
+        # retries to interrupt a potential infinite loop
+        while ! flock -w 5 9; do
+          true
+        done
+        echo "Aquired lock on '$PWD/autotest.lock'"
+        date
+        # ----------------------
+        cd ${AUTOTEST_ROOT}/autotest || \
+          { echo "Invalid 'autotest' dir: ${AUTOTEST_ROOT}/autotest"; exit 1; }
+        mkdir -p ${MACHINE_NAME}
+        rundir="${MACHINE_NAME}/$(date +%Y-%m-%d)-gitlab-${BASELINE_TEST}-${CI_COMMIT_REF_SLUG}"
+        rundir=$(${CI_PROJECT_DIR}/.gitlab/scripts/safe_create_rundir ${rundir})
+        cp ${CI_PROJECT_DIR}/${ARTIFACTS_DIR}/* ${rundir}
+        # We create an autotest-email.html file, because that's how we signal that there was a diff (temporary).
+        if [[ -f ${rundir}/${BASELINE_TEST}.err ]]; then
+          cp ${rundir}/${BASELINE_TEST}.err ${rundir}/autotest-email.html
+        fi
+        printf "%s\n" "" "Pipeline URL:" "$CI_PIPELINE_URL" \
+          >> ${rundir}/pipeline.txt
+        msg="GitLab CI log for ${BASELINE_TEST} on ${MACHINE_NAME} ($(date +%Y-%m-%d))"
+        if [[ "$AUTOTEST_COMMIT" == "YES" ]]; then
+          git pull && \
+          git add ${rundir} && \
+          git commit -m "${msg}" && \
+          git push origin master
+        else
+          for file in ${rundir}/*; do
+            echo "------------------------------"
+            echo "Content of '$file'"
+            echo "******************************"
+            cat $file
+            echo "******************************"
+          done
+          rm -rf ${rundir} || true
+        fi
+        err=$?
+        # ----------------------
+        # sleep for a period to allow NFS to propagate the above changes;
+        # clearly, there is no guarantee that other NFS clients will see the
+        # changes even after the timeout
+        sleep 10
+        exit $err
+      ) 9> autotest.lock
 
 baselinepublish_mfem_quartz:
   extends: [.on_quartz]
@@ -56,6 +119,10 @@ baselinepublish_mfem_quartz:
     - if: '$CI_COMMIT_BRANCH == "master" || $REBASELINE == "YES"'
       when: manual
   script:
+    - echo ${BUILD_ROOT}
+    - echo ${PWD}
+    - echo ${ARTIFACTS_DIR}
+    - ls -lA ${ARTIFACTS_DIR}
     - .gitlab/scripts/rebaseline
 
 include:

--- a/.gitlab/quartz-baseline.yml
+++ b/.gitlab/quartz-baseline.yml
@@ -56,6 +56,7 @@ report_baseline:
   extends: [.on_quartz]
   stage: baseline_report
   script:
+    - echo ${MACHINE_NAME}
     - echo ${AUTOTEST}
     - echo ${AUTOTEST_COMMIT}
     - echo "AUTOTEST_ROOT ${AUTOTEST_ROOT}"

--- a/.gitlab/quartz-baseline.yml
+++ b/.gitlab/quartz-baseline.yml
@@ -89,7 +89,7 @@ report_baseline:
         printf "%s\n" "" "Pipeline URL:" "$CI_PIPELINE_URL" \
           >> ${rundir}/pipeline.txt
         msg="GitLab CI log for ${BASELINE_TEST} on ${MACHINE_NAME} ($(date +%Y-%m-%d))"
-        if [[ "$AUTOTEST_COMMIT" == "YES" ]]; then
+        if [[ "$AUTOTEST_COMMIT" != "NO" ]]; then
           git pull && \
           git add ${rundir} && \
           git commit -m "${msg}" && \

--- a/.gitlab/quartz-build-and-test.yml
+++ b/.gitlab/quartz-build-and-test.yml
@@ -22,6 +22,7 @@ allocate_resource:
   extends: .on_quartz
   stage: allocate_resource
   script:
+    - echo ${ALLOC_NAME}
     - salloc --exclusive --nodes=1 --partition=pdebug --time=30 --no-shell --job-name=${ALLOC_NAME}
   timeout: 6h
 
@@ -73,23 +74,26 @@ release_resource:
   extends: .on_quartz
   stage: release_resource_and_report
   script:
+    - echo ${ALLOC_NAME}
     - export JOBID=$(squeue -h --name=${ALLOC_NAME} --format=%A)
+    - echo ${JOBID}
     - ([[ -n "${JOBID}" ]] && scancel ${JOBID})
 
 # Jobs report
 report_job_success:
-  extends: .on_quartz
   stage: release_resource_and_report
-  script:
-    - .gitlab/scripts/report_build_and_test_success
+  extends:
+    - .on_quartz
+    - .report_job_success
 
 report_job_failure:
-  extends: .on_quartz
   stage: release_resource_and_report
-  script:
-    - .gitlab/scripts/report_build_and_test_failure
+  extends:
+    - .on_quartz
+    - .report_job_failure
 
 include:
   - local: .gitlab/configs/common.yml
   - local: .gitlab/configs/quartz-config.yml
   - local: .gitlab/configs/setup-build-and-test.yml
+  - local: .gitlab/configs/report-build-and-test.yml

--- a/.gitlab/scripts/baseline
+++ b/.gitlab/scripts/baseline
@@ -20,7 +20,8 @@ base_out=${base}.out
 artifacts_path=${CI_PROJECT_DIR}/${ARTIFACTS_DIR}
 
 # prepare
-cd ${BUILD_ROOT}
+cd ${BUILD_ROOT} || \
+  { echo "Invalid BUILD_ROOT=$BUILD_ROOT"; exit 1; }
 ln -snf ${CI_PROJECT_DIR} mfem
 cd tests
 [[ -d _${BASELINE_TEST} ]] && rm -rf _${BASELINE_TEST}
@@ -33,6 +34,9 @@ elif [[ ${MACHINE_NAME} == "corona" ]]; then
   srun --nodes=1 -t 60 -p mi60 ../runtest ../../mfem "${BASELINE_TEST} ${TPLS_DIR}"
 elif [[ ${MACHINE_NAME} == "lassen" ]]; then
   lalloc 1 -q pdebug ../runtest ../../mfem "${BASELINE_TEST} ${TPLS_DIR}"
+else
+  echo "Unknown machine: MACHINE_NAME=$MACHINE_NAME"
+  exit 1
 fi
 
 # post
@@ -58,6 +62,10 @@ elif [[ -f ${base_out} ]]
 then
   echo "${BASELINE_TEST}: Differences found, replacement file generated"
   cp ${base_out} ${artifacts_path}/${base_out}
+fi
+
+if [[ -f ${BASELINE_TEST}.out ]]; then
+  cp ${BASELINE_TEST}.out ${artifacts_path}
 fi
 
 # base_diff won't even exist if there is no difference.

--- a/.gitlab/scripts/report_build_and_test_failure
+++ b/.gitlab/scripts/report_build_and_test_failure
@@ -28,7 +28,7 @@ msg="GitLab CI log for build-and-test on ${MACHINE_NAME} ($(date +%Y-%m-%d))"
 # Create 'autotest-email.html' to indicate failure:
 cp ${rundir}/gitlab.err ${rundir}/autotest-email.html
 
-if [[ "$AUTOTEST_COMMIT" == "YES" ]]; then
+if [[ "$AUTOTEST_COMMIT" != "NO" ]]; then
   git pull && \
   git add ${rundir} && \
   git commit -m "${msg}" && \

--- a/.gitlab/scripts/report_build_and_test_failure
+++ b/.gitlab/scripts/report_build_and_test_failure
@@ -13,20 +13,33 @@
 
 echo "Runs if there was at least one failure on ${MACHINE_NAME}"
 
-cd ${AUTOTEST_ROOT}/autotest && git pull
+cd ${AUTOTEST_ROOT}/autotest || \
+  { echo "Invalid 'autotest' dir: ${AUTOTEST_ROOT}/autotest"; exit 1; }
 mkdir -p ${MACHINE_NAME}
 
 rundir="${MACHINE_NAME}/$(date +%Y-%m-%d)-gitlab-ci-${CI_COMMIT_REF_SLUG}"
 rundir=$(${CI_PROJECT_DIR}/.gitlab/scripts/safe_create_rundir $rundir)
 
-echo "There was an error while running CI on ${MACHINE_NAME}" > ${rundir}/gitlab.err
-echo "See the pipeline here -> $CI_PIPELINE_URL" >> ${rundir}/gitlab.err
+printf "%s\n" "Some 'build-and-test' jobs on ${MACHINE_NAME} FAILED." \
+  "Pipeline URL:" "$CI_PIPELINE_URL" > ${rundir}/gitlab.err
 
 msg="GitLab CI log for build-and-test on ${MACHINE_NAME} ($(date +%Y-%m-%d))"
 
+# Create 'autotest-email.html' to indicate failure:
 cp ${rundir}/gitlab.err ${rundir}/autotest-email.html
 
-git pull
-git add ${rundir}
-git commit -am "${msg}"
-git push origin master
+if [[ "$AUTOTEST_COMMIT" == "YES" ]]; then
+  git pull && \
+  git add ${rundir} && \
+  git commit -m "${msg}" && \
+  git push origin master
+else
+  for file in ${rundir}/*; do
+    echo "------------------------------"
+    echo "Content of '$file'"
+    echo "******************************"
+    cat $file
+    echo "******************************"
+  done
+  rm -rf ${rundir} || true
+fi

--- a/.gitlab/scripts/report_build_and_test_success
+++ b/.gitlab/scripts/report_build_and_test_success
@@ -13,18 +13,30 @@
 
 echo "Can only run if all the ${MACHINE_NAME} jobs passed"
 
-cd ${AUTOTEST_ROOT}/autotest && git pull
+cd ${AUTOTEST_ROOT}/autotest || \
+  { echo "Invalid 'autotest' dir: ${AUTOTEST_ROOT}/autotest"; exit 1; }
 mkdir -p ${MACHINE_NAME}
 
 rundir="${MACHINE_NAME}/$(date +%Y-%m-%d)-gitlab-ci-${CI_COMMIT_REF_SLUG}"
 rundir=$(${CI_PROJECT_DIR}/.gitlab/scripts/safe_create_rundir $rundir)
 
-echo "The ${MACHINE_NAME} jobs were successful" > ${rundir}/gitlab.out
-echo "See the pipeline here -> $CI_PIPELINE_URL" >> ${rundir}/gitlab.err
+printf "%s\n" "The 'build-and-test' jobs on ${MACHINE_NAME} were SUCCESSFUL." \
+  "Pipeline URL:" "$CI_PIPELINE_URL" > ${rundir}/gitlab.out
 
 msg="GitLab CI log for build-and-test on ${MACHINE_NAME} ($(date +%Y-%m-%d))"
 
-git pull
-git add ${rundir}
-git commit -am "${msg}"
-git push origin master
+if [[ "$AUTOTEST_COMMIT" == "YES" ]]; then
+  git pull && \
+  git add ${rundir} && \
+  git commit -m "${msg}" && \
+  git push origin master
+else
+  for file in ${rundir}/*; do
+    echo "------------------------------"
+    echo "Content of '$file'"
+    echo "******************************"
+    cat $file
+    echo "******************************"
+  done
+  rm -rf ${rundir} || true
+fi

--- a/.gitlab/scripts/report_build_and_test_success
+++ b/.gitlab/scripts/report_build_and_test_success
@@ -25,7 +25,7 @@ printf "%s\n" "The 'build-and-test' jobs on ${MACHINE_NAME} were SUCCESSFUL." \
 
 msg="GitLab CI log for build-and-test on ${MACHINE_NAME} ($(date +%Y-%m-%d))"
 
-if [[ "$AUTOTEST_COMMIT" == "YES" ]]; then
+if [[ "$AUTOTEST_COMMIT" != "NO" ]]; then
   git pull && \
   git add ${rundir} && \
   git commit -m "${msg}" && \

--- a/miniapps/shifted/makefile
+++ b/miniapps/shifted/makefile
@@ -25,9 +25,9 @@ include $(DEFAULTS_MK)
 MFEM_LIB_FILE = mfem_is_not_built
 -include $(CONFIG_MK)
 
-DIFFUSION_SRC = dist_solver.cpp sbm_solver.cpp marking.cpp
+DIFFUSION_SRC = diffusion.cpp dist_solver.cpp sbm_solver.cpp marking.cpp
 DIFFUSION_OBJ = $(DIFFUSION_SRC:.cpp=.o)
-DISTANCE_SRC = dist_solver.cpp
+DISTANCE_SRC = distance.cpp dist_solver.cpp
 DISTANCE_OBJ = $(DISTANCE_SRC:.cpp=.o)
 
 PAR_MINIAPPS = distance diffusion
@@ -53,16 +53,16 @@ COMMON_LIB += $(if $(MFEM_SHARED:YES=),,\
 %: %.cpp
 %.o: %.cpp
 
-%.o: $(SRC)%.cpp $(SRC)%.hpp $(MFEM_LIB_FILE) $(CONFIG_MK) | lib-common
+%.o: $(SRC)%.cpp $(wildcard $(SRC)%.hpp) $(MFEM_LIB_FILE) $(CONFIG_MK) | lib-common
 	$(MFEM_CXX) $(MFEM_FLAGS) -c $< -o $@
-	
+
 all: $(MINIAPPS)
 
-distance: distance.cpp sbm_aux.hpp $(DISTANCE_OBJ)
-	$(MFEM_CXX) $(MFEM_LINK_FLAGS) $@.cpp -o $@ $(DISTANCE_OBJ) $(COMMON_LIB) $(MFEM_LIBS)
+distance: sbm_aux.hpp $(DISTANCE_OBJ)
+	$(MFEM_CXX) $(MFEM_LINK_FLAGS) -o $@ $(DISTANCE_OBJ) $(COMMON_LIB) $(MFEM_LIBS)
 
-diffusion: diffusion.cpp sbm_aux.hpp $(DIFFUSION_OBJ)
-	$(MFEM_CXX) $(MFEM_LINK_FLAGS) $@.cpp -o $@ $(DIFFUSION_OBJ) $(COMMON_LIB) $(MFEM_LIBS)
+diffusion: sbm_aux.hpp $(DIFFUSION_OBJ)
+	$(MFEM_CXX) $(MFEM_LINK_FLAGS) -o $@ $(DIFFUSION_OBJ) $(COMMON_LIB) $(MFEM_LIBS)
 
 # Rule for building lib-common
 lib-common:

--- a/tests/gitlab/README.md
+++ b/tests/gitlab/README.md
@@ -13,10 +13,7 @@ This directory contains utility scripts related to GitLab testing at LLNL.
   perform testing.
 
    While designed to be used in CI context, this script can also be used
-   standalone on LLNL's LC in order to reproduce a similar build. The script
-   uses environment variables for configuration (a place for improvement), such
-   as "BUILD_ROOT", "HOST_CONFIG", "SPEC", etc. Some are mandatory, while
-   others have default values.
+   standalone on LLNL's LC in order to reproduce a similar build.
    Please refer to tests/gitlab/reproduce-ci-jobs-interactively.md for details.
 
 * `get_mfem_uberenv` sets uberenv up for use with MFEM, notably to install TPLs

--- a/tests/gitlab/build_and_test
+++ b/tests/gitlab/build_and_test
@@ -22,13 +22,13 @@ function usage()
   echo ""
   echo "Syntax:"
   echo "> ${script_name} --spec \"spack spec\" [--deps-only] [--data]"
-  echo "                 [--build-root /path/to/build/resource]"
+  echo "                 [--data-dir=/path/to/mfem/data]"
   echo ""
   echo "> ${script_name} --build-only [--data]"
-  echo "                 [--build-root /path/to/build/resource]"
+  echo "                 [--data-dir=/path/to/mfem/data]"
   echo ""
   echo "> ${script_name} --test-only [--data]"
-  echo "                 [--build-root /path/to/build/resource]"
+  echo "                 [--data-dir=/path/to/mfem/data]"
   echo ""
   echo "Options:"
   echo " --spec"
@@ -53,24 +53,20 @@ function usage()
   echo "    data directory is not present in the parent of the mfem root directory."
   echo "    Note: default behavior is to run data tests if data dir is present."
   echo ""
-  echo " --build-root=/path/to/build/resource"
-  echo "    The script will use this directory to find the external resource"
-  echo "    needed, e.g. the data directory. Defaults to the parent location"
-  echo "    of the MFEM clone."
+  echo " --data-dir=/path/to/mfem/data"
+  echo "    Path to a clone of the MFEM/data repo: https://github.com/mfem/data"
+  echo "    The default path is: '../data'."
   echo ""
 }
 
-hostname="$(hostname)"
 project_dir="$(pwd)"
 
 mode=""
-build_root=""
 spec=""
+data_dir=""
 with_data=false
 
 sys_type=${SYS_TYPE:-""}
-py_env_path=${PYTHON_ENVIRONMENT_PATH:-""}
-ci_context=${CI:-""}
 
 threads=${THREADS:-""}
 
@@ -93,8 +89,8 @@ do
             with_data=true
             shift # past argument
             ;;
-        --build-root)
-            build_root="$2"
+        --data-dir)
+            data_dir="$2"
             shift # past argument
             shift # past value
             ;;
@@ -134,14 +130,16 @@ then
     # otherwise.
     if [[ -d "/dev/shm" && "${mode}" != "--deps-only" ]]
     then
-        prefix="/dev/shm/${hostname}/${CI_PIPELINE_ID:-"NONE"}_${RANDOM}"
+        prefix="/dev/shm/${USER}_${CI_PIPELINE_ID:-"NONE"}_${RANDOM}"
         mkdir -p ${prefix}
-        echo ${spec} > spec.txt
+        # clean up ${prefix} at exit:
+        trap 'rm -rf "${prefix}"' EXIT
         prefix_opt="--prefix=${prefix}"
     fi
+    echo ${spec} > spec.txt
 
     echo "Fetching uberenv."
-    tests/gitlab/get_mfem_uberenv || ( echo "Error fetching Uberenv" && exit 1 );
+    tests/gitlab/get_mfem_uberenv || { echo "Error fetching Uberenv"; exit 1; }
 
     echo "Removing existing configuration"
     make distclean
@@ -172,20 +170,30 @@ then
         exit 1
     fi
 
-    # Build and Data Directories
-    if [[ -z ${build_root} ]]
+    # Setup the MFEM/data repository directory
+    # Some additional unit tests are enabled when '../data' is present
+    if [[ -z "${data_dir}" ]]
     then
-        # By default, build_root is the project parent dir.
-        build_root="${project_dir}/.."
+        # By default, data_dir is ../data.
+        data_dir="../data"
     else
-        # build_root is specified, so we need to link its content into the
+        # data_dir is specified, so we need to link its content into the
         # project parent dir.
-        ln -sf ${build_root}/data ${project_dir}/../
+        if [[ -e "../data" && ! -L "../data" ]]; then
+          echo "Error: '../data' already exists and it's NOT a link"
+          exit 1
+        fi
+        ln -sf "${data_dir}" "../data"
+    fi
+    # The PUMI examples expect the PUMI datafiles to be in 'data/pumi'
+    if [[ -d "../data/pumi" ]]; then
+        ln -sf "../../data/pumi" "data"
     fi
 
-    if [[ "$with_data" == "true" && ! -d ${build_root}/data ]]
+    if [[ "$with_data" == "true" && ! -d "../data" ]]
     then
-        echo "ERROR: ${build_root}/data not found while asking for --data".
+        echo "ERROR: '$data_dir' is not a directory while asking for --data"
+        exit 1
     fi
 fi
 
@@ -194,8 +202,14 @@ if [[ "${mode}" != "--deps-only" ]]
 then
     echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
     echo "~ Project Dir: ${project_dir}"
-    echo "~ Build Root: ${build_root}"
+    echo "~ Data Dir: ${data_dir}"
     echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
+
+    echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
+    echo "~~~~~ MFEM configuration"
+    echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
+
+    make info
 
     echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
     echo "~~~~~ Building MFEM"

--- a/tests/gitlab/build_and_test
+++ b/tests/gitlab/build_and_test
@@ -179,9 +179,14 @@ then
     else
         # data_dir is specified, so we need to link its content into the
         # project parent dir.
-        if [[ -e "../data" && ! -L "../data" ]]; then
-          echo "Error: '../data' already exists and it's NOT a link"
-          exit 1
+        if [[ -e "../data" ]]; then
+            if [[ -L "../data" ]]; then
+                echo "'../data' link already exists. Deleting."
+                rm "../data"
+            else
+                echo "Error: '../data' already exists and it's NOT a link"
+                exit 1
+            fi
         fi
         ln -sf "${data_dir}" "../data"
     fi

--- a/tests/gitlab/reproduce-ci-jobs-interactively.md
+++ b/tests/gitlab/reproduce-ci-jobs-interactively.md
@@ -66,12 +66,12 @@ those files were generated, otherwise `make all` would just regenerate them.
 
 **NOTE**
 
-The `build_and_test` script behaves slightly differently between CI context and
-elsewhere (depending on environment variable $CI). In CI, and if launched on
-quartz, ruby or corona, the script will build and install dependencies in
+When `build_and_test` needs to build the dependencies, i.e. (a) `--deps-only` is
+used, or (b) none of the `--XXX-only` options is used, then the script behaves
+slightly differently. In case (b), it will build and install dependencies in
 `/dev/shm` for better performance. However, this is only valid if we don’t want
 the installation to persist. Installation will happen locally to the uberenv
-directory if not in CI context.
+directory in case (a), i.e. if `--deps-only` is used.
 
 ### Option #2: Calling uberenv directly
 


### PR DESCRIPTION
Update the Gitlab CI to fix some issues:
- Use a single (per user) clone of the internal MFEM/autotests repo
- Use a single (per user) clone of the Github MFEM/data repo
- Properly set the location for the pipeline-common temporary directory, BUILD_ROOT; add a cleanup step for BUILD_ROOT
- Various other small tweaks and additions

<!--GHEX{"id":2634,"author":"v-dobrev","editor":"tzanio","reviewers":["jandrej","pazner"],"assignment":"2021-11-03T08:03:22-07:00","approval":"2021-11-06T00:27:45.025Z","merge":"2021-11-06T22:57:13.264Z"}XEHG--><!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge| 
 | --- | --- | --- | --- | --- | --- | --- | 
| [#2634](https://github.com/mfem/mfem/pull/2634) | @v-dobrev | @tzanio | @jandrej + @pazner | 11/03/21 | 11/05/21 | 11/06/21 | |
<!--ELBATXEHG-->