### PR TITLE
Fix some compiler warnings from new clang and gcc versions

### DIFF
--- a/fem/conduitdatacollection.cpp
+++ b/fem/conduitdatacollection.cpp
@@ -330,7 +330,7 @@ ConduitDataCollection::BlueprintMeshToMesh(const Node &n_mesh,
          }
          else
          {
-            Node &(n_bndry_conn_conv) =
+            Node &n_bndry_conn_conv =
                n_conv["topologies"][bndry_topo_name]["elements/connectivity"];
             n_bndry_conn.to_int_array(n_bndry_conn_conv);
             bndry_indices = (n_bndry_conn_conv).value();

--- a/fem/fmsconvert.cpp
+++ b/fem/fmsconvert.cpp
@@ -112,7 +112,7 @@ FmsFieldToGridFunction(FmsMesh fms_mesh, FmsField f, Mesh *mesh,
    // NOTE: transplanted from the FmsMeshToMesh function
    //       We should do this work once and save it.
    //--------------------------------------------------
-   FmsInt dim, n_vert, n_elem, space_dim;
+   FmsInt dim, n_elem, space_dim;
 
    // Find the first component that has coordinates - that will be the new mfem
    // mesh.
@@ -144,7 +144,6 @@ FmsFieldToGridFunction(FmsMesh fms_mesh, FmsField f, Mesh *mesh,
          n_ents[et] += num_ents;
       }
    }
-   n_vert = n_ents[FMS_VERTEX];
    //--------------------------------------------------
 
    // Interrogate the field.

--- a/fem/qinterp/eval.hpp
+++ b/fem/qinterp/eval.hpp
@@ -65,12 +65,12 @@ static void Values2D(const int NE,
       MFEM_SHARED double sm0[NBZ][MDQ*MDQ];
       MFEM_SHARED double sm1[NBZ][MDQ*MDQ];
 
+      kernels::internal::LoadB<MD1,MQ1>(D1D,Q1D,b,sB);
+
       ConstDeviceMatrix B(sB, D1D,Q1D);
       DeviceMatrix DD(sm0[tidz], MD1, MD1);
       DeviceMatrix DQ(sm1[tidz], MD1, MQ1);
       DeviceMatrix QQ(sm0[tidz], MQ1, MQ1);
-
-      kernels::internal::LoadB<MD1,MQ1>(D1D,Q1D,b,sB);
 
       for (int c = 0; c < VDIM; c++)
       {
@@ -126,13 +126,13 @@ static void Values3D(const int NE,
       MFEM_SHARED double sm0[MDQ*MDQ*MDQ];
       MFEM_SHARED double sm1[MDQ*MDQ*MDQ];
 
+      kernels::internal::LoadB<MD1,MQ1>(D1D,Q1D,b,sB);
+
       ConstDeviceMatrix B(sB, D1D,Q1D);
       DeviceCube DDD(sm0, MD1,MD1,MD1);
       DeviceCube DDQ(sm1, MD1,MD1,MQ1);
       DeviceCube DQQ(sm0, MD1,MQ1,MQ1);
       DeviceCube QQQ(sm1, MQ1,MQ1,MQ1);
-
-      kernels::internal::LoadB<MD1,MQ1>(D1D,Q1D,b,sB);
 
       for (int c = 0; c < VDIM; c++)
       {

--- a/fem/tmop/tmop_pa_da3.cpp
+++ b/fem/tmop/tmop_pa_da3.cpp
@@ -55,6 +55,8 @@ MFEM_REGISTER_TMOP_KERNELS(void, DatcSize,
       MFEM_SHARED double sm0[MDQ*MDQ*MDQ];
       MFEM_SHARED double sm1[MDQ*MDQ*MDQ];
 
+      kernels::internal::LoadB<MD1,MQ1>(D1D,Q1D,b,sB);
+
       ConstDeviceMatrix B(sB, D1D, Q1D);
       DeviceCube DDD(sm0, MD1,MD1,MD1);
       DeviceCube DDQ(sm1, MD1,MD1,MQ1);
@@ -88,7 +90,6 @@ MFEM_REGISTER_TMOP_KERNELS(void, DatcSize,
       }
       min = min_size[0];
 
-      kernels::internal::LoadB<MD1,MQ1>(D1D,Q1D,b,sB);
       kernels::internal::EvalX(D1D,Q1D,B,DDD,DDQ);
       kernels::internal::EvalY(D1D,Q1D,B,DDQ,DQQ);
       kernels::internal::EvalZ(D1D,Q1D,B,DQQ,QQQ);

--- a/fem/tmop/tmop_pa_h3s_c0.cpp
+++ b/fem/tmop/tmop_pa_h3s_c0.cpp
@@ -55,6 +55,7 @@ MFEM_REGISTER_TMOP_KERNELS(void, SetupGradPA_Kernel_C0_3D,
       constexpr int MDQ = (MQ1 > MD1) ? MQ1 : MD1;
 
       MFEM_SHARED double sBLD[MQ1*MD1];
+      kernels::internal::LoadB<MD1,MQ1>(D1D,Q1D,bld,sBLD);
       ConstDeviceMatrix BLD(sBLD, D1D, Q1D);
 
       MFEM_SHARED double sm0[MDQ*MDQ*MDQ];
@@ -65,8 +66,6 @@ MFEM_REGISTER_TMOP_KERNELS(void, SetupGradPA_Kernel_C0_3D,
       DeviceCube QQQ(sm1, MQ1,MQ1,MQ1);
 
       kernels::internal::LoadX(e,D1D,LD,DDD);
-
-      kernels::internal::LoadB<MD1,MQ1>(D1D,Q1D,bld,sBLD);
 
       kernels::internal::EvalX(D1D,Q1D,BLD,DDD,DDQ);
       kernels::internal::EvalY(D1D,Q1D,BLD,DDQ,DQQ);

--- a/fem/tmop/tmop_pa_p3_c0.cpp
+++ b/fem/tmop/tmop_pa_p3_c0.cpp
@@ -62,6 +62,7 @@ MFEM_REGISTER_TMOP_KERNELS(void, AddMultPA_Kernel_C0_3D,
 
       MFEM_SHARED double B[MQ1*MD1];
       MFEM_SHARED double sBLD[MQ1*MD1];
+      kernels::internal::LoadB<MD1,MQ1>(D1D,Q1D,bld,sBLD);
       ConstDeviceMatrix BLD(sBLD, D1D, Q1D);
 
       MFEM_SHARED double sm0[MDQ*MDQ*MDQ];
@@ -86,7 +87,6 @@ MFEM_REGISTER_TMOP_KERNELS(void, AddMultPA_Kernel_C0_3D,
       kernels::internal::LoadX<MD1>(e,D1D,X1,DDD1);
 
       kernels::internal::LoadB<MD1,MQ1>(D1D,Q1D,b,B);
-      kernels::internal::LoadB<MD1,MQ1>(D1D,Q1D,bld,sBLD);
 
       kernels::internal::EvalX(D1D,Q1D,BLD,DDD,DDQ);
       kernels::internal::EvalY(D1D,Q1D,BLD,DDQ,DQQ);

--- a/fem/tmop/tmop_pa_w3_c0.cpp
+++ b/fem/tmop/tmop_pa_w3_c0.cpp
@@ -63,6 +63,7 @@ MFEM_REGISTER_TMOP_KERNELS(double, EnergyPA_C0_3D,
 
       MFEM_SHARED double B[MQ1*MD1];
       MFEM_SHARED double sBLD[MQ1*MD1];
+      kernels::internal::LoadB<MD1,MQ1>(D1D,Q1D,bld,sBLD);
       ConstDeviceMatrix BLD(sBLD, D1D, Q1D);
 
       MFEM_SHARED double sm0[MDQ*MDQ*MDQ];
@@ -87,7 +88,6 @@ MFEM_REGISTER_TMOP_KERNELS(double, EnergyPA_C0_3D,
       kernels::internal::LoadX<MD1>(e,D1D,X1,DDD1);
 
       kernels::internal::LoadB<MD1,MQ1>(D1D,Q1D,b,B);
-      kernels::internal::LoadB<MD1,MQ1>(D1D,Q1D,bld,sBLD);
 
       kernels::internal::EvalX(D1D,Q1D,BLD,DDD,DDQ);
       kernels::internal::EvalY(D1D,Q1D,BLD,DDQ,DQQ);

--- a/linalg/simd/auto.hpp
+++ b/linalg/simd/auto.hpp
@@ -29,6 +29,10 @@ struct MFEM_AUTOSIMD_ALIGN__ AutoSIMD
 
    scalar_t vec[size];
 
+   AutoSIMD() = default;
+
+   AutoSIMD(const AutoSIMD &) = default;
+
    inline MFEM_ALWAYS_INLINE scalar_t &operator[](int i)
    {
       return vec[i];

--- a/linalg/simd/m128.hpp
+++ b/linalg/simd/m128.hpp
@@ -38,6 +38,10 @@ template <> struct AutoSIMD<double,2,16>
       double vec[size];
    };
 
+   AutoSIMD() = default;
+
+   AutoSIMD(const AutoSIMD &) = default;
+
    inline MFEM_ALWAYS_INLINE double &operator[](int i)
    {
       return vec[i];

--- a/linalg/simd/m256.hpp
+++ b/linalg/simd/m256.hpp
@@ -38,6 +38,10 @@ template <> struct AutoSIMD<double,4,32>
       double vec[size];
    };
 
+   AutoSIMD() = default;
+
+   AutoSIMD(const AutoSIMD &) = default;
+
    inline MFEM_ALWAYS_INLINE double &operator[](int i)
    {
       return vec[i];

--- a/linalg/simd/m512.hpp
+++ b/linalg/simd/m512.hpp
@@ -39,6 +39,10 @@ template <> struct AutoSIMD<double,8,64>
       double vec[size];
    };
 
+   AutoSIMD() = default;
+
+   AutoSIMD(const AutoSIMD &) = default;
+
    inline MFEM_ALWAYS_INLINE double &operator[](int i)
    {
       return vec[i];

--- a/linalg/simd/qpx256.hpp
+++ b/linalg/simd/qpx256.hpp
@@ -34,6 +34,10 @@ template <> struct AutoSIMD<double,4,32>
       double vec[size];
    };
 
+   AutoSIMD() = default;
+
+   AutoSIMD(const AutoSIMD &) = default;
+
    inline __ATTRS_ai double &operator[](int i) { return vec[i]; }
 
    inline __ATTRS_ai const double &operator[](int i) const { return vec[i]; }

--- a/linalg/simd/sve.hpp
+++ b/linalg/simd/sve.hpp
@@ -33,6 +33,10 @@ template <> struct MFEM_AUTOSIMD_ALIGN_SVE AutoSIMD<double,8,64>
 
    double vec[size];
 
+   AutoSIMD() = default;
+
+   AutoSIMD(const AutoSIMD &) = default;
+
    inline MFEM_ALWAYS_INLINE double &operator[](int i)
    {
       return vec[i];

--- a/linalg/simd/vsx128.hpp
+++ b/linalg/simd/vsx128.hpp
@@ -34,6 +34,10 @@ template <> struct AutoSIMD<double,2,16>
       double vec[size];
    };
 
+   AutoSIMD() = default;
+
+   AutoSIMD(const AutoSIMD &) = default;
+
    inline MFEM_ALWAYS_INLINE double &operator[](int i)
    {
       return vec[i];

--- a/mesh/ncmesh.hpp
+++ b/mesh/ncmesh.hpp
@@ -737,6 +737,8 @@ protected: // implementation
 
       Point() { dim = 0; }
 
+      Point(const Point &) = default;
+
       Point(double x)
       { dim = 1; coord[0] = x; }
 


### PR DESCRIPTION
These changes fix warnings that show up with apple-clang 13.0.0 (with `-pedantic -Wall -Wextra -Wno-unused-parameter`) and gcc 11.2 (with `-pedantic -Wall`).

There are changes that move the fetching of data in a few GPU/CPU kernels.
<!--GHEX{"id":2709,"author":"v-dobrev","editor":"tzanio","reviewers":["camierjs","tzanio"],"assignment":"2021-12-15T08:40:25-08:00","approval":"2021-12-23T22:47:54.429Z","merge":"2021-12-28T17:58:33.824Z"}XEHG--><!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge| 
 | --- | --- | --- | --- | --- | --- | --- | 
| [#2709](https://github.com/mfem/mfem/pull/2709) | @v-dobrev | @tzanio | @camierjs + @tzanio | 12/15/21 | 12/23/21 | 12/28/21 | |
<!--ELBATXEHG-->