### PR TITLE
Fixing shadow variables in general classes [shadow-gen-dev]

### DIFF
--- a/general/device.cpp
+++ b/general/device.cpp
@@ -177,7 +177,7 @@ Device::~Device()
    Get().device_mem_class = MemoryClass::HOST;
 }
 
-void Device::Configure(const std::string &device, const int dev)
+void Device::Configure(const std::string &device, const int dev_)
 {
    // If a device was configured via the environment, skip the configuration,
    // and avoid the 'singleton_device' to destroy the mm.
@@ -240,7 +240,7 @@ void Device::Configure(const std::string &device, const int dev)
 #endif
 
    // Perform setup.
-   Get().Setup(dev);
+   Get().Setup(dev_);
 
    // Enable the device
    Enable();

--- a/general/device.cpp
+++ b/general/device.cpp
@@ -177,7 +177,7 @@ Device::~Device()
    Get().device_mem_class = MemoryClass::HOST;
 }
 
-void Device::Configure(const std::string &device, const int dev_)
+void Device::Configure(const std::string &device, const int device_id)
 {
    // If a device was configured via the environment, skip the configuration,
    // and avoid the 'singleton_device' to destroy the mm.
@@ -240,7 +240,7 @@ void Device::Configure(const std::string &device, const int dev_)
 #endif
 
    // Perform setup.
-   Get().Setup(dev_);
+   Get().Setup(device_id);
 
    // Enable the device
    Enable();
@@ -276,35 +276,35 @@ void Device::SetMemoryTypes(MemoryType h_mt, MemoryType d_mt)
    // the call mm.Configure(...) in UpdateMemoryTypeAndClass()
 }
 
-void Device::Print(std::ostream &out)
+void Device::Print(std::ostream &os)
 {
-   out << "Device configuration: ";
+   os << "Device configuration: ";
    bool add_comma = false;
    for (int i = 0; i < Backend::NUM_BACKENDS; i++)
    {
       if (backends & internal::backend_list[i])
       {
-         if (add_comma) { out << ','; }
+         if (add_comma) { os << ','; }
          add_comma = true;
-         out << internal::backend_name[i];
+         os << internal::backend_name[i];
       }
    }
-   out << '\n';
+   os << '\n';
 #ifdef MFEM_USE_CEED
    if (Allows(Backend::CEED_MASK))
    {
       const char *ceed_backend;
       CeedGetResource(internal::ceed, &ceed_backend);
-      out << "libCEED backend: " << ceed_backend << '\n';
+      os << "libCEED backend: " << ceed_backend << '\n';
    }
 #endif
-   out << "Memory configuration: "
-       << MemoryTypeName[static_cast<int>(host_mem_type)];
+   os << "Memory configuration: "
+      << MemoryTypeName[static_cast<int>(host_mem_type)];
    if (Device::Allows(Backend::DEVICE_MASK))
    {
-      out << ',' << MemoryTypeName[static_cast<int>(device_mem_type)];
+      os << ',' << MemoryTypeName[static_cast<int>(device_mem_type)];
    }
-   out << std::endl;
+   os << std::endl;
 }
 
 void Device::UpdateMemoryTypeAndClass()
@@ -502,12 +502,12 @@ static void CeedDeviceSetup(const char* ceed_spec)
 #endif
 }
 
