### PR TITLE
PA for some more H(curl) integrators

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -11,7 +11,10 @@
 Version 4.3.1 (development)
 ===========================
 
-- Add hipSPARSE support for sparse mat-vec multiplications.
+- Added PA support for MixedScalarCurlIntegrator in 2D and
+  MixedVectorGradientIntegrator in 2D and 3D, as well as their transposes.
+
+- Added hipSPARSE support for sparse mat-vec multiplications.
 
 - Added support for using the HYPRE library built with HIP support. Similar to
   the HYPRE + CUDA support added earlier, most of the MFEM examples and miniapps

--- a/fem/bilininteg.hpp
+++ b/fem/bilininteg.hpp
@@ -931,7 +931,9 @@ protected:
 
 /** Class for integrating the bilinear form a(u,v) := (Q u, curl v) in 2D where
     Q is an optional scalar coefficient, u is in L2 or H1, and v is in
-    H(Curl). */
+    H(Curl). Partial assembly (PA) is supported but could be further optimized
+    by using more efficient threading and shared memory.
+*/
 class MixedScalarWeakCurlIntegrator : public MixedScalarIntegrator
 {
 public:
@@ -1717,7 +1719,10 @@ public:
 
 /** Class for integrating the bilinear form a(u,v) := (Q grad u, v) in either 2D
     or 3D and where Q is an optional coefficient (of type scalar, matrix, or
-    diagonal matrix) u is in H1 and v is in H(Curl) or H(Div). */
+    diagonal matrix) u is in H1 and v is in H(Curl) or H(Div). Partial assembly
+    (PA) is supported but could be further optimized by using more efficient
+    threading and shared memory.
+*/
 class MixedVectorGradientIntegrator : public MixedVectorIntegrator
 {
 public:

--- a/fem/bilininteg.hpp
+++ b/fem/bilininteg.hpp
@@ -1757,6 +1757,7 @@ protected:
                            const FiniteElementSpace &test_fes);
 
    virtual void AddMultPA(const Vector&, Vector&) const;
+   virtual void AddMultTransposePA(const Vector&, Vector&) const;
 
 private:
    DenseMatrix Jinv;

--- a/fem/bilininteg.hpp
+++ b/fem/bilininteg.hpp
@@ -891,8 +891,8 @@ protected:
       const FiniteElement & test_fe) const
    {
       return (trial_fe.GetDim() == 2 && test_fe.GetDim() == 2 &&
-              trial_fe.GetDerivType() == mfem::FiniteElement::CURL  &&
-              test_fe.GetRangeType()  == mfem::FiniteElement::SCALAR );
+              trial_fe.GetDerivType() == mfem::FiniteElement::CURL &&
+              test_fe.GetRangeType()  == mfem::FiniteElement::SCALAR);
    }
 
    inline virtual const char * FiniteElementTypeFailureMessage() const
@@ -925,8 +925,7 @@ protected:
    Vector pa_data;
    const DofToQuad *mapsO;         ///< Not owned. DOF-to-quad map, open.
    const DofToQuad *mapsC;         ///< Not owned. DOF-to-quad map, closed.
