### PR TITLE
Fix boundary attribute number for wedges in Mesh::Make3D

### DIFF
--- a/mesh/mesh.cpp
+++ b/mesh/mesh.cpp
@@ -3218,7 +3218,7 @@ void Mesh::Make3D(int nx, int ny, int nz, Element::Type type,
          }
          else if (type == Element::WEDGE)
          {
-            AddBdrQuadAsTriangles(ind, 1);
+            AddBdrQuadAsTriangles(ind, 6);
          }
          else
          {


### PR DESCRIPTION
This small PR is meant to resolve issue #2850 raised by @goxberry. <!--GHEX{"author":"mlstowell","assignment":"2022-02-23T20:12:27","editor":"tzanio","id":2851,"reviewers":["tzanio","psocratis"],"merge":"2022-02-24T16:49:51","approval":"2022-02-23T20:12:53"}XEHG-->
<!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge|
 | --- | --- | --- | --- | --- | --- | --- |
| [#2851](https://github.com/mfem/mfem/pull/2851) | @mlstowell | @tzanio | @tzanio + @psocratis | 2/23/22 | 2/23/22 | 2/24/22 | |
<!--ELBATXEHG-->