### PR TITLE
vsx128 GNU fix [vsx]

### DIFF
--- a/linalg/simd/vsx128.hpp
+++ b/linalg/simd/vsx128.hpp
@@ -17,6 +17,10 @@
 #include "../../config/tconfig.hpp"
 #include <altivec.h>
 
+#ifdef __GNUC__
+#undef bool
+#endif
+
 namespace mfem
 {
 
@@ -107,7 +111,11 @@ template <> struct AutoSIMD<double,2,16>
    inline MFEM_ALWAYS_INLINE AutoSIMD operator-() const
    {
       AutoSIMD r;
+#ifndef __GNUC__
       r.vd = vec_neg(vd);
+#else
+      r.vd = vec_splats(0.0) - vd;
+#endif
       return r;
    }
 


### PR DESCRIPTION
Allow to use `gcc` on `ppc64le` architecture.
<!--GHEX{"id":2740,"author":"camierjs","editor":"tzanio","reviewers":["tzanio","v-dobrev"],"assignment":"2021-12-23T18:12:43-08:00","approval":"2022-01-19T23:19:42.439Z","merge":"2022-01-20T16:08:04.265Z"}XEHG--><!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge| 
 | --- | --- | --- | --- | --- | --- | --- | 
| [#2740](https://github.com/mfem/mfem/pull/2740) | @camierjs | @tzanio | @tzanio + @v-dobrev | 12/23/21 | 01/19/22 | 01/20/22 | |
<!--ELBATXEHG-->