### PR TITLE
In Gitlab CI, disable the `rebaseline` job for `master`

### DIFF
--- a/.gitlab/quartz-baseline.yml
+++ b/.gitlab/quartz-baseline.yml
@@ -117,7 +117,8 @@ baselinepublish_mfem_quartz:
   extends: [.on_quartz]
   stage: baseline_publish
   rules:
-    - if: '$CI_COMMIT_BRANCH == "master" || $REBASELINE == "YES"'
+    # - if: '$CI_COMMIT_BRANCH == "master" || $REBASELINE == "YES"'
+    - if: '$REBASELINE == "YES"'
       when: manual
   script:
     - echo ${BUILD_ROOT}


### PR DESCRIPTION
Disable the `rebaseline` job until we figure out how to complete the main Gitlab CI pipeline without blocking to wait for `rebaseline`.
<!--GHEX{"id":2661,"author":"v-dobrev","editor":"tzanio","reviewers":["tzanio","jandrej"],"assignment":"2021-11-11T15:34:12-08:00","approval":"2021-11-12T16:11:29.110Z","merge":"2021-11-12T16:11:52.464Z"}XEHG--><!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge| 
 | --- | --- | --- | --- | --- | --- | --- | 
| [#2661](https://github.com/mfem/mfem/pull/2661) | @v-dobrev | @tzanio | @tzanio + @jandrej | 11/11/21 | 11/12/21 | 11/12/21 | |
<!--ELBATXEHG-->