### PR TITLE
Initialize element matrices to zero when no integrators.

### DIFF
--- a/fem/bilinearform_ext.cpp
+++ b/fem/bilinearform_ext.cpp
@@ -514,6 +514,10 @@ void EABilinearFormExtension::Assemble()
 
    Array<BilinearFormIntegrator*> &integrators = *a->GetDBFI();
    const int integratorCount = integrators.Size();
+   if ( integratorCount == 0 )
+   {
+      ea_data = 0.0;
+   }
    for (int i = 0; i < integratorCount; ++i)
    {
       integrators[i]->AssembleEA(*a->FESpace(), ea_data, i);


### PR DESCRIPTION
Currently the element matrices where left uninitialized when no integrator were provided, this PR initializes the element matrices to zero in such a case.