### PR TITLE
Fix `ParFiniteElementSpace::GetEssentialVDofs()` for non-conforming meshes

### DIFF
--- a/fem/pfespace.cpp
+++ b/fem/pfespace.cpp
@@ -1010,12 +1010,9 @@ void ParFiniteElementSpace::GetEssentialVDofs(const Array<int> &bdr_attr_is_ess,
 {
    FiniteElementSpace::GetEssentialVDofs(bdr_attr_is_ess, ess_dofs, component);
 
-   if (Conforming())
-   {
-      // Make sure that processors without boundary elements mark
-      // their boundary dofs (if they have any).
-      Synchronize(ess_dofs);
-   }
+   // Make sure that processors without boundary elements mark
+   // their boundary dofs (if they have any).
+   Synchronize(ess_dofs);
 }
 
 void ParFiniteElementSpace::GetEssentialTrueDofs(const Array<int>
@@ -1041,7 +1038,8 @@ void ParFiniteElementSpace::GetEssentialTrueDofs(const Array<int>
    {
       if (bool(ted[i]) != bool(true_ess_dofs2[i])) { counter++; }
    }
-   MFEM_VERIFY(counter == 0, "internal MFEM error: counter = " << counter);
+   MFEM_VERIFY(counter == 0, "internal MFEM error: counter = " << counter
+               << ", rank = " << MyRank);
 #endif
 
    MarkerToList(true_ess_dofs, ess_tdof_list);


### PR DESCRIPTION
This should address issue #2559.
<!--GHEX{"id":2722,"author":"v-dobrev","editor":"tzanio","reviewers":["bslazarov","psocratis"],"assignment":"2021-12-16T07:28:36-08:00","approval":"2021-12-20T22:43:45.108Z","merge":"2021-12-21T16:36:07.697Z"}XEHG--><!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge| 
 | --- | --- | --- | --- | --- | --- | --- | 
| [#2722](https://github.com/mfem/mfem/pull/2722) | @v-dobrev | @tzanio | @bslazarov + @psocratis | 12/16/21 | 12/20/21 | 12/21/21 | |
<!--ELBATXEHG-->