### PR TITLE
Parallel Unstructured Mesh Infrastructure (PUMI): Attaching Gmsh Physical Entity Tags [cws/pumi-gmsh-phys-ents]

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -354,7 +354,7 @@ endif()
 if (MFEM_USE_PUMI)
   # If PUMI_DIR was specified, only link to that directory,
   # i.e. don't link to another installation in /usr/lib by mistake
-  find_package(SCOREC 2.1.0 REQUIRED OPTIONAL_COMPONENTS gmi_sim
+  find_package(SCOREC 2.2.6 REQUIRED OPTIONAL_COMPONENTS gmi_sim
     CONFIG PATHS ${PUMI_DIR} NO_DEFAULT_PATH)
   if (SCOREC_FOUND)
     # Define a header file with the MFEM_USE_SIMMETRIX preprocessor variable

--- a/INSTALL
+++ b/INSTALL
@@ -704,7 +704,7 @@ The specific libraries and their options are:
   URL: https://scorec.rpi.edu/pumi
        https://github.com/SCOREC/core
   Options: PUMI_OPT, PUMI_LIB.
-  Versions: PUMI == 2.2.3.
+  Versions: PUMI >= 2.2.6.
 
 - HiOp (optional), used when MFEM_USE_HIOP = YES.
   URL: https://github.com/LLNL/hiop

--- a/examples/pumi/ex1p.cpp
+++ b/examples/pumi/ex1p.cpp
@@ -145,7 +145,7 @@ int main(int argc, char *argv[])
    // Perform Uniform refinement
    if (ref_levels > 1)
    {
-      const ma::Input* uniInput = ma::configureUniformRefine(pumi_mesh, ref_levels);
+      auto uniInput = ma::configureUniformRefine(pumi_mesh, ref_levels);
 
       if (geom_order > 1)
       {

--- a/examples/pumi/ex6p.cpp
+++ b/examples/pumi/ex6p.cpp
@@ -150,7 +150,7 @@ int main(int argc, char *argv[])
 
    if (ref_levels > 1)
    {
-      const ma::Input* uniInput = ma::configureUniformRefine(pumi_mesh, ref_levels);
+      auto uniInput = ma::configureUniformRefine(pumi_mesh, ref_levels);
 
       if ( geom_order > 1)
       {
@@ -345,7 +345,7 @@ int main(int argc, char *argv[])
       apf::destroyField(ipfield);
 
       // 18. Perform MesAdapt.
-      const ma::Input* erinput = ma::configure(pumi_mesh, sizefield);
+      auto erinput = ma::configure(pumi_mesh, sizefield);
       if ( geom_order > 1)
       {
          crv::adapt(erinput);

--- a/mesh/pumi.cpp
+++ b/mesh/pumi.cpp
@@ -360,6 +360,10 @@ void PumiMesh::ReadSCORECMesh(apf::Mesh2* apf_mesh, apf::Numbering* v_num_loc,
    NumOfElements = countOwned(apf_mesh,Dim);
    elements.SetSize(NumOfElements);
 
+   // Look for the gmsh physical entity tag
+   const char* gmshTagName = "gmsh_physical_entity";
+   apf::MeshTag* gmshPhysEnt = apf_mesh->findTag(gmshTagName);
+
    // Read elements from SCOREC Mesh
    itr = apf_mesh->begin(Dim);
    unsigned int j=0;
@@ -368,8 +372,11 @@ void PumiMesh::ReadSCORECMesh(apf::Mesh2* apf_mesh, apf::Numbering* v_num_loc,
       // Get vertices
       apf::Downward verts;
       apf_mesh->getDownward(ent,0,verts); // num_vert
-      // Get attribute Tag vs Geometry
+      // Get attribute Tag from gmsh if it exists
       int attr = 1;
+      if( gmshPhysEnt ) {
+         apf_mesh->getIntTag(ent,gmshPhysEnt,&attr);
+      }
 
       int geom_type = apf_mesh->getType(ent);
       elements[j] = NewElement(geom_type);

--- a/mesh/pumi.cpp
+++ b/mesh/pumi.cpp
@@ -374,7 +374,8 @@ void PumiMesh::ReadSCORECMesh(apf::Mesh2* apf_mesh, apf::Numbering* v_num_loc,
       apf_mesh->getDownward(ent,0,verts); // num_vert
       // Get attribute Tag from gmsh if it exists
       int attr = 1;
-      if( gmshPhysEnt ) {
+      if ( gmshPhysEnt )
+      {
          apf_mesh->getIntTag(ent,gmshPhysEnt,&attr);
       }
 
@@ -531,7 +532,8 @@ ParPumiMesh::ParPumiMesh(MPI_Comm comm, apf::Mesh2* apf_mesh,
       apf_mesh->getDownward(ent,0,verts);
       // Get attribute Tag from gmsh if it exists
       int attr = 1;
-      if( gmshPhysEnt ) {
+      if ( gmshPhysEnt )
+      {
          apf_mesh->getIntTag(ent,gmshPhysEnt,&attr);
       }
 

--- a/mesh/pumi.cpp
+++ b/mesh/pumi.cpp
@@ -533,7 +533,6 @@ ParPumiMesh::ParPumiMesh(MPI_Comm comm, apf::Mesh2* apf_mesh,
       int attr = 1;
       if( gmshPhysEnt ) {
          apf_mesh->getIntTag(ent,gmshPhysEnt,&attr);
-         if(!MyRank) fprintf(stderr, "read attr %d\n", attr);
       }
 
       // Get attribute Tag vs Geometry


### PR DESCRIPTION
This PR adds support for attaching Gmsh physical entity tags stored in PUMI meshes as an attribute on an MFEM mesh.  See issue #2726 for development and testing discussion.

This PR **is backward compatible** with PUMI meshes created with PUMI <= 2.2.6, but only PUMI meshes created with the upcoming [PUMI 2.2.7 release](https://github.com/SCOREC/core/issues/357) or the current [master@19185e9](https://github.com/SCOREC/core/tree/19185e9a8590176575721f7057764a4feafe3e4c) branch will contain the Gmsh physical entity tags.
<!--GHEX{"id":2782,"author":"cwsmith","editor":"tzanio","reviewers":["tzanio","mlstowell"],"assignment":"2022-01-27T08:15:26-08:00","approval":"2022-02-01T15:37:45.809Z","merge":"2022-02-08T17:46:55.803Z"}XEHG--><!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge| 
 | --- | --- | --- | --- | --- | --- | --- | 
| [#2782](https://github.com/mfem/mfem/pull/2782) | @cwsmith | @tzanio | @tzanio + @mlstowell | 01/27/22 | 02/01/22 | 02/08/22 | |
<!--ELBATXEHG-->