### PR TITLE
Var-order-transfer-unit-test and non-uniform ConvergenceStudy rates

### DIFF
--- a/fem/convergence.hpp
+++ b/fem/convergence.hpp
@@ -29,8 +29,8 @@ namespace mfem
 
     Here, k is called the asymptotic rate of convergence
 
-    For successive uniform h-refinements the rate can be estimated by
-    k = log(||u - u_h|| / ||u - u_{h/2}||)/log(2)
+    For successive h-refinements the rate can be estimated by
+    k = log(||u - u_h|| / ||u - u_{h/2}||)/(1/dim * log(N_{h/2}/N_{h})
 */
 class ConvergenceStudy
 {

--- a/tests/unit/fem/test_transfer.cpp
+++ b/tests/unit/fem/test_transfer.cpp
@@ -268,6 +268,8 @@ TEST_CASE("Variable Order Transfer", "[Transfer][VariableOrder]")
    FiniteElementSpace *f_fespace =
       new FiniteElementSpace(&mesh, f_fec,spaceDimension);
 
+   RandomPRefinement(*f_fespace);
+
    Operator* referenceOperator = nullptr;
 
    referenceOperator = new PRefinementTransferOperator(*c_fespace,


### PR DESCRIPTION
A small PR which 
1. fixes a variable order transfer test (before the where was no refinement happening in the test)
2. adds support in the ConvergenceStudy to produce correct rates for adaptive h-ref

<!--GHEX{"author":"psocratis","assignment":"2022-03-01T20:44:05","editor":"tzanio","id":2860,"reviewers":["tzanio","brendankeith"],"merge":"2022-03-03T16:22:50","approval":"2022-03-01T21:32:15"}XEHG-->
<!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge|
 | --- | --- | --- | --- | --- | --- | --- |
| [#2860](https://github.com/mfem/mfem/pull/2860) | @psocratis | @tzanio | @tzanio + @brendankeith | 3/1/22 | 3/1/22 | 3/3/22 | |
<!--ELBATXEHG-->