### PR TITLE
Variable order transfer operator

### DIFF
--- a/fem/transfer.cpp
+++ b/fem/transfer.cpp
@@ -903,7 +903,8 @@ TransferOperator::TransferOperator(const FiniteElementSpace& lFESpace_,
                                    const FiniteElementSpace& hFESpace_)
    : Operator(hFESpace_.GetVSize(), lFESpace_.GetVSize())
 {
-   if (lFESpace_.FEColl() == hFESpace_.FEColl())
+   bool isvar_order = lFESpace_.IsVariableOrder() || hFESpace_.IsVariableOrder();
+   if (lFESpace_.FEColl() == hFESpace_.FEColl() && !isvar_order)
    {
       OperatorPtr P(Operator::ANY_TYPE);
       hFESpace_.GetTransferOperator(lFESpace_, P);
@@ -912,8 +913,11 @@ TransferOperator::TransferOperator(const FiniteElementSpace& lFESpace_,
    }
    else if (lFESpace_.GetMesh()->GetNE() > 0
             && hFESpace_.GetMesh()->GetNE() > 0
+            && lFESpace_.GetVDim() == 1
+            && hFESpace_.GetVDim() == 1
             && dynamic_cast<const TensorBasisElement*>(lFESpace_.GetFE(0))
             && dynamic_cast<const TensorBasisElement*>(hFESpace_.GetFE(0))
+            && !isvar_order
             && (hFESpace_.FEColl()->GetContType() ==
                 mfem::FiniteElementCollection::CONTINUOUS ||
                 hFESpace_.FEColl()->GetContType() ==
@@ -945,6 +949,7 @@ PRefinementTransferOperator::PRefinementTransferOperator(
    : Operator(hFESpace_.GetVSize(), lFESpace_.GetVSize()), lFESpace(lFESpace_),
      hFESpace(hFESpace_)
 {
+   isvar_order = lFESpace_.IsVariableOrder() || hFESpace_.IsVariableOrder();
 }
 
 PRefinementTransferOperator::~PRefinementTransferOperator() {}
@@ -969,7 +974,7 @@ void PRefinementTransferOperator::Mult(const Vector& x, Vector& y) const
       DofTransformation * doftrans_l = lFESpace.GetElementDofs(i, l_dofs);
 
       const Geometry::Type geom = mesh->GetElementBaseGeometry(i);
-      if (geom != cached_geom)
+      if (geom != cached_geom || isvar_order)
       {
          h_fe = hFESpace.GetFE(i);
          l_fe = lFESpace.GetFE(i);
@@ -1026,7 +1031,7 @@ void PRefinementTransferOperator::MultTranspose(const Vector& x,
       DofTransformation * doftrans_l = lFESpace.GetElementDofs(i, l_dofs);
 
       const Geometry::Type geom = mesh->GetElementBaseGeometry(i);
-      if (geom != cached_geom)
+      if (geom != cached_geom || isvar_order)
       {
          h_fe = hFESpace.GetFE(i);
          l_fe = lFESpace.GetFE(i);
@@ -1424,20 +1429,35 @@ void TensorProductPRefinementTransferOperator::MultTranspose(const Vector& x,
    elem_restrict_lex_l->MultTranspose(localL, y);
 }
 
-#ifdef MFEM_USE_MPI
-TrueTransferOperator::TrueTransferOperator(const
-                                           ParFiniteElementSpace& lFESpace_,
-                                           const ParFiniteElementSpace& hFESpace_)
+
+TrueTransferOperator::TrueTransferOperator(const FiniteElementSpace& lFESpace_,
+                                           const FiniteElementSpace& hFESpace_)
    : Operator(hFESpace_.GetTrueVSize(), lFESpace_.GetTrueVSize()),
      lFESpace(lFESpace_),
      hFESpace(hFESpace_)
 {
    localTransferOperator = new TransferOperator(lFESpace_, hFESpace_);
 
-   tmpL.SetSize(lFESpace_.GetVSize());
-   tmpH.SetSize(hFESpace_.GetVSize());
+   P = lFESpace.GetProlongationMatrix();
+   R = hFESpace.GetRestrictionMatrix();
 
-   hFESpace.GetRestrictionMatrix()->BuildTranspose();
+   // P and R can be both null
+   // P can be null and R not null
+   // If P is not null it's assummed that R is not null as well
+   if (P) MFEM_VERIFY(R, "Both P and R have to be not NULL")
+
+   if (P)
+   {
+      tmpL.SetSize(lFESpace_.GetVSize());
+      tmpH.SetSize(hFESpace_.GetVSize());
+      R->BuildTranspose();
+   }
+   // P can be null and R not null
+   else if (R)
+   {
+      tmpH.SetSize(hFESpace_.GetVSize());
+      R->BuildTranspose();
+   }
 }
 
 TrueTransferOperator::~TrueTransferOperator()
@@ -1447,17 +1467,40 @@ TrueTransferOperator::~TrueTransferOperator()
 
 void TrueTransferOperator::Mult(const Vector& x, Vector& y) const
 {
-   lFESpace.GetProlongationMatrix()->Mult(x, tmpL);
-   localTransferOperator->Mult(tmpL, tmpH);
-   hFESpace.GetRestrictionMatrix()->Mult(tmpH, y);
+   if (P)
+   {
+      P->Mult(x, tmpL);
+      localTransferOperator->Mult(tmpL, tmpH);
+      R->Mult(tmpH, y);
+   }
+   else if (R)
+   {
+      localTransferOperator->Mult(x, tmpH);
+      R->Mult(tmpH, y);
+   }
+   else
+   {
+      localTransferOperator->Mult(x, y);
+   }
 }
 
 void TrueTransferOperator::MultTranspose(const Vector& x, Vector& y) const
 {
-   hFESpace.GetRestrictionMatrix()->MultTranspose(x, tmpH);
-   localTransferOperator->MultTranspose(tmpH, tmpL);
-   lFESpace.GetProlongationMatrix()->MultTranspose(tmpL, y);
+   if (P)
+   {
+      R->MultTranspose(x, tmpH);
+      localTransferOperator->MultTranspose(tmpH, tmpL);
+      P->MultTranspose(tmpL, y);
+   }
+   else if (R)
+   {
+      R->MultTranspose(x, tmpH);
+      localTransferOperator->MultTranspose(tmpH, y);
+   }
+   else
+   {
+      localTransferOperator->MultTranspose(x, y);
+   }
 }
-#endif
 
 } // namespace mfem

--- a/fem/transfer.cpp
+++ b/fem/transfer.cpp
@@ -1443,8 +1443,8 @@ TrueTransferOperator::TrueTransferOperator(const FiniteElementSpace& lFESpace_,
 
    // P and R can be both null
    // P can be null and R not null
-   // If P is not null it's assummed that R is not null as well
-   if (P) MFEM_VERIFY(R, "Both P and R have to be not NULL")
+   // If P is not null it is assummed that R is not null as well
+   if (P) { MFEM_VERIFY(R, "Both P and R have to be not NULL") }
 
    if (P)
    {

--- a/fem/transfer.cpp
+++ b/fem/transfer.cpp
@@ -1430,34 +1430,20 @@ void TensorProductPRefinementTransferOperator::MultTranspose(const Vector& x,
 }
 
 
-TrueTransferOperator::TrueTransferOperator(const FiniteElementSpace& lFESpace_,
-                                           const FiniteElementSpace& hFESpace_)
+#ifdef MFEM_USE_MPI
+TrueTransferOperator::TrueTransferOperator(const
+                                           ParFiniteElementSpace& lFESpace_,
+                                           const ParFiniteElementSpace& hFESpace_)
    : Operator(hFESpace_.GetTrueVSize(), lFESpace_.GetTrueVSize()),
      lFESpace(lFESpace_),
      hFESpace(hFESpace_)
 {
    localTransferOperator = new TransferOperator(lFESpace_, hFESpace_);
 
-   P = lFESpace.GetProlongationMatrix();
-   R = hFESpace.GetRestrictionMatrix();
+   tmpL.SetSize(lFESpace_.GetVSize());
+   tmpH.SetSize(hFESpace_.GetVSize());
 
-   // P and R can be both null
-   // P can be null and R not null
-   // If P is not null it is assummed that R is not null as well
-   if (P) { MFEM_VERIFY(R, "Both P and R have to be not NULL") }
-
-   if (P)
-   {
-      tmpL.SetSize(lFESpace_.GetVSize());
-      tmpH.SetSize(hFESpace_.GetVSize());
-      R->BuildTranspose();
-   }
-   // P can be null and R not null
-   else if (R)
-   {
-      tmpH.SetSize(hFESpace_.GetVSize());
-      R->BuildTranspose();
-   }
+   hFESpace.GetRestrictionMatrix()->BuildTranspose();
 }
 
 TrueTransferOperator::~TrueTransferOperator()
@@ -1467,40 +1453,17 @@ TrueTransferOperator::~TrueTransferOperator()
 
 void TrueTransferOperator::Mult(const Vector& x, Vector& y) const
 {
-   if (P)
-   {
-      P->Mult(x, tmpL);
-      localTransferOperator->Mult(tmpL, tmpH);
-      R->Mult(tmpH, y);
-   }
-   else if (R)
-   {
-      localTransferOperator->Mult(x, tmpH);
-      R->Mult(tmpH, y);
-   }
-   else
-   {
-      localTransferOperator->Mult(x, y);
-   }
+   lFESpace.GetProlongationMatrix()->Mult(x, tmpL);
+   localTransferOperator->Mult(tmpL, tmpH);
+   hFESpace.GetRestrictionMatrix()->Mult(tmpH, y);
 }
 
 void TrueTransferOperator::MultTranspose(const Vector& x, Vector& y) const
 {
-   if (P)
-   {
-      R->MultTranspose(x, tmpH);
-      localTransferOperator->MultTranspose(tmpH, tmpL);
-      P->MultTranspose(tmpL, y);
-   }
-   else if (R)
-   {
-      R->MultTranspose(x, tmpH);
-      localTransferOperator->MultTranspose(tmpH, y);
-   }
-   else
-   {
-      localTransferOperator->MultTranspose(x, y);
-   }
+   hFESpace.GetRestrictionMatrix()->MultTranspose(x, tmpH);
+   localTransferOperator->MultTranspose(tmpH, tmpL);
+   lFESpace.GetProlongationMatrix()->MultTranspose(tmpL, y);
 }
+#endif
 
 } // namespace mfem

--- a/fem/transfer.hpp
+++ b/fem/transfer.hpp
@@ -387,6 +387,7 @@ class PRefinementTransferOperator : public Operator
 private:
    const FiniteElementSpace& lFESpace;
    const FiniteElementSpace& hFESpace;
+   bool isvar_order;
 
 public:
    /// @brief Constructs a transfer operator from \p lFESpace to \p hFESpace
@@ -452,14 +453,15 @@ public:
    virtual void MultTranspose(const Vector& x, Vector& y) const override;
 };
 
-#ifdef MFEM_USE_MPI
 /// @brief Matrix-free transfer operator between finite element spaces working
 /// on true degrees of freedom
 class TrueTransferOperator : public Operator
 {
 private:
-   const ParFiniteElementSpace& lFESpace;
-   const ParFiniteElementSpace& hFESpace;
+   const FiniteElementSpace& lFESpace;
+   const FiniteElementSpace& hFESpace;
+   const Operator * P = nullptr;
+   const SparseMatrix * R = nullptr;
    TransferOperator* localTransferOperator;
    mutable Vector tmpL;
    mutable Vector tmpH;
@@ -467,8 +469,8 @@ private:
 public:
    /// @brief Constructs a transfer operator working on true degrees of freedom
    /// from \p lFESpace to \p hFESpace
-   TrueTransferOperator(const ParFiniteElementSpace& lFESpace_,
-                        const ParFiniteElementSpace& hFESpace_);
+   TrueTransferOperator(const FiniteElementSpace& lFESpace_,
+                        const FiniteElementSpace& hFESpace_);
 
    /// Destructor
    ~TrueTransferOperator();
@@ -484,7 +486,6 @@ public:
        the true dof vector \p y corresponding to the coarse space. */
    virtual void MultTranspose(const Vector& x, Vector& y) const override;
 };
-#endif
 
 } // namespace mfem
 

--- a/fem/transfer.hpp
+++ b/fem/transfer.hpp
@@ -453,15 +453,14 @@ public:
    virtual void MultTranspose(const Vector& x, Vector& y) const override;
 };
 
+#ifdef MFEM_USE_MPI
 /// @brief Matrix-free transfer operator between finite element spaces working
 /// on true degrees of freedom
 class TrueTransferOperator : public Operator
 {
 private:
-   const FiniteElementSpace& lFESpace;
-   const FiniteElementSpace& hFESpace;
-   const Operator * P = nullptr;
-   const SparseMatrix * R = nullptr;
+   const ParFiniteElementSpace& lFESpace;
+   const ParFiniteElementSpace& hFESpace;
    TransferOperator* localTransferOperator;
    mutable Vector tmpL;
    mutable Vector tmpH;
@@ -469,8 +468,8 @@ private:
 public:
    /// @brief Constructs a transfer operator working on true degrees of freedom
    /// from \p lFESpace to \p hFESpace
-   TrueTransferOperator(const FiniteElementSpace& lFESpace_,
-                        const FiniteElementSpace& hFESpace_);
+   TrueTransferOperator(const ParFiniteElementSpace& lFESpace_,
+                        const ParFiniteElementSpace& hFESpace_);
 
    /// Destructor
    ~TrueTransferOperator();
@@ -486,6 +485,7 @@ public:
        the true dof vector \p y corresponding to the coarse space. */
    virtual void MultTranspose(const Vector& x, Vector& y) const override;
 };
+#endif
 
 } // namespace mfem
 

--- a/fem/transfer.hpp
+++ b/fem/transfer.hpp
@@ -453,14 +453,15 @@ public:
    virtual void MultTranspose(const Vector& x, Vector& y) const override;
 };
 
-#ifdef MFEM_USE_MPI
 /// @brief Matrix-free transfer operator between finite element spaces working
 /// on true degrees of freedom
 class TrueTransferOperator : public Operator
 {
 private:
-   const ParFiniteElementSpace& lFESpace;
-   const ParFiniteElementSpace& hFESpace;
+   const FiniteElementSpace& lFESpace;
+   const FiniteElementSpace& hFESpace;
+   const Operator * P = nullptr;
+   const SparseMatrix * R = nullptr;
    TransferOperator* localTransferOperator;
    mutable Vector tmpL;
    mutable Vector tmpH;
@@ -468,8 +469,8 @@ private:
 public:
    /// @brief Constructs a transfer operator working on true degrees of freedom
    /// from \p lFESpace to \p hFESpace
-   TrueTransferOperator(const ParFiniteElementSpace& lFESpace_,
-                        const ParFiniteElementSpace& hFESpace_);
+   TrueTransferOperator(const FiniteElementSpace& lFESpace_,
+                        const FiniteElementSpace& hFESpace_);
 
    /// Destructor
    ~TrueTransferOperator();
@@ -485,7 +486,6 @@ public:
        the true dof vector \p y corresponding to the coarse space. */
    virtual void MultTranspose(const Vector& x, Vector& y) const override;
 };
-#endif
 
 } // namespace mfem
 

--- a/tests/unit/fem/test_transfer.cpp
+++ b/tests/unit/fem/test_transfer.cpp
@@ -57,9 +57,9 @@ double coeff(const Vector& X)
       z = X[2];
       if (coeff_order == 1)
       {
-        return 1.1 * x + 2.0 * y + 3.0 * z;
+         return 1.1 * x + 2.0 * y + 3.0 * z;
       }
-      else  
+      else
       {
          return (1.-x)*x*(1.-y)*y*(1.-z)*z;
       }

--- a/tests/unit/fem/test_transfer.cpp
+++ b/tests/unit/fem/test_transfer.cpp
@@ -389,7 +389,7 @@ TEST_CASE("variable_order_true_transfer")
                new FiniteElementSpace(&mesh, c_fec, spaceDimension);
             FiniteElementSpace* f_fespace =
                new FiniteElementSpace(&mesh, f_fec,spaceDimension);
-            f_fespace->SetRelaxedHpConformity(true);
+
             int maxorder = RandomPRefinement(*f_fespace);
 
             std::cout  << "  Max fine order: " << maxorder << "\n";

--- a/tests/unit/fem/test_transfer.cpp
+++ b/tests/unit/fem/test_transfer.cpp
@@ -125,19 +125,19 @@ TEST_CASE("transfer")
                      {
                         c_fec = new H1_FECollection(order, dimension);
                         f_fec = (geometric == 1) ? c_fec : new
-                                   H1_FECollection(fineOrder, dimension);
+                                H1_FECollection(fineOrder, dimension);
                      }
                      else if (vectorspace == 2)
                      {
                         c_fec = new ND_FECollection(order+1, dimension);
                         f_fec = (geometric == 1) ? c_fec : new
-                                   ND_FECollection(fineOrder, dimension);
+                                ND_FECollection(fineOrder, dimension);
                      }
                      else
                      {
                         c_fec = new RT_FECollection(order, dimension);
                         f_fec = (geometric == 1) ? c_fec : new
-                                   RT_FECollection(fineOrder, dimension);
+                                RT_FECollection(fineOrder, dimension);
                      }
 
                      Mesh fineMesh(mesh);
@@ -241,10 +241,10 @@ TEST_CASE("variable_order_transfer")
             for (int order = 1; order <= 4; order *= 2)
             {
                std::cout << "Testing variable order transfer:\n"
-                           << "  Vectorspace:    " << vectorspace << "\n"
-                           << "  Dimension:      " << dimension << "\n"
-                           << "  Elements:       " << std::pow(ne, dimension) << "\n"
-                           << "  Coarse order:   " << order << "\n";
+                         << "  Vectorspace:    " << vectorspace << "\n"
+                         << "  Dimension:      " << dimension << "\n"
+                         << "  Elements:       " << std::pow(ne, dimension) << "\n"
+                         << "  Coarse order:   " << order << "\n";
 
                Mesh mesh;
                if (dimension == 2)
@@ -294,7 +294,7 @@ TEST_CASE("variable_order_transfer")
                Operator* referenceOperator = nullptr;
 
                referenceOperator = new PRefinementTransferOperator(*c_fespace,
-                                                                     *f_fespace);
+                                                                   *f_fespace);
 
                TransferOperator testTransferOperator(*c_fespace, *f_fespace);
                GridFunction X(c_fespace);
@@ -354,9 +354,9 @@ TEST_CASE("variable_order_true_transfer")
          for (int order = 1; order <= 3; order++)
          {
             std::cout << "Testing variable order true transfer:\n"
-                        << "  Vectorspace:    " << vectorspace << "\n"
-                        << "  Dimension:      " << dimension << "\n"
-                        << "  Coarse order:   " << order << "\n";
+                      << "  Vectorspace:    " << vectorspace << "\n"
+                      << "  Dimension:      " << dimension << "\n"
+                      << "  Coarse order:   " << order << "\n";
 
             Mesh mesh;
             if (dimension == 2)
@@ -418,7 +418,7 @@ TEST_CASE("variable_order_true_transfer")
             else
             {
                Xc = xc;
-            }  
+            }
             T.Mult(Xc, Xf);
 
             BilinearFormIntegrator * massc=nullptr;
@@ -426,14 +426,14 @@ TEST_CASE("variable_order_true_transfer")
 
             switch (vectorspace)
             {
-            case 0:
-               massc = new MassIntegrator;
-               massf = new MassIntegrator;
-               break;
-            default:
-               massc = new VectorMassIntegrator;   
-               massf = new VectorMassIntegrator;   
-               break;
+               case 0:
+                  massc = new MassIntegrator;
+                  massf = new MassIntegrator;
+                  break;
+               default:
+                  massc = new VectorMassIntegrator;
+                  massf = new VectorMassIntegrator;
+                  break;
             }
 
 

--- a/tests/unit/fem/test_transfer.cpp
+++ b/tests/unit/fem/test_transfer.cpp
@@ -17,14 +17,15 @@ using namespace mfem;
 int RandomPRefinement(FiniteElementSpace & fes)
 {
    Mesh * mesh = fes.GetMesh();
-   Array<Refinement> refs;
-   int maxorder = fes.GetElementOrder(0);
+   int maxorder = 0;
+   int order;
    for (int i = 0; i < mesh->GetNE(); i++)
    {
+      order = fes.GetElementOrder(i);
+      maxorder = std::max(maxorder,order);
       if ((double) rand() / RAND_MAX < 0.5)
       {
-         int order = fes.GetElementOrder(i) + 1;
-         fes.SetElementOrder(i,order);
+         fes.SetElementOrder(i,order+1);
          maxorder = std::max(maxorder,order);
       }
    }
@@ -338,6 +339,7 @@ TEST_CASE("variable_order_transfer")
                delete referenceOperator;
                delete f_fespace;
                delete c_fespace;
+               delete f_fec;
                delete c_fec;
             }
          }
@@ -464,6 +466,7 @@ TEST_CASE("variable_order_true_transfer")
 
             delete f_fespace;
             delete c_fespace;
+            delete f_fec;
             delete c_fec;
          }
       }


### PR DESCRIPTION
This PR adds support in `PRefinementTransferOperator`/`(True)TransferOperator` for variable order Finite Element Spaces (in serial)
Some unit tests are added accordingly. This is needed in the DRL4AMR project. <!--GHEX{"author":"psocratis","assignment":"2022-01-15T02:08:07","editor":"pazner","id":2770,"reviewers":["rw-anderson","dylan-copeland"],"merge":"2022-02-14T22:21:26","approval":"2022-02-09T22:48:53"}XEHG-->
<!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge|
 | --- | --- | --- | --- | --- | --- | --- |
| [#2770](https://github.com/mfem/mfem/pull/2770) | @psocratis | @pazner | @rw-anderson + @dylan-copeland | 1/14/22 | 2/9/22 | 2/14/22 | |
<!--ELBATXEHG-->