### PR TITLE
Conduit Blueprint Bugfix

### DIFF
--- a/fem/conduitdatacollection.cpp
+++ b/fem/conduitdatacollection.cpp
@@ -777,11 +777,13 @@ ConduitDataCollection::MeshToBlueprintMesh(Mesh *mesh,
       int num_bndry_ele = mesh->GetNBE();
 
       // must initialize this to something
-      Element::Type bndry_ele_type   = (num_bndry_ele > 0) ? mesh->GetBdrElementType(0) : mfem::Element::POINT;
+      Element::Type bndry_ele_type   = (num_bndry_ele > 0) ? mesh->GetBdrElementType(
+                                          0) : mfem::Element::POINT;
       std::string bndry_ele_shape    = ElementTypeToShapeName(bndry_ele_type);
       n_bndry_topo["elements/shape"] = bndry_ele_shape;
 
-      int bndry_geom          = (num_bndry_ele > 0) ? mesh->GetBdrElementBaseGeometry(0) : mfem::Element::POINT;
+      int bndry_geom          = (num_bndry_ele > 0) ? mesh->GetBdrElementBaseGeometry(
+                                   0) : mfem::Element::POINT;
       int bndry_idxs_per_ele  = Geometry::NumVerts[bndry_geom];
       int num_bndry_conn_idxs =  num_bndry_ele * bndry_idxs_per_ele;
 
@@ -952,7 +954,7 @@ ConduitDataCollection::HasBoundaryElements(mfem::Mesh* mesh)
    {
       int hasBndElts_g;
       MPI_Allreduce(&hasBndElts, &hasBndElts_g, 1,
-         MPI_INT, MPI_MAX,pmesh->GetComm());
+                    MPI_INT, MPI_MAX,pmesh->GetComm());
       hasBndElts = hasBndElts_g;
    }
 #endif

--- a/fem/conduitdatacollection.hpp
+++ b/fem/conduitdatacollection.hpp
@@ -209,6 +209,9 @@ public:
                                                      const conduit::Node &n_field,
                                                      bool zero_copy = false);
 
+   /** Checks if any rank in the mesh has boundary elements */
+   static bool HasBoundaryElements(mfem::Mesh *mesh);
+
 private:
    /// Converts from MFEM element type enum to mesh bp shape name
    static std::string ElementTypeToShapeName(Element::Type element_type);

--- a/fem/conduitdatacollection.hpp
+++ b/fem/conduitdatacollection.hpp
@@ -209,9 +209,6 @@ public:
                                                      const conduit::Node &n_field,
                                                      bool zero_copy = false);
 
-   /** Checks if any rank in the mesh has boundary elements */
-   static bool HasBoundaryElements(mfem::Mesh *mesh);
-
 private:
    /// Converts from MFEM element type enum to mesh bp shape name
    static std::string ElementTypeToShapeName(Element::Type element_type);

--- a/general/forall.hpp
+++ b/general/forall.hpp
@@ -25,8 +25,8 @@ namespace mfem
 
 // Maximum size of dofs and quads in 1D.
 #ifdef MFEM_USE_HIP
-const int MAX_D1D = 11;
-const int MAX_Q1D = 11;
+const int MAX_D1D = 10;
+const int MAX_Q1D = 10;
 #else
 const int MAX_D1D = 14;
 const int MAX_Q1D = 14;

--- a/mesh/mesh.hpp
+++ b/mesh/mesh.hpp
@@ -1012,6 +1012,9 @@ public:
    void GetElementData(int geom, Array<int> &elem_vtx, Array<int> &attr) const
    { GetElementData(elements, geom, elem_vtx, attr); }
 
+   /// Checks if the mesh has boundary elements
+   virtual bool HasBoundaryElements() const { return (NumOfBdrElements > 0); }
+
    void GetBdrElementData(int geom, Array<int> &bdr_elem_vtx,
                           Array<int> &bdr_attr) const
    { GetElementData(boundary, geom, bdr_elem_vtx, bdr_attr); }

--- a/mesh/pmesh.cpp
+++ b/mesh/pmesh.cpp
@@ -1594,6 +1594,15 @@ void ParMesh::SetAttributes()
    }
 }
 
+bool ParMesh::HasBoundaryElements() const
+{
+   // maximum number of boundary elements over all ranks
+   int maxNumOfBdrElements;
+   MPI_Allreduce(&NumOfBdrElements, &maxNumOfBdrElements, 1,
+                 MPI_C_BOOL, MPI_MAX, MyComm);
+   return (maxNumOfBdrElements > 0);
+}
+
 void ParMesh::GroupEdge(int group, int i, int &edge, int &o)
 {
    int sedge = group_sedge.GetRow(group-1)[i];

--- a/mesh/pmesh.hpp
+++ b/mesh/pmesh.hpp
@@ -282,6 +282,9 @@ public:
 
    void SetAttributes() override;
 
+   /// Checks if any rank in the mesh has boundary elements
+   bool HasBoundaryElements() const override;
+
    MPI_Comm GetComm() const { return MyComm; }
    int GetNRanks() const { return NRanks; }
    int GetMyRank() const { return MyRank; }


### PR DESCRIPTION
This fixes a bug in `ConduitDataCollection::MeshToBlueprintMesh()` wherein boundary topology is missing if a rank happens not to have any boundary elements (i.e., is purely internal).  First, I cribbed a function from `SidreDataCollection` to determine whether any rank has any boundary elements (an all-periodic mesh might have none), then I initialized a few geometry-related fields to unimportant data in case there are no boundary elements to use.  This technically gives the wrong answer for some ranks, and it assumes all boundary elements are of the same type, but that's probably okay for now since it's never used.<!--GHEX{"author":"aaronskinner","assignment":"2022-03-02T19:16:05","editor":"tzanio","id":2864,"reviewers":["tzanio","v-dobrev","camierjs"],"merge":"2022-03-07T22:05:25","approval":"2022-03-07T22:05:21"}XEHG-->
<!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge|
 | --- | --- | --- | --- | --- | --- | --- |
| [#2864](https://github.com/mfem/mfem/pull/2864) | @aaronskinner | @tzanio | @tzanio + @v-dobrev + @camierjs | 3/2/22 | 3/7/22 | 3/7/22 | |
<!--ELBATXEHG-->