### PR TITLE
Diffusion PA kernel fix [diffusion_pa_ker_revert]

### DIFF
--- a/fem/bilininteg_diffusion_pa.cpp
+++ b/fem/bilininteg_diffusion_pa.cpp
@@ -1311,6 +1311,7 @@ static void SmemPADiffusionApply2D(const int NE,
             Y(dx,dy,e) += (u + v);
          }
       }
+      MFEM_SYNC_THREAD;
    });
 }
 
@@ -1507,33 +1508,6 @@ static void PADiffusionApply3D(const int NE,
    });
 }
 
-// Half of B and G are stored in shared to get B, Bt, G and Gt.
-// Indices computation for SmemPADiffusionApply3D.
-static MFEM_HOST_DEVICE inline int qi(const int q, const int d, const int Q)
-{
-   return (q<=d) ? q : Q-1-q;
-}
-
-static MFEM_HOST_DEVICE inline int dj(const int q, const int d, const int D)
-{
-   return (q<=d) ? d : D-1-d;
-}
-
-static MFEM_HOST_DEVICE inline int qk(const int q, const int d, const int Q)
-{
-   return (q<=d) ? Q-1-q : q;
-}
-
-static MFEM_HOST_DEVICE inline int dl(const int q, const int d, const int D)
-{
-   return (q<=d) ? D-1-d : d;
-}
-
-static MFEM_HOST_DEVICE inline double sign(const int q, const int d)
-{
-   return (q<=d) ? -1.0 : 1.0;
-}
-
 template<int T_D1D = 0, int T_Q1D = 0>
 static void SmemPADiffusionApply3D(const int NE,
                                    const bool symmetric,
@@ -1563,11 +1537,11 @@ static void SmemPADiffusionApply3D(const int NE,
       constexpr int MQ1 = T_Q1D ? T_Q1D : MAX_Q1D;
       constexpr int MD1 = T_D1D ? T_D1D : MAX_D1D;
       constexpr int MDQ = (MQ1 > MD1) ? MQ1 : MD1;
-      MFEM_SHARED double sBG[MQ1*MD1];
-      double (*B)[MD1] = (double (*)[MD1]) sBG;
-      double (*G)[MD1] = (double (*)[MD1]) sBG;
-      double (*Bt)[MQ1] = (double (*)[MQ1]) sBG;
-      double (*Gt)[MQ1] = (double (*)[MQ1]) sBG;
+      MFEM_SHARED double sBG[2][MQ1*MD1];
+      double (*B)[MD1] = (double (*)[MD1]) (sBG+0);
+      double (*G)[MD1] = (double (*)[MD1]) (sBG+1);
+      double (*Bt)[MQ1] = (double (*)[MQ1]) (sBG+0);
+      double (*Gt)[MQ1] = (double (*)[MQ1]) (sBG+1);
       MFEM_SHARED double sm0[3][MDQ*MDQ*MDQ];
       MFEM_SHARED double sm1[3][MDQ*MDQ*MDQ];
       double (*X)[MD1][MD1]    = (double (*)[MD1][MD1]) (sm0+2);
@@ -1601,12 +1575,8 @@ static void SmemPADiffusionApply3D(const int NE,
          {
             MFEM_FOREACH_THREAD(qx,x,Q1D)
             {
-               const int i = qi(qx,dy,Q1D);
-               const int j = dj(qx,dy,D1D);
-               const int k = qk(qx,dy,Q1D);
-               const int l = dl(qx,dy,D1D);
-               B[i][j] = b(qx,dy);
-               G[k][l] = g(qx,dy) * sign(qx,dy);
+               B[qx][dy] = b(qx,dy);
+               G[qx][dy] = g(qx,dy);
             }
          }
       }
@@ -1621,14 +1591,9 @@ static void SmemPADiffusionApply3D(const int NE,
                MFEM_UNROLL(MD1)
                for (int dx = 0; dx < D1D; ++dx)
                {
-                  const int i = qi(qx,dx,Q1D);
-                  const int j = dj(qx,dx,D1D);
-                  const int k = qk(qx,dx,Q1D);
-                  const int l = dl(qx,dx,D1D);
-                  const double s = sign(qx,dx);
                   const double coords = X[dz][dy][dx];
-                  u += coords * B[i][j];
-                  v += coords * G[k][l] * s;
+                  u += coords * B[qx][dx];
+                  v += coords * G[qx][dx];
                }
                DDQ0[dz][dy][qx] = u;
                DDQ1[dz][dy][qx] = v;
@@ -1646,14 +1611,9 @@ static void SmemPADiffusionApply3D(const int NE,
                MFEM_UNROLL(MD1)
                for (int dy = 0; dy < D1D; ++dy)
                {
-                  const int i = qi(qy,dy,Q1D);
-                  const int j = dj(qy,dy,D1D);
-                  const int k = qk(qy,dy,Q1D);
-                  const int l = dl(qy,dy,D1D);
-                  const double s = sign(qy,dy);
-                  u += DDQ1[dz][dy][qx] * B[i][j];
-                  v += DDQ0[dz][dy][qx] * G[k][l] * s;
-                  w += DDQ0[dz][dy][qx] * B[i][j];
+                  u += DDQ1[dz][dy][qx] * B[qy][dy];
+                  v += DDQ0[dz][dy][qx] * G[qy][dy];
+                  w += DDQ0[dz][dy][qx] * B[qy][dy];
                }
                DQQ0[dz][qy][qx] = u;
                DQQ1[dz][qy][qx] = v;
@@ -1672,14 +1632,9 @@ static void SmemPADiffusionApply3D(const int NE,
                MFEM_UNROLL(MD1)
                for (int dz = 0; dz < D1D; ++dz)
                {
-                  const int i = qi(qz,dz,Q1D);
-                  const int j = dj(qz,dz,D1D);
-                  const int k = qk(qz,dz,Q1D);
-                  const int l = dl(qz,dz,D1D);
-                  const double s = sign(qz,dz);
-                  u += DQQ0[dz][qy][qx] * B[i][j];
-                  v += DQQ1[dz][qy][qx] * B[i][j];
-                  w += DQQ2[dz][qy][qx] * G[k][l] * s;
+                  u += DQQ0[dz][qy][qx] * B[qz][dz];
+                  v += DQQ1[dz][qy][qx] * B[qz][dz];
+                  w += DQQ2[dz][qy][qx] * G[qz][dz];
                }
                const double O11 = d(qx,qy,qz,0,e);
                const double O12 = d(qx,qy,qz,1,e);
@@ -1702,16 +1657,12 @@ static void SmemPADiffusionApply3D(const int NE,
       MFEM_SYNC_THREAD;
       if (MFEM_THREAD_ID(z) == 0)
       {
-         MFEM_FOREACH_THREAD(d,y,D1D)
+         MFEM_FOREACH_THREAD(dy,y,D1D)
          {
-            MFEM_FOREACH_THREAD(q,x,Q1D)
+            MFEM_FOREACH_THREAD(qx,x,Q1D)
             {
-               const int i = qi(q,d,Q1D);
-               const int j = dj(q,d,D1D);
-               const int k = qk(q,d,Q1D);
-               const int l = dl(q,d,D1D);
-               Bt[j][i] = b(q,d);
-               Gt[l][k] = g(q,d) * sign(q,d);
+               Bt[dy][qx] = b(qx,dy);
+               Gt[dy][qx] = g(qx,dy);
             }
          }
       }
@@ -1726,14 +1677,9 @@ static void SmemPADiffusionApply3D(const int NE,
                MFEM_UNROLL(MQ1)
                for (int qx = 0; qx < Q1D; ++qx)
                {
-                  const int i = qi(qx,dx,Q1D);
-                  const int j = dj(qx,dx,D1D);
-                  const int k = qk(qx,dx,Q1D);
-                  const int l = dl(qx,dx,D1D);
-                  const double s = sign(qx,dx);
-                  u += QQQ0[qz][qy][qx] * Gt[l][k] * s;
-                  v += QQQ1[qz][qy][qx] * Bt[j][i];
-                  w += QQQ2[qz][qy][qx] * Bt[j][i];
+                  u += QQQ0[qz][qy][qx] * Gt[dx][qx];
+                  v += QQQ1[qz][qy][qx] * Bt[dx][qx];
+                  w += QQQ2[qz][qy][qx] * Bt[dx][qx];
                }
                QQD0[qz][qy][dx] = u;
                QQD1[qz][qy][dx] = v;
@@ -1752,14 +1698,9 @@ static void SmemPADiffusionApply3D(const int NE,
                MFEM_UNROLL(Q1D)
                for (int qy = 0; qy < Q1D; ++qy)
                {
-                  const int i = qi(qy,dy,Q1D);
-                  const int j = dj(qy,dy,D1D);
-                  const int k = qk(qy,dy,Q1D);
-                  const int l = dl(qy,dy,D1D);
-                  const double s = sign(qy,dy);
-                  u += QQD0[qz][qy][dx] * Bt[j][i];
-                  v += QQD1[qz][qy][dx] * Gt[l][k] * s;
-                  w += QQD2[qz][qy][dx] * Bt[j][i];
+                  u += QQD0[qz][qy][dx] * Bt[dy][qy];
+                  v += QQD1[qz][qy][dx] * Gt[dy][qy];
+                  w += QQD2[qz][qy][dx] * Bt[dy][qy];
                }
                QDD0[qz][dy][dx] = u;
                QDD1[qz][dy][dx] = v;
@@ -1778,19 +1719,15 @@ static void SmemPADiffusionApply3D(const int NE,
                MFEM_UNROLL(MQ1)
                for (int qz = 0; qz < Q1D; ++qz)
                {
-                  const int i = qi(qz,dz,Q1D);
-                  const int j = dj(qz,dz,D1D);
-                  const int k = qk(qz,dz,Q1D);
-                  const int l = dl(qz,dz,D1D);
-                  const double s = sign(qz,dz);
-                  u += QDD0[qz][dy][dx] * Bt[j][i];
-                  v += QDD1[qz][dy][dx] * Bt[j][i];
-                  w += QDD2[qz][dy][dx] * Gt[l][k] * s;
+                  u += QDD0[qz][dy][dx] * Bt[dz][qz];
+                  v += QDD1[qz][dy][dx] * Bt[dz][qz];
+                  w += QDD2[qz][dy][dx] * Gt[dz][qz];
                }
                y(dx,dy,dz,e) += (u + v + w);
             }
          }
       }
+      MFEM_SYNC_THREAD;
    });
 }
 
@@ -1824,6 +1761,7 @@ static void PADiffusionApply(const int dim,
    }
 #endif // MFEM_USE_OCCA
    const int ID = (D1D << 4) | Q1D;
+   printf("\033[32m[0x%x]\033[m\n",ID); fflush(0);
 
    if (dim == 2)
    {
@@ -1858,7 +1796,7 @@ static void PADiffusionApply(const int dim,
          default:   return PADiffusionApply3D(NE,symm,B,G,Bt,Gt,D,X,Y,D1D,Q1D);
       }
    }
-   MFEM_ABORT("Unknown kernel.");
+   MFEM_ABORT("Unknown kernel: 0x"<<std::hex << ID << std::dec);
 }
 
 // PA Diffusion Apply kernel

--- a/fem/bilininteg_diffusion_pa.cpp
+++ b/fem/bilininteg_diffusion_pa.cpp
@@ -1758,11 +1758,11 @@ static void PADiffusionApply(const int dim,
       MFEM_ABORT("OCCA PADiffusionApply unknown kernel!");
    }
 #endif // MFEM_USE_OCCA
-   const int ID = (D1D << 4) | Q1D;
+   const int id = (D1D << 4) | Q1D;
 
    if (dim == 2)
    {
-      switch (ID)
+      switch (id)
       {
          case 0x22: return SmemPADiffusionApply2D<2,2,16>(NE,symm,B,G,D,X,Y);
          case 0x33: return SmemPADiffusionApply2D<3,3,16>(NE,symm,B,G,D,X,Y);
@@ -1778,7 +1778,7 @@ static void PADiffusionApply(const int dim,
 
    if (dim == 3)
    {
-      switch (ID)
+      switch (id)
       {
          case 0x22: return SmemPADiffusionApply3D<2,2>(NE,symm,B,G,D,X,Y);
          case 0x23: return SmemPADiffusionApply3D<2,3>(NE,symm,B,G,D,X,Y);
@@ -1793,7 +1793,7 @@ static void PADiffusionApply(const int dim,
          default:   return PADiffusionApply3D(NE,symm,B,G,Bt,Gt,D,X,Y,D1D,Q1D);
       }
    }
-   MFEM_ABORT("Unknown kernel: 0x"<<std::hex << ID << std::dec);
+   MFEM_ABORT("Unknown kernel: 0x"<<std::hex << id << std::dec);
 }
 
 // PA Diffusion Apply kernel

--- a/fem/bilininteg_diffusion_pa.cpp
+++ b/fem/bilininteg_diffusion_pa.cpp
@@ -1311,7 +1311,6 @@ static void SmemPADiffusionApply2D(const int NE,
             Y(dx,dy,e) += (u + v);
          }
       }
-      MFEM_SYNC_THREAD;
    });
 }
 
@@ -1727,7 +1726,6 @@ static void SmemPADiffusionApply3D(const int NE,
             }
          }
       }
