### PR TITLE
Fix Memory leaks in PMesh

### DIFF
--- a/mesh/pmesh.cpp
+++ b/mesh/pmesh.cpp
@@ -6178,6 +6178,9 @@ void ParMesh::Destroy()
       FreeElement(shared_edges[i]);
    }
    shared_edges.DeleteAll();
+
+   delete face_nbr_el_to_face;
+   face_nbr_el_to_face = NULL;
 }
 
 ParMesh::~ParMesh()

--- a/mesh/pmesh.cpp
+++ b/mesh/pmesh.cpp
@@ -2711,6 +2711,7 @@ STable3D *ParMesh::GetFaceNbrElementToFaceTable(int ret_ftbl)
    }
    face_nbr_el_to_face->Finalize();
 
+   delete sfaces_tbl;
    if (ret_ftbl)
    {
       return faces_tbl;


### PR DESCRIPTION
* `face_nbr_el_to_face` may be `new`d and is not `delete`d in the dtor
*  `sfaces_tbl` is `new`d and assigned to a local variable but never `delete`d

This was caught by our leak-sanitizer build
<!--GHEX{"id":2655,"author":"tomstitt","editor":"pazner","reviewers":["mlstowell","YohannDudouit"],"assignment":"2021-11-10T12:02:29-08:00","approval":"2021-11-30T22:32:04.889Z","merge":"2021-12-13T18:40:33.409Z"}XEHG--><!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge| 
 | --- | --- | --- | --- | --- | --- | --- | 
| [#2655](https://github.com/mfem/mfem/pull/2655) | @tomstitt | @pazner | @mlstowell + @YohannDudouit | 11/10/21 | 11/30/21 | 12/13/21 | |
<!--ELBATXEHG-->