### PR TITLE
Fix hash table resize on NCMesh load [hash-resize-fix]

### DIFF
--- a/general/hash.hpp
+++ b/general/hash.hpp
@@ -591,6 +591,7 @@ void HashTable<T>::Alloc(int id, int p1, int p2)
       item.p2 = p2;
 
       Insert(Hash(p1, p2), id, item);
+      CheckRehash();
    }
 }
 


### PR DESCRIPTION
The `HashTable` normally resizes itself when it becomes overfull, but this was missing in the special case of the `Alloc()` method, which is used when loading an NC mesh.

The fix consists of adding the line `CheckRehash()` in `HashTable<T>::Alloc`.

Also added a debugging method to dump a histogram if bin sizes.