-      MFEM_SYNC_THREAD;
    });
 }
 

--- a/fem/bilininteg_diffusion_pa.cpp
+++ b/fem/bilininteg_diffusion_pa.cpp
@@ -1761,7 +1761,6 @@ static void PADiffusionApply(const int dim,
    }
 #endif // MFEM_USE_OCCA
    const int ID = (D1D << 4) | Q1D;
-   printf("\033[32m[0x%x]\033[m\n",ID); fflush(0);
 
    if (dim == 2)
    {

--- a/fem/bilininteg_mass_pa.cpp
+++ b/fem/bilininteg_mass_pa.cpp
@@ -1179,6 +1179,7 @@ static void PAMassApply(const int dim,
    }
 #endif // MFEM_USE_OCCA
    const int id = (D1D << 4) | Q1D;
+
    if (dim == 2)
    {
       switch (id)

--- a/tests/unit/fem/test_assembly_levels.cpp
+++ b/tests/unit/fem/test_assembly_levels.cpp
@@ -16,7 +16,7 @@
 
 using namespace mfem;
 
-namespace ea_kernels
+namespace assembly_levels
 {
 
 void velocity_function(const Vector &x, Vector &v)
@@ -170,4 +170,4 @@ TEST_CASE("Assembly Levels", "[AssemblyLevel], [PartialAssembly]")
    }
 } // test case
 
-} // namespace pa_kernels
+} // namespace assembly_levels

