### PR TITLE
Reduce some unit test runtimes

### DIFF
--- a/tests/unit/fem/test_assemblediagonalpa.cpp
+++ b/tests/unit/fem/test_assemblediagonalpa.cpp
@@ -411,7 +411,9 @@ TEST_CASE("Hcurl/Hdiv diagonal PA",
                                << " and coeffType " << coeffType << ": "
                                << std::pow(ne, dimension) << " elements." << std::endl;
 
-                  for (int order = 1; order < 4; ++order)
+                  int max_order = (dimension == 3) ? 2 : 3;
+
+                  for (int order = 1; order <= max_order; ++order)
                   {
                      Mesh mesh;
                      if (dimension == 2)

--- a/tests/unit/fem/test_assembly_levels.cpp
+++ b/tests/unit/fem/test_assembly_levels.cpp
@@ -111,13 +111,13 @@ TEST_CASE("Assembly Levels", "[AssemblyLevel], [PartialAssembly]")
 {
    auto assembly = GENERATE(AssemblyLevel::PARTIAL, AssemblyLevel::ELEMENT,
                             AssemblyLevel::FULL);
-   auto pb = GENERATE(0, 1, 2);
-   auto dg = GENERATE(true, false);
-   auto order_2d = GENERATE(2, 3, 4);
+   auto order_2d = GENERATE(2, 3);
    auto order_3d = GENERATE(2);
 
    SECTION("2D")
    {
+      auto pb = GENERATE(0, 1, 2);
+      auto dg = GENERATE(true, false);
       test_assembly_level("../../data/periodic-square.mesh",
                           order_2d, dg, pb, assembly);
       test_assembly_level("../../data/periodic-hexagon.mesh",
@@ -128,6 +128,8 @@ TEST_CASE("Assembly Levels", "[AssemblyLevel], [PartialAssembly]")
 
    SECTION("3D")
    {
+      auto pb = GENERATE(0, 1, 2);
+      auto dg = GENERATE(true, false);
       test_assembly_level("../../data/periodic-cube.mesh",
                           order_3d, dg, pb, assembly);
       test_assembly_level("../../data/fichera-q3.mesh",

--- a/tests/unit/fem/test_assembly_levels.cpp
+++ b/tests/unit/fem/test_assembly_levels.cpp
@@ -111,12 +111,12 @@ TEST_CASE("Assembly Levels", "[AssemblyLevel], [PartialAssembly]")
 {
    auto assembly = GENERATE(AssemblyLevel::PARTIAL, AssemblyLevel::ELEMENT,
                             AssemblyLevel::FULL);
+   auto dg = GENERATE(true, false);
 
    SECTION("2D")
    {
       auto order_2d = GENERATE(2, 3);
       auto pb = GENERATE(0, 1, 2);
-      auto dg = GENERATE(true, false);
       test_assembly_level("../../data/periodic-square.mesh",
                           order_2d, dg, pb, assembly);
       test_assembly_level("../../data/periodic-hexagon.mesh",
@@ -129,7 +129,6 @@ TEST_CASE("Assembly Levels", "[AssemblyLevel], [PartialAssembly]")
    {
       int order_3d = 2;
       auto pb = GENERATE(0, 1, 2);
-      auto dg = GENERATE(true, false);
       test_assembly_level("../../data/periodic-cube.mesh",
                           order_3d, dg, pb, assembly);
       test_assembly_level("../../data/fichera-q3.mesh",
@@ -141,13 +140,13 @@ TEST_CASE("Assembly Levels", "[AssemblyLevel], [PartialAssembly]")
    {
       auto order_2d = GENERATE(2, 3);
       test_assembly_level("../../data/amr-quad.mesh",
-                          order_2d, false, 0, assembly);
+                          order_2d, dg, 0, assembly);
    }
    SECTION("AMR 3D")
    {
       int order_3d = 2;
       test_assembly_level("../../data/fichera-amr.mesh",
-                          order_3d, false, 0, assembly);
+                          order_3d, dg, 0, assembly);
    }
 } // test case
 

--- a/tests/unit/fem/test_assembly_levels.cpp
+++ b/tests/unit/fem/test_assembly_levels.cpp
@@ -111,11 +111,10 @@ TEST_CASE("Assembly Levels", "[AssemblyLevel], [PartialAssembly]")
 {
    auto assembly = GENERATE(AssemblyLevel::PARTIAL, AssemblyLevel::ELEMENT,
                             AssemblyLevel::FULL);
-   auto order_2d = GENERATE(2, 3);
-   auto order_3d = GENERATE(2);
 
    SECTION("2D")
    {
+      auto order_2d = GENERATE(2, 3);
       auto pb = GENERATE(0, 1, 2);
       auto dg = GENERATE(true, false);
       test_assembly_level("../../data/periodic-square.mesh",
@@ -128,6 +127,7 @@ TEST_CASE("Assembly Levels", "[AssemblyLevel], [PartialAssembly]")
 
    SECTION("3D")
    {
+      int order_3d = 2;
       auto pb = GENERATE(0, 1, 2);
       auto dg = GENERATE(true, false);
       test_assembly_level("../../data/periodic-cube.mesh",
@@ -139,11 +139,13 @@ TEST_CASE("Assembly Levels", "[AssemblyLevel], [PartialAssembly]")
    // Test AMR cases (DG not implemented)
    SECTION("AMR 2D")
    {
+      auto order_2d = GENERATE(2, 3);
       test_assembly_level("../../data/amr-quad.mesh",
                           order_2d, false, 0, assembly);
    }
    SECTION("AMR 3D")
    {
+      int order_3d = 2;
       test_assembly_level("../../data/fichera-amr.mesh",
                           order_3d, false, 0, assembly);
    }

--- a/tests/unit/fem/test_assembly_levels.cpp
+++ b/tests/unit/fem/test_assembly_levels.cpp
@@ -111,12 +111,12 @@ TEST_CASE("Assembly Levels", "[AssemblyLevel], [PartialAssembly]")
 {
    auto assembly = GENERATE(AssemblyLevel::PARTIAL, AssemblyLevel::ELEMENT,
                             AssemblyLevel::FULL);
-   auto dg = GENERATE(true, false);
 
    SECTION("2D")
    {
       auto order_2d = GENERATE(2, 3);
       auto pb = GENERATE(0, 1, 2);
+      auto dg = GENERATE(true, false);
       test_assembly_level("../../data/periodic-square.mesh",
                           order_2d, dg, pb, assembly);
       test_assembly_level("../../data/periodic-hexagon.mesh",
@@ -129,6 +129,7 @@ TEST_CASE("Assembly Levels", "[AssemblyLevel], [PartialAssembly]")
    {
       int order_3d = 2;
       auto pb = GENERATE(0, 1, 2);
+      auto dg = GENERATE(true, false);
       test_assembly_level("../../data/periodic-cube.mesh",
                           order_3d, dg, pb, assembly);
       test_assembly_level("../../data/fichera-q3.mesh",
@@ -140,13 +141,13 @@ TEST_CASE("Assembly Levels", "[AssemblyLevel], [PartialAssembly]")
    {
       auto order_2d = GENERATE(2, 3);
       test_assembly_level("../../data/amr-quad.mesh",
-                          order_2d, dg, 0, assembly);
+                          order_2d, false, 0, assembly);
    }
    SECTION("AMR 3D")
    {
       int order_3d = 2;
       test_assembly_level("../../data/fichera-amr.mesh",
-                          order_3d, dg, 0, assembly);
+                          order_3d, false, 0, assembly);
    }
 } // test case
 


### PR DESCRIPTION
Reduces the runtimes of some of the longer unit tests:

* In "Assembly Levels" there were some completely redundant tests. I also got rid of order 4 in 2D.
    * Runtime reduction from 49.3s to ~13.2s~ now down to 5.9s.
* In "Hcurl/Hdiv diagonal PA" I got rid of order 3 in 3D.
    * Runtime reduction from 15.1s to 1.5s.

Overall reduction in debug mode on my machine from 1:57 to ~1:15~ 1:05.

Personally I don't think the extra tests are worth the longer runtime (they are just running the same code at higher orders), but in the "Assembly Levels", some of the tests are actually duplicated and can be removed without any consequences.<!--GHEX{"author":"pazner","assignment":"2022-02-18T16:11:42","editor":"tzanio","id":2837,"reviewers":["dylan-copeland","YohannDudouit","v-dobrev"],"merge":"2022-02-23T19:51:47","approval":"2022-02-22T20:14:42"}XEHG-->
<!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge|
 | --- | --- | --- | --- | --- | --- | --- |
| [#2837](https://github.com/mfem/mfem/pull/2837) | @pazner | @tzanio | @dylan-copeland + @YohannDudouit + @v-dobrev | 2/18/22 | 2/22/22 | 2/23/22 | |
<!--ELBATXEHG-->