### PR TITLE
Positive diagonal in Jacobi smoothers

### DIFF
--- a/.gitlab/configs/lassen-config.yml
+++ b/.gitlab/configs/lassen-config.yml
@@ -45,5 +45,5 @@ variables:
     - echo ${MFEM_DATA_DIR}
     - echo ${SPEC}
     # Next script uses 'THREADS': leaving it empty --> it uses 'make all -j'
-    - lalloc 1 -W 30 -q pdebug tests/gitlab/build_and_test --spec "${SPEC}" --data-dir "${MFEM_DATA_DIR}" --data
+    - lalloc 1 -W 30 -q pdebug --atsdisable tests/gitlab/build_and_test --spec "${SPEC}" --data-dir "${MFEM_DATA_DIR}" --data
   needs: [setup]

--- a/linalg/solvers.cpp
+++ b/linalg/solvers.cpp
@@ -199,13 +199,15 @@ void OperatorJacobiSmoother::Setup(const Vector &diag)
    const double delta = damping;
    auto D = diag.Read();
    auto DI = dinv.Write();
+   const bool use_abs_diag_ = use_abs_diag;
    MFEM_FORALL(i, height,
    {
-      if (!(std::abs(D[i]) > 0.0))
+      if (D[i] == 0.0)
       {
          MFEM_ABORT_KERNEL("Zero diagonal entry in OperatorJacobiSmoother");
       }
-      DI[i] = delta / D[i];
+      if (!use_abs_diag_) { DI[i] = delta / D[i]; }
+      else                { DI[i] = delta / std::abs(D[i]); }
    });
    if (ess_tdof_list && ess_tdof_list->Size() > 0)
    {
@@ -238,8 +240,7 @@ void OperatorJacobiSmoother::Mult(const Vector &x, Vector &y) const
    auto Y = y.ReadWrite();
    MFEM_FORALL(i, height,
    {
-      if (use_abs_diag) { Y[i] += fabs(DI[i]) * R[i]; }
-      else              { Y[i] += DI[i] * R[i]; }
+      Y[i] += DI[i] * R[i];
    });
 }
 

--- a/linalg/solvers.cpp
+++ b/linalg/solvers.cpp
@@ -199,7 +199,14 @@ void OperatorJacobiSmoother::Setup(const Vector &diag)
    const double delta = damping;
    auto D = diag.Read();
    auto DI = dinv.Write();
-   MFEM_FORALL(i, height, DI[i] = delta / D[i]; );
+   MFEM_FORALL(i, height,
+   {
+      if (!(std::abs(D[i]) > 0.0))
+      {
+         MFEM_ABORT_KERNEL("Zero diagonal entry in OperatorJacobiSmoother");
+      }
+      DI[i] = delta / D[i];
+   });
    if (ess_tdof_list && ess_tdof_list->Size() > 0)
    {
       auto I = ess_tdof_list->Read();
@@ -229,7 +236,11 @@ void OperatorJacobiSmoother::Mult(const Vector &x, Vector &y) const
    auto DI = dinv.Read();
    auto R = residual.Read();
    auto Y = y.ReadWrite();
-   MFEM_FORALL(i, height, Y[i] += DI[i] * R[i]; );
+   MFEM_FORALL(i, height,
+   {
+      if (use_abs_diag) { Y[i] += fabs(DI[i]) * R[i]; }
+      else              { Y[i] += DI[i] * R[i]; }
+   });
 }
 
 OperatorChebyshevSmoother::OperatorChebyshevSmoother(const Operator &oper_,

--- a/linalg/solvers.hpp
+++ b/linalg/solvers.hpp
@@ -163,6 +163,9 @@ public:
 
    ~OperatorJacobiSmoother() {}
 
+   /// Replace diagonal entries with their absolute values.
+   void SetPositiveDiagonal(bool pos_diag = true) { use_abs_diag = pos_diag; }
+
    void Mult(const Vector &x, Vector &y) const;
    void MultTranspose(const Vector &x, Vector &y) const { Mult(x, y); }
 
@@ -184,6 +187,9 @@ private:
    const double damping;
    const Array<int> *ess_tdof_list; // not owned; may be NULL
    mutable Vector residual;
+   /// Uses absolute values of the diagonal entries.
+   bool use_abs_diag = false;
+
 
    const Operator *oper; // not owned
 

--- a/linalg/solvers.hpp
+++ b/linalg/solvers.hpp
@@ -190,7 +190,6 @@ private:
    /// Uses absolute values of the diagonal entries.
    bool use_abs_diag = false;
 
-
    const Operator *oper; // not owned
 
    // To preserve the original behavior, some constructors set this flag to

--- a/linalg/sparsemat.cpp
+++ b/linalg/sparsemat.cpp
@@ -2382,7 +2382,7 @@ double SparseMatrix::GetJacobiScaling() const
 }
 
 void SparseMatrix::Jacobi(const Vector &b, const Vector &x0, Vector &x1,
-                          double sc) const
+                          double sc, bool use_abs_diag) const
 {
    MFEM_VERIFY(Finalized(), "Matrix must be finalized.");
 
@@ -2403,7 +2403,12 @@ void SparseMatrix::Jacobi(const Vector &b, const Vector &x0, Vector &x1,
       }
       if (d >= 0 && A[d] != 0.0)
       {
-         x1(i) = sc * (sum / A[d]) + (1.0 - sc) * x0(i);
+         if (!(std::abs(A[d]) > 0.0))
+         {
+            MFEM_ABORT_KERNEL("Zero diagonal in SparseMatrix::Jacobi");
+         }
+         double diag = (use_abs_diag) ? fabs(A[d]) : A[d];
+         x1(i) = sc * (sum / diag) + (1.0 - sc) * x0(i);
       }
       else
       {
@@ -2412,7 +2417,8 @@ void SparseMatrix::Jacobi(const Vector &b, const Vector &x0, Vector &x1,
    }
 }
 
-void SparseMatrix::DiagScale(const Vector &b, Vector &x, double sc) const
+void SparseMatrix::DiagScale(const Vector &b, Vector &x,
+                             double sc, bool use_abs_diag) const
 {
    MFEM_VERIFY(Finalized(), "Matrix must be finalized.");
 
@@ -2442,7 +2448,8 @@ void SparseMatrix::DiagScale(const Vector &b, Vector &x, double sc) const
             {
                MFEM_ABORT_KERNEL("Zero diagonal in SparseMatrix::DiagScale");
             }
-            xp[i] = sc * bp[i] / Ap[j];
+            if (use_abs_diag) { xp[i] = sc * bp[i] / fabs(Ap[j]); }
+            else              { xp[i] = sc * bp[i] / Ap[j]; }
             break;
          }
       }

--- a/linalg/sparsemat.cpp
+++ b/linalg/sparsemat.cpp
@@ -2403,11 +2403,7 @@ void SparseMatrix::Jacobi(const Vector &b, const Vector &x0, Vector &x1,
       }
       if (d >= 0 && A[d] != 0.0)
       {
-         if (!(std::abs(A[d]) > 0.0))
-         {
-            MFEM_ABORT_KERNEL("Zero diagonal in SparseMatrix::Jacobi");
-         }
-         double diag = (use_abs_diag) ? fabs(A[d]) : A[d];
+         const double diag = (use_abs_diag) ? fabs(A[d]) : A[d];
          x1(i) = sc * (sum / diag) + (1.0 - sc) * x0(i);
       }
       else
@@ -2444,12 +2440,12 @@ void SparseMatrix::DiagScale(const Vector &b, Vector &x,
          }
          if (Jp[j] == i)
          {
-            if (!(std::abs(Ap[j]) > 0.0))
+            const double diag = (use_abs_diag) ? fabs(Ap[j]) : Ap[j];
+            if (diag == 0.0)
             {
                MFEM_ABORT_KERNEL("Zero diagonal in SparseMatrix::DiagScale");
             }
-            if (use_abs_diag) { xp[i] = sc * bp[i] / fabs(Ap[j]); }
-            else              { xp[i] = sc * bp[i] / Ap[j]; }
+            xp[i] = sc * bp[i] / diag;
             break;
          }
       }

--- a/linalg/sparsemat.hpp
+++ b/linalg/sparsemat.hpp
@@ -446,10 +446,14 @@ public:
    /// Determine appropriate scaling for Jacobi iteration
    double GetJacobiScaling() const;
    /** One scaled Jacobi iteration for the system A x = b.
-       x1 = x0 + sc D^{-1} (b - A x0)  where D is the diag of A. */
-   void Jacobi(const Vector &b, const Vector &x0, Vector &x1, double sc) const;
+       x1 = x0 + sc D^{-1} (b - A x0)  where D is the diag of A.
+       Absolute values of D are used when use_abs_diag = true. */
+   void Jacobi(const Vector &b, const Vector &x0, Vector &x1,
+               double sc, bool use_abs_diag = false) const;
 
-   void DiagScale(const Vector &b, Vector &x, double sc = 1.0) const;
+   /// x = sc b / A_ii. When use_abs_diag = true, |A_ii| is used.
+   void DiagScale(const Vector &b, Vector &x,
+                  double sc = 1.0, bool use_abs_diag = false) const;
 
    /** x1 = x0 + sc D^{-1} (b - A x0) where \f$ D_{ii} = \sum_j |A_{ij}| \f$. */
    void Jacobi2(const Vector &b, const Vector &x0, Vector &x1,

--- a/linalg/sparsesmoothers.cpp
+++ b/linalg/sparsesmoothers.cpp
@@ -65,7 +65,7 @@ void DSmoother::Mult(const Vector &x, Vector &y) const
 {
    if (!iterative_mode && type == 0 && iterations == 1)
    {
-      oper->DiagScale(x, y, scale);
+      oper->DiagScale(x, y, scale, use_abs_diag);
       return;
    }
 
@@ -90,7 +90,7 @@ void DSmoother::Mult(const Vector &x, Vector &y) const
    {
       if (type == 0)
       {
-         oper->Jacobi(x, *p, *r, scale);
+         oper->Jacobi(x, *p, *r, scale, use_abs_diag);
       }
       else if (type == 1)
       {

--- a/linalg/sparsesmoothers.hpp
+++ b/linalg/sparsesmoothers.hpp
@@ -76,8 +76,6 @@ public:
 
    /// Matrix vector multiplication with Jacobi smoother.
    virtual void Mult(const Vector &x, Vector &y) const;
-
-
 };
 
 }

--- a/linalg/sparsesmoothers.hpp
+++ b/linalg/sparsesmoothers.hpp
@@ -58,6 +58,8 @@ protected:
    int type; // 0, 1, 2 - scaled Jacobi, scaled l1-Jacobi, scaled lumped-Jacobi
    double scale;
    int iterations;
+   /// Uses abs values of the diagonal entries. Relevant only when type = 0.
+   bool use_abs_diag = false;
 
    mutable Vector z;
 
@@ -69,8 +71,13 @@ public:
    /// Create Jacobi smoother.
    DSmoother(const SparseMatrix &a, int t = 0, double s = 1., int it = 1);
 
+   /// Replace diag entries with their abs values. Relevant only when type = 0.
+   void SetPositiveDiagonal(bool pos_diag = true) { use_abs_diag = pos_diag; }
+
    /// Matrix vector multiplication with Jacobi smoother.
    virtual void Mult(const Vector &x, Vector &y) const;
+
+
 };
 
 }

--- a/miniapps/meshing/mesh-optimizer.cpp
+++ b/miniapps/meshing/mesh-optimizer.cpp
@@ -1033,11 +1033,15 @@ int main(int argc, char *argv[])
          if (pa)
          {
             MFEM_VERIFY(lin_solver != 4, "PA l1-Jacobi is not implemented");
-            S_prec = new OperatorJacobiSmoother;
+            auto js = new OperatorJacobiSmoother;
+            js->SetPositiveDiagonal(true);
+            S_prec = js;
          }
          else
          {
-            S_prec = new DSmoother((lin_solver == 3) ? 0 : 1, 1.0, 1);
+            auto ds = new DSmoother((lin_solver == 3) ? 0 : 1, 1.0, 1);
+            ds->SetPositiveDiagonal(true);
+            S_prec = ds;
          }
          minres->SetPreconditioner(*S_prec);
       }

--- a/miniapps/meshing/pmesh-optimizer.cpp
+++ b/miniapps/meshing/pmesh-optimizer.cpp
@@ -1074,13 +1074,16 @@ int main (int argc, char *argv[])
          if (pa)
          {
             MFEM_VERIFY(lin_solver != 4, "PA l1-Jacobi is not implemented");
-            S_prec = new OperatorJacobiSmoother;
+            auto js = new OperatorJacobiSmoother;
+            js->SetPositiveDiagonal(true);
+            S_prec = js;
          }
          else
          {
-            HypreSmoother *hs = new HypreSmoother;
+            auto hs = new HypreSmoother;
             hs->SetType((lin_solver == 3) ? HypreSmoother::Jacobi
-                        : HypreSmoother::l1Jacobi, 1);
+                        /* */             : HypreSmoother::l1Jacobi, 1);
+            hs->SetPositiveDiagonal(true);
             S_prec = hs;
          }
          minres->SetPreconditioner(*S_prec);


### PR DESCRIPTION
Options to take abs values of the diagonal entries in OperatorJacobiSmoother, DSmoother.

Used it in the TMOP miniapp sample runs, it made no difference.
<!--GHEX{"id":2677,"author":"vladotomov","editor":"pazner","reviewers":["kmittal2","tzanio","v-dobrev"],"assignment":"2021-11-30T09:48:05-08:00","approval":"2021-12-13T18:52:45.144Z","merge":"2021-12-17T01:58:22.794Z"}XEHG--><!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge| 
 | --- | --- | --- | --- | --- | --- | --- | 
| [#2677](https://github.com/mfem/mfem/pull/2677) | @vladotomov | @pazner | @kmittal2 + @tzanio + @v-dobrev | 11/30/21 | 12/13/21 | 12/16/21 | |
<!--ELBATXEHG-->