### PR TITLE
Shifted bug fix

### DIFF
--- a/miniapps/shifted/CMakeLists.txt
+++ b/miniapps/shifted/CMakeLists.txt
@@ -17,6 +17,7 @@ if (MFEM_USE_MPI)
   list(APPEND DIST_COMMON_HEADERS
         dist_solver.hpp
         sbm_solver.hpp
+	sbm_aux.hpp
         marking.hpp)
 
 convert_filenames_to_full_paths(DIST_COMMON_SOURCES)

--- a/miniapps/shifted/makefile
+++ b/miniapps/shifted/makefile
@@ -53,15 +53,15 @@ COMMON_LIB += $(if $(MFEM_SHARED:YES=),,\
 %: %.cpp
 %.o: %.cpp
 
-%.o: $(SRC)%.cpp $(wildcard $(SRC)%.hpp) $(MFEM_LIB_FILE) $(CONFIG_MK) | lib-common
+%.o: $(SRC)%.cpp sbm_aux.hpp $(wildcard $(SRC)%.hpp) $(MFEM_LIB_FILE) $(CONFIG_MK) | lib-common
 	$(MFEM_CXX) $(MFEM_FLAGS) -c $< -o $@
 
 all: $(MINIAPPS)
 
-distance: sbm_aux.hpp $(DISTANCE_OBJ)
+distance: $(DISTANCE_OBJ)
 	$(MFEM_CXX) $(MFEM_LINK_FLAGS) -o $@ $(DISTANCE_OBJ) $(COMMON_LIB) $(MFEM_LIBS)
 
-diffusion: sbm_aux.hpp $(DIFFUSION_OBJ)
+diffusion: $(DIFFUSION_OBJ)
 	$(MFEM_CXX) $(MFEM_LINK_FLAGS) -o $@ $(DIFFUSION_OBJ) $(COMMON_LIB) $(MFEM_LIBS)
 
 # Rule for building lib-common

--- a/miniapps/shifted/sbm_solver.cpp
+++ b/miniapps/shifted/sbm_solver.cpp
@@ -324,10 +324,9 @@ void SBM2DirichletIntegrator::AssembleFaceMatrix(
       w = ip.weight*alpha*hinvdx;
       // + <alpha * hinv * u + grad u.d + h.o.t, w + grad w.d + h.o.t> - Term 4
       AddMult_a_VVt(w, wrk, temp_elmat);
-
-      int offset = elem1f ? 0 : ndof1;
-      elmat.CopyMN(temp_elmat, offset, offset);
    } // p < ir->GetNPoints()
+   int offset = elem1f ? 0 : ndof1;
+   elmat.CopyMN(temp_elmat, offset, offset);
 
    for (int i = 0; i < dkphi_dxk.Size(); i++)
    {
@@ -436,8 +435,8 @@ void SBM2DirichletLFIntegrator::AssembleRHSElementVect(
       }
    }
 
-   temp_elvect.SetSize(ndof);
-   temp_elvect = 0.0;
+   int offset = elem1f ? 0 : ndof1;
+   temp_elvect.SetDataAndSize(elvect.GetData()+offset, ndof);
 
    nor.SetSize(dim);
    nh.SetSize(dim);
@@ -544,8 +543,6 @@ void SBM2DirichletLFIntegrator::AssembleRHSElementVect(
    //           +<alpha h^{-1} u_D, w + \nabla w.d + h.o.t>
    for (int p = 0; p < ir->GetNPoints(); p++)
    {
-      // reset the temp_elvect to zero at each quadrature point
-      temp_elvect = 0.0;
       const IntegrationPoint &ip = ir->IntPoint(p);
 
       // Set the integration point in the face and the neighboring element
@@ -637,12 +634,6 @@ void SBM2DirichletLFIntegrator::AssembleRHSElementVect(
       wrk += dshape_dd; // \grad w .d
       wrk += q_hess_dot_d;
       temp_elvect.Add(w, wrk); // <u, gradw.d>
-
-      int offset = elem1f ? 0 : ndof1;
-      for (int i = 0; i < temp_elvect.Size(); i++)
-      {
-         elvect(i+offset) += temp_elvect(i);
-      }
    }
 
    for (int i = 0; i < dkphi_dxk.Size(); i++)
@@ -928,9 +919,9 @@ void SBM2NeumannIntegrator::AssembleFaceMatrix(
       wrk *= ip.weight * n_dot_ntilde;
 
       AddMult_a_VWt(1., shape, wrk, temp_elmat);
-      int offset = elem1f ? 0 : ndof1;
-      elmat.CopyMN(temp_elmat, offset, offset);
    } //p < ir->GetNPoints()
+   int offset = elem1f ? 0 : ndof1;
+   elmat.CopyMN(temp_elmat, offset, offset);
 
    for (int i = 0; i < dkphi_dxk.Size(); i++)
    {
@@ -1037,8 +1028,8 @@ void SBM2NeumannLFIntegrator::AssembleRHSElementVect(
       }
    }
 
-   temp_elvect.SetSize(ndof);
-   temp_elvect = 0.0;
+   int offset = elem1f ? 0 : ndof1;
+   temp_elvect.SetDataAndSize(elvect.GetData()+offset, ndof);
 
    nor.SetSize(dim);
    shape.SetSize(ndof);
@@ -1092,15 +1083,8 @@ void SBM2NeumannLFIntegrator::AssembleRHSElementVect(
       }
 
       double n_dot_ntilde = nor*Nhat;
-      wrk.Set(n_dot_ntilde*w, shape);
-      //<w, (nhat.n)t_n)
+      wrk.Set(n_dot_ntilde*w, shape); //<w, (nhat.n)t_n)
       temp_elvect.Add(1., wrk);
-
-      int offset = elem1f ? 0 : ndof1;
-      for (int i = 0; i < temp_elvect.Size(); i++)
-      {
-         elvect(i+offset) = temp_elvect(i);
-      }
    }
 }
 

--- a/miniapps/shifted/sbm_solver.cpp
+++ b/miniapps/shifted/sbm_solver.cpp
@@ -641,7 +641,7 @@ void SBM2DirichletLFIntegrator::AssembleRHSElementVect(
       int offset = elem1f ? 0 : ndof1;
       for (int i = 0; i < temp_elvect.Size(); i++)
       {
-         elvect(i+offset) = temp_elvect(i);
+         elvect(i+offset) += temp_elvect(i);
       }
    }
 

--- a/miniapps/shifted/sbm_solver.cpp
+++ b/miniapps/shifted/sbm_solver.cpp
@@ -233,7 +233,7 @@ void SBM2DirichletIntegrator::AssembleFaceMatrix(
    Vector D(vD->GetVDim());
    // Assemble: -< \nabla u.n, w >
    //           -< u + \nabla u.d + h.o.t, \nabla w.n>
-   //           -<alpha h^{-1} (u + \nabla u.d + h.o.t), w + \nabla w.d + h.o.t>
+   //           +<alpha h^{-1} (u + \nabla u.d + h.o.t), w + \nabla w.d + h.o.t>
    for (int p = 0; p < ir->GetNPoints(); p++)
    {
       const IntegrationPoint &ip = ir->IntPoint(p);
@@ -541,10 +541,11 @@ void SBM2DirichletLFIntegrator::AssembleRHSElementVect(
    Vector D(vD->GetVDim());
    Vector wrk = shape;
    // Assemble: -< u_D, \nabla w.n >
-   //           -<alpha h^{-1} u_D, w + \nabla w.d + h.o.t>
+   //           +<alpha h^{-1} u_D, w + \nabla w.d + h.o.t>
    for (int p = 0; p < ir->GetNPoints(); p++)
    {
-
+      // reset the temp_elvect to zero at each quadrature point
+      temp_elvect = 0.0;
       const IntegrationPoint &ip = ir->IntPoint(p);
 
       // Set the integration point in the face and the neighboring element

--- a/miniapps/shifted/sbm_solver.cpp
+++ b/miniapps/shifted/sbm_solver.cpp
@@ -1083,7 +1083,8 @@ void SBM2NeumannLFIntegrator::AssembleRHSElementVect(
       }
 
       double n_dot_ntilde = nor*Nhat;
-      wrk.Set(n_dot_ntilde*w, shape); //<w, (nhat.n)t_n)
+      wrk.Set(n_dot_ntilde*w, shape);
+      //<w, (nhat.n)t_n)
       temp_elvect.Add(1., wrk);
    }
 }

--- a/miniapps/shifted/sbm_solver.hpp
+++ b/miniapps/shifted/sbm_solver.hpp
@@ -78,7 +78,7 @@ public:
 /// method.
 /// A(u, w) = -<nabla u.n, w>
 ///           -<u + nabla u.d + h.o.t, nabla w.n>
-///           -<alpha h^{-1} (u + nabla u.d + h.o.t), w + nabla w.d + h.o.t>
+///           +<alpha h^{-1} (u + nabla u.d + h.o.t), w + nabla w.d + h.o.t>
 /// where h.o.t include higher-order derivatives (nabla^k u) due to Taylor
 /// expansion. Since this interior face integrator is applied to the surrogate
 /// boundary (see marking.hpp for notes on how the surrogate faces are
@@ -133,7 +133,7 @@ public:
 /// LinearFormIntegrator for the high-order extension of shifted boundary
 /// method.
 /// (u, w) = -<u_D, nabla w.n >
-///          -<alpha h^{-1} u_D, w + nabla w.d + h.o.t>
+///          +<alpha h^{-1} u_D, w + nabla w.d + h.o.t>
 /// where h.o.t include higher-order derivatives (nabla^k u) due to Taylor
 /// expansion. Since this interior face integrator is applied to the surrogate
 /// boundary (see marking.hpp for notes on how the surrogate faces are


### PR DESCRIPTION
Fixed a bug in sbm_solver.cpp file. I have to reset the temp_elvect vector to zero at the beginning of the quadrature point loop. 
I also fixed a small typo in the comments pertaining to the sign of the penalty term in variational form.
<!--GHEX{"id":2754,"author":"atallah727","editor":"tzanio","reviewers":["vladotomov","kmittal2"],"assignment":"2022-01-05T14:58:03-08:00","approval":"2022-01-14T20:15:52.492Z","merge":"2022-01-18T01:51:44.124Z"}XEHG--><!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge| 
 | --- | --- | --- | --- | --- | --- | --- | 
| [#2754](https://github.com/mfem/mfem/pull/2754) | @atallah727 | @tzanio | @vladotomov + @kmittal2 | 01/05/22 | 01/14/22 | 01/17/22 | |
<!--ELBATXEHG-->