-void Device::Setup(const int device)
+void Device::Setup(const int device_id)
 {
    MFEM_VERIFY(ngpu == -1, "the mfem::Device is already configured!");
 
    ngpu = 0;
-   dev = device;
+   dev = device_id;
 #ifndef MFEM_USE_CUDA
    MFEM_VERIFY(!Allows(Backend::CUDA_MASK),
                "the CUDA backends require MFEM built with MFEM_USE_CUDA=YES");

--- a/general/device.hpp
+++ b/general/device.hpp
@@ -150,7 +150,7 @@ private:
    static Device& Get() { return device_singleton; }
 
    /// Setup switcher based on configuration settings
-   void Setup(const int dev = 0);
+   void Setup(const int device_id = 0);
 
    void MarkBackend(Backend::Id b) { backends |= b; }
 

--- a/general/gecko.cpp
+++ b/general/gecko.cpp
@@ -1228,12 +1228,12 @@ Graph::reweight(uint k)
 
 // Linearly order graph.
 void
-Graph::order(Functional* functional, uint iterations, uint window, uint period,
-             uint seed, Progress* progress)
+Graph::order(Functional* functional_, uint iterations, uint window, uint period,
+             uint seed, Progress* progress_)
 {
    // Initialize graph.
-   this->functional = functional;
-   progress = this->progress = progress ? progress : new Progress;
+   this->functional = functional_;
+   progress_ = this->progress = progress_ ? progress_ : new Progress;
    for (level = 0; (1u << level) < nodes(); level++);
    place();
    Float mincost = cost();

--- a/general/mem_manager.hpp
+++ b/general/mem_manager.hpp
@@ -849,13 +849,13 @@ inline void Memory<T>::New(int size, MemoryType mt)
 }
 
 template <typename T>
-inline void Memory<T>::New(int size_, MemoryType h_mt_, MemoryType d_mt_)
+inline void Memory<T>::New(int size, MemoryType host_mt, MemoryType device_mt)
 {
-   capacity = size_;
-   const size_t bytes = size_*sizeof(T);
-   this->h_mt = h_mt_;
-   T *h_tmp = (h_mt_ == MemoryType::HOST) ? NewHOST(size_) : nullptr;
-   h_ptr = (T*)MemoryManager::New_(h_tmp, bytes, h_mt_, d_mt_,
+   capacity = size;
+   const size_t bytes = size*sizeof(T);
+   this->h_mt = host_mt;
+   T *h_tmp = (host_mt == MemoryType::HOST) ? NewHOST(size) : nullptr;
+   h_ptr = (T*)MemoryManager::New_(h_tmp, bytes, host_mt, device_mt,
                                    VALID_HOST, flags);
 }
 

--- a/general/mem_manager.hpp
+++ b/general/mem_manager.hpp
@@ -849,13 +849,14 @@ inline void Memory<T>::New(int size, MemoryType mt)
 }
 
 template <typename T>
-inline void Memory<T>::New(int size, MemoryType h_mt, MemoryType d_mt)
+inline void Memory<T>::New(int size_, MemoryType h_mt_, MemoryType d_mt_)
 {
-   capacity = size;
-   const size_t bytes = size*sizeof(T);
-   this->h_mt = h_mt;
-   T *h_tmp = (h_mt == MemoryType::HOST) ? NewHOST(size) : nullptr;
-   h_ptr = (T*)MemoryManager::New_(h_tmp, bytes, h_mt, d_mt, VALID_HOST, flags);
+   capacity = size_;
+   const size_t bytes = size_*sizeof(T);
+   this->h_mt = h_mt_;
+   T *h_tmp = (h_mt_ == MemoryType::HOST) ? NewHOST(size_) : nullptr;
+   h_ptr = (T*)MemoryManager::New_(h_tmp, bytes, h_mt_, d_mt_,
+                                   VALID_HOST, flags);
 }
 
 template <typename T>


### PR DESCRIPTION
This PR partially addresses issue #2701.

I tried to make minimal changes and keep the spirit of the original variable names. Hopefully, splitting these into small PRs will assist the original authors and/or reviewers in assessing the changes.

The compiler has no trouble determining which variable is intended but the choice is not always obvious to developers who may not be aware of one or the other of the possibilities.
<!--GHEX{"id":2736,"author":"mlstowell","editor":"tzanio","reviewers":["tzanio","camierjs"],"assignment":"2021-12-28T10:11:24-08:00","approval":"2022-01-14T03:06:19.480Z","merge":"2022-01-18T01:53:31.281Z"}XEHG--><!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge| 
 | --- | --- | --- | --- | --- | --- | --- | 
| [#2736](https://github.com/mfem/mfem/pull/2736) | @mlstowell | @tzanio | @tzanio + @camierjs | 12/28/21 | 01/13/22 | 01/17/22 | |
<!--ELBATXEHG-->