### PR TITLE
Remove duplicated code.

### DIFF
--- a/fem/bilininteg_dgtrace_pa.cpp
+++ b/fem/bilininteg_dgtrace_pa.cpp
@@ -192,8 +192,10 @@ void DGTraceIntegrator::SetupPA(const FiniteElementSpace &fes, FaceType type)
          }
          else if ( face.IsOfFaceType(type) )
          {
+            const int mask = FaceElementTransformations::HAVE_ELEM1 |
+                             FaceElementTransformations::HAVE_LOC1;
             FaceElementTransformations &T =
-               *fes.GetMesh()->GetFaceElementTransformations(f,5); // Elem1 and Loc1
+               *fes.GetMesh()->GetFaceElementTransformations(f, mask);
             for (int q = 0; q < nq; ++q)
             {
                // Convert to lexicographic ordering

--- a/fem/prestriction.cpp
+++ b/fem/prestriction.cpp
@@ -311,9 +311,12 @@ ParL2FaceRestriction::ParL2FaceRestriction(const ParFiniteElementSpace &fes,
    ComputeGatherIndices(ordering, type);
 }
 
-void ParL2FaceRestriction::ParDoubleValuedConformingMult(
+void ParL2FaceRestriction::DoubleValuedConformingMult(
    const Vector& x, Vector& y) const
 {
+   MFEM_ASSERT(
+      m == L2FaceValues::DoubleValued,
+      "This method should be called when m == L2FaceValues::DoubleValued.");
    const ParFiniteElementSpace &pfes =
       static_cast<const ParFiniteElementSpace&>(this->fes);
    ParGridFunction x_gf;
@@ -366,7 +369,7 @@ void ParL2FaceRestriction::Mult(const Vector& x, Vector& y) const
 {
    if (m==L2FaceValues::DoubleValued)
    {
-      ParDoubleValuedConformingMult(x, y);
+      DoubleValuedConformingMult(x, y);
    }
    else
    {
@@ -672,9 +675,12 @@ ParNCL2FaceRestriction::ParNCL2FaceRestriction(const ParFiniteElementSpace &fes,
    ComputeGatherIndices(ordering, type);
 }
 
-void ParNCL2FaceRestriction::ParSingleValuedNonConformingMult(
+void ParNCL2FaceRestriction::SingleValuedNonConformingMult(
    const Vector& x, Vector& y) const
 {
+   MFEM_ASSERT(
+      m == L2FaceValues::SingleValued,
+      "This method should be called when m == L2FaceValues::SingleValued.");
    // Assumes all elements have the same number of dofs
    const int nface_dofs = face_dofs;
    const int vd = vdim;
@@ -751,9 +757,12 @@ void ParNCL2FaceRestriction::ParSingleValuedNonConformingMult(
    });
 }
 
-void ParNCL2FaceRestriction::ParDoubleValuedNonConformingMult(
+void ParNCL2FaceRestriction::DoubleValuedNonConformingMult(
    const Vector& x, Vector& y) const
 {
+   MFEM_ASSERT(
+      m == L2FaceValues::DoubleValued,
+      "This method should be called when m == L2FaceValues::DoubleValued.");
    const ParFiniteElementSpace &pfes =
       static_cast<const ParFiniteElementSpace&>(this->fes);
    ParGridFunction x_gf;
@@ -861,7 +870,7 @@ void ParNCL2FaceRestriction::Mult(const Vector& x, Vector& y) const
 {
    if ( type==FaceType::Interior && m==L2FaceValues::DoubleValued )
    {
-      ParDoubleValuedNonConformingMult(x, y);
+      DoubleValuedNonConformingMult(x, y);
    }
    else if ( type==FaceType::Boundary && m==L2FaceValues::DoubleValued )
    {
@@ -869,7 +878,7 @@ void ParNCL2FaceRestriction::Mult(const Vector& x, Vector& y) const
    }
    else if ( type==FaceType::Interior && m==L2FaceValues::SingleValued )
    {
-      ParSingleValuedNonConformingMult(x, y);
+      SingleValuedNonConformingMult(x, y);
    }
    else if ( type==FaceType::Boundary && m==L2FaceValues::SingleValued )
    {

--- a/fem/prestriction.cpp
+++ b/fem/prestriction.cpp
@@ -26,9 +26,9 @@ namespace mfem
 ParNCH1FaceRestriction::ParNCH1FaceRestriction(const ParFiniteElementSpace &fes,
                                                ElementDofOrdering ordering,
                                                FaceType type)
-   : H1FaceRestriction(fes,type),
+   : H1FaceRestriction(fes, ordering, type, false),
      type(type),
-     interpolations(fes,ordering,type)
+     interpolations(fes, ordering, type)
 {
    if (nf==0) { return; }
    // If fespace == H1
@@ -328,7 +328,7 @@ ParL2FaceRestriction::ParL2FaceRestriction(const ParFiniteElementSpace &fes,
                                            ElementDofOrdering ordering,
                                            FaceType type,
                                            L2FaceValues m)
-   : L2FaceRestriction(fes, type, m)
+   : L2FaceRestriction(fes, ordering, type, m, false)
 {
    if (nf==0) { return; }
    // If fespace == L2
@@ -390,7 +390,7 @@ void ParL2FaceRestriction::ParDoubleValuedConformingMult(
    auto d_indices2 = scatter_indices2.Read();
    auto d_x = Reshape(x.Read(), t?vd:ndofs, t?ndofs:vd);
    auto d_x_shared = Reshape(x_gf.FaceNbrData().Read(),
-                              t?vd:nsdofs, t?nsdofs:vd);
+                             t?vd:nsdofs, t?nsdofs:vd);
    auto d_y = Reshape(y.Write(), nface_dofs, vd, 2, nf);
    MFEM_FORALL(i, nfdofs,
    {
@@ -411,7 +411,7 @@ void ParL2FaceRestriction::ParDoubleValuedConformingMult(
          else if (idx2>=threshold) // shared boundary
          {
             d_y(dof, c, 1, face) = d_x_shared(t?c:(idx2-threshold),
-                                                t?(idx2-threshold):c);
+                                              t?(idx2-threshold):c);
          }
          else // true boundary
          {
@@ -719,7 +719,7 @@ ParNCL2FaceRestriction::ParNCL2FaceRestriction(const ParFiniteElementSpace &fes,
                                                ElementDofOrdering ordering,
                                                FaceType type,
                                                L2FaceValues m)
-   : L2FaceRestriction(fes, type, m), interpolations(fes, ordering, type)
+   : NCL2FaceRestriction(fes, ordering, type, m, false)
 {
    if (nf==0) { return; }
    // If fespace==L2
@@ -859,7 +859,7 @@ void ParNCL2FaceRestriction::ParDoubleValuedNonConformingMult(
    auto d_indices2 = scatter_indices2.Read();
    auto d_x = Reshape(x.Read(), t?vd:ndofs, t?ndofs:vd);
    auto d_x_shared = Reshape(x_gf.FaceNbrData().Read(),
-                              t?vd:nsdofs, t?nsdofs:vd);
+                             t?vd:nsdofs, t?nsdofs:vd);
    auto d_y = Reshape(y.Write(), nface_dofs, vd, 2, nf);
    auto interp_config_ptr = interpolations.GetFaceInterpConfig().Read();
    auto interpolators = interpolations.GetInterpolators().Read();

--- a/fem/prestriction.cpp
+++ b/fem/prestriction.cpp
@@ -883,23 +883,29 @@ void ParNCL2FaceRestriction::Mult(const Vector& x, Vector& y) const
 
 void ParNCL2FaceRestriction::AddMultTranspose(const Vector &x, Vector &y) const
 {
-   // Interpolation from slave to master face dofs
-   if ( type==FaceType::Interior && m==L2FaceValues::DoubleValued )
+   if (type==FaceType::Interior)
    {
-      DoubleValuedNonConformingTransposeInterpolation(x);
+      if ( m==L2FaceValues::DoubleValued )
+      {
+         DoubleValuedNonConformingTransposeInterpolation(x);
+         DoubleValuedConformingAddMultTranspose(x_interp, y);
+      }
+      else // Single Valued
+      {
+         SingleValuedNonConformingTransposeInterpolation(x);
+         SingleValuedConformingAddMultTranspose(x_interp, y);
+      }
    }
-   else if ( type==FaceType::Interior && m==L2FaceValues::SingleValued )
+   else
    {
-      SingleValuedNonConformingTransposeInterpolation(x);
-   }
-
-   if ( m==L2FaceValues::DoubleValued )
-   {
-      DoubleValuedConformingAddMultTranspose(x_interp, y);
-   }
-   else // Single valued
-   {
-      SingleValuedConformingAddMultTranspose(x_interp, y);
+      if ( m==L2FaceValues::DoubleValued )
+      {
+         DoubleValuedConformingAddMultTranspose(x, y);
+      }
+      else // Single valued
+      {
+         SingleValuedConformingAddMultTranspose(x, y);
+      }
    }
 }
 

--- a/fem/prestriction.cpp
+++ b/fem/prestriction.cpp
@@ -299,9 +299,11 @@ void ParNCH1FaceRestriction::ComputeGatherIndices(
 ParL2FaceRestriction::ParL2FaceRestriction(const ParFiniteElementSpace &fes,
                                            ElementDofOrdering ordering,
                                            FaceType type,
-                                           L2FaceValues m)
+                                           L2FaceValues m,
+                                           bool build)
    : L2FaceRestriction(fes, ordering, type, m, false)
 {
+   if (!build) { return; }
    if (nf==0) { return; }
 
    CheckFESpace(ordering);
@@ -310,6 +312,13 @@ ParL2FaceRestriction::ParL2FaceRestriction(const ParFiniteElementSpace &fes,
 
    ComputeGatherIndices(ordering, type);
 }
+
+ParL2FaceRestriction::ParL2FaceRestriction(const ParFiniteElementSpace &fes,
+                                           ElementDofOrdering ordering,
+                                           FaceType type,
+                                           L2FaceValues m)
+   : ParL2FaceRestriction(fes, ordering, type, m, true)
+{ }
 
 void ParL2FaceRestriction::DoubleValuedConformingMult(
    const Vector& x, Vector& y) const
@@ -663,7 +672,9 @@ ParNCL2FaceRestriction::ParNCL2FaceRestriction(const ParFiniteElementSpace &fes,
                                                ElementDofOrdering ordering,
                                                FaceType type,
                                                L2FaceValues m)
-   : NCL2FaceRestriction(fes, ordering, type, m, false)
+   : L2FaceRestriction(fes, ordering, type, m, false),
+     NCL2FaceRestriction(fes, ordering, type, m, false),
+     ParL2FaceRestriction(fes, ordering, type, m, false)
 {
    if (nf==0) { return; }
    x_interp.UseDevice(true);

--- a/fem/prestriction.hpp
+++ b/fem/prestriction.hpp
@@ -184,6 +184,9 @@ private:
    */
    void ComputeGatherIndices(const ElementDofOrdering ordering,
                              const FaceType type);
+
+protected:
+   void ParDoubleValuedConformingMult(const Vector& x, Vector& y) const;
 };
 
 /// Operator that extracts Face degrees of freedom for NCMesh in parallel.
@@ -299,6 +302,11 @@ private:
    */
    void ComputeGatherIndices(const ElementDofOrdering ordering,
                              const FaceType type);
+
+protected:
+   void ParSingleValuedNonConformingMult(const Vector& x, Vector& y) const;
+
+   void ParDoubleValuedNonConformingMult(const Vector& x, Vector& y) const;
 };
 
 }

--- a/fem/prestriction.hpp
+++ b/fem/prestriction.hpp
@@ -92,8 +92,25 @@ private:
 /// Operator that extracts Face degrees of freedom in parallel.
 /** Objects of this type are typically created and owned by FiniteElementSpace
     objects, see FiniteElementSpace::GetFaceRestriction(). */
-class ParL2FaceRestriction : public L2FaceRestriction
+class ParL2FaceRestriction : virtual public L2FaceRestriction
 {
+protected:
+   /** @brief Constructs an ParL2FaceRestriction.
+
+       @param[in] fes      The ParFiniteElementSpace on which this operates
+       @param[in] ordering Request a specific ordering
+       @param[in] type     Request internal or boundary faces dofs
+       @param[in] m        Request the face dofs for elem1, or both elem1 and
+                           elem2
+       @param[in] build    Request the ParL2FaceRestriction to compute the
+                           scatter/gather indices. False should only be used
+                           when inheriting from ParL2FaceRestriction. */
+   ParL2FaceRestriction(const ParFiniteElementSpace& fes,
+                        ElementDofOrdering ordering,
+                        FaceType type,
+                        L2FaceValues m,
+                        bool build);
+
 public:
    /** @brief Constructs an ParL2FaceRestriction.
 
@@ -203,7 +220,8 @@ protected:
 /// Operator that extracts Face degrees of freedom for NCMesh in parallel.
 /** Objects of this type are typically created and owned by FiniteElementSpace
     objects, see FiniteElementSpace::GetFaceRestriction(). */
-class ParNCL2FaceRestriction : public NCL2FaceRestriction
+class ParNCL2FaceRestriction
+   : public NCL2FaceRestriction, public ParL2FaceRestriction
 {
 public:
    /** @brief Constructs an ParNCL2FaceRestriction.

--- a/fem/prestriction.hpp
+++ b/fem/prestriction.hpp
@@ -192,12 +192,8 @@ protected:
 /// Operator that extracts Face degrees of freedom for NCMesh in parallel.
 /** Objects of this type are typically created and owned by FiniteElementSpace
     objects, see FiniteElementSpace::GetFaceRestriction(). */
-class ParNCL2FaceRestriction : public L2FaceRestriction
+class ParNCL2FaceRestriction : public NCL2FaceRestriction
 {
-protected:
-   InterpolationManager interpolations;
-   mutable Vector x_interp;
-
 public:
    /** @brief Constructs an ParNCL2FaceRestriction.
 

--- a/fem/prestriction.hpp
+++ b/fem/prestriction.hpp
@@ -186,7 +186,18 @@ private:
                              const FaceType type);
 
 protected:
-   void ParDoubleValuedConformingMult(const Vector& x, Vector& y) const;
+   /** @brief Scatter the degrees of freedom, i.e. goes from L-Vector to
+       face E-Vector. Should only be used with conforming faces and when:
+       m == L2FacesValues::DoubleValued
+
+       @param[in]  x The L-vector degrees of freedom.
+       @param[out] y The face E-Vector degrees of freedom with the given format:
+                     face_dofs x vdim x 2 x nf
+                     where nf is the number of interior or boundary faces
+                     requested by @a type in the constructor.
+                     The face_dofs are ordered according to the given
+                     ElementDofOrdering. */
+   void DoubleValuedConformingMult(const Vector& x, Vector& y) const override;
 };
 
 /// Operator that extracts Face degrees of freedom for NCMesh in parallel.
@@ -300,9 +311,31 @@ private:
                              const FaceType type);
 
 protected:
-   void ParSingleValuedNonConformingMult(const Vector& x, Vector& y) const;
+   /** @brief Scatter the degrees of freedom, i.e. goes from L-Vector to
+       face E-Vector. Should only be used with non-conforming faces and when:
+       L2FaceValues m == L2FaceValues::SingleValued
 
-   void ParDoubleValuedNonConformingMult(const Vector& x, Vector& y) const;
+       @param[in]  x The L-vector degrees of freedom.
+       @param[out] y The face E-Vector degrees of freedom with the given format:
+                     (face_dofs x vdim x nf),
+                     where nf is the number of interior or boundary faces
+                     requested by @a type in the constructor.
+                     The face_dofs are ordered according to the given
+                     ElementDofOrdering. */
+   void SingleValuedNonConformingMult(const Vector& x, Vector& y) const;
+
+   /** @brief Scatter the degrees of freedom, i.e. goes from L-Vector to
+       face E-Vector. Should only be used with non-conforming faces and when:
+       L2FaceValues m == L2FaceValues::DoubleValued
+
+       @param[in]  x The L-vector degrees of freedom.
+       @param[out] y The face E-Vector degrees of freedom with the given format:
+                     (face_dofs x vdim x 2 x nf),
+                     where nf is the number of interior or boundary faces
+                     requested by @a type in the constructor.
+                     The face_dofs are ordered according to the given
+                     ElementDofOrdering. */
+   void DoubleValuedNonConformingMult(const Vector& x, Vector& y) const override;
 };
 
 }

--- a/fem/restriction.cpp
+++ b/fem/restriction.cpp
@@ -685,6 +685,8 @@ H1FaceRestriction::H1FaceRestriction(const FiniteElementSpace &fes,
      gather_indices(nf*face_dofs),
      face_map(face_dofs)
 {
+   height = vdim*nf*face_dofs;
+   width = fes.GetVSize();
    if (!build) { return; }
    if (nf==0) { return; }
 
@@ -774,8 +776,6 @@ void H1FaceRestriction::CheckFESpace(const ElementDofOrdering e_ordering)
                "H1FaceRestriction.");
 
    // Assuming all finite elements are using Gauss-Lobatto.
-   height = vdim*nf*face_dofs;
-   width = fes.GetVSize();
    const bool dof_reorder = (e_ordering == ElementDofOrdering::LEXICOGRAPHIC);
    if (dof_reorder && nf > 0)
    {
@@ -1081,6 +1081,8 @@ L2FaceRestriction::L2FaceRestriction(const FiniteElementSpace &fes,
      gather_indices((m==L2FaceValues::DoubleValued? 2 : 1)*nf*face_dofs),
      face_map(face_dofs)
 {
+   height = (m==L2FaceValues::DoubleValued? 2 : 1)*vdim*nf*face_dofs;
+   width = fes.GetVSize();
    if (!build) { return; }
 
    CheckFESpace(e_ordering);
@@ -1369,8 +1371,6 @@ void L2FaceRestriction::CheckFESpace(const ElementDofOrdering e_ordering)
                "Only Gauss-Lobatto and Bernstein basis are supported in "
                "L2FaceRestriction.");
    if (nf==0) { return; }
-   height = (m==L2FaceValues::DoubleValued? 2 : 1)*vdim*nf*face_dofs;
-   width = fes.GetVSize();
    const bool dof_reorder = (e_ordering == ElementDofOrdering::LEXICOGRAPHIC);
    if (!dof_reorder)
    {

--- a/fem/restriction.cpp
+++ b/fem/restriction.cpp
@@ -1100,6 +1100,9 @@ L2FaceRestriction::L2FaceRestriction(const FiniteElementSpace &fes,
 void L2FaceRestriction::SingleValuedConformingMult(const Vector& x,
                                                    Vector& y) const
 {
+   MFEM_ASSERT(
+      m == L2FaceValues::SingleValued,
+      "This method should be called when m == L2FaceValues::SingleValued.");
    // Assumes all elements have the same number of dofs
    const int nface_dofs = face_dofs;
    const int vd = vdim;
@@ -1122,6 +1125,9 @@ void L2FaceRestriction::SingleValuedConformingMult(const Vector& x,
 void L2FaceRestriction::DoubleValuedConformingMult(const Vector& x,
                                                    Vector& y) const
 {
+   MFEM_ASSERT(
+      m == L2FaceValues::DoubleValued,
+      "This method should be called when m == L2FaceValues::DoubleValued.");
    // Assumes all elements have the same number of dofs
    const int nface_dofs = face_dofs;
    const int vd = vdim;
@@ -1867,6 +1873,9 @@ void NCL2FaceRestriction::Mult(const Vector& x, Vector& y) const
 void NCL2FaceRestriction::SingleValuedNonConformingTransposeInterpolation(
    const Vector& x) const
 {
+   MFEM_ASSERT(
+      m == L2FaceValues::SingleValued,
+      "This method should be called when m == L2FaceValues::SingleValued.");
    if (x_interp.Size()==0)
    {
       x_interp.SetSize(x.Size());
@@ -1917,6 +1926,9 @@ void NCL2FaceRestriction::SingleValuedNonConformingTransposeInterpolation(
 void NCL2FaceRestriction::DoubleValuedNonConformingTransposeInterpolation(
    const Vector& x) const
 {
+   MFEM_ASSERT(
+      m == L2FaceValues::DoubleValued,
+      "This method should be called when m == L2FaceValues::DoubleValued.");
    if (x_interp.Size()==0)
    {
       x_interp.SetSize(x.Size());

--- a/fem/restriction.hpp
+++ b/fem/restriction.hpp
@@ -467,6 +467,14 @@ protected:
     */
    void PermuteAndSetFaceDofsGatherIndices2(const Mesh::FaceInformation &face,
                                             const int face_index);
+
+   void SingleValuedConformingMult(const Vector& x, Vector& y) const;
+
+   void DoubleValuedConformingMult(const Vector& x, Vector& y) const;
+
+   void SingleValuedConformingAddMultTranspose(const Vector& x, Vector& y) const;
+
+   void DoubleValuedConformingAddMultTranspose(const Vector& x, Vector& y) const;
 };
 
 /** This class stores which side is the master non-conforming side and the
@@ -719,6 +727,13 @@ private:
    */
    void ComputeGatherIndices(const ElementDofOrdering ordering,
                              const FaceType type);
+
+protected:
+   void DoubleValuedNonConformingMult(const Vector& x, Vector& y) const;
+
+   void SingleValuedNonConformingTransposeInterpolation(const Vector& x) const;
+
+   void DoubleValuedNonConformingTransposeInterpolation(const Vector& x) const;
 };
 
 /** @brief Return the face map that extracts the degrees of freedom for the

--- a/fem/restriction.hpp
+++ b/fem/restriction.hpp
@@ -503,12 +503,56 @@ protected:
    void PermuteAndSetFaceDofsGatherIndices2(const Mesh::FaceInformation &face,
                                             const int face_index);
 
+   /** @brief Scatter the degrees of freedom, i.e. goes from L-Vector to
+       face E-Vector. Should only be used with conforming faces and when:
+       m == L2FacesValues::SingleValued
+
+       @param[in]  x The L-vector degrees of freedom.
+       @param[out] y The face E-Vector degrees of freedom with the given format:
+                     face_dofs x vdim x nf
+                     where nf is the number of interior or boundary faces
+                     requested by @a type in the constructor.
+                     The face_dofs are ordered according to the given
+                     ElementDofOrdering. */
    void SingleValuedConformingMult(const Vector& x, Vector& y) const;
 
-   void DoubleValuedConformingMult(const Vector& x, Vector& y) const;
+   /** @brief Scatter the degrees of freedom, i.e. goes from L-Vector to
+       face E-Vector. Should only be used with conforming faces and when:
+       m == L2FacesValues::DoubleValued
 
+       @param[in]  x The L-vector degrees of freedom.
+       @param[out] y The face E-Vector degrees of freedom with the given format:
+                     face_dofs x vdim x 2 x nf
+                     where nf is the number of interior or boundary faces
+                     requested by @a type in the constructor.
+                     The face_dofs are ordered according to the given
+                     ElementDofOrdering. */
+   virtual void DoubleValuedConformingMult(const Vector& x, Vector& y) const;
+
+   /** @brief Gather the degrees of freedom, i.e. goes from face E-Vector to
+       L-Vector. Should only be used with conforming faces and when:
+       m == L2FacesValues::SingleValued
+
+       @param[in]  x The face E-Vector degrees of freedom with the given format:
+                     face_dofs x vdim x nf
+                     where nf is the number of interior or boundary faces
+                     requested by @a type in the constructor.
+                     The face_dofs should be ordered according to the given
+                     ElementDofOrdering
+       @param[in,out] y The L-vector degrees of freedom. */
    void SingleValuedConformingAddMultTranspose(const Vector& x, Vector& y) const;
 
+   /** @brief Gather the degrees of freedom, i.e. goes from face E-Vector to
+       L-Vector. Should only be used with conforming faces and when:
+       m == L2FacesValues::DoubleValued
+
+       @param[in]  x The face E-Vector degrees of freedom with the given format:
+                     face_dofs x vdim x 2 x nf
+                     where nf is the number of interior or boundary faces
+                     requested by @a type in the constructor.
+                     The face_dofs should be ordered according to the given
+                     ElementDofOrdering
+       @param[in,out] y The L-vector degrees of freedom. */
    void DoubleValuedConformingAddMultTranspose(const Vector& x, Vector& y) const;
 };
 
@@ -783,10 +827,35 @@ private:
                              const FaceType type);
 
 protected:
-   void DoubleValuedNonConformingMult(const Vector& x, Vector& y) const;
+   /** @brief Scatter the degrees of freedom, i.e. goes from L-Vector to
+       face E-Vector. Should only be used with non-conforming faces and when:
+       L2FaceValues m == L2FaceValues::DoubleValued
 
+       @param[in]  x The L-vector degrees of freedom.
+       @param[out] y The face E-Vector degrees of freedom with the given format:
+                     (face_dofs x vdim x 2 x nf),
+                     where nf is the number of interior or boundary faces
+                     requested by @a type in the constructor.
+                     The face_dofs are ordered according to the given
+                     ElementDofOrdering. */
+   virtual void DoubleValuedNonConformingMult(const Vector& x, Vector& y) const;
+
+   /** @brief Apply a change of basis from fine element basis to coarse element
+       basis for the coarse face dofs. Should only be used when:
+       L2FaceValues m == L2FaceValues::SingleValued
+
+       @param[in] x The dofs vector that needs coarse dofs to be express in term
+                    of the coarse basis, the result is stored in x_interp.
+   */
    void SingleValuedNonConformingTransposeInterpolation(const Vector& x) const;
 
+   /** @brief Apply a change of basis from fine element basis to coarse element
+       basis for the coarse face dofs. Should only be used when:
+       L2FaceValues m == L2FaceValues::DoubleValued
+
+       @param[in] x The dofs vector that needs coarse dofs to be express in term
+                    of the coarse basis, the result is stored in x_interp.
+   */
    void DoubleValuedNonConformingTransposeInterpolation(const Vector& x) const;
 };
 

--- a/fem/restriction.hpp
+++ b/fem/restriction.hpp
@@ -255,8 +255,6 @@ protected:
 
    /** @brief Verify that H1FaceRestriction is build from an H1 FESpace.
 
-       Note: Requires the gather offsets to be computed.
-
        @param[in] ordering The FESpace element ordering.
    */
    void CheckFESpace(const ElementDofOrdering ordering);
@@ -433,8 +431,6 @@ protected:
    mutable Array<int> face_map; // Used in the computation of GetFaceDofs
 
    /** @brief Verify that L2FaceRestriction is build from an L2 FESpace.
-
-       Note: Requires the gather offsets to be computed.
 
        @param[in] ordering The FESpace element ordering.
    */

--- a/fem/restriction.hpp
+++ b/fem/restriction.hpp
@@ -253,6 +253,14 @@ private:
 protected:
    mutable Array<int> face_map; // Used in the computation of GetFaceDofs
 
+   /** @brief Verify that H1FaceRestriction is build from an H1 FESpace.
+
+       Note: Requires the gather offsets to be computed.
+
+       @param[in] ordering The FESpace element ordering.
+   */
+   void CheckFESpace(const ElementDofOrdering ordering);
+
    /** @brief Set the scattering indices of elem1, and increment the offsets for
        the face described by the @a face.
 
@@ -423,6 +431,14 @@ private:
 
 protected:
    mutable Array<int> face_map; // Used in the computation of GetFaceDofs
+
+   /** @brief Verify that H1FaceRestriction is build from an L2 FESpace.
+
+       Note: Requires the gather offsets to be computed.
+
+       @param[in] ordering The FESpace element ordering.
+   */
+   void CheckFESpace(const ElementDofOrdering ordering);
 
    /** @brief Set the scattering indices of elem1, and increment the offsets for
        the face described by the @a face. The ordering of the face dofs of elem1

--- a/fem/restriction.hpp
+++ b/fem/restriction.hpp
@@ -693,7 +693,7 @@ private:
     operator interpolates master (coarse) face degrees of freedom onto the
     slave (fine) face. This allows face integrators to treat non-conforming
     faces just as regular conforming faces. */
-class NCL2FaceRestriction : public L2FaceRestriction
+class NCL2FaceRestriction : virtual public L2FaceRestriction
 {
 protected:
    InterpolationManager interpolations;

--- a/fem/restriction.hpp
+++ b/fem/restriction.hpp
@@ -432,7 +432,7 @@ private:
 protected:
    mutable Array<int> face_map; // Used in the computation of GetFaceDofs
 
-   /** @brief Verify that H1FaceRestriction is build from an L2 FESpace.
+   /** @brief Verify that L2FaceRestriction is build from an L2 FESpace.
 
        Note: Requires the gather offsets to be computed.
 

--- a/fem/restriction.hpp
+++ b/fem/restriction.hpp
@@ -183,13 +183,19 @@ protected:
    Array<int> gather_offsets; // offsets for the gathering indices of each dof
    Array<int> gather_indices; // gathering indices for each dof
 
-   /** @brief Initialize an H1FaceRestriction.
+   /** @brief Construct an H1FaceRestriction.
 
        @param[in] fes      The FiniteElementSpace on which this operates
-       @param[in] type     Request internal or boundary faces dofs */
+       @param[in] ordering Request a specific element ordering
+       @param[in] type     Request internal or boundary faces dofs
+       @param[in] build    Request the NCL2FaceRestriction to compute the
+                           scatter/gather indices. False should only be used
+                           when inheriting from H1FaceRestriction.
+   */
    H1FaceRestriction(const FiniteElementSpace& fes,
-                     const FaceType type);
-
+                     const ElementDofOrdering ordering,
+                     const FaceType type,
+                     bool build);
 public:
    /** @brief Construct an H1FaceRestriction.
 
@@ -292,9 +298,22 @@ protected:
    Array<int> gather_offsets; // offsets for the gathering indices of each dof
    Array<int> gather_indices; // gathering indices for each dof
 
-   L2FaceRestriction(const FiniteElementSpace&,
-                     const FaceType,
-                     const L2FaceValues m = L2FaceValues::DoubleValued);
+   /** @brief Constructs an L2FaceRestriction.
+
+       @param[in] fes      The FiniteElementSpace on which this operates
+       @param[in] ordering Request a specific ordering
+       @param[in] type     Request internal or boundary faces dofs
+       @param[in] m        Request the face dofs for elem1, or both elem1 and
+                           elem2
+       @param[in] build    Request the NCL2FaceRestriction to compute the
+                           scatter/gather indices. False should only be used
+                           when inheriting from L2FaceRestriction.
+   */
+   L2FaceRestriction(const FiniteElementSpace& fes,
+                     const ElementDofOrdering ordering,
+                     const FaceType type,
+                     const L2FaceValues m,
+                     bool build);
 
 public:
    /** @brief Constructs an L2FaceRestriction.
@@ -619,6 +638,24 @@ class NCL2FaceRestriction : public L2FaceRestriction
 protected:
    InterpolationManager interpolations;
    mutable Vector x_interp;
+
+   /** @brief Constructs an NCL2FaceRestriction, this is a specialization of a
+       L2FaceRestriction for non-conforming meshes.
+
+       @param[in] fes      The FiniteElementSpace on which this operates
+       @param[in] ordering Request a specific ordering
+       @param[in] type     Request internal or boundary faces dofs
+       @param[in] m        Request the face dofs for elem1, or both elem1 and
+                           elem2
+       @param[in] build    Request the NCL2FaceRestriction to compute the
+                           scatter/gather indices. False should only be used
+                           when inheriting from NCL2FaceRestriction.
+   */
+   NCL2FaceRestriction(const FiniteElementSpace& fes,
+                       const ElementDofOrdering ordering,
+                       const FaceType type,
+                       const L2FaceValues m,
+                       bool build);
 public:
    /** @brief Constructs an NCL2FaceRestriction, this is a specialization of a
        L2FaceRestriction for non-conforming meshes.
@@ -627,7 +664,8 @@ public:
        @param[in] ordering Request a specific ordering
        @param[in] type     Request internal or boundary faces dofs
        @param[in] m        Request the face dofs for elem1, or both elem1 and
-                           elem2 */
+                           elem2
+   */
    NCL2FaceRestriction(const FiniteElementSpace& fes,
                        const ElementDofOrdering ordering,
                        const FaceType type,

--- a/mesh/ncmesh.cpp
+++ b/mesh/ncmesh.cpp
@@ -1642,8 +1642,8 @@ void NCMesh::DerefineElement(int elem)
          el.node[i] = ch.node[i];
       }
       // Sets faces attributes from childs' faces
-      constexpr int nb_cube_face = 6;
-      for (int i = 0; i < nb_cube_face; i++)
+      constexpr int nb_cube_faces = 6;
+      for (int i = 0; i < nb_cube_faces; i++)
       {
          const int child_local_index = hex_deref_table[ref_type_key]
                                        [i + nb_cube_childs];
@@ -1669,8 +1669,8 @@ void NCMesh::DerefineElement(int elem)
       }
       el.node[6] = el.node[7] = -1;
 
-      constexpr int nb_prism_face = 5;
-      for (int i = 0; i < nb_prism_face; i++)
+      constexpr int nb_prism_faces = 5;
+      for (int i = 0; i < nb_prism_faces; i++)
       {
          const int child_local_index = prism_deref_table[ref_type_key]
                                        [i + nb_prism_childs];
@@ -1705,8 +1705,8 @@ void NCMesh::DerefineElement(int elem)
          Element &ch = elements[child_global_index];
          el.node[i] = ch.node[i];
       }
-      constexpr int nb_square_face = 4;
-      for (int i = 0; i < nb_square_face; i++)
+      constexpr int nb_square_faces = 4;
+      for (int i = 0; i < nb_square_faces; i++)
       {
          const int child_local_index = quad_deref_table[ref_type_key]
                                        [i + nb_square_childs];

--- a/tests/unit/fem/test_pa_kernels.cpp
+++ b/tests/unit/fem/test_pa_kernels.cpp
@@ -429,7 +429,11 @@ void test_pa_convection(const std::string &meshname, int order, int prob,
 // Basic unit test for convection
 TEST_CASE("PA Convection", "[PartialAssembly][MFEMData]")
 {
-   // prob: 0: CG, 1: DG continuous coeff, 2: DG discontinuous coeff, 3: Bernstein
+   // prob:
+   // - 0: CG,
+   // - 1: DG continuous coeff,
+   // - 2: DG discontinuous coeff,
+   // - 3: DG Bernstein discontinuous coeff.
    auto prob = GENERATE(0, 1, 2, 3);
    auto order_2d = GENERATE(2, 3, 4);
    auto order_3d = GENERATE(2);
@@ -445,7 +449,7 @@ TEST_CASE("PA Convection", "[PartialAssembly][MFEMData]")
                          refinement_2d);
       test_pa_convection("../../data/star-q3.mesh", order_2d, prob,
                          refinement_2d);
-      test_pa_convection(mfem_data_dir+"/data/gmsh/v22/unstructured_quad.v22.msh",
+      test_pa_convection(mfem_data_dir+"/gmsh/v22/unstructured_quad.v22.msh",
                          order_2d, prob, refinement_2d);
    }
 
@@ -455,7 +459,7 @@ TEST_CASE("PA Convection", "[PartialAssembly][MFEMData]")
                          refinement_3d);
       test_pa_convection("../../data/fichera-q3.mesh", order_3d, prob,
                          refinement_3d);
-      test_pa_convection(mfem_data_dir+"/data/gmsh/v22/unstructured_hex.v22.msh",
+      test_pa_convection(mfem_data_dir+"/gmsh/v22/unstructured_hex.v22.msh",
                          order_3d, prob, refinement_3d);
    }
 


### PR DESCRIPTION
This PR removes duplicated code in the different `Mult` and `AddMultTranspose` `FaceRestriction` methods, and factorize verification code that was inlined into a `CheckFESpace` method.