--- a/tests/unit/fem/test_pa_kernels.cpp
+++ b/tests/unit/fem/test_pa_kernels.cpp
@@ -21,6 +21,7 @@ namespace pa_kernels
 
 double zero_field(const Vector &x)
 {
+   MFEM_CONTRACT_VAR(x);
    return 0.0;
 }
 
@@ -468,39 +469,59 @@ TEST_CASE("PA Convection", "[PartialAssembly][MFEMData]")
                             order_3d, prob, refinement_3d);
       }
    }
+} // PA Convection test case
 
-} // test case
-
-TEST_CASE("PA Mass", "[PartialAssembly]")
+template <typename INTEGRATOR>
+static void test_pa_integrator()
 {
+   const bool all_tests = launch_all_non_regression_tests;
+
    auto fname = GENERATE("../../data/star.mesh", "../../data/star-q3.mesh",
                          "../../data/fichera.mesh", "../../data/fichera-q3.mesh");
    auto map_type = GENERATE(FiniteElement::VALUE, FiniteElement::INTEGRAL);
-   int order = 2;
+
+   auto order = !all_tests ? 2: GENERATE(1, 2, 3, 4);
+   auto q_order_inc = !all_tests ? 3 : GENERATE(1, 3);
 
    Mesh mesh(fname);
    int dim = mesh.Dimension();
    L2_FECollection fec(order, dim, BasisType::GaussLobatto, map_type);
    FiniteElementSpace fes(&mesh, &fec);
 
+   const int q = 2*order + q_order_inc;
+   const Geometry::Type geom_type = fes.GetFE(0)->GetGeomType();
+   const IntegrationRule *ir = &IntRules.Get(geom_type, q);
+
    GridFunction x(&fes), y_fa(&fes), y_pa(&fes);
    x.Randomize(1);
 
+   ConstantCoefficient pi(M_PI);
+
    BilinearForm blf_fa(&fes);
-   blf_fa.AddDomainIntegrator(new MassIntegrator);
+   blf_fa.AddDomainIntegrator(new INTEGRATOR(pi,ir));
    blf_fa.Assemble();
    blf_fa.Finalize();
    blf_fa.Mult(x, y_fa);
 
    BilinearForm blf_pa(&fes);
    blf_pa.SetAssemblyLevel(AssemblyLevel::PARTIAL);
-   blf_pa.AddDomainIntegrator(new MassIntegrator);
+   blf_pa.AddDomainIntegrator(new INTEGRATOR(pi,ir));
    blf_pa.Assemble();
    blf_pa.Mult(x, y_pa);
 
    y_fa -= y_pa;
 
    REQUIRE(y_fa.Normlinf() == MFEM_Approx(0.0));
-} // test case
+}
+
+TEST_CASE("PA Mass", "[PartialAssembly], [CUDA]")
+{
+   test_pa_integrator<MassIntegrator>();
+} // PA Mass test case
+
+TEST_CASE("PA Diffusion", "[PartialAssembly], [CUDA]")
+{
+   test_pa_integrator<DiffusionIntegrator>();
+} // PA Diffusion test case
 
 } // namespace pa_kernels

