### PR TITLE
Fix erroneous comment in StopWatch

### DIFF
--- a/general/tic_toc.hpp
+++ b/general/tic_toc.hpp
@@ -42,7 +42,7 @@ public:
    /// Clear the elapsed time on the stopwatch and restart it if it's running.
    void Clear();
 
-   /// Clear the elapsed time and start the stopwatch.
+   /// Start the stopwatch. The elapsed time is @b not cleared.
    void Start();
 
    /// Stop the stopwatch.


### PR DESCRIPTION
Restarting a `StopWatch` by calling `Start()` does **not** clear the elapsed time, despite what the comment says.
<!--GHEX{"id":2771,"author":"pazner","editor":"v-dobrev","reviewers":["v-dobrev","tzanio"],"assignment":"2022-01-14T18:12:44-08:00","approval":"2022-01-18T20:09:12.690Z","merge":"2022-01-18T20:12:07.301Z"}XEHG--><!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge| 
 | --- | --- | --- | --- | --- | --- | --- | 
| [#2771](https://github.com/mfem/mfem/pull/2771) | @pazner | @v-dobrev | @v-dobrev + @tzanio | 01/14/22 | 01/18/22 | 01/18/22 | |
<!--ELBATXEHG-->