### PR TITLE
Optional copy_to_host for ReleasePADeviceMemory

### DIFF
--- a/fem/tmop.cpp
+++ b/fem/tmop.cpp
@@ -2311,13 +2311,14 @@ AdaptivityEvaluator::~AdaptivityEvaluator()
 #endif
 }
 
-void TMOP_Integrator::ReleasePADeviceMemory()
+void TMOP_Integrator::ReleasePADeviceMemory(bool copy_to_host)
 {
    if (PA.enabled)
    {
-      PA.H.GetMemory().DeleteDevice();
-      PA.H0.GetMemory().DeleteDevice();
-      PA.Jtr.GetMemory().DeleteDevice();
+      PA.H.GetMemory().DeleteDevice(copy_to_host);
+      PA.H0.GetMemory().DeleteDevice(copy_to_host);
+      if (!copy_to_host && !PA.Jtr.GetMemory().HostIsValid()) { PA.Jtr_needs_update = true; }
+      PA.Jtr.GetMemory().DeleteDevice(copy_to_host);
    }
 }
 

--- a/fem/tmop.cpp
+++ b/fem/tmop.cpp
@@ -2317,7 +2317,10 @@ void TMOP_Integrator::ReleasePADeviceMemory(bool copy_to_host)
    {
       PA.H.GetMemory().DeleteDevice(copy_to_host);
       PA.H0.GetMemory().DeleteDevice(copy_to_host);
-      if (!copy_to_host && !PA.Jtr.GetMemory().HostIsValid()) { PA.Jtr_needs_update = true; }
+      if (!copy_to_host && !PA.Jtr.GetMemory().HostIsValid())
+      {
+         PA.Jtr_needs_update = true;
+      }
       PA.Jtr.GetMemory().DeleteDevice(copy_to_host);
    }
 }

--- a/fem/tmop.hpp
+++ b/fem/tmop.hpp
@@ -1551,7 +1551,7 @@ public:
 
    /// Release the device memory of large PA allocations. This will copy device
    /// memory back to the host before releasing.
-   void ReleasePADeviceMemory();
+   void ReleasePADeviceMemory(bool copy_to_host=true);
 
    /// Prescribe a set of integration rules; relevant for mixed meshes.
    /** This function has priority over SetIntRule(), if both are called. */

--- a/fem/tmop.hpp
+++ b/fem/tmop.hpp
@@ -1551,7 +1551,7 @@ public:
 
    /// Release the device memory of large PA allocations. This will copy device
    /// memory back to the host before releasing.
-   void ReleasePADeviceMemory(bool copy_to_host=true);
+   void ReleasePADeviceMemory(bool copy_to_host = true);
 
    /// Prescribe a set of integration rules; relevant for mixed meshes.
    /** This function has priority over SetIntRule(), if both are called. */


### PR DESCRIPTION
adds optional `copy_to_host` (`true` by default) option to `ReleasePADeviceMemory`  since it can be expensive and may not be needed<!--GHEX{"author":"tomstitt","assignment":"2022-02-16T00:33:38","editor":"tzanio","id":2833,"reviewers":["tzanio","camierjs"],"merge":"2022-02-20T00:36:02","approval":"2022-02-17T23:51:02"}XEHG-->
<!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge|
 | --- | --- | --- | --- | --- | --- | --- |
| [#2833](https://github.com/mfem/mfem/pull/2833) | @tomstitt | @tzanio | @tzanio + @camierjs | 2/15/22 | 2/17/22 | 2/19/22 | |
<!--ELBATXEHG-->