--- a/tests/unit/fem/test_pa_kernels.cpp
+++ b/tests/unit/fem/test_pa_kernels.cpp
@@ -9,13 +9,13 @@
 // terms of the BSD-3 license. We welcome feedback and contributions, see file
 // CONTRIBUTING.md for details.
 
-#include "unit_tests.hpp"
-#include "mfem.hpp"
-
 #ifdef _WIN32
 #define _USE_MATH_DEFINES
 #include <cmath>
 #endif
+
+#include "unit_tests.hpp"
+#include "mfem.hpp"
 
 #include <fstream>
 #include <iostream>

--- a/tests/unit/fem/test_pa_kernels.cpp
+++ b/tests/unit/fem/test_pa_kernels.cpp
@@ -512,17 +512,19 @@ static void test_pa_integrator()
                          "../../data/fichera.mesh", "../../data/fichera-q3.mesh");
    auto map_type = GENERATE(FiniteElement::VALUE, FiniteElement::INTEGRAL);
 
-   auto order = !all_tests ? 2: GENERATE(1, 2, 3, 4);
-   auto q_order_inc = !all_tests ? 3 : GENERATE(1, 3);
+   auto order = !all_tests ? 2 : GENERATE(1, 2, 3);
+   auto q_order_inc = !all_tests ? 0 : GENERATE(0, 1, 3);
 
    Mesh mesh(fname);
    int dim = mesh.Dimension();
    L2_FECollection fec(order, dim, BasisType::GaussLobatto, map_type);
    FiniteElementSpace fes(&mesh, &fec);
 
