### PR TITLE
Add move constructors/assignment for Vector and HypreParVector [hypreparvec-move-dev]

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -67,6 +67,9 @@ Version 4.3.1 (development)
 - Added initial TMOP-based capabilities for surface fitting and tangential
   relaxation in the mesh-optimizer and pmesh-optimizer miniapps.
 
+- `HypreParVector` and `Vector` now support move semantics, and the copy
+  constructor for `HypreParVector` now copies the local vector data.
+
 
 Version 4.3, released on July 29, 2021
 ======================================

--- a/linalg/hypre.cpp
+++ b/linalg/hypre.cpp
@@ -147,10 +147,7 @@ HypreParVector::HypreParVector(const HypreParVector &y) : Vector()
 HypreParVector::HypreParVector(HypreParVector &&y) : HypreParVector(
       static_cast<HYPRE_ParVector>(y))
 {
-   // If the argument vector owns its data, then the constructed vector will as well
-   own_ParVector = y.own_ParVector;
-   // Either way, the argument vector will not own its data
-   y.own_ParVector = 0;
+   *this = std::move(y);
 }
 
 HypreParVector::HypreParVector(const HypreParMatrix &A,
@@ -234,6 +231,9 @@ HypreParVector& HypreParVector::operator=(HypreParVector &&y)
    WrapHypreParVector(static_cast<hypre_ParVector*>(y), y.own_ParVector);
    // Either way the argument vector will no longer own its data
    y.own_ParVector = 0;
+   y.x = nullptr;
+   y.data.Reset();
+   y.size = 0;
    return *this;
 }
 

--- a/linalg/hypre.cpp
+++ b/linalg/hypre.cpp
@@ -141,12 +141,13 @@ HypreParVector::HypreParVector(const HypreParVector &y) : Vector()
    own_ParVector = 1;
 }
 
-HypreParVector::HypreParVector(HypreParVector &&other) : HypreParVector(static_cast<HYPRE_ParVector>(other))
+HypreParVector::HypreParVector(HypreParVector &&y) : HypreParVector(
+      static_cast<HYPRE_ParVector>(y))
 {
    // If the argument vector owns its data, then the constructed vector will as well
-   own_ParVector = other.own_ParVector;
+   own_ParVector = y.own_ParVector;
    // Either way, the argument vector will not own its data
-   other.own_ParVector = 0;
+   y.own_ParVector = 0;
 }
 
 HypreParVector::HypreParVector(const HypreParMatrix &A,
@@ -221,6 +222,21 @@ HypreParVector& HypreParVector::operator=(const HypreParVector &y)
 #endif
 
    Vector::operator=(y);
+   return *this;
+}
+
+HypreParVector& HypreParVector::operator=(HypreParVector &&y)
+{
+#ifdef MFEM_DEBUG
+   if (size != y.Size())
+   {
+      mfem_error("HypreParVector::operator=");
+   }
+#endif
+   // If the argument vector owns its data, then the calling vector will as well
+   WrapHypreParVector(static_cast<hypre_ParVector*>(y), y.own_ParVector);
+   // Either way the argument vector will no longer own its data
+   y.own_ParVector = 0;
    return *this;
 }
 

--- a/linalg/hypre.cpp
+++ b/linalg/hypre.cpp
@@ -144,8 +144,7 @@ HypreParVector::HypreParVector(const HypreParVector &y) : Vector()
    own_ParVector = 1;
 }
 
-HypreParVector::HypreParVector(HypreParVector &&y) : HypreParVector(
-      static_cast<HYPRE_ParVector>(y))
+HypreParVector::HypreParVector(HypreParVector &&y)
 {
    *this = std::move(y);
 }

--- a/linalg/hypre.cpp
+++ b/linalg/hypre.cpp
@@ -227,12 +227,6 @@ HypreParVector& HypreParVector::operator=(const HypreParVector &y)
 
 HypreParVector& HypreParVector::operator=(HypreParVector &&y)
 {
-#ifdef MFEM_DEBUG
-   if (size != y.Size())
-   {
-      mfem_error("HypreParVector::operator=");
-   }
-#endif
    // If the argument vector owns its data, then the calling vector will as well
    WrapHypreParVector(static_cast<hypre_ParVector*>(y), y.own_ParVector);
    // Either way the argument vector will no longer own its data

--- a/linalg/hypre.cpp
+++ b/linalg/hypre.cpp
@@ -141,6 +141,14 @@ HypreParVector::HypreParVector(const HypreParVector &y) : Vector()
    own_ParVector = 1;
 }
 
