### PR TITLE
Async memcpy for DtoD

### DIFF
--- a/general/mem_manager.cpp
+++ b/general/mem_manager.cpp
@@ -470,7 +470,10 @@ public:
    void *HtoD(void *dst, const void *src, size_t bytes)
    { return HipMemcpyHtoD(dst, src, bytes); }
    void *DtoD(void* dst, const void* src, size_t bytes)
-   { return HipMemcpyDtoD(dst, src, bytes); }
+   // Unlike cudaMemcpy(DtoD), hipMemcpy(DtoD) causes a host-side synchronization so
+   // instead we use hipMemcpyAsync to get similar behavior.
+   // for more info see: https://github.com/mfem/mfem/pull/2780
+   { return HipMemcpyDtoDAsync(dst, src, bytes); }
    void *DtoH(void *dst, const void *src, size_t bytes)
    { return HipMemcpyDtoH(dst, src, bytes); }
 };
@@ -593,6 +596,9 @@ public:
       return CuMemcpyDtoD(dst, src, bytes);
 #endif
 #ifdef MFEM_USE_HIP
+      // Unlike cudaMemcpy(DtoD), hipMemcpy(DtoD) causes a host-side synchronization so
+      // instead we use hipMemcpyAsync to get similar behavior.
+      // for more info see: https://github.com/mfem/mfem/pull/2780
       return HipMemcpyDtoDAsync(dst, src, bytes);
 #endif
       // rm.copy(dst, const_cast<void*>(src), bytes); return dst;

--- a/general/mem_manager.cpp
+++ b/general/mem_manager.cpp
@@ -593,7 +593,7 @@ public:
       return CuMemcpyDtoD(dst, src, bytes);
 #endif
 #ifdef MFEM_USE_HIP
-      return HipMemcpyDtoD(dst, src, bytes);
+      return HipMemcpyDtoDAsync(dst, src, bytes);
 #endif
       // rm.copy(dst, const_cast<void*>(src), bytes); return dst;
    }


### PR DESCRIPTION
Use `HipMemcpyDtoDAsync` (on the default stream) instead of `HipMemcpyDtoD` to avoid unnecessary host blocking. I noticed this in the profiler and after reading some documentation it seems like cuda and hip have different behavior for synchronous DtoD memcpys.

The cuda docs specifically say that "for transfers from device memory to device memory, no host-side synchronization is performed," for synchronous memcpy ([see the cuda docs](https://docs.nvidia.com/cuda/cuda-runtime-api/api-sync-behavior.html#api-sync-behavior__memcpy-sync)), while for hip every synchronous memcpy will:
- wait for all previous commands to complete.
- will not return control back to host until the command completes.
- ([see the rocm/hip docs](http://rocm-developer-tools.github.io/HIP/Synchonization.html))

I've only tested this for the Umpire device memory space and we see a performance improvement resulting from better kernel packing in a iterative routine with a few kernels followed by a DtoD transfer followed by a few kernels followed by a DtoD transfer followed by ... .  

From what I understand this change is okay because the default stream waits for "tasks" on other streams to complete before running so this will be synchronous wrt other device tasks on non-default streams (if we ever add support for that in mfem). Hard to find this in the docs but someone from amd mentioned it [here](https://github.com/ROCm-Developer-Tools/HIP/issues/129).

I am happy to make this change for other hip device memory spaces if desired.
<!--GHEX{"id":2780,"author":"tomstitt","editor":"tzanio","reviewers":["artv3","camierjs","v-dobrev"],"assignment":"2022-01-21T15:37:35-08:00","approval":"2022-01-27T23:28:39.337Z","merge":"2022-01-31T01:17:59.189Z"}XEHG--><!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge| 
 | --- | --- | --- | --- | --- | --- | --- | 
| [#2780](https://github.com/mfem/mfem/pull/2780) | @tomstitt | @tzanio | @artv3 + @camierjs + @v-dobrev | 01/21/22 | 01/27/22 | 01/30/22 | |
<!--ELBATXEHG-->