-   const int q = 2*order + q_order_inc;
-   const Geometry::Type geom_type = fes.GetFE(0)->GetGeomType();
-   const IntegrationRule *ir = &IntRules.Get(geom_type, q);
+   const int q_order = 2*order + q_order_inc;
+   // Don't use a special integration rule if q_order_inc == 0
+   const bool use_ir = q_order_inc > 0;
+   const IntegrationRule *ir =
+      use_ir ? &IntRules.Get(mesh.GetElementGeometry(0), q_order) : nullptr;
 
    GridFunction x(&fes), y_fa(&fes), y_pa(&fes);
    x.Randomize(1);

--- a/tests/unit/fem/test_pa_kernels.cpp
+++ b/tests/unit/fem/test_pa_kernels.cpp
@@ -11,6 +11,12 @@
 
 #include "unit_tests.hpp"
 #include "mfem.hpp"
+
+#ifdef _WIN32
+#define _USE_MATH_DEFINES
+#include <cmath>
+#endif
+
 #include <fstream>
 #include <iostream>
 


### PR DESCRIPTION
Remove the indices computation for `SmemPADiffusionApply3D` that added extra requirements on `dofs1D` and `quad1D`.
The instanciatied kernels with `dofs1D==quad1D` are now also tested in the unit tests.

<!--GHEX{"author":"camierjs","assignment":"2022-03-02T01:40:42","editor":"tzanio","id":2861,"reviewers":["tzanio","v-dobrev"],"merge":"2022-03-03T20:27:23","approval":"2022-03-03T03:35:18"}XEHG-->
<!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge|
 | --- | --- | --- | --- | --- | --- | --- |
| [#2861](https://github.com/mfem/mfem/pull/2861) | @camierjs | @tzanio | @tzanio + @v-dobrev | 3/1/22 | 3/2/22 | 3/3/22 | |
<!--ELBATXEHG-->