### PR TITLE
Remove nvcc warnings about partially overridden virtual functions [nvwarnings]

### DIFF
--- a/fem/coefficient.hpp
+++ b/fem/coefficient.hpp
@@ -574,6 +574,7 @@ public:
    /// Evaluate the coefficient.
    virtual void Eval(Vector &V, ElementTransformation &T,
                      const IntegrationPoint &ip);
+   using VectorCoefficient::Eval;
 };
 
 /// A general vector function coefficient

--- a/fem/doftrans.hpp
+++ b/fem/doftrans.hpp
@@ -243,6 +243,7 @@ public:
    void TransformDual(double *v) const;
 
    void InvTransformDual(double *v) const;
+   using DofTransformation::InvTransformDual;
 };
 
 /// DoF transformation implementation for the Nedelec basis on tetrahedra


### PR DESCRIPTION
Remove warnings from:

```
fem/coefficient.hpp(514): warning: overloaded virtual function "mfem::VectorCoefficient::Eval" is only partially overridden in class "mfem::PWVectorCoefficient"
```

```
doftrans.hpp(230): warning: overloaded virtual function "mfem::DofTransformation::InvTransformDual" is only partially overridden in class "mfem::ND_TriDofTransformation"
```
<!--GHEX{"id":2698,"author":"camierjs","editor":"tzanio","reviewers":["tzanio","artv3"],"assignment":"2021-12-12T11:26:01-08:00","approval":"2021-12-13T00:44:15.124Z","merge":"2021-12-13T21:13:30.201Z"}XEHG--><!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge| 
 | --- | --- | --- | --- | --- | --- | --- | 
| [#2698](https://github.com/mfem/mfem/pull/2698) | @camierjs | @tzanio | @tzanio + @artv3 | 12/12/21 | 12/12/21 | 12/13/21 | |
<!--ELBATXEHG-->