### PR TITLE
Allow for customizing compiler flags for generating dependencies

### DIFF
--- a/config/defaults.mk
+++ b/config/defaults.mk
@@ -59,6 +59,9 @@ HIP_FLAGS = --amdgpu-target=$(HIP_ARCH)
 HIP_XCOMPILER =
 HIP_XLINKER   = -Wl,
 
+# Flags for generating dependencies.
+DEP_FLAGS = -MM -MT
+
 ifneq ($(NOTMAC),)
    AR      = ar
    ARFLAGS = crv
@@ -86,6 +89,9 @@ else
    BUILD_RPATH = $(XLINKER)-undefined,dynamic_lookup
    INSTALL_SOFLAGS = $(subst $1 ,,$(call MAKE_SOFLAGS,$(MFEM_LIB_DIR)))
    INSTALL_RPATH = $(XLINKER)-undefined,dynamic_lookup
+   # Silence unused command line argument warnings when generating dependencies
+   # with mpicxx and clang
+   DEP_FLAGS := -Wno-unused-command-line-argument $(DEP_FLAGS)
 endif
 
 # Set CXXFLAGS to overwrite the default selection of DEBUG_FLAGS/OPTIM_FLAGS

--- a/makefile
+++ b/makefile
@@ -500,7 +500,7 @@ hpc:
 deps:
 	rm -f $(BLD)deps.mk
 	for i in $(RELSRC_FILES:.cpp=); do \
-	   $(DEP_CXX) $(MFEM_BUILD_FLAGS) -MM -MT $(BLD)$${i}.o $(SRC)$${i}.cpp\
+	   $(DEP_CXX) $(MFEM_BUILD_FLAGS) $(DEP_FLAGS) $(BLD)$${i}.o $(SRC)$${i}.cpp\
 	      >> $(BLD)deps.mk; done
 
 check: lib


### PR DESCRIPTION
On Mac, by default, add the flag `-Wno-unused-command-line-argument` to silence warnings.
The user can override these choices in `user.mk`.
<!--GHEX{"id":2659,"author":"pazner","editor":"tzanio","reviewers":["v-dobrev","camierjs"],"assignment":"2021-11-10T14:48:41-08:00","approval":"2021-11-11T00:45:57.191Z","merge":"2021-11-11T23:39:42.344Z"}XEHG--><!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge| 
 | --- | --- | --- | --- | --- | --- | --- | 
| [#2659](https://github.com/mfem/mfem/pull/2659) | @pazner | @tzanio | @v-dobrev + @camierjs | 11/10/21 | 11/10/21 | 11/11/21 | |
<!--ELBATXEHG-->