+HypreParVector::HypreParVector(HypreParVector &&other) : HypreParVector(static_cast<HYPRE_ParVector>(other))
+{
+   // If the argument vector owns its data, then the constructed vector will as well
+   own_ParVector = other.own_ParVector;
+   // Either way, the argument vector will not own its data
+   other.own_ParVector = 0;
+}
+
 HypreParVector::HypreParVector(const HypreParMatrix &A,
                                int transpose) : Vector()
 {

--- a/linalg/hypre.cpp
+++ b/linalg/hypre.cpp
@@ -137,6 +137,9 @@ HypreParVector::HypreParVector(const HypreParVector &y) : Vector()
 #endif
    hypre_ParVectorSetDataOwner(x,1);
    hypre_SeqVectorSetDataOwner(hypre_ParVectorLocalVector(x),1);
+   // Deep copy the local data
+   hypre_SeqVectorCopy(hypre_ParVectorLocalVector(y.x),
+                       hypre_ParVectorLocalVector(x));
    _SetDataAndSize_();
    own_ParVector = 1;
 }

--- a/linalg/hypre.hpp
+++ b/linalg/hypre.hpp
@@ -194,6 +194,8 @@ public:
    HypreParVector& operator= (double d);
    /// Define '=' for hypre vectors.
    HypreParVector& operator= (const HypreParVector &y);
+   /// Move assignment
+   HypreParVector& operator= (HypreParVector &&y);
 
    using Vector::Read;
 

--- a/linalg/hypre.hpp
+++ b/linalg/hypre.hpp
@@ -141,7 +141,7 @@ public:
        allocated in the memory location HYPRE_MEMORY_DEVICE. */
    HypreParVector(MPI_Comm comm, HYPRE_BigInt glob_size, double *data_,
                   HYPRE_BigInt *col, bool is_device_ptr = false);
-   /// Creates vector compatible with y containing a deep copy of the local data
+   /// Creates a deep copy of @a y
    HypreParVector(const HypreParVector &y);
    /// Move constructor for HypreParVector. "Steals" data from its argument.
    HypreParVector(HypreParVector&& other);

--- a/linalg/hypre.hpp
+++ b/linalg/hypre.hpp
@@ -143,6 +143,8 @@ public:
                   HYPRE_BigInt *col, bool is_device_ptr = false);
    /// Creates vector compatible with y
    HypreParVector(const HypreParVector &y);
+   /// Move constructor for HypreParVector. "Steals" data from its argument.
+   HypreParVector(HypreParVector&& other);
    /// Creates vector compatible with (i.e. in the domain of) A or A^T
    explicit HypreParVector(const HypreParMatrix &A, int transpose = 0);
    /// Creates vector wrapping y

--- a/linalg/hypre.hpp
+++ b/linalg/hypre.hpp
@@ -141,7 +141,7 @@ public:
        allocated in the memory location HYPRE_MEMORY_DEVICE. */
    HypreParVector(MPI_Comm comm, HYPRE_BigInt glob_size, double *data_,
                   HYPRE_BigInt *col, bool is_device_ptr = false);
-   /// Creates vector compatible with y
+   /// Creates vector compatible with y containing a deep copy of the local data
    HypreParVector(const HypreParVector &y);
    /// Move constructor for HypreParVector. "Steals" data from its argument.
    HypreParVector(HypreParVector&& other);

--- a/linalg/hypre.hpp
+++ b/linalg/hypre.hpp
@@ -152,6 +152,10 @@ public:
    /// Create a true dof parallel vector on a given ParFiniteElementSpace
    explicit HypreParVector(ParFiniteElementSpace *pfes);
 
+   /// \brief Constructs a  @p HypreParVector *compatible* with the calling vector
+   /// - meaning that it will be the same size and have the same partitioning.
+   HypreParVector CreateCompatibleVector() const;
+
    /// MPI communicator
    MPI_Comm GetComm() const { return x->comm; }
 

