### PR TITLE
Small fix in Github actions

### DIFF
--- a/.github/workflows/builds-and-tests.yml
+++ b/.github/workflows/builds-and-tests.yml
@@ -166,7 +166,7 @@ jobs:
 
     # MFEM build and test
     - name: build
-      uses: mfem/github-actions/build-mfem@v2.0
+      uses: mfem/github-actions/build-mfem@v2.0-tweak
       with:
         os: ${{ matrix.os }}
         target: ${{ matrix.target }}

--- a/.github/workflows/builds-and-tests.yml
+++ b/.github/workflows/builds-and-tests.yml
@@ -166,7 +166,7 @@ jobs:
 
     # MFEM build and test
     - name: build
-      uses: mfem/github-actions/build-mfem@v2.0-tweak
+      uses: mfem/github-actions/build-mfem@v2.0
       with:
         os: ${{ matrix.os }}
         target: ${{ matrix.target }}

--- a/.github/workflows/mfem-analysis.yml
+++ b/.github/workflows/mfem-analysis.yml
@@ -79,7 +79,7 @@ jobs:
 
     # MFEM build and test
     - name: build-mfem
-      uses: mfem/github-actions/build-mfem@v2.0-tweak
+      uses: mfem/github-actions/build-mfem@v2.0
       with:
         os: ${{ runner.os }}
         target: opt

--- a/.github/workflows/mfem-analysis.yml
+++ b/.github/workflows/mfem-analysis.yml
@@ -79,12 +79,12 @@ jobs:
 
     # MFEM build and test
     - name: build-mfem
-      uses: mfem/github-actions/build-mfem@v2.0
+      uses: mfem/github-actions/build-mfem@v2.0-tweak
       with:
         os: ${{ runner.os }}
-        target: optim
+        target: opt
         codecov: NO
-        mpi: parallel
+        mpi: par
         build-system: make
         hypre-dir: ${{ env.HYPRE_TOP_DIR }}
         metis-dir: ${{ env.METIS_TOP_DIR }}


### PR DESCRIPTION
Fix the `gitignore` github action.

Test with the external github action (remove before merge): `mfem/github-actions/build-mfem@v2.0-tweak`

TODO:
- [x] Before merging: in the repo https://github.com/mfem/github-actions merge branch `v2.0-tweak` into `v2.0`
- [x] Before merging: switch back to `mfem/github-actions/build-mfem@v2.0`

Edit: for the first bullet above, see https://github.com/mfem/github-actions/pull/5
<!--GHEX{"id":2649,"author":"v-dobrev","editor":"tzanio","reviewers":["tzanio","jandrej"],"assignment":"2021-11-06T21:46:15-07:00","approval":"2021-11-08T15:45:04.350Z","merge":"2021-11-09T04:11:30.343Z"}XEHG--><!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge| 
 | --- | --- | --- | --- | --- | --- | --- | 
| [#2649](https://github.com/mfem/mfem/pull/2649) | @v-dobrev | @tzanio | @tzanio + @jandrej | 11/06/21 | 11/08/21 | 11/08/21 | |
<!--ELBATXEHG-->