### PR TITLE
Adding checks to avoid using FindPointsGSLIB for variable order space

### DIFF
--- a/fem/gslib.cpp
+++ b/fem/gslib.cpp
@@ -78,6 +78,8 @@ void FindPointsGSLIB::Setup(Mesh &m, const double bb_t, const double newt_tol,
    MFEM_VERIFY(m.GetNodes() != NULL, "Mesh nodes are required.");
    MFEM_VERIFY(m.GetNumGeometries(m.Dimension()) == 1,
                "Mixed meshes are not currently supported in FindPointsGSLIB.");
+   MFEM_VERIFY(!(m.GetNodes()->FESpace()->IsVariableOrder()),
+               "Variable order mesh is not currently supported.");
 
    // call FreeData if FindPointsGSLIB::Setup has been called already
    if (setupflag) { FreeData(); }
@@ -590,7 +592,8 @@ void FindPointsGSLIB::Interpolate(const GridFunction &field_in,
    const L2_FECollection *fec_l2 = dynamic_cast<const L2_FECollection *>(fec_in);
 
    if (fec_h1 && gf_order == mesh_order &&
-       fec_h1->GetBasisType() == BasisType::GaussLobatto)
+       fec_h1->GetBasisType() == BasisType::GaussLobatto &&
+       !field_in.FESpace()->IsVariableOrder())
    {
       InterpolateH1(field_in, field_out);
       return;
@@ -857,6 +860,8 @@ void OversetFindPointsGSLIB::Setup(Mesh &m, const int meshid,
    MFEM_VERIFY(m.GetNodes() != NULL, "Mesh nodes are required.");
    MFEM_VERIFY(m.GetNumGeometries(m.Dimension()) == 1,
                "Mixed meshes are not currently supported in FindPointsGSLIB.");
+   MFEM_VERIFY(!(m.GetNodes()->FESpace()->IsVariableOrder()),
+               "Variable order mesh is not currently supported.");
 
    // FreeData if OversetFindPointsGSLIB::Setup has been called already
    if (setupflag) { FreeData(); }

--- a/miniapps/gslib/findpts.cpp
+++ b/miniapps/gslib/findpts.cpp
@@ -182,18 +182,7 @@ int main (int argc, char *argv[])
    }
 
    // Random h-refinements to mesh
-   if (hrefinement)
-   {
-      Array<Refinement> refs;
-      for (int e = 0; e < mesh.GetNE(); e++)
-      {
-         if ((double) rand() / RAND_MAX < 0.5)
-         {
-            refs.Append(Refinement(e));
-         }
-      }
-      mesh.GeneralRefinement(refs, -1, 0);
-   }
+   if (hrefinement) { mesh.RandomRefinement(0.5); }
 
    // Curve the mesh based on the chosen polynomial degree.
    H1_FECollection fecm(mesh_poly_deg, dim);
@@ -240,7 +229,7 @@ int main (int argc, char *argv[])
    {
       for (int e = 0; e < mesh.GetNE(); e++)
       {
-         if ((double) rand() / RAND_MAX < 0.5)
+         if (rand() % 2 == 0)
          {
             int element_order = sc_fes.GetElementOrder(e);
             sc_fes.SetElementOrder(e, element_order + 1);

--- a/miniapps/gslib/findpts.cpp
+++ b/miniapps/gslib/findpts.cpp
@@ -30,6 +30,7 @@
 //    findpts -m ../../data/rt-2d-p4-tri.mesh -o 4
 //    findpts -m ../../data/inline-tri.mesh -o 3
 //    findpts -m ../../data/inline-quad.mesh -o 3
+//    findpts -m ../../data/inline-quad.mesh -o 3 -hr -pr
 //    findpts -m ../../data/inline-tet.mesh -o 3
 //    findpts -m ../../data/inline-hex.mesh -o 3
 //    findpts -m ../../data/inline-wedge.mesh -o 3
@@ -40,6 +41,56 @@
 
 using namespace mfem;
 using namespace std;
+.
+GridFunction* ProlongToMaxOrder(const GridFunction *x)
+{
+   const FiniteElementSpace *fespace = x->FESpace();
+   Mesh *mesh = fespace->GetMesh();
+   const FiniteElementCollection *fec = fespace->FEColl();
+
+   // find the max order in the space
+   int max_order = 1;
+   for (int i = 0; i < mesh->GetNE(); i++)
+   {
+      max_order = std::max(fespace->GetElementOrder(i), max_order);
+   }
+
+   // create a visualization space of max order for all elements
+   FiniteElementCollection *l2fec =
+      new H1_FECollection(max_order, mesh->Dimension());
+   // new L2_FECollection(max_order, mesh->Dimension(), BasisType::GaussLobatto);
+   FiniteElementSpace *l2space = new FiniteElementSpace(mesh, l2fec);
+
+   IsoparametricTransformation T;
+   DenseMatrix I;
+
+   GridFunction *prolonged_x = new GridFunction(l2space);
+
+   // interpolate solution vector in the larger space
+   for (int i = 0; i < mesh->GetNE(); i++)
+   {
+      Geometry::Type geom = mesh->GetElementGeometry(i);
+      T.SetIdentityTransformation(geom);
+
+      Array<int> dofs;
+      fespace->GetElementDofs(i, dofs);
+      Vector elemvect, l2vect;
+      x->GetSubVector(dofs, elemvect);
+
+      const auto *fe = fec->GetFE(geom, fespace->GetElementOrder(i));
+      const auto *l2fe = l2fec->GetFE(geom, max_order);
+
+      l2fe->GetTransferMatrix(*fe, T, I);
+      l2space->GetElementDofs(i, dofs);
+      l2vect.SetSize(dofs.Size());
+
+      I.Mult(elemvect, l2vect);
+      prolonged_x->SetSubVector(dofs, l2vect);
+   }
+
+   prolonged_x->MakeOwner(l2fec);
+   return prolonged_x;
+}
 
 // Scalar function to project
 double field_func(const Vector &x)
@@ -66,6 +117,8 @@ int main (int argc, char *argv[])
    bool visualization    = true;
    int fieldtype         = 0;
    int ncomp             = 1;
+   bool hrefinement      = false;
+   bool prefinement      = false;
 
    // Parse command-line options.
    OptionsParser args(argc, argv);
@@ -84,6 +137,13 @@ int main (int argc, char *argv[])
    args.AddOption(&visualization, "-vis", "--visualization", "-no-vis",
                   "--no-visualization",
                   "Enable or disable GLVis visualization.");
+   args.AddOption(&hrefinement, "-hr", "--h-refinement", "-no-hr",
+                  "--no-h-refinement",
+                  "Do random h refinements to mesh.");
+   args.AddOption(&prefinement, "-pr", "--p-refinement", "-no-pr",
+                  "--no-p-refinement",
+                  "Do random p refinements to solution field.");
+
    args.Parse();
    if (!args.Good())
    {
@@ -105,12 +165,27 @@ int main (int argc, char *argv[])
    Vector pos_min, pos_max;
    MFEM_VERIFY(mesh_poly_deg > 0, "The order of the mesh must be positive.");
    mesh.GetBoundingBox(pos_min, pos_max, mesh_poly_deg);
+   if (hrefinement || prefinement) { mesh.EnsureNCMesh(); }
    cout << "--- Generating equidistant point for:\n"
         << "x in [" << pos_min(0) << ", " << pos_max(0) << "]\n"
         << "y in [" << pos_min(1) << ", " << pos_max(1) << "]\n";
    if (dim == 3)
    {
       cout << "z in [" << pos_min(2) << ", " << pos_max(2) << "]\n";
+   }
+
+   // Random h-refinements to mesh
+   if (hrefinement)
+   {
+      Array<Refinement> refs;
+      for (int e = 0; e < mesh.GetNE(); e++)
+      {
+         if ((double) rand() / RAND_MAX < 0.5)
+         {
+            refs.Append(Refinement(e));
+         }
+      }
+      mesh.GeneralRefinement(refs, -1, 0);
    }
 
    // Curve the mesh based on the chosen polynomial degree.
@@ -153,9 +228,28 @@ int main (int argc, char *argv[])
    FiniteElementSpace sc_fes(&mesh, fec, ncomp);
    GridFunction field_vals(&sc_fes);
 
+   // Random p-refinements to the solution field
+   if (prefinement)
+   {
+      for (int e = 0; e < mesh.GetNE(); e++)
+      {
+         if ((double) rand() / RAND_MAX < 0.5)
+         {
+            int element_order = sc_fes.GetElementOrder(e);
+            sc_fes.SetElementOrder(e, element_order + 1);
+         }
+      }
+      sc_fes.Update(false);
+      field_vals.Update();
+   }
+
    // Project the GridFunction using VectorFunctionCoefficient.
    VectorFunctionCoefficient F(vec_dim, F_exact);
    field_vals.ProjectCoefficient(F);
+
+   GridFunction *field_vals_max_order = prefinement ?
+                                        ProlongToMaxOrder(&field_vals) :
+                                        &field_vals;
 
    // Display the mesh and the field through glvis.
    if (visualization)
@@ -172,7 +266,7 @@ int main (int argc, char *argv[])
       else
       {
          sout.precision(8);
-         sout << "solution\n" << mesh << field_vals;
+         sout << "solution\n" << mesh << *field_vals_max_order;
          if (dim == 2) { sout << "keys RmjA*****\n"; }
          if (dim == 3) { sout << "keys mA\n"; }
          sout << flush;
@@ -192,8 +286,8 @@ int main (int argc, char *argv[])
       for (int i = 0; i < ir.GetNPoints(); i++)
       {
          const IntegrationPoint &ip = ir.IntPoint(i);
-         vxyz(i)           = 100*pos_min(0) + ip.x * (pos_max(0)-pos_min(0));
-         vxyz(pts_cnt + i) = 100*pos_min(1) + ip.y * (pos_max(1)-pos_min(1));
+         vxyz(i)           = pos_min(0) + ip.x * (pos_max(0)-pos_min(0));
+         vxyz(pts_cnt + i) = pos_min(1) + ip.y * (pos_max(1)-pos_min(1));
       }
    }
    else
@@ -252,6 +346,7 @@ int main (int argc, char *argv[])
    // Free the internal gslib data.
    finder.FreeData();
 
+   if (prefinement) { delete field_vals_max_order; }
    delete fec;
 
    return 0;

--- a/miniapps/gslib/pfindpts.cpp
+++ b/miniapps/gslib/pfindpts.cpp
@@ -30,7 +30,7 @@
 //    mpirun -np 2 pfindpts -m ../../data/rt-2d-p4-tri.mesh -o 4
 //    mpirun -np 2 pfindpts -m ../../data/inline-tri.mesh -o 3
 //    mpirun -np 2 pfindpts -m ../../data/inline-quad.mesh -o 3
-//    mpirun -np 2 pfindpts -m ../../data/inline-quad.mesh -o 3 -hr -pr
+//    mpirun -np 2 pfindpts -m ../../data/inline-quad.mesh -o 3 -hr
 //    mpirun -np 2 pfindpts -m ../../data/inline-tet.mesh -o 3
 //    mpirun -np 2 pfindpts -m ../../data/inline-hex.mesh -o 3
 //    mpirun -np 2 pfindpts -m ../../data/inline-wedge.mesh -o 3

--- a/miniapps/gslib/pfindpts.cpp
+++ b/miniapps/gslib/pfindpts.cpp
@@ -146,19 +146,7 @@ int main (int argc, char *argv[])
    for (int lev = 0; lev < rp_levels; lev++) { pmesh.UniformRefinement(); }
 
    // Random h-refinements to mesh
-   if (hrefinement)
-   {
-      Array<Refinement> refs;
-      for (int e = 0; e < pmesh.GetNE(); e++)
-      {
-         if ((double) rand() / RAND_MAX < 0.5)
-         {
-            refs.Append(Refinement(e));
-         }
-      }
-      pmesh.GeneralRefinement(refs, -1, 0);
-   }
-
+   if (hrefinement) { pmesh.RandomRefinement(0.5); }
 
    // Curve the mesh based on the chosen polynomial degree.
    H1_FECollection fecm(mesh_poly_deg, dim);

--- a/miniapps/gslib/pfindpts.cpp
+++ b/miniapps/gslib/pfindpts.cpp
@@ -30,6 +30,7 @@
 //    mpirun -np 2 pfindpts -m ../../data/rt-2d-p4-tri.mesh -o 4
 //    mpirun -np 2 pfindpts -m ../../data/inline-tri.mesh -o 3
 //    mpirun -np 2 pfindpts -m ../../data/inline-quad.mesh -o 3
+//    mpirun -np 2 pfindpts -m ../../data/inline-quad.mesh -o 3 -hr -pr
 //    mpirun -np 2 pfindpts -m ../../data/inline-tet.mesh -o 3
 //    mpirun -np 2 pfindpts -m ../../data/inline-hex.mesh -o 3
 //    mpirun -np 2 pfindpts -m ../../data/inline-wedge.mesh -o 3
@@ -75,6 +76,7 @@ int main (int argc, char *argv[])
    int fieldtype         = 0;
    int ncomp             = 1;
    bool search_on_rank_0 = false;
+   bool hrefinement      = false;
 
    // Parse command-line options.
    OptionsParser args(argc, argv);
@@ -98,6 +100,10 @@ int main (int argc, char *argv[])
    args.AddOption(&search_on_rank_0, "-sr0", "--search-on-r0", "-no-sr0",
                   "--no-search-on-r0",
                   "Enable search only on rank 0 (disable to search points on all tasks).");
+   args.AddOption(&hrefinement, "-hr", "--h-refinement", "-no-hr",
+                  "--no-h-refinement",
+                  "Do random h refinements to mesh.");
+
    args.Parse();
    if (!args.Good())
    {
@@ -134,9 +140,25 @@ int main (int argc, char *argv[])
    }
 
    // Distribute the mesh.
+   if (hrefinement) { mesh->EnsureNCMesh(); }
    ParMesh pmesh(MPI_COMM_WORLD, *mesh);
    delete mesh;
    for (int lev = 0; lev < rp_levels; lev++) { pmesh.UniformRefinement(); }
+
+   // Random h-refinements to mesh
+   if (hrefinement)
+   {
+      Array<Refinement> refs;
+      for (int e = 0; e < pmesh.GetNE(); e++)
+      {
+         if ((double) rand() / RAND_MAX < 0.5)
+         {
+            refs.Append(Refinement(e));
+         }
+      }
+      pmesh.GeneralRefinement(refs, -1, 0);
+   }
+
 
    // Curve the mesh based on the chosen polynomial degree.
    H1_FECollection fecm(mesh_poly_deg, dim);


### PR DESCRIPTION
@dylan-copeland pointed out that there was a bug in `FindPointsGSLIB` because we were trying to use GSLIB's native interpolation functions for variable order spaces. This has now been fixed such that MFEM's `GetValue` is used for interpolation.
<!--GHEX{"id":2766,"author":"kmittal2","editor":"tzanio","reviewers":["dylan-copeland","pazner"],"assignment":"2022-01-23T17:01:17-08:00","approval":"2022-01-28T20:52:02.497Z","merge":"2022-01-31T01:18:34.963Z"}XEHG--><!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge| 
 | --- | --- | --- | --- | --- | --- | --- | 
| [#2766](https://github.com/mfem/mfem/pull/2766) | @kmittal2 | @tzanio | @dylan-copeland + @pazner | 01/23/22 | 01/28/22 | 01/30/22 | |
<!--ELBATXEHG-->