--- a/linalg/vector.cpp
+++ b/linalg/vector.cpp
@@ -54,6 +54,12 @@ Vector::Vector(const Vector &v)
    UseDevice(v.UseDevice());
 }
 
+Vector::Vector(Vector &&v) : data(std::move(v.data)), size(v.size)
+{
+   data.SetHostPtrOwner(v.data.OwnsHostPtr());
+   v.data.Reset();
+}
+
 void Vector::Load(std::istream **in, int np, int *dim)
 {
    int i, j, s;
@@ -143,6 +149,15 @@ Vector &Vector::operator=(const Vector &v)
    data.CopyFrom(v.data, v.Size());
    v.UseDevice(vuse);
 #endif
+   return *this;
+}
+
+Vector &Vector::operator=(Vector &&v)
+{
+   data = std::move(v.data);
+   size = v.size;
+   data.SetHostPtrOwner(v.data.OwnsHostPtr());
+   v.data.Reset();
    return *this;
 }
 

--- a/linalg/vector.cpp
+++ b/linalg/vector.cpp
@@ -54,11 +54,9 @@ Vector::Vector(const Vector &v)
    UseDevice(v.UseDevice());
 }
 
-Vector::Vector(Vector &&v) : data(std::move(v.data)), size(v.size)
+Vector::Vector(Vector &&v)
 {
-   data.SetHostPtrOwner(v.data.OwnsHostPtr());
-   v.data.Reset();
-   v.size = 0;
+   *this = std::move(v);
 }
 
 void Vector::Load(std::istream **in, int np, int *dim)

--- a/linalg/vector.cpp
+++ b/linalg/vector.cpp
@@ -155,7 +155,6 @@ Vector &Vector::operator=(Vector &&v)
 {
    data = std::move(v.data);
    size = v.size;
-   data.SetHostPtrOwner(v.data.OwnsHostPtr());
    v.data.Reset();
    v.size = 0;
    return *this;

--- a/linalg/vector.cpp
+++ b/linalg/vector.cpp
@@ -58,6 +58,7 @@ Vector::Vector(Vector &&v) : data(std::move(v.data)), size(v.size)
 {
    data.SetHostPtrOwner(v.data.OwnsHostPtr());
    v.data.Reset();
+   v.size = 0;
 }
 
 void Vector::Load(std::istream **in, int np, int *dim)
@@ -158,6 +159,7 @@ Vector &Vector::operator=(Vector &&v)
    size = v.size;
    data.SetHostPtrOwner(v.data.OwnsHostPtr());
    v.data.Reset();
+   v.size = 0;
    return *this;
 }
 

--- a/linalg/vector.hpp
+++ b/linalg/vector.hpp
@@ -72,6 +72,9 @@ public:
    /// Copy constructor. Allocates a new data array and copies the data.
    Vector(const Vector &);
 
+   /// Move constructor. "Steals" data from its argument.
+   Vector(Vector&& v);
+
    /// @brief Creates vector of size s.
    /// @warning Entries are not initialized to zero!
    explicit Vector(int s);
@@ -277,6 +280,9 @@ public:
    /** @note Defining this method overwrites the implicitly defined copy
        assignment operator. */
    Vector &operator=(const Vector &v);
+
+   /// Move assignment
+   Vector &operator=(Vector&& v);
 
    /// Redefine '=' for vector = constant.
    Vector &operator=(double value);

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -29,6 +29,7 @@ set(UNIT_TESTS_SRCS
   linalg/test_constrainedsolver.cpp
   linalg/test_direct_solvers.cpp
   linalg/test_hypre_ilu.cpp
+  linalg/test_hypre_vector.cpp
   linalg/test_ilu.cpp
   linalg/test_matrix_block.cpp
   linalg/test_matrix_dense.cpp

--- a/tests/unit/linalg/test_hypre_vector.cpp
+++ b/tests/unit/linalg/test_hypre_vector.cpp
@@ -17,6 +17,31 @@ namespace mfem
 
 #ifdef MFEM_USE_MPI
 
+namespace detail
+{
+
+std::vector<HYPRE_BigInt> GenerateColumnPartitioning(const int world_size,
+                                                     const int rank, const int size_per_rank)
+{
+   std::vector<HYPRE_BigInt> col;
+   if (HYPRE_AssumedPartitionCheck())
+   {
+      int offset = rank*size_per_rank;
+      col = {offset, offset + size_per_rank};
+   }
+   else
+   {
+      col.resize(world_size+1);
+      for (int i=1; i<=world_size; ++i)
+      {
+         col[i] = i*size_per_rank;
+      }
+   }
+   return col;
+}
+
+} // namespace detail
+
 TEST_CASE("HypreParVector I/O", "[Parallel], [HypreParVector]")
 {
    // Create a test vector (two entries per rank) with entries increasing
@@ -29,20 +54,8 @@ TEST_CASE("HypreParVector I/O", "[Parallel], [HypreParVector]")
    int size_per_rank = 2;
 
    HYPRE_BigInt glob_size = world_size*size_per_rank;
-   std::vector<HYPRE_BigInt> col;
-   if (HYPRE_AssumedPartitionCheck())
-   {
-      int offset = rank*size_per_rank;
-      col = {offset, offset + size_per_rank};
-   }
-   else
-   {
-      col.resize(world_size+1);
-      for (int i=0; i<world_size; ++i)
-      {
-         col[i] = i*size_per_rank;
-      }
-   }
+   std::vector<HYPRE_BigInt> col = detail::GenerateColumnPartitioning(world_size,
+                                                                      rank, size_per_rank);
 
    // Initialize vector and write to files
    HypreParVector v1(MPI_COMM_WORLD, glob_size, col.data());
@@ -63,6 +76,97 @@ TEST_CASE("HypreParVector I/O", "[Parallel], [HypreParVector]")
    std::string suffix = std::to_string(rank);
    remove((prefix + suffix).c_str());
    remove((prefix + "INFO." + suffix).c_str());
+}
+
+TEST_CASE("HypreParVector Move Constructor", "[Parallel], [HypreParVector]")
+{
+   int world_size, rank;
+   MPI_Comm_size(MPI_COMM_WORLD, &world_size);
+   MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+   int size_per_rank = 2;
+
+   HYPRE_BigInt glob_size = world_size*size_per_rank;
+   std::vector<HYPRE_BigInt> col = detail::GenerateColumnPartitioning(world_size,
+                                                                      rank, size_per_rank);
+
+   // Initialize vector
+   HypreParVector v1(MPI_COMM_WORLD, glob_size, col.data());
+   for (int i=0; i<size_per_rank; ++i)
+   {
+      v1(i) = rank*size_per_rank + i;
+   }
+
+   // Make a copy so we can compare it later
+   HypreParVector v1_copy(v1);
+   Vector v1_base_copy(v1);
+
+   // Also save off the data pointer
+   double* v1_data = v1.GetData();
+
+   // Now move from the original and compare
+   HypreParVector v1_move(std::move(v1));
+
+   REQUIRE(v1.GetOwnership() == 0);
+   REQUIRE(v1_move.GetOwnership() == 1);
+   REQUIRE(v1_move.Size() == v1_copy.Size());
+   REQUIRE(v1_move.GlobalSize() == v1_copy.GlobalSize());
+
+   REQUIRE(v1_move.GetData() == v1_data);
+
+   // The local subvectors should be the same
+   // Would expect the copy created with the HypreParVec copy ctor
+   // to be the same as well, but this is apparently not the case.
+   Vector v1_base_move(v1_move);
+   for (int i = 0; i < v1_base_move.Size(); i++)
+   {
+      REQUIRE((v1_base_move(i) - v1_base_copy(i)) == MFEM_Approx(0.0));
+   }
+}
+
+TEST_CASE("HypreParVector Move Assignment", "[Parallel], [HypreParVector]")
+{
+   int world_size, rank;
+   MPI_Comm_size(MPI_COMM_WORLD, &world_size);
+   MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+   int size_per_rank = 2;
+
+   HYPRE_BigInt glob_size = world_size*size_per_rank;
+   std::vector<HYPRE_BigInt> col = detail::GenerateColumnPartitioning(world_size,
+                                                                      rank, size_per_rank);
+
+   // Initialize vector
+   HypreParVector v1(MPI_COMM_WORLD, glob_size, col.data());
+   for (int i=0; i<size_per_rank; ++i)
+   {
+      v1(i) = rank*size_per_rank + i;
+   }
+
+   // Make a copy so we can compare it later
+   HypreParVector v1_copy(v1);
+   Vector v1_base_copy(v1);
+
+   // Also save off the data pointer
+   double* v1_data = v1.GetData();
+
+   // Now move from the original and compare
+   HypreParVector v1_move;
+   v1_move = std::move(v1);
+
+   REQUIRE(v1.GetOwnership() == 0);
+   REQUIRE(v1_move.GetOwnership() == 1);
+   REQUIRE(v1_move.Size() == v1_copy.Size());
+   REQUIRE(v1_move.GlobalSize() == v1_copy.GlobalSize());
+
+   REQUIRE(v1_move.GetData() == v1_data);
+
+   // The local subvectors should be the same
+   // Would expect the copy created with the HypreParVec copy ctor
+   // to be the same as well, but this is apparently not the case.
+   Vector v1_base_move(v1_move);
+   for (int i = 0; i < v1_base_move.Size(); i++)
+   {
+      REQUIRE((v1_base_move(i) - v1_base_copy(i)) == MFEM_Approx(0.0));
+   }
 }
 
 #endif // MFEM_USE_MPI

--- a/tests/unit/linalg/test_hypre_vector.cpp
+++ b/tests/unit/linalg/test_hypre_vector.cpp
@@ -114,13 +114,15 @@ TEST_CASE("HypreParVector Move Constructor", "[Parallel], [HypreParVector]")
    REQUIRE(v1_move.GetData() == v1_data);
 
    // The local subvectors should be the same
-   // Would expect the copy created with the HypreParVec copy ctor
-   // to be the same as well, but this is apparently not the case.
    Vector v1_base_move(v1_move);
    for (int i = 0; i < v1_base_move.Size(); i++)
    {
       REQUIRE((v1_base_move(i) - v1_base_copy(i)) == MFEM_Approx(0.0));
    }
+
+   // The full HypreParVectors should also be the same
+   v1_copy -= v1_move;
+   REQUIRE(InnerProduct(v1_copy, v1_copy) == MFEM_Approx(0.0));
 }
 
 TEST_CASE("HypreParVector Move Assignment", "[Parallel], [HypreParVector]")
@@ -160,13 +162,15 @@ TEST_CASE("HypreParVector Move Assignment", "[Parallel], [HypreParVector]")
    REQUIRE(v1_move.GetData() == v1_data);
 
    // The local subvectors should be the same
-   // Would expect the copy created with the HypreParVec copy ctor
-   // to be the same as well, but this is apparently not the case.
    Vector v1_base_move(v1_move);
    for (int i = 0; i < v1_base_move.Size(); i++)
    {
       REQUIRE((v1_base_move(i) - v1_base_copy(i)) == MFEM_Approx(0.0));
    }
+
+   // The full HypreParVectors should also be the same
+   v1_copy -= v1_move;
+   REQUIRE(InnerProduct(v1_copy, v1_copy) == MFEM_Approx(0.0));
 }
 
 #endif // MFEM_USE_MPI

--- a/tests/unit/linalg/test_hypre_vector.cpp
+++ b/tests/unit/linalg/test_hypre_vector.cpp
@@ -109,6 +109,8 @@ TEST_CASE("HypreParVector Move Constructor", "[Parallel], [HypreParVector]")
    REQUIRE(v1_move.GetOwnership() == 1);
    REQUIRE(v1_move.Size() == v1_copy.Size());
    REQUIRE(v1_move.GlobalSize() == v1_copy.GlobalSize());
+   REQUIRE(v1.Size() == 0);
+   REQUIRE(v1.GetData() == nullptr);
 
    REQUIRE(v1_move.GetData() == v1_data);
 
@@ -149,6 +151,8 @@ TEST_CASE("HypreParVector Move Assignment", "[Parallel], [HypreParVector]")
    REQUIRE(v1_move.GetOwnership() == 1);
    REQUIRE(v1_move.Size() == v1_copy.Size());
    REQUIRE(v1_move.GlobalSize() == v1_copy.GlobalSize());
+   REQUIRE(v1.Size() == 0);
+   REQUIRE(v1.GetData() == nullptr);
 
    REQUIRE(v1_move.GetData() == v1_data);
 

--- a/tests/unit/linalg/test_vector.cpp
+++ b/tests/unit/linalg/test_vector.cpp
@@ -26,6 +26,96 @@ TEST_CASE("Vector init-list construction", "[Vector]")
    }
 }
 
+TEST_CASE("Vector Move Constructor", "[Vector]")
+{
+   constexpr int N = 6;
+   double ContigData[N] = {6.0, 5.0, 4.0, 3.0, 2.0, 1.0};
+   Vector a(ContigData, N);
+   Vector b(N);
+   for (int i = 0; i < N; i++)
+   {
+      b(i) = N - i;
+   }
+
+   double* a_data = a.GetData();
+   double* b_data = b.GetData();
+
+   Vector move_non_owning(std::move(a));
+   Vector move_owning(std::move(b));
+
+   REQUIRE(a.Size() == 0);
+   REQUIRE(a.GetData() == nullptr);
+   REQUIRE(b.Size() == 0);
+   REQUIRE(b.GetData() == nullptr);
+
+   // Should both be no-ops
+   a.Destroy();
+   b.Destroy();
+
+   REQUIRE(move_non_owning.OwnsData() == false);
+   REQUIRE(move_owning.OwnsData() == true);
+
+   REQUIRE(move_non_owning.Size() == N);
+   REQUIRE(move_owning.Size() == N);
+
+   // Make sure that the pointers were reused
+   REQUIRE(move_non_owning.GetData() == a_data);
+   REQUIRE(move_owning.GetData() == b_data);
+
+   for (int i = 0; i < N; i++)
+   {
+      REQUIRE(move_non_owning(i) == N - i);
+      REQUIRE(move_owning(i) == N - i);
+   }
+}
+
+TEST_CASE("Vector Move Assignment", "[Vector]")
+{
+   constexpr int N = 6;
+   double ContigData[N] = {6.0, 5.0, 4.0, 3.0, 2.0, 1.0};
+   Vector a(ContigData, N);
+   Vector b(N);
+   for (int i = 0; i < N; i++)
+   {
+      b(i) = N - i;
+   }
+
+   double* a_data = a.GetData();
+   double* b_data = b.GetData();
+
+   Vector move_non_owning;
+   move_non_owning = std::move(a);
+   Vector move_owning;
+   move_owning = std::move(b);
+
+   REQUIRE(a.Size() == 0);
+   REQUIRE(a.GetData() == nullptr);
+   REQUIRE(b.Size() == 0);
+   REQUIRE(b.GetData() == nullptr);
+
+   // Should both be no-ops
+   a.Destroy();
+   b.Destroy();
+
+   REQUIRE(move_non_owning.OwnsData() == false);
+   REQUIRE(move_owning.OwnsData() == true);
+
+   REQUIRE(move_non_owning.Size() == N);
+   REQUIRE(move_owning.Size() == N);
+
+   // Make sure that the pointers were reused
+   REQUIRE(move_non_owning.GetData() == a_data);
+   REQUIRE(move_owning.GetData() == b_data);
+
+   for (int i = 0; i < N; i++)
+   {
+      REQUIRE(move_non_owning(i) == N - i);
+      REQUIRE(move_owning(i) == N - i);
+   }
+}
+
+
+
 TEST_CASE("Vector Tests", "[Vector]")
 {
    double tol = 1e-12;


### PR DESCRIPTION
This PR adds move constructors and assignment operators to `Vector` and `HypreParVector` to avoid unnecessary copies and to allow for defaulted move constructors/assignment of types that are composed of `Vector` or `HypreParVector` 
<!--GHEX{"id":2639,"author":"joshessman-llnl","editor":"pazner","reviewers":["pazner","mlstowell"],"assignment":"2021-11-05T17:31:57-07:00","approval":"2021-11-22T17:31:13.258Z","merge":"2021-11-30T17:47:58.560Z"}XEHG--><!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge| 
 | --- | --- | --- | --- | --- | --- | --- | 
| [#2639](https://github.com/mfem/mfem/pull/2639) | @joshessman-llnl | @pazner | @pazner + @mlstowell | 11/05/21 | 11/22/21 | 11/30/21 | |
<!--ELBATXEHG-->