### PR TITLE
Scale LOR integrated basis if using map type VALUE [lor-scale-integrated]

### DIFF
--- a/fem/fe/fe_base.cpp
+++ b/fem/fe/fe_base.cpp
@@ -1838,11 +1838,16 @@ void Poly_1D::Basis::EvalIntegrated(const Vector &d_aux, Vector &u) const
    MFEM_VERIFY(etype == Integrated,
                "EvalIntegrated is only valid for Integrated basis type");
    int p = d_aux.Size() - 1;
+   // See Gerritsma, M. (2010).  "Edge functions for spectral element methods",
+   // in Lecture Notes in Computational Science and Engineering, 199--207.
    u[0] = -d_aux[0];
    for (int j=1; j<p; ++j)
    {
       u[j] = u[j-1] - d_aux[j];
    }
+   // If scale_integrated is true, the degrees of freedom represent mean values,
+   // otherwise they represent subcell integrals. Generally, scale_integrated
+   // should be true for MapType::VALUE, and false for other map types.
    if (scale_integrated)
    {
       Vector &aux_nodes = auxiliary_basis->x;
@@ -2395,6 +2400,10 @@ NodalTensorFiniteElement::NodalTensorFiniteElement(const int dims,
 void NodalTensorFiniteElement::SetMapType(const int map_type)
 {
    ScalarFiniteElement::SetMapType(map_type);
+   // If we are using the "integrated" basis, the basis functions should be
+   // scaled for MapType::VALUE, and not scaled for MapType::INTEGRAL. This
+   // ensures spectral equivalence of the mass matrix with its low-order-refined
+   // counterpart (cf. LORDiscretization)
    if (basis1d.IsIntegratedType())
    {
       basis1d.ScaleIntegrated(map_type == VALUE);

--- a/fem/fe/fe_base.hpp
+++ b/fem/fe/fe_base.hpp
@@ -955,43 +955,68 @@ public:
 };
 
 
-/// Class for computing 1D special polynomials and their associated basis
+/// @brief Class for computing 1D special polynomials and their associated basis
 /// functions
 class Poly_1D
 {
 public:
+   /// One-dimensional basis evaluation type
    enum EvalType
    {
-      ChangeOfBasis = 0, // Use change of basis, O(p^2) Evals
-      Barycentric   = 1, // Use barycentric Lagrangian interpolation, O(p) Evals
-      Positive      = 2, // Fast evaluation of Bernstein polynomials
-      Integrated    = 3, // Integrated indicator functions (cf. Gerritsma)
-      NumEvalTypes  = 4  // Keep count of the number of eval types
+      ChangeOfBasis = 0, ///< Use change of basis, O(p^2) Evals
+      Barycentric   = 1, ///< Use barycentric Lagrangian interpolation, O(p) Evals
+      Positive      = 2, ///< Fast evaluation of Bernstein polynomials
+      Integrated    = 3, ///< Integrated indicator functions (cf. Gerritsma)
+      NumEvalTypes  = 4  ///< Keep count of the number of eval types
    };
 
+   /// @brief Class for evaluating 1D nodal, positive (Bernstein), or integrated
+   /// (Gerritsma) bases.
    class Basis
    {
    private:
-      int etype;
+      EvalType etype; ///< Determines how the basis functions should be evaluated.
       DenseMatrixInverse Ai;
       mutable Vector x, w;
-      // The following data members are used for "integrated basis type", which
-      // is defined in terms of nodal basis of one degree higher.
+      /// The following data members are used for "integrated basis type", which
+      /// is defined in terms of nodal basis of one degree higher.
+      ///@{
       mutable Vector u_aux, d_aux, d2_aux;
-      Basis *auxiliary_basis; // Non-NULL only for etype == Integrated
+      ///@}
+      /// @brief An auxuliary nodal basis used to evaluate the integrated basis.
+      /// This member variable is NULL whenever etype != Integrated.
+      Basis *auxiliary_basis;
+      /// Should the integrated basis functions be scaled? See ScaleIntegrated.
       bool scale_integrated;
 
    public:
-      /// Create a nodal or positive (Bernstein) basis
+      /// Create a nodal or positive (Bernstein) basis of degree @a p
       Basis(const int p, const double *nodes, EvalType etype = Barycentric);
+      /// Evaluate the basis functions at point @a x in [0,1]
       void Eval(const double x, Vector &u) const;
+      /// @brief Evaluate the basis functions and their derivatives at point @a
+      /// x in [0,1]
       void Eval(const double x, Vector &u, Vector &d) const;
+      /// @brief Evaluate the basis functions and their first two derivatives at
+      /// point @a x in [0,1]
       void Eval(const double x, Vector &u, Vector &d, Vector &d2) const;
-      /// Evaluate the "integrated" basis, which is given by the negative
-      /// partial sum of the corresponding closed basis derivatives. The closed
-      /// basis derivatives are given by @a d, and the result is stored in @a i.
+      /// @brief Evaluate the "integrated" basis type using pre-computed closed
+      /// basis derivatives.
+      ///
+      /// This basis  is given by the negative partial sum of the corresponding
+      /// closed basis derivatives. The closed basis derivatives are given by @a
+      /// d, and the result is stored in @a i.
       void EvalIntegrated(const Vector &d, Vector &i) const;
+      /// @brief Set whether the "integrated" basis should be scaled by the
+      /// subcell sizes. Has no effect for non-integrated bases.
+      ///
+      /// Generally, this should be true for mfem::FiniteElement::MapType VALUE
+      /// and false for all other map types. If this option is enabled, the
+      /// basis functions will be scaled by the widths of the subintervals, so
+      /// that the basis functions represent mean values. Otherwise, the basis
+      /// functions represent integrated values.
       void ScaleIntegrated(bool scale_integrated_);
+      /// Returns true if the basis is "integrated", false otherwise.
       bool IsIntegratedType() const { return etype == Integrated; }
       ~Basis();
    };

--- a/fem/fe/fe_base.hpp
+++ b/fem/fe/fe_base.hpp
@@ -983,7 +983,7 @@ public:
       ///@{
       mutable Vector u_aux, d_aux, d2_aux;
       ///@}
-      /// @brief An auxuliary nodal basis used to evaluate the integrated basis.
+      /// @brief An auxiliary nodal basis used to evaluate the integrated basis.
       /// This member variable is NULL whenever etype != Integrated.
       Basis *auxiliary_basis;
       /// Should the integrated basis functions be scaled? See ScaleIntegrated.
@@ -1003,7 +1003,7 @@ public:
       /// @brief Evaluate the "integrated" basis type using pre-computed closed
       /// basis derivatives.
       ///
-      /// This basis  is given by the negative partial sum of the corresponding
+      /// This basis is given by the negative partial sum of the corresponding
       /// closed basis derivatives. The closed basis derivatives are given by @a
       /// d, and the result is stored in @a i.
       void EvalIntegrated(const Vector &d, Vector &i) const;

--- a/fem/fe/fe_base.hpp
+++ b/fem/fe/fe_base.hpp
@@ -657,7 +657,7 @@ public:
    /** @brief Set the FiniteElement::MapType of the element to either VALUE or
        INTEGRAL. Also sets the FiniteElement::DerivType to GRAD if the
        FiniteElement::MapType is VALUE. */
-   void SetMapType(int M)
+   virtual void SetMapType(int M)
    {
       MFEM_VERIFY(M == VALUE || M == INTEGRAL, "unknown MapType");
       map_type = M;
@@ -979,6 +979,7 @@ public:
       // is defined in terms of nodal basis of one degree higher.
       mutable Vector u_aux, d_aux, d2_aux;
       Basis *auxiliary_basis; // Non-NULL only for etype == Integrated
+      bool scale_integrated;
 
    public:
       /// Create a nodal or positive (Bernstein) basis
@@ -990,6 +991,7 @@ public:
       /// partial sum of the corresponding closed basis derivatives. The closed
       /// basis derivatives are given by @a d, and the result is stored in @a i.
       void EvalIntegrated(const Vector &d, Vector &i) const;
+      void ScaleIntegrated(bool scale_integrated_);
       bool IsIntegratedType() const { return etype == Integrated; }
       ~Basis();
    };
@@ -1192,6 +1194,8 @@ public:
              ScalarFiniteElement::GetDofToQuad(ir, mode) :
              ScalarFiniteElement::GetTensorDofToQuad(*this, ir, mode);
    }
+
+   virtual void SetMapType(const int map_type_);
 
    virtual void GetTransferMatrix(const FiniteElement &fe,
                                   ElementTransformation &Trans,


### PR DESCRIPTION
The LOR basis `IntegratedGLL` gives a spectrally equivalent L2 mass matrix when using map type `INTEGRAL`, but when using map type `VALUE`, it requires an additional scaling by the LOR subcell size.

This PR implements that scaling whenever map type is `VALUE`. See also #2752.
<!--GHEX{"id":2753,"author":"pazner","editor":"mlstowell","reviewers":["mlstowell","dylan-copeland"],"assignment":"2022-01-06T11:45:32-08:00","approval":"2022-01-20T11:45:32-08:00","merge":"2022-02-15T21:57:26.439Z"}XEHG--><!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge| 
 | --- | --- | --- | --- | --- | --- | --- | 
| [#2753](https://github.com/mfem/mfem/pull/2753) | @pazner | @mlstowell | @mlstowell + @dylan-copeland | 01/06/22 | 01/20/22 | 02/15/22 | |
<!--ELBATXEHG-->