### PR TITLE
Typo in `test_matrix_rectangular.cpp`

### DIFF
--- a/tests/unit/linalg/test_matrix_rectangular.cpp
+++ b/tests/unit/linalg/test_matrix_rectangular.cpp
@@ -27,7 +27,7 @@ void gradf1(const Vector &x, Vector &u)
 {
    u(0) = 2*x(0);
    if (x.Size() >= 2) { u(1) = 3*pow(x(1), 2); }
-   if (x.Size() >= 3) { u(2) = 4*pow(x(1), 3); }
+   if (x.Size() >= 3) { u(2) = 4*pow(x(2), 3); }
 }
 
 TEST_CASE("FormRectangular", "[FormRectangularSystemMatrix]")


### PR DESCRIPTION
Small typo in `tests/unit/linalg`.<!--GHEX{"author":"rezgarshakeri","assignment":"2022-02-01T17:38:16","editor":"pazner","id":2800,"reviewers":["pazner","jandrej"],"merge":"2022-03-07T22:02:47","approval":"2022-03-07T22:02:43"}XEHG-->
<!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge|
 | --- | --- | --- | --- | --- | --- | --- |
| [#2800](https://github.com/mfem/mfem/pull/2800) | @rezgarshakeri | @pazner | @pazner + @jandrej | 2/1/22 | 3/7/22 | 3/7/22 | |
<!--ELBATXEHG-->