### PR TITLE
bug-fix in BuildConformingProlongation

### DIFF
--- a/fem/fespace.cpp
+++ b/fem/fespace.cpp
@@ -1055,6 +1055,7 @@ void FiniteElementSpace::BuildConformingInterpolation() const
             // get lowest order variant DOFs and FE
             int p = GetEntityDofs(entity, i, master_dofs, geom, 0);
             const auto *master_fe = fec->GetFE(geom, p);
+            if (!master_fe) { break; }
 
             // constrain all higher order DOFs: interpolate lowest order function
             for (int variant = 1; ; variant++)


### PR DESCRIPTION
Small bug-fix in  `BuildConformingProlongation` in the DG case. 


I would also like to ask ... is there a reason that this method still goes into counting master and slave dofs in order to identify if the Prolongation is null (identity) or not? Why not check and always return null if it's an L2 space?