### PR TITLE
Device support for LBFGS

### DIFF
--- a/linalg/solvers.cpp
+++ b/linalg/solvers.cpp
@@ -2027,6 +2027,11 @@ void LBFGSSolver::Mult(const Vector &b, Vector &x) const
    c = r;           // initial descent direction
 
    norm0 = norm = Norm(r);
+   if (print_options.first_and_last && !print_options.iterations)
+   {
+      mfem::out << "LBFGS iteration " << setw(2) << 0
+                << " : ||r|| = " << norm << "...\n";
+   }
    norm_goal = std::max(rel_tol*norm, abs_tol);
    for (it = 0; true; it++)
    {
@@ -2115,6 +2120,7 @@ void LBFGSSolver::Mult(const Vector &b, Vector &x) const
 
       norm = Norm(r);
    }
+
    final_iter = it;
    final_norm = norm;
 

--- a/linalg/solvers.cpp
+++ b/linalg/solvers.cpp
@@ -1995,11 +1995,6 @@ void LBFGSSolver::Mult(const Vector &b, Vector &x) const
 
    // Quadrature points that are checked for negative Jacobians etc.
    Vector sk, rk, yk, rho, alpha;
-   for (int i = 0; i < m; i++)
-   {
-      skArray[i]->SetSize(width);
-      ykArray[i]->SetSize(width);
-   }
 
    // r - r_{k+1}, c - descent direction
    sk.SetSize(width);    // x_{k+1}-x_k

--- a/linalg/solvers.cpp
+++ b/linalg/solvers.cpp
@@ -2031,7 +2031,7 @@ void LBFGSSolver::Mult(const Vector &b, Vector &x) const
    for (it = 0; true; it++)
    {
       MFEM_ASSERT(IsFinite(norm), "norm = " << norm);
-      if (print_level >= 0)
+      if (print_options.iterations)
       {
          mfem::out << "LBFGS iteration " <<  it
                    << " : ||r|| = " << norm;
@@ -2044,13 +2044,13 @@ void LBFGSSolver::Mult(const Vector &b, Vector &x) const
 
       if (norm <= norm_goal)
       {
-         converged = 1;
+         converged = true;
          break;
       }
 
       if (it >= max_iter)
       {
-         converged = 0;
+         converged = false;
          break;
       }
 
@@ -2058,7 +2058,7 @@ void LBFGSSolver::Mult(const Vector &b, Vector &x) const
       const double c_scale = ComputeScalingFactor(x, b);
       if (c_scale == 0.0)
       {
-         converged = 0;
+         converged = false;
          break;
       }
       add(x, -c_scale, c, x); // x_{k+1} = x_k - c_scale*c
@@ -2117,6 +2117,17 @@ void LBFGSSolver::Mult(const Vector &b, Vector &x) const
    }
    final_iter = it;
    final_norm = norm;
+
+   if (print_options.summary || (!converged && print_options.warnings) ||
+       print_options.first_and_last)
+   {
+      mfem::out << "LBFGS: Number of iterations: " << final_iter << '\n'
+                << "   ||r|| = " << final_norm << '\n';
+   }
+   if (print_options.summary || (!converged && print_options.warnings))
+   {
+      mfem::out << "LBFGS: No convergence!\n";
+   }
 }
 
 int aGMRES(const Operator &A, Vector &x, const Vector &b,

--- a/linalg/solvers.hpp
+++ b/linalg/solvers.hpp
@@ -701,34 +701,6 @@ protected:
    int m = 10;
    mutable Array<Vector *> skArray, ykArray;
 
-public:
-   LBFGSSolver() : NewtonSolver()
-   {
-      InitializeStorageVectors();
-   }
-
-#ifdef MFEM_USE_MPI
-   LBFGSSolver(MPI_Comm comm_) : NewtonSolver(comm_)
-   {
-      InitializeStorageVectors();
-   }
-#endif
-
-   void SetHistorySize(int dim)
-   {
-      m = dim;
-      InitializeStorageVectors();
-   }
-
-   /// Solve the nonlinear system with right-hand side @a b.
-   /** If `b.Size() != Height()`, then @a b is assumed to be zero. */
-   virtual void Mult(const Vector &b, Vector &x) const;
-
-   virtual void SetPreconditioner(Solver &pr)
-   { MFEM_WARNING("L-BFGS won't use the given preconditioner."); }
-   virtual void SetSolver(Solver &solver)
-   { MFEM_WARNING("L-BFGS won't use the given solver."); }
-
    void DeleteStorageVectors()
    {
       for (int i = 0; i < skArray.Size(); i++)
@@ -751,6 +723,34 @@ public:
          ykArray[i]->UseDevice(true);
       }
    }
+
+public:
+   LBFGSSolver() : NewtonSolver() { }
+
+#ifdef MFEM_USE_MPI
+   LBFGSSolver(MPI_Comm comm_) : NewtonSolver(comm_) { }
+#endif
+
+   virtual void SetOperator(const Operator &op)
+   {
+      NewtonSolver::SetOperator(op);
+      InitializeStorageVectors();
+   }
+
+   void SetHistorySize(int dim)
+   {
+      m = dim;
+      InitializeStorageVectors();
+   }
+
+   /// Solve the nonlinear system with right-hand side @a b.
+   /** If `b.Size() != Height()`, then @a b is assumed to be zero. */
+   virtual void Mult(const Vector &b, Vector &x) const;
+
+   virtual void SetPreconditioner(Solver &pr)
+   { MFEM_WARNING("L-BFGS won't use the given preconditioner."); }
+   virtual void SetSolver(Solver &solver)
+   { MFEM_WARNING("L-BFGS won't use the given solver."); }
 
    virtual ~LBFGSSolver() { DeleteStorageVectors(); }
 };

--- a/miniapps/meshing/pmesh-optimizer.cpp
+++ b/miniapps/meshing/pmesh-optimizer.cpp
@@ -75,6 +75,7 @@
 //
 //   Blade shape:
 //     mpirun -np 4 pmesh-optimizer -m blade.mesh -o 4 -mid 2 -tid 1 -ni 30 -ls 3 -art 1 -bnd -qt 1 -qo 8
+//   * mpirun -np 4 pmesh-optimizer -m blade.mesh -o 4 -mid 2 -tid 1 -ni 30 -ls 3 -art 1 -bnd -qt 1 -qo 8 -d cuda
 //   Blade shape with FD-based solver:
 //     mpirun -np 4 pmesh-optimizer -m blade.mesh -o 4 -mid 2 -tid 1 -ni 30 -ls 4 -bnd -qt 1 -qo 8 -fd
 //   Blade limited shape:


### PR DESCRIPTION
The LBFGS solver does not currently work on GPUs because it uses `DenseMatrix` to store the history of relevant `Vector`s. Now using an `Array` of Vectors instead as a work around. We need this for TMOP related thrusts. cc: @camierjs
<!--GHEX{"id":2786,"author":"kmittal2","editor":"v-dobrev","reviewers":["vladotomov","camierjs"],"assignment":"2022-01-27T05:08:27-08:00","approval":"2022-02-14T22:58:16.425Z","merge":"2022-02-24T23:57:15.916Z"}XEHG--><!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge| 
 | --- | --- | --- | --- | --- | --- | --- | 
| [#2786](https://github.com/mfem/mfem/pull/2786) | @kmittal2 | @v-dobrev | @vladotomov + @camierjs | 01/27/22 | 02/14/22 | 02/24/22 | |
<!--ELBATXEHG-->