### PR TITLE
Fix for linear/bilinear form domain integrators with markers

### DIFF
--- a/fem/bilinearform.cpp
+++ b/fem/bilinearform.cpp
@@ -415,8 +415,8 @@ void BilinearForm::Assemble(int skip_zeros)
       {
          if (domain_integs_marker[k] != NULL)
          {
-            MFEM_VERIFY(mesh->attributes.Size() ==
-                        domain_integs_marker[k]->Size(),
+            MFEM_VERIFY(domain_integs_marker[k]->Size() ==
+                        (mesh->attributes.Size() ? mesh->attributes.Max() : 0),
                         "invalid element marker for domain integrator #"
                         << k << ", counting from zero");
          }

--- a/fem/bilinearform.hpp
+++ b/fem/bilinearform.hpp
@@ -91,7 +91,8 @@ protected:
 
    /// Set of Domain Integrators to be applied.
    Array<BilinearFormIntegrator*> domain_integs;
-   /// Element attribute marker (should be of length mesh->attributes)
+   /// Element attribute marker (should be of length mesh->attributes.Max() or
+   /// 0 if mesh->attributes is empty)
    /// Includes all by default.
    /// 0 - ignore attribute
    /// 1 - include attribute

--- a/fem/linearform.cpp
+++ b/fem/linearform.cpp
@@ -120,8 +120,9 @@ void LinearForm::Assemble()
       {
          if (domain_integs_marker[k] != NULL)
          {
-            MFEM_VERIFY(fes->GetMesh()->attributes.Size() ==
-                        domain_integs_marker[k]->Size(),
+            MFEM_VERIFY(domain_integs_marker[k]->Size() ==
+                        (fes->GetMesh()->attributes.Size() ?
+                         fes->GetMesh()->attributes.Max() : 0),
                         "invalid element marker for domain linear form "
                         "integrator #" << k << ", counting from zero");
          }

--- a/fem/linearform.hpp
+++ b/fem/linearform.hpp
@@ -33,7 +33,8 @@ protected:
 
    /// Set of Domain Integrators to be applied.
    Array<LinearFormIntegrator*> domain_integs;
-   /// Element attribute marker (should be of length mesh->attributes)
+   /// Element attribute marker (should be of length mesh->attributes.Max() or
+   /// 0 if mesh->attributes is empty)
    /// Includes all by default.
    /// 0 - ignore attribute
    /// 1 - include attribute


### PR DESCRIPTION
Resolves #2646
<!--GHEX{"author":"sebastiangrimberg","assignment":"2021-11-08T10:20:36","editor":"mlstowell","id":2648,"reviewers":["jamiebramwell","dylan-copeland"],"merge":"2022-03-17T03:06:37","approval":"2021-11-22T10:20:36"}XEHG--><!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge|
 | --- | --- | --- | --- | --- | --- | --- |
| [#2648](https://github.com/mfem/mfem/pull/2648) | @sebastiangrimberg | @mlstowell | @jamiebramwell + @dylan-copeland | 11/8/21 | 11/22/21 | 3/16/22 | |
<!--ELBATXEHG-->