### PR TITLE
Include `omp` header on macOS [omp-macos]

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -252,6 +252,11 @@ if (MFEM_USE_OPENMP OR MFEM_USE_LEGACY_OPENMP)
   endif()
   find_package(OpenMP REQUIRED)
   set(OPENMP_LIBRARIES ${OpenMP_CXX_LIBRARIES})
+  if(APPLE)
+    # On macOS, the compiler needs additional help to find the <omp.h> header.
+    # See issue #2642 for more information.
+    include_directories(${OpenMP_CXX_INCLUDE_DIRS})
+  endif(APPLE)
 endif()
 
 # SuiteSparse (before SUNDIALS which may depend on KLU)


### PR DESCRIPTION
This PR contributes a very minor update to the Cmake build system as discussed in issue #2642. I detailed the problem in #2642 and I don't repeat it here. To test if this PR solves the problem as expected, one would have to run the commands detailed in the same issue.
<!--GHEX{"id":2645,"author":"TobiasDuswald","editor":"tzanio","reviewers":["tzanio","v-dobrev"],"assignment":"2021-11-06T16:36:33-07:00","approval":"2021-11-07T03:36:26.777Z","merge":"2021-11-08T15:38:58.609Z"}XEHG--><!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge| 
 | --- | --- | --- | --- | --- | --- | --- | 
| [#2645](https://github.com/mfem/mfem/pull/2645) | @TobiasDuswald | @tzanio | @tzanio + @v-dobrev | 11/06/21 | 11/06/21 | 11/08/21 | |
<!--ELBATXEHG-->