### PR TITLE
Iterable DataCollection

### DIFF
--- a/config/defaults.mk
+++ b/config/defaults.mk
@@ -24,7 +24,7 @@ EGREP_BIN = $(shell command -v egrep 2> /dev/null)
 CXX = g++
 MPICXX = mpicxx
 
-BASE_FLAGS  = -std=c++11
+BASE_FLAGS  = -std=c++17
 OPTIM_FLAGS = -O3 $(BASE_FLAGS)
 DEBUG_FLAGS = -g $(XCOMPILER)-Wall $(BASE_FLAGS)
 

--- a/examples/ex9p.cpp
+++ b/examples/ex9p.cpp
@@ -250,6 +250,7 @@ int main(int argc, char *argv[])
    double t_final = 10.0;
    double dt = 0.01;
    bool visualization = true;
+   bool internal = false;
    bool visit = false;
    bool paraview = false;
    bool adios2 = false;
@@ -298,6 +299,9 @@ int main(int argc, char *argv[])
    args.AddOption(&visualization, "-vis", "--visualization", "-no-vis",
                   "--no-visualization",
                   "Enable or disable GLVis visualization.");
+   args.AddOption(&internal, "-idf", "--mfem-datafiles", "-no-idf",
+                  "--no-mfem-datafiles",
+                  "Save data files in the internal formal.");
    args.AddOption(&visit, "-visit", "--visit-datafiles", "-no-visit",
                   "--no-visit-datafiles",
                   "Save data files for VisIt (visit.llnl.gov) visualization.");
@@ -503,6 +507,18 @@ int main(int argc, char *argv[])
       pd->Save();
    }
 
+   MFEMDataCollection *idc = NULL;
+   if (internal)
+   {
+      idc = new MFEMDataCollection("Example9P-internal", *pmesh, false);
+      idc->SetPrefixPath("internal");
+      idc->RegisterField("solution", u);
+      idc->ResetMetadata();
+      idc->SetCycle(0);
+      idc->SetTime(0.0);
+      idc->Save();
+   }
+
    // Optionally output a BP (binary pack) file using ADIOS2. This can be
    // visualized with the ParaView VTX reader.
 #ifdef MFEM_USE_ADIOS2
@@ -604,6 +620,13 @@ int main(int argc, char *argv[])
             pd->Save();
          }
 
+         if (internal)
+         {
+            idc->SetCycle(ti);
+            idc->SetTime(t);
+            idc->Save();
+         }
+
 #ifdef MFEM_USE_ADIOS2
          // transient solutions can be visualized with ParaView
          if (adios2)
@@ -637,6 +660,7 @@ int main(int argc, char *argv[])
    delete fes;
    delete pmesh;
    delete ode_solver;
+   delete idc;
    delete pd;
 #ifdef MFEM_USE_ADIOS2
    if (adios2)

--- a/miniapps/tools/makefile
+++ b/miniapps/tools/makefile
@@ -26,7 +26,7 @@ MFEM_LIB_FILE = mfem_is_not_built
 -include $(CONFIG_MK)
 
 SEQ_MINIAPPS = display-basis load-dc convert-dc get-values lor-transfer
-PAR_MINIAPPS =
+PAR_MINIAPPS = replay-simulation
 ifeq ($(MFEM_USE_MPI),NO)
    MINIAPPS = $(SEQ_MINIAPPS)
 else
@@ -76,7 +76,7 @@ RUN_MPI = $(MFEM_MPIEXEC) $(MFEM_MPIEXEC_NP) $(MFEM_MPI_NP)
 
 # Testing: Specific execution options
 # Do not test: display-basis, load-dc, convert-dc, get-values, lor-transfer
-NO_TEST_APPS = display-basis load-dc convert-dc get-values lor-transfer
+NO_TEST_APPS = display-basis load-dc convert-dc get-values lor-transfer replay-simulation
 $(foreach app,$(NO_TEST_APPS),$(app)-test-seq $(app)-test-par):
 	@true
 

--- a/miniapps/tools/replay-simulation.cpp
+++ b/miniapps/tools/replay-simulation.cpp
@@ -1,0 +1,67 @@
+#include "mfem.hpp"
+#include <memory>
+#include <iostream>
+#include <fstream>
+
+using namespace std;
+using namespace mfem;
+
+int main(int argc, char *argv[])
+{
+    MPI_Session mpi;
+    const int myid = mpi.WorldRank();
+
+    // 1. Parse command-line options
+    const char *dc_folder = "../../examples/internal/";
+    const char *simulation_name = "Example9P-internal";
+    const char *field_name = "solution";
+    // const auto t0 = 0.0;
+    // const auto T = std::numeric_limits<double>::infinity();
+    const char* vishost = "localhost";
+    int visport = 19916;
+    int precision = 8;
+
+    OptionsParser args(argc, argv);
+    args.AddOption(&dc_folder, "-dc", "--data-collection-folder",
+                    "Folder containing the DataCollections in MFEM internal format.");
+    args.AddOption(&simulation_name, "-sn", "--simulation-name",
+                    "Name of the DataCollection.");
+    args.Parse();
+    if (!args.Good())
+    {
+        if (myid == 0)
+        {
+            args.PrintUsage(cout);
+        }
+        return 1;
+    }
+    if (myid == 0)
+    {
+        args.PrintOptions(cout);
+    }
+
+    // Load data collection
+    auto dc = std::make_shared<MFEMDataCollection>(simulation_name);
+    dc->SetPrefixPath(dc_folder);
+    auto metainfo = dc->ReloadMetaInfo();
+    if(!metainfo)
+    {
+        mfem_error("Failed to load meta info.");
+    }
+
+    socketstream vis;
+    vis.open(vishost, visport);
+    vis.precision(precision);
+
+    for(auto [cycle, t, Δt] : metainfo.value())
+    {
+        dc->Load(cycle);
+        auto pmesh = dc->GetParMesh();
+        auto u = dc->GetParField(field_name);
+        vis << "parallel " << pmesh->GetNRanks() << " " << pmesh->GetMyRank() << "\n";
+        vis << "solution\n" << *pmesh << *u << std::flush;
+        vis << "plot_caption 't=" << t << "'\n";
+    }
+
+    return 0;
+}


### PR DESCRIPTION
For post-processing purposes it can be useful to load a DataCollection at the stored cycles. Assuming these cycles are not contiguous, this PR presents a very simple take on designing an iterable DataCollection (called MFEMDataCollection in the first version) along a simple miniapp to replay parallel simulations with GLVis.

Currently the `\Delta t` in the is the time step length used at the corresponding time point in the simulation, and not the time difference between two consecutive calls to `Save`. AMR may be not functional at the current state.

**NOTE!** This PR primarily exists for the purpose of discussing possible interfaces (see #2574 , ping @v-dobrev).