### PR TITLE
Fix for HypreParMatrixFromBlocks for square matrices

### DIFF
--- a/linalg/hypre.cpp
+++ b/linalg/hypre.cpp
@@ -2976,10 +2976,8 @@ HypreParMatrix * HypreParMatrixFromBlocks(Array2D<HypreParMatrix*> &blocks,
    rowStarts2[0] = first_loc_row;
    rowStarts2[1] = first_loc_row + all_num_loc_rows[rank];
 
-   int square = (first_loc_row == first_loc_col &&
-                 all_num_loc_rows[rank] == all_num_loc_cols[rank]);
-   MPI_Allreduce(MPI_IN_PLACE, &square, 1, MPI_INT, MPI_MAX, comm);
-
+   int square = std::equal(all_num_loc_rows.begin(), all_num_loc_rows.end(),
+                           all_num_loc_cols.begin());
    if (square)
    {
       return new HypreParMatrix(comm, num_loc_rows, glob_nrows, glob_ncols,

--- a/linalg/hypre.cpp
+++ b/linalg/hypre.cpp
@@ -2976,8 +2976,11 @@ HypreParMatrix * HypreParMatrixFromBlocks(Array2D<HypreParMatrix*> &blocks,
    rowStarts2[0] = first_loc_row;
    rowStarts2[1] = first_loc_row + all_num_loc_rows[rank];
 
-   if (first_loc_row == first_loc_col &&
-       all_num_loc_rows[rank] == all_num_loc_cols[rank])
+   int square = (first_loc_row == first_loc_col &&
+                 all_num_loc_rows[rank] == all_num_loc_cols[rank]);
+   MPI_Allreduce(MPI_IN_PLACE, &square, 1, MPI_INT, MPI_MAX, comm);
+
+   if (square)
    {
       return new HypreParMatrix(comm, num_loc_rows, glob_nrows, glob_ncols,
                                 opI.data(), opJ.data(),

--- a/linalg/hypre.cpp
+++ b/linalg/hypre.cpp
@@ -2969,22 +2969,34 @@ HypreParMatrix * HypreParMatrixFromBlocks(Array2D<HypreParMatrix*> &blocks,
       }
    }
 
+   MFEM_VERIFY(HYPRE_AssumedPartitionCheck(),
+               "only 'assumed partition' mode is supported");
+
    std::vector<HYPRE_BigInt> rowStarts2(2);
    rowStarts2[0] = first_loc_row;
    rowStarts2[1] = first_loc_row + all_num_loc_rows[rank];
 
-   std::vector<HYPRE_BigInt> colStarts2(2);
-   colStarts2[0] = first_loc_col;
-   colStarts2[1] = first_loc_col + all_num_loc_cols[rank];
+   if (first_loc_row == first_loc_col &&
+       all_num_loc_rows[rank] == all_num_loc_cols[rank])
+   {
+      return new HypreParMatrix(comm, num_loc_rows, glob_nrows, glob_ncols,
+                                opI.data(), opJ.data(),
+                                data.data(),
+                                rowStarts2.data(),
+                                rowStarts2.data());
+   }
+   else
+   {
+      std::vector<HYPRE_BigInt> colStarts2(2);
+      colStarts2[0] = first_loc_col;
+      colStarts2[1] = first_loc_col + all_num_loc_cols[rank];
 
-   MFEM_VERIFY(HYPRE_AssumedPartitionCheck(),
-               "only 'assumed partition' mode is supported");
-
-   return new HypreParMatrix(comm, num_loc_rows, glob_nrows, glob_ncols,
-                             opI.data(), opJ.data(),
-                             data.data(),
-                             rowStarts2.data(),
-                             colStarts2.data());
+      return new HypreParMatrix(comm, num_loc_rows, glob_nrows, glob_ncols,
+                                opI.data(), opJ.data(),
+                                data.data(),
+                                rowStarts2.data(),
+                                colStarts2.data());
+   }
 }
 
 void EliminateBC(const HypreParMatrix &A, const HypreParMatrix &Ae,

--- a/tests/unit/linalg/test_matrix_rectangular.cpp
+++ b/tests/unit/linalg/test_matrix_rectangular.cpp
@@ -159,7 +159,7 @@ TEST_CASE("ParallelFormRectangular",
    }
 }
 
-TEST_CASE("HypreParMatrixBlocks",
+TEST_CASE("HypreParMatrixBlocksRectangular",
           "[Parallel], [BlockMatrix]")
 {
    SECTION("HypreParMatrixFromBlocks")

--- a/tests/unit/linalg/test_matrix_square.cpp
+++ b/tests/unit/linalg/test_matrix_square.cpp
@@ -169,6 +169,111 @@ TEST_CASE("ParallelFormLinearSystem", "[Parallel], [ParallelFormLinearSystem]")
    }
 }
 
+TEST_CASE("HypreParMatrixBlocksSquare",
+          "[Parallel], [BlockMatrix]")
+{
+   SECTION("HypreParMatrixFromBlocks")
+   {
+      int rank;
+      MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+
+      Mesh mesh = Mesh::MakeCartesian2D(
+                     10, 10, Element::QUADRILATERAL, 0, 1.0, 1.0);
+      int dim = mesh.Dimension();
+      int order = 2;
+
+      int nattr = mesh.bdr_attributes.Max();
+      Array<int> ess_trial_tdof_list, ess_test_tdof_list;
+
+      Array<int> ess_bdr(nattr);
+      ess_bdr = 0;
+      ess_bdr[0] = 1;
+
+      ParMesh pmesh(MPI_COMM_WORLD, mesh);
+
+      FiniteElementCollection *hdiv_coll(new RT_FECollection(order, dim));
+      FiniteElementCollection *l2_coll(new L2_FECollection(order, dim));
+
+      ParFiniteElementSpace R_space(&pmesh, hdiv_coll);
+      ParFiniteElementSpace W_space(&pmesh, l2_coll);
+
+      ParBilinearForm RmVarf(&R_space);
+      ParBilinearForm WmVarf(&W_space);
+      ParMixedBilinearForm bVarf(&R_space, &W_space);
+
+      HypreParMatrix *MR, *MW, *B;
+
+      RmVarf.AddDomainIntegrator(new VectorFEMassIntegrator());
+      RmVarf.Assemble();
+      RmVarf.Finalize();
+      MR = RmVarf.ParallelAssemble();
+
+      WmVarf.AddDomainIntegrator(new MassIntegrator());
+      WmVarf.Assemble();
+      WmVarf.Finalize();
+      MW = WmVarf.ParallelAssemble();
+
+      bVarf.AddDomainIntegrator(new VectorFEDivergenceIntegrator);
+      bVarf.Assemble();
+      bVarf.Finalize();
+      B = bVarf.ParallelAssemble();
+      (*B) *= -1;
+
+      HypreParMatrix *BT = B->Transpose();
+
+      Array<int> blockRow_trueOffsets(3); // number of variables + 1
+      blockRow_trueOffsets[0] = 0;
+      blockRow_trueOffsets[1] = R_space.TrueVSize();
+      blockRow_trueOffsets[2] = W_space.TrueVSize();
+      blockRow_trueOffsets.PartialSum();
+
+      BlockOperator blockOper(blockRow_trueOffsets, blockRow_trueOffsets);
+      blockOper.SetBlock(0, 0, MR);
+      blockOper.SetBlock(0, 1, BT);
+      blockOper.SetBlock(1, 0, B);
+      blockOper.SetBlock(1, 1, MW, 3.14);
+
+      Array2D<HypreParMatrix*> hBlocks(2,2);
+      hBlocks = NULL;
+      hBlocks(0, 0) = MR;
+      hBlocks(0, 1) = BT;
+      hBlocks(1, 0) = B;
+      hBlocks(1, 1) = MW;
+
+      Array2D<double> blockCoeff(2,2);
+      blockCoeff = 1.0;
+      blockCoeff(1, 1) = 3.14;
+      HypreParMatrix *H = HypreParMatrixFromBlocks(hBlocks, &blockCoeff);
+
+      Vector yB(blockRow_trueOffsets[2]);
+      Vector yH(blockRow_trueOffsets[2]);
+      Vector yBR(yB, 0, R_space.TrueVSize());
+      Vector yBW(yB, R_space.TrueVSize(), W_space.TrueVSize());
+
+      yB = 0.0;
+      yH = 0.0;
+
+      MR->GetDiag(yBR);
+      MW->GetDiag(yBW);
+      yBW *= 3.14;
+      H->GetDiag(yH);
+
+      yH -= yB;
+      double error = yH.Norml2();
+      std::cout << "  order: " << order
+                << ", block matrix error norm on rank " << rank << ": " << error << std::endl;
+      REQUIRE(error < EPS);
+
+      delete H;
+      delete BT;
+      delete B;
+      delete MW;
+      delete MR;
+      delete l2_coll;
+      delete hdiv_coll;
+   }
+}
+
 #endif // MFEM_USE_MPI
 
 } // namespace mfem


### PR DESCRIPTION
If using `HypreParMatrixFromBlocks` to form a square matrix, we should call the `HypreParMatrix` constructor with `row_starts = col_starts` so that `hypre_CSRMatrixReorder` gets properly called. Without this, methods like `HypreParMatrix::GetDiag` will fail on the merged matrix.<!--GHEX{"author":"sebastiangrimberg","assignment":"2022-02-04T22:29:08","editor":"pazner","id":2804,"reviewers":["dylan-copeland","jandrej"],"merge":"2022-02-25T22:29:08","approval":"2022-03-22T23:43:59"}XEHG-->
<!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge|
 | --- | --- | --- | --- | --- | --- | --- |
| [#2804](https://github.com/mfem/mfem/pull/2804) | @sebastiangrimberg | @pazner | @dylan-copeland + @jandrej | 2/4/22 | 3/22/22 | ⌛due 2/25/22 | |
<!--ELBATXEHG-->