### PR TITLE
Fix size of ScaledOperator and add MultTranspose

### DIFF
--- a/linalg/operator.hpp
+++ b/linalg/operator.hpp
@@ -701,11 +701,15 @@ private:
 public:
    /// Create an operator which is a scalar multiple of A.
    explicit ScaledOperator(const Operator *A, double a)
-      : Operator(A->Width(), A->Height()), A_(*A), a_(a) { }
+     : Operator(A->Height(), A->Width()), A_(*A), a_(a) { }
 
    /// Operator application
    virtual void Mult(const Vector &x, Vector &y) const
    { A_.Mult(x, y); y *= a_; }
+
+   /// Application of the transpose.
+   virtual void MultTranspose(const Vector &x, Vector &y) const
+   { A_.MultTranspose(x, y); y *= a_; }
 };
 
 

--- a/linalg/operator.hpp
+++ b/linalg/operator.hpp
@@ -701,7 +701,7 @@ private:
 public:
    /// Create an operator which is a scalar multiple of A.
    explicit ScaledOperator(const Operator *A, double a)
-     : Operator(A->Height(), A->Width()), A_(*A), a_(a) { }
+      : Operator(A->Height(), A->Width()), A_(*A), a_(a) { }
 
    /// Operator application
    virtual void Mult(const Vector &x, Vector &y) const


### PR DESCRIPTION
Fix width and height of ScaledOperator constructor.
Add ScaledOperator::MultTranspose
<!--GHEX{"id":2730,"author":"sshiraiwa","editor":"v-dobrev","reviewers":["mlstowell","v-dobrev","tzanio"],"assignment":"2021-12-22T05:37:35-08:00","approval":"2021-12-23T19:10:18.635Z","merge":"2021-12-28T18:27:49.605Z"}XEHG--><!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge| 
 | --- | --- | --- | --- | --- | --- | --- | 
| [#2730](https://github.com/mfem/mfem/pull/2730) | @sshiraiwa | @v-dobrev | @mlstowell + @v-dobrev + @tzanio | 12/22/21 | 12/23/21 | 12/28/21 | |
<!--ELBATXEHG-->