-   const GeometricFactors *geom;   ///< Not owned
-   int dim, ne, dofs1D, quad1D;
+   int dim, ne, dofs1D, quad1D, dofs1Dtest;
 };
 
 /** Class for integrating the bilinear form a(u,v) := (Q u, curl v) in 2D where

--- a/fem/bilininteg.hpp
+++ b/fem/bilininteg.hpp
@@ -914,6 +914,19 @@ protected:
       DenseMatrix dshape(shape.GetData(), shape.Size(), 1);
       trial_fe.CalcPhysCurlShape(Trans, dshape);
    }
+
+   using BilinearFormIntegrator::AssemblePA;
+   virtual void AssemblePA(const FiniteElementSpace &trial_fes,
+                           const FiniteElementSpace &test_fes);
+
+   virtual void AddMultPA(const Vector&, Vector&) const;
+
+   // PA extension
+   Vector pa_data;
+   const DofToQuad *mapsO;         ///< Not owned. DOF-to-quad map, open.
+   const DofToQuad *mapsC;         ///< Not owned. DOF-to-quad map, closed.
+   const GeometricFactors *geom;   ///< Not owned
+   int dim, ne, dofs1D, quad1D;
 };
 
 /** Class for integrating the bilinear form a(u,v) := (Q u, curl v) in 2D where

--- a/fem/bilininteg.hpp
+++ b/fem/bilininteg.hpp
@@ -920,6 +920,7 @@ protected:
                            const FiniteElementSpace &test_fes);
 
    virtual void AddMultPA(const Vector&, Vector&) const;
+   virtual void AddMultTransposePA(const Vector &x, Vector &y) const;
 
    // PA extension
    Vector pa_data;

--- a/fem/bilininteg_hcurl.cpp
+++ b/fem/bilininteg_hcurl.cpp
@@ -2952,6 +2952,205 @@ void PAHcurlH1Apply3D(const int D1D,
    }); // end of element loop
 }
 
+// Apply to x corresponding to DOF's in H(curl), integrated
+// against gradients of H^1 functions corresponding to y.
+void PAHcurlH1ApplyTranspose3D(const int D1D,
+                               const int Q1D,
+                               const int NE,
+                               const Array<double> &bc,
+                               const Array<double> &bo,
+                               const Array<double> &bct,
+                               const Array<double> &gct,
+                               const Vector &pa_data,
+                               const Vector &x,
+                               Vector &y)
+{
+   constexpr static int MAX_D1D = HCURL_MAX_D1D;
+   constexpr static int MAX_Q1D = HCURL_MAX_Q1D;
+
+   MFEM_VERIFY(D1D <= MAX_D1D, "Error: D1D > MAX_D1D");
+   MFEM_VERIFY(Q1D <= MAX_Q1D, "Error: Q1D > MAX_Q1D");
+
+   constexpr static int VDIM = 3;
+
+   auto Bc = Reshape(bc.Read(), Q1D, D1D);
+   auto Bo = Reshape(bo.Read(), Q1D, D1D-1);
+   auto Bt = Reshape(bct.Read(), D1D, Q1D);
+   auto Gt = Reshape(gct.Read(), D1D, Q1D);
+   auto op = Reshape(pa_data.Read(), Q1D, Q1D, Q1D, 6, NE);
+   auto X = Reshape(x.Read(), 3*(D1D-1)*D1D*D1D, NE);
+   auto Y = Reshape(y.ReadWrite(), D1D, D1D, D1D, NE);
+
+   MFEM_FORALL(e, NE,
+   {
+      double mass[MAX_Q1D][MAX_Q1D][MAX_Q1D][VDIM];
+
+      for (int qz = 0; qz < Q1D; ++qz)
+      {
+         for (int qy = 0; qy < Q1D; ++qy)
+         {
+            for (int qx = 0; qx < Q1D; ++qx)
+            {
+               for (int c = 0; c < VDIM; ++c)
+               {
+                  mass[qz][qy][qx][c] = 0.0;
+               }
+            }
+         }
+      }
+
+      int osc = 0;
+
+      for (int c = 0; c < VDIM; ++c)  // loop over x, y, z components
+      {
+         const int D1Dz = (c == 2) ? D1D - 1 : D1D;
+         const int D1Dy = (c == 1) ? D1D - 1 : D1D;
+         const int D1Dx = (c == 0) ? D1D - 1 : D1D;
+
+         for (int dz = 0; dz < D1Dz; ++dz)
+         {
+            double massXY[MAX_Q1D][MAX_Q1D];
+            for (int qy = 0; qy < Q1D; ++qy)
+            {
+               for (int qx = 0; qx < Q1D; ++qx)
+               {
+                  massXY[qy][qx] = 0.0;
+               }
+            }
+
+            for (int dy = 0; dy < D1Dy; ++dy)
+            {
+               double massX[MAX_Q1D];
+               for (int qx = 0; qx < Q1D; ++qx)
+               {
+                  massX[qx] = 0.0;
+               }
+
+               for (int dx = 0; dx < D1Dx; ++dx)
+               {
+                  const double t = X(dx + ((dy + (dz * D1Dy)) * D1Dx) + osc, e);
+                  for (int qx = 0; qx < Q1D; ++qx)
+                  {
+                     massX[qx] += t * ((c == 0) ? Bo(qx,dx) : Bc(qx,dx));
+                  }
+               }
+
+               for (int qy = 0; qy < Q1D; ++qy)
+               {
+                  const double wy = (c == 1) ? Bo(qy,dy) : Bc(qy,dy);
+                  for (int qx = 0; qx < Q1D; ++qx)
+                  {
+                     const double wx = massX[qx];
+                     massXY[qy][qx] += wx * wy;
+                  }
+               }
+            }
+
+            for (int qz = 0; qz < Q1D; ++qz)
+            {
+               const double wz = (c == 2) ? Bo(qz,dz) : Bc(qz,dz);
+               for (int qy = 0; qy < Q1D; ++qy)
+               {
+                  for (int qx = 0; qx < Q1D; ++qx)
+                  {
+                     mass[qz][qy][qx][c] += massXY[qy][qx] * wz;
+                  }
+               }
+            }
+         }
+
+         osc += D1Dx * D1Dy * D1Dz;
+      }  // loop (c) over components
+
+      // Apply D operator.
+      for (int qz = 0; qz < Q1D; ++qz)
+      {
+         for (int qy = 0; qy < Q1D; ++qy)
+         {
+            for (int qx = 0; qx < Q1D; ++qx)
+            {
+               const double O11 = op(qx,qy,qz,0,e);
+               const double O12 = op(qx,qy,qz,1,e);
+               const double O13 = op(qx,qy,qz,2,e);
+               const double O22 = op(qx,qy,qz,3,e);
+               const double O23 = op(qx,qy,qz,4,e);
+               const double O33 = op(qx,qy,qz,5,e);
+               const double massX = mass[qz][qy][qx][0];
+               const double massY = mass[qz][qy][qx][1];
+               const double massZ = mass[qz][qy][qx][2];
+               mass[qz][qy][qx][0] = (O11*massX)+(O12*massY)+(O13*massZ);
+               mass[qz][qy][qx][1] = (O12*massX)+(O22*massY)+(O23*massZ);
+               mass[qz][qy][qx][2] = (O13*massX)+(O23*massY)+(O33*massZ);
+            }
+         }
+      }
+
+      for (int qz = 0; qz < Q1D; ++qz)
+      {
+         double gradXY[MAX_D1D][MAX_D1D][3];
+         for (int dy = 0; dy < D1D; ++dy)
+         {
+            for (int dx = 0; dx < D1D; ++dx)
+            {
+               gradXY[dy][dx][0] = 0;
+               gradXY[dy][dx][1] = 0;
+               gradXY[dy][dx][2] = 0;
+            }
+         }
+         for (int qy = 0; qy < Q1D; ++qy)
+         {
+            double gradX[MAX_D1D][3];
+            for (int dx = 0; dx < D1D; ++dx)
+            {
+               gradX[dx][0] = 0;
+               gradX[dx][1] = 0;
+               gradX[dx][2] = 0;
+            }
+            for (int qx = 0; qx < Q1D; ++qx)
+            {
+               const double gX = mass[qz][qy][qx][0];
+               const double gY = mass[qz][qy][qx][1];
+               const double gZ = mass[qz][qy][qx][2];
+               for (int dx = 0; dx < D1D; ++dx)
+               {
+                  const double wx  = Bt(dx,qx);
+                  const double wDx = Gt(dx,qx);
+                  gradX[dx][0] += gX * wDx;
+                  gradX[dx][1] += gY * wx;
+                  gradX[dx][2] += gZ * wx;
+               }
+            }
+            for (int dy = 0; dy < D1D; ++dy)
+            {
+               const double wy  = Bt(dy,qy);
+               const double wDy = Gt(dy,qy);
+               for (int dx = 0; dx < D1D; ++dx)
+               {
+                  gradXY[dy][dx][0] += gradX[dx][0] * wy;
+                  gradXY[dy][dx][1] += gradX[dx][1] * wDy;
+                  gradXY[dy][dx][2] += gradX[dx][2] * wy;
+               }
+            }
+         }
+         for (int dz = 0; dz < D1D; ++dz)
+         {
+            const double wz  = Bt(dz,qz);
+            const double wDz = Gt(dz,qz);
+            for (int dy = 0; dy < D1D; ++dy)
+            {
+               for (int dx = 0; dx < D1D; ++dx)
+               {
+                  Y(dx,dy,dz,e) +=
+                     ((gradXY[dy][dx][0] * wz) +
+                      (gradXY[dy][dx][1] * wz) +
+                      (gradXY[dy][dx][2] * wDz));
+               }
+            }
+         }
+      }  // loop qz
+   }); // end of element loop
+}
+
 // Apply to x corresponding to DOF's in H^1 (trial), whose gradients are
 // integrated against H(curl) test functions corresponding to y.
 void PAHcurlH1Apply2D(const int D1D,
@@ -3072,6 +3271,131 @@ void PAHcurlH1Apply2D(const int D1D,
 
             osc += D1Dx * D1Dy;
          }  // loop c
+      }
+   }); // end of element loop
+}
+
+// Apply to x corresponding to DOF's in H(curl), integrated
+// against gradients of H^1 functions corresponding to y.
+void PAHcurlH1ApplyTranspose2D(const int D1D,
+                               const int Q1D,
+                               const int NE,
+                               const Array<double> &bc,
+                               const Array<double> &bo,
+                               const Array<double> &bct,
+                               const Array<double> &gct,
+                               const Vector &pa_data,
+                               const Vector &x,
+                               Vector &y)
+{
+   constexpr static int VDIM = 2;
+   constexpr static int MAX_D1D = HCURL_MAX_D1D;
+   constexpr static int MAX_Q1D = HCURL_MAX_Q1D;
+
+   auto Bc = Reshape(bc.Read(), Q1D, D1D);
+   auto Bo = Reshape(bo.Read(), Q1D, D1D-1);
+   auto Bt = Reshape(bct.Read(), D1D, Q1D);
+   auto Gt = Reshape(gct.Read(), D1D, Q1D);
+   auto op = Reshape(pa_data.Read(), Q1D, Q1D, 3, NE);
+   auto X = Reshape(x.Read(), 2*(D1D-1)*D1D, NE);
+   auto Y = Reshape(y.ReadWrite(), D1D, D1D, NE);
+
+   MFEM_FORALL(e, NE,
+   {
+      double mass[MAX_Q1D][MAX_Q1D][VDIM];
+
+      for (int qy = 0; qy < Q1D; ++qy)
+      {
+         for (int qx = 0; qx < Q1D; ++qx)
+         {
+            for (int c = 0; c < VDIM; ++c)
+            {
+               mass[qy][qx][c] = 0.0;
+            }
+         }
+      }
+
+      int osc = 0;
+
+      for (int c = 0; c < VDIM; ++c)  // loop over x, y components
+      {
+         const int D1Dy = (c == 1) ? D1D - 1 : D1D;
+         const int D1Dx = (c == 0) ? D1D - 1 : D1D;
+
+         for (int dy = 0; dy < D1Dy; ++dy)
+         {
+            double massX[MAX_Q1D];
+            for (int qx = 0; qx < Q1D; ++qx)
+            {
+               massX[qx] = 0.0;
+            }
+
+            for (int dx = 0; dx < D1Dx; ++dx)
+            {
+               const double t = X(dx + (dy * D1Dx) + osc, e);
+               for (int qx = 0; qx < Q1D; ++qx)
+               {
+                  massX[qx] += t * ((c == 0) ? Bo(qx,dx) : Bc(qx,dx));
+               }
+            }
+
+            for (int qy = 0; qy < Q1D; ++qy)
+            {
+               const double wy = (c == 1) ? Bo(qy,dy) : Bc(qy,dy);
+               for (int qx = 0; qx < Q1D; ++qx)
+               {
+                  mass[qy][qx][c] += massX[qx] * wy;
+               }
+            }
+         }
+
+         osc += D1Dx * D1Dy;
+      }  // loop (c) over components
+
+      // Apply D operator.
+      for (int qy = 0; qy < Q1D; ++qy)
+      {
+         for (int qx = 0; qx < Q1D; ++qx)
+         {
+            const double O11 = op(qx,qy,0,e);
+            const double O12 = op(qx,qy,1,e);
+            const double O22 = op(qx,qy,2,e);
+            const double massX = mass[qy][qx][0];
+            const double massY = mass[qy][qx][1];
+            mass[qy][qx][0] = (O11*massX)+(O12*massY);
+            mass[qy][qx][1] = (O12*massX)+(O22*massY);
+         }
+      }
+
+      for (int qy = 0; qy < Q1D; ++qy)
+      {
+         double gradX[MAX_D1D][2];
+         for (int dx = 0; dx < D1D; ++dx)
+         {
+            gradX[dx][0] = 0;
+            gradX[dx][1] = 0;
+         }
+         for (int qx = 0; qx < Q1D; ++qx)
+         {
+            const double gX = mass[qy][qx][0];
+            const double gY = mass[qy][qx][1];
+            for (int dx = 0; dx < D1D; ++dx)
+            {
+               const double wx  = Bt(dx,qx);
+               const double wDx = Gt(dx,qx);
+               gradX[dx][0] += gX * wDx;
+               gradX[dx][1] += gY * wx;
+            }
+         }
+         for (int dy = 0; dy < D1D; ++dy)
+         {
+            const double wy  = Bt(dy,qy);
+            const double wDy = Gt(dy,qy);
+            for (int dx = 0; dx < D1D; ++dx)
+            {
+               Y(dx,dy,e) += ((gradX[dx][0] * wy) + (gradX[dx][1] * wDy));
+            }
+         }
       }
    }); // end of element loop
 }

--- a/fem/bilininteg_vectorfe.cpp
+++ b/fem/bilininteg_vectorfe.cpp
@@ -113,6 +113,17 @@ void PAHcurlH1Apply2D(const int D1D,
                       const Vector &x,
                       Vector &y);
 
+void PAHcurlH1ApplyTranspose2D(const int D1D,
+                               const int Q1D,
+                               const int NE,
+                               const Array<double> &bc,
+                               const Array<double> &bo,
+                               const Array<double> &bct,
+                               const Array<double> &gct,
+                               const Vector &pa_data,
+                               const Vector &x,
+                               Vector &y);
+
 void PAHcurlH1Apply3D(const int D1D,
                       const int Q1D,
                       const int NE,
@@ -123,6 +134,17 @@ void PAHcurlH1Apply3D(const int D1D,
                       const Vector &pa_data,
                       const Vector &x,
                       Vector &y);
+
+void PAHcurlH1ApplyTranspose3D(const int D1D,
+                               const int Q1D,
+                               const int NE,
+                               const Array<double> &bc,
+                               const Array<double> &bo,
+                               const Array<double> &bct,
+                               const Array<double> &gct,
+                               const Vector &pa_data,
+                               const Vector &x,
+                               Vector &y);
 
 void PAHdivMassAssembleDiagonal2D(const int D1D,
                                   const int Q1D,
@@ -1123,6 +1145,21 @@ void MixedVectorGradientIntegrator::AddMultPA(const Vector &x, Vector &y) const
    else if (dim == 2)
       PAHcurlH1Apply2D(dofs1D, quad1D, ne, mapsC->B, mapsC->G,
                        mapsO->Bt, mapsC->Bt, pa_data, x, y);
+   else
+   {
+      MFEM_ABORT("Unsupported dimension!");
+   }
+}
+
+void MixedVectorGradientIntegrator::AddMultTransposePA(const Vector &x,
+                                                       Vector &y) const
+{
+   if (dim == 3)
+      PAHcurlH1ApplyTranspose3D(dofs1D, quad1D, ne, mapsC->B, mapsO->B,
+                                mapsC->Bt, mapsC->Gt, pa_data, x, y);
+   else if (dim == 2)
+      PAHcurlH1ApplyTranspose2D(dofs1D, quad1D, ne, mapsC->B, mapsO->B,
+                                mapsC->Bt, mapsC->Gt, pa_data, x, y);
    else
    {
       MFEM_ABORT("Unsupported dimension!");

--- a/tests/unit/fem/test_pa_coeff.cpp
+++ b/tests/unit/fem/test_pa_coeff.cpp
@@ -800,7 +800,7 @@ TEST_CASE("Hcurl/Hdiv mixed pa_coeff",
 
                   const SparseMatrix& A_explicit = assemblyform->SpMat();
 
-                  Vector *xin = new Vector((spaceType == 0) ? s_fespace.GetTrueVSize() :
+                  Vector *xin = new Vector((spaceType == HcurlH1) ? s_fespace.GetTrueVSize() :
                                            v_fespace.GetTrueVSize());
                   xin->Randomize();
                   Vector y_mat((spaceType == HdivL2 || spaceType == HcurlH1_2D ||
@@ -831,15 +831,14 @@ TEST_CASE("Hcurl/Hdiv mixed pa_coeff",
                   REQUIRE(assembly_error < 1.e-12);
 
                   delete xin;
-                  if (spaceType == HdivL2)
+                  if (spaceType == HdivL2 || spaceType == HcurlH1_2D || (spaceType == HcurlL2 &&
+                                                                         dimension == 2))
                   {
                      // Test the transpose.
-                     xin = new Vector((spaceType == 0) ? v_fespace.GetTrueVSize() :
-                                      s_fespace.GetTrueVSize());
+                     xin = new Vector(s_fespace.GetTrueVSize());
                      xin->Randomize();
 
-                     y_mat.SetSize((spaceType == 0) ? s_fespace.GetTrueVSize() :
-                                   v_fespace.GetTrueVSize());
+                     y_mat.SetSize(v_fespace.GetTrueVSize());
                      y_assembly.SetSize(y_mat.Size());
                      y_pa.SetSize(y_mat.Size());
 

--- a/tests/unit/fem/test_pa_coeff.cpp
+++ b/tests/unit/fem/test_pa_coeff.cpp
@@ -831,14 +831,16 @@ TEST_CASE("Hcurl/Hdiv mixed pa_coeff",
                   REQUIRE(assembly_error < 1.e-12);
 
                   delete xin;
-                  if (spaceType == HdivL2 || spaceType == HcurlH1_2D || (spaceType == HcurlL2 &&
-                                                                         dimension == 2))
+                  if (spaceType == HdivL2 || spaceType == HcurlH1_2D ||
+                      spaceType == HcurlH1 || (spaceType == HcurlL2 && dimension == 2))
                   {
                      // Test the transpose.
-                     xin = new Vector(s_fespace.GetTrueVSize());
+                     xin = new Vector(spaceType == HcurlH1 ? v_fespace.GetTrueVSize() :
+                                      s_fespace.GetTrueVSize());
                      xin->Randomize();
 
-                     y_mat.SetSize(v_fespace.GetTrueVSize());
+                     y_mat.SetSize(spaceType == HcurlH1 ? s_fespace.GetTrueVSize() :
+                                   v_fespace.GetTrueVSize());
                      y_assembly.SetSize(y_mat.Size());
                      y_pa.SetSize(y_mat.Size());
 

--- a/tests/unit/fem/test_pa_coeff.cpp
+++ b/tests/unit/fem/test_pa_coeff.cpp
@@ -665,7 +665,7 @@ TEST_CASE("Hcurl/Hdiv mixed pa_coeff",
             dcoeff = new VectorFunctionCoefficient(dimension, &vectorCoeffFunction);
          }
 
-         enum MixedSpaces {HcurlH1, HcurlL2, HdivL2, NumSpaceTypes};
+         enum MixedSpaces {HcurlH1, HcurlL2, HdivL2, HcurlH1_2D, NumSpaceTypes};
          for (int spaceType = 0; spaceType < NumSpaceTypes; ++spaceType)
          {
             if (spaceType == HdivL2 && coeffType == 1)
@@ -677,6 +677,10 @@ TEST_CASE("Hcurl/Hdiv mixed pa_coeff",
                continue;  // Case not implemented yet
             }
             if (spaceType == HcurlL2 && dimension == 2 && coeffType == 2)
+            {
+               continue;  // Case not implemented yet
+            }
+            if (spaceType == HcurlH1_2D && dimension != 2)
             {
                continue;  // Case not implemented yet
             }
@@ -700,7 +704,7 @@ TEST_CASE("Hcurl/Hdiv mixed pa_coeff",
                for (int order = 1; order < 4; ++order)
                {
                   FiniteElementCollection* vec_fec = nullptr;
-                  if (spaceType == HcurlH1 || spaceType == HcurlL2)
+                  if (spaceType == HcurlH1 || spaceType == HcurlL2 || spaceType == HcurlH1_2D)
                   {
                      vec_fec = (FiniteElementCollection*) new ND_FECollection(order, dimension);
                   }
@@ -710,14 +714,9 @@ TEST_CASE("Hcurl/Hdiv mixed pa_coeff",
                   }
 
                   FiniteElementCollection* scalar_fec = nullptr;
-                  if (spaceType == HcurlH1)
+                  if (spaceType == HcurlH1 || spaceType == HcurlH1_2D)
                   {
                      scalar_fec = (FiniteElementCollection*) new H1_FECollection(order, dimension);
-                  }
-                  else if (spaceType == HcurlL2 && dimension == 2)
-                  {
-                     scalar_fec = (FiniteElementCollection*) new L2_FECollection(order-1,
-                                                                                 dimension);   // TODO: remove this redundant case
                   }
                   else
                   {
@@ -775,7 +774,7 @@ TEST_CASE("Hcurl/Hdiv mixed pa_coeff",
                         }
                      }
                   }
-                  else if (spaceType == HcurlL2 && dimension == 2)
+                  else if (spaceType == HcurlH1_2D || (spaceType == HcurlL2 && dimension == 2))
                   {
                      assemblyform = new MixedBilinearForm(&v_fespace, &s_fespace);
                      paform = new MixedBilinearForm(&v_fespace, &s_fespace);
@@ -804,8 +803,9 @@ TEST_CASE("Hcurl/Hdiv mixed pa_coeff",
                   Vector *xin = new Vector((spaceType == 0) ? s_fespace.GetTrueVSize() :
                                            v_fespace.GetTrueVSize());
                   xin->Randomize();
-                  Vector y_mat((spaceType == HdivL2 || (spaceType == HcurlL2 &&
-                                                        dimension == 2)) ? s_fespace.GetTrueVSize() :
+                  Vector y_mat((spaceType == HdivL2 || spaceType == HcurlH1_2D ||
+                                (spaceType == HcurlL2 &&
+                                 dimension == 2)) ? s_fespace.GetTrueVSize() :
                                v_fespace.GetTrueVSize());
                   y_mat = 0.0;
                   Vector y_assembly(y_mat.Size());


### PR DESCRIPTION
This PR adds PA support for `MixedScalarCurlIntegrator` in 2D and `MixedVectorGradientIntegrator` in 2D and 3D, as well as their transposes.<!--GHEX{"author":"dylan-copeland","assignment":"2022-03-01T19:30:14","editor":"tzanio","id":2856,"reviewers":["tzanio","YohannDudouit"],"merge":"2022-03-03T16:23:37","approval":"2022-03-03T03:32:40"}XEHG-->
<!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge|
 | --- | --- | --- | --- | --- | --- | --- |
| [#2856](https://github.com/mfem/mfem/pull/2856) | @dylan-copeland | @tzanio | @tzanio + @YohannDudouit | 3/1/22 | 3/2/22 | 3/3/22 | |
<!--ELBATXEHG-->