### PR TITLE
Support HYPRE_Init/Finalize

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -107,6 +107,10 @@ Version 4.3.1 (development)
 - Added ParaView visualization of `QuadratureFunction` fields, through both
   `QuadratureFunction::SaveVTU` and `ParaViewDataCollection::RegisterQField`.
 
+- Added a simple convenience class, HYPRE_Session, to automatically set hypre's
+  global parameters, particularly GPU-relevant options. Updated example codes
+  and miniapps to use it.
+
 
 Version 4.3, released on July 29, 2021
 ======================================

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -112,7 +112,7 @@ Version 4.3.1 (development)
   and miniapps to call Hypre::Init() where appropriate.
 
 - Added a simple singleton class, Mpi, as a replacement for MPI_Session. New
-  code should use Mpi::Init() and Mpi::Session() instead of MPI_Session.
+  code should use Mpi::Init() and other Mpi methods instead of MPI_Session.
 
 - Added Nedelec and Raviart-Thomas basis functions for modeling three
   dimensional vector fields in 1D or 2D domains.

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -107,9 +107,9 @@ Version 4.3.1 (development)
 - Added ParaView visualization of `QuadratureFunction` fields, through both
   `QuadratureFunction::SaveVTU` and `ParaViewDataCollection::RegisterQField`.
 
-- Added a simple convenience class, HYPRE_Session, to automatically set hypre's
-  global parameters, particularly GPU-relevant options. Updated example codes
-  and miniapps to use it.
+- Added a simple singleton class, Hypre, to automatically set hypre's global
+  parameters, particularly GPU-relevant options. Updated parallel example codes
+  and miniapps to call Hypre::Init() where appropriate.
 
 
 Version 4.3, released on July 29, 2021

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -111,6 +111,9 @@ Version 4.3.1 (development)
   parameters, particularly GPU-relevant options. Updated parallel example codes
   and miniapps to call Hypre::Init() where appropriate.
 
+- Added a simple singleton class, MPI, as a replacement for MPI_Session. New
+  code should use MPI::Init() and MPI::Session() instead of MPI_Session.
+
 
 Version 4.3, released on July 29, 2021
 ======================================

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -111,8 +111,8 @@ Version 4.3.1 (development)
   parameters, particularly GPU-relevant options. Updated parallel example codes
   and miniapps to call Hypre::Init() where appropriate.
 
-- Added a simple singleton class, MPI, as a replacement for MPI_Session. New
-  code should use MPI::Init() and MPI::Session() instead of MPI_Session.
+- Added a simple singleton class, Mpi, as a replacement for MPI_Session. New
+  code should use Mpi::Init() and Mpi::Session() instead of MPI_Session.
 
 
 Version 4.3, released on July 29, 2021

--- a/examples/amgx/ex1p.cpp
+++ b/examples/amgx/ex1p.cpp
@@ -38,10 +38,9 @@ using namespace mfem;
 int main(int argc, char *argv[])
 {
    // 1. Initialize MPI and HYPRE.
-   int num_procs, myid;
-   MPI_Init(&argc, &argv);
-   MPI_Comm_size(MPI_COMM_WORLD, &num_procs);
-   MPI_Comm_rank(MPI_COMM_WORLD, &myid);
+   Mpi::Init(argc, argv);
+   int num_procs = Mpi::WorldSize();
+   int myid = Mpi::WorldRank();
    Hypre::Init();
 
    // 2. Parse command-line options.
@@ -88,7 +87,6 @@ int main(int argc, char *argv[])
       {
          args.PrintUsage(cout);
       }
-      MPI_Finalize();
       return 1;
    }
    if (myid == 0)
@@ -321,7 +319,6 @@ int main(int argc, char *argv[])
    {
       delete fec;
    }
-   MPI_Finalize();
 
    return 0;
 }

--- a/examples/amgx/ex1p.cpp
+++ b/examples/amgx/ex1p.cpp
@@ -42,7 +42,7 @@ int main(int argc, char *argv[])
    MPI_Init(&argc, &argv);
    MPI_Comm_size(MPI_COMM_WORLD, &num_procs);
    MPI_Comm_rank(MPI_COMM_WORLD, &myid);
-   HYPRE_Session hypre;
+   Hypre::Init();
 
    // 2. Parse command-line options.
    const char *mesh_file = "../../data/star.mesh";

--- a/examples/amgx/ex1p.cpp
+++ b/examples/amgx/ex1p.cpp
@@ -37,11 +37,12 @@ using namespace mfem;
 
 int main(int argc, char *argv[])
 {
-   // 1. Initialize MPI.
+   // 1. Initialize MPI and HYPRE.
    int num_procs, myid;
    MPI_Init(&argc, &argv);
    MPI_Comm_size(MPI_COMM_WORLD, &num_procs);
    MPI_Comm_rank(MPI_COMM_WORLD, &myid);
+   HYPRE_Session hypre;
 
    // 2. Parse command-line options.
    const char *mesh_file = "../../data/star.mesh";

--- a/examples/caliper/ex1p.cpp
+++ b/examples/caliper/ex1p.cpp
@@ -63,7 +63,7 @@ int main(int argc, char *argv[])
    MPI_Init(&argc, &argv);
    MPI_Comm_size(MPI_COMM_WORLD, &num_procs);
    MPI_Comm_rank(MPI_COMM_WORLD, &myid);
-   HYPRE_Session hypre;
+   Hypre::Init();
    // Define Caliper ConfigManager
    cali::ConfigManager mgr;
    // Caliper instrumentation

--- a/examples/caliper/ex1p.cpp
+++ b/examples/caliper/ex1p.cpp
@@ -59,10 +59,9 @@ using namespace mfem;
 int main(int argc, char *argv[])
 {
    // 1. Initialize MPI and HYPRE.
-   int num_procs, myid;
-   MPI_Init(&argc, &argv);
-   MPI_Comm_size(MPI_COMM_WORLD, &num_procs);
-   MPI_Comm_rank(MPI_COMM_WORLD, &myid);
+   Mpi::Init(argc, argv);
+   int num_procs = Mpi::WorldSize();
+   int myid = Mpi::WorldRank();
    Hypre::Init();
    // Define Caliper ConfigManager
    cali::ConfigManager mgr;
@@ -102,7 +101,6 @@ int main(int argc, char *argv[])
       {
          args.PrintUsage(cout);
       }
-      MPI_Finalize();
       return 1;
    }
    if (myid == 0)
@@ -294,7 +292,6 @@ int main(int argc, char *argv[])
    }
    // Flush output before MPI_finalize
    mgr.flush();
-   MPI_Finalize();
 
    return 0;
 }

--- a/examples/caliper/ex1p.cpp
+++ b/examples/caliper/ex1p.cpp
@@ -58,11 +58,12 @@ using namespace mfem;
 
 int main(int argc, char *argv[])
 {
-   // 1. Initialize MPI.
+   // 1. Initialize MPI and HYPRE.
    int num_procs, myid;
    MPI_Init(&argc, &argv);
    MPI_Comm_size(MPI_COMM_WORLD, &num_procs);
    MPI_Comm_rank(MPI_COMM_WORLD, &myid);
+   HYPRE_Session hypre;
    // Define Caliper ConfigManager
    cali::ConfigManager mgr;
    // Caliper instrumentation

--- a/examples/ex0.cpp
+++ b/examples/ex0.cpp
@@ -21,7 +21,7 @@ using namespace mfem;
 
 int main(int argc, char *argv[])
 {
-   // 1. Parse command line options
+   // 1. Parse command line options.
    const char *mesh_file = "../data/star.mesh";
    int order = 1;
 

--- a/examples/ex0p.cpp
+++ b/examples/ex0p.cpp
@@ -22,7 +22,7 @@ using namespace mfem;
 int main(int argc, char *argv[])
 {
    // 1. Initialize MPI and HYPRE.
-   MPI::Init(argc, argv);
+   Mpi::Init(argc, argv);
    Hypre::Init();
 
    // 2. Parse command line options.
@@ -48,7 +48,7 @@ int main(int argc, char *argv[])
    H1_FECollection fec(order, mesh.Dimension());
    ParFiniteElementSpace fespace(&mesh, &fec);
    HYPRE_BigInt total_num_dofs = fespace.GlobalTrueVSize();
-   if (MPI::Session().Root())
+   if (Mpi::Session().Root())
    {
       cout << "Number of unknowns: " << total_num_dofs << endl;
    }

--- a/examples/ex0p.cpp
+++ b/examples/ex0p.cpp
@@ -22,7 +22,7 @@ using namespace mfem;
 int main(int argc, char *argv[])
 {
    // 1. Initialize MPI and HYPRE.
-   MPI_Session mpi(argc, argv);
+   MPI::Init(argc, argv);
    Hypre::Init();
 
    // 2. Parse command line options.
@@ -48,7 +48,10 @@ int main(int argc, char *argv[])
    H1_FECollection fec(order, mesh.Dimension());
    ParFiniteElementSpace fespace(&mesh, &fec);
    HYPRE_BigInt total_num_dofs = fespace.GlobalTrueVSize();
-   if (mpi.Root()) { cout << "Number of unknowns: " << total_num_dofs << endl; }
+   if (MPI::Session().Root())
+   {
+      cout << "Number of unknowns: " << total_num_dofs << endl;
+   }
 
    // 6. Extract the list of all the boundary DOFs. These will be marked as
    //    Dirichlet in order to enforce zero boundary conditions.

--- a/examples/ex0p.cpp
+++ b/examples/ex0p.cpp
@@ -48,7 +48,7 @@ int main(int argc, char *argv[])
    H1_FECollection fec(order, mesh.Dimension());
    ParFiniteElementSpace fespace(&mesh, &fec);
    HYPRE_BigInt total_num_dofs = fespace.GlobalTrueVSize();
-   if (Mpi::Session().Root())
+   if (Mpi::Root())
    {
       cout << "Number of unknowns: " << total_num_dofs << endl;
    }

--- a/examples/ex0p.cpp
+++ b/examples/ex0p.cpp
@@ -23,7 +23,7 @@ int main(int argc, char *argv[])
 {
    // 1. Initialize MPI and HYPRE.
    MPI_Session mpi(argc, argv);
-   HYPRE_Session hypre;
+   Hypre::Init();
 
    // 2. Parse command line options.
    const char *mesh_file = "../data/star.mesh";

--- a/examples/ex0p.cpp
+++ b/examples/ex0p.cpp
@@ -21,10 +21,11 @@ using namespace mfem;
 
 int main(int argc, char *argv[])
 {
-   // 1. Initialize MPI
+   // 1. Initialize MPI and HYPRE.
    MPI_Session mpi(argc, argv);
+   HYPRE_Session hypre;
 
-   // 2. Parse command line options
+   // 2. Parse command line options.
    const char *mesh_file = "../data/star.mesh";
    int order = 1;
 

--- a/examples/ex10p.cpp
+++ b/examples/ex10p.cpp
@@ -162,11 +162,12 @@ void visualize(ostream &os, ParMesh *mesh,
 
 int main(int argc, char *argv[])
 {
-   // 1. Initialize MPI.
+   // 1. Initialize MPI and HYPRE.
    int num_procs, myid;
    MPI_Init(&argc, &argv);
    MPI_Comm_size(MPI_COMM_WORLD, &num_procs);
    MPI_Comm_rank(MPI_COMM_WORLD, &myid);
+   HYPRE_Session hypre;
 
    // 2. Parse command-line options.
    const char *mesh_file = "../data/beam-quad.mesh";

--- a/examples/ex10p.cpp
+++ b/examples/ex10p.cpp
@@ -163,10 +163,8 @@ void visualize(ostream &os, ParMesh *mesh,
 int main(int argc, char *argv[])
 {
    // 1. Initialize MPI and HYPRE.
-   int num_procs, myid;
-   MPI_Init(&argc, &argv);
-   MPI_Comm_size(MPI_COMM_WORLD, &num_procs);
-   MPI_Comm_rank(MPI_COMM_WORLD, &myid);
+   Mpi::Init(argc, argv);
+   int myid = Mpi::WorldRank();
    Hypre::Init();
 
    // 2. Parse command-line options.
@@ -224,7 +222,6 @@ int main(int argc, char *argv[])
       {
          args.PrintUsage(cout);
       }
-      MPI_Finalize();
       return 1;
    }
    if (myid == 0)
@@ -264,7 +261,6 @@ int main(int argc, char *argv[])
             cout << "Unknown ODE solver type: " << ode_solver_type << '\n';
          }
          delete mesh;
-         MPI_Finalize();
          return 3;
    }
 
@@ -434,8 +430,6 @@ int main(int argc, char *argv[])
    // 12. Free the used memory.
    delete ode_solver;
    delete pmesh;
-
-   MPI_Finalize();
 
    return 0;
 }

--- a/examples/ex10p.cpp
+++ b/examples/ex10p.cpp
@@ -167,7 +167,7 @@ int main(int argc, char *argv[])
    MPI_Init(&argc, &argv);
    MPI_Comm_size(MPI_COMM_WORLD, &num_procs);
    MPI_Comm_rank(MPI_COMM_WORLD, &myid);
-   HYPRE_Session hypre;
+   Hypre::Init();
 
    // 2. Parse command-line options.
    const char *mesh_file = "../data/beam-quad.mesh";

--- a/examples/ex11p.cpp
+++ b/examples/ex11p.cpp
@@ -58,10 +58,9 @@ using namespace mfem;
 int main(int argc, char *argv[])
 {
    // 1. Initialize MPI and HYPRE.
-   int num_procs, myid;
-   MPI_Init(&argc, &argv);
-   MPI_Comm_size(MPI_COMM_WORLD, &num_procs);
-   MPI_Comm_rank(MPI_COMM_WORLD, &myid);
+   Mpi::Init(argc, argv);
+   int num_procs = Mpi::WorldSize();
+   int myid = Mpi::WorldRank();
    Hypre::Init();
 
    // 2. Parse command-line options.
@@ -124,7 +123,6 @@ int main(int argc, char *argv[])
          {
             args.PrintUsage(cout);
          }
-         MPI_Finalize();
          return 1;
       }
    }
@@ -386,8 +384,6 @@ int main(int argc, char *argv[])
       delete fec;
    }
    delete pmesh;
-
-   MPI_Finalize();
 
    return 0;
 }

--- a/examples/ex11p.cpp
+++ b/examples/ex11p.cpp
@@ -57,11 +57,12 @@ using namespace mfem;
 
 int main(int argc, char *argv[])
 {
-   // 1. Initialize MPI.
+   // 1. Initialize MPI and HYPRE.
    int num_procs, myid;
    MPI_Init(&argc, &argv);
    MPI_Comm_size(MPI_COMM_WORLD, &num_procs);
    MPI_Comm_rank(MPI_COMM_WORLD, &myid);
+   HYPRE_Session hypre;
 
    // 2. Parse command-line options.
    const char *mesh_file = "../data/star.mesh";

--- a/examples/ex11p.cpp
+++ b/examples/ex11p.cpp
@@ -62,7 +62,7 @@ int main(int argc, char *argv[])
    MPI_Init(&argc, &argv);
    MPI_Comm_size(MPI_COMM_WORLD, &num_procs);
    MPI_Comm_rank(MPI_COMM_WORLD, &myid);
-   HYPRE_Session hypre;
+   Hypre::Init();
 
    // 2. Parse command-line options.
    const char *mesh_file = "../data/star.mesh";

--- a/examples/ex12p.cpp
+++ b/examples/ex12p.cpp
@@ -49,10 +49,9 @@ using namespace mfem;
 int main(int argc, char *argv[])
 {
    // 1. Initialize MPI and HYPRE.
-   int num_procs, myid;
-   MPI_Init(&argc, &argv);
-   MPI_Comm_size(MPI_COMM_WORLD, &num_procs);
-   MPI_Comm_rank(MPI_COMM_WORLD, &myid);
+   Mpi::Init(argc, argv);
+   int num_procs = Mpi::WorldSize();
+   int myid = Mpi::WorldRank();
    Hypre::Init();
 
    // 2. Parse command-line options.
@@ -90,7 +89,6 @@ int main(int argc, char *argv[])
       {
          args.PrintUsage(cout);
       }
-      MPI_Finalize();
       return 1;
    }
    if (myid == 0)
@@ -110,7 +108,6 @@ int main(int argc, char *argv[])
          cerr << "\nInput mesh should have at least two materials!"
               << " (See schematic in ex12p.cpp)\n"
               << endl;
-      MPI_Finalize();
       return 3;
    }
 
@@ -365,8 +362,6 @@ int main(int argc, char *argv[])
       delete fec;
    }
    delete pmesh;
-
-   MPI_Finalize();
 
    return 0;
 }

--- a/examples/ex12p.cpp
+++ b/examples/ex12p.cpp
@@ -53,7 +53,7 @@ int main(int argc, char *argv[])
    MPI_Init(&argc, &argv);
    MPI_Comm_size(MPI_COMM_WORLD, &num_procs);
    MPI_Comm_rank(MPI_COMM_WORLD, &myid);
-   HYPRE_Session hypre;
+   Hypre::Init();
 
    // 2. Parse command-line options.
    const char *mesh_file = "../data/beam-tri.mesh";

--- a/examples/ex12p.cpp
+++ b/examples/ex12p.cpp
@@ -48,11 +48,12 @@ using namespace mfem;
 
 int main(int argc, char *argv[])
 {
-   // 1. Initialize MPI.
+   // 1. Initialize MPI and HYPRE.
    int num_procs, myid;
    MPI_Init(&argc, &argv);
    MPI_Comm_size(MPI_COMM_WORLD, &num_procs);
    MPI_Comm_rank(MPI_COMM_WORLD, &myid);
+   HYPRE_Session hypre;
 
    // 2. Parse command-line options.
    const char *mesh_file = "../data/beam-tri.mesh";

--- a/examples/ex13p.cpp
+++ b/examples/ex13p.cpp
@@ -42,11 +42,12 @@ using namespace mfem;
 
 int main(int argc, char *argv[])
 {
-   // 1. Initialize MPI.
+   // 1. Initialize MPI and HYPRE.
    int num_procs, myid;
    MPI_Init(&argc, &argv);
    MPI_Comm_size(MPI_COMM_WORLD, &num_procs);
    MPI_Comm_rank(MPI_COMM_WORLD, &myid);
+   HYPRE_Session hypre;
 
    // 2. Parse command-line options.
    const char *mesh_file = "../data/beam-tet.mesh";

--- a/examples/ex13p.cpp
+++ b/examples/ex13p.cpp
@@ -43,10 +43,9 @@ using namespace mfem;
 int main(int argc, char *argv[])
 {
    // 1. Initialize MPI and HYPRE.
-   int num_procs, myid;
-   MPI_Init(&argc, &argv);
-   MPI_Comm_size(MPI_COMM_WORLD, &num_procs);
-   MPI_Comm_rank(MPI_COMM_WORLD, &myid);
+   Mpi::Init(argc, argv);
+   int num_procs = Mpi::WorldSize();
+   int myid = Mpi::WorldRank();
    Hypre::Init();
 
    // 2. Parse command-line options.
@@ -82,7 +81,6 @@ int main(int argc, char *argv[])
       {
          args.PrintUsage(cout);
       }
-      MPI_Finalize();
       return 1;
    }
    if (myid == 0)
@@ -270,8 +268,6 @@ int main(int argc, char *argv[])
    delete fespace;
    delete fec;
    delete pmesh;
-
-   MPI_Finalize();
 
    return 0;
 }

--- a/examples/ex13p.cpp
+++ b/examples/ex13p.cpp
@@ -47,7 +47,7 @@ int main(int argc, char *argv[])
    MPI_Init(&argc, &argv);
    MPI_Comm_size(MPI_COMM_WORLD, &num_procs);
    MPI_Comm_rank(MPI_COMM_WORLD, &myid);
-   HYPRE_Session hypre;
+   Hypre::Init();
 
    // 2. Parse command-line options.
    const char *mesh_file = "../data/beam-tet.mesh";

--- a/examples/ex14p.cpp
+++ b/examples/ex14p.cpp
@@ -70,11 +70,12 @@ private:
 
 int main(int argc, char *argv[])
 {
-   // 1. Initialize MPI.
+   // 1. Initialize MPI and HYPRE.
    int num_procs, myid;
    MPI_Init(&argc, &argv);
    MPI_Comm_size(MPI_COMM_WORLD, &num_procs);
    MPI_Comm_rank(MPI_COMM_WORLD, &myid);
+   HYPRE_Session hypre;
 
    // 2. Parse command-line options.
    const char *mesh_file = "../data/star.mesh";

--- a/examples/ex14p.cpp
+++ b/examples/ex14p.cpp
@@ -71,10 +71,9 @@ private:
 int main(int argc, char *argv[])
 {
    // 1. Initialize MPI and HYPRE.
-   int num_procs, myid;
-   MPI_Init(&argc, &argv);
-   MPI_Comm_size(MPI_COMM_WORLD, &num_procs);
-   MPI_Comm_rank(MPI_COMM_WORLD, &myid);
+   Mpi::Init(argc, argv);
+   int num_procs = Mpi::WorldSize();
+   int myid = Mpi::WorldRank();
    Hypre::Init();
 
    // 2. Parse command-line options.
@@ -114,7 +113,6 @@ int main(int argc, char *argv[])
       {
          args.PrintUsage(cout);
       }
-      MPI_Finalize();
       return 1;
    }
    if (kappa < 0)
@@ -282,8 +280,6 @@ int main(int argc, char *argv[])
    delete fespace;
    delete fec;
    delete pmesh;
-
-   MPI_Finalize();
 
    return 0;
 }

--- a/examples/ex14p.cpp
+++ b/examples/ex14p.cpp
@@ -75,7 +75,7 @@ int main(int argc, char *argv[])
    MPI_Init(&argc, &argv);
    MPI_Comm_size(MPI_COMM_WORLD, &num_procs);
    MPI_Comm_rank(MPI_COMM_WORLD, &myid);
-   HYPRE_Session hypre;
+   Hypre::Init();
 
    // 2. Parse command-line options.
    const char *mesh_file = "../data/star.mesh";

--- a/examples/ex15p.cpp
+++ b/examples/ex15p.cpp
@@ -79,11 +79,12 @@ void UpdateAndRebalance(ParMesh &pmesh, ParFiniteElementSpace &fespace,
 
 int main(int argc, char *argv[])
 {
-   // 1. Initialize MPI.
+   // 1. Initialize MPI and HYPRE.
    int num_procs, myid;
    MPI_Init(&argc, &argv);
    MPI_Comm_size(MPI_COMM_WORLD, &num_procs);
    MPI_Comm_rank(MPI_COMM_WORLD, &myid);
+   HYPRE_Session hypre;
 
    // 2. Parse command-line options.
    problem = 0;

--- a/examples/ex15p.cpp
+++ b/examples/ex15p.cpp
@@ -80,10 +80,9 @@ void UpdateAndRebalance(ParMesh &pmesh, ParFiniteElementSpace &fespace,
 int main(int argc, char *argv[])
 {
    // 1. Initialize MPI and HYPRE.
-   int num_procs, myid;
-   MPI_Init(&argc, &argv);
-   MPI_Comm_size(MPI_COMM_WORLD, &num_procs);
-   MPI_Comm_rank(MPI_COMM_WORLD, &myid);
+   Mpi::Init(argc, argv);
+   int num_procs = Mpi::WorldSize();
+   int myid = Mpi::WorldRank();
    Hypre::Init();
 
    // 2. Parse command-line options.
@@ -135,7 +134,6 @@ int main(int argc, char *argv[])
       {
          args.PrintUsage(cout);
       }
-      MPI_Finalize();
       return 1;
    }
    if (myid == 0)
@@ -391,7 +389,6 @@ int main(int argc, char *argv[])
    delete estimator;
 
    // 25. Exit
-   MPI_Finalize();
    return 0;
 }
 

--- a/examples/ex15p.cpp
+++ b/examples/ex15p.cpp
@@ -84,7 +84,7 @@ int main(int argc, char *argv[])
    MPI_Init(&argc, &argv);
    MPI_Comm_size(MPI_COMM_WORLD, &num_procs);
    MPI_Comm_rank(MPI_COMM_WORLD, &myid);
-   HYPRE_Session hypre;
+   Hypre::Init();
 
    // 2. Parse command-line options.
    problem = 0;

--- a/examples/ex16p.cpp
+++ b/examples/ex16p.cpp
@@ -93,11 +93,12 @@ double InitialTemperature(const Vector &x);
 
 int main(int argc, char *argv[])
 {
-   // 1. Initialize MPI.
+   // 1. Initialize MPI and HYPRE.
    int num_procs, myid;
    MPI_Init(&argc, &argv);
    MPI_Comm_size(MPI_COMM_WORLD, &num_procs);
    MPI_Comm_rank(MPI_COMM_WORLD, &myid);
+   HYPRE_Session hypre;
 
    // 2. Parse command-line options.
    const char *mesh_file = "../data/star.mesh";

--- a/examples/ex16p.cpp
+++ b/examples/ex16p.cpp
@@ -94,10 +94,9 @@ double InitialTemperature(const Vector &x);
 int main(int argc, char *argv[])
 {
    // 1. Initialize MPI and HYPRE.
-   int num_procs, myid;
-   MPI_Init(&argc, &argv);
-   MPI_Comm_size(MPI_COMM_WORLD, &num_procs);
-   MPI_Comm_rank(MPI_COMM_WORLD, &myid);
+   Mpi::Init(argc, argv);
+   int num_procs = Mpi::WorldSize();
+   int myid = Mpi::WorldRank();
    Hypre::Init();
 
    // 2. Parse command-line options.
@@ -153,7 +152,6 @@ int main(int argc, char *argv[])
    if (!args.Good())
    {
       args.PrintUsage(cout);
-      MPI_Finalize();
       return 1;
    }
 
@@ -380,8 +378,6 @@ int main(int argc, char *argv[])
    // 12. Free the used memory.
    delete ode_solver;
    delete pmesh;
-
-   MPI_Finalize();
 
    return 0;
 }

--- a/examples/ex16p.cpp
+++ b/examples/ex16p.cpp
@@ -98,7 +98,7 @@ int main(int argc, char *argv[])
    MPI_Init(&argc, &argv);
    MPI_Comm_size(MPI_COMM_WORLD, &num_procs);
    MPI_Comm_rank(MPI_COMM_WORLD, &myid);
-   HYPRE_Session hypre;
+   Hypre::Init();
 
    // 2. Parse command-line options.
    const char *mesh_file = "../data/star.mesh";

--- a/examples/ex17p.cpp
+++ b/examples/ex17p.cpp
@@ -308,10 +308,8 @@ int main(int argc, char *argv[])
       x.Neg(); // x = -x
 
       ostringstream mesh_name, sol_name;
-      mesh_name << "mesh." << setfill('0')
-                << setw(6) << Mpi::WorldRank();
-      sol_name << "sol." << setfill('0')
-               << setw(6) << Mpi::WorldRank();
+      mesh_name << "mesh." << setfill('0') << setw(6) << Mpi::WorldRank();
+      sol_name << "sol." << setfill('0') << setw(6) << Mpi::WorldRank();
 
       ofstream mesh_ofs(mesh_name.str().c_str());
       mesh_ofs.precision(8);

--- a/examples/ex17p.cpp
+++ b/examples/ex17p.cpp
@@ -101,6 +101,7 @@ ostream &operator<<(ostream &v, void (*f)(VisMan&));
 int main(int argc, char *argv[])
 {
    MPI_Session mpi(argc, argv);
+   HYPRE_Session hypre;
 
    // 1. Define and parse command-line options.
    const char *mesh_file = "../data/beam-tri.mesh";

--- a/examples/ex17p.cpp
+++ b/examples/ex17p.cpp
@@ -100,7 +100,7 @@ ostream &operator<<(ostream &v, void (*f)(VisMan&));
 
 int main(int argc, char *argv[])
 {
-   MPI_Session mpi(argc, argv);
+   MPI::Init(argc, argv);
    Hypre::Init();
 
    // 1. Define and parse command-line options.
@@ -140,14 +140,14 @@ int main(int argc, char *argv[])
    args.Parse();
    if (!args.Good())
    {
-      if (mpi.Root()) { args.PrintUsage(cout); }
+      if (MPI::Session().Root()) { args.PrintUsage(cout); }
       return 1;
    }
    if (kappa < 0)
    {
       kappa = (order+1)*(order+1);
    }
-   if (mpi.Root()) { args.PrintOptions(cout); }
+   if (MPI::Session().Root()) { args.PrintOptions(cout); }
 
    // 2. Read the mesh from the given mesh file.
    Mesh mesh(mesh_file, 1, 1);
@@ -155,7 +155,7 @@ int main(int argc, char *argv[])
 
    if (mesh.attributes.Max() < 2 || mesh.bdr_attributes.Max() < 2)
    {
-      if (mpi.Root())
+      if (MPI::Session().Root())
       {
          cerr << "\nInput mesh should have at least two materials and "
               << "two boundary attributes! (See schematic in ex17p.cpp)\n"
@@ -192,7 +192,7 @@ int main(int argc, char *argv[])
    ParFiniteElementSpace fespace(&pmesh, &fec, dim, Ordering::byVDIM);
 
    HYPRE_BigInt glob_size = fespace.GlobalTrueVSize();
-   if (mpi.Root())
+   if (MPI::Session().Root())
    {
       cout << "Number of finite element unknowns: " << glob_size
            << "\nAssembling: " << flush;
@@ -236,7 +236,7 @@ int main(int argc, char *argv[])
    //    VectorFunctionCoefficient 'x_init' which in turn is based on the
    //    function 'InitDisplacement'.
    ParLinearForm b(&fespace);
-   if (mpi.Root()) { cout << "r.h.s. ... " << flush; }
+   if (MPI::Session().Root()) { cout << "r.h.s. ... " << flush; }
    b.AddBdrFaceIntegrator(
       new DGElasticityDirichletLFIntegrator(
          init_x, lambda_c, mu_c, alpha, kappa), dir_bdr);
@@ -257,13 +257,13 @@ int main(int argc, char *argv[])
       new DGElasticityIntegrator(lambda_c, mu_c, alpha, kappa), dir_bdr);
 
    // 10. Assemble the bilinear form and the corresponding linear system.
-   if (mpi.Root()) { cout << "matrix ... " << flush; }
+   if (MPI::Session().Root()) { cout << "matrix ... " << flush; }
    a.Assemble();
 
    HypreParMatrix A;
    Vector B, X;
    a.FormLinearSystem(ess_tdof_list, x, b, A, X, B);
-   if (mpi.Root()) { cout << "done." << endl; }
+   if (MPI::Session().Root()) { cout << "done." << endl; }
 
    // 11. Define a simple symmetric Gauss-Seidel preconditioner and use it to
    //     solve the system Ax=b with PCG for the symmetric formulation, or GMRES
@@ -308,8 +308,10 @@ int main(int argc, char *argv[])
       x.Neg(); // x = -x
 
       ostringstream mesh_name, sol_name;
-      mesh_name << "mesh." << setfill('0') << setw(6) << mpi.WorldRank();
-      sol_name << "sol." << setfill('0') << setw(6) << mpi.WorldRank();
+      mesh_name << "mesh." << setfill('0')
+                << setw(6) << MPI::Session().WorldRank();
+      sol_name << "sol." << setfill('0')
+               << setw(6) << MPI::Session().WorldRank();
 
       ofstream mesh_ofs(mesh_name.str().c_str());
       mesh_ofs.precision(8);

--- a/examples/ex17p.cpp
+++ b/examples/ex17p.cpp
@@ -140,14 +140,14 @@ int main(int argc, char *argv[])
    args.Parse();
    if (!args.Good())
    {
-      if (Mpi::Session().Root()) { args.PrintUsage(cout); }
+      if (Mpi::Root()) { args.PrintUsage(cout); }
       return 1;
    }
    if (kappa < 0)
    {
       kappa = (order+1)*(order+1);
    }
-   if (Mpi::Session().Root()) { args.PrintOptions(cout); }
+   if (Mpi::Root()) { args.PrintOptions(cout); }
 
    // 2. Read the mesh from the given mesh file.
    Mesh mesh(mesh_file, 1, 1);
@@ -155,7 +155,7 @@ int main(int argc, char *argv[])
 
    if (mesh.attributes.Max() < 2 || mesh.bdr_attributes.Max() < 2)
    {
-      if (Mpi::Session().Root())
+      if (Mpi::Root())
       {
          cerr << "\nInput mesh should have at least two materials and "
               << "two boundary attributes! (See schematic in ex17p.cpp)\n"
@@ -192,7 +192,7 @@ int main(int argc, char *argv[])
    ParFiniteElementSpace fespace(&pmesh, &fec, dim, Ordering::byVDIM);
 
    HYPRE_BigInt glob_size = fespace.GlobalTrueVSize();
-   if (Mpi::Session().Root())
+   if (Mpi::Root())
    {
       cout << "Number of finite element unknowns: " << glob_size
            << "\nAssembling: " << flush;
@@ -236,7 +236,7 @@ int main(int argc, char *argv[])
    //    VectorFunctionCoefficient 'x_init' which in turn is based on the
    //    function 'InitDisplacement'.
    ParLinearForm b(&fespace);
-   if (Mpi::Session().Root()) { cout << "r.h.s. ... " << flush; }
+   if (Mpi::Root()) { cout << "r.h.s. ... " << flush; }
    b.AddBdrFaceIntegrator(
       new DGElasticityDirichletLFIntegrator(
          init_x, lambda_c, mu_c, alpha, kappa), dir_bdr);
@@ -257,13 +257,13 @@ int main(int argc, char *argv[])
       new DGElasticityIntegrator(lambda_c, mu_c, alpha, kappa), dir_bdr);
 
    // 10. Assemble the bilinear form and the corresponding linear system.
-   if (Mpi::Session().Root()) { cout << "matrix ... " << flush; }
+   if (Mpi::Root()) { cout << "matrix ... " << flush; }
    a.Assemble();
 
    HypreParMatrix A;
    Vector B, X;
    a.FormLinearSystem(ess_tdof_list, x, b, A, X, B);
-   if (Mpi::Session().Root()) { cout << "done." << endl; }
+   if (Mpi::Root()) { cout << "done." << endl; }
 
    // 11. Define a simple symmetric Gauss-Seidel preconditioner and use it to
    //     solve the system Ax=b with PCG for the symmetric formulation, or GMRES
@@ -309,9 +309,9 @@ int main(int argc, char *argv[])
 
       ostringstream mesh_name, sol_name;
       mesh_name << "mesh." << setfill('0')
-                << setw(6) << Mpi::Session().WorldRank();
+                << setw(6) << Mpi::WorldRank();
       sol_name << "sol." << setfill('0')
-               << setw(6) << Mpi::Session().WorldRank();
+               << setw(6) << Mpi::WorldRank();
 
       ofstream mesh_ofs(mesh_name.str().c_str());
       mesh_ofs.precision(8);

--- a/examples/ex17p.cpp
+++ b/examples/ex17p.cpp
@@ -100,7 +100,7 @@ ostream &operator<<(ostream &v, void (*f)(VisMan&));
 
 int main(int argc, char *argv[])
 {
-   MPI::Init(argc, argv);
+   Mpi::Init(argc, argv);
    Hypre::Init();
 
    // 1. Define and parse command-line options.
@@ -140,14 +140,14 @@ int main(int argc, char *argv[])
    args.Parse();
    if (!args.Good())
    {
-      if (MPI::Session().Root()) { args.PrintUsage(cout); }
+      if (Mpi::Session().Root()) { args.PrintUsage(cout); }
       return 1;
    }
    if (kappa < 0)
    {
       kappa = (order+1)*(order+1);
    }
-   if (MPI::Session().Root()) { args.PrintOptions(cout); }
+   if (Mpi::Session().Root()) { args.PrintOptions(cout); }
 
    // 2. Read the mesh from the given mesh file.
    Mesh mesh(mesh_file, 1, 1);
@@ -155,7 +155,7 @@ int main(int argc, char *argv[])
 
    if (mesh.attributes.Max() < 2 || mesh.bdr_attributes.Max() < 2)
    {
-      if (MPI::Session().Root())
+      if (Mpi::Session().Root())
       {
          cerr << "\nInput mesh should have at least two materials and "
               << "two boundary attributes! (See schematic in ex17p.cpp)\n"
@@ -192,7 +192,7 @@ int main(int argc, char *argv[])
    ParFiniteElementSpace fespace(&pmesh, &fec, dim, Ordering::byVDIM);
 
    HYPRE_BigInt glob_size = fespace.GlobalTrueVSize();
-   if (MPI::Session().Root())
+   if (Mpi::Session().Root())
    {
       cout << "Number of finite element unknowns: " << glob_size
            << "\nAssembling: " << flush;
@@ -236,7 +236,7 @@ int main(int argc, char *argv[])
    //    VectorFunctionCoefficient 'x_init' which in turn is based on the
    //    function 'InitDisplacement'.
    ParLinearForm b(&fespace);
-   if (MPI::Session().Root()) { cout << "r.h.s. ... " << flush; }
+   if (Mpi::Session().Root()) { cout << "r.h.s. ... " << flush; }
    b.AddBdrFaceIntegrator(
       new DGElasticityDirichletLFIntegrator(
          init_x, lambda_c, mu_c, alpha, kappa), dir_bdr);
@@ -257,13 +257,13 @@ int main(int argc, char *argv[])
       new DGElasticityIntegrator(lambda_c, mu_c, alpha, kappa), dir_bdr);
 
    // 10. Assemble the bilinear form and the corresponding linear system.
-   if (MPI::Session().Root()) { cout << "matrix ... " << flush; }
+   if (Mpi::Session().Root()) { cout << "matrix ... " << flush; }
    a.Assemble();
 
    HypreParMatrix A;
    Vector B, X;
    a.FormLinearSystem(ess_tdof_list, x, b, A, X, B);
-   if (MPI::Session().Root()) { cout << "done." << endl; }
+   if (Mpi::Session().Root()) { cout << "done." << endl; }
 
    // 11. Define a simple symmetric Gauss-Seidel preconditioner and use it to
    //     solve the system Ax=b with PCG for the symmetric formulation, or GMRES
@@ -309,9 +309,9 @@ int main(int argc, char *argv[])
 
       ostringstream mesh_name, sol_name;
       mesh_name << "mesh." << setfill('0')
-                << setw(6) << MPI::Session().WorldRank();
+                << setw(6) << Mpi::Session().WorldRank();
       sol_name << "sol." << setfill('0')
-               << setw(6) << MPI::Session().WorldRank();
+               << setw(6) << Mpi::Session().WorldRank();
 
       ofstream mesh_ofs(mesh_name.str().c_str());
       mesh_ofs.precision(8);

--- a/examples/ex17p.cpp
+++ b/examples/ex17p.cpp
@@ -101,7 +101,7 @@ ostream &operator<<(ostream &v, void (*f)(VisMan&));
 int main(int argc, char *argv[])
 {
    MPI_Session mpi(argc, argv);
-   HYPRE_Session hypre;
+   Hypre::Init();
 
    // 1. Define and parse command-line options.
    const char *mesh_file = "../data/beam-tri.mesh";

--- a/examples/ex18p.cpp
+++ b/examples/ex18p.cpp
@@ -111,10 +111,10 @@ int main(int argc, char *argv[])
    args.Parse();
    if (!args.Good())
    {
-      if (Mpi::Session().Root()) { args.PrintUsage(cout); }
+      if (Mpi::Root()) { args.PrintUsage(cout); }
       return 1;
    }
-   if (Mpi::Session().Root()) { args.PrintOptions(cout); }
+   if (Mpi::Root()) { args.PrintOptions(cout); }
 
    // 3. Read the mesh from the given mesh file. This example requires a 2D
    //    periodic mesh, such as ../data/periodic-square.mesh.
@@ -134,7 +134,7 @@ int main(int argc, char *argv[])
       case 4: ode_solver = new RK4Solver; break;
       case 6: ode_solver = new RK6Solver; break;
       default:
-         if (Mpi::Session().Root())
+         if (Mpi::Root())
          {
             cout << "Unknown ODE solver type: " << ode_solver_type << '\n';
          }
@@ -173,7 +173,7 @@ int main(int argc, char *argv[])
    MFEM_ASSERT(fes.GetOrdering() == Ordering::byNODES, "");
 
    HYPRE_BigInt glob_size = vfes.GlobalTrueVSize();
-   if (Mpi::Session().Root())
+   if (Mpi::Root())
    {
       cout << "Number of unknowns: " << glob_size << endl;
    }
@@ -199,7 +199,7 @@ int main(int argc, char *argv[])
    {
       ostringstream mesh_name;
       mesh_name << "vortex-mesh." << setfill('0')
-                << setw(6) << Mpi::Session().WorldRank();
+                << setw(6) << Mpi::WorldRank();
       ofstream mesh_ofs(mesh_name.str().c_str());
       mesh_ofs.precision(precision);
       mesh_ofs << pmesh;
@@ -210,7 +210,7 @@ int main(int argc, char *argv[])
          ostringstream sol_name;
          sol_name << "vortex-" << k << "-init."
                   << setfill('0') << setw(6)
-                  << Mpi::Session().WorldRank();
+                  << Mpi::WorldRank();
          ofstream sol_ofs(sol_name.str().c_str());
          sol_ofs.precision(precision);
          sol_ofs << uk;
@@ -243,26 +243,26 @@ int main(int argc, char *argv[])
       sout.open(vishost, visport);
       if (!sout)
       {
-         if (Mpi::Session().Root())
+         if (Mpi::Root())
          {
             cout << "Unable to connect to GLVis server at "
                  << vishost << ':' << visport << endl;
          }
          visualization = false;
-         if (Mpi::Session().Root())
+         if (Mpi::Root())
          {
             cout << "GLVis visualization disabled.\n";
          }
       }
       else
       {
-         sout << "parallel " << Mpi::Session().WorldSize()
-              << " " << Mpi::Session().WorldRank() << "\n";
+         sout << "parallel " << Mpi::WorldSize()
+              << " " << Mpi::WorldRank() << "\n";
          sout.precision(precision);
          sout << "solution\n" << pmesh << mom;
          sout << "pause\n";
          sout << flush;
-         if (Mpi::Session().Root())
+         if (Mpi::Root())
          {
             cout << "GLVis visualization paused."
                  << " Press space (in the GLVis window) to resume it.\n";
@@ -331,22 +331,22 @@ int main(int argc, char *argv[])
       done = (t >= t_final - 1e-8*dt);
       if (done || ti % vis_steps == 0)
       {
-         if (Mpi::Session().Root())
+         if (Mpi::Root())
          {
             cout << "time step: " << ti << ", time: " << t << endl;
          }
          if (visualization)
          {
             MPI_Barrier(pmesh.GetComm());
-            sout << "parallel " << Mpi::Session().WorldSize()
-                 << " " << Mpi::Session().WorldRank() << "\n";
+            sout << "parallel " << Mpi::WorldSize()
+                 << " " << Mpi::WorldRank() << "\n";
             sout << "solution\n" << pmesh << mom << flush;
          }
       }
    }
 
    tic_toc.Stop();
-   if (Mpi::Session().Root())
+   if (Mpi::Root())
    {
       cout << " done, " << tic_toc.RealTime() << "s." << endl;
    }
@@ -358,7 +358,7 @@ int main(int argc, char *argv[])
       ParGridFunction uk(&fes, u_block.GetBlock(k));
       ostringstream sol_name;
       sol_name << "vortex-" << k << "-final."
-               << setfill('0') << setw(6) << Mpi::Session().WorldRank();
+               << setfill('0') << setw(6) << Mpi::WorldRank();
       ofstream sol_ofs(sol_name.str().c_str());
       sol_ofs.precision(precision);
       sol_ofs << uk;
@@ -368,7 +368,7 @@ int main(int argc, char *argv[])
    if (t_final == 2.0)
    {
       const double error = sol.ComputeLpError(2, u0);
-      if (Mpi::Session().Root())
+      if (Mpi::Root())
       {
          cout << "Solution error: " << error << endl;
       }

--- a/examples/ex18p.cpp
+++ b/examples/ex18p.cpp
@@ -60,8 +60,9 @@ double max_char_speed;
 
 int main(int argc, char *argv[])
 {
-   // 1. Initialize MPI.
+   // 1. Initialize MPI and HYPRE.
    MPI_Session mpi(argc, argv);
+   HYPRE_Session hypre;
 
    // 2. Parse command-line options.
    problem = 1;

--- a/examples/ex18p.cpp
+++ b/examples/ex18p.cpp
@@ -209,8 +209,7 @@ int main(int argc, char *argv[])
          ParGridFunction uk(&fes, u_block.GetBlock(k));
          ostringstream sol_name;
          sol_name << "vortex-" << k << "-init."
-                  << setfill('0') << setw(6)
-                  << Mpi::WorldRank();
+                  << setfill('0') << setw(6) << Mpi::WorldRank();
          ofstream sol_ofs(sol_name.str().c_str());
          sol_ofs.precision(precision);
          sol_ofs << uk;

--- a/examples/ex18p.cpp
+++ b/examples/ex18p.cpp
@@ -62,7 +62,7 @@ int main(int argc, char *argv[])
 {
    // 1. Initialize MPI and HYPRE.
    MPI_Session mpi(argc, argv);
-   HYPRE_Session hypre;
+   Hypre::Init();
 
    // 2. Parse command-line options.
    problem = 1;

--- a/examples/ex18p.cpp
+++ b/examples/ex18p.cpp
@@ -61,7 +61,7 @@ double max_char_speed;
 int main(int argc, char *argv[])
 {
    // 1. Initialize MPI and HYPRE.
-   MPI::Init(argc, argv);
+   Mpi::Init(argc, argv);
    Hypre::Init();
 
    // 2. Parse command-line options.
@@ -111,10 +111,10 @@ int main(int argc, char *argv[])
    args.Parse();
    if (!args.Good())
    {
-      if (MPI::Session().Root()) { args.PrintUsage(cout); }
+      if (Mpi::Session().Root()) { args.PrintUsage(cout); }
       return 1;
    }
-   if (MPI::Session().Root()) { args.PrintOptions(cout); }
+   if (Mpi::Session().Root()) { args.PrintOptions(cout); }
 
    // 3. Read the mesh from the given mesh file. This example requires a 2D
    //    periodic mesh, such as ../data/periodic-square.mesh.
@@ -134,7 +134,7 @@ int main(int argc, char *argv[])
       case 4: ode_solver = new RK4Solver; break;
       case 6: ode_solver = new RK6Solver; break;
       default:
-         if (MPI::Session().Root())
+         if (Mpi::Session().Root())
          {
             cout << "Unknown ODE solver type: " << ode_solver_type << '\n';
          }
@@ -173,7 +173,7 @@ int main(int argc, char *argv[])
    MFEM_ASSERT(fes.GetOrdering() == Ordering::byNODES, "");
 
    HYPRE_BigInt glob_size = vfes.GlobalTrueVSize();
-   if (MPI::Session().Root())
+   if (Mpi::Session().Root())
    {
       cout << "Number of unknowns: " << glob_size << endl;
    }
@@ -199,7 +199,7 @@ int main(int argc, char *argv[])
    {
       ostringstream mesh_name;
       mesh_name << "vortex-mesh." << setfill('0')
-                << setw(6) << MPI::Session().WorldRank();
+                << setw(6) << Mpi::Session().WorldRank();
       ofstream mesh_ofs(mesh_name.str().c_str());
       mesh_ofs.precision(precision);
       mesh_ofs << pmesh;
@@ -210,7 +210,7 @@ int main(int argc, char *argv[])
          ostringstream sol_name;
          sol_name << "vortex-" << k << "-init."
                   << setfill('0') << setw(6)
-                  << MPI::Session().WorldRank();
+                  << Mpi::Session().WorldRank();
          ofstream sol_ofs(sol_name.str().c_str());
          sol_ofs.precision(precision);
          sol_ofs << uk;
@@ -243,26 +243,26 @@ int main(int argc, char *argv[])
       sout.open(vishost, visport);
       if (!sout)
       {
-         if (MPI::Session().Root())
+         if (Mpi::Session().Root())
          {
             cout << "Unable to connect to GLVis server at "
                  << vishost << ':' << visport << endl;
          }
          visualization = false;
-         if (MPI::Session().Root())
+         if (Mpi::Session().Root())
          {
             cout << "GLVis visualization disabled.\n";
          }
       }
       else
       {
-         sout << "parallel " << MPI::Session().WorldSize()
-              << " " << MPI::Session().WorldRank() << "\n";
+         sout << "parallel " << Mpi::Session().WorldSize()
+              << " " << Mpi::Session().WorldRank() << "\n";
          sout.precision(precision);
          sout << "solution\n" << pmesh << mom;
          sout << "pause\n";
          sout << flush;
-         if (MPI::Session().Root())
+         if (Mpi::Session().Root())
          {
             cout << "GLVis visualization paused."
                  << " Press space (in the GLVis window) to resume it.\n";
@@ -331,22 +331,22 @@ int main(int argc, char *argv[])
       done = (t >= t_final - 1e-8*dt);
       if (done || ti % vis_steps == 0)
       {
-         if (MPI::Session().Root())
+         if (Mpi::Session().Root())
          {
             cout << "time step: " << ti << ", time: " << t << endl;
          }
          if (visualization)
          {
             MPI_Barrier(pmesh.GetComm());
-            sout << "parallel " << MPI::Session().WorldSize()
-                 << " " << MPI::Session().WorldRank() << "\n";
+            sout << "parallel " << Mpi::Session().WorldSize()
+                 << " " << Mpi::Session().WorldRank() << "\n";
             sout << "solution\n" << pmesh << mom << flush;
          }
       }
    }
 
    tic_toc.Stop();
-   if (MPI::Session().Root())
+   if (Mpi::Session().Root())
    {
       cout << " done, " << tic_toc.RealTime() << "s." << endl;
    }
@@ -358,7 +358,7 @@ int main(int argc, char *argv[])
       ParGridFunction uk(&fes, u_block.GetBlock(k));
       ostringstream sol_name;
       sol_name << "vortex-" << k << "-final."
-               << setfill('0') << setw(6) << MPI::Session().WorldRank();
+               << setfill('0') << setw(6) << Mpi::Session().WorldRank();
       ofstream sol_ofs(sol_name.str().c_str());
       sol_ofs.precision(precision);
       sol_ofs << uk;
@@ -368,7 +368,7 @@ int main(int argc, char *argv[])
    if (t_final == 2.0)
    {
       const double error = sol.ComputeLpError(2, u0);
-      if (MPI::Session().Root())
+      if (Mpi::Session().Root())
       {
          cout << "Solution error: " << error << endl;
       }

--- a/examples/ex19p.cpp
+++ b/examples/ex19p.cpp
@@ -203,9 +203,10 @@ int main(int argc, char *argv[])
    return 242;
 #endif
 
-   // 1. Initialize MPI
+   // 1. Initialize MPI and HYPRE.
    MPI_Session mpi;
    const int myid = mpi.WorldRank();
+   HYPRE_Session hypre;
 
    // 2. Parse command-line options
    const char *mesh_file = "../data/beam-tet.mesh";

--- a/examples/ex19p.cpp
+++ b/examples/ex19p.cpp
@@ -206,7 +206,7 @@ int main(int argc, char *argv[])
    // 1. Initialize MPI and HYPRE.
    MPI_Session mpi;
    const int myid = mpi.WorldRank();
-   HYPRE_Session hypre;
+   Hypre::Init();
 
    // 2. Parse command-line options
    const char *mesh_file = "../data/beam-tet.mesh";

--- a/examples/ex19p.cpp
+++ b/examples/ex19p.cpp
@@ -205,7 +205,7 @@ int main(int argc, char *argv[])
 
    // 1. Initialize MPI and HYPRE.
    Mpi::Init();
-   const int myid = Mpi::Session().WorldRank();
+   const int myid = Mpi::WorldRank();
    Hypre::Init();
 
    // 2. Parse command-line options

--- a/examples/ex19p.cpp
+++ b/examples/ex19p.cpp
@@ -204,8 +204,8 @@ int main(int argc, char *argv[])
 #endif
 
    // 1. Initialize MPI and HYPRE.
-   MPI::Init();
-   const int myid = MPI::Session().WorldRank();
+   Mpi::Init();
+   const int myid = Mpi::Session().WorldRank();
    Hypre::Init();
 
    // 2. Parse command-line options

--- a/examples/ex19p.cpp
+++ b/examples/ex19p.cpp
@@ -204,8 +204,8 @@ int main(int argc, char *argv[])
 #endif
 
    // 1. Initialize MPI and HYPRE.
-   MPI_Session mpi;
-   const int myid = mpi.WorldRank();
+   MPI::Init();
+   const int myid = MPI::Session().WorldRank();
    Hypre::Init();
 
    // 2. Parse command-line options

--- a/examples/ex1p.cpp
+++ b/examples/ex1p.cpp
@@ -65,8 +65,8 @@ int main(int argc, char *argv[])
 {
    // 1. Initialize MPI and HYPRE.
    Mpi::Init();
-   int num_procs = Mpi::Session().WorldSize();
-   int myid = Mpi::Session().WorldRank();
+   int num_procs = Mpi::WorldSize();
+   int myid = Mpi::WorldRank();
    Hypre::Init();
 
    // 2. Parse command-line options.

--- a/examples/ex1p.cpp
+++ b/examples/ex1p.cpp
@@ -65,6 +65,7 @@ int main(int argc, char *argv[])
 {
    // 1. Initialize MPI and HYPRE.
    Mpi::Init();
+   int num_procs = Mpi::WorldSize();
    int myid = Mpi::WorldRank();
    Hypre::Init();
 

--- a/examples/ex1p.cpp
+++ b/examples/ex1p.cpp
@@ -64,9 +64,9 @@ using namespace mfem;
 int main(int argc, char *argv[])
 {
    // 1. Initialize MPI and HYPRE.
-   MPI::Init();
-   int num_procs = MPI::Session().WorldSize();
-   int myid = MPI::Session().WorldRank();
+   Mpi::Init();
+   int num_procs = Mpi::Session().WorldSize();
+   int myid = Mpi::Session().WorldRank();
    Hypre::Init();
 
    // 2. Parse command-line options.

--- a/examples/ex1p.cpp
+++ b/examples/ex1p.cpp
@@ -64,9 +64,9 @@ using namespace mfem;
 int main(int argc, char *argv[])
 {
    // 1. Initialize MPI and HYPRE.
-   MPI_Session mpi;
-   int num_procs = mpi.WorldSize();
-   int myid = mpi.WorldRank();
+   MPI::Init();
+   int num_procs = MPI::Session().WorldSize();
+   int myid = MPI::Session().WorldRank();
    Hypre::Init();
 
    // 2. Parse command-line options.

--- a/examples/ex1p.cpp
+++ b/examples/ex1p.cpp
@@ -65,7 +65,6 @@ int main(int argc, char *argv[])
 {
    // 1. Initialize MPI and HYPRE.
    Mpi::Init();
-   int num_procs = Mpi::WorldSize();
    int myid = Mpi::WorldRank();
    Hypre::Init();
 

--- a/examples/ex1p.cpp
+++ b/examples/ex1p.cpp
@@ -67,7 +67,7 @@ int main(int argc, char *argv[])
    MPI_Session mpi;
    int num_procs = mpi.WorldSize();
    int myid = mpi.WorldRank();
-   HYPRE_Session hypre;
+   Hypre::Init();
 
    // 2. Parse command-line options.
    const char *mesh_file = "../data/star.mesh";

--- a/examples/ex1p.cpp
+++ b/examples/ex1p.cpp
@@ -63,10 +63,11 @@ using namespace mfem;
 
 int main(int argc, char *argv[])
 {
-   // 1. Initialize MPI.
+   // 1. Initialize MPI and HYPRE.
    MPI_Session mpi;
    int num_procs = mpi.WorldSize();
    int myid = mpi.WorldRank();
+   HYPRE_Session hypre;
 
    // 2. Parse command-line options.
    const char *mesh_file = "../data/star.mesh";

--- a/examples/ex20p.cpp
+++ b/examples/ex20p.cpp
@@ -102,7 +102,7 @@ int main(int argc, char *argv[])
    MPI_Init(&argc, &argv);
    MPI_Comm_size(comm, &num_procs);
    MPI_Comm_rank(comm, &myid);
-   HYPRE_Session hypre;
+   Hypre::Init();
 
    // 2. Parse command-line options.
    int order  = 1;

--- a/examples/ex20p.cpp
+++ b/examples/ex20p.cpp
@@ -96,12 +96,13 @@ public:
 
 int main(int argc, char *argv[])
 {
-   // 1. Initialize MPI.
+   // 1. Initialize MPI and HYPRE.
    int num_procs, myid;
    MPI_Comm comm = MPI_COMM_WORLD;
    MPI_Init(&argc, &argv);
    MPI_Comm_size(comm, &num_procs);
    MPI_Comm_rank(comm, &myid);
+   HYPRE_Session hypre;
 
    // 2. Parse command-line options.
    int order  = 1;

--- a/examples/ex20p.cpp
+++ b/examples/ex20p.cpp
@@ -97,12 +97,11 @@ public:
 int main(int argc, char *argv[])
 {
    // 1. Initialize MPI and HYPRE.
-   int num_procs, myid;
-   MPI_Comm comm = MPI_COMM_WORLD;
-   MPI_Init(&argc, &argv);
-   MPI_Comm_size(comm, &num_procs);
-   MPI_Comm_rank(comm, &myid);
+   Mpi::Init(argc, argv);
    Hypre::Init();
+   int num_procs = Mpi::WorldSize();
+   int myid = Mpi::WorldRank();
+   MPI_Comm comm = MPI_COMM_WORLD;
 
    // 2. Parse command-line options.
    int order  = 1;
@@ -141,7 +140,6 @@ int main(int argc, char *argv[])
       {
          args.PrintUsage(cout);
       }
-      MPI_Finalize();
       return 1;
    }
    if (myid == 0)
@@ -318,8 +316,6 @@ int main(int argc, char *argv[])
            << "window_title 'Energy in Phase Space'\n"
            << "keys\n maac\n" << "axis_labels 'q' 'p' 't'\n"<< flush;
    }
-
-   MPI_Finalize();
 }
 
 double hamiltonian(double q, double p, double t)

--- a/examples/ex21p.cpp
+++ b/examples/ex21p.cpp
@@ -37,11 +37,12 @@ using namespace mfem;
 
 int main(int argc, char *argv[])
 {
-   // 0. Initialize MPI.
+   // 0. Initialize MPI and HYPRE.
    int num_procs, myid;
    MPI_Init(&argc, &argv);
    MPI_Comm_size(MPI_COMM_WORLD, &num_procs);
    MPI_Comm_rank(MPI_COMM_WORLD, &myid);
+   HYPRE_Session hypre;
 
    // 1. Parse command-line options.
    const char *mesh_file = "../data/beam-tri.mesh";

--- a/examples/ex21p.cpp
+++ b/examples/ex21p.cpp
@@ -38,10 +38,9 @@ using namespace mfem;
 int main(int argc, char *argv[])
 {
    // 0. Initialize MPI and HYPRE.
-   int num_procs, myid;
-   MPI_Init(&argc, &argv);
-   MPI_Comm_size(MPI_COMM_WORLD, &num_procs);
-   MPI_Comm_rank(MPI_COMM_WORLD, &myid);
+   Mpi::Init(argc, argv);
+   int num_procs = Mpi::WorldSize();
+   int myid = Mpi::WorldRank();
    Hypre::Init();
 
    // 1. Parse command-line options.
@@ -71,7 +70,6 @@ int main(int argc, char *argv[])
       {
          args.PrintUsage(cout);
       }
-      MPI_Finalize();
       return 1;
    }
    if (myid == 0)
@@ -90,7 +88,6 @@ int main(int argc, char *argv[])
       cerr << "\nInput mesh should have at least two materials and "
            << "two boundary attributes! (See schematic in ex2.cpp)\n"
            << endl;
-      MPI_Finalize();
       return 3;
    }
 
@@ -362,6 +359,5 @@ int main(int argc, char *argv[])
       x.Save(x_out);
    }
 
-   MPI_Finalize();
    return 0;
 }

--- a/examples/ex21p.cpp
+++ b/examples/ex21p.cpp
@@ -42,7 +42,7 @@ int main(int argc, char *argv[])
    MPI_Init(&argc, &argv);
    MPI_Comm_size(MPI_COMM_WORLD, &num_procs);
    MPI_Comm_rank(MPI_COMM_WORLD, &myid);
-   HYPRE_Session hypre;
+   Hypre::Init();
 
    // 1. Parse command-line options.
    const char *mesh_file = "../data/beam-tri.mesh";

--- a/examples/ex22p.cpp
+++ b/examples/ex22p.cpp
@@ -75,11 +75,12 @@ bool check_for_inline_mesh(const char * mesh_file);
 
 int main(int argc, char *argv[])
 {
-   // 1. Initialize MPI.
+   // 1. Initialize MPI and HYPRE.
    int num_procs, myid;
    MPI_Init(&argc, &argv);
    MPI_Comm_size(MPI_COMM_WORLD, &num_procs);
    MPI_Comm_rank(MPI_COMM_WORLD, &myid);
+   HYPRE_Session hypre;
 
    // 2. Parse command-line options.
    const char *mesh_file = "../data/inline-quad.mesh";

--- a/examples/ex22p.cpp
+++ b/examples/ex22p.cpp
@@ -80,7 +80,7 @@ int main(int argc, char *argv[])
    MPI_Init(&argc, &argv);
    MPI_Comm_size(MPI_COMM_WORLD, &num_procs);
    MPI_Comm_rank(MPI_COMM_WORLD, &myid);
-   HYPRE_Session hypre;
+   Hypre::Init();
 
    // 2. Parse command-line options.
    const char *mesh_file = "../data/inline-quad.mesh";

--- a/examples/ex22p.cpp
+++ b/examples/ex22p.cpp
@@ -76,10 +76,9 @@ bool check_for_inline_mesh(const char * mesh_file);
 int main(int argc, char *argv[])
 {
    // 1. Initialize MPI and HYPRE.
-   int num_procs, myid;
-   MPI_Init(&argc, &argv);
-   MPI_Comm_size(MPI_COMM_WORLD, &num_procs);
-   MPI_Comm_rank(MPI_COMM_WORLD, &myid);
+   Mpi::Init(argc, argv);
+   int num_procs = Mpi::WorldSize();
+   int myid = Mpi::WorldRank();
    Hypre::Init();
 
    // 2. Parse command-line options.
@@ -138,7 +137,6 @@ int main(int argc, char *argv[])
       {
          args.PrintUsage(cout);
       }
-      MPI_Finalize();
       return 1;
    }
    if (myid == 0)
@@ -598,8 +596,6 @@ int main(int argc, char *argv[])
    delete fespace;
    delete fec;
    delete pmesh;
-
-   MPI_Finalize();
 
    return 0;
 }

--- a/examples/ex24p.cpp
+++ b/examples/ex24p.cpp
@@ -56,10 +56,9 @@ double freq = 1.0, kappa;
 int main(int argc, char *argv[])
 {
    // 1. Initialize MPI and HYPRE.
-   int num_procs, myid;
-   MPI_Init(&argc, &argv);
-   MPI_Comm_size(MPI_COMM_WORLD, &num_procs);
-   MPI_Comm_rank(MPI_COMM_WORLD, &myid);
+   Mpi::Init(argc, argv);
+   int num_procs = Mpi::WorldSize();
+   int myid = Mpi::WorldRank();
    Hypre::Init();
 
    // 2. Parse command-line options.
@@ -95,7 +94,6 @@ int main(int argc, char *argv[])
       {
          args.PrintUsage(cout);
       }
-      MPI_Finalize();
       return 1;
    }
    if (myid == 0)
@@ -439,8 +437,6 @@ int main(int argc, char *argv[])
    delete trial_fec;
    delete test_fec;
    delete pmesh;
-
-   MPI_Finalize();
 
    return 0;
 }

--- a/examples/ex24p.cpp
+++ b/examples/ex24p.cpp
@@ -55,11 +55,12 @@ double freq = 1.0, kappa;
 
 int main(int argc, char *argv[])
 {
-   // 1. Initialize MPI.
+   // 1. Initialize MPI and HYPRE.
    int num_procs, myid;
    MPI_Init(&argc, &argv);
    MPI_Comm_size(MPI_COMM_WORLD, &num_procs);
    MPI_Comm_rank(MPI_COMM_WORLD, &myid);
+   HYPRE_Session hypre;
 
    // 2. Parse command-line options.
    const char *mesh_file = "../data/beam-hex.mesh";

--- a/examples/ex24p.cpp
+++ b/examples/ex24p.cpp
@@ -60,7 +60,7 @@ int main(int argc, char *argv[])
    MPI_Init(&argc, &argv);
    MPI_Comm_size(MPI_COMM_WORLD, &num_procs);
    MPI_Comm_rank(MPI_COMM_WORLD, &myid);
-   HYPRE_Session hypre;
+   Hypre::Init();
 
    // 2. Parse command-line options.
    const char *mesh_file = "../data/beam-hex.mesh";

--- a/examples/ex25p.cpp
+++ b/examples/ex25p.cpp
@@ -155,10 +155,9 @@ prob_type prob;
 int main(int argc, char *argv[])
 {
    // 1. Initialize MPI and HYPRE.
-   int num_procs, myid;
-   MPI_Init(&argc, &argv);
-   MPI_Comm_size(MPI_COMM_WORLD, &num_procs);
-   MPI_Comm_rank(MPI_COMM_WORLD, &myid);
+   Mpi::Init(argc, argv);
+   int num_procs = Mpi::WorldSize();
+   int myid = Mpi::WorldRank();
    Hypre::Init();
 
    // 2. Parse command-line options.
@@ -258,7 +257,6 @@ int main(int argc, char *argv[])
       {
          args.PrintUsage(cout);
       }
-      MPI_Finalize();
       return 1;
    }
    if (myid == 0)
@@ -693,7 +691,6 @@ int main(int argc, char *argv[])
    delete fespace;
    delete fec;
    delete pmesh;
-   MPI_Finalize();
    return 0;
 }
 

--- a/examples/ex25p.cpp
+++ b/examples/ex25p.cpp
@@ -154,11 +154,12 @@ prob_type prob;
 
 int main(int argc, char *argv[])
 {
-   // 1. Initialize MPI.
+   // 1. Initialize MPI and HYPRE.
    int num_procs, myid;
    MPI_Init(&argc, &argv);
    MPI_Comm_size(MPI_COMM_WORLD, &num_procs);
    MPI_Comm_rank(MPI_COMM_WORLD, &myid);
+   HYPRE_Session hypre;
 
    // 2. Parse command-line options.
    const char *mesh_file = nullptr;

--- a/examples/ex25p.cpp
+++ b/examples/ex25p.cpp
@@ -159,7 +159,7 @@ int main(int argc, char *argv[])
    MPI_Init(&argc, &argv);
    MPI_Comm_size(MPI_COMM_WORLD, &num_procs);
    MPI_Comm_rank(MPI_COMM_WORLD, &myid);
-   HYPRE_Session hypre;
+   Hypre::Init();
 
    // 2. Parse command-line options.
    const char *mesh_file = nullptr;

--- a/examples/ex26p.cpp
+++ b/examples/ex26p.cpp
@@ -130,7 +130,7 @@ int main(int argc, char *argv[])
    MPI_Init(&argc, &argv);
    MPI_Comm_size(MPI_COMM_WORLD, &num_procs);
    MPI_Comm_rank(MPI_COMM_WORLD, &myid);
-   HYPRE_Session hypre;
+   Hypre::Init();
 
    // 2. Parse command-line options.
    const char *mesh_file = "../data/star.mesh";

--- a/examples/ex26p.cpp
+++ b/examples/ex26p.cpp
@@ -125,11 +125,12 @@ private:
 
 int main(int argc, char *argv[])
 {
-   // 1. Initialize MPI.
+   // 1. Initialize MPI and HYPRE.
    int num_procs, myid;
    MPI_Init(&argc, &argv);
    MPI_Comm_size(MPI_COMM_WORLD, &num_procs);
    MPI_Comm_rank(MPI_COMM_WORLD, &myid);
+   HYPRE_Session hypre;
 
    // 2. Parse command-line options.
    const char *mesh_file = "../data/star.mesh";

--- a/examples/ex26p.cpp
+++ b/examples/ex26p.cpp
@@ -126,10 +126,9 @@ private:
 int main(int argc, char *argv[])
 {
    // 1. Initialize MPI and HYPRE.
-   int num_procs, myid;
-   MPI_Init(&argc, &argv);
-   MPI_Comm_size(MPI_COMM_WORLD, &num_procs);
-   MPI_Comm_rank(MPI_COMM_WORLD, &myid);
+   Mpi::Init(argc, argv);
+   int num_procs = Mpi::WorldSize();
+   int myid = Mpi::WorldRank();
    Hypre::Init();
 
    // 2. Parse command-line options.
@@ -158,7 +157,6 @@ int main(int argc, char *argv[])
       {
          args.PrintUsage(cout);
       }
-      MPI_Finalize();
       return 1;
    }
    if (myid == 0)
@@ -311,8 +309,6 @@ int main(int argc, char *argv[])
    {
       delete collections[level];
    }
-
-   MPI_Finalize();
 
    return 0;
 }

--- a/examples/ex27p.cpp
+++ b/examples/ex27p.cpp
@@ -376,10 +376,8 @@ int main(int argc, char *argv[])
    //     viewed later using GLVis: "glvis -np <np> -m mesh -g sol".
    {
       ostringstream mesh_name, sol_name;
-      mesh_name << "mesh." << setfill('0')
-                << setw(6) << Mpi::WorldRank();
-      sol_name << "sol." << setfill('0')
-               << setw(6) << Mpi::WorldRank();
+      mesh_name << "mesh." << setfill('0') << setw(6) << Mpi::WorldRank();
+      sol_name << "sol." << setfill('0') << setw(6) << Mpi::WorldRank();
 
       ofstream mesh_ofs(mesh_name.str().c_str());
       mesh_ofs.precision(8);

--- a/examples/ex27p.cpp
+++ b/examples/ex27p.cpp
@@ -80,8 +80,8 @@ double IntegrateBC(const ParGridFunction &sol, const Array<int> &bdr_marker,
 int main(int argc, char *argv[])
 {
    // 1. Initialize MPI and HYPRE.
-   MPI_Session mpi;
-   if (!mpi.Root()) { mfem::out.Disable(); mfem::err.Disable(); }
+   MPI::Init();
+   if (!MPI::Session().Root()) { mfem::out.Disable(); mfem::err.Disable(); }
    Hypre::Init();
 
    // 2. Parse command-line options.
@@ -376,8 +376,10 @@ int main(int argc, char *argv[])
    //     viewed later using GLVis: "glvis -np <np> -m mesh -g sol".
    {
       ostringstream mesh_name, sol_name;
-      mesh_name << "mesh." << setfill('0') << setw(6) << mpi.WorldRank();
-      sol_name << "sol." << setfill('0') << setw(6) << mpi.WorldRank();
+      mesh_name << "mesh." << setfill('0')
+                << setw(6) << MPI::Session().WorldRank();
+      sol_name << "sol." << setfill('0')
+               << setw(6) << MPI::Session().WorldRank();
 
       ofstream mesh_ofs(mesh_name.str().c_str());
       mesh_ofs.precision(8);
@@ -395,8 +397,8 @@ int main(int argc, char *argv[])
       char vishost[] = "localhost";
       int  visport   = 19916;
       socketstream sol_sock(vishost, visport);
-      sol_sock << "parallel " << mpi.WorldSize()
-               << " " << mpi.WorldRank() << "\n";
+      sol_sock << "parallel " << MPI::Session().WorldSize()
+               << " " << MPI::Session().WorldRank() << "\n";
       sol_sock.precision(8);
       sol_sock << "solution\n" << pmesh << u
                << "window_title '" << title_str << " Solution'"

--- a/examples/ex27p.cpp
+++ b/examples/ex27p.cpp
@@ -82,7 +82,7 @@ int main(int argc, char *argv[])
    // 1. Initialize MPI and HYPRE.
    MPI_Session mpi;
    if (!mpi.Root()) { mfem::out.Disable(); mfem::err.Disable(); }
-   HYPRE_Session hypre;
+   Hypre::Init();
 
    // 2. Parse command-line options.
    int ser_ref_levels = 2;

--- a/examples/ex27p.cpp
+++ b/examples/ex27p.cpp
@@ -79,9 +79,10 @@ double IntegrateBC(const ParGridFunction &sol, const Array<int> &bdr_marker,
 
 int main(int argc, char *argv[])
 {
-   // 1. Initialize MPI.
+   // 1. Initialize MPI and HYPRE.
    MPI_Session mpi;
    if (!mpi.Root()) { mfem::out.Disable(); mfem::err.Disable(); }
+   HYPRE_Session hypre;
 
    // 2. Parse command-line options.
    int ser_ref_levels = 2;

--- a/examples/ex27p.cpp
+++ b/examples/ex27p.cpp
@@ -81,7 +81,7 @@ int main(int argc, char *argv[])
 {
    // 1. Initialize MPI and HYPRE.
    Mpi::Init();
-   if (!Mpi::Session().Root()) { mfem::out.Disable(); mfem::err.Disable(); }
+   if (!Mpi::Root()) { mfem::out.Disable(); mfem::err.Disable(); }
    Hypre::Init();
 
    // 2. Parse command-line options.
@@ -377,9 +377,9 @@ int main(int argc, char *argv[])
    {
       ostringstream mesh_name, sol_name;
       mesh_name << "mesh." << setfill('0')
-                << setw(6) << Mpi::Session().WorldRank();
+                << setw(6) << Mpi::WorldRank();
       sol_name << "sol." << setfill('0')
-               << setw(6) << Mpi::Session().WorldRank();
+               << setw(6) << Mpi::WorldRank();
 
       ofstream mesh_ofs(mesh_name.str().c_str());
       mesh_ofs.precision(8);
@@ -397,8 +397,8 @@ int main(int argc, char *argv[])
       char vishost[] = "localhost";
       int  visport   = 19916;
       socketstream sol_sock(vishost, visport);
-      sol_sock << "parallel " << Mpi::Session().WorldSize()
-               << " " << Mpi::Session().WorldRank() << "\n";
+      sol_sock << "parallel " << Mpi::WorldSize()
+               << " " << Mpi::WorldRank() << "\n";
       sol_sock.precision(8);
       sol_sock << "solution\n" << pmesh << u
                << "window_title '" << title_str << " Solution'"

--- a/examples/ex27p.cpp
+++ b/examples/ex27p.cpp
@@ -80,8 +80,8 @@ double IntegrateBC(const ParGridFunction &sol, const Array<int> &bdr_marker,
 int main(int argc, char *argv[])
 {
    // 1. Initialize MPI and HYPRE.
-   MPI::Init();
-   if (!MPI::Session().Root()) { mfem::out.Disable(); mfem::err.Disable(); }
+   Mpi::Init();
+   if (!Mpi::Session().Root()) { mfem::out.Disable(); mfem::err.Disable(); }
    Hypre::Init();
 
    // 2. Parse command-line options.
@@ -377,9 +377,9 @@ int main(int argc, char *argv[])
    {
       ostringstream mesh_name, sol_name;
       mesh_name << "mesh." << setfill('0')
-                << setw(6) << MPI::Session().WorldRank();
+                << setw(6) << Mpi::Session().WorldRank();
       sol_name << "sol." << setfill('0')
-               << setw(6) << MPI::Session().WorldRank();
+               << setw(6) << Mpi::Session().WorldRank();
 
       ofstream mesh_ofs(mesh_name.str().c_str());
       mesh_ofs.precision(8);
@@ -397,8 +397,8 @@ int main(int argc, char *argv[])
       char vishost[] = "localhost";
       int  visport   = 19916;
       socketstream sol_sock(vishost, visport);
-      sol_sock << "parallel " << MPI::Session().WorldSize()
-               << " " << MPI::Session().WorldRank() << "\n";
+      sol_sock << "parallel " << Mpi::Session().WorldSize()
+               << " " << Mpi::Session().WorldRank() << "\n";
       sol_sock.precision(8);
       sol_sock << "solution\n" << pmesh << u
                << "window_title '" << title_str << " Solution'"

--- a/examples/ex28p.cpp
+++ b/examples/ex28p.cpp
@@ -88,10 +88,9 @@ int main(int argc, char *argv[])
 #endif
 
    // 1. Initialize MPI and HYPRE.
-   int num_procs, myid;
-   MPI_Init(&argc, &argv);
-   MPI_Comm_size(MPI_COMM_WORLD, &num_procs);
-   MPI_Comm_rank(MPI_COMM_WORLD, &myid);
+   Mpi::Init(argc, argv);
+   int num_procs = Mpi::WorldSize();
+   int myid = Mpi::WorldRank();
    Hypre::Init();
 
    // 2. Parse command-line options.
@@ -124,7 +123,6 @@ int main(int argc, char *argv[])
       {
          args.PrintUsage(cout);
       }
-      MPI_Finalize();
       return 1;
    }
    if (myid == 0)
@@ -368,7 +366,6 @@ int main(int argc, char *argv[])
    delete pmesh;
 
    // HYPRE_Finalize();
-   MPI_Finalize();
 
    return 0;
 }

--- a/examples/ex28p.cpp
+++ b/examples/ex28p.cpp
@@ -87,11 +87,12 @@ int main(int argc, char *argv[])
    return 242;
 #endif
 
-   // 1. Initialize MPI.
+   // 1. Initialize MPI and HYPRE.
    int num_procs, myid;
    MPI_Init(&argc, &argv);
    MPI_Comm_size(MPI_COMM_WORLD, &num_procs);
    MPI_Comm_rank(MPI_COMM_WORLD, &myid);
+   HYPRE_Session hypre;
 
    // 2. Parse command-line options.
    int order = 1;

--- a/examples/ex28p.cpp
+++ b/examples/ex28p.cpp
@@ -92,7 +92,7 @@ int main(int argc, char *argv[])
    MPI_Init(&argc, &argv);
    MPI_Comm_size(MPI_COMM_WORLD, &num_procs);
    MPI_Comm_rank(MPI_COMM_WORLD, &myid);
-   HYPRE_Session hypre;
+   Hypre::Init();
 
    // 2. Parse command-line options.
    int order = 1;

--- a/examples/ex29p.cpp
+++ b/examples/ex29p.cpp
@@ -64,9 +64,9 @@ void fluxExact(const Vector &x, Vector &f)
 int main(int argc, char *argv[])
 {
    // 1. Initialize MPI and HYPRE.
-   MPI_Session mpi(argc, argv);
-   int num_procs = mpi.WorldSize();
-   int myid = mpi.WorldRank();
+   MPI::Init(argc, argv);
+   int num_procs = MPI::Session().WorldSize();
+   int myid = MPI::Session().WorldRank();
    Hypre::Init();
 
    // 2. Parse command-line options.
@@ -128,7 +128,10 @@ int main(int argc, char *argv[])
    H1_FECollection fec(order, dim);
    ParFiniteElementSpace fespace(&pmesh, &fec);
    HYPRE_Int total_num_dofs = fespace.GlobalTrueVSize();
-   if (mpi.Root()) { cout << "Number of unknowns: " << total_num_dofs << endl; }
+   if (MPI::Session().Root())
+   {
+      cout << "Number of unknowns: " << total_num_dofs << endl;
+   }
 
    // 8. Determine the list of true (i.e. conforming) essential boundary dofs.
    //    In this example, the boundary conditions are defined by marking all

--- a/examples/ex29p.cpp
+++ b/examples/ex29p.cpp
@@ -67,7 +67,7 @@ int main(int argc, char *argv[])
    MPI_Session mpi(argc, argv);
    int num_procs = mpi.WorldSize();
    int myid = mpi.WorldRank();
-   HYPRE_Session hypre;
+   Hypre::Init();
 
    // 2. Parse command-line options.
    int order = 3;

--- a/examples/ex29p.cpp
+++ b/examples/ex29p.cpp
@@ -65,8 +65,8 @@ int main(int argc, char *argv[])
 {
    // 1. Initialize MPI and HYPRE.
    Mpi::Init(argc, argv);
-   int num_procs = Mpi::Session().WorldSize();
-   int myid = Mpi::Session().WorldRank();
+   int num_procs = Mpi::WorldSize();
+   int myid = Mpi::WorldRank();
    Hypre::Init();
 
    // 2. Parse command-line options.
@@ -128,7 +128,7 @@ int main(int argc, char *argv[])
    H1_FECollection fec(order, dim);
    ParFiniteElementSpace fespace(&pmesh, &fec);
    HYPRE_Int total_num_dofs = fespace.GlobalTrueVSize();
-   if (Mpi::Session().Root())
+   if (Mpi::Root())
    {
       cout << "Number of unknowns: " << total_num_dofs << endl;
    }

--- a/examples/ex29p.cpp
+++ b/examples/ex29p.cpp
@@ -63,10 +63,11 @@ void fluxExact(const Vector &x, Vector &f)
 
 int main(int argc, char *argv[])
 {
-   // 1. Initialize MPI.
+   // 1. Initialize MPI and HYPRE.
    MPI_Session mpi(argc, argv);
    int num_procs = mpi.WorldSize();
    int myid = mpi.WorldRank();
+   HYPRE_Session hypre;
 
    // 2. Parse command-line options.
    int order = 3;

--- a/examples/ex29p.cpp
+++ b/examples/ex29p.cpp
@@ -64,9 +64,9 @@ void fluxExact(const Vector &x, Vector &f)
 int main(int argc, char *argv[])
 {
    // 1. Initialize MPI and HYPRE.
-   MPI::Init(argc, argv);
-   int num_procs = MPI::Session().WorldSize();
-   int myid = MPI::Session().WorldRank();
+   Mpi::Init(argc, argv);
+   int num_procs = Mpi::Session().WorldSize();
+   int myid = Mpi::Session().WorldRank();
    Hypre::Init();
 
    // 2. Parse command-line options.
@@ -128,7 +128,7 @@ int main(int argc, char *argv[])
    H1_FECollection fec(order, dim);
    ParFiniteElementSpace fespace(&pmesh, &fec);
    HYPRE_Int total_num_dofs = fespace.GlobalTrueVSize();
-   if (MPI::Session().Root())
+   if (Mpi::Session().Root())
    {
       cout << "Number of unknowns: " << total_num_dofs << endl;
    }

--- a/examples/ex2p.cpp
+++ b/examples/ex2p.cpp
@@ -53,7 +53,7 @@ int main(int argc, char *argv[])
    MPI_Init(&argc, &argv);
    MPI_Comm_size(MPI_COMM_WORLD, &num_procs);
    MPI_Comm_rank(MPI_COMM_WORLD, &myid);
-   HYPRE_Session hypre;
+   Hypre::Init();
 
    // 2. Parse command-line options.
    const char *mesh_file = "../data/beam-tri.mesh";

--- a/examples/ex2p.cpp
+++ b/examples/ex2p.cpp
@@ -49,10 +49,9 @@ using namespace mfem;
 int main(int argc, char *argv[])
 {
    // 1. Initialize MPI and HYPRE.
-   int num_procs, myid;
-   MPI_Init(&argc, &argv);
-   MPI_Comm_size(MPI_COMM_WORLD, &num_procs);
-   MPI_Comm_rank(MPI_COMM_WORLD, &myid);
+   Mpi::Init(argc, argv);
+   int num_procs = Mpi::WorldSize();
+   int myid = Mpi::WorldRank();
    Hypre::Init();
 
    // 2. Parse command-line options.
@@ -89,7 +88,6 @@ int main(int argc, char *argv[])
       {
          args.PrintUsage(cout);
       }
-      MPI_Finalize();
       return 1;
    }
    if (myid == 0)
@@ -114,7 +112,6 @@ int main(int argc, char *argv[])
          cerr << "\nInput mesh should have at least two materials and "
               << "two boundary attributes! (See schematic in ex2.cpp)\n"
               << endl;
-      MPI_Finalize();
       return 3;
    }
 
@@ -337,8 +334,6 @@ int main(int argc, char *argv[])
       delete fec;
    }
    delete pmesh;
-
-   MPI_Finalize();
 
    return 0;
 }

--- a/examples/ex2p.cpp
+++ b/examples/ex2p.cpp
@@ -48,11 +48,12 @@ using namespace mfem;
 
 int main(int argc, char *argv[])
 {
-   // 1. Initialize MPI.
+   // 1. Initialize MPI and HYPRE.
    int num_procs, myid;
    MPI_Init(&argc, &argv);
    MPI_Comm_size(MPI_COMM_WORLD, &num_procs);
    MPI_Comm_rank(MPI_COMM_WORLD, &myid);
+   HYPRE_Session hypre;
 
    // 2. Parse command-line options.
    const char *mesh_file = "../data/beam-tri.mesh";

--- a/examples/ex30p.cpp
+++ b/examples/ex30p.cpp
@@ -87,10 +87,9 @@ double singular_function(const Vector &p)
 int main(int argc, char *argv[])
 {
    // 0. Initialize MPI and HYPRE.
-   int num_procs, myid;
-   MPI_Init(&argc, &argv);
-   MPI_Comm_size(MPI_COMM_WORLD, &num_procs);
-   MPI_Comm_rank(MPI_COMM_WORLD, &myid);
+   Mpi::Init(argc, argv);
+   int num_procs = Mpi::WorldSize();
+   int myid = Mpi::WorldRank();
    Hypre::Init();
 
    // 1. Parse command-line options.
@@ -131,7 +130,6 @@ int main(int argc, char *argv[])
       {
          args.PrintUsage(cout);
       }
-      MPI_Finalize();
       return 1;
    }
    if (myid == 0)
@@ -245,6 +243,5 @@ int main(int argc, char *argv[])
       sol_sock << "mesh\n" << pmesh << flush;
    }
 
-   MPI_Finalize();
    return 0;
 }

--- a/examples/ex30p.cpp
+++ b/examples/ex30p.cpp
@@ -85,7 +85,7 @@ int main(int argc, char *argv[])
    MPI_Init(&argc, &argv);
    MPI_Comm_size(MPI_COMM_WORLD, &num_procs);
    MPI_Comm_rank(MPI_COMM_WORLD, &myid);
-   HYPRE_Session hypre;
+   Hypre::Init();
 
    // 1. Parse command-line options.
    const char *mesh_file = "../data/star.mesh";

--- a/examples/ex30p.cpp
+++ b/examples/ex30p.cpp
@@ -80,11 +80,12 @@ double singular_function(const Vector &p)
 
 int main(int argc, char *argv[])
 {
-   // 0. Initialize MPI.
+   // 0. Initialize MPI and HYPRE.
    int num_procs, myid;
    MPI_Init(&argc, &argv);
    MPI_Comm_size(MPI_COMM_WORLD, &num_procs);
    MPI_Comm_rank(MPI_COMM_WORLD, &myid);
+   HYPRE_Session hypre;
 
    // 1. Parse command-line options.
    const char *mesh_file = "../data/star.mesh";

--- a/examples/ex3p.cpp
+++ b/examples/ex3p.cpp
@@ -64,7 +64,7 @@ int main(int argc, char *argv[])
    MPI_Init(&argc, &argv);
    MPI_Comm_size(MPI_COMM_WORLD, &num_procs);
    MPI_Comm_rank(MPI_COMM_WORLD, &myid);
-   HYPRE_Session hypre;
+   Hypre::Init();
 
    // 2. Parse command-line options.
    const char *mesh_file = "../data/beam-tet.mesh";

--- a/examples/ex3p.cpp
+++ b/examples/ex3p.cpp
@@ -59,11 +59,12 @@ int dim;
 
 int main(int argc, char *argv[])
 {
-   // 1. Initialize MPI.
+   // 1. Initialize MPI and HYPRE.
    int num_procs, myid;
    MPI_Init(&argc, &argv);
    MPI_Comm_size(MPI_COMM_WORLD, &num_procs);
    MPI_Comm_rank(MPI_COMM_WORLD, &myid);
+   HYPRE_Session hypre;
 
    // 2. Parse command-line options.
    const char *mesh_file = "../data/beam-tet.mesh";

--- a/examples/ex3p.cpp
+++ b/examples/ex3p.cpp
@@ -60,10 +60,9 @@ int dim;
 int main(int argc, char *argv[])
 {
    // 1. Initialize MPI and HYPRE.
-   int num_procs, myid;
-   MPI_Init(&argc, &argv);
-   MPI_Comm_size(MPI_COMM_WORLD, &num_procs);
-   MPI_Comm_rank(MPI_COMM_WORLD, &myid);
+   Mpi::Init(argc, argv);
+   int num_procs = Mpi::WorldSize();
+   int myid = Mpi::WorldRank();
    Hypre::Init();
 
    // 2. Parse command-line options.
@@ -106,8 +105,6 @@ int main(int argc, char *argv[])
       {
          args.PrintUsage(cout);
       }
-      // HYPRE_Finalize();
-      MPI_Finalize();
       return 1;
    }
    if (myid == 0)
@@ -298,8 +295,6 @@ int main(int argc, char *argv[])
    delete fespace;
    delete fec;
    delete pmesh;
-
-   MPI_Finalize();
 
    return 0;
 }

--- a/examples/ex4p.cpp
+++ b/examples/ex4p.cpp
@@ -59,10 +59,9 @@ double freq = 1.0, kappa;
 int main(int argc, char *argv[])
 {
    // 1. Initialize MPI and HYPRE.
-   int num_procs, myid;
-   MPI_Init(&argc, &argv);
-   MPI_Comm_size(MPI_COMM_WORLD, &num_procs);
-   MPI_Comm_rank(MPI_COMM_WORLD, &myid);
+   Mpi::Init(argc, argv);
+   int num_procs = Mpi::WorldSize();
+   int myid = Mpi::WorldRank();
    Hypre::Init();
 
    // 2. Parse command-line options.
@@ -102,7 +101,6 @@ int main(int argc, char *argv[])
       {
          args.PrintUsage(cout);
       }
-      MPI_Finalize();
       return 1;
    }
    if (myid == 0)
@@ -303,8 +301,6 @@ int main(int argc, char *argv[])
    delete fespace;
    delete fec;
    delete pmesh;
-
-   MPI_Finalize();
 
    return 0;
 }

--- a/examples/ex4p.cpp
+++ b/examples/ex4p.cpp
@@ -58,11 +58,12 @@ double freq = 1.0, kappa;
 
 int main(int argc, char *argv[])
 {
-   // 1. Initialize MPI.
+   // 1. Initialize MPI and HYPRE.
    int num_procs, myid;
    MPI_Init(&argc, &argv);
    MPI_Comm_size(MPI_COMM_WORLD, &num_procs);
    MPI_Comm_rank(MPI_COMM_WORLD, &myid);
+   HYPRE_Session hypre;
 
    // 2. Parse command-line options.
    const char *mesh_file = "../data/star.mesh";

--- a/examples/ex4p.cpp
+++ b/examples/ex4p.cpp
@@ -63,7 +63,7 @@ int main(int argc, char *argv[])
    MPI_Init(&argc, &argv);
    MPI_Comm_size(MPI_COMM_WORLD, &num_procs);
    MPI_Comm_rank(MPI_COMM_WORLD, &myid);
-   HYPRE_Session hypre;
+   Hypre::Init();
 
    // 2. Parse command-line options.
    const char *mesh_file = "../data/star.mesh";

--- a/examples/ex5p.cpp
+++ b/examples/ex5p.cpp
@@ -55,11 +55,12 @@ int main(int argc, char *argv[])
 {
    StopWatch chrono;
 
-   // 1. Initialize MPI.
+   // 1. Initialize MPI and HYPRE.
    int num_procs, myid;
    MPI_Init(&argc, &argv);
    MPI_Comm_size(MPI_COMM_WORLD, &num_procs);
    MPI_Comm_rank(MPI_COMM_WORLD, &myid);
+   HYPRE_Session hypre;
    bool verbose = (myid == 0);
 
    // 2. Parse command-line options.

--- a/examples/ex5p.cpp
+++ b/examples/ex5p.cpp
@@ -56,10 +56,9 @@ int main(int argc, char *argv[])
    StopWatch chrono;
 
    // 1. Initialize MPI and HYPRE.
-   int num_procs, myid;
-   MPI_Init(&argc, &argv);
-   MPI_Comm_size(MPI_COMM_WORLD, &num_procs);
-   MPI_Comm_rank(MPI_COMM_WORLD, &myid);
+   Mpi::Init(argc, argv);
+   int num_procs = Mpi::WorldSize();
+   int myid = Mpi::WorldRank();
    Hypre::Init();
    bool verbose = (myid == 0);
 
@@ -100,7 +99,6 @@ int main(int argc, char *argv[])
       {
          args.PrintUsage(cout);
       }
-      MPI_Finalize();
       return 1;
    }
    if (verbose)
@@ -488,8 +486,6 @@ int main(int argc, char *argv[])
    delete l2_coll;
    delete hdiv_coll;
    delete pmesh;
-
-   MPI_Finalize();
 
    return 0;
 }

--- a/examples/ex5p.cpp
+++ b/examples/ex5p.cpp
@@ -60,7 +60,7 @@ int main(int argc, char *argv[])
    MPI_Init(&argc, &argv);
    MPI_Comm_size(MPI_COMM_WORLD, &num_procs);
    MPI_Comm_rank(MPI_COMM_WORLD, &myid);
-   HYPRE_Session hypre;
+   Hypre::Init();
    bool verbose = (myid == 0);
 
    // 2. Parse command-line options.

--- a/examples/ex6p.cpp
+++ b/examples/ex6p.cpp
@@ -57,7 +57,7 @@ int main(int argc, char *argv[])
    MPI_Init(&argc, &argv);
    MPI_Comm_size(MPI_COMM_WORLD, &num_procs);
    MPI_Comm_rank(MPI_COMM_WORLD, &myid);
-   HYPRE_Session hypre;
+   Hypre::Init();
 
    // 2. Parse command-line options.
    const char *mesh_file = "../data/star.mesh";

--- a/examples/ex6p.cpp
+++ b/examples/ex6p.cpp
@@ -52,11 +52,12 @@ using namespace mfem;
 
 int main(int argc, char *argv[])
 {
-   // 1. Initialize MPI.
+   // 1. Initialize MPI and HYPRE.
    int num_procs, myid;
    MPI_Init(&argc, &argv);
    MPI_Comm_size(MPI_COMM_WORLD, &num_procs);
    MPI_Comm_rank(MPI_COMM_WORLD, &myid);
+   HYPRE_Session hypre;
 
    // 2. Parse command-line options.
    const char *mesh_file = "../data/star.mesh";

--- a/examples/ex6p.cpp
+++ b/examples/ex6p.cpp
@@ -53,10 +53,9 @@ using namespace mfem;
 int main(int argc, char *argv[])
 {
    // 1. Initialize MPI and HYPRE.
-   int num_procs, myid;
-   MPI_Init(&argc, &argv);
-   MPI_Comm_size(MPI_COMM_WORLD, &num_procs);
-   MPI_Comm_rank(MPI_COMM_WORLD, &myid);
+   Mpi::Init(argc, argv);
+   int num_procs = Mpi::WorldSize();
+   int myid = Mpi::WorldRank();
    Hypre::Init();
 
    // 2. Parse command-line options.
@@ -103,7 +102,6 @@ int main(int argc, char *argv[])
       {
          args.PrintUsage(cout);
       }
-      MPI_Finalize();
       return 1;
    }
    if (myid == 0)
@@ -395,6 +393,5 @@ int main(int argc, char *argv[])
    delete smooth_flux_fec;
    delete pmesh;
 
-   MPI_Finalize();
    return 0;
 }

--- a/examples/ex7p.cpp
+++ b/examples/ex7p.cpp
@@ -34,11 +34,12 @@ void SnapNodes(Mesh &mesh);
 
 int main(int argc, char *argv[])
 {
-   // 1. Initialize MPI.
+   // 1. Initialize MPI and HYPRE.
    int num_procs, myid;
    MPI_Init(&argc, &argv);
    MPI_Comm_size(MPI_COMM_WORLD, &num_procs);
    MPI_Comm_rank(MPI_COMM_WORLD, &myid);
+   HYPRE_Session hypre;
 
    // 2. Parse command-line options.
    int elem_type = 1;

--- a/examples/ex7p.cpp
+++ b/examples/ex7p.cpp
@@ -35,10 +35,9 @@ void SnapNodes(Mesh &mesh);
 int main(int argc, char *argv[])
 {
    // 1. Initialize MPI and HYPRE.
-   int num_procs, myid;
-   MPI_Init(&argc, &argv);
-   MPI_Comm_size(MPI_COMM_WORLD, &num_procs);
-   MPI_Comm_rank(MPI_COMM_WORLD, &myid);
+   Mpi::Init(argc, argv);
+   int num_procs = Mpi::WorldSize();
+   int myid = Mpi::WorldRank();
    Hypre::Init();
 
    // 2. Parse command-line options.
@@ -76,7 +75,6 @@ int main(int argc, char *argv[])
       {
          args.PrintUsage(cout);
       }
-      MPI_Finalize();
       return 1;
    }
    if (myid == 0)
@@ -321,8 +319,6 @@ int main(int argc, char *argv[])
    delete amg;
    delete fespace;
    delete pmesh;
-
-   MPI_Finalize();
 
    return 0;
 }

--- a/examples/ex7p.cpp
+++ b/examples/ex7p.cpp
@@ -39,7 +39,7 @@ int main(int argc, char *argv[])
    MPI_Init(&argc, &argv);
    MPI_Comm_size(MPI_COMM_WORLD, &num_procs);
    MPI_Comm_rank(MPI_COMM_WORLD, &myid);
-   HYPRE_Session hypre;
+   Hypre::Init();
 
    // 2. Parse command-line options.
    int elem_type = 1;

--- a/examples/ex8p.cpp
+++ b/examples/ex8p.cpp
@@ -42,10 +42,9 @@ using namespace mfem;
 int main(int argc, char *argv[])
 {
    // 1. Initialize MPI and HYPRE.
-   int num_procs, myid;
-   MPI_Init(&argc, &argv);
-   MPI_Comm_size(MPI_COMM_WORLD, &num_procs);
-   MPI_Comm_rank(MPI_COMM_WORLD, &myid);
+   Mpi::Init(argc, argv);
+   int num_procs = Mpi::WorldSize();
+   int myid = Mpi::WorldRank();
    Hypre::Init();
 
    // 2. Parse command-line options.
@@ -68,7 +67,6 @@ int main(int argc, char *argv[])
       {
          args.PrintUsage(cout);
       }
-      MPI_Finalize();
       return 1;
    }
    if (myid == 0)
@@ -339,8 +337,6 @@ int main(int argc, char *argv[])
    delete xhat_fec;
    delete x0_fec;
    delete pmesh;
-
-   MPI_Finalize();
 
    return 0;
 }

--- a/examples/ex8p.cpp
+++ b/examples/ex8p.cpp
@@ -41,11 +41,12 @@ using namespace mfem;
 
 int main(int argc, char *argv[])
 {
-   // 1. Initialize MPI.
+   // 1. Initialize MPI and HYPRE.
    int num_procs, myid;
    MPI_Init(&argc, &argv);
    MPI_Comm_size(MPI_COMM_WORLD, &num_procs);
    MPI_Comm_rank(MPI_COMM_WORLD, &myid);
+   HYPRE_Session hypre;
 
    // 2. Parse command-line options.
    const char *mesh_file = "../data/star.mesh";

--- a/examples/ex8p.cpp
+++ b/examples/ex8p.cpp
@@ -46,7 +46,7 @@ int main(int argc, char *argv[])
    MPI_Init(&argc, &argv);
    MPI_Comm_size(MPI_COMM_WORLD, &num_procs);
    MPI_Comm_rank(MPI_COMM_WORLD, &myid);
-   HYPRE_Session hypre;
+   Hypre::Init();
 
    // 2. Parse command-line options.
    const char *mesh_file = "../data/star.mesh";

--- a/examples/ex9p.cpp
+++ b/examples/ex9p.cpp
@@ -234,8 +234,8 @@ int main(int argc, char *argv[])
 {
    // 1. Initialize MPI and HYPRE.
    Mpi::Init();
-   int num_procs = Mpi::Session().WorldSize();
-   int myid = Mpi::Session().WorldRank();
+   int num_procs = Mpi::WorldSize();
+   int myid = Mpi::WorldRank();
    Hypre::Init();
 
    // 2. Parse command-line options.
@@ -317,19 +317,19 @@ int main(int argc, char *argv[])
    args.Parse();
    if (!args.Good())
    {
-      if (Mpi::Session().Root())
+      if (Mpi::Root())
       {
          args.PrintUsage(cout);
       }
       return 1;
    }
-   if (Mpi::Session().Root())
+   if (Mpi::Root())
    {
       args.PrintOptions(cout);
    }
 
    Device device(device_config);
-   if (Mpi::Session().Root()) { device.Print(); }
+   if (Mpi::Root()) { device.Print(); }
 
    // 3. Read the serial mesh from the given mesh file on all processors. We can
    //    handle geometrically periodic meshes in this code.
@@ -356,7 +356,7 @@ int main(int argc, char *argv[])
       case 23: ode_solver = new SDIRK23Solver; break;
       case 24: ode_solver = new SDIRK34Solver; break;
       default:
-         if (Mpi::Session().Root())
+         if (Mpi::Root())
          {
             cout << "Unknown ODE solver type: " << ode_solver_type << '\n';
          }
@@ -394,7 +394,7 @@ int main(int argc, char *argv[])
    ParFiniteElementSpace *fes = new ParFiniteElementSpace(pmesh, &fec);
 
    HYPRE_BigInt global_vSize = fes->GlobalTrueVSize();
-   if (Mpi::Session().Root())
+   if (Mpi::Root())
    {
       cout << "Number of unknowns: " << global_vSize << endl;
    }
@@ -535,11 +535,11 @@ int main(int argc, char *argv[])
       sout.open(vishost, visport);
       if (!sout)
       {
-         if (Mpi::Session().Root())
+         if (Mpi::Root())
             cout << "Unable to connect to GLVis server at "
                  << vishost << ':' << visport << endl;
          visualization = false;
-         if (Mpi::Session().Root())
+         if (Mpi::Root())
          {
             cout << "GLVis visualization disabled.\n";
          }
@@ -551,7 +551,7 @@ int main(int argc, char *argv[])
          sout << "solution\n" << *pmesh << *u;
          sout << "pause\n";
          sout << flush;
-         if (Mpi::Session().Root())
+         if (Mpi::Root())
             cout << "GLVis visualization paused."
                  << " Press space (in the GLVis window) to resume it.\n";
       }
@@ -577,7 +577,7 @@ int main(int argc, char *argv[])
 
       if (done || ti % vis_steps == 0)
       {
-         if (Mpi::Session().Root())
+         if (Mpi::Root())
          {
             cout << "time step: " << ti << ", time: " << t << endl;
          }

--- a/examples/ex9p.cpp
+++ b/examples/ex9p.cpp
@@ -233,9 +233,9 @@ public:
 int main(int argc, char *argv[])
 {
    // 1. Initialize MPI and HYPRE.
-   MPI::Init();
-   int num_procs = MPI::Session().WorldSize();
-   int myid = MPI::Session().WorldRank();
+   Mpi::Init();
+   int num_procs = Mpi::Session().WorldSize();
+   int myid = Mpi::Session().WorldRank();
    Hypre::Init();
 
    // 2. Parse command-line options.
@@ -317,19 +317,19 @@ int main(int argc, char *argv[])
    args.Parse();
    if (!args.Good())
    {
-      if (MPI::Session().Root())
+      if (Mpi::Session().Root())
       {
          args.PrintUsage(cout);
       }
       return 1;
    }
-   if (MPI::Session().Root())
+   if (Mpi::Session().Root())
    {
       args.PrintOptions(cout);
    }
 
    Device device(device_config);
-   if (MPI::Session().Root()) { device.Print(); }
+   if (Mpi::Session().Root()) { device.Print(); }
 
    // 3. Read the serial mesh from the given mesh file on all processors. We can
    //    handle geometrically periodic meshes in this code.
@@ -356,7 +356,7 @@ int main(int argc, char *argv[])
       case 23: ode_solver = new SDIRK23Solver; break;
       case 24: ode_solver = new SDIRK34Solver; break;
       default:
-         if (MPI::Session().Root())
+         if (Mpi::Session().Root())
          {
             cout << "Unknown ODE solver type: " << ode_solver_type << '\n';
          }
@@ -394,7 +394,7 @@ int main(int argc, char *argv[])
    ParFiniteElementSpace *fes = new ParFiniteElementSpace(pmesh, &fec);
 
    HYPRE_BigInt global_vSize = fes->GlobalTrueVSize();
-   if (MPI::Session().Root())
+   if (Mpi::Session().Root())
    {
       cout << "Number of unknowns: " << global_vSize << endl;
    }
@@ -535,11 +535,11 @@ int main(int argc, char *argv[])
       sout.open(vishost, visport);
       if (!sout)
       {
-         if (MPI::Session().Root())
+         if (Mpi::Session().Root())
             cout << "Unable to connect to GLVis server at "
                  << vishost << ':' << visport << endl;
          visualization = false;
-         if (MPI::Session().Root())
+         if (Mpi::Session().Root())
          {
             cout << "GLVis visualization disabled.\n";
          }
@@ -551,7 +551,7 @@ int main(int argc, char *argv[])
          sout << "solution\n" << *pmesh << *u;
          sout << "pause\n";
          sout << flush;
-         if (MPI::Session().Root())
+         if (Mpi::Session().Root())
             cout << "GLVis visualization paused."
                  << " Press space (in the GLVis window) to resume it.\n";
       }
@@ -577,7 +577,7 @@ int main(int argc, char *argv[])
 
       if (done || ti % vis_steps == 0)
       {
-         if (MPI::Session().Root())
+         if (Mpi::Session().Root())
          {
             cout << "time step: " << ti << ", time: " << t << endl;
          }

--- a/examples/ex9p.cpp
+++ b/examples/ex9p.cpp
@@ -233,9 +233,9 @@ public:
 int main(int argc, char *argv[])
 {
    // 1. Initialize MPI and HYPRE.
-   MPI_Session mpi;
-   int num_procs = mpi.WorldSize();
-   int myid = mpi.WorldRank();
+   MPI::Init();
+   int num_procs = MPI::Session().WorldSize();
+   int myid = MPI::Session().WorldRank();
    Hypre::Init();
 
    // 2. Parse command-line options.
@@ -317,19 +317,19 @@ int main(int argc, char *argv[])
    args.Parse();
    if (!args.Good())
    {
-      if (mpi.Root())
+      if (MPI::Session().Root())
       {
          args.PrintUsage(cout);
       }
       return 1;
    }
-   if (mpi.Root())
+   if (MPI::Session().Root())
    {
       args.PrintOptions(cout);
    }
 
    Device device(device_config);
-   if (mpi.Root()) { device.Print(); }
+   if (MPI::Session().Root()) { device.Print(); }
 
    // 3. Read the serial mesh from the given mesh file on all processors. We can
    //    handle geometrically periodic meshes in this code.
@@ -356,7 +356,7 @@ int main(int argc, char *argv[])
       case 23: ode_solver = new SDIRK23Solver; break;
       case 24: ode_solver = new SDIRK34Solver; break;
       default:
-         if (mpi.Root())
+         if (MPI::Session().Root())
          {
             cout << "Unknown ODE solver type: " << ode_solver_type << '\n';
          }
@@ -394,7 +394,7 @@ int main(int argc, char *argv[])
    ParFiniteElementSpace *fes = new ParFiniteElementSpace(pmesh, &fec);
 
    HYPRE_BigInt global_vSize = fes->GlobalTrueVSize();
-   if (mpi.Root())
+   if (MPI::Session().Root())
    {
       cout << "Number of unknowns: " << global_vSize << endl;
    }
@@ -535,11 +535,11 @@ int main(int argc, char *argv[])
       sout.open(vishost, visport);
       if (!sout)
       {
-         if (mpi.Root())
+         if (MPI::Session().Root())
             cout << "Unable to connect to GLVis server at "
                  << vishost << ':' << visport << endl;
          visualization = false;
-         if (mpi.Root())
+         if (MPI::Session().Root())
          {
             cout << "GLVis visualization disabled.\n";
          }
@@ -551,7 +551,7 @@ int main(int argc, char *argv[])
          sout << "solution\n" << *pmesh << *u;
          sout << "pause\n";
          sout << flush;
-         if (mpi.Root())
+         if (MPI::Session().Root())
             cout << "GLVis visualization paused."
                  << " Press space (in the GLVis window) to resume it.\n";
       }
@@ -577,7 +577,7 @@ int main(int argc, char *argv[])
 
       if (done || ti % vis_steps == 0)
       {
-         if (mpi.Root())
+         if (MPI::Session().Root())
          {
             cout << "time step: " << ti << ", time: " << t << endl;
          }

--- a/examples/ex9p.cpp
+++ b/examples/ex9p.cpp
@@ -236,7 +236,7 @@ int main(int argc, char *argv[])
    MPI_Session mpi;
    int num_procs = mpi.WorldSize();
    int myid = mpi.WorldRank();
-   HYPRE_Session hypre;
+   Hypre::Init();
 
    // 2. Parse command-line options.
    problem = 0;

--- a/examples/ex9p.cpp
+++ b/examples/ex9p.cpp
@@ -232,10 +232,11 @@ public:
 
 int main(int argc, char *argv[])
 {
-   // 1. Initialize MPI.
+   // 1. Initialize MPI and HYPRE.
    MPI_Session mpi;
    int num_procs = mpi.WorldSize();
    int myid = mpi.WorldRank();
+   HYPRE_Session hypre;
 
    // 2. Parse command-line options.
    problem = 0;

--- a/examples/hiop/ex9p.cpp
+++ b/examples/hiop/ex9p.cpp
@@ -239,11 +239,12 @@ public:
 
 int main(int argc, char *argv[])
 {
-   // 1. Initialize MPI.
+   // 1. Initialize MPI and HYPRE.
    int num_procs, myid;
    MPI_Init(&argc, &argv);
    MPI_Comm_size(MPI_COMM_WORLD, &num_procs);
    MPI_Comm_rank(MPI_COMM_WORLD, &myid);
+   HYPRE_Session hypre;
 
    // 2. Parse command-line options.
    problem = 0;

--- a/examples/hiop/ex9p.cpp
+++ b/examples/hiop/ex9p.cpp
@@ -244,7 +244,7 @@ int main(int argc, char *argv[])
    MPI_Init(&argc, &argv);
    MPI_Comm_size(MPI_COMM_WORLD, &num_procs);
    MPI_Comm_rank(MPI_COMM_WORLD, &myid);
-   HYPRE_Session hypre;
+   Hypre::Init();
 
    // 2. Parse command-line options.
    problem = 0;

--- a/examples/hiop/ex9p.cpp
+++ b/examples/hiop/ex9p.cpp
@@ -240,10 +240,9 @@ public:
 int main(int argc, char *argv[])
 {
    // 1. Initialize MPI and HYPRE.
-   int num_procs, myid;
-   MPI_Init(&argc, &argv);
-   MPI_Comm_size(MPI_COMM_WORLD, &num_procs);
-   MPI_Comm_rank(MPI_COMM_WORLD, &myid);
+   Mpi::Init(argc, argv);
+   int num_procs = Mpi::WorldSize();
+   int myid = Mpi::WorldRank();
    Hypre::Init();
 
    // 2. Parse command-line options.
@@ -300,7 +299,6 @@ int main(int argc, char *argv[])
    if (!args.Good())
    {
       if (myid == 0) { args.PrintUsage(cout); }
-      MPI_Finalize();
       return 1;
    }
    if (myid == 0) { args.PrintOptions(cout); }
@@ -326,7 +324,6 @@ int main(int argc, char *argv[])
             cout << "Unknown ODE solver type: " << ode_solver_type << '\n';
          }
          delete mesh;
-         MPI_Finalize();
          return 3;
    }
 
@@ -571,7 +568,6 @@ int main(int argc, char *argv[])
    delete ode_solver;
    delete dc;
 
-   MPI_Finalize();
    return 0;
 }
 

--- a/examples/petsc/ex10p.cpp
+++ b/examples/petsc/ex10p.cpp
@@ -190,7 +190,7 @@ int main(int argc, char *argv[])
    MPI_Init(&argc, &argv);
    MPI_Comm_size(MPI_COMM_WORLD, &num_procs);
    MPI_Comm_rank(MPI_COMM_WORLD, &myid);
-   HYPRE_Session hypre;
+   Hypre::Init();
 
    // 2. Parse command-line options.
    const char *mesh_file = "../../data/beam-quad.mesh";

--- a/examples/petsc/ex10p.cpp
+++ b/examples/petsc/ex10p.cpp
@@ -185,11 +185,12 @@ void visualize(ostream &out, ParMesh *mesh, ParGridFunction *deformed_nodes,
 
 int main(int argc, char *argv[])
 {
-   // 1. Initialize MPI.
+   // 1. Initialize MPI and HYPRE.
    int num_procs, myid;
    MPI_Init(&argc, &argv);
    MPI_Comm_size(MPI_COMM_WORLD, &num_procs);
    MPI_Comm_rank(MPI_COMM_WORLD, &myid);
+   HYPRE_Session hypre;
 
    // 2. Parse command-line options.
    const char *mesh_file = "../../data/beam-quad.mesh";

--- a/examples/petsc/ex10p.cpp
+++ b/examples/petsc/ex10p.cpp
@@ -186,10 +186,9 @@ void visualize(ostream &os, ParMesh *mesh, ParGridFunction *deformed_nodes,
 int main(int argc, char *argv[])
 {
    // 1. Initialize MPI and HYPRE.
-   int num_procs, myid;
-   MPI_Init(&argc, &argv);
-   MPI_Comm_size(MPI_COMM_WORLD, &num_procs);
-   MPI_Comm_rank(MPI_COMM_WORLD, &myid);
+   Mpi::Init(argc, argv);
+   int num_procs = Mpi::WorldSize();
+   int myid = Mpi::WorldRank();
    Hypre::Init();
 
    // 2. Parse command-line options.
@@ -252,7 +251,6 @@ int main(int argc, char *argv[])
       {
          args.PrintUsage(cout);
       }
-      MPI_Finalize();
       return 1;
    }
    if (myid == 0)
@@ -296,7 +294,6 @@ int main(int argc, char *argv[])
          {
             cout << "Unknown ODE solver type: " << ode_solver_type << '\n';
          }
-         MPI_Finalize();
          return 3;
    }
 
@@ -472,8 +469,6 @@ int main(int argc, char *argv[])
 
    // We finalize PETSc
    if (use_petsc) { MFEMFinalizePetsc(); }
-
-   MPI_Finalize();
 
    return 0;
 }

--- a/examples/petsc/ex11p.cpp
+++ b/examples/petsc/ex11p.cpp
@@ -42,10 +42,9 @@ using namespace mfem;
 int main(int argc, char *argv[])
 {
    // 1. Initialize MPI and HYPRE.
-   int num_procs, myid;
-   MPI_Init(&argc, &argv);
-   MPI_Comm_size(MPI_COMM_WORLD, &num_procs);
-   MPI_Comm_rank(MPI_COMM_WORLD, &myid);
+   Mpi::Init(argc, argv);
+   int num_procs = Mpi::WorldSize();
+   int myid = Mpi::WorldRank();
    Hypre::Init();
 
    // 2. Parse command-line options.
@@ -112,7 +111,6 @@ int main(int argc, char *argv[])
          {
             args.PrintUsage(cout);
          }
-         MPI_Finalize();
          return 1;
       }
    }
@@ -437,7 +435,6 @@ int main(int argc, char *argv[])
 
    // We finalize SLEPc
    MFEMFinalizeSlepc();
-   MPI_Finalize();
 
    return 0;
 }

--- a/examples/petsc/ex11p.cpp
+++ b/examples/petsc/ex11p.cpp
@@ -46,7 +46,7 @@ int main(int argc, char *argv[])
    MPI_Init(&argc, &argv);
    MPI_Comm_size(MPI_COMM_WORLD, &num_procs);
    MPI_Comm_rank(MPI_COMM_WORLD, &myid);
-   HYPRE_Session hypre;
+   Hypre::Init();
 
    // 2. Parse command-line options.
    const char *mesh_file = "../../data/star.mesh";

--- a/examples/petsc/ex11p.cpp
+++ b/examples/petsc/ex11p.cpp
@@ -41,11 +41,12 @@ using namespace mfem;
 
 int main(int argc, char *argv[])
 {
-   // 1. Initialize MPI.
+   // 1. Initialize MPI and HYPRE.
    int num_procs, myid;
    MPI_Init(&argc, &argv);
    MPI_Comm_size(MPI_COMM_WORLD, &num_procs);
    MPI_Comm_rank(MPI_COMM_WORLD, &myid);
+   HYPRE_Session hypre;
 
    // 2. Parse command-line options.
    const char *mesh_file = "../../data/star.mesh";

--- a/examples/petsc/ex1p.cpp
+++ b/examples/petsc/ex1p.cpp
@@ -80,7 +80,7 @@ int main(int argc, char *argv[])
    MPI_Init(&argc, &argv);
    MPI_Comm_size(MPI_COMM_WORLD, &num_procs);
    MPI_Comm_rank(MPI_COMM_WORLD, &myid);
-   HYPRE_Session hypre;
+   Hypre::Init();
 
    // 2. Parse command-line options.
    const char *mesh_file = "../../data/star.mesh";

--- a/examples/petsc/ex1p.cpp
+++ b/examples/petsc/ex1p.cpp
@@ -75,11 +75,12 @@ public:
 
 int main(int argc, char *argv[])
 {
-   // 1. Initialize MPI.
+   // 1. Initialize MPI and HYPRE.
    int num_procs, myid;
    MPI_Init(&argc, &argv);
    MPI_Comm_size(MPI_COMM_WORLD, &num_procs);
    MPI_Comm_rank(MPI_COMM_WORLD, &myid);
+   HYPRE_Session hypre;
 
    // 2. Parse command-line options.
    const char *mesh_file = "../../data/star.mesh";

--- a/examples/petsc/ex1p.cpp
+++ b/examples/petsc/ex1p.cpp
@@ -76,10 +76,9 @@ public:
 int main(int argc, char *argv[])
 {
    // 1. Initialize MPI and HYPRE.
-   int num_procs, myid;
-   MPI_Init(&argc, &argv);
-   MPI_Comm_size(MPI_COMM_WORLD, &num_procs);
-   MPI_Comm_rank(MPI_COMM_WORLD, &myid);
+   Mpi::Init(argc, argv);
+   int num_procs = Mpi::WorldSize();
+   int myid = Mpi::WorldRank();
    Hypre::Init();
 
    // 2. Parse command-line options.
@@ -131,7 +130,6 @@ int main(int argc, char *argv[])
       {
          args.PrintUsage(cout);
       }
-      MPI_Finalize();
       return 1;
    }
    if (myid == 0)
@@ -380,8 +378,6 @@ int main(int argc, char *argv[])
 
    // We finalize PETSc
    MFEMFinalizePetsc();
-
-   MPI_Finalize();
 
    return 0;
 }

--- a/examples/petsc/ex2p.cpp
+++ b/examples/petsc/ex2p.cpp
@@ -50,11 +50,12 @@ using namespace mfem;
 
 int main(int argc, char *argv[])
 {
-   // 1. Initialize MPI.
+   // 1. Initialize MPI and HYPRE.
    int num_procs, myid;
    MPI_Init(&argc, &argv);
    MPI_Comm_size(MPI_COMM_WORLD, &num_procs);
    MPI_Comm_rank(MPI_COMM_WORLD, &myid);
+   HYPRE_Session hypre;
 
    // 2. Parse command-line options.
    const char *mesh_file = "../../data/beam-tri.mesh";

--- a/examples/petsc/ex2p.cpp
+++ b/examples/petsc/ex2p.cpp
@@ -55,7 +55,7 @@ int main(int argc, char *argv[])
    MPI_Init(&argc, &argv);
    MPI_Comm_size(MPI_COMM_WORLD, &num_procs);
    MPI_Comm_rank(MPI_COMM_WORLD, &myid);
-   HYPRE_Session hypre;
+   Hypre::Init();
 
    // 2. Parse command-line options.
    const char *mesh_file = "../../data/beam-tri.mesh";

--- a/examples/petsc/ex2p.cpp
+++ b/examples/petsc/ex2p.cpp
@@ -51,10 +51,9 @@ using namespace mfem;
 int main(int argc, char *argv[])
 {
    // 1. Initialize MPI and HYPRE.
-   int num_procs, myid;
-   MPI_Init(&argc, &argv);
-   MPI_Comm_size(MPI_COMM_WORLD, &num_procs);
-   MPI_Comm_rank(MPI_COMM_WORLD, &myid);
+   Mpi::Init(argc, argv);
+   int num_procs = Mpi::WorldSize();
+   int myid = Mpi::WorldRank();
    Hypre::Init();
 
    // 2. Parse command-line options.
@@ -102,7 +101,6 @@ int main(int argc, char *argv[])
       {
          args.PrintUsage(cout);
       }
-      MPI_Finalize();
       return 1;
    }
    if (myid == 0)
@@ -125,7 +123,6 @@ int main(int argc, char *argv[])
          cerr << "\nInput mesh should have at least two materials and "
               << "two boundary attributes! (See schematic in ex2.cpp)\n"
               << endl;
-      MPI_Finalize();
       return 3;
    }
 
@@ -393,8 +390,6 @@ int main(int argc, char *argv[])
 
    // We finalize PETSc
    if (use_petsc) { MFEMFinalizePetsc(); }
-
-   MPI_Finalize();
 
    return 0;
 }

--- a/examples/petsc/ex3p.cpp
+++ b/examples/petsc/ex3p.cpp
@@ -45,11 +45,12 @@ int dim;
 
 int main(int argc, char *argv[])
 {
-   // 1. Initialize MPI.
+   // 1. Initialize MPI and HYPRE.
    int num_procs, myid;
    MPI_Init(&argc, &argv);
    MPI_Comm_size(MPI_COMM_WORLD, &num_procs);
    MPI_Comm_rank(MPI_COMM_WORLD, &myid);
+   HYPRE_Session hypre;
 
    // 2. Parse command-line options.
    const char *mesh_file = "../../data/beam-tet.mesh";

--- a/examples/petsc/ex3p.cpp
+++ b/examples/petsc/ex3p.cpp
@@ -50,7 +50,7 @@ int main(int argc, char *argv[])
    MPI_Init(&argc, &argv);
    MPI_Comm_size(MPI_COMM_WORLD, &num_procs);
    MPI_Comm_rank(MPI_COMM_WORLD, &myid);
-   HYPRE_Session hypre;
+   Hypre::Init();
 
    // 2. Parse command-line options.
    const char *mesh_file = "../../data/beam-tet.mesh";

--- a/examples/petsc/ex3p.cpp
+++ b/examples/petsc/ex3p.cpp
@@ -46,10 +46,9 @@ int dim;
 int main(int argc, char *argv[])
 {
    // 1. Initialize MPI and HYPRE.
-   int num_procs, myid;
-   MPI_Init(&argc, &argv);
-   MPI_Comm_size(MPI_COMM_WORLD, &num_procs);
-   MPI_Comm_rank(MPI_COMM_WORLD, &myid);
+   Mpi::Init(argc, argv);
+   int num_procs = Mpi::WorldSize();
+   int myid = Mpi::WorldRank();
    Hypre::Init();
 
    // 2. Parse command-line options.
@@ -89,7 +88,6 @@ int main(int argc, char *argv[])
       {
          args.PrintUsage(cout);
       }
-      MPI_Finalize();
       return 1;
    }
    if (myid == 0)
@@ -308,8 +306,6 @@ int main(int argc, char *argv[])
 
    // We finalize PETSc
    if (use_petsc) { MFEMFinalizePetsc(); }
-
-   MPI_Finalize();
 
    return 0;
 }

--- a/examples/petsc/ex4p.cpp
+++ b/examples/petsc/ex4p.cpp
@@ -45,7 +45,7 @@ int main(int argc, char *argv[])
    MPI_Init(&argc, &argv);
    MPI_Comm_size(MPI_COMM_WORLD, &num_procs);
    MPI_Comm_rank(MPI_COMM_WORLD, &myid);
-   HYPRE_Session hypre;
+   Hypre::Init();
 
    // 2. Parse command-line options.
    const char *mesh_file = "../../data/star.mesh";

--- a/examples/petsc/ex4p.cpp
+++ b/examples/petsc/ex4p.cpp
@@ -40,11 +40,12 @@ double freq = 1.0, kappa;
 
 int main(int argc, char *argv[])
 {
-   // 1. Initialize MPI.
+   // 1. Initialize MPI and HYPRE.
    int num_procs, myid;
    MPI_Init(&argc, &argv);
    MPI_Comm_size(MPI_COMM_WORLD, &num_procs);
    MPI_Comm_rank(MPI_COMM_WORLD, &myid);
+   HYPRE_Session hypre;
 
    // 2. Parse command-line options.
    const char *mesh_file = "../../data/star.mesh";

--- a/examples/petsc/ex4p.cpp
+++ b/examples/petsc/ex4p.cpp
@@ -41,10 +41,9 @@ double freq = 1.0, kappa;
 int main(int argc, char *argv[])
 {
    // 1. Initialize MPI and HYPRE.
-   int num_procs, myid;
-   MPI_Init(&argc, &argv);
-   MPI_Comm_size(MPI_COMM_WORLD, &num_procs);
-   MPI_Comm_rank(MPI_COMM_WORLD, &myid);
+   Mpi::Init(argc, argv);
+   int num_procs = Mpi::WorldSize();
+   int myid = Mpi::WorldRank();
    Hypre::Init();
 
    // 2. Parse command-line options.
@@ -90,7 +89,6 @@ int main(int argc, char *argv[])
       {
          args.PrintUsage(cout);
       }
-      MPI_Finalize();
       return 1;
    }
    if (myid == 0)
@@ -329,8 +327,6 @@ int main(int argc, char *argv[])
 
    // We finalize PETSc
    if (use_petsc) { MFEMFinalizePetsc(); }
-
-   MPI_Finalize();
 
    return 0;
 }

--- a/examples/petsc/ex5p.cpp
+++ b/examples/petsc/ex5p.cpp
@@ -50,11 +50,12 @@ int main(int argc, char *argv[])
 {
    StopWatch chrono;
 
-   // 1. Initialize MPI.
+   // 1. Initialize MPI and HYPRE.
    int num_procs, myid;
    MPI_Init(&argc, &argv);
    MPI_Comm_size(MPI_COMM_WORLD, &num_procs);
    MPI_Comm_rank(MPI_COMM_WORLD, &myid);
+   HYPRE_Session hypre;
    bool verbose = (myid == 0);
 
    // 2. Parse command-line options.

--- a/examples/petsc/ex5p.cpp
+++ b/examples/petsc/ex5p.cpp
@@ -51,10 +51,9 @@ int main(int argc, char *argv[])
    StopWatch chrono;
 
    // 1. Initialize MPI and HYPRE.
-   int num_procs, myid;
-   MPI_Init(&argc, &argv);
-   MPI_Comm_size(MPI_COMM_WORLD, &num_procs);
-   MPI_Comm_rank(MPI_COMM_WORLD, &myid);
+   Mpi::Init(argc, argv);
+   int num_procs = Mpi::WorldSize();
+   int myid = Mpi::WorldRank();
    Hypre::Init();
    bool verbose = (myid == 0);
 
@@ -98,7 +97,6 @@ int main(int argc, char *argv[])
       {
          args.PrintUsage(cout);
       }
-      MPI_Finalize();
       return 1;
    }
    if (verbose)
@@ -546,8 +544,6 @@ int main(int argc, char *argv[])
 
    // We finalize PETSc
    if (use_petsc) { MFEMFinalizePetsc(); }
-
-   MPI_Finalize();
 
    return 0;
 }

--- a/examples/petsc/ex5p.cpp
+++ b/examples/petsc/ex5p.cpp
@@ -55,7 +55,7 @@ int main(int argc, char *argv[])
    MPI_Init(&argc, &argv);
    MPI_Comm_size(MPI_COMM_WORLD, &num_procs);
    MPI_Comm_rank(MPI_COMM_WORLD, &myid);
-   HYPRE_Session hypre;
+   Hypre::Init();
    bool verbose = (myid == 0);
 
    // 2. Parse command-line options.

--- a/examples/petsc/ex6p.cpp
+++ b/examples/petsc/ex6p.cpp
@@ -40,10 +40,9 @@ using namespace mfem;
 int main(int argc, char *argv[])
 {
    // 1. Initialize MPI and HYPRE.
-   int num_procs, myid;
-   MPI_Init(&argc, &argv);
-   MPI_Comm_size(MPI_COMM_WORLD, &num_procs);
-   MPI_Comm_rank(MPI_COMM_WORLD, &myid);
+   Mpi::Init(argc, argv);
+   int num_procs = Mpi::WorldSize();
+   int myid = Mpi::WorldRank();
    Hypre::Init();
 
    // 2. Parse command-line options.
@@ -81,7 +80,6 @@ int main(int argc, char *argv[])
       {
          args.PrintUsage(cout);
       }
-      MPI_Finalize();
       return 1;
    }
    if (myid == 0)
@@ -318,6 +316,5 @@ int main(int argc, char *argv[])
    // We finalize PETSc
    if (use_petsc) { MFEMFinalizePetsc(); }
 
-   MPI_Finalize();
    return 0;
 }

--- a/examples/petsc/ex6p.cpp
+++ b/examples/petsc/ex6p.cpp
@@ -44,7 +44,7 @@ int main(int argc, char *argv[])
    MPI_Init(&argc, &argv);
    MPI_Comm_size(MPI_COMM_WORLD, &num_procs);
    MPI_Comm_rank(MPI_COMM_WORLD, &myid);
-   HYPRE_Session hypre;
+   Hypre::Init();
 
    // 2. Parse command-line options.
    const char *mesh_file = "../../data/star.mesh";

--- a/examples/petsc/ex6p.cpp
+++ b/examples/petsc/ex6p.cpp
@@ -39,11 +39,12 @@ using namespace mfem;
 
 int main(int argc, char *argv[])
 {
-   // 1. Initialize MPI.
+   // 1. Initialize MPI and HYPRE.
    int num_procs, myid;
    MPI_Init(&argc, &argv);
    MPI_Comm_size(MPI_COMM_WORLD, &num_procs);
    MPI_Comm_rank(MPI_COMM_WORLD, &myid);
+   HYPRE_Session hypre;
 
    // 2. Parse command-line options.
    const char *mesh_file = "../../data/star.mesh";

--- a/examples/petsc/ex9p.cpp
+++ b/examples/petsc/ex9p.cpp
@@ -136,11 +136,12 @@ public:
 
 int main(int argc, char *argv[])
 {
-   // 1. Initialize MPI.
+   // 1. Initialize MPI and HYPRE.
    int num_procs, myid;
    MPI_Init(&argc, &argv);
    MPI_Comm_size(MPI_COMM_WORLD, &num_procs);
    MPI_Comm_rank(MPI_COMM_WORLD, &myid);
+   HYPRE_Session hypre;
 
    // 2. Parse command-line options.
    problem = 0;

--- a/examples/petsc/ex9p.cpp
+++ b/examples/petsc/ex9p.cpp
@@ -141,7 +141,7 @@ int main(int argc, char *argv[])
    MPI_Init(&argc, &argv);
    MPI_Comm_size(MPI_COMM_WORLD, &num_procs);
    MPI_Comm_rank(MPI_COMM_WORLD, &myid);
-   HYPRE_Session hypre;
+   Hypre::Init();
 
    // 2. Parse command-line options.
    problem = 0;

--- a/examples/petsc/ex9p.cpp
+++ b/examples/petsc/ex9p.cpp
@@ -137,10 +137,9 @@ public:
 int main(int argc, char *argv[])
 {
    // 1. Initialize MPI and HYPRE.
-   int num_procs, myid;
-   MPI_Init(&argc, &argv);
-   MPI_Comm_size(MPI_COMM_WORLD, &num_procs);
-   MPI_Comm_rank(MPI_COMM_WORLD, &myid);
+   Mpi::Init(argc, argv);
+   int num_procs = Mpi::WorldSize();
+   int myid = Mpi::WorldRank();
    Hypre::Init();
 
    // 2. Parse command-line options.
@@ -223,7 +222,6 @@ int main(int argc, char *argv[])
       {
          args.PrintUsage(cout);
       }
-      MPI_Finalize();
       return 1;
    }
    if (myid == 0)
@@ -258,7 +256,6 @@ int main(int argc, char *argv[])
             {
                cout << "Unknown ODE solver type: " << ode_solver_type << '\n';
             }
-            MPI_Finalize();
             return 3;
       }
    }
@@ -516,7 +513,6 @@ int main(int argc, char *argv[])
    // We finalize PETSc
    if (use_petsc) { MFEMFinalizePetsc(); }
 
-   MPI_Finalize();
    return 0;
 }
 

--- a/examples/pumi/ex1.cpp
+++ b/examples/pumi/ex1.cpp
@@ -69,7 +69,7 @@ int main(int argc, char *argv[])
    MPI_Init(&argc, &argv);
    MPI_Comm_size(MPI_COMM_WORLD, &num_procs);
    MPI_Comm_rank(MPI_COMM_WORLD, &myid);
-   HYPRE_Session hypre;
+   Hypre::Init();
 
    // 2. Parse command-line options.
    const char *mesh_file = "../../data/pumi/serial/Kova.smb";

--- a/examples/pumi/ex1.cpp
+++ b/examples/pumi/ex1.cpp
@@ -64,11 +64,12 @@ using namespace mfem;
 
 int main(int argc, char *argv[])
 {
-   // 1. Initialize MPI (required by PUMI).
+   // 1. Initialize MPI (required by PUMI) and HYPRE.
    int num_procs, myid;
    MPI_Init(&argc, &argv);
    MPI_Comm_size(MPI_COMM_WORLD, &num_procs);
    MPI_Comm_rank(MPI_COMM_WORLD, &myid);
+   HYPRE_Session hypre;
 
    // 2. Parse command-line options.
    const char *mesh_file = "../../data/pumi/serial/Kova.smb";

--- a/examples/pumi/ex1.cpp
+++ b/examples/pumi/ex1.cpp
@@ -65,10 +65,9 @@ using namespace mfem;
 int main(int argc, char *argv[])
 {
    // 1. Initialize MPI (required by PUMI) and HYPRE.
-   int num_procs, myid;
-   MPI_Init(&argc, &argv);
-   MPI_Comm_size(MPI_COMM_WORLD, &num_procs);
-   MPI_Comm_rank(MPI_COMM_WORLD, &myid);
+   Mpi::Init(argc, argv);
+   int num_procs = Mpi::WorldSize();
+   int myid = Mpi::WorldRank();
    Hypre::Init();
 
    // 2. Parse command-line options.
@@ -105,7 +104,6 @@ int main(int argc, char *argv[])
       {
          args.PrintUsage(cout);
       }
-      MPI_Finalize();
       return 1;
    }
    if (myid == 0)
@@ -269,6 +267,5 @@ int main(int argc, char *argv[])
    Sim_unregisterAllKeys();
 #endif
 
-   MPI_Finalize();
    return 0;
 }

--- a/examples/pumi/ex1p.cpp
+++ b/examples/pumi/ex1p.cpp
@@ -74,7 +74,7 @@ int main(int argc, char *argv[])
    MPI_Init(&argc, &argv);
    MPI_Comm_size(MPI_COMM_WORLD, &num_procs);
    MPI_Comm_rank(MPI_COMM_WORLD, &myid);
-   HYPRE_Session hypre;
+   Hypre::Init();
 
    // 2. Parse command-line options.
    const char *mesh_file = "../../data/pumi/parallel/Kova/Kova100k_8.smb";

--- a/examples/pumi/ex1p.cpp
+++ b/examples/pumi/ex1p.cpp
@@ -69,11 +69,12 @@ using namespace mfem;
 
 int main(int argc, char *argv[])
 {
-   // 1. Initialize MPI.
+   // 1. Initialize MPI and HYPRE.
    int num_procs, myid;
    MPI_Init(&argc, &argv);
    MPI_Comm_size(MPI_COMM_WORLD, &num_procs);
    MPI_Comm_rank(MPI_COMM_WORLD, &myid);
+   HYPRE_Session hypre;
 
    // 2. Parse command-line options.
    const char *mesh_file = "../../data/pumi/parallel/Kova/Kova100k_8.smb";

--- a/examples/pumi/ex1p.cpp
+++ b/examples/pumi/ex1p.cpp
@@ -70,10 +70,9 @@ using namespace mfem;
 int main(int argc, char *argv[])
 {
    // 1. Initialize MPI and HYPRE.
-   int num_procs, myid;
-   MPI_Init(&argc, &argv);
-   MPI_Comm_size(MPI_COMM_WORLD, &num_procs);
-   MPI_Comm_rank(MPI_COMM_WORLD, &myid);
+   Mpi::Init(argc, argv);
+   int num_procs = Mpi::WorldSize();
+   int myid = Mpi::WorldRank();
    Hypre::Init();
 
    // 2. Parse command-line options.
@@ -110,7 +109,6 @@ int main(int argc, char *argv[])
       {
          args.PrintUsage(cout);
       }
-      MPI_Finalize();
       return 1;
    }
    if (myid == 0)
@@ -298,8 +296,6 @@ int main(int argc, char *argv[])
    gmi_sim_stop();
    Sim_unregisterAllKeys();
 #endif
-
-   MPI_Finalize();
 
    return 0;
 }

--- a/examples/pumi/ex2.cpp
+++ b/examples/pumi/ex2.cpp
@@ -83,7 +83,7 @@ int main(int argc, char *argv[])
    MPI_Init(&argc, &argv);
    MPI_Comm_size(MPI_COMM_WORLD, &num_proc);
    MPI_Comm_rank(MPI_COMM_WORLD, &myId);
-   HYPRE_Session hypre;
+   Hypre::Init();
 
    // 2. Parse command-line options.
    const char *mesh_file = "../../data/pumi/serial/pillbox.smb";

--- a/examples/pumi/ex2.cpp
+++ b/examples/pumi/ex2.cpp
@@ -78,11 +78,12 @@ using namespace mfem;
 
 int main(int argc, char *argv[])
 {
-   // 1. Initialize MPI (required by PUMI).
+   // 1. Initialize MPI (required by PUMI) and HYPRE.
    int num_proc, myId;
    MPI_Init(&argc, &argv);
    MPI_Comm_size(MPI_COMM_WORLD, &num_proc);
    MPI_Comm_rank(MPI_COMM_WORLD, &myId);
+   HYPRE_Session hypre;
 
    // 2. Parse command-line options.
    const char *mesh_file = "../../data/pumi/serial/pillbox.smb";

--- a/examples/pumi/ex2.cpp
+++ b/examples/pumi/ex2.cpp
@@ -80,7 +80,6 @@ int main(int argc, char *argv[])
 {
    // 1. Initialize MPI (required by PUMI) and HYPRE.
    Mpi::Init(argc, argv);
-   Hypre::Init();
    int num_proc = Mpi::WorldSize();
    int myId = Mpi::WorldRank();
    Hypre::Init();

--- a/examples/pumi/ex2.cpp
+++ b/examples/pumi/ex2.cpp
@@ -79,10 +79,10 @@ using namespace mfem;
 int main(int argc, char *argv[])
 {
    // 1. Initialize MPI (required by PUMI) and HYPRE.
-   int num_proc, myId;
-   MPI_Init(&argc, &argv);
-   MPI_Comm_size(MPI_COMM_WORLD, &num_proc);
-   MPI_Comm_rank(MPI_COMM_WORLD, &myId);
+   Mpi::Init(argc, argv);
+   Hypre::Init();
+   int num_proc = Mpi::WorldSize();
+   int myId = Mpi::WorldRank();
    Hypre::Init();
 
    // 2. Parse command-line options.
@@ -419,8 +419,6 @@ int main(int argc, char *argv[])
    gmi_sim_stop();
    Sim_unregisterAllKeys();
 #endif
-
-   MPI_Finalize();
 
    return 0;
 }

--- a/examples/pumi/ex6p.cpp
+++ b/examples/pumi/ex6p.cpp
@@ -56,7 +56,7 @@ int main(int argc, char *argv[])
    MPI_Init(&argc, &argv);
    MPI_Comm_size(MPI_COMM_WORLD, &num_procs);
    MPI_Comm_rank(MPI_COMM_WORLD, &myid);
-   HYPRE_Session hypre;
+   Hypre::Init();
 
    // 2. Parse command-line options.
    const char *mesh_file = "../../data/pumi/parallel/Kova/Kova100k_8.smb";

--- a/examples/pumi/ex6p.cpp
+++ b/examples/pumi/ex6p.cpp
@@ -51,11 +51,12 @@ using namespace mfem;
 
 int main(int argc, char *argv[])
 {
-   // 1. Initialize MPI.
+   // 1. Initialize MPI and HYPRE.
    int num_procs, myid;
    MPI_Init(&argc, &argv);
    MPI_Comm_size(MPI_COMM_WORLD, &num_procs);
    MPI_Comm_rank(MPI_COMM_WORLD, &myid);
+   HYPRE_Session hypre;
 
    // 2. Parse command-line options.
    const char *mesh_file = "../../data/pumi/parallel/Kova/Kova100k_8.smb";

--- a/examples/pumi/ex6p.cpp
+++ b/examples/pumi/ex6p.cpp
@@ -52,10 +52,9 @@ using namespace mfem;
 int main(int argc, char *argv[])
 {
    // 1. Initialize MPI and HYPRE.
-   int num_procs, myid;
-   MPI_Init(&argc, &argv);
-   MPI_Comm_size(MPI_COMM_WORLD, &num_procs);
-   MPI_Comm_rank(MPI_COMM_WORLD, &myid);
+   Mpi::Init(argc, argv);
+   int num_procs = Mpi::WorldSize();
+   int myid = Mpi::WorldRank();
    Hypre::Init();
 
    // 2. Parse command-line options.
@@ -100,7 +99,6 @@ int main(int argc, char *argv[])
       {
          args.PrintUsage(cout);
       }
-      MPI_Finalize();
       return 1;
    }
    if (myid == 0)
@@ -389,8 +387,6 @@ int main(int argc, char *argv[])
    gmi_sim_stop();
    Sim_unregisterAllKeys();
 #endif
-
-   MPI_Finalize();
 
    return 0;
 }

--- a/examples/sundials/ex10p.cpp
+++ b/examples/sundials/ex10p.cpp
@@ -216,10 +216,9 @@ void visualize(ostream &os, ParMesh *mesh, ParGridFunction *deformed_nodes,
 int main(int argc, char *argv[])
 {
    // 1. Initialize MPI and HYPRE.
-   int num_procs, myid;
-   MPI_Init(&argc, &argv);
-   MPI_Comm_size(MPI_COMM_WORLD, &num_procs);
-   MPI_Comm_rank(MPI_COMM_WORLD, &myid);
+   Mpi::Init(argc, argv);
+   int num_procs = Mpi::WorldSize();
+   int myid = Mpi::WorldRank();
    Hypre::Init();
 
    // 2. Parse command-line options.
@@ -299,7 +298,6 @@ int main(int argc, char *argv[])
       {
          args.PrintUsage(cout);
       }
-      MPI_Finalize();
       return 1;
    }
    if (myid == 0)
@@ -314,7 +312,6 @@ int main(int argc, char *argv[])
       {
          cout << "Unknown ODE solver type: " << ode_solver_type << '\n';
       }
-      MPI_Finalize();
       return 1;
    }
 
@@ -335,7 +332,6 @@ int main(int argc, char *argv[])
          cout << "Unknown type of nonlinear solver: " << nls << endl;
       }
       delete mesh;
-      MPI_Finalize();
       return 4;
    }
 
@@ -579,8 +575,6 @@ int main(int argc, char *argv[])
    // 13. Free the used memory.
    delete ode_solver;
    delete pmesh;
-
-   MPI_Finalize();
 
    return 0;
 }

--- a/examples/sundials/ex10p.cpp
+++ b/examples/sundials/ex10p.cpp
@@ -220,7 +220,7 @@ int main(int argc, char *argv[])
    MPI_Init(&argc, &argv);
    MPI_Comm_size(MPI_COMM_WORLD, &num_procs);
    MPI_Comm_rank(MPI_COMM_WORLD, &myid);
-   HYPRE_Session hypre;
+   Hypre::Init();
 
    // 2. Parse command-line options.
    const char *mesh_file = "../../data/beam-quad.mesh";

--- a/examples/sundials/ex10p.cpp
+++ b/examples/sundials/ex10p.cpp
@@ -215,11 +215,12 @@ void visualize(ostream &out, ParMesh *mesh, ParGridFunction *deformed_nodes,
 
 int main(int argc, char *argv[])
 {
-   // 1. Initialize MPI.
+   // 1. Initialize MPI and HYPRE.
    int num_procs, myid;
    MPI_Init(&argc, &argv);
    MPI_Comm_size(MPI_COMM_WORLD, &num_procs);
    MPI_Comm_rank(MPI_COMM_WORLD, &myid);
+   HYPRE_Session hypre;
 
    // 2. Parse command-line options.
    const char *mesh_file = "../../data/beam-quad.mesh";

--- a/examples/sundials/ex16p.cpp
+++ b/examples/sundials/ex16p.cpp
@@ -102,10 +102,9 @@ double InitialTemperature(const Vector &x);
 int main(int argc, char *argv[])
 {
    // 1. Initialize MPI and HYPRE.
-   int num_procs, myid;
-   MPI_Init(&argc, &argv);
-   MPI_Comm_size(MPI_COMM_WORLD, &num_procs);
-   MPI_Comm_rank(MPI_COMM_WORLD, &myid);
+   Mpi::Init(argc, argv);
+   int num_procs = Mpi::WorldSize();
+   int myid = Mpi::WorldRank();
    Hypre::Init();
 
    // 2. Parse command-line options.
@@ -171,7 +170,6 @@ int main(int argc, char *argv[])
    if (!args.Good())
    {
       args.PrintUsage(cout);
-      MPI_Finalize();
       return 1;
    }
 
@@ -187,7 +185,6 @@ int main(int argc, char *argv[])
       {
          cout << "Unknown ODE solver type: " << ode_solver_type << '\n';
       }
-      MPI_Finalize();
       return 1;
    }
 
@@ -415,8 +412,6 @@ int main(int argc, char *argv[])
    // 12. Free the used memory.
    delete ode_solver;
    delete pmesh;
-
-   MPI_Finalize();
 
    return 0;
 }

--- a/examples/sundials/ex16p.cpp
+++ b/examples/sundials/ex16p.cpp
@@ -101,11 +101,12 @@ double InitialTemperature(const Vector &x);
 
 int main(int argc, char *argv[])
 {
-   // 1. Initialize MPI.
+   // 1. Initialize MPI and HYPRE.
    int num_procs, myid;
    MPI_Init(&argc, &argv);
    MPI_Comm_size(MPI_COMM_WORLD, &num_procs);
    MPI_Comm_rank(MPI_COMM_WORLD, &myid);
+   HYPRE_Session hypre;
 
    // 2. Parse command-line options.
    const char *mesh_file = "../../data/star.mesh";

--- a/examples/sundials/ex16p.cpp
+++ b/examples/sundials/ex16p.cpp
@@ -106,7 +106,7 @@ int main(int argc, char *argv[])
    MPI_Init(&argc, &argv);
    MPI_Comm_size(MPI_COMM_WORLD, &num_procs);
    MPI_Comm_rank(MPI_COMM_WORLD, &myid);
-   HYPRE_Session hypre;
+   Hypre::Init();
 
    // 2. Parse command-line options.
    const char *mesh_file = "../../data/star.mesh";

--- a/examples/sundials/ex9p.cpp
+++ b/examples/sundials/ex9p.cpp
@@ -157,7 +157,7 @@ int main(int argc, char *argv[])
    MPI_Init(&argc, &argv);
    MPI_Comm_size(MPI_COMM_WORLD, &num_procs);
    MPI_Comm_rank(MPI_COMM_WORLD, &myid);
-   HYPRE_Session hypre;
+   Hypre::Init();
 
    // 2. Parse command-line options.
    problem = 0;

--- a/examples/sundials/ex9p.cpp
+++ b/examples/sundials/ex9p.cpp
@@ -152,11 +152,12 @@ public:
 
 int main(int argc, char *argv[])
 {
-   // 1. Initialize MPI.
+   // 1. Initialize MPI and HYPRE.
    int num_procs, myid;
    MPI_Init(&argc, &argv);
    MPI_Comm_size(MPI_COMM_WORLD, &num_procs);
    MPI_Comm_rank(MPI_COMM_WORLD, &myid);
+   HYPRE_Session hypre;
 
    // 2. Parse command-line options.
    problem = 0;

--- a/examples/sundials/ex9p.cpp
+++ b/examples/sundials/ex9p.cpp
@@ -153,10 +153,9 @@ public:
 int main(int argc, char *argv[])
 {
    // 1. Initialize MPI and HYPRE.
-   int num_procs, myid;
-   MPI_Init(&argc, &argv);
-   MPI_Comm_size(MPI_COMM_WORLD, &num_procs);
-   MPI_Comm_rank(MPI_COMM_WORLD, &myid);
+   Mpi::Init(argc, argv);
+   int num_procs = Mpi::WorldSize();
+   int myid = Mpi::WorldRank();
    Hypre::Init();
 
    // 2. Parse command-line options.
@@ -242,7 +241,6 @@ int main(int argc, char *argv[])
       {
          args.PrintUsage(cout);
       }
-      MPI_Finalize();
       return 1;
    }
    if (myid == 0)
@@ -257,7 +255,6 @@ int main(int argc, char *argv[])
       {
          cout << "Unknown ODE solver type: " << ode_solver_type << '\n';
       }
-      MPI_Finalize();
       return 3;
    }
 
@@ -583,7 +580,6 @@ int main(int argc, char *argv[])
 #endif
    delete dc;
 
-   MPI_Finalize();
    return 0;
 }
 

--- a/examples/superlu/ex1p.cpp
+++ b/examples/superlu/ex1p.cpp
@@ -54,10 +54,9 @@ using namespace mfem;
 int main(int argc, char *argv[])
 {
    // 1. Initialize MPI and HYPRE.
-   int num_procs, myid;
-   MPI_Init(&argc, &argv);
-   MPI_Comm_size(MPI_COMM_WORLD, &num_procs);
-   MPI_Comm_rank(MPI_COMM_WORLD, &myid);
+   Mpi::Init(argc, argv);
+   int num_procs = Mpi::WorldSize();
+   int myid = Mpi::WorldRank();
    Hypre::Init();
 
    // 2. Parse command-line options.
@@ -97,7 +96,6 @@ int main(int argc, char *argv[])
       {
          args.PrintUsage(cout);
       }
-      MPI_Finalize();
       return 1;
    }
    if (myid == 0)
@@ -324,7 +322,6 @@ int main(int argc, char *argv[])
    {
       delete fec;
    }
-   MPI_Finalize();
 
    return 0;
 }

--- a/examples/superlu/ex1p.cpp
+++ b/examples/superlu/ex1p.cpp
@@ -58,7 +58,7 @@ int main(int argc, char *argv[])
    MPI_Init(&argc, &argv);
    MPI_Comm_size(MPI_COMM_WORLD, &num_procs);
    MPI_Comm_rank(MPI_COMM_WORLD, &myid);
-   HYPRE_Session hypre;
+   Hypre::Init();
 
    // 2. Parse command-line options.
    const char *mesh_file = "../../data/star.mesh";

--- a/examples/superlu/ex1p.cpp
+++ b/examples/superlu/ex1p.cpp
@@ -53,11 +53,12 @@ using namespace mfem;
 
 int main(int argc, char *argv[])
 {
-   // 1. Initialize MPI.
+   // 1. Initialize MPI and HYPRE.
    int num_procs, myid;
    MPI_Init(&argc, &argv);
    MPI_Comm_size(MPI_COMM_WORLD, &num_procs);
    MPI_Comm_rank(MPI_COMM_WORLD, &myid);
+   HYPRE_Session hypre;
 
    // 2. Parse command-line options.
    const char *mesh_file = "../../data/star.mesh";

--- a/general/communication.cpp
+++ b/general/communication.cpp
@@ -34,13 +34,6 @@ using namespace std;
 namespace mfem
 {
 
-void MPI_Session::GetRankAndSize()
-{
-   MPI_Comm_rank(MPI_COMM_WORLD, &world_rank);
-   MPI_Comm_size(MPI_COMM_WORLD, &world_size);
-}
-
-
 GroupTopology::GroupTopology(const GroupTopology &gt)
    : MyComm(gt.MyComm),
      group_lproc(gt.group_lproc)

--- a/general/communication.hpp
+++ b/general/communication.hpp
@@ -75,9 +75,11 @@ private:
    /// Initialize MPI
    static void Init_(int *argc, char ***argv)
    {
-      static Mpi mpi;
       MFEM_VERIFY(!IsInitialized(), "MPI already initialized!")
       MPI_Init(argc, argv);
+      // The "mpi" object below needs to be created after MPI_Init() for some
+      // MPI implementations
+      static Mpi mpi;
    }
    /// Finalize MPI
    ~Mpi() { Finalize(); }

--- a/general/communication.hpp
+++ b/general/communication.hpp
@@ -85,9 +85,9 @@ private:
    Mpi() { }
 };
 
-/** @brief A simple convenience class based on the MPI singleton class above.
+/** @brief A simple convenience class based on the Mpi singleton class above.
     Preserved for backward compatibility. New code should use Mpi::Init() and
-    Mpi::Session() instead. */
+    other Mpi methods instead. */
 class MPI_Session
 {
 public:

--- a/general/communication.hpp
+++ b/general/communication.hpp
@@ -29,17 +29,17 @@ namespace mfem
 /** @brief A simple singleton class that calls MPI_Init() at construction and
     MPI_Finalize() at destruction. It also provides easy access to
     MPI_COMM_WORLD's rank and size. */
-class MPI
+class Mpi
 {
 public:
-   /// Singleton creation with MPI::Init();
+   /// Singleton creation with Mpi::Init();
    static void Init() { Init_(NULL, NULL); }
-   /// Singleton creation with MPI::Init(argc,argv);
+   /// Singleton creation with Mpi::Init(argc,argv);
    static void Init(int &argc, char **&argv) { Init_(&argc, &argv); }
-   /// Access to the singleton with MPI::Session()
-   static MPI &Session()
+   /// Access to the singleton with Mpi::Session()
+   static Mpi &Session()
    {
-      MPI &mpi = Instance();
+      Mpi &mpi = Instance();
       MFEM_VERIFY(mpi.initialized, "MPI not initialized!");
       return mpi;
    }
@@ -51,7 +51,7 @@ private:
    /// Initialize MPI
    static void Init_(int *argc, char ***argv)
    {
-      MPI &mpi = Instance();
+      Mpi &mpi = Instance();
       MFEM_VERIFY(!mpi.initialized, "MPI already initialized!")
       MPI_Init(argc, argv);
       MPI_Comm_rank(MPI_COMM_WORLD, &mpi.world_rank);
@@ -59,34 +59,34 @@ private:
       mpi.initialized = true;
    }
    /// Finalize MPI
-   ~MPI() { MPI_Finalize(); }
+   ~Mpi() { if (initialized) { MPI_Finalize(); } }
    /// Access the singleton instance
-   static MPI &Instance()
+   static Mpi &Instance()
    {
-      static MPI mpi;
+      static Mpi mpi;
       return mpi;
    }
    /// Prevent direct construction of objects of this class
-   MPI() { }
+   Mpi() { }
    int world_rank = 0;
    int world_size = 0;
    bool initialized = false;
 };
 
 /** @brief A simple convenience class based on the MPI singleton class above.
-    Preserved for backward compatibility. New code should use MPI::Init() and
-    MPI::Session() instead. */
+    Preserved for backward compatibility. New code should use Mpi::Init() and
+    Mpi::Session() instead. */
 class MPI_Session
 {
 public:
-   MPI_Session() { MPI::Init(); }
-   MPI_Session(int &argc, char **&argv) { MPI::Init(argc, argv); }
+   MPI_Session() { Mpi::Init(); }
+   MPI_Session(int &argc, char **&argv) { Mpi::Init(argc, argv); }
    /// Return MPI_COMM_WORLD's rank.
-   int WorldRank() const { return MPI::Session().WorldRank(); }
+   int WorldRank() const { return Mpi::Session().WorldRank(); }
    /// Return MPI_COMM_WORLD's size.
-   int WorldSize() const { return MPI::Session().WorldSize(); }
+   int WorldSize() const { return Mpi::Session().WorldSize(); }
    /// Return true if WorldRank() == 0.
-   bool Root() const { return MPI::Session().Root(); }
+   bool Root() const { return Mpi::Session().Root(); }
 };
 
 

--- a/general/optparser.cpp
+++ b/general/optparser.cpp
@@ -265,7 +265,7 @@ void OptionsParser::ParseCheck(std::ostream &os)
    {
       if (my_rank == 0) { PrintUsage(os); }
 #ifdef MFEM_USE_MPI
-      if (mpi_is_initialized && !MPI::IsInitialized()) { MPI_Finalize(); }
+      if (mpi_is_initialized && !Mpi::IsInitialized()) { MPI_Finalize(); }
 #endif
       std::exit(1);
    }

--- a/general/optparser.cpp
+++ b/general/optparser.cpp
@@ -11,6 +11,7 @@
 
 #include "optparser.hpp"
 #include "../linalg/vector.hpp"
+#include "../general/communication.hpp"
 #include <cctype>
 
 namespace mfem

--- a/general/optparser.cpp
+++ b/general/optparser.cpp
@@ -264,7 +264,7 @@ void OptionsParser::ParseCheck(std::ostream &os)
    {
       if (my_rank == 0) { PrintUsage(os); }
 #ifdef MFEM_USE_MPI
-      if (mpi_is_initialized) { MPI_Finalize(); }
+      if (mpi_is_initialized && !MPI::IsInitialized()) { MPI_Finalize(); }
 #endif
       std::exit(1);
    }

--- a/general/optparser.cpp
+++ b/general/optparser.cpp
@@ -254,18 +254,14 @@ void OptionsParser::ParseCheck(std::ostream &os)
    Parse();
    int my_rank = 0;
 #ifdef MFEM_USE_MPI
-   int mpi_is_initialized;
-   int mpi_err = MPI_Initialized(&mpi_is_initialized);
-   if (mpi_err == MPI_SUCCESS && mpi_is_initialized)
-   {
-      MPI_Comm_rank(MPI_COMM_WORLD, &my_rank);
-   }
+   int mpi_is_initialized = Mpi::IsInitialized();
+   if (mpi_is_initialized) { my_rank = Mpi::WorldRank(); }
 #endif
    if (!Good())
    {
       if (my_rank == 0) { PrintUsage(os); }
 #ifdef MFEM_USE_MPI
-      if (mpi_is_initialized && !Mpi::IsInitialized()) { MPI_Finalize(); }
+      Mpi::Finalize();
 #endif
       std::exit(1);
    }

--- a/linalg/hypre.cpp
+++ b/linalg/hypre.cpp
@@ -38,7 +38,7 @@ Hypre::Hypre()
    HYPRE_Init();
 #endif
 
-   // Global hypre options we set by default
+   // Global hypre options that we set by default
    SetDefaultOptions();
 }
 
@@ -69,7 +69,7 @@ void Hypre::SetDefaultOptions()
 #endif
 #endif
 
-   // The following options are the defaults as of hypre-2.24
+   // The following options are hypre's defaults as of hypre-2.24
 
    // Allocate hypre objects in GPU memory (default)
    // HYPRE_SetMemoryLocation(HYPRE_MEMORY_DEVICE);

--- a/linalg/hypre.cpp
+++ b/linalg/hypre.cpp
@@ -31,10 +31,29 @@ using namespace std;
 namespace mfem
 {
 
+
+HYPRE_Session::HYPRE_Session()
+{
+#if MFEM_HYPRE_VERSION >= 21500
+   HYPRE_Init();
+#endif
+
+   SetGlobalOptions();
+}
+
+HYPRE_Session::~HYPRE_Session()
+{
+#if MFEM_HYPRE_VERSION >= 21500
+   HYPRE_Finalize();
+#endif
+}
+
 void HYPRE_Session::SetGlobalOptions()
 {
+#if MFEM_HYPRE_VERSION >= 22100
    // Use hypre's SpGEMM instead of cuSPARSE.
    HYPRE_SetSpGemmUseCusparse(0);
+#endif
 
 #if 0
    // Additional global options, see

--- a/linalg/hypre.cpp
+++ b/linalg/hypre.cpp
@@ -31,7 +31,6 @@ using namespace std;
 namespace mfem
 {
 
-
 HYPRE_Session::HYPRE_Session()
 {
 #if MFEM_HYPRE_VERSION >= 21500
@@ -71,6 +70,7 @@ void HYPRE_Session::SetGlobalOptions()
    HYPRE_SetUmpireDevicePoolName("HYPRE_DEVICE_POOL_TEST");
 #endif
 }
+
 
 template<typename TargetT, typename SourceT>
 static TargetT *DuplicateAs(const SourceT *array, int size,

--- a/linalg/hypre.cpp
+++ b/linalg/hypre.cpp
@@ -31,6 +31,28 @@ using namespace std;
 namespace mfem
 {
 
+void HYPRE_Session::SetGlobalOptions()
+{
+   // Use hypre's SpGEMM instead of cuSPARSE.
+   HYPRE_SetSpGemmUseCusparse(0);
+
+#if 0
+   // Additional global options, see
+   // https://hypre.readthedocs.io/en/latest/solvers-boomeramg.html#gpu-supported-options
+   // for more details
+
+   // AMG in GPU memory (default)
+   HYPRE_SetMemoryLocation(HYPRE_MEMORY_DEVICE);
+   // Setup AMG on GPUs
+   HYPRE_SetExecutionPolicy(HYPRE_EXEC_DEVICE);
+   // Use GPU RNG
+   HYPRE_SetUseGpuRand(1);
+   // Umpire memory pool
+   HYPRE_SetUmpireUMPoolName("HYPRE_UM_POOL_TEST");
+   HYPRE_SetUmpireDevicePoolName("HYPRE_DEVICE_POOL_TEST");
+#endif
+}
+
 template<typename TargetT, typename SourceT>
 static TargetT *DuplicateAs(const SourceT *array, int size,
                             bool cplusplus = true)

--- a/linalg/hypre.cpp
+++ b/linalg/hypre.cpp
@@ -42,12 +42,16 @@ Hypre::Hypre()
    SetDefaultOptions();
 }
 
-Hypre::~Hypre()
+void Hypre::Finalize()
 {
+   Hypre &hypre = Instance();
+   if (!hypre.finalized)
+   {
 #if MFEM_HYPRE_VERSION >= 21500
-   // Finalizing hypre
-   HYPRE_Finalize();
+      HYPRE_Finalize();
 #endif
+      hypre.finalized = true;
+   }
 }
 
 void Hypre::SetDefaultOptions()

--- a/linalg/hypre.cpp
+++ b/linalg/hypre.cpp
@@ -31,31 +31,33 @@ using namespace std;
 namespace mfem
 {
 
-HYPRE_Session::HYPRE_Session()
+Hypre::Hypre()
 {
 #if MFEM_HYPRE_VERSION >= 21500
+   // Initializing hypre
    HYPRE_Init();
 #endif
 
-   SetGlobalOptions();
+   // Global hypre options we set by default
+   SetDefaultOptions();
 }
 
-HYPRE_Session::~HYPRE_Session()
+Hypre::~Hypre()
 {
 #if MFEM_HYPRE_VERSION >= 21500
+   // Finalizing hypre
    HYPRE_Finalize();
 #endif
 }
 
-void HYPRE_Session::SetGlobalOptions()
+void Hypre::SetDefaultOptions()
 {
-   // Additional global options, see
+   // Global hypre options, see
    // https://hypre.readthedocs.io/en/latest/solvers-boomeramg.html#gpu-supported-options
-   // for more details
 
 #if MFEM_HYPRE_VERSION >= 22100
 #ifdef HYPRE_USING_CUDA
-   // Use hypre's SpGEMM instead of cuSPARSE for performance reasons.
+   // Use hypre's SpGEMM instead of cuSPARSE for performance reasons
    HYPRE_SetSpGemmUseCusparse(0);
 #elif defined(HYPRE_USING_HIP)
    // Use rocSPARSE instead of hypre's SpGEMM for performance reasons (default)
@@ -63,7 +65,7 @@ void HYPRE_Session::SetGlobalOptions()
 #endif
 #endif
 
-   // The following 3 options are the defaults as of hypre-2.24
+   // The following options are the defaults as of hypre-2.24
 
    // Allocate hypre objects in GPU memory (default)
    // HYPRE_SetMemoryLocation(HYPRE_MEMORY_DEVICE);

--- a/linalg/hypre.hpp
+++ b/linalg/hypre.hpp
@@ -66,7 +66,7 @@ public:
    /// Calling HYPRE_Finalize() manually is not compatible with this class.
    static void Init() { Instance(); }
 
-   /// @brief Finalize hypre (called automatically at progam exit if
+   /// @brief Finalize hypre (called automatically at program exit if
    /// Hypre::Init() has been called).
    ///
    /// Multiple calls to Hypre::Finalize() have no effect. This function can be

--- a/linalg/hypre.hpp
+++ b/linalg/hypre.hpp
@@ -59,18 +59,38 @@ class HypreParMatrix;
 class Hypre
 {
 public:
-   /// Singleton creation with Hypre::Init();
-   static void Init() { static Hypre hypre; }
+   /// @brief Initialize hypre by calling HYPRE_Init() and set default options.
+   /// After calling Hypre::Init(), hypre will be finalized automatically at
+   /// program exit.
+   ///
+   /// Calling HYPRE_Finalize() manually is not compatible with this class.
+   static void Init() { Instance(); }
+
+   /// @brief Finalize hypre (called automatically at progam exit if
+   /// Hypre::Init() has been called).
+   ///
+   /// Multiple calls to Hypre::Finalize() have no effect. This function can be
+   /// called manually to more precisely control when hypre is finalized.
+   static void Finalize();
 
 private:
-   /// A single Hypre object should be created before any hypre calls.
+   /// Calls HYPRE_Init() when the singleton is constructed.
    Hypre();
 
-   /// The Hypre object should be destroyed after the last hypre call.
-   ~Hypre();
+   /// The singleton destructor (called at program exit) finalizes hypre.
+   ~Hypre() { Finalize(); }
 
-   /// Set the default hypre global options (mostly GPU-relevant)
+   /// Set the default hypre global options (mostly GPU-relevant).
    void SetDefaultOptions();
+
+   /// Create and return the Hypre singleton object.
+   static Hypre &Instance()
+   {
+      static Hypre hypre;
+      return hypre;
+   }
+
+   bool finalized = false; ///< Has Hypre::Finalize() been called already?
 };
 
 

--- a/linalg/hypre.hpp
+++ b/linalg/hypre.hpp
@@ -53,9 +53,9 @@ class ParFiniteElementSpace;
 class HypreParMatrix;
 
 
-/** @brief A simple singleton class for hypre's global settings, that 1) calls
-    HYPRE_Init() and sets some GPU-relevant options at construction and 2) calls
-    HYPRE_Finalize() at destruction. */
+/// @brief A simple singleton class for hypre's global settings, that 1) calls
+/// HYPRE_Init() and sets some GPU-relevant options at construction and 2) calls
+/// HYPRE_Finalize() at destruction.
 class Hypre
 {
 public:

--- a/linalg/hypre.hpp
+++ b/linalg/hypre.hpp
@@ -53,21 +53,24 @@ class ParFiniteElementSpace;
 class HypreParMatrix;
 
 
-/** @brief A simple convenience class for hypre's global settings, that 1) calls
+/** @brief A simple singleton class for hypre's global settings, that 1) calls
     HYPRE_Init() and sets some GPU-relevant options at construction and 2) calls
     HYPRE_Finalize() at destruction. */
-class HYPRE_Session
+class Hypre
 {
-private:
-   /// Set the default hypre global options (mostly GPU-relevant)
-   void SetGlobalOptions();
-
 public:
-   /// Single HYPRE_Session object should be created before any hypre calls.
-   HYPRE_Session();
+   /// Singleton creation with Hypre::Init();
+   static void Init() { static Hypre hypre; }
 
-   /// The HYPRE_Session object should be destroyed after the last hypre call.
-   ~HYPRE_Session();
+private:
+   /// A single Hypre object should be created before any hypre calls.
+   Hypre();
+
+   /// The Hypre object should be destroyed after the last hypre call.
+   ~Hypre();
+
+   /// Set the default hypre global options (mostly GPU-relevant)
+   void SetDefaultOptions();
 };
 
 

--- a/linalg/hypre.hpp
+++ b/linalg/hypre.hpp
@@ -52,6 +52,25 @@ namespace mfem
 class ParFiniteElementSpace;
 class HypreParMatrix;
 
+
+/** @brief A simple convenience class for hypre's global settings, that 1) calls
+    HYPRE_Init() and sets some GPU-relevant options at construction and 2) calls
+    HYPRE_Finalize() at destruction. */
+class HYPRE_Session
+{
+private:
+   /// Set the default hypre global options (mostly GPU-relevant)
+   void SetGlobalOptions();
+
+public:
+   /// Single HYPRE_Session object should be created before any hypre calls.
+   HYPRE_Session() { HYPRE_Init(); SetGlobalOptions(); }
+
+   /// The HYPRE_Session object should be destroyed after the last hypre call.
+   ~HYPRE_Session() { HYPRE_Finalize(); }
+};
+
+
 namespace internal
 {
 

--- a/linalg/hypre.hpp
+++ b/linalg/hypre.hpp
@@ -64,10 +64,10 @@ private:
 
 public:
    /// Single HYPRE_Session object should be created before any hypre calls.
-   HYPRE_Session() { HYPRE_Init(); SetGlobalOptions(); }
+   HYPRE_Session();
 
    /// The HYPRE_Session object should be destroyed after the last hypre call.
-   ~HYPRE_Session() { HYPRE_Finalize(); }
+   ~HYPRE_Session();
 };
 
 

--- a/miniapps/adjoint/adjoint_advection_diffusion.cpp
+++ b/miniapps/adjoint/adjoint_advection_diffusion.cpp
@@ -203,7 +203,6 @@ int main(int argc, char *argv[])
 {
    // Initialize MPI and HYPRE.
    Mpi::Init(argc, argv);
-   int num_procs = Mpi::WorldSize();
    int myid = Mpi::WorldRank();
    Hypre::Init();
 

--- a/miniapps/adjoint/adjoint_advection_diffusion.cpp
+++ b/miniapps/adjoint/adjoint_advection_diffusion.cpp
@@ -202,10 +202,9 @@ double u_init(const Vector &x)
 int main(int argc, char *argv[])
 {
    // Initialize MPI and HYPRE.
-   int num_procs, myid;
-   MPI_Init(&argc, &argv);
-   MPI_Comm_size(MPI_COMM_WORLD, &num_procs);
-   MPI_Comm_rank(MPI_COMM_WORLD, &myid);
+   Mpi::Init(argc, argv);
+   int num_procs = Mpi::WorldSize();
+   int myid = Mpi::WorldRank();
    Hypre::Init();
 
    // Parse command-line options.
@@ -238,7 +237,6 @@ int main(int argc, char *argv[])
       {
          args.PrintUsage(cout);
       }
-      MPI_Finalize();
       return 1;
    }
    if (myid == 0)
@@ -410,7 +408,6 @@ int main(int argc, char *argv[])
    delete V;
    delete cvodes;
 
-   MPI_Finalize();
    return 0;
 }
 

--- a/miniapps/adjoint/adjoint_advection_diffusion.cpp
+++ b/miniapps/adjoint/adjoint_advection_diffusion.cpp
@@ -201,11 +201,12 @@ double u_init(const Vector &x)
 
 int main(int argc, char *argv[])
 {
-   // Initialize MPI.
+   // Initialize MPI and HYPRE.
    int num_procs, myid;
    MPI_Init(&argc, &argv);
    MPI_Comm_size(MPI_COMM_WORLD, &num_procs);
    MPI_Comm_rank(MPI_COMM_WORLD, &myid);
+   HYPRE_Session hypre;
 
    // Parse command-line options.
    int ser_ref_levels = 0;

--- a/miniapps/adjoint/adjoint_advection_diffusion.cpp
+++ b/miniapps/adjoint/adjoint_advection_diffusion.cpp
@@ -206,7 +206,7 @@ int main(int argc, char *argv[])
    MPI_Init(&argc, &argv);
    MPI_Comm_size(MPI_COMM_WORLD, &num_procs);
    MPI_Comm_rank(MPI_COMM_WORLD, &myid);
-   HYPRE_Session hypre;
+   Hypre::Init();
 
    // Parse command-line options.
    int ser_ref_levels = 0;

--- a/miniapps/autodiff/par_example.cpp
+++ b/miniapps/autodiff/par_example.cpp
@@ -285,11 +285,12 @@ private:
 
 int main(int argc, char *argv[])
 {
-   // 1. Initialize MPI
+   // 1. Initialize MPI and HYPRE.
    int num_procs, myrank;
    MPI_Init(&argc, &argv);
    MPI_Comm_size(MPI_COMM_WORLD, &num_procs);
    MPI_Comm_rank(MPI_COMM_WORLD, &myrank);
+   HYPRE_Session hypre;
    // Define Caliper ConfigManager
 #ifdef MFEM_USE_CALIPER
    cali::ConfigManager mgr;

--- a/miniapps/autodiff/par_example.cpp
+++ b/miniapps/autodiff/par_example.cpp
@@ -286,10 +286,9 @@ private:
 int main(int argc, char *argv[])
 {
    // 1. Initialize MPI and HYPRE.
-   int num_procs, myrank;
-   MPI_Init(&argc, &argv);
-   MPI_Comm_size(MPI_COMM_WORLD, &num_procs);
-   MPI_Comm_rank(MPI_COMM_WORLD, &myrank);
+   Mpi::Init(argc, argv);
+   int num_procs = Mpi::WorldSize();
+   int myrank = Mpi::WorldRank();
    Hypre::Init();
    // Define Caliper ConfigManager
 #ifdef MFEM_USE_CALIPER
@@ -369,7 +368,6 @@ int main(int argc, char *argv[])
       {
          args.PrintUsage(std::cout);
       }
-      MPI_Finalize();
       return 1;
    }
    if (myrank == 0)
@@ -548,7 +546,6 @@ int main(int argc, char *argv[])
 #ifdef MFEM_USE_CALIPER
    mgr.flush();
 #endif
-   MPI_Finalize();
 
    return 0;
 }

--- a/miniapps/autodiff/par_example.cpp
+++ b/miniapps/autodiff/par_example.cpp
@@ -290,7 +290,7 @@ int main(int argc, char *argv[])
    MPI_Init(&argc, &argv);
    MPI_Comm_size(MPI_COMM_WORLD, &num_procs);
    MPI_Comm_rank(MPI_COMM_WORLD, &myrank);
-   HYPRE_Session hypre;
+   Hypre::Init();
    // Define Caliper ConfigManager
 #ifdef MFEM_USE_CALIPER
    cali::ConfigManager mgr;

--- a/miniapps/autodiff/par_example.cpp
+++ b/miniapps/autodiff/par_example.cpp
@@ -287,7 +287,6 @@ int main(int argc, char *argv[])
 {
    // 1. Initialize MPI and HYPRE.
    Mpi::Init(argc, argv);
-   int num_procs = Mpi::WorldSize();
    int myrank = Mpi::WorldRank();
    Hypre::Init();
    // Define Caliper ConfigManager

--- a/miniapps/electromagnetics/joule.cpp
+++ b/miniapps/electromagnetics/joule.cpp
@@ -129,7 +129,7 @@ int main(int argc, char *argv[])
    // 1. Initialize MPI and HYPRE.
    MPI_Session mpi(argc, argv);
    int myid = mpi.WorldRank();
-   HYPRE_Session hypre;
+   Hypre::Init();
 
    // print the cool banner
    if (mpi.Root()) { display_banner(cout); }

--- a/miniapps/electromagnetics/joule.cpp
+++ b/miniapps/electromagnetics/joule.cpp
@@ -127,12 +127,12 @@ int electromagnetics::STATIC_COND        = 0;
 int main(int argc, char *argv[])
 {
    // 1. Initialize MPI and HYPRE.
-   MPI_Session mpi(argc, argv);
-   int myid = mpi.WorldRank();
+   MPI::Init(argc, argv);
+   int myid = MPI::Session().WorldRank();
    Hypre::Init();
 
    // print the cool banner
-   if (mpi.Root()) { display_banner(cout); }
+   if (MPI::Session().Root()) { display_banner(cout); }
 
    // 2. Parse command-line options.
    const char *mesh_file = "cylinder-hex.mesh";
@@ -202,13 +202,13 @@ int main(int argc, char *argv[])
    args.Parse();
    if (!args.Good())
    {
-      if (mpi.Root())
+      if (MPI::Session().Root())
       {
          args.PrintUsage(cout);
       }
       return 1;
    }
-   if (mpi.Root())
+   if (MPI::Session().Root())
    {
       args.PrintOptions(cout);
    }
@@ -217,7 +217,7 @@ int main(int argc, char *argv[])
    sj_  = sigma;
    wj_  = 2.0*M_PI*freq;
 
-   if (mpi.Root())
+   if (MPI::Session().Root())
    {
       cout << "\nSkin depth sqrt(2.0/(wj*mj*sj)) = " << sqrt(2.0/(wj_*mj_*sj_))
            << "\nSkin depth sqrt(2.0*dt/(mj*sj)) = " << sqrt(2.0*dt/(mj_*sj_))
@@ -361,7 +361,7 @@ int main(int argc, char *argv[])
       case 23: ode_solver = new SDIRK23Solver; break;
       case 34: ode_solver = new SDIRK34Solver; break;
       default:
-         if (mpi.Root())
+         if (MPI::Session().Root())
          {
             cout << "Unknown ODE solver type: " << ode_solver_type << '\n';
          }
@@ -451,7 +451,7 @@ int main(int argc, char *argv[])
    HYPRE_BigInt glob_size_rt = HDivFESpace.GlobalTrueVSize();
    HYPRE_BigInt glob_size_h1 = HGradFESpace.GlobalTrueVSize();
 
-   if (mpi.Root())
+   if (MPI::Session().Root())
    {
       cout << "Number of Temperature Flux unknowns:  " << glob_size_rt << endl;
       cout << "Number of Temperature unknowns:       " << glob_size_l2 << endl;
@@ -659,7 +659,7 @@ int main(int argc, char *argv[])
       {
          double el = oper.ElectricLosses(E_gf);
 
-         if (mpi.Root())
+         if (MPI::Session().Root())
          {
             cout << fixed;
             cout << "step " << setw(6) << ti << ",\tt = " << setw(6)

--- a/miniapps/electromagnetics/joule.cpp
+++ b/miniapps/electromagnetics/joule.cpp
@@ -127,12 +127,12 @@ int electromagnetics::STATIC_COND        = 0;
 int main(int argc, char *argv[])
 {
    // 1. Initialize MPI and HYPRE.
-   MPI::Init(argc, argv);
-   int myid = MPI::Session().WorldRank();
+   Mpi::Init(argc, argv);
+   int myid = Mpi::Session().WorldRank();
    Hypre::Init();
 
    // print the cool banner
-   if (MPI::Session().Root()) { display_banner(cout); }
+   if (Mpi::Session().Root()) { display_banner(cout); }
 
    // 2. Parse command-line options.
    const char *mesh_file = "cylinder-hex.mesh";
@@ -202,13 +202,13 @@ int main(int argc, char *argv[])
    args.Parse();
    if (!args.Good())
    {
-      if (MPI::Session().Root())
+      if (Mpi::Session().Root())
       {
          args.PrintUsage(cout);
       }
       return 1;
    }
-   if (MPI::Session().Root())
+   if (Mpi::Session().Root())
    {
       args.PrintOptions(cout);
    }
@@ -217,7 +217,7 @@ int main(int argc, char *argv[])
    sj_  = sigma;
    wj_  = 2.0*M_PI*freq;
 
-   if (MPI::Session().Root())
+   if (Mpi::Session().Root())
    {
       cout << "\nSkin depth sqrt(2.0/(wj*mj*sj)) = " << sqrt(2.0/(wj_*mj_*sj_))
            << "\nSkin depth sqrt(2.0*dt/(mj*sj)) = " << sqrt(2.0*dt/(mj_*sj_))
@@ -361,7 +361,7 @@ int main(int argc, char *argv[])
       case 23: ode_solver = new SDIRK23Solver; break;
       case 34: ode_solver = new SDIRK34Solver; break;
       default:
-         if (MPI::Session().Root())
+         if (Mpi::Session().Root())
          {
             cout << "Unknown ODE solver type: " << ode_solver_type << '\n';
          }
@@ -451,7 +451,7 @@ int main(int argc, char *argv[])
    HYPRE_BigInt glob_size_rt = HDivFESpace.GlobalTrueVSize();
    HYPRE_BigInt glob_size_h1 = HGradFESpace.GlobalTrueVSize();
 
-   if (MPI::Session().Root())
+   if (Mpi::Session().Root())
    {
       cout << "Number of Temperature Flux unknowns:  " << glob_size_rt << endl;
       cout << "Number of Temperature unknowns:       " << glob_size_l2 << endl;
@@ -659,7 +659,7 @@ int main(int argc, char *argv[])
       {
          double el = oper.ElectricLosses(E_gf);
 
-         if (MPI::Session().Root())
+         if (Mpi::Session().Root())
          {
             cout << fixed;
             cout << "step " << setw(6) << ti << ",\tt = " << setw(6)

--- a/miniapps/electromagnetics/joule.cpp
+++ b/miniapps/electromagnetics/joule.cpp
@@ -126,9 +126,10 @@ int electromagnetics::STATIC_COND        = 0;
 
 int main(int argc, char *argv[])
 {
-   // 1. Initialize MPI.
+   // 1. Initialize MPI and HYPRE.
    MPI_Session mpi(argc, argv);
    int myid = mpi.WorldRank();
+   HYPRE_Session hypre;
 
    // print the cool banner
    if (mpi.Root()) { display_banner(cout); }

--- a/miniapps/electromagnetics/joule.cpp
+++ b/miniapps/electromagnetics/joule.cpp
@@ -128,11 +128,11 @@ int main(int argc, char *argv[])
 {
    // 1. Initialize MPI and HYPRE.
    Mpi::Init(argc, argv);
-   int myid = Mpi::Session().WorldRank();
+   int myid = Mpi::WorldRank();
    Hypre::Init();
 
    // print the cool banner
-   if (Mpi::Session().Root()) { display_banner(cout); }
+   if (Mpi::Root()) { display_banner(cout); }
 
    // 2. Parse command-line options.
    const char *mesh_file = "cylinder-hex.mesh";
@@ -202,13 +202,13 @@ int main(int argc, char *argv[])
    args.Parse();
    if (!args.Good())
    {
-      if (Mpi::Session().Root())
+      if (Mpi::Root())
       {
          args.PrintUsage(cout);
       }
       return 1;
    }
-   if (Mpi::Session().Root())
+   if (Mpi::Root())
    {
       args.PrintOptions(cout);
    }
@@ -217,7 +217,7 @@ int main(int argc, char *argv[])
    sj_  = sigma;
    wj_  = 2.0*M_PI*freq;
 
-   if (Mpi::Session().Root())
+   if (Mpi::Root())
    {
       cout << "\nSkin depth sqrt(2.0/(wj*mj*sj)) = " << sqrt(2.0/(wj_*mj_*sj_))
            << "\nSkin depth sqrt(2.0*dt/(mj*sj)) = " << sqrt(2.0*dt/(mj_*sj_))
@@ -361,7 +361,7 @@ int main(int argc, char *argv[])
       case 23: ode_solver = new SDIRK23Solver; break;
       case 34: ode_solver = new SDIRK34Solver; break;
       default:
-         if (Mpi::Session().Root())
+         if (Mpi::Root())
          {
             cout << "Unknown ODE solver type: " << ode_solver_type << '\n';
          }
@@ -451,7 +451,7 @@ int main(int argc, char *argv[])
    HYPRE_BigInt glob_size_rt = HDivFESpace.GlobalTrueVSize();
    HYPRE_BigInt glob_size_h1 = HGradFESpace.GlobalTrueVSize();
 
-   if (Mpi::Session().Root())
+   if (Mpi::Root())
    {
       cout << "Number of Temperature Flux unknowns:  " << glob_size_rt << endl;
       cout << "Number of Temperature unknowns:       " << glob_size_l2 << endl;
@@ -659,7 +659,7 @@ int main(int argc, char *argv[])
       {
          double el = oper.ElectricLosses(E_gf);
 
-         if (Mpi::Session().Root())
+         if (Mpi::Root())
          {
             cout << fixed;
             cout << "step " << setw(6) << ti << ",\tt = " << setw(6)

--- a/miniapps/electromagnetics/maxwell.cpp
+++ b/miniapps/electromagnetics/maxwell.cpp
@@ -129,7 +129,7 @@ int main(int argc, char *argv[])
    Mpi::Init();
    Hypre::Init();
 
-   if ( Mpi::Session().Root() ) { display_banner(cout); }
+   if ( Mpi::Root() ) { display_banner(cout); }
 
    // Parse command-line options.
    const char *mesh_file = "../../data/ball-nurbs.mesh";
@@ -190,13 +190,13 @@ int main(int argc, char *argv[])
    args.Parse();
    if (!args.Good())
    {
-      if (Mpi::Session().Root())
+      if (Mpi::Root())
       {
          args.PrintUsage(cout);
       }
       return 1;
    }
-   if (Mpi::Session().Root())
+   if (Mpi::Root())
    {
       args.PrintOptions(cout);
    }
@@ -208,7 +208,7 @@ int main(int argc, char *argv[])
    ifstream imesh(mesh_file);
    if (!imesh)
    {
-      if (Mpi::Session().Root())
+      if (Mpi::Root())
       {
          cerr << "\nCan not open mesh file: " << mesh_file << '\n' << endl;
       }
@@ -267,7 +267,7 @@ int main(int argc, char *argv[])
 
    // Compute the energy of the initial fields
    double energy = Maxwell.GetEnergy();
-   if ( Mpi::Session().Root() )
+   if ( Mpi::Root() )
    {
       cout << "Energy(" << ti << "ns):  " << energy << "J" << endl;
    }
@@ -280,14 +280,14 @@ int main(int argc, char *argv[])
    tf *= tScale_;
    ts *= tScale_;
 
-   if ( Mpi::Session().Root() )
+   if ( Mpi::Root() )
    {
       cout << "Maximum Time Step:     " << dtmax / tScale_ << "ns" << endl;
    }
 
    // Round down the time step so that tf-ti is an integer multiple of dt
    int nsteps = SnapTimeStep(tf-ti, dtsf * dtmax, dt);
-   if ( Mpi::Session().Root() )
+   if ( Mpi::Root() )
    {
       cout << "Number of Time Steps:  " << nsteps << endl;
       cout << "Time Step Size:        " << dt / tScale_ << "ns" << endl;
@@ -337,7 +337,7 @@ int main(int argc, char *argv[])
 
       // Approximate the current energy if the fields
       energy = Maxwell.GetEnergy();
-      if ( Mpi::Session().Root() )
+      if ( Mpi::Root() )
       {
          cout << "Energy(" << t/tScale_ << "ns):  " << energy << "J" << endl;
       }

--- a/miniapps/electromagnetics/maxwell.cpp
+++ b/miniapps/electromagnetics/maxwell.cpp
@@ -126,10 +126,10 @@ void display_banner(ostream & os);
 
 int main(int argc, char *argv[])
 {
-   MPI_Session mpi(argc, argv);
+   MPI::Init();
    Hypre::Init();
 
-   if ( mpi.Root() ) { display_banner(cout); }
+   if ( MPI::Session().Root() ) { display_banner(cout); }
 
    // Parse command-line options.
    const char *mesh_file = "../../data/ball-nurbs.mesh";
@@ -190,13 +190,13 @@ int main(int argc, char *argv[])
    args.Parse();
    if (!args.Good())
    {
-      if (mpi.Root())
+      if (MPI::Session().Root())
       {
          args.PrintUsage(cout);
       }
       return 1;
    }
-   if (mpi.Root())
+   if (MPI::Session().Root())
    {
       args.PrintOptions(cout);
    }
@@ -208,7 +208,7 @@ int main(int argc, char *argv[])
    ifstream imesh(mesh_file);
    if (!imesh)
    {
-      if (mpi.Root())
+      if (MPI::Session().Root())
       {
          cerr << "\nCan not open mesh file: " << mesh_file << '\n' << endl;
       }
@@ -267,7 +267,7 @@ int main(int argc, char *argv[])
 
    // Compute the energy of the initial fields
    double energy = Maxwell.GetEnergy();
-   if ( mpi.Root() )
+   if ( MPI::Session().Root() )
    {
       cout << "Energy(" << ti << "ns):  " << energy << "J" << endl;
    }
@@ -280,14 +280,14 @@ int main(int argc, char *argv[])
    tf *= tScale_;
    ts *= tScale_;
 
-   if ( mpi.Root() )
+   if ( MPI::Session().Root() )
    {
       cout << "Maximum Time Step:     " << dtmax / tScale_ << "ns" << endl;
    }
 
    // Round down the time step so that tf-ti is an integer multiple of dt
    int nsteps = SnapTimeStep(tf-ti, dtsf * dtmax, dt);
-   if ( mpi.Root() )
+   if ( MPI::Session().Root() )
    {
       cout << "Number of Time Steps:  " << nsteps << endl;
       cout << "Time Step Size:        " << dt / tScale_ << "ns" << endl;
@@ -337,7 +337,7 @@ int main(int argc, char *argv[])
 
       // Approximate the current energy if the fields
       energy = Maxwell.GetEnergy();
-      if ( mpi.Root() )
+      if ( MPI::Session().Root() )
       {
          cout << "Energy(" << t/tScale_ << "ns):  " << energy << "J" << endl;
       }

--- a/miniapps/electromagnetics/maxwell.cpp
+++ b/miniapps/electromagnetics/maxwell.cpp
@@ -127,6 +127,7 @@ void display_banner(ostream & os);
 int main(int argc, char *argv[])
 {
    MPI_Session mpi(argc, argv);
+   HYPRE_Session hypre;
 
    if ( mpi.Root() ) { display_banner(cout); }
 

--- a/miniapps/electromagnetics/maxwell.cpp
+++ b/miniapps/electromagnetics/maxwell.cpp
@@ -127,7 +127,7 @@ void display_banner(ostream & os);
 int main(int argc, char *argv[])
 {
    MPI_Session mpi(argc, argv);
-   HYPRE_Session hypre;
+   Hypre::Init();
 
    if ( mpi.Root() ) { display_banner(cout); }
 

--- a/miniapps/electromagnetics/maxwell.cpp
+++ b/miniapps/electromagnetics/maxwell.cpp
@@ -126,10 +126,10 @@ void display_banner(ostream & os);
 
 int main(int argc, char *argv[])
 {
-   MPI::Init();
+   Mpi::Init();
    Hypre::Init();
 
-   if ( MPI::Session().Root() ) { display_banner(cout); }
+   if ( Mpi::Session().Root() ) { display_banner(cout); }
 
    // Parse command-line options.
    const char *mesh_file = "../../data/ball-nurbs.mesh";
@@ -190,13 +190,13 @@ int main(int argc, char *argv[])
    args.Parse();
    if (!args.Good())
    {
-      if (MPI::Session().Root())
+      if (Mpi::Session().Root())
       {
          args.PrintUsage(cout);
       }
       return 1;
    }
-   if (MPI::Session().Root())
+   if (Mpi::Session().Root())
    {
       args.PrintOptions(cout);
    }
@@ -208,7 +208,7 @@ int main(int argc, char *argv[])
    ifstream imesh(mesh_file);
    if (!imesh)
    {
-      if (MPI::Session().Root())
+      if (Mpi::Session().Root())
       {
          cerr << "\nCan not open mesh file: " << mesh_file << '\n' << endl;
       }
@@ -267,7 +267,7 @@ int main(int argc, char *argv[])
 
    // Compute the energy of the initial fields
    double energy = Maxwell.GetEnergy();
-   if ( MPI::Session().Root() )
+   if ( Mpi::Session().Root() )
    {
       cout << "Energy(" << ti << "ns):  " << energy << "J" << endl;
    }
@@ -280,14 +280,14 @@ int main(int argc, char *argv[])
    tf *= tScale_;
    ts *= tScale_;
 
-   if ( MPI::Session().Root() )
+   if ( Mpi::Session().Root() )
    {
       cout << "Maximum Time Step:     " << dtmax / tScale_ << "ns" << endl;
    }
 
    // Round down the time step so that tf-ti is an integer multiple of dt
    int nsteps = SnapTimeStep(tf-ti, dtsf * dtmax, dt);
-   if ( MPI::Session().Root() )
+   if ( Mpi::Session().Root() )
    {
       cout << "Number of Time Steps:  " << nsteps << endl;
       cout << "Time Step Size:        " << dt / tScale_ << "ns" << endl;
@@ -337,7 +337,7 @@ int main(int argc, char *argv[])
 
       // Approximate the current energy if the fields
       energy = Maxwell.GetEnergy();
-      if ( MPI::Session().Root() )
+      if ( Mpi::Session().Root() )
       {
          cout << "Energy(" << t/tScale_ << "ns):  " << energy << "J" << endl;
       }

--- a/miniapps/electromagnetics/tesla.cpp
+++ b/miniapps/electromagnetics/tesla.cpp
@@ -107,6 +107,7 @@ void display_banner(ostream & os);
 int main(int argc, char *argv[])
 {
    MPI_Session mpi(argc, argv);
+   HYPRE_Session hypre;
 
    if ( mpi.Root() ) { display_banner(cout); }
 

--- a/miniapps/electromagnetics/tesla.cpp
+++ b/miniapps/electromagnetics/tesla.cpp
@@ -106,10 +106,10 @@ void display_banner(ostream & os);
 
 int main(int argc, char *argv[])
 {
-   MPI::Init(argc, argv);
+   Mpi::Init(argc, argv);
    Hypre::Init();
 
-   if ( MPI::Session().Root() ) { display_banner(cout); }
+   if ( Mpi::Session().Root() ) { display_banner(cout); }
 
    // Parse command-line options.
    const char *mesh_file = "../../data/ball-nurbs.mesh";
@@ -162,13 +162,13 @@ int main(int argc, char *argv[])
    args.Parse();
    if (!args.Good())
    {
-      if (MPI::Session().Root())
+      if (Mpi::Session().Root())
       {
          args.PrintUsage(cout);
       }
       return 1;
    }
-   if (MPI::Session().Root())
+   if (Mpi::Session().Root())
    {
       args.PrintOptions(cout);
    }
@@ -178,7 +178,7 @@ int main(int argc, char *argv[])
    // and volume meshes with the same code.
    Mesh *mesh = new Mesh(mesh_file, 1, 1);
 
-   if (MPI::Session().Root())
+   if (Mpi::Session().Root())
    {
       cout << "Starting initialization." << endl;
    }
@@ -222,7 +222,7 @@ int main(int argc, char *argv[])
         ( kbcs.Size() > 0 && vbcs.Size() == 0 ) ||
         ( vbcv.Size() < vbcs.Size() ) )
    {
-      if ( MPI::Session().Root() )
+      if ( Mpi::Session().Root() )
       {
          cout << "The surface current (K) boundary condition requires "
               << "surface current boundary condition surfaces (with -kbcs), "
@@ -256,7 +256,7 @@ int main(int argc, char *argv[])
    {
       Tesla.RegisterVisItFields(visit_dc);
    }
-   if (MPI::Session().Root()) { cout << "Initialization done." << endl; }
+   if (Mpi::Session().Root()) { cout << "Initialization done." << endl; }
 
    // The main AMR loop. In each iteration we solve the problem on the current
    // mesh, visualize the solution, estimate the error on all elements, refine
@@ -266,7 +266,7 @@ int main(int argc, char *argv[])
    const int max_dofs = 10000000;
    for (int it = 1; it <= maxit; it++)
    {
-      if (MPI::Session().Root())
+      if (Mpi::Session().Root())
       {
          cout << "\nAMR Iteration " << it << endl;
       }
@@ -295,7 +295,7 @@ int main(int argc, char *argv[])
          Tesla.DisplayToGLVis();
       }
 
-      if (MPI::Session().Root())
+      if (Mpi::Session().Root())
       {
          cout << "AMR iteration " << it << " complete." << endl;
       }
@@ -303,7 +303,7 @@ int main(int argc, char *argv[])
       // Check stopping criteria
       if (prob_size > max_dofs)
       {
-         if (MPI::Session().Root())
+         if (Mpi::Session().Root())
          {
             cout << "Reached maximum number of dofs, exiting..." << endl;
          }
@@ -316,7 +316,7 @@ int main(int argc, char *argv[])
 
       // Wait for user input. Ask every 10th iteration.
       char c = 'c';
-      if (MPI::Session().Root() && (it % 10 == 0))
+      if (Mpi::Session().Root() && (it % 10 == 0))
       {
          cout << "press (q)uit or (c)ontinue --> " << flush;
          cin >> c;
@@ -341,15 +341,15 @@ int main(int argc, char *argv[])
       // maximum element error.
       const double frac = 0.5;
       double threshold = frac * global_max_err;
-      if (MPI::Session().Root()) { cout << "Refining ..." << endl; }
+      if (Mpi::Session().Root()) { cout << "Refining ..." << endl; }
       pmesh.RefineByError(errors, threshold);
 
       // Update the magnetostatic solver to reflect the new state of the mesh.
       Tesla.Update();
 
-      if (pmesh.Nonconforming() && MPI::Session().WorldSize() > 1)
+      if (pmesh.Nonconforming() && Mpi::Session().WorldSize() > 1)
       {
-         if (MPI::Session().Root()) { cout << "Rebalancing ..." << endl; }
+         if (Mpi::Session().Root()) { cout << "Rebalancing ..." << endl; }
          pmesh.Rebalance();
 
          // Update again after rebalancing

--- a/miniapps/electromagnetics/tesla.cpp
+++ b/miniapps/electromagnetics/tesla.cpp
@@ -107,7 +107,7 @@ void display_banner(ostream & os);
 int main(int argc, char *argv[])
 {
    MPI_Session mpi(argc, argv);
-   HYPRE_Session hypre;
+   Hypre::Init();
 
    if ( mpi.Root() ) { display_banner(cout); }
 

--- a/miniapps/electromagnetics/tesla.cpp
+++ b/miniapps/electromagnetics/tesla.cpp
@@ -106,10 +106,10 @@ void display_banner(ostream & os);
 
 int main(int argc, char *argv[])
 {
-   MPI_Session mpi(argc, argv);
+   MPI::Init(argc, argv);
    Hypre::Init();
 
-   if ( mpi.Root() ) { display_banner(cout); }
+   if ( MPI::Session().Root() ) { display_banner(cout); }
 
    // Parse command-line options.
    const char *mesh_file = "../../data/ball-nurbs.mesh";
@@ -162,13 +162,13 @@ int main(int argc, char *argv[])
    args.Parse();
    if (!args.Good())
    {
-      if (mpi.Root())
+      if (MPI::Session().Root())
       {
          args.PrintUsage(cout);
       }
       return 1;
    }
-   if (mpi.Root())
+   if (MPI::Session().Root())
    {
       args.PrintOptions(cout);
    }
@@ -178,7 +178,7 @@ int main(int argc, char *argv[])
    // and volume meshes with the same code.
    Mesh *mesh = new Mesh(mesh_file, 1, 1);
 
-   if (mpi.Root())
+   if (MPI::Session().Root())
    {
       cout << "Starting initialization." << endl;
    }
@@ -222,7 +222,7 @@ int main(int argc, char *argv[])
         ( kbcs.Size() > 0 && vbcs.Size() == 0 ) ||
         ( vbcv.Size() < vbcs.Size() ) )
    {
-      if ( mpi.Root() )
+      if ( MPI::Session().Root() )
       {
          cout << "The surface current (K) boundary condition requires "
               << "surface current boundary condition surfaces (with -kbcs), "
@@ -256,7 +256,7 @@ int main(int argc, char *argv[])
    {
       Tesla.RegisterVisItFields(visit_dc);
    }
-   if (mpi.Root()) { cout << "Initialization done." << endl; }
+   if (MPI::Session().Root()) { cout << "Initialization done." << endl; }
 
    // The main AMR loop. In each iteration we solve the problem on the current
    // mesh, visualize the solution, estimate the error on all elements, refine
@@ -266,7 +266,7 @@ int main(int argc, char *argv[])
    const int max_dofs = 10000000;
    for (int it = 1; it <= maxit; it++)
    {
-      if (mpi.Root())
+      if (MPI::Session().Root())
       {
          cout << "\nAMR Iteration " << it << endl;
       }
@@ -295,7 +295,7 @@ int main(int argc, char *argv[])
          Tesla.DisplayToGLVis();
       }
 
-      if (mpi.Root())
+      if (MPI::Session().Root())
       {
          cout << "AMR iteration " << it << " complete." << endl;
       }
@@ -303,7 +303,7 @@ int main(int argc, char *argv[])
       // Check stopping criteria
       if (prob_size > max_dofs)
       {
-         if (mpi.Root())
+         if (MPI::Session().Root())
          {
             cout << "Reached maximum number of dofs, exiting..." << endl;
          }
@@ -316,7 +316,7 @@ int main(int argc, char *argv[])
 
       // Wait for user input. Ask every 10th iteration.
       char c = 'c';
-      if (mpi.Root() && (it % 10 == 0))
+      if (MPI::Session().Root() && (it % 10 == 0))
       {
          cout << "press (q)uit or (c)ontinue --> " << flush;
          cin >> c;
@@ -341,15 +341,15 @@ int main(int argc, char *argv[])
       // maximum element error.
       const double frac = 0.5;
       double threshold = frac * global_max_err;
-      if (mpi.Root()) { cout << "Refining ..." << endl; }
+      if (MPI::Session().Root()) { cout << "Refining ..." << endl; }
       pmesh.RefineByError(errors, threshold);
 
       // Update the magnetostatic solver to reflect the new state of the mesh.
       Tesla.Update();
 
-      if (pmesh.Nonconforming() && mpi.WorldSize() > 1)
+      if (pmesh.Nonconforming() && MPI::Session().WorldSize() > 1)
       {
-         if (mpi.Root()) { cout << "Rebalancing ..." << endl; }
+         if (MPI::Session().Root()) { cout << "Rebalancing ..." << endl; }
          pmesh.Rebalance();
 
          // Update again after rebalancing

--- a/miniapps/electromagnetics/tesla.cpp
+++ b/miniapps/electromagnetics/tesla.cpp
@@ -109,7 +109,7 @@ int main(int argc, char *argv[])
    Mpi::Init(argc, argv);
    Hypre::Init();
 
-   if ( Mpi::Session().Root() ) { display_banner(cout); }
+   if ( Mpi::Root() ) { display_banner(cout); }
 
    // Parse command-line options.
    const char *mesh_file = "../../data/ball-nurbs.mesh";
@@ -162,13 +162,13 @@ int main(int argc, char *argv[])
    args.Parse();
    if (!args.Good())
    {
-      if (Mpi::Session().Root())
+      if (Mpi::Root())
       {
          args.PrintUsage(cout);
       }
       return 1;
    }
-   if (Mpi::Session().Root())
+   if (Mpi::Root())
    {
       args.PrintOptions(cout);
    }
@@ -178,7 +178,7 @@ int main(int argc, char *argv[])
    // and volume meshes with the same code.
    Mesh *mesh = new Mesh(mesh_file, 1, 1);
 
-   if (Mpi::Session().Root())
+   if (Mpi::Root())
    {
       cout << "Starting initialization." << endl;
    }
@@ -222,7 +222,7 @@ int main(int argc, char *argv[])
         ( kbcs.Size() > 0 && vbcs.Size() == 0 ) ||
         ( vbcv.Size() < vbcs.Size() ) )
    {
-      if ( Mpi::Session().Root() )
+      if ( Mpi::Root() )
       {
          cout << "The surface current (K) boundary condition requires "
               << "surface current boundary condition surfaces (with -kbcs), "
@@ -256,7 +256,7 @@ int main(int argc, char *argv[])
    {
       Tesla.RegisterVisItFields(visit_dc);
    }
-   if (Mpi::Session().Root()) { cout << "Initialization done." << endl; }
+   if (Mpi::Root()) { cout << "Initialization done." << endl; }
 
    // The main AMR loop. In each iteration we solve the problem on the current
    // mesh, visualize the solution, estimate the error on all elements, refine
@@ -266,7 +266,7 @@ int main(int argc, char *argv[])
    const int max_dofs = 10000000;
    for (int it = 1; it <= maxit; it++)
    {
-      if (Mpi::Session().Root())
+      if (Mpi::Root())
       {
          cout << "\nAMR Iteration " << it << endl;
       }
@@ -295,7 +295,7 @@ int main(int argc, char *argv[])
          Tesla.DisplayToGLVis();
       }
 
-      if (Mpi::Session().Root())
+      if (Mpi::Root())
       {
          cout << "AMR iteration " << it << " complete." << endl;
       }
@@ -303,7 +303,7 @@ int main(int argc, char *argv[])
       // Check stopping criteria
       if (prob_size > max_dofs)
       {
-         if (Mpi::Session().Root())
+         if (Mpi::Root())
          {
             cout << "Reached maximum number of dofs, exiting..." << endl;
          }
@@ -316,7 +316,7 @@ int main(int argc, char *argv[])
 
       // Wait for user input. Ask every 10th iteration.
       char c = 'c';
-      if (Mpi::Session().Root() && (it % 10 == 0))
+      if (Mpi::Root() && (it % 10 == 0))
       {
          cout << "press (q)uit or (c)ontinue --> " << flush;
          cin >> c;
@@ -341,15 +341,15 @@ int main(int argc, char *argv[])
       // maximum element error.
       const double frac = 0.5;
       double threshold = frac * global_max_err;
-      if (Mpi::Session().Root()) { cout << "Refining ..." << endl; }
+      if (Mpi::Root()) { cout << "Refining ..." << endl; }
       pmesh.RefineByError(errors, threshold);
 
       // Update the magnetostatic solver to reflect the new state of the mesh.
       Tesla.Update();
 
-      if (pmesh.Nonconforming() && Mpi::Session().WorldSize() > 1)
+      if (pmesh.Nonconforming() && Mpi::WorldSize() > 1)
       {
-         if (Mpi::Session().Root()) { cout << "Rebalancing ..." << endl; }
+         if (Mpi::Root()) { cout << "Rebalancing ..." << endl; }
          pmesh.Rebalance();
 
          // Update again after rebalancing

--- a/miniapps/electromagnetics/volta.cpp
+++ b/miniapps/electromagnetics/volta.cpp
@@ -101,7 +101,7 @@ void display_banner(ostream & os);
 int main(int argc, char *argv[])
 {
    MPI_Session mpi(argc, argv);
-   HYPRE_Session hypre;
+   Hypre::Init();
 
    if ( mpi.Root() ) { display_banner(cout); }
 

--- a/miniapps/electromagnetics/volta.cpp
+++ b/miniapps/electromagnetics/volta.cpp
@@ -100,10 +100,10 @@ void display_banner(ostream & os);
 
 int main(int argc, char *argv[])
 {
-   MPI::Init(argc, argv);
+   Mpi::Init(argc, argv);
    Hypre::Init();
 
-   if ( MPI::Session().Root() ) { display_banner(cout); }
+   if ( Mpi::Session().Root() ) { display_banner(cout); }
 
    // Parse command-line options.
    const char *mesh_file = "../../data/ball-nurbs.mesh";
@@ -166,13 +166,13 @@ int main(int argc, char *argv[])
    args.Parse();
    if (!args.Good())
    {
-      if (MPI::Session().Root())
+      if (Mpi::Session().Root())
       {
          args.PrintUsage(cout);
       }
       return 1;
    }
-   if (MPI::Session().Root())
+   if (Mpi::Session().Root())
    {
       args.PrintOptions(cout);
    }
@@ -183,7 +183,7 @@ int main(int argc, char *argv[])
    Mesh *mesh = new Mesh(mesh_file, 1, 1);
    int sdim = mesh->SpaceDimension();
 
-   if (MPI::Session().Root())
+   if (Mpi::Session().Root())
    {
       cout << "Starting initialization." << endl;
    }
@@ -269,7 +269,7 @@ int main(int argc, char *argv[])
    {
       Volta.RegisterVisItFields(visit_dc);
    }
-   if (MPI::Session().Root()) { cout << "Initialization done." << endl; }
+   if (Mpi::Session().Root()) { cout << "Initialization done." << endl; }
 
    // The main AMR loop. In each iteration we solve the problem on the current
    // mesh, visualize the solution, estimate the error on all elements, refine
@@ -279,7 +279,7 @@ int main(int argc, char *argv[])
    const int max_dofs = 10000000;
    for (int it = 1; it <= maxit; it++)
    {
-      if (MPI::Session().Root())
+      if (Mpi::Session().Root())
       {
          cout << "\nAMR Iteration " << it << endl;
       }
@@ -308,7 +308,7 @@ int main(int argc, char *argv[])
          Volta.DisplayToGLVis();
       }
 
-      if (MPI::Session().Root())
+      if (Mpi::Session().Root())
       {
          cout << "AMR iteration " << it << " complete." << endl;
       }
@@ -316,7 +316,7 @@ int main(int argc, char *argv[])
       // Check stopping criteria
       if (prob_size > max_dofs)
       {
-         if (MPI::Session().Root())
+         if (Mpi::Session().Root())
          {
             cout << "Reached maximum number of dofs, exiting..." << endl;
          }
@@ -329,7 +329,7 @@ int main(int argc, char *argv[])
 
       // Wait for user input. Ask every 10th iteration.
       char c = 'c';
-      if (MPI::Session().Root() && (it % 10 == 0))
+      if (Mpi::Session().Root() && (it % 10 == 0))
       {
          cout << "press (q)uit or (c)ontinue --> " << flush;
          cin >> c;
@@ -354,15 +354,15 @@ int main(int argc, char *argv[])
       // maximum element error.
       const double frac = 0.7;
       double threshold = frac * global_max_err;
-      if (MPI::Session().Root()) { cout << "Refining ..." << endl; }
+      if (Mpi::Session().Root()) { cout << "Refining ..." << endl; }
       pmesh.RefineByError(errors, threshold);
 
       // Update the electrostatic solver to reflect the new state of the mesh.
       Volta.Update();
 
-      if (pmesh.Nonconforming() && MPI::Session().WorldSize() > 1)
+      if (pmesh.Nonconforming() && Mpi::Session().WorldSize() > 1)
       {
-         if (MPI::Session().Root()) { cout << "Rebalancing ..." << endl; }
+         if (Mpi::Session().Root()) { cout << "Rebalancing ..." << endl; }
          pmesh.Rebalance();
 
          // Update again after rebalancing

--- a/miniapps/electromagnetics/volta.cpp
+++ b/miniapps/electromagnetics/volta.cpp
@@ -101,6 +101,7 @@ void display_banner(ostream & os);
 int main(int argc, char *argv[])
 {
    MPI_Session mpi(argc, argv);
+   HYPRE_Session hypre;
 
    if ( mpi.Root() ) { display_banner(cout); }
 

--- a/miniapps/electromagnetics/volta.cpp
+++ b/miniapps/electromagnetics/volta.cpp
@@ -100,10 +100,10 @@ void display_banner(ostream & os);
 
 int main(int argc, char *argv[])
 {
-   MPI_Session mpi(argc, argv);
+   MPI::Init(argc, argv);
    Hypre::Init();
 
-   if ( mpi.Root() ) { display_banner(cout); }
+   if ( MPI::Session().Root() ) { display_banner(cout); }
 
    // Parse command-line options.
    const char *mesh_file = "../../data/ball-nurbs.mesh";
@@ -166,13 +166,13 @@ int main(int argc, char *argv[])
    args.Parse();
    if (!args.Good())
    {
-      if (mpi.Root())
+      if (MPI::Session().Root())
       {
          args.PrintUsage(cout);
       }
       return 1;
    }
-   if (mpi.Root())
+   if (MPI::Session().Root())
    {
       args.PrintOptions(cout);
    }
@@ -183,7 +183,7 @@ int main(int argc, char *argv[])
    Mesh *mesh = new Mesh(mesh_file, 1, 1);
    int sdim = mesh->SpaceDimension();
 
-   if (mpi.Root())
+   if (MPI::Session().Root())
    {
       cout << "Starting initialization." << endl;
    }
@@ -269,7 +269,7 @@ int main(int argc, char *argv[])
    {
       Volta.RegisterVisItFields(visit_dc);
    }
-   if (mpi.Root()) { cout << "Initialization done." << endl; }
+   if (MPI::Session().Root()) { cout << "Initialization done." << endl; }
 
    // The main AMR loop. In each iteration we solve the problem on the current
    // mesh, visualize the solution, estimate the error on all elements, refine
@@ -279,7 +279,7 @@ int main(int argc, char *argv[])
    const int max_dofs = 10000000;
    for (int it = 1; it <= maxit; it++)
    {
-      if (mpi.Root())
+      if (MPI::Session().Root())
       {
          cout << "\nAMR Iteration " << it << endl;
       }
@@ -308,7 +308,7 @@ int main(int argc, char *argv[])
          Volta.DisplayToGLVis();
       }
 
-      if (mpi.Root())
+      if (MPI::Session().Root())
       {
          cout << "AMR iteration " << it << " complete." << endl;
       }
@@ -316,7 +316,7 @@ int main(int argc, char *argv[])
       // Check stopping criteria
       if (prob_size > max_dofs)
       {
-         if (mpi.Root())
+         if (MPI::Session().Root())
          {
             cout << "Reached maximum number of dofs, exiting..." << endl;
          }
@@ -329,7 +329,7 @@ int main(int argc, char *argv[])
 
       // Wait for user input. Ask every 10th iteration.
       char c = 'c';
-      if (mpi.Root() && (it % 10 == 0))
+      if (MPI::Session().Root() && (it % 10 == 0))
       {
          cout << "press (q)uit or (c)ontinue --> " << flush;
          cin >> c;
@@ -354,15 +354,15 @@ int main(int argc, char *argv[])
       // maximum element error.
       const double frac = 0.7;
       double threshold = frac * global_max_err;
-      if (mpi.Root()) { cout << "Refining ..." << endl; }
+      if (MPI::Session().Root()) { cout << "Refining ..." << endl; }
       pmesh.RefineByError(errors, threshold);
 
       // Update the electrostatic solver to reflect the new state of the mesh.
       Volta.Update();
 
-      if (pmesh.Nonconforming() && mpi.WorldSize() > 1)
+      if (pmesh.Nonconforming() && MPI::Session().WorldSize() > 1)
       {
-         if (mpi.Root()) { cout << "Rebalancing ..." << endl; }
+         if (MPI::Session().Root()) { cout << "Rebalancing ..." << endl; }
          pmesh.Rebalance();
 
          // Update again after rebalancing

--- a/miniapps/electromagnetics/volta.cpp
+++ b/miniapps/electromagnetics/volta.cpp
@@ -103,7 +103,7 @@ int main(int argc, char *argv[])
    Mpi::Init(argc, argv);
    Hypre::Init();
 
-   if ( Mpi::Session().Root() ) { display_banner(cout); }
+   if ( Mpi::Root() ) { display_banner(cout); }
 
    // Parse command-line options.
    const char *mesh_file = "../../data/ball-nurbs.mesh";
@@ -166,13 +166,13 @@ int main(int argc, char *argv[])
    args.Parse();
    if (!args.Good())
    {
-      if (Mpi::Session().Root())
+      if (Mpi::Root())
       {
          args.PrintUsage(cout);
       }
       return 1;
    }
-   if (Mpi::Session().Root())
+   if (Mpi::Root())
    {
       args.PrintOptions(cout);
    }
@@ -183,7 +183,7 @@ int main(int argc, char *argv[])
    Mesh *mesh = new Mesh(mesh_file, 1, 1);
    int sdim = mesh->SpaceDimension();
 
-   if (Mpi::Session().Root())
+   if (Mpi::Root())
    {
       cout << "Starting initialization." << endl;
    }
@@ -269,7 +269,7 @@ int main(int argc, char *argv[])
    {
       Volta.RegisterVisItFields(visit_dc);
    }
-   if (Mpi::Session().Root()) { cout << "Initialization done." << endl; }
+   if (Mpi::Root()) { cout << "Initialization done." << endl; }
 
    // The main AMR loop. In each iteration we solve the problem on the current
    // mesh, visualize the solution, estimate the error on all elements, refine
@@ -279,7 +279,7 @@ int main(int argc, char *argv[])
    const int max_dofs = 10000000;
    for (int it = 1; it <= maxit; it++)
    {
-      if (Mpi::Session().Root())
+      if (Mpi::Root())
       {
          cout << "\nAMR Iteration " << it << endl;
       }
@@ -308,7 +308,7 @@ int main(int argc, char *argv[])
          Volta.DisplayToGLVis();
       }
 
-      if (Mpi::Session().Root())
+      if (Mpi::Root())
       {
          cout << "AMR iteration " << it << " complete." << endl;
       }
@@ -316,7 +316,7 @@ int main(int argc, char *argv[])
       // Check stopping criteria
       if (prob_size > max_dofs)
       {
-         if (Mpi::Session().Root())
+         if (Mpi::Root())
          {
             cout << "Reached maximum number of dofs, exiting..." << endl;
          }
@@ -329,7 +329,7 @@ int main(int argc, char *argv[])
 
       // Wait for user input. Ask every 10th iteration.
       char c = 'c';
-      if (Mpi::Session().Root() && (it % 10 == 0))
+      if (Mpi::Root() && (it % 10 == 0))
       {
          cout << "press (q)uit or (c)ontinue --> " << flush;
          cin >> c;
@@ -354,15 +354,15 @@ int main(int argc, char *argv[])
       // maximum element error.
       const double frac = 0.7;
       double threshold = frac * global_max_err;
-      if (Mpi::Session().Root()) { cout << "Refining ..." << endl; }
+      if (Mpi::Root()) { cout << "Refining ..." << endl; }
       pmesh.RefineByError(errors, threshold);
 
       // Update the electrostatic solver to reflect the new state of the mesh.
       Volta.Update();
 
-      if (pmesh.Nonconforming() && Mpi::Session().WorldSize() > 1)
+      if (pmesh.Nonconforming() && Mpi::WorldSize() > 1)
       {
-         if (Mpi::Session().Root()) { cout << "Rebalancing ..." << endl; }
+         if (Mpi::Root()) { cout << "Rebalancing ..." << endl; }
          pmesh.Rebalance();
 
          // Update again after rebalancing

--- a/miniapps/gslib/pfindpts.cpp
+++ b/miniapps/gslib/pfindpts.cpp
@@ -60,11 +60,12 @@ void F_exact(const Vector &p, Vector &F)
 
 int main (int argc, char *argv[])
 {
-   // Initialize MPI.
+   // Initialize MPI and HYPRE.
    int num_procs, myid;
    MPI_Init(&argc, &argv);
    MPI_Comm_size(MPI_COMM_WORLD, &num_procs);
    MPI_Comm_rank(MPI_COMM_WORLD, &myid);
+   HYPRE_Session hypre;
 
    // Set the method's default parameters.
    const char *mesh_file = "../../data/rt-2d-q3.mesh";

--- a/miniapps/gslib/pfindpts.cpp
+++ b/miniapps/gslib/pfindpts.cpp
@@ -61,10 +61,9 @@ void F_exact(const Vector &p, Vector &F)
 int main (int argc, char *argv[])
 {
    // Initialize MPI and HYPRE.
-   int num_procs, myid;
-   MPI_Init(&argc, &argv);
-   MPI_Comm_size(MPI_COMM_WORLD, &num_procs);
-   MPI_Comm_rank(MPI_COMM_WORLD, &myid);
+   Mpi::Init(argc, argv);
+   int num_procs = Mpi::WorldSize();
+   int myid = Mpi::WorldRank();
    Hypre::Init();
 
    // Set the method's default parameters.
@@ -313,6 +312,5 @@ int main (int argc, char *argv[])
 
    delete fec;
 
-   MPI_Finalize();
    return 0;
 }

--- a/miniapps/gslib/pfindpts.cpp
+++ b/miniapps/gslib/pfindpts.cpp
@@ -65,7 +65,7 @@ int main (int argc, char *argv[])
    MPI_Init(&argc, &argv);
    MPI_Comm_size(MPI_COMM_WORLD, &num_procs);
    MPI_Comm_rank(MPI_COMM_WORLD, &myid);
-   HYPRE_Session hypre;
+   Hypre::Init();
 
    // Set the method's default parameters.
    const char *mesh_file = "../../data/rt-2d-q3.mesh";

--- a/miniapps/gslib/schwarz_ex1p.cpp
+++ b/miniapps/gslib/schwarz_ex1p.cpp
@@ -78,7 +78,7 @@ int main(int argc, char *argv[])
    MPI_Init(&argc, &argv);
    MPI_Comm_size(MPI_COMM_WORLD, &num_procs);
    MPI_Comm_rank(MPI_COMM_WORLD, &myid);
-   HYPRE_Session hypre;
+   Hypre::Init();
 
    // Parse command-line options.
    int lim_meshes = 3; // should be greater than nmeshes

--- a/miniapps/gslib/schwarz_ex1p.cpp
+++ b/miniapps/gslib/schwarz_ex1p.cpp
@@ -73,11 +73,12 @@ void GetInterdomainBoundaryPoints(OversetFindPointsGSLIB &finder,
 
 int main(int argc, char *argv[])
 {
-   // Initialize MPI.
+   // Initialize MPI and HYPRE.
    int num_procs, myid;
    MPI_Init(&argc, &argv);
    MPI_Comm_size(MPI_COMM_WORLD, &num_procs);
    MPI_Comm_rank(MPI_COMM_WORLD, &myid);
+   HYPRE_Session hypre;
 
    // Parse command-line options.
    int lim_meshes = 3; // should be greater than nmeshes

--- a/miniapps/gslib/schwarz_ex1p.cpp
+++ b/miniapps/gslib/schwarz_ex1p.cpp
@@ -74,10 +74,9 @@ void GetInterdomainBoundaryPoints(OversetFindPointsGSLIB &finder,
 int main(int argc, char *argv[])
 {
    // Initialize MPI and HYPRE.
-   int num_procs, myid;
-   MPI_Init(&argc, &argv);
-   MPI_Comm_size(MPI_COMM_WORLD, &num_procs);
-   MPI_Comm_rank(MPI_COMM_WORLD, &myid);
+   Mpi::Init(argc, argv);
+   int num_procs = Mpi::WorldSize();
+   int myid = Mpi::WorldRank();
    Hypre::Init();
 
    // Parse command-line options.
@@ -429,8 +428,6 @@ int main(int argc, char *argv[])
    delete pmesh;
    delete comml;
 
-
-   MPI_Finalize();
 
    return 0;
 }

--- a/miniapps/meshing/pmesh-optimizer.cpp
+++ b/miniapps/meshing/pmesh-optimizer.cpp
@@ -114,10 +114,8 @@ using namespace std;
 int main (int argc, char *argv[])
 {
    // 0. Initialize MPI and HYPRE.
-   int num_procs, myid;
-   MPI_Init(&argc, &argv);
-   MPI_Comm_size(MPI_COMM_WORLD, &num_procs);
-   MPI_Comm_rank(MPI_COMM_WORLD, &myid);
+   Mpi::Init(argc, argv);
+   int myid = Mpi::WorldRank();
    Hypre::Init();
 
    // 1. Set the method's default parameters.
@@ -1249,6 +1247,5 @@ int main (int argc, char *argv[])
    delete fec;
    delete pmesh;
 
-   MPI_Finalize();
    return 0;
 }

--- a/miniapps/meshing/pmesh-optimizer.cpp
+++ b/miniapps/meshing/pmesh-optimizer.cpp
@@ -118,7 +118,7 @@ int main (int argc, char *argv[])
    MPI_Init(&argc, &argv);
    MPI_Comm_size(MPI_COMM_WORLD, &num_procs);
    MPI_Comm_rank(MPI_COMM_WORLD, &myid);
-   HYPRE_Session hypre;
+   Hypre::Init();
 
    // 1. Set the method's default parameters.
    const char *mesh_file = "icf.mesh";

--- a/miniapps/meshing/pmesh-optimizer.cpp
+++ b/miniapps/meshing/pmesh-optimizer.cpp
@@ -113,11 +113,12 @@ using namespace std;
 
 int main (int argc, char *argv[])
 {
-   // 0. Initialize MPI.
+   // 0. Initialize MPI and HYPRE.
    int num_procs, myid;
    MPI_Init(&argc, &argv);
    MPI_Comm_size(MPI_COMM_WORLD, &num_procs);
    MPI_Comm_rank(MPI_COMM_WORLD, &myid);
+   HYPRE_Session hypre;
 
    // 1. Set the method's default parameters.
    const char *mesh_file = "icf.mesh";

--- a/miniapps/meshing/pminimal-surface.cpp
+++ b/miniapps/meshing/pminimal-surface.cpp
@@ -1292,6 +1292,7 @@ int main(int argc, char *argv[])
    MPI_Init(&argc, &argv);
    MPI_Comm_rank(MPI_COMM_WORLD, &opt.id);
    MPI_Comm_size(MPI_COMM_WORLD, &opt.sz);
+   HYPRE_Session hypre;
    // Parse command-line options.
    OptionsParser args(argc, argv);
    args.AddOption(&opt.pb, "-p", "--problem", "Problem to solve.");

--- a/miniapps/meshing/pminimal-surface.cpp
+++ b/miniapps/meshing/pminimal-surface.cpp
@@ -1293,6 +1293,7 @@ int main(int argc, char *argv[])
    MPI_Comm_rank(MPI_COMM_WORLD, &opt.id);
    MPI_Comm_size(MPI_COMM_WORLD, &opt.sz);
    HYPRE_Session hypre;
+
    // Parse command-line options.
    OptionsParser args(argc, argv);
    args.AddOption(&opt.pb, "-p", "--problem", "Problem to solve.");

--- a/miniapps/meshing/pminimal-surface.cpp
+++ b/miniapps/meshing/pminimal-surface.cpp
@@ -1292,7 +1292,7 @@ int main(int argc, char *argv[])
    MPI_Init(&argc, &argv);
    MPI_Comm_rank(MPI_COMM_WORLD, &opt.id);
    MPI_Comm_size(MPI_COMM_WORLD, &opt.sz);
-   HYPRE_Session hypre;
+   Hypre::Init();
 
    // Parse command-line options.
    OptionsParser args(argc, argv);

--- a/miniapps/meshing/pminimal-surface.cpp
+++ b/miniapps/meshing/pminimal-surface.cpp
@@ -1289,9 +1289,9 @@ static int Problem1(Opt &opt)
 int main(int argc, char *argv[])
 {
    Opt opt;
-   MPI_Init(&argc, &argv);
-   MPI_Comm_rank(MPI_COMM_WORLD, &opt.id);
-   MPI_Comm_size(MPI_COMM_WORLD, &opt.sz);
+   Mpi::Init(argc, argv);
+   opt.id = Mpi::WorldRank();
+   opt.sz = Mpi::WorldSize();
    Hypre::Init();
 
    // Parse command-line options.
@@ -1329,7 +1329,7 @@ int main(int argc, char *argv[])
    args.AddOption(&opt.snapshot, "-ss", "--snapshot", "-no-ss", "--no-snapshot",
                   "Enable or disable GLVis snapshot.");
    args.Parse();
-   if (!args.Good()) { args.PrintUsage(mfem::out); MPI_Finalize(); return 1; }
+   if (!args.Good()) { args.PrintUsage(mfem::out); return 1; }
    MFEM_VERIFY(opt.lambda >= 0.0 && opt.lambda <= 1.0,"");
    if (!opt.id) { args.PrintOptions(mfem::out); }
 
@@ -1341,6 +1341,5 @@ int main(int argc, char *argv[])
 
    if (opt.pb == 1) { Problem1(opt); }
 
-   MPI_Finalize();
    return 0;
 }

--- a/miniapps/mtop/parheat.cpp
+++ b/miniapps/mtop/parheat.cpp
@@ -50,9 +50,8 @@
 int main(int argc, char *argv[])
 {
    // 1. Initialize MPI and HYPRE.
-   Mpi::Init(argc, argv);
-   int nprocs = Mpi::WorldSize();
-   int myrank = Mpi::WorldRank();
+   mfem::Mpi::Init(argc, argv);
+   int myrank = mfem::Mpi::WorldRank();
    mfem::Hypre::Init();
 
    // Parse command-line options.

--- a/miniapps/mtop/parheat.cpp
+++ b/miniapps/mtop/parheat.cpp
@@ -50,10 +50,9 @@
 int main(int argc, char *argv[])
 {
    // 1. Initialize MPI and HYPRE.
-   int nprocs, myrank;
-   MPI_Init(&argc, &argv);
-   MPI_Comm_size(MPI_COMM_WORLD, &nprocs);
-   MPI_Comm_rank(MPI_COMM_WORLD, &myrank);
+   Mpi::Init(argc, argv);
+   int nprocs = Mpi::WorldSize();
+   int myrank = Mpi::WorldRank();
    mfem::Hypre::Init();
 
    // Parse command-line options.
@@ -109,7 +108,6 @@ int main(int argc, char *argv[])
       {
          args.PrintUsage(std::cout);
       }
-      MPI_Finalize();
       return 1;
    }
 
@@ -351,6 +349,5 @@ int main(int argc, char *argv[])
    delete loadco;
    delete diffco;
 
-   MPI_Finalize();
    return 0;
 }

--- a/miniapps/mtop/parheat.cpp
+++ b/miniapps/mtop/parheat.cpp
@@ -49,11 +49,12 @@
 
 int main(int argc, char *argv[])
 {
-   // Initialize MPI.
+   // 1. Initialize MPI and HYPRE.
    int nprocs, myrank;
    MPI_Init(&argc, &argv);
    MPI_Comm_size(MPI_COMM_WORLD, &nprocs);
    MPI_Comm_rank(MPI_COMM_WORLD, &myrank);
+   mfem::HYPRE_Session hypre;
 
    // Parse command-line options.
    const char *mesh_file = "../../data/star.mesh";

--- a/miniapps/mtop/parheat.cpp
+++ b/miniapps/mtop/parheat.cpp
@@ -54,7 +54,7 @@ int main(int argc, char *argv[])
    MPI_Init(&argc, &argv);
    MPI_Comm_size(MPI_COMM_WORLD, &nprocs);
    MPI_Comm_rank(MPI_COMM_WORLD, &myrank);
-   mfem::HYPRE_Session hypre;
+   mfem::Hypre::Init();
 
    // Parse command-line options.
    const char *mesh_file = "../../data/star.mesh";

--- a/miniapps/navier/navier_3dfoc.cpp
+++ b/miniapps/navier/navier_3dfoc.cpp
@@ -60,7 +60,7 @@ int main(int argc, char *argv[])
       mesh->UniformRefinement();
    }
 
-   if (Mpi::Session().Root())
+   if (Mpi::Root())
    {
       std::cout << "Number of elements: " << mesh->GetNE() << std::endl;
    }
@@ -122,7 +122,7 @@ int main(int argc, char *argv[])
          pvdc.Save();
       }
 
-      if (Mpi::Session().Root())
+      if (Mpi::Root())
       {
          printf("%11s %11s\n", "Time", "dt");
          printf("%.5E %.5E\n", t, dt);

--- a/miniapps/navier/navier_3dfoc.cpp
+++ b/miniapps/navier/navier_3dfoc.cpp
@@ -49,6 +49,7 @@ void vel(const Vector &x, double t, Vector &u)
 int main(int argc, char *argv[])
 {
    MPI_Session mpi(argc, argv);
+   HYPRE_Session hypre;
 
    int serial_refinements = 0;
 

--- a/miniapps/navier/navier_3dfoc.cpp
+++ b/miniapps/navier/navier_3dfoc.cpp
@@ -49,7 +49,7 @@ void vel(const Vector &x, double t, Vector &u)
 int main(int argc, char *argv[])
 {
    MPI_Session mpi(argc, argv);
-   HYPRE_Session hypre;
+   Hypre::Init();
 
    int serial_refinements = 0;
 

--- a/miniapps/navier/navier_3dfoc.cpp
+++ b/miniapps/navier/navier_3dfoc.cpp
@@ -48,7 +48,7 @@ void vel(const Vector &x, double t, Vector &u)
 
 int main(int argc, char *argv[])
 {
-   MPI_Session mpi(argc, argv);
+   MPI::Init(argc, argv);
    Hypre::Init();
 
    int serial_refinements = 0;
@@ -60,7 +60,7 @@ int main(int argc, char *argv[])
       mesh->UniformRefinement();
    }
 
-   if (mpi.Root())
+   if (MPI::Session().Root())
    {
       std::cout << "Number of elements: " << mesh->GetNE() << std::endl;
    }
@@ -122,7 +122,7 @@ int main(int argc, char *argv[])
          pvdc.Save();
       }
 
-      if (mpi.Root())
+      if (MPI::Session().Root())
       {
          printf("%11s %11s\n", "Time", "dt");
          printf("%.5E %.5E\n", t, dt);

--- a/miniapps/navier/navier_3dfoc.cpp
+++ b/miniapps/navier/navier_3dfoc.cpp
@@ -48,7 +48,7 @@ void vel(const Vector &x, double t, Vector &u)
 
 int main(int argc, char *argv[])
 {
-   MPI::Init(argc, argv);
+   Mpi::Init(argc, argv);
    Hypre::Init();
 
    int serial_refinements = 0;
@@ -60,7 +60,7 @@ int main(int argc, char *argv[])
       mesh->UniformRefinement();
    }
 
-   if (MPI::Session().Root())
+   if (Mpi::Session().Root())
    {
       std::cout << "Number of elements: " << mesh->GetNE() << std::endl;
    }
@@ -122,7 +122,7 @@ int main(int argc, char *argv[])
          pvdc.Save();
       }
 
-      if (MPI::Session().Root())
+      if (Mpi::Session().Root())
       {
          printf("%11s %11s\n", "Time", "dt");
          printf("%.5E %.5E\n", t, dt);

--- a/miniapps/navier/navier_cht.cpp
+++ b/miniapps/navier/navier_cht.cpp
@@ -133,10 +133,9 @@ void VisualizeField(socketstream &sock, const char *vishost, int visport,
 int main(int argc, char *argv[])
 {
    // Initialize MPI and HYPRE.
-   int num_procs, myid;
-   MPI_Init(&argc, &argv);
-   MPI_Comm_size(MPI_COMM_WORLD, &num_procs);
-   MPI_Comm_rank(MPI_COMM_WORLD, &myid);
+   Mpi::Init(argc, argv);
+   int num_procs = Mpi::WorldSize();
+   int myid = Mpi::WorldRank();
    Hypre::Init();
 
    // Parse command-line options.
@@ -404,8 +403,6 @@ int main(int argc, char *argv[])
    delete flowsolver;
    delete pmesh;
    delete comml;
-
-   MPI_Finalize();
 
    return 0;
 }

--- a/miniapps/navier/navier_cht.cpp
+++ b/miniapps/navier/navier_cht.cpp
@@ -132,11 +132,12 @@ void VisualizeField(socketstream &sock, const char *vishost, int visport,
 
 int main(int argc, char *argv[])
 {
-   // Initialize MPI.
+   // Initialize MPI and HYPRE.
    int num_procs, myid;
    MPI_Init(&argc, &argv);
    MPI_Comm_size(MPI_COMM_WORLD, &num_procs);
    MPI_Comm_rank(MPI_COMM_WORLD, &myid);
+   HYPRE_Session hypre;
 
    // Parse command-line options.
    int lim_meshes = 2; // should be greater than nmeshes

--- a/miniapps/navier/navier_cht.cpp
+++ b/miniapps/navier/navier_cht.cpp
@@ -137,7 +137,7 @@ int main(int argc, char *argv[])
    MPI_Init(&argc, &argv);
    MPI_Comm_size(MPI_COMM_WORLD, &num_procs);
    MPI_Comm_rank(MPI_COMM_WORLD, &myid);
-   HYPRE_Session hypre;
+   Hypre::Init();
 
    // Parse command-line options.
    int lim_meshes = 2; // should be greater than nmeshes

--- a/miniapps/navier/navier_kovasznay.cpp
+++ b/miniapps/navier/navier_kovasznay.cpp
@@ -81,6 +81,7 @@ double pres_kovasznay(const Vector &x, double t)
 int main(int argc, char *argv[])
 {
    MPI_Session mpi(argc, argv);
+   HYPRE_Session hypre;
 
    OptionsParser args(argc, argv);
    args.AddOption(&ctx.ser_ref_levels,

--- a/miniapps/navier/navier_kovasznay.cpp
+++ b/miniapps/navier/navier_kovasznay.cpp
@@ -81,7 +81,7 @@ double pres_kovasznay(const Vector &x, double t)
 int main(int argc, char *argv[])
 {
    MPI_Session mpi(argc, argv);
-   HYPRE_Session hypre;
+   Hypre::Init();
 
    OptionsParser args(argc, argv);
    args.AddOption(&ctx.ser_ref_levels,

--- a/miniapps/navier/navier_kovasznay.cpp
+++ b/miniapps/navier/navier_kovasznay.cpp
@@ -122,13 +122,13 @@ int main(int argc, char *argv[])
    args.Parse();
    if (!args.Good())
    {
-      if (Mpi::Session().Root())
+      if (Mpi::Root())
       {
          args.PrintUsage(mfem::out);
       }
       return 1;
    }
-   if (Mpi::Session().Root())
+   if (Mpi::Root())
    {
       args.PrintOptions(mfem::out);
    }
@@ -145,7 +145,7 @@ int main(int argc, char *argv[])
       mesh.UniformRefinement();
    }
 
-   if (Mpi::Session().Root())
+   if (Mpi::Root())
    {
       std::cout << "Number of elements: " << mesh.GetNE() << std::endl;
    }
@@ -211,7 +211,7 @@ int main(int argc, char *argv[])
 
       double cfl = flowsolver.ComputeCFL(*u_gf, dt);
 
-      if (Mpi::Session().Root())
+      if (Mpi::Root())
       {
          printf("%5s %8s %8s %8s %11s %11s\n",
                 "Order",
@@ -237,8 +237,8 @@ int main(int argc, char *argv[])
       int visport = 19916;
       socketstream sol_sock(vishost, visport);
       sol_sock.precision(8);
-      sol_sock << "parallel " << Mpi::Session().WorldSize() << " "
-               << Mpi::Session().WorldRank() << "\n";
+      sol_sock << "parallel " << Mpi::WorldSize() << " "
+               << Mpi::WorldRank() << "\n";
       sol_sock << "solution\n" << *pmesh << *u_ic << std::flush;
    }
 
@@ -251,7 +251,7 @@ int main(int argc, char *argv[])
       double tol_p = 1e-5;
       if (err_u > tol_u || err_p > tol_p)
       {
-         if (Mpi::Session().Root())
+         if (Mpi::Root())
          {
             mfem::out << "Result has a larger error than expected."
                       << std::endl;

--- a/miniapps/navier/navier_kovasznay.cpp
+++ b/miniapps/navier/navier_kovasznay.cpp
@@ -80,7 +80,7 @@ double pres_kovasznay(const Vector &x, double t)
 
 int main(int argc, char *argv[])
 {
-   MPI::Init(argc, argv);
+   Mpi::Init(argc, argv);
    Hypre::Init();
 
    OptionsParser args(argc, argv);
@@ -122,13 +122,13 @@ int main(int argc, char *argv[])
    args.Parse();
    if (!args.Good())
    {
-      if (MPI::Session().Root())
+      if (Mpi::Session().Root())
       {
          args.PrintUsage(mfem::out);
       }
       return 1;
    }
-   if (MPI::Session().Root())
+   if (Mpi::Session().Root())
    {
       args.PrintOptions(mfem::out);
    }
@@ -145,7 +145,7 @@ int main(int argc, char *argv[])
       mesh.UniformRefinement();
    }
 
-   if (MPI::Session().Root())
+   if (Mpi::Session().Root())
    {
       std::cout << "Number of elements: " << mesh.GetNE() << std::endl;
    }
@@ -211,7 +211,7 @@ int main(int argc, char *argv[])
 
       double cfl = flowsolver.ComputeCFL(*u_gf, dt);
 
-      if (MPI::Session().Root())
+      if (Mpi::Session().Root())
       {
          printf("%5s %8s %8s %8s %11s %11s\n",
                 "Order",
@@ -237,8 +237,8 @@ int main(int argc, char *argv[])
       int visport = 19916;
       socketstream sol_sock(vishost, visport);
       sol_sock.precision(8);
-      sol_sock << "parallel " << MPI::Session().WorldSize() << " "
-               << MPI::Session().WorldRank() << "\n";
+      sol_sock << "parallel " << Mpi::Session().WorldSize() << " "
+               << Mpi::Session().WorldRank() << "\n";
       sol_sock << "solution\n" << *pmesh << *u_ic << std::flush;
    }
 
@@ -251,7 +251,7 @@ int main(int argc, char *argv[])
       double tol_p = 1e-5;
       if (err_u > tol_u || err_p > tol_p)
       {
-         if (MPI::Session().Root())
+         if (Mpi::Session().Root())
          {
             mfem::out << "Result has a larger error than expected."
                       << std::endl;

--- a/miniapps/navier/navier_kovasznay.cpp
+++ b/miniapps/navier/navier_kovasznay.cpp
@@ -80,7 +80,7 @@ double pres_kovasznay(const Vector &x, double t)
 
 int main(int argc, char *argv[])
 {
-   MPI_Session mpi(argc, argv);
+   MPI::Init(argc, argv);
    Hypre::Init();
 
    OptionsParser args(argc, argv);
@@ -122,13 +122,13 @@ int main(int argc, char *argv[])
    args.Parse();
    if (!args.Good())
    {
-      if (mpi.Root())
+      if (MPI::Session().Root())
       {
          args.PrintUsage(mfem::out);
       }
       return 1;
    }
-   if (mpi.Root())
+   if (MPI::Session().Root())
    {
       args.PrintOptions(mfem::out);
    }
@@ -145,7 +145,7 @@ int main(int argc, char *argv[])
       mesh.UniformRefinement();
    }
 
-   if (mpi.Root())
+   if (MPI::Session().Root())
    {
       std::cout << "Number of elements: " << mesh.GetNE() << std::endl;
    }
@@ -211,7 +211,7 @@ int main(int argc, char *argv[])
 
       double cfl = flowsolver.ComputeCFL(*u_gf, dt);
 
-      if (mpi.Root())
+      if (MPI::Session().Root())
       {
          printf("%5s %8s %8s %8s %11s %11s\n",
                 "Order",
@@ -237,8 +237,8 @@ int main(int argc, char *argv[])
       int visport = 19916;
       socketstream sol_sock(vishost, visport);
       sol_sock.precision(8);
-      sol_sock << "parallel " << mpi.WorldSize() << " " << mpi.WorldRank()
-               << "\n";
+      sol_sock << "parallel " << MPI::Session().WorldSize() << " "
+               << MPI::Session().WorldRank() << "\n";
       sol_sock << "solution\n" << *pmesh << *u_ic << std::flush;
    }
 
@@ -251,7 +251,7 @@ int main(int argc, char *argv[])
       double tol_p = 1e-5;
       if (err_u > tol_u || err_p > tol_p)
       {
-         if (mpi.Root())
+         if (MPI::Session().Root())
          {
             mfem::out << "Result has a larger error than expected."
                       << std::endl;

--- a/miniapps/navier/navier_kovasznay_vs.cpp
+++ b/miniapps/navier/navier_kovasznay_vs.cpp
@@ -84,7 +84,7 @@ double pres_kovasznay(const Vector &x, double t)
 
 int main(int argc, char *argv[])
 {
-   MPI::Init(argc, argv);
+   Mpi::Init(argc, argv);
    Hypre::Init();
 
    OptionsParser args(argc, argv);
@@ -126,13 +126,13 @@ int main(int argc, char *argv[])
    args.Parse();
    if (!args.Good())
    {
-      if (MPI::Session().Root())
+      if (Mpi::Session().Root())
       {
          args.PrintUsage(mfem::out);
       }
       return 1;
    }
-   if (MPI::Session().Root())
+   if (Mpi::Session().Root())
    {
       args.PrintOptions(mfem::out);
    }
@@ -149,7 +149,7 @@ int main(int argc, char *argv[])
       mesh.UniformRefinement();
    }
 
-   if (MPI::Session().Root())
+   if (Mpi::Session().Root())
    {
       std::cout << "Number of elements: " << mesh.GetNE() << std::endl;
    }
@@ -214,7 +214,7 @@ int main(int argc, char *argv[])
       if (error_est >= 1.0)
       {
          // Reject the time step
-         if (MPI::Session().Root())
+         if (Mpi::Session().Root())
          {
             std::cout
                   << "Step reached maximum CFL, retrying with smaller step size..."
@@ -252,7 +252,7 @@ int main(int argc, char *argv[])
       err_u = u_gf->ComputeL2Error(u_excoeff);
       err_p = p_gf->ComputeL2Error(p_ex_gf_coeff);
 
-      if (MPI::Session().Root())
+      if (Mpi::Session().Root())
       {
          printf("%5s %8s %8s %8s %11s %11s\n",
                 "Order",
@@ -278,8 +278,8 @@ int main(int argc, char *argv[])
       int visport = 19916;
       socketstream sol_sock(vishost, visport);
       sol_sock.precision(8);
-      sol_sock << "parallel " << MPI::Session().WorldSize() << " "
-               << MPI::Session().WorldRank() << "\n";
+      sol_sock << "parallel " << Mpi::Session().WorldSize() << " "
+               << Mpi::Session().WorldRank() << "\n";
       sol_sock << "solution\n" << *pmesh << *u_ic << std::flush;
    }
 
@@ -292,7 +292,7 @@ int main(int argc, char *argv[])
       double tol_p = 1e-5;
       if (err_u > tol_u || err_p > tol_p)
       {
-         if (MPI::Session().Root())
+         if (Mpi::Session().Root())
          {
             mfem::out << "Result has a larger error than expected."
                       << std::endl;

--- a/miniapps/navier/navier_kovasznay_vs.cpp
+++ b/miniapps/navier/navier_kovasznay_vs.cpp
@@ -84,7 +84,7 @@ double pres_kovasznay(const Vector &x, double t)
 
 int main(int argc, char *argv[])
 {
-   MPI_Session mpi(argc, argv);
+   MPI::Init(argc, argv);
    Hypre::Init();
 
    OptionsParser args(argc, argv);
@@ -126,13 +126,13 @@ int main(int argc, char *argv[])
    args.Parse();
    if (!args.Good())
    {
-      if (mpi.Root())
+      if (MPI::Session().Root())
       {
          args.PrintUsage(mfem::out);
       }
       return 1;
    }
-   if (mpi.Root())
+   if (MPI::Session().Root())
    {
       args.PrintOptions(mfem::out);
    }
@@ -149,7 +149,7 @@ int main(int argc, char *argv[])
       mesh.UniformRefinement();
    }
 
-   if (mpi.Root())
+   if (MPI::Session().Root())
    {
       std::cout << "Number of elements: " << mesh.GetNE() << std::endl;
    }
@@ -214,7 +214,7 @@ int main(int argc, char *argv[])
       if (error_est >= 1.0)
       {
          // Reject the time step
-         if (mpi.Root())
+         if (MPI::Session().Root())
          {
             std::cout
                   << "Step reached maximum CFL, retrying with smaller step size..."
@@ -252,7 +252,7 @@ int main(int argc, char *argv[])
       err_u = u_gf->ComputeL2Error(u_excoeff);
       err_p = p_gf->ComputeL2Error(p_ex_gf_coeff);
 
-      if (mpi.Root())
+      if (MPI::Session().Root())
       {
          printf("%5s %8s %8s %8s %11s %11s\n",
                 "Order",
@@ -278,8 +278,8 @@ int main(int argc, char *argv[])
       int visport = 19916;
       socketstream sol_sock(vishost, visport);
       sol_sock.precision(8);
-      sol_sock << "parallel " << mpi.WorldSize() << " " << mpi.WorldRank()
-               << "\n";
+      sol_sock << "parallel " << MPI::Session().WorldSize() << " "
+               << MPI::Session().WorldRank() << "\n";
       sol_sock << "solution\n" << *pmesh << *u_ic << std::flush;
    }
 
@@ -292,7 +292,7 @@ int main(int argc, char *argv[])
       double tol_p = 1e-5;
       if (err_u > tol_u || err_p > tol_p)
       {
-         if (mpi.Root())
+         if (MPI::Session().Root())
          {
             mfem::out << "Result has a larger error than expected."
                       << std::endl;

--- a/miniapps/navier/navier_kovasznay_vs.cpp
+++ b/miniapps/navier/navier_kovasznay_vs.cpp
@@ -126,13 +126,13 @@ int main(int argc, char *argv[])
    args.Parse();
    if (!args.Good())
    {
-      if (Mpi::Session().Root())
+      if (Mpi::Root())
       {
          args.PrintUsage(mfem::out);
       }
       return 1;
    }
-   if (Mpi::Session().Root())
+   if (Mpi::Root())
    {
       args.PrintOptions(mfem::out);
    }
@@ -149,7 +149,7 @@ int main(int argc, char *argv[])
       mesh.UniformRefinement();
    }
 
-   if (Mpi::Session().Root())
+   if (Mpi::Root())
    {
       std::cout << "Number of elements: " << mesh.GetNE() << std::endl;
    }
@@ -214,7 +214,7 @@ int main(int argc, char *argv[])
       if (error_est >= 1.0)
       {
          // Reject the time step
-         if (Mpi::Session().Root())
+         if (Mpi::Root())
          {
             std::cout
                   << "Step reached maximum CFL, retrying with smaller step size..."
@@ -252,7 +252,7 @@ int main(int argc, char *argv[])
       err_u = u_gf->ComputeL2Error(u_excoeff);
       err_p = p_gf->ComputeL2Error(p_ex_gf_coeff);
 
-      if (Mpi::Session().Root())
+      if (Mpi::Root())
       {
          printf("%5s %8s %8s %8s %11s %11s\n",
                 "Order",
@@ -278,8 +278,8 @@ int main(int argc, char *argv[])
       int visport = 19916;
       socketstream sol_sock(vishost, visport);
       sol_sock.precision(8);
-      sol_sock << "parallel " << Mpi::Session().WorldSize() << " "
-               << Mpi::Session().WorldRank() << "\n";
+      sol_sock << "parallel " << Mpi::WorldSize() << " "
+               << Mpi::WorldRank() << "\n";
       sol_sock << "solution\n" << *pmesh << *u_ic << std::flush;
    }
 
@@ -292,7 +292,7 @@ int main(int argc, char *argv[])
       double tol_p = 1e-5;
       if (err_u > tol_u || err_p > tol_p)
       {
-         if (Mpi::Session().Root())
+         if (Mpi::Root())
          {
             mfem::out << "Result has a larger error than expected."
                       << std::endl;

--- a/miniapps/navier/navier_kovasznay_vs.cpp
+++ b/miniapps/navier/navier_kovasznay_vs.cpp
@@ -85,7 +85,7 @@ double pres_kovasznay(const Vector &x, double t)
 int main(int argc, char *argv[])
 {
    MPI_Session mpi(argc, argv);
-   HYPRE_Session hypre;
+   Hypre::Init();
 
    OptionsParser args(argc, argv);
    args.AddOption(&ctx.ser_ref_levels,

--- a/miniapps/navier/navier_kovasznay_vs.cpp
+++ b/miniapps/navier/navier_kovasznay_vs.cpp
@@ -85,6 +85,7 @@ double pres_kovasznay(const Vector &x, double t)
 int main(int argc, char *argv[])
 {
    MPI_Session mpi(argc, argv);
+   HYPRE_Session hypre;
 
    OptionsParser args(argc, argv);
    args.AddOption(&ctx.ser_ref_levels,

--- a/miniapps/navier/navier_mms.cpp
+++ b/miniapps/navier/navier_mms.cpp
@@ -85,7 +85,7 @@ void accel(const Vector &x, double t, Vector &u)
 
 int main(int argc, char *argv[])
 {
-   MPI_Session mpi(argc, argv);
+   MPI::Init(argc, argv);
    Hypre::Init();
 
    OptionsParser args(argc, argv);
@@ -127,13 +127,13 @@ int main(int argc, char *argv[])
    args.Parse();
    if (!args.Good())
    {
-      if (mpi.Root())
+      if (MPI::Session().Root())
       {
          args.PrintUsage(mfem::out);
       }
       return 1;
    }
-   if (mpi.Root())
+   if (MPI::Session().Root())
    {
       args.PrintOptions(mfem::out);
    }
@@ -149,7 +149,7 @@ int main(int argc, char *argv[])
       mesh->UniformRefinement();
    }
 
-   if (mpi.Root())
+   if (MPI::Session().Root())
    {
       std::cout << "Number of elements: " << mesh->GetNE() << std::endl;
    }
@@ -208,7 +208,7 @@ int main(int argc, char *argv[])
       err_u = u_gf->ComputeL2Error(u_excoeff);
       err_p = p_gf->ComputeL2Error(p_excoeff);
 
-      if (mpi.Root())
+      if (MPI::Session().Root())
       {
          printf("%11s %11s %11s %11s\n", "Time", "dt", "err_u", "err_p");
          printf("%.5E %.5E %.5E %.5E err\n", t, dt, err_u, err_p);
@@ -221,8 +221,8 @@ int main(int argc, char *argv[])
       char vishost[] = "localhost";
       int visport = 19916;
       socketstream sol_sock(vishost, visport);
-      sol_sock << "parallel " << mpi.WorldSize() << " " << mpi.WorldRank()
-               << "\n";
+      sol_sock << "parallel " << MPI::Session().WorldSize() << " "
+               << MPI::Session().WorldRank() << "\n";
       sol_sock << "solution\n" << *pmesh << *u_ic << std::flush;
    }
 
@@ -234,7 +234,7 @@ int main(int argc, char *argv[])
       double tol = 1e-3;
       if (err_u > tol || err_p > tol)
       {
-         if (mpi.Root())
+         if (MPI::Session().Root())
          {
             mfem::out << "Result has a larger error than expected."
                       << std::endl;

--- a/miniapps/navier/navier_mms.cpp
+++ b/miniapps/navier/navier_mms.cpp
@@ -86,7 +86,7 @@ void accel(const Vector &x, double t, Vector &u)
 int main(int argc, char *argv[])
 {
    MPI_Session mpi(argc, argv);
-   HYPRE_Session hypre;
+   Hypre::Init();
 
    OptionsParser args(argc, argv);
    args.AddOption(&ctx.ser_ref_levels,

--- a/miniapps/navier/navier_mms.cpp
+++ b/miniapps/navier/navier_mms.cpp
@@ -127,13 +127,13 @@ int main(int argc, char *argv[])
    args.Parse();
    if (!args.Good())
    {
-      if (Mpi::Session().Root())
+      if (Mpi::Root())
       {
          args.PrintUsage(mfem::out);
       }
       return 1;
    }
-   if (Mpi::Session().Root())
+   if (Mpi::Root())
    {
       args.PrintOptions(mfem::out);
    }
@@ -149,7 +149,7 @@ int main(int argc, char *argv[])
       mesh->UniformRefinement();
    }
 
-   if (Mpi::Session().Root())
+   if (Mpi::Root())
    {
       std::cout << "Number of elements: " << mesh->GetNE() << std::endl;
    }
@@ -208,7 +208,7 @@ int main(int argc, char *argv[])
       err_u = u_gf->ComputeL2Error(u_excoeff);
       err_p = p_gf->ComputeL2Error(p_excoeff);
 
-      if (Mpi::Session().Root())
+      if (Mpi::Root())
       {
          printf("%11s %11s %11s %11s\n", "Time", "dt", "err_u", "err_p");
          printf("%.5E %.5E %.5E %.5E err\n", t, dt, err_u, err_p);
@@ -221,8 +221,8 @@ int main(int argc, char *argv[])
       char vishost[] = "localhost";
       int visport = 19916;
       socketstream sol_sock(vishost, visport);
-      sol_sock << "parallel " << Mpi::Session().WorldSize() << " "
-               << Mpi::Session().WorldRank() << "\n";
+      sol_sock << "parallel " << Mpi::WorldSize() << " "
+               << Mpi::WorldRank() << "\n";
       sol_sock << "solution\n" << *pmesh << *u_ic << std::flush;
    }
 
@@ -234,7 +234,7 @@ int main(int argc, char *argv[])
       double tol = 1e-3;
       if (err_u > tol || err_p > tol)
       {
-         if (Mpi::Session().Root())
+         if (Mpi::Root())
          {
             mfem::out << "Result has a larger error than expected."
                       << std::endl;

--- a/miniapps/navier/navier_mms.cpp
+++ b/miniapps/navier/navier_mms.cpp
@@ -86,6 +86,7 @@ void accel(const Vector &x, double t, Vector &u)
 int main(int argc, char *argv[])
 {
    MPI_Session mpi(argc, argv);
+   HYPRE_Session hypre;
 
    OptionsParser args(argc, argv);
    args.AddOption(&ctx.ser_ref_levels,

--- a/miniapps/navier/navier_mms.cpp
+++ b/miniapps/navier/navier_mms.cpp
@@ -85,7 +85,7 @@ void accel(const Vector &x, double t, Vector &u)
 
 int main(int argc, char *argv[])
 {
-   MPI::Init(argc, argv);
+   Mpi::Init(argc, argv);
    Hypre::Init();
 
    OptionsParser args(argc, argv);
@@ -127,13 +127,13 @@ int main(int argc, char *argv[])
    args.Parse();
    if (!args.Good())
    {
-      if (MPI::Session().Root())
+      if (Mpi::Session().Root())
       {
          args.PrintUsage(mfem::out);
       }
       return 1;
    }
-   if (MPI::Session().Root())
+   if (Mpi::Session().Root())
    {
       args.PrintOptions(mfem::out);
    }
@@ -149,7 +149,7 @@ int main(int argc, char *argv[])
       mesh->UniformRefinement();
    }
 
-   if (MPI::Session().Root())
+   if (Mpi::Session().Root())
    {
       std::cout << "Number of elements: " << mesh->GetNE() << std::endl;
    }
@@ -208,7 +208,7 @@ int main(int argc, char *argv[])
       err_u = u_gf->ComputeL2Error(u_excoeff);
       err_p = p_gf->ComputeL2Error(p_excoeff);
 
-      if (MPI::Session().Root())
+      if (Mpi::Session().Root())
       {
          printf("%11s %11s %11s %11s\n", "Time", "dt", "err_u", "err_p");
          printf("%.5E %.5E %.5E %.5E err\n", t, dt, err_u, err_p);
@@ -221,8 +221,8 @@ int main(int argc, char *argv[])
       char vishost[] = "localhost";
       int visport = 19916;
       socketstream sol_sock(vishost, visport);
-      sol_sock << "parallel " << MPI::Session().WorldSize() << " "
-               << MPI::Session().WorldRank() << "\n";
+      sol_sock << "parallel " << Mpi::Session().WorldSize() << " "
+               << Mpi::Session().WorldRank() << "\n";
       sol_sock << "solution\n" << *pmesh << *u_ic << std::flush;
    }
 
@@ -234,7 +234,7 @@ int main(int argc, char *argv[])
       double tol = 1e-3;
       if (err_u > tol || err_p > tol)
       {
-         if (MPI::Session().Root())
+         if (Mpi::Session().Root())
          {
             mfem::out << "Result has a larger error than expected."
                       << std::endl;

--- a/miniapps/navier/navier_shear.cpp
+++ b/miniapps/navier/navier_shear.cpp
@@ -65,7 +65,7 @@ void vel_shear_ic(const Vector &x, double t, Vector &u)
 int main(int argc, char *argv[])
 {
    MPI_Session mpi(argc, argv);
-   HYPRE_Session hypre;
+   Hypre::Init();
 
    int serial_refinements = 2;
 

--- a/miniapps/navier/navier_shear.cpp
+++ b/miniapps/navier/navier_shear.cpp
@@ -64,7 +64,7 @@ void vel_shear_ic(const Vector &x, double t, Vector &u)
 
 int main(int argc, char *argv[])
 {
-   MPI::Init(argc, argv);
+   Mpi::Init(argc, argv);
    Hypre::Init();
 
    int serial_refinements = 2;
@@ -80,7 +80,7 @@ int main(int argc, char *argv[])
       mesh->UniformRefinement();
    }
 
-   if (MPI::Session().Root())
+   if (Mpi::Session().Root())
    {
       std::cout << "Number of elements: " << mesh->GetNE() << std::endl;
    }
@@ -138,7 +138,7 @@ int main(int argc, char *argv[])
          pvdc.Save();
       }
 
-      if (MPI::Session().Root())
+      if (Mpi::Session().Root())
       {
          printf("%11s %11s\n", "Time", "dt");
          printf("%.5E %.5E\n", t, dt);

--- a/miniapps/navier/navier_shear.cpp
+++ b/miniapps/navier/navier_shear.cpp
@@ -65,6 +65,7 @@ void vel_shear_ic(const Vector &x, double t, Vector &u)
 int main(int argc, char *argv[])
 {
    MPI_Session mpi(argc, argv);
+   HYPRE_Session hypre;
 
    int serial_refinements = 2;
 

--- a/miniapps/navier/navier_shear.cpp
+++ b/miniapps/navier/navier_shear.cpp
@@ -80,7 +80,7 @@ int main(int argc, char *argv[])
       mesh->UniformRefinement();
    }
 
-   if (Mpi::Session().Root())
+   if (Mpi::Root())
    {
       std::cout << "Number of elements: " << mesh->GetNE() << std::endl;
    }
@@ -138,7 +138,7 @@ int main(int argc, char *argv[])
          pvdc.Save();
       }
 
-      if (Mpi::Session().Root())
+      if (Mpi::Root())
       {
          printf("%11s %11s\n", "Time", "dt");
          printf("%.5E %.5E\n", t, dt);

--- a/miniapps/navier/navier_shear.cpp
+++ b/miniapps/navier/navier_shear.cpp
@@ -64,7 +64,7 @@ void vel_shear_ic(const Vector &x, double t, Vector &u)
 
 int main(int argc, char *argv[])
 {
-   MPI_Session mpi(argc, argv);
+   MPI::Init(argc, argv);
    Hypre::Init();
 
    int serial_refinements = 2;
@@ -80,7 +80,7 @@ int main(int argc, char *argv[])
       mesh->UniformRefinement();
    }
 
-   if (mpi.Root())
+   if (MPI::Session().Root())
    {
       std::cout << "Number of elements: " << mesh->GetNE() << std::endl;
    }
@@ -138,7 +138,7 @@ int main(int argc, char *argv[])
          pvdc.Save();
       }
 
-      if (mpi.Root())
+      if (MPI::Session().Root())
       {
          printf("%11s %11s\n", "Time", "dt");
          printf("%.5E %.5E\n", t, dt);

--- a/miniapps/navier/navier_tgv.cpp
+++ b/miniapps/navier/navier_tgv.cpp
@@ -253,13 +253,13 @@ int main(int argc, char *argv[])
    args.Parse();
    if (!args.Good())
    {
-      if (Mpi::Session().Root())
+      if (Mpi::Root())
       {
          args.PrintUsage(mfem::out);
       }
       return 1;
    }
-   if (Mpi::Session().Root())
+   if (Mpi::Root())
    {
       args.PrintOptions(mfem::out);
    }
@@ -274,7 +274,7 @@ int main(int argc, char *argv[])
    *nodes *= M_PI;
 
    int nel = mesh.GetNE();
-   if (Mpi::Session().Root())
+   if (Mpi::Root())
    {
       mfem::out << "Number of elements: " << nel << std::endl;
    }
@@ -330,7 +330,7 @@ int main(int argc, char *argv[])
    std::string fname = "tgv_out_p_" + std::to_string(ctx.order) + ".txt";
    FILE *f = NULL;
 
-   if (Mpi::Session().Root())
+   if (Mpi::Root())
    {
       int nel1d = std::round(pow(nel, 1.0 / 3.0));
       int ngridpts = p_gf->ParFESpace()->GlobalVSize();
@@ -372,7 +372,7 @@ int main(int argc, char *argv[])
       u_inf = GlobalLpNorm(infinity(), u_inf_loc, MPI_COMM_WORLD);
       p_inf = GlobalLpNorm(infinity(), p_inf_loc, MPI_COMM_WORLD);
       ke = kin_energy.ComputeKineticEnergy(*u_gf);
-      if (Mpi::Session().Root())
+      if (Mpi::Root())
       {
          printf("%.5E %.5E %.5E %.5E %.5E\n", t, dt, u_inf, p_inf, ke);
          fprintf(f, "%20.16e     %20.16e\n", t, ke);
@@ -390,7 +390,7 @@ int main(int argc, char *argv[])
       double ke_expected = 1.25e-1;
       if (fabs(ke - ke_expected) > tol)
       {
-         if (Mpi::Session().Root())
+         if (Mpi::Root())
          {
             mfem::out << "Result has a larger error than expected."
                       << std::endl;

--- a/miniapps/navier/navier_tgv.cpp
+++ b/miniapps/navier/navier_tgv.cpp
@@ -212,7 +212,7 @@ void ComputeQCriterion(ParGridFunction &u, ParGridFunction &q)
 int main(int argc, char *argv[])
 {
    MPI_Session mpi(argc, argv);
-   HYPRE_Session hypre;
+   Hypre::Init();
 
    OptionsParser args(argc, argv);
    args.AddOption(&ctx.element_subdivisions,

--- a/miniapps/navier/navier_tgv.cpp
+++ b/miniapps/navier/navier_tgv.cpp
@@ -211,7 +211,7 @@ void ComputeQCriterion(ParGridFunction &u, ParGridFunction &q)
 
 int main(int argc, char *argv[])
 {
-   MPI::Init(argc, argv);
+   Mpi::Init(argc, argv);
    Hypre::Init();
 
    OptionsParser args(argc, argv);
@@ -253,13 +253,13 @@ int main(int argc, char *argv[])
    args.Parse();
    if (!args.Good())
    {
-      if (MPI::Session().Root())
+      if (Mpi::Session().Root())
       {
          args.PrintUsage(mfem::out);
       }
       return 1;
    }
-   if (MPI::Session().Root())
+   if (Mpi::Session().Root())
    {
       args.PrintOptions(mfem::out);
    }
@@ -274,7 +274,7 @@ int main(int argc, char *argv[])
    *nodes *= M_PI;
 
    int nel = mesh.GetNE();
-   if (MPI::Session().Root())
+   if (Mpi::Session().Root())
    {
       mfem::out << "Number of elements: " << nel << std::endl;
    }
@@ -330,7 +330,7 @@ int main(int argc, char *argv[])
    std::string fname = "tgv_out_p_" + std::to_string(ctx.order) + ".txt";
    FILE *f = NULL;
 
-   if (MPI::Session().Root())
+   if (Mpi::Session().Root())
    {
       int nel1d = std::round(pow(nel, 1.0 / 3.0));
       int ngridpts = p_gf->ParFESpace()->GlobalVSize();
@@ -372,7 +372,7 @@ int main(int argc, char *argv[])
       u_inf = GlobalLpNorm(infinity(), u_inf_loc, MPI_COMM_WORLD);
       p_inf = GlobalLpNorm(infinity(), p_inf_loc, MPI_COMM_WORLD);
       ke = kin_energy.ComputeKineticEnergy(*u_gf);
-      if (MPI::Session().Root())
+      if (Mpi::Session().Root())
       {
          printf("%.5E %.5E %.5E %.5E %.5E\n", t, dt, u_inf, p_inf, ke);
          fprintf(f, "%20.16e     %20.16e\n", t, ke);
@@ -390,7 +390,7 @@ int main(int argc, char *argv[])
       double ke_expected = 1.25e-1;
       if (fabs(ke - ke_expected) > tol)
       {
-         if (MPI::Session().Root())
+         if (Mpi::Session().Root())
          {
             mfem::out << "Result has a larger error than expected."
                       << std::endl;

--- a/miniapps/navier/navier_tgv.cpp
+++ b/miniapps/navier/navier_tgv.cpp
@@ -212,6 +212,7 @@ void ComputeQCriterion(ParGridFunction &u, ParGridFunction &q)
 int main(int argc, char *argv[])
 {
    MPI_Session mpi(argc, argv);
+   HYPRE_Session hypre;
 
    OptionsParser args(argc, argv);
    args.AddOption(&ctx.element_subdivisions,

--- a/miniapps/navier/navier_tgv.cpp
+++ b/miniapps/navier/navier_tgv.cpp
@@ -211,7 +211,7 @@ void ComputeQCriterion(ParGridFunction &u, ParGridFunction &q)
 
 int main(int argc, char *argv[])
 {
-   MPI_Session mpi(argc, argv);
+   MPI::Init(argc, argv);
    Hypre::Init();
 
    OptionsParser args(argc, argv);
@@ -253,13 +253,13 @@ int main(int argc, char *argv[])
    args.Parse();
    if (!args.Good())
    {
-      if (mpi.Root())
+      if (MPI::Session().Root())
       {
          args.PrintUsage(mfem::out);
       }
       return 1;
    }
-   if (mpi.Root())
+   if (MPI::Session().Root())
    {
       args.PrintOptions(mfem::out);
    }
@@ -274,7 +274,7 @@ int main(int argc, char *argv[])
    *nodes *= M_PI;
 
    int nel = mesh.GetNE();
-   if (mpi.Root())
+   if (MPI::Session().Root())
    {
       mfem::out << "Number of elements: " << nel << std::endl;
    }
@@ -330,7 +330,7 @@ int main(int argc, char *argv[])
    std::string fname = "tgv_out_p_" + std::to_string(ctx.order) + ".txt";
    FILE *f = NULL;
 
-   if (mpi.Root())
+   if (MPI::Session().Root())
    {
       int nel1d = std::round(pow(nel, 1.0 / 3.0));
       int ngridpts = p_gf->ParFESpace()->GlobalVSize();
@@ -372,7 +372,7 @@ int main(int argc, char *argv[])
       u_inf = GlobalLpNorm(infinity(), u_inf_loc, MPI_COMM_WORLD);
       p_inf = GlobalLpNorm(infinity(), p_inf_loc, MPI_COMM_WORLD);
       ke = kin_energy.ComputeKineticEnergy(*u_gf);
-      if (mpi.Root())
+      if (MPI::Session().Root())
       {
          printf("%.5E %.5E %.5E %.5E %.5E\n", t, dt, u_inf, p_inf, ke);
          fprintf(f, "%20.16e     %20.16e\n", t, ke);
@@ -390,7 +390,7 @@ int main(int argc, char *argv[])
       double ke_expected = 1.25e-1;
       if (fabs(ke - ke_expected) > tol)
       {
-         if (mpi.Root())
+         if (MPI::Session().Root())
          {
             mfem::out << "Result has a larger error than expected."
                       << std::endl;

--- a/miniapps/nurbs/nurbs_ex11p.cpp
+++ b/miniapps/nurbs/nurbs_ex11p.cpp
@@ -52,7 +52,7 @@ int main(int argc, char *argv[])
    MPI_Init(&argc, &argv);
    MPI_Comm_size(MPI_COMM_WORLD, &num_procs);
    MPI_Comm_rank(MPI_COMM_WORLD, &myid);
-   HYPRE_Session hypre;
+   Hypre::Init();
 
    // 2. Parse command-line options.
    const char *mesh_file = "../../data/star.mesh";

--- a/miniapps/nurbs/nurbs_ex11p.cpp
+++ b/miniapps/nurbs/nurbs_ex11p.cpp
@@ -48,10 +48,9 @@ using namespace mfem;
 int main(int argc, char *argv[])
 {
    // 1. Initialize MPI and HYPRE.
-   int num_procs, myid;
-   MPI_Init(&argc, &argv);
-   MPI_Comm_size(MPI_COMM_WORLD, &num_procs);
-   MPI_Comm_rank(MPI_COMM_WORLD, &myid);
+   Mpi::Init(argc, argv);
+   int num_procs = Mpi::WorldSize();
+   int myid = Mpi::WorldRank();
    Hypre::Init();
 
    // 2. Parse command-line options.
@@ -110,7 +109,6 @@ int main(int argc, char *argv[])
          {
             args.PrintUsage(cout);
          }
-         MPI_Finalize();
          return 1;
       }
    }
@@ -396,8 +394,6 @@ int main(int argc, char *argv[])
       delete fec;
    }
    delete pmesh;
-
-   MPI_Finalize();
 
    return 0;
 }

--- a/miniapps/nurbs/nurbs_ex11p.cpp
+++ b/miniapps/nurbs/nurbs_ex11p.cpp
@@ -47,11 +47,12 @@ using namespace mfem;
 
 int main(int argc, char *argv[])
 {
-   // 1. Initialize MPI.
+   // 1. Initialize MPI and HYPRE.
    int num_procs, myid;
    MPI_Init(&argc, &argv);
    MPI_Comm_size(MPI_COMM_WORLD, &num_procs);
    MPI_Comm_rank(MPI_COMM_WORLD, &myid);
+   HYPRE_Session hypre;
 
    // 2. Parse command-line options.
    const char *mesh_file = "../../data/star.mesh";

--- a/miniapps/nurbs/nurbs_ex1p.cpp
+++ b/miniapps/nurbs/nurbs_ex1p.cpp
@@ -136,10 +136,9 @@ public:
 int main(int argc, char *argv[])
 {
    // 1. Initialize MPI and HYPRE.
-   int num_procs, myid;
-   MPI_Init(&argc, &argv);
-   MPI_Comm_size(MPI_COMM_WORLD, &num_procs);
-   MPI_Comm_rank(MPI_COMM_WORLD, &myid);
+   Mpi::Init(argc, argv);
+   int num_procs = Mpi::WorldSize();
+   int myid = Mpi::WorldRank();
    Hypre::Init();
 
    // 2. Parse command-line options.
@@ -182,7 +181,6 @@ int main(int argc, char *argv[])
       {
          args.PrintUsage(cout);
       }
-      MPI_Finalize();
       return 1;
    }
    if (!strongBC & (kappa < 0))
@@ -434,8 +432,6 @@ int main(int argc, char *argv[])
    delete fespace;
    if (own_fec) { delete fec; }
    delete pmesh;
-
-   MPI_Finalize();
 
    return 0;
 }

--- a/miniapps/nurbs/nurbs_ex1p.cpp
+++ b/miniapps/nurbs/nurbs_ex1p.cpp
@@ -140,7 +140,7 @@ int main(int argc, char *argv[])
    MPI_Init(&argc, &argv);
    MPI_Comm_size(MPI_COMM_WORLD, &num_procs);
    MPI_Comm_rank(MPI_COMM_WORLD, &myid);
-   HYPRE_Session hypre;
+   Hypre::Init();
 
    // 2. Parse command-line options.
    const char *mesh_file = "../../data/star.mesh";

--- a/miniapps/nurbs/nurbs_ex1p.cpp
+++ b/miniapps/nurbs/nurbs_ex1p.cpp
@@ -135,11 +135,12 @@ public:
 
 int main(int argc, char *argv[])
 {
-   // 1. Initialize MPI.
+   // 1. Initialize MPI and HYPRE.
    int num_procs, myid;
    MPI_Init(&argc, &argv);
    MPI_Comm_size(MPI_COMM_WORLD, &num_procs);
    MPI_Comm_rank(MPI_COMM_WORLD, &myid);
+   HYPRE_Session hypre;
 
    // 2. Parse command-line options.
    const char *mesh_file = "../../data/star.mesh";

--- a/miniapps/parelag/MultilevelHcurlHdivSolver.cpp
+++ b/miniapps/parelag/MultilevelHcurlHdivSolver.cpp
@@ -38,7 +38,7 @@ int main(int argc, char *argv[])
    int num_ranks, myid;
    MPI_Comm_size(comm, &num_ranks);
    MPI_Comm_rank(comm, &myid);
-   HYPRE_Session hypre;
+   Hypre::Init();
 
    Timer total_timer = TimeManager::AddTimer("Program Execution -- Total");
    Timer init_timer = TimeManager::AddTimer("Initial Setup");

--- a/miniapps/parelag/MultilevelHcurlHdivSolver.cpp
+++ b/miniapps/parelag/MultilevelHcurlHdivSolver.cpp
@@ -33,11 +33,9 @@ void rhsfunc(const Vector &, Vector &);
 int main(int argc, char *argv[])
 {
    // Initialize MPI and HYPRE.
-   mpi_session session(argc, argv);
-   MPI_Comm comm = MPI_COMM_WORLD;
-   int num_ranks, myid;
-   MPI_Comm_size(comm, &num_ranks);
-   MPI_Comm_rank(comm, &myid);
+   Mpi::Init();
+   int num_ranks = Mpi::WorldSize();
+   int myid = Mpi::WorldRank();
    Hypre::Init();
 
    Timer total_timer = TimeManager::AddTimer("Program Execution -- Total");
@@ -227,7 +225,7 @@ int main(int argc, char *argv[])
                   << "*      Coarse mesh size: " << mesh->GetNE() << "\n*\n";
       }
 
-      pmesh = make_shared<ParMesh>(comm, *mesh);
+      pmesh = make_shared<ParMesh>(MPI_COMM_WORLD, *mesh);
    }
 
    // Mark essential boundary attributes.
@@ -337,7 +335,7 @@ int main(int argc, char *argv[])
    {
       size_t local_num_elmts = pmesh->GetNE(), global_num_elmts;
       MPI_Reduce(&local_num_elmts, &global_num_elmts, 1, GetMPIType<size_t>(0),
-                 MPI_SUM, 0, comm);
+                 MPI_SUM, 0, MPI_COMM_WORLD);
       if (!myid)
       {
          mesh_msg << "*  Parallel refinements: " << par_ref_levels << '\n'
@@ -700,7 +698,7 @@ int main(int argc, char *argv[])
          local_norm *= local_norm;
          double global_norm;
          MPI_Reduce(&local_norm, &global_norm, 1, GetMPIType(local_norm),
-                    MPI_SUM, 0, comm);
+                    MPI_SUM, 0, MPI_COMM_WORLD);
          if (!myid)
          {
             cout << "Initial residual l2 norm: " << sqrt(global_norm) << '\n';
@@ -728,7 +726,7 @@ int main(int argc, char *argv[])
          local_norm *= local_norm;
          double global_norm;
          MPI_Reduce(&local_norm, &global_norm, 1, GetMPIType(local_norm),
-                    MPI_SUM, 0, comm);
+                    MPI_SUM, 0, MPI_COMM_WORLD);
          if (!myid)
          {
             cout << "Final residual l2 norm: " << sqrt(global_norm) << '\n';

--- a/miniapps/parelag/MultilevelHcurlHdivSolver.cpp
+++ b/miniapps/parelag/MultilevelHcurlHdivSolver.cpp
@@ -32,12 +32,13 @@ void rhsfunc(const Vector &, Vector &);
 
 int main(int argc, char *argv[])
 {
-   // Initialize MPI.
+   // Initialize MPI and HYPRE.
    mpi_session session(argc, argv);
    MPI_Comm comm = MPI_COMM_WORLD;
    int num_ranks, myid;
    MPI_Comm_size(comm, &num_ranks);
    MPI_Comm_rank(comm, &myid);
+   HYPRE_Session hypre;
 
    Timer total_timer = TimeManager::AddTimer("Program Execution -- Total");
    Timer init_timer = TimeManager::AddTimer("Initial Setup");

--- a/miniapps/performance/ex1p.cpp
+++ b/miniapps/performance/ex1p.cpp
@@ -89,7 +89,6 @@ int main(int argc, char *argv[])
 {
    // 1. Initialize MPI and HYPRE.
    Mpi::Init(argc, argv);
-   int num_procs = Mpi::WorldSize();
    int myid = Mpi::WorldRank();
    Hypre::Init();
 

--- a/miniapps/performance/ex1p.cpp
+++ b/miniapps/performance/ex1p.cpp
@@ -92,7 +92,7 @@ int main(int argc, char *argv[])
    MPI_Init(&argc, &argv);
    MPI_Comm_size(MPI_COMM_WORLD, &num_procs);
    MPI_Comm_rank(MPI_COMM_WORLD, &myid);
-   HYPRE_Session hypre;
+   Hypre::Init();
 
    // 2. Parse command-line options.
 #ifdef MFEM_HPC_EX1_2D

--- a/miniapps/performance/ex1p.cpp
+++ b/miniapps/performance/ex1p.cpp
@@ -87,11 +87,12 @@ struct ex1_t
 
 int main(int argc, char *argv[])
 {
-   // 1. Initialize MPI.
+   // 1. Initialize MPI and HYPRE.
    int num_procs, myid;
    MPI_Init(&argc, &argv);
    MPI_Comm_size(MPI_COMM_WORLD, &num_procs);
    MPI_Comm_rank(MPI_COMM_WORLD, &myid);
+   HYPRE_Session hypre;
 
    // 2. Parse command-line options.
 #ifdef MFEM_HPC_EX1_2D

--- a/miniapps/performance/ex1p.cpp
+++ b/miniapps/performance/ex1p.cpp
@@ -88,10 +88,9 @@ struct ex1_t
 int main(int argc, char *argv[])
 {
    // 1. Initialize MPI and HYPRE.
-   int num_procs, myid;
-   MPI_Init(&argc, &argv);
-   MPI_Comm_size(MPI_COMM_WORLD, &num_procs);
-   MPI_Comm_rank(MPI_COMM_WORLD, &myid);
+   Mpi::Init(argc, argv);
+   int num_procs = Mpi::WorldSize();
+   int myid = Mpi::WorldRank();
    Hypre::Init();
 
    // 2. Parse command-line options.
@@ -143,7 +142,6 @@ int main(int argc, char *argv[])
       {
          args.PrintUsage(cout);
       }
-      MPI_Finalize();
       return 1;
    }
    if (static_cond && perf && matrix_free)
@@ -153,7 +151,6 @@ int main(int argc, char *argv[])
          cout << "\nStatic condensation can not be used with matrix-free"
               " evaluation!\n" << endl;
       }
-      MPI_Finalize();
       return 2;
    }
    MFEM_VERIFY(perf || !matrix_free,
@@ -237,7 +234,6 @@ int ex1_t<dim>::run(Mesh *mesh, int ser_ref_levels, int par_ref_levels,
                  << "Recompile with suitable 'geom' value." << endl;
          }
          delete mesh;
-         MPI_Finalize();
          return 4;
       }
       else if (!mesh_t::MatchesNodes(*mesh))
@@ -342,7 +338,6 @@ int ex1_t<dim>::run(Mesh *mesh, int ser_ref_levels, int par_ref_levels,
       delete fespace;
       delete fec;
       delete mesh;
-      MPI_Finalize();
       return 5;
    }
 
@@ -571,8 +566,6 @@ int ex1_t<dim>::run(Mesh *mesh, int ser_ref_levels, int par_ref_levels,
    if (order > 0) { delete fec; }
    delete pmesh;
    delete pcg;
-
-   MPI_Finalize();
 
    return 0;
 }

--- a/miniapps/shifted/diffusion.cpp
+++ b/miniapps/shifted/diffusion.cpp
@@ -94,7 +94,7 @@ int main(int argc, char *argv[])
    MPI_Init(&argc, &argv);
    MPI_Comm_size(MPI_COMM_WORLD, &num_procs);
    MPI_Comm_rank(MPI_COMM_WORLD, &myid);
-   HYPRE_Session hypre;
+   Hypre::Init();
 
    // Parse command-line options.
    const char *mesh_file = "../../data/inline-quad.mesh";

--- a/miniapps/shifted/diffusion.cpp
+++ b/miniapps/shifted/diffusion.cpp
@@ -89,11 +89,12 @@ int main(int argc, char *argv[])
    return 242;
 #endif
 
-   // Initialize MPI.
+   // Initialize MPI and HYPRE.
    int num_procs, myid;
    MPI_Init(&argc, &argv);
    MPI_Comm_size(MPI_COMM_WORLD, &num_procs);
    MPI_Comm_rank(MPI_COMM_WORLD, &myid);
+   HYPRE_Session hypre;
 
    // Parse command-line options.
    const char *mesh_file = "../../data/inline-quad.mesh";

--- a/miniapps/shifted/diffusion.cpp
+++ b/miniapps/shifted/diffusion.cpp
@@ -90,10 +90,8 @@ int main(int argc, char *argv[])
 #endif
 
    // Initialize MPI and HYPRE.
-   int num_procs, myid;
-   MPI_Init(&argc, &argv);
-   MPI_Comm_size(MPI_COMM_WORLD, &num_procs);
-   MPI_Comm_rank(MPI_COMM_WORLD, &myid);
+   Mpi::Init(argc, argv);
+   int myid = Mpi::WorldRank();
    Hypre::Init();
 
    // Parse command-line options.
@@ -140,7 +138,6 @@ int main(int argc, char *argv[])
       {
          args.PrintUsage(cout);
       }
-      MPI_Finalize();
       return 1;
    }
    if (myid == 0) { args.PrintOptions(cout); }
@@ -655,8 +652,6 @@ int main(int argc, char *argv[])
    delete neumann_dist_coef;
    delete dirichlet_dist_coef;
    delete dirichlet_dist_coef_2;
-
-   MPI_Finalize();
 
    return 0;
 }

--- a/miniapps/shifted/distance.cpp
+++ b/miniapps/shifted/distance.cpp
@@ -173,10 +173,8 @@ void DGyroid(const mfem::Vector &xx, mfem::Vector &vals)
 int main(int argc, char *argv[])
 {
    // Initialize MPI and HYPRE.
-   int num_procs, myid;
-   MPI_Init(&argc, &argv);
-   MPI_Comm_size(MPI_COMM_WORLD, &num_procs);
-   MPI_Comm_rank(MPI_COMM_WORLD, &myid);
+   Mpi::Init(argc, argv);
+   int myid = Mpi::WorldRank();
    Hypre::Init();
 
    // Parse command-line options.
@@ -222,7 +220,6 @@ int main(int argc, char *argv[])
       {
          args.PrintUsage(cout);
       }
-      MPI_Finalize();
       return 1;
    }
    if (myid == 0) { args.PrintOptions(cout); }
@@ -358,6 +355,5 @@ int main(int argc, char *argv[])
 
    delete dist_solver;
 
-   MPI_Finalize();
    return 0;
 }

--- a/miniapps/shifted/distance.cpp
+++ b/miniapps/shifted/distance.cpp
@@ -177,7 +177,7 @@ int main(int argc, char *argv[])
    MPI_Init(&argc, &argv);
    MPI_Comm_size(MPI_COMM_WORLD, &num_procs);
    MPI_Comm_rank(MPI_COMM_WORLD, &myid);
-   HYPRE_Session hypre;
+   Hypre::Init();
 
    // Parse command-line options.
    const char *mesh_file = "../../data/inline-quad.mesh";

--- a/miniapps/shifted/distance.cpp
+++ b/miniapps/shifted/distance.cpp
@@ -172,11 +172,12 @@ void DGyroid(const mfem::Vector &xx, mfem::Vector &vals)
 
 int main(int argc, char *argv[])
 {
-   // Initialize MPI.
+   // Initialize MPI and HYPRE.
    int num_procs, myid;
    MPI_Init(&argc, &argv);
    MPI_Comm_size(MPI_COMM_WORLD, &num_procs);
    MPI_Comm_rank(MPI_COMM_WORLD, &myid);
+   HYPRE_Session hypre;
 
    // Parse command-line options.
    const char *mesh_file = "../../data/inline-quad.mesh";

--- a/miniapps/shifted/extrapolate.cpp
+++ b/miniapps/shifted/extrapolate.cpp
@@ -109,9 +109,10 @@ void PrintIntegral(int myid, ParGridFunction &g, std::string text)
 
 int main(int argc, char *argv[])
 {
-   // Initialize MPI.
+   // Initialize MPI and HYPRE.
    MPI_Session mpi;
    int myid = mpi.WorldRank();
+   HYPRE_Session hypre;
 
    // Parse command-line options.
    const char *mesh_file = "../../data/inline-quad.mesh";

--- a/miniapps/shifted/extrapolate.cpp
+++ b/miniapps/shifted/extrapolate.cpp
@@ -112,7 +112,7 @@ int main(int argc, char *argv[])
    // Initialize MPI and HYPRE.
    MPI_Session mpi;
    int myid = mpi.WorldRank();
-   HYPRE_Session hypre;
+   Hypre::Init();
 
    // Parse command-line options.
    const char *mesh_file = "../../data/inline-quad.mesh";

--- a/miniapps/shifted/extrapolate.cpp
+++ b/miniapps/shifted/extrapolate.cpp
@@ -110,8 +110,8 @@ void PrintIntegral(int myid, ParGridFunction &g, std::string text)
 int main(int argc, char *argv[])
 {
    // Initialize MPI and HYPRE.
-   MPI::Init();
-   int myid = MPI::Session().WorldRank();;
+   Mpi::Init();
+   int myid = Mpi::Session().WorldRank();;
    Hypre::Init();
 
    // Parse command-line options.

--- a/miniapps/shifted/extrapolate.cpp
+++ b/miniapps/shifted/extrapolate.cpp
@@ -110,8 +110,8 @@ void PrintIntegral(int myid, ParGridFunction &g, std::string text)
 int main(int argc, char *argv[])
 {
    // Initialize MPI and HYPRE.
-   MPI_Session mpi;
-   int myid = mpi.WorldRank();
+   MPI::Init();
+   int myid = MPI::Session().WorldRank();;
    Hypre::Init();
 
    // Parse command-line options.

--- a/miniapps/shifted/extrapolate.cpp
+++ b/miniapps/shifted/extrapolate.cpp
@@ -111,7 +111,7 @@ int main(int argc, char *argv[])
 {
    // Initialize MPI and HYPRE.
    Mpi::Init();
-   int myid = Mpi::Session().WorldRank();;
+   int myid = Mpi::WorldRank();;
    Hypre::Init();
 
    // Parse command-line options.

--- a/miniapps/solvers/block-solvers.cpp
+++ b/miniapps/solvers/block-solvers.cpp
@@ -233,7 +233,7 @@ int main(int argc, char *argv[])
 
    // Initialize MPI and HYPRE.
    MPI_Session mpi(argc, argv);
-   HYPRE_Session hypre;
+   Hypre::Init();
 
    StopWatch chrono;
    auto ResetTimer = [&chrono]() { chrono.Clear(); chrono.Start(); };

--- a/miniapps/solvers/block-solvers.cpp
+++ b/miniapps/solvers/block-solvers.cpp
@@ -267,12 +267,12 @@ int main(int argc, char *argv[])
    args.Parse();
    if (!args.Good())
    {
-      if (Mpi::Session().Root()) { args.PrintUsage(cout); }
+      if (Mpi::Root()) { args.PrintUsage(cout); }
       return 1;
    }
-   if (Mpi::Session().Root()) { args.PrintOptions(cout); }
+   if (Mpi::Root()) { args.PrintOptions(cout); }
 
-   if (Mpi::Session().Root() && par_ref_levels == 0)
+   if (Mpi::Root() && par_ref_levels == 0)
    {
       std::cout << "WARNING: DivFree solver is equivalent to BDPMinresSolver "
                 << "when par_ref_levels == 0.\n";
@@ -282,7 +282,7 @@ int main(int argc, char *argv[])
    Mesh *mesh = new Mesh(mesh_file, 1, 1);
    int dim = mesh->Dimension();
    int ser_ref_lvls =
-      (int)ceil(log(Mpi::Session().WorldSize()/mesh->GetNE())/log(2.)/dim);
+      (int)ceil(log(Mpi::WorldSize()/mesh->GetNE())/log(2.)/dim);
    for (int i = 0; i < ser_ref_lvls; ++i)
    {
       mesh->UniformRefinement();
@@ -297,7 +297,7 @@ int main(int argc, char *argv[])
    }
    if (IsAllNeumannBoundary(ess_bdr))
    {
-      if (Mpi::Session().Root())
+      if (Mpi::Root())
       {
          cout << "\nSolution is not unique when Neumann boundary condition is "
               << "imposed on the entire boundary. \nPlease provide a different "
@@ -318,7 +318,7 @@ int main(int argc, char *argv[])
    const DFSData& DFS_data = darcy.GetDFSData();
    delete mesh;
 
-   if (Mpi::Session().Root())
+   if (Mpi::Root())
    {
       cout << line << "System assembled in " << chrono.RealTime() << "s.\n";
       cout << "Dimension of the physical space: " << dim << "\n";
@@ -362,7 +362,7 @@ int main(int argc, char *argv[])
       solver->Mult(darcy.GetRHS(), sol);
       chrono.Stop();
 
-      if (Mpi::Session().Root())
+      if (Mpi::Root())
       {
          cout << line << name << " solver:\n   Setup time: "
               << setup_time[solver] << "s.\n   Solve time: "
@@ -372,9 +372,9 @@ int main(int argc, char *argv[])
       }
       if (show_error && std::strcmp(coef_file, "") == 0)
       {
-         darcy.ShowError(sol, Mpi::Session().Root());
+         darcy.ShowError(sol, Mpi::Root());
       }
-      else if (show_error && Mpi::Session().Root())
+      else if (show_error && Mpi::Root())
       {
          cout << "Exact solution is unknown for coefficient '" << coef_file
               << "'.\nApproximation error is computed in this case!\n\n";

--- a/miniapps/solvers/block-solvers.cpp
+++ b/miniapps/solvers/block-solvers.cpp
@@ -232,7 +232,7 @@ int main(int argc, char *argv[])
 #endif
 
    // Initialize MPI and HYPRE.
-   MPI::Init(argc, argv);
+   Mpi::Init(argc, argv);
    Hypre::Init();
 
    StopWatch chrono;
@@ -267,12 +267,12 @@ int main(int argc, char *argv[])
    args.Parse();
    if (!args.Good())
    {
-      if (MPI::Session().Root()) { args.PrintUsage(cout); }
+      if (Mpi::Session().Root()) { args.PrintUsage(cout); }
       return 1;
    }
-   if (MPI::Session().Root()) { args.PrintOptions(cout); }
+   if (Mpi::Session().Root()) { args.PrintOptions(cout); }
 
-   if (MPI::Session().Root() && par_ref_levels == 0)
+   if (Mpi::Session().Root() && par_ref_levels == 0)
    {
       std::cout << "WARNING: DivFree solver is equivalent to BDPMinresSolver "
                 << "when par_ref_levels == 0.\n";
@@ -282,7 +282,7 @@ int main(int argc, char *argv[])
    Mesh *mesh = new Mesh(mesh_file, 1, 1);
    int dim = mesh->Dimension();
    int ser_ref_lvls =
-      (int)ceil(log(MPI::Session().WorldSize()/mesh->GetNE())/log(2.)/dim);
+      (int)ceil(log(Mpi::Session().WorldSize()/mesh->GetNE())/log(2.)/dim);
    for (int i = 0; i < ser_ref_lvls; ++i)
    {
       mesh->UniformRefinement();
@@ -297,7 +297,7 @@ int main(int argc, char *argv[])
    }
    if (IsAllNeumannBoundary(ess_bdr))
    {
-      if (MPI::Session().Root())
+      if (Mpi::Session().Root())
       {
          cout << "\nSolution is not unique when Neumann boundary condition is "
               << "imposed on the entire boundary. \nPlease provide a different "
@@ -318,7 +318,7 @@ int main(int argc, char *argv[])
    const DFSData& DFS_data = darcy.GetDFSData();
    delete mesh;
 
-   if (MPI::Session().Root())
+   if (Mpi::Session().Root())
    {
       cout << line << "System assembled in " << chrono.RealTime() << "s.\n";
       cout << "Dimension of the physical space: " << dim << "\n";
@@ -362,7 +362,7 @@ int main(int argc, char *argv[])
       solver->Mult(darcy.GetRHS(), sol);
       chrono.Stop();
 
-      if (MPI::Session().Root())
+      if (Mpi::Session().Root())
       {
          cout << line << name << " solver:\n   Setup time: "
               << setup_time[solver] << "s.\n   Solve time: "
@@ -372,9 +372,9 @@ int main(int argc, char *argv[])
       }
       if (show_error && std::strcmp(coef_file, "") == 0)
       {
-         darcy.ShowError(sol, MPI::Session().Root());
+         darcy.ShowError(sol, Mpi::Session().Root());
       }
-      else if (show_error && MPI::Session().Root())
+      else if (show_error && Mpi::Session().Root())
       {
          cout << "Exact solution is unknown for coefficient '" << coef_file
               << "'.\nApproximation error is computed in this case!\n\n";

--- a/miniapps/solvers/block-solvers.cpp
+++ b/miniapps/solvers/block-solvers.cpp
@@ -232,7 +232,7 @@ int main(int argc, char *argv[])
 #endif
 
    // Initialize MPI and HYPRE.
-   MPI_Session mpi(argc, argv);
+   MPI::Init(argc, argv);
    Hypre::Init();
 
    StopWatch chrono;
@@ -267,12 +267,12 @@ int main(int argc, char *argv[])
    args.Parse();
    if (!args.Good())
    {
-      if (mpi.Root()) { args.PrintUsage(cout); }
+      if (MPI::Session().Root()) { args.PrintUsage(cout); }
       return 1;
    }
-   if (mpi.Root()) { args.PrintOptions(cout); }
+   if (MPI::Session().Root()) { args.PrintOptions(cout); }
 
-   if (mpi.Root() && par_ref_levels == 0)
+   if (MPI::Session().Root() && par_ref_levels == 0)
    {
       std::cout << "WARNING: DivFree solver is equivalent to BDPMinresSolver "
                 << "when par_ref_levels == 0.\n";
@@ -281,7 +281,8 @@ int main(int argc, char *argv[])
    // Initialize the mesh, boundary attributes, and solver parameters
    Mesh *mesh = new Mesh(mesh_file, 1, 1);
    int dim = mesh->Dimension();
-   int ser_ref_lvls = (int)ceil(log(mpi.WorldSize()/mesh->GetNE())/log(2.)/dim);
+   int ser_ref_lvls =
+      (int)ceil(log(MPI::Session().WorldSize()/mesh->GetNE())/log(2.)/dim);
    for (int i = 0; i < ser_ref_lvls; ++i)
    {
       mesh->UniformRefinement();
@@ -296,7 +297,7 @@ int main(int argc, char *argv[])
    }
    if (IsAllNeumannBoundary(ess_bdr))
    {
-      if (mpi.Root())
+      if (MPI::Session().Root())
       {
          cout << "\nSolution is not unique when Neumann boundary condition is "
               << "imposed on the entire boundary. \nPlease provide a different "
@@ -317,7 +318,7 @@ int main(int argc, char *argv[])
    const DFSData& DFS_data = darcy.GetDFSData();
    delete mesh;
 
-   if (mpi.Root())
+   if (MPI::Session().Root())
    {
       cout << line << "System assembled in " << chrono.RealTime() << "s.\n";
       cout << "Dimension of the physical space: " << dim << "\n";
@@ -361,7 +362,7 @@ int main(int argc, char *argv[])
       solver->Mult(darcy.GetRHS(), sol);
       chrono.Stop();
 
-      if (mpi.Root())
+      if (MPI::Session().Root())
       {
          cout << line << name << " solver:\n   Setup time: "
               << setup_time[solver] << "s.\n   Solve time: "
@@ -371,9 +372,9 @@ int main(int argc, char *argv[])
       }
       if (show_error && std::strcmp(coef_file, "") == 0)
       {
-         darcy.ShowError(sol, mpi.Root());
+         darcy.ShowError(sol, MPI::Session().Root());
       }
-      else if (show_error && mpi.Root())
+      else if (show_error && MPI::Session().Root())
       {
          cout << "Exact solution is unknown for coefficient '" << coef_file
               << "'.\nApproximation error is computed in this case!\n\n";

--- a/miniapps/solvers/block-solvers.cpp
+++ b/miniapps/solvers/block-solvers.cpp
@@ -231,8 +231,9 @@ int main(int argc, char *argv[])
    return 242;
 #endif
 
-   // Initialize MPI.
+   // Initialize MPI and HYPRE.
    MPI_Session mpi(argc, argv);
+   HYPRE_Session hypre;
 
    StopWatch chrono;
    auto ResetTimer = [&chrono]() { chrono.Clear(); chrono.Start(); };

--- a/miniapps/solvers/plor_solvers.cpp
+++ b/miniapps/solvers/plor_solvers.cpp
@@ -71,7 +71,7 @@ bool grad_div_problem = false;
 int main(int argc, char *argv[])
 {
    MPI_Session mpi;
-   HYPRE_Session hypre;
+   Hypre::Init();
 
    const char *mesh_file = "../../data/star.mesh";
    int ser_ref_levels = 1, par_ref_levels = 1;

--- a/miniapps/solvers/plor_solvers.cpp
+++ b/miniapps/solvers/plor_solvers.cpp
@@ -71,6 +71,7 @@ bool grad_div_problem = false;
 int main(int argc, char *argv[])
 {
    MPI_Session mpi;
+   HYPRE_Session hypre;
 
    const char *mesh_file = "../../data/star.mesh";
    int ser_ref_levels = 1, par_ref_levels = 1;

--- a/miniapps/solvers/plor_solvers.cpp
+++ b/miniapps/solvers/plor_solvers.cpp
@@ -132,7 +132,7 @@ int main(int argc, char *argv[])
 
    ParFiniteElementSpace fes(&mesh, fec.get());
    HYPRE_Int ndofs = fes.GlobalTrueVSize();
-   if (Mpi::Session().Root()) { cout << "Number of DOFs: " << ndofs << endl; }
+   if (Mpi::Root()) { cout << "Number of DOFs: " << ndofs << endl; }
 
    Array<int> ess_dofs;
    // In DG, boundary conditions are enforced weakly, so no essential DOFs.
@@ -208,7 +208,7 @@ int main(int argc, char *argv[])
 
    double er =
       (H1 || L2) ? x.ComputeL2Error(u_coeff) : x.ComputeL2Error(u_vec_coeff);
-   if (Mpi::Session().Root()) { cout << "L2 error: " << er << endl; }
+   if (Mpi::Root()) { cout << "L2 error: " << er << endl; }
 
    if (visualization)
    {

--- a/miniapps/solvers/plor_solvers.cpp
+++ b/miniapps/solvers/plor_solvers.cpp
@@ -70,7 +70,7 @@ bool grad_div_problem = false;
 
 int main(int argc, char *argv[])
 {
-   MPI::Init();
+   Mpi::Init();
    Hypre::Init();
 
    const char *mesh_file = "../../data/star.mesh";
@@ -132,7 +132,7 @@ int main(int argc, char *argv[])
 
    ParFiniteElementSpace fes(&mesh, fec.get());
    HYPRE_Int ndofs = fes.GlobalTrueVSize();
-   if (MPI::Session().Root()) { cout << "Number of DOFs: " << ndofs << endl; }
+   if (Mpi::Session().Root()) { cout << "Number of DOFs: " << ndofs << endl; }
 
    Array<int> ess_dofs;
    // In DG, boundary conditions are enforced weakly, so no essential DOFs.
@@ -208,7 +208,7 @@ int main(int argc, char *argv[])
 
    double er =
       (H1 || L2) ? x.ComputeL2Error(u_coeff) : x.ComputeL2Error(u_vec_coeff);
-   if (MPI::Session().Root()) { cout << "L2 error: " << er << endl; }
+   if (Mpi::Session().Root()) { cout << "L2 error: " << er << endl; }
 
    if (visualization)
    {

--- a/miniapps/solvers/plor_solvers.cpp
+++ b/miniapps/solvers/plor_solvers.cpp
@@ -70,7 +70,7 @@ bool grad_div_problem = false;
 
 int main(int argc, char *argv[])
 {
-   MPI_Session mpi;
+   MPI::Init();
    Hypre::Init();
 
    const char *mesh_file = "../../data/star.mesh";
@@ -132,7 +132,7 @@ int main(int argc, char *argv[])
 
    ParFiniteElementSpace fes(&mesh, fec.get());
    HYPRE_Int ndofs = fes.GlobalTrueVSize();
-   if (mpi.Root()) { cout << "Number of DOFs: " << ndofs << endl; }
+   if (MPI::Session().Root()) { cout << "Number of DOFs: " << ndofs << endl; }
 
    Array<int> ess_dofs;
    // In DG, boundary conditions are enforced weakly, so no essential DOFs.
@@ -208,7 +208,7 @@ int main(int argc, char *argv[])
 
    double er =
       (H1 || L2) ? x.ComputeL2Error(u_coeff) : x.ComputeL2Error(u_vec_coeff);
-   if (mpi.Root()) { cout << "L2 error: " << er << endl; }
+   if (MPI::Session().Root()) { cout << "L2 error: " << er << endl; }
 
    if (visualization)
    {

--- a/miniapps/tools/convert-dc.cpp
+++ b/miniapps/tools/convert-dc.cpp
@@ -108,7 +108,7 @@ int main(int argc, char *argv[])
 {
 #ifdef MFEM_USE_MPI
    Mpi::Init();
-   if (!Mpi::Session().Root()) { mfem::out.Disable(); mfem::err.Disable(); }
+   if (!Mpi::Root()) { mfem::out.Disable(); mfem::err.Disable(); }
    Hypre::Init();
 #endif
 

--- a/miniapps/tools/convert-dc.cpp
+++ b/miniapps/tools/convert-dc.cpp
@@ -107,8 +107,8 @@ DataCollection *create_data_collection(const std::string &dc_name,
 int main(int argc, char *argv[])
 {
 #ifdef MFEM_USE_MPI
-   MPI::Init();
-   if (!MPI::Session().Root()) { mfem::out.Disable(); mfem::err.Disable(); }
+   Mpi::Init();
+   if (!Mpi::Session().Root()) { mfem::out.Disable(); mfem::err.Disable(); }
    Hypre::Init();
 #endif
 

--- a/miniapps/tools/convert-dc.cpp
+++ b/miniapps/tools/convert-dc.cpp
@@ -109,7 +109,7 @@ int main(int argc, char *argv[])
 #ifdef MFEM_USE_MPI
    MPI_Session mpi;
    if (!mpi.Root()) { mfem::out.Disable(); mfem::err.Disable(); }
-   HYPRE_Session hypre;
+   Hypre::Init();
 #endif
 
    // Parse command-line options.

--- a/miniapps/tools/convert-dc.cpp
+++ b/miniapps/tools/convert-dc.cpp
@@ -109,6 +109,7 @@ int main(int argc, char *argv[])
 #ifdef MFEM_USE_MPI
    MPI_Session mpi;
    if (!mpi.Root()) { mfem::out.Disable(); mfem::err.Disable(); }
+   HYPRE_Session hypre;
 #endif
 
    // Parse command-line options.

--- a/miniapps/tools/convert-dc.cpp
+++ b/miniapps/tools/convert-dc.cpp
@@ -107,8 +107,8 @@ DataCollection *create_data_collection(const std::string &dc_name,
 int main(int argc, char *argv[])
 {
 #ifdef MFEM_USE_MPI
-   MPI_Session mpi;
-   if (!mpi.Root()) { mfem::out.Disable(); mfem::err.Disable(); }
+   MPI::Init();
+   if (!MPI::Session().Root()) { mfem::out.Disable(); mfem::err.Disable(); }
    Hypre::Init();
 #endif
 

--- a/miniapps/tools/get-values.cpp
+++ b/miniapps/tools/get-values.cpp
@@ -68,6 +68,7 @@ int main(int argc, char *argv[])
 #ifdef MFEM_USE_MPI
    MPI_Session mpi;
    if (!mpi.Root()) { mfem::out.Disable(); mfem::err.Disable(); }
+   HYPRE_Session hypre;
 #endif
 
    // Parse command-line options.

--- a/miniapps/tools/get-values.cpp
+++ b/miniapps/tools/get-values.cpp
@@ -66,8 +66,8 @@ void writeLegend(const DataCollection::FieldMapType &fields,
 int main(int argc, char *argv[])
 {
 #ifdef MFEM_USE_MPI
-   MPI::Init();
-   if (!MPI::Session().Root()) { mfem::out.Disable(); mfem::err.Disable(); }
+   Mpi::Init();
+   if (!Mpi::Session().Root()) { mfem::out.Disable(); mfem::err.Disable(); }
    Hypre::Init();
 #endif
 
@@ -160,7 +160,7 @@ int main(int argc, char *argv[])
    ofstream ofs;
    if (strcmp(out_file_c_str,"") != 0
 #ifdef MFEM_USE_MPI
-       && MPI::Session().Root()
+       && Mpi::Session().Root()
 #endif
       )
    {

--- a/miniapps/tools/get-values.cpp
+++ b/miniapps/tools/get-values.cpp
@@ -67,7 +67,7 @@ int main(int argc, char *argv[])
 {
 #ifdef MFEM_USE_MPI
    Mpi::Init();
-   if (!Mpi::Session().Root()) { mfem::out.Disable(); mfem::err.Disable(); }
+   if (!Mpi::Root()) { mfem::out.Disable(); mfem::err.Disable(); }
    Hypre::Init();
 #endif
 
@@ -160,7 +160,7 @@ int main(int argc, char *argv[])
    ofstream ofs;
    if (strcmp(out_file_c_str,"") != 0
 #ifdef MFEM_USE_MPI
-       && Mpi::Session().Root()
+       && Mpi::Root()
 #endif
       )
    {

--- a/miniapps/tools/get-values.cpp
+++ b/miniapps/tools/get-values.cpp
@@ -68,7 +68,7 @@ int main(int argc, char *argv[])
 #ifdef MFEM_USE_MPI
    MPI_Session mpi;
    if (!mpi.Root()) { mfem::out.Disable(); mfem::err.Disable(); }
-   HYPRE_Session hypre;
+   Hypre::Init();
 #endif
 
    // Parse command-line options.

--- a/miniapps/tools/get-values.cpp
+++ b/miniapps/tools/get-values.cpp
@@ -66,8 +66,8 @@ void writeLegend(const DataCollection::FieldMapType &fields,
 int main(int argc, char *argv[])
 {
 #ifdef MFEM_USE_MPI
-   MPI_Session mpi;
-   if (!mpi.Root()) { mfem::out.Disable(); mfem::err.Disable(); }
+   MPI::Init();
+   if (!MPI::Session().Root()) { mfem::out.Disable(); mfem::err.Disable(); }
    Hypre::Init();
 #endif
 
@@ -160,7 +160,7 @@ int main(int argc, char *argv[])
    ofstream ofs;
    if (strcmp(out_file_c_str,"") != 0
 #ifdef MFEM_USE_MPI
-       && mpi.Root()
+       && MPI::Session().Root()
 #endif
       )
    {

--- a/miniapps/tools/load-dc.cpp
+++ b/miniapps/tools/load-dc.cpp
@@ -33,8 +33,8 @@ using namespace mfem;
 int main(int argc, char *argv[])
 {
 #ifdef MFEM_USE_MPI
-   MPI_Session mpi;
-   if (!mpi.Root()) { mfem::out.Disable(); mfem::err.Disable(); }
+   MPI::Init();
+   if (!MPI::Session().Root()) { mfem::out.Disable(); mfem::err.Disable(); }
    Hypre::Init();
 #endif
 
@@ -106,8 +106,8 @@ int main(int argc, char *argv[])
          return 1;
       }
 #ifdef MFEM_USE_MPI
-      sol_sock << "parallel " << mpi.WorldSize() << " " << mpi.WorldRank()
-               << "\n";
+      sol_sock << "parallel " << MPI::Session().WorldSize() << " "
+               << MPI::Session().WorldRank() << "\n";
 #endif
       if (fields.begin() == fields.end())
       {

--- a/miniapps/tools/load-dc.cpp
+++ b/miniapps/tools/load-dc.cpp
@@ -35,7 +35,7 @@ int main(int argc, char *argv[])
 #ifdef MFEM_USE_MPI
    MPI_Session mpi;
    if (!mpi.Root()) { mfem::out.Disable(); mfem::err.Disable(); }
-   HYPRE_Session hypre;
+   Hypre::Init();
 #endif
 
    // Parse command-line options.

--- a/miniapps/tools/load-dc.cpp
+++ b/miniapps/tools/load-dc.cpp
@@ -33,8 +33,8 @@ using namespace mfem;
 int main(int argc, char *argv[])
 {
 #ifdef MFEM_USE_MPI
-   MPI::Init();
-   if (!MPI::Session().Root()) { mfem::out.Disable(); mfem::err.Disable(); }
+   Mpi::Init();
+   if (!Mpi::Session().Root()) { mfem::out.Disable(); mfem::err.Disable(); }
    Hypre::Init();
 #endif
 
@@ -106,8 +106,8 @@ int main(int argc, char *argv[])
          return 1;
       }
 #ifdef MFEM_USE_MPI
-      sol_sock << "parallel " << MPI::Session().WorldSize() << " "
-               << MPI::Session().WorldRank() << "\n";
+      sol_sock << "parallel " << Mpi::Session().WorldSize() << " "
+               << Mpi::Session().WorldRank() << "\n";
 #endif
       if (fields.begin() == fields.end())
       {

--- a/miniapps/tools/load-dc.cpp
+++ b/miniapps/tools/load-dc.cpp
@@ -35,6 +35,7 @@ int main(int argc, char *argv[])
 #ifdef MFEM_USE_MPI
    MPI_Session mpi;
    if (!mpi.Root()) { mfem::out.Disable(); mfem::err.Disable(); }
+   HYPRE_Session hypre;
 #endif
 
    // Parse command-line options.

--- a/miniapps/tools/load-dc.cpp
+++ b/miniapps/tools/load-dc.cpp
@@ -34,7 +34,7 @@ int main(int argc, char *argv[])
 {
 #ifdef MFEM_USE_MPI
    Mpi::Init();
-   if (!Mpi::Session().Root()) { mfem::out.Disable(); mfem::err.Disable(); }
+   if (!Mpi::Root()) { mfem::out.Disable(); mfem::err.Disable(); }
    Hypre::Init();
 #endif
 
@@ -106,8 +106,8 @@ int main(int argc, char *argv[])
          return 1;
       }
 #ifdef MFEM_USE_MPI
-      sol_sock << "parallel " << Mpi::Session().WorldSize() << " "
-               << Mpi::Session().WorldRank() << "\n";
+      sol_sock << "parallel " << Mpi::WorldSize() << " "
+               << Mpi::WorldRank() << "\n";
 #endif
       if (fields.begin() == fields.end())
       {

--- a/tests/convergence/prates.cpp
+++ b/tests/convergence/prates.cpp
@@ -69,11 +69,12 @@ int prob=0;
 
 int main(int argc, char *argv[])
 {
-   // 1. Initialize MPI.
+   // 1. Initialize MPI and HYPRE.
    int num_procs, myid;
    MPI_Init(&argc, &argv);
    MPI_Comm_size(MPI_COMM_WORLD, &num_procs);
    MPI_Comm_rank(MPI_COMM_WORLD, &myid);
+   HYPRE_Session hypre;
 
    // 2. Parse command-line options.
    const char *mesh_file = "../../data/inline-quad.mesh";

--- a/tests/convergence/prates.cpp
+++ b/tests/convergence/prates.cpp
@@ -74,7 +74,7 @@ int main(int argc, char *argv[])
    MPI_Init(&argc, &argv);
    MPI_Comm_size(MPI_COMM_WORLD, &num_procs);
    MPI_Comm_rank(MPI_COMM_WORLD, &myid);
-   HYPRE_Session hypre;
+   Hypre::Init();
 
    // 2. Parse command-line options.
    const char *mesh_file = "../../data/inline-quad.mesh";

--- a/tests/convergence/prates.cpp
+++ b/tests/convergence/prates.cpp
@@ -70,10 +70,9 @@ int prob=0;
 int main(int argc, char *argv[])
 {
    // 1. Initialize MPI and HYPRE.
-   int num_procs, myid;
-   MPI_Init(&argc, &argv);
-   MPI_Comm_size(MPI_COMM_WORLD, &num_procs);
-   MPI_Comm_rank(MPI_COMM_WORLD, &myid);
+   Mpi::Init(argc, argv);
+   int num_procs = Mpi::WorldSize();
+   int myid = Mpi::WorldRank();
    Hypre::Init();
 
    // 2. Parse command-line options.
@@ -115,7 +114,6 @@ int main(int argc, char *argv[])
       {
          args.PrintUsage(cout);
       }
-      MPI_Finalize();
       return 1;
    }
    if (prob >3 || prob <0) { prob = 0; } // default problem = H1
@@ -338,8 +336,6 @@ int main(int argc, char *argv[])
    delete fespace;
    delete fec;
    delete pmesh;
-
-   MPI_Finalize();
 
    return 0;
 }

--- a/tests/mem_manager/dangling-aliases.cpp
+++ b/tests/mem_manager/dangling-aliases.cpp
@@ -17,7 +17,7 @@ using namespace mfem;
 int main(int argc, char *argv[])
 {
    MPI_Session mpi;
-   HYPRE_Session hypre;
+   Hypre::Init();
 
    const char *device_config = "cpu";
 

--- a/tests/mem_manager/dangling-aliases.cpp
+++ b/tests/mem_manager/dangling-aliases.cpp
@@ -16,7 +16,7 @@ using namespace mfem;
 
 int main(int argc, char *argv[])
 {
-   MPI::Init();
+   Mpi::Init();
    Hypre::Init();
 
    const char *device_config = "cpu";
@@ -27,13 +27,13 @@ int main(int argc, char *argv[])
    args.Parse();
    if (!args.Good())
    {
-      if (MPI::Session().Root()) { args.PrintUsage(cout); }
+      if (Mpi::Session().Root()) { args.PrintUsage(cout); }
       return 1;
    }
-   if (MPI::Session().Root()) { args.PrintOptions(cout); }
+   if (Mpi::Session().Root()) { args.PrintOptions(cout); }
 
    Device device(device_config);
-   if (MPI::Session().Root()) { device.Print(); }
+   if (Mpi::Session().Root()) { device.Print(); }
 
    //-----------------------------------------------------------
    int width = 1000;
@@ -43,7 +43,7 @@ int main(int argc, char *argv[])
       Vector v(width);
       v.UseDevice(true);
       v = 0.0;
-      cout << MPI::Session().WorldRank() << ": v.HostRead() = "
+      cout << Mpi::Session().WorldRank() << ": v.HostRead() = "
            << v.HostRead() << endl;
 
       v_r.MakeRef(v, 0, width/2);
@@ -52,12 +52,12 @@ int main(int argc, char *argv[])
    Vector w(width);
    w.UseDevice(true);
    w = 0.0;
-   cout << MPI::Session().WorldRank() << ": w.HostRead() = "
+   cout << Mpi::Session().WorldRank() << ": w.HostRead() = "
         << w.HostRead() << endl;
    Vector w_r, w_i;
 
    MPI_Barrier(MPI_COMM_WORLD);
-   cout << MPI::Session().WorldRank() << ": == # START # ==" << endl;
+   cout << Mpi::Session().WorldRank() << ": == # START # ==" << endl;
    MPI_Barrier(MPI_COMM_WORLD);
    w_r.MakeRef(w, 0, width/2);        // fails
    w_i.MakeRef(w, width/2, width/2);  // fails
@@ -68,7 +68,7 @@ int main(int argc, char *argv[])
    //    ... in file: general/mem_manager.cpp:1377
    // 2) alias already exists with different base/offset!
    MPI_Barrier(MPI_COMM_WORLD);
-   cout << MPI::Session().WorldRank() << ": == # END # ==" << endl;
+   cout << Mpi::Session().WorldRank() << ": == # END # ==" << endl;
 
    return 0;
 }

--- a/tests/mem_manager/dangling-aliases.cpp
+++ b/tests/mem_manager/dangling-aliases.cpp
@@ -27,13 +27,13 @@ int main(int argc, char *argv[])
    args.Parse();
    if (!args.Good())
    {
-      if (Mpi::Session().Root()) { args.PrintUsage(cout); }
+      if (Mpi::Root()) { args.PrintUsage(cout); }
       return 1;
    }
-   if (Mpi::Session().Root()) { args.PrintOptions(cout); }
+   if (Mpi::Root()) { args.PrintOptions(cout); }
 
    Device device(device_config);
-   if (Mpi::Session().Root()) { device.Print(); }
+   if (Mpi::Root()) { device.Print(); }
 
    //-----------------------------------------------------------
    int width = 1000;
@@ -43,7 +43,7 @@ int main(int argc, char *argv[])
       Vector v(width);
       v.UseDevice(true);
       v = 0.0;
-      cout << Mpi::Session().WorldRank() << ": v.HostRead() = "
+      cout << Mpi::WorldRank() << ": v.HostRead() = "
            << v.HostRead() << endl;
 
       v_r.MakeRef(v, 0, width/2);
@@ -52,12 +52,12 @@ int main(int argc, char *argv[])
    Vector w(width);
    w.UseDevice(true);
    w = 0.0;
-   cout << Mpi::Session().WorldRank() << ": w.HostRead() = "
+   cout << Mpi::WorldRank() << ": w.HostRead() = "
         << w.HostRead() << endl;
    Vector w_r, w_i;
 
    MPI_Barrier(MPI_COMM_WORLD);
-   cout << Mpi::Session().WorldRank() << ": == # START # ==" << endl;
+   cout << Mpi::WorldRank() << ": == # START # ==" << endl;
    MPI_Barrier(MPI_COMM_WORLD);
    w_r.MakeRef(w, 0, width/2);        // fails
    w_i.MakeRef(w, width/2, width/2);  // fails
@@ -68,7 +68,7 @@ int main(int argc, char *argv[])
    //    ... in file: general/mem_manager.cpp:1377
    // 2) alias already exists with different base/offset!
    MPI_Barrier(MPI_COMM_WORLD);
-   cout << Mpi::Session().WorldRank() << ": == # END # ==" << endl;
+   cout << Mpi::WorldRank() << ": == # END # ==" << endl;
 
    return 0;
 }

--- a/tests/mem_manager/dangling-aliases.cpp
+++ b/tests/mem_manager/dangling-aliases.cpp
@@ -17,6 +17,7 @@ using namespace mfem;
 int main(int argc, char *argv[])
 {
    MPI_Session mpi;
+   HYPRE_Session hypre;
 
    const char *device_config = "cpu";
 

--- a/tests/mem_manager/dangling-aliases.cpp
+++ b/tests/mem_manager/dangling-aliases.cpp
@@ -16,7 +16,7 @@ using namespace mfem;
 
 int main(int argc, char *argv[])
 {
-   MPI_Session mpi;
+   MPI::Init();
    Hypre::Init();
 
    const char *device_config = "cpu";
@@ -27,13 +27,13 @@ int main(int argc, char *argv[])
    args.Parse();
    if (!args.Good())
    {
-      if (mpi.Root()) { args.PrintUsage(cout); }
+      if (MPI::Session().Root()) { args.PrintUsage(cout); }
       return 1;
    }
-   if (mpi.Root()) { args.PrintOptions(cout); }
+   if (MPI::Session().Root()) { args.PrintOptions(cout); }
 
    Device device(device_config);
-   if (mpi.Root()) { device.Print(); }
+   if (MPI::Session().Root()) { device.Print(); }
 
    //-----------------------------------------------------------
    int width = 1000;
@@ -43,7 +43,8 @@ int main(int argc, char *argv[])
       Vector v(width);
       v.UseDevice(true);
       v = 0.0;
-      cout << mpi.WorldRank() << ": v.HostRead() = " << v.HostRead() << endl;
+      cout << MPI::Session().WorldRank() << ": v.HostRead() = "
+           << v.HostRead() << endl;
 
       v_r.MakeRef(v, 0, width/2);
       v_i.MakeRef(v, width/2, width/2);
@@ -51,11 +52,12 @@ int main(int argc, char *argv[])
    Vector w(width);
    w.UseDevice(true);
    w = 0.0;
-   cout << mpi.WorldRank() << ": w.HostRead() = " << w.HostRead() << endl;
+   cout << MPI::Session().WorldRank() << ": w.HostRead() = "
+        << w.HostRead() << endl;
    Vector w_r, w_i;
 
    MPI_Barrier(MPI_COMM_WORLD);
-   cout << mpi.WorldRank() << ": == # START # ==" << endl;
+   cout << MPI::Session().WorldRank() << ": == # START # ==" << endl;
    MPI_Barrier(MPI_COMM_WORLD);
    w_r.MakeRef(w, 0, width/2);        // fails
    w_i.MakeRef(w, width/2, width/2);  // fails
@@ -66,7 +68,7 @@ int main(int argc, char *argv[])
    //    ... in file: general/mem_manager.cpp:1377
    // 2) alias already exists with different base/offset!
    MPI_Barrier(MPI_COMM_WORLD);
-   cout << mpi.WorldRank() << ": == # END # ==" << endl;
+   cout << MPI::Session().WorldRank() << ": == # END # ==" << endl;
 
    return 0;
 }

--- a/tests/par-mesh-format/ex1p.cpp
+++ b/tests/par-mesh-format/ex1p.cpp
@@ -38,11 +38,12 @@ using namespace mfem;
 
 int main(int argc, char *argv[])
 {
-   // 1. Initialize MPI.
+   // 1. Initialize MPI and HYPRE.
    int num_procs, myid;
    MPI_Init(&argc, &argv);
    MPI_Comm_size(MPI_COMM_WORLD, &num_procs);
    MPI_Comm_rank(MPI_COMM_WORLD, &myid);
+   HYPRE_Session hypre;
 
    // 2. Parse command-line options.
    const char *not_set = "(not set)";

--- a/tests/par-mesh-format/ex1p.cpp
+++ b/tests/par-mesh-format/ex1p.cpp
@@ -39,10 +39,9 @@ using namespace mfem;
 int main(int argc, char *argv[])
 {
    // 1. Initialize MPI and HYPRE.
-   int num_procs, myid;
-   MPI_Init(&argc, &argv);
-   MPI_Comm_size(MPI_COMM_WORLD, &num_procs);
-   MPI_Comm_rank(MPI_COMM_WORLD, &myid);
+   Mpi::Init(argc, argv);
+   int num_procs = Mpi::WorldSize();
+   int myid = Mpi::WorldRank();
    Hypre::Init();
 
    // 2. Parse command-line options.
@@ -79,7 +78,6 @@ int main(int argc, char *argv[])
       {
          args.PrintUsage(cout);
       }
-      MPI_Finalize();
       return 1;
    }
    if (myid == 0)
@@ -263,8 +261,6 @@ int main(int argc, char *argv[])
    delete fespace;
    if (order > 0) { delete fec; }
    if (serial_mode) { delete pmesh; }
-
-   MPI_Finalize();
 
    return 0;
 }

--- a/tests/par-mesh-format/ex1p.cpp
+++ b/tests/par-mesh-format/ex1p.cpp
@@ -43,7 +43,7 @@ int main(int argc, char *argv[])
    MPI_Init(&argc, &argv);
    MPI_Comm_size(MPI_COMM_WORLD, &num_procs);
    MPI_Comm_rank(MPI_COMM_WORLD, &myid);
-   HYPRE_Session hypre;
+   Hypre::Init();
 
    // 2. Parse command-line options.
    const char *not_set = "(not set)";

--- a/tests/unit/miniapps/test_sedov.cpp
+++ b/tests/unit/miniapps/test_sedov.cpp
@@ -27,12 +27,10 @@
 #endif
 
 #if defined(MFEM_USE_MPI) && defined(MFEM_SEDOV_MPI)
-extern mfem::MPI *GlobalMPISession;
 #define PFesGetParMeshGetComm(pfes) pfes.GetParMesh()->GetComm()
 #define PFesGetParMeshGetComm0(pfes) pfes.GetParMesh()->GetComm()
 #else
 #define HYPRE_BigInt int
-typedef int MPI;
 #define ParMesh Mesh
 #define GetParMesh GetMesh
 #define GlobalTrueVSize GetVSize
@@ -2185,7 +2183,7 @@ static void sedov_tests(int myid)
 #ifndef MFEM_SEDOV_DEVICE
 TEST_CASE("Sedov", "[Sedov], [Parallel]")
 {
-   sedov_tests(GlobalMPISession->WorldRank());
+   sedov_tests(MPI::Session().)WorldRank());
 }
 #else
 TEST_CASE("Sedov", "[Sedov], [Parallel]")
@@ -2202,7 +2200,7 @@ TEST_CASE("Sedov", "[Sedov], [Parallel]")
    Device device;
    device.Configure(MFEM_SEDOV_DEVICE);
    device.Print();
-   sedov_tests(GlobalMPISession->WorldRank());
+   sedov_tests(MPI::Session().WorldRank());
 }
 #endif
 #else

--- a/tests/unit/miniapps/test_sedov.cpp
+++ b/tests/unit/miniapps/test_sedov.cpp
@@ -39,7 +39,6 @@
 #define ParFiniteElementSpace FiniteElementSpace
 #define PFesGetParMeshGetComm(...)
 #define PFesGetParMeshGetComm0(...) 0
-#define MPI_Finalize()
 #define MPI_Allreduce(src,dst,...) *dst = *src
 #define MPI_Reduce(src, dst, n, T,...) *dst = *src
 #endif

--- a/tests/unit/miniapps/test_sedov.cpp
+++ b/tests/unit/miniapps/test_sedov.cpp
@@ -2183,7 +2183,7 @@ static void sedov_tests(int myid)
 #ifndef MFEM_SEDOV_DEVICE
 TEST_CASE("Sedov", "[Sedov], [Parallel]")
 {
-   sedov_tests(MPI::Session().)WorldRank());
+   sedov_tests(MPI::Session().WorldRank());
 }
 #else
 TEST_CASE("Sedov", "[Sedov], [Parallel]")

--- a/tests/unit/miniapps/test_sedov.cpp
+++ b/tests/unit/miniapps/test_sedov.cpp
@@ -2183,7 +2183,7 @@ static void sedov_tests(int myid)
 #ifndef MFEM_SEDOV_DEVICE
 TEST_CASE("Sedov", "[Sedov], [Parallel]")
 {
-   sedov_tests(Mpi::Session().WorldRank());
+   sedov_tests(Mpi::WorldRank());
 }
 #else
 TEST_CASE("Sedov", "[Sedov], [Parallel]")
@@ -2200,7 +2200,7 @@ TEST_CASE("Sedov", "[Sedov], [Parallel]")
    Device device;
    device.Configure(MFEM_SEDOV_DEVICE);
    device.Print();
-   sedov_tests(Mpi::Session().WorldRank());
+   sedov_tests(Mpi::WorldRank());
 }
 #endif
 #else

--- a/tests/unit/miniapps/test_sedov.cpp
+++ b/tests/unit/miniapps/test_sedov.cpp
@@ -27,12 +27,12 @@
 #endif
 
 #if defined(MFEM_USE_MPI) && defined(MFEM_SEDOV_MPI)
-extern mfem::MPI_Session *GlobalMPISession;
+extern mfem::MPI *GlobalMPISession;
 #define PFesGetParMeshGetComm(pfes) pfes.GetParMesh()->GetComm()
 #define PFesGetParMeshGetComm0(pfes) pfes.GetParMesh()->GetComm()
 #else
 #define HYPRE_BigInt int
-typedef int MPI_Session;
+typedef int MPI;
 #define ParMesh Mesh
 #define GetParMesh GetMesh
 #define GlobalTrueVSize GetVSize

--- a/tests/unit/miniapps/test_sedov.cpp
+++ b/tests/unit/miniapps/test_sedov.cpp
@@ -2183,7 +2183,7 @@ static void sedov_tests(int myid)
 #ifndef MFEM_SEDOV_DEVICE
 TEST_CASE("Sedov", "[Sedov], [Parallel]")
 {
-   sedov_tests(MPI::Session().WorldRank());
+   sedov_tests(Mpi::Session().WorldRank());
 }
 #else
 TEST_CASE("Sedov", "[Sedov], [Parallel]")
@@ -2200,7 +2200,7 @@ TEST_CASE("Sedov", "[Sedov], [Parallel]")
    Device device;
    device.Configure(MFEM_SEDOV_DEVICE);
    device.Print();
-   sedov_tests(MPI::Session().WorldRank());
+   sedov_tests(Mpi::Session().WorldRank());
 }
 #endif
 #else

--- a/tests/unit/miniapps/test_tmop_pa.cpp
+++ b/tests/unit/miniapps/test_tmop_pa.cpp
@@ -27,13 +27,11 @@
 #endif
 
 #if defined(MFEM_USE_MPI) && defined(MFEM_TMOP_MPI)
-extern mfem::MPI *GlobalMPISession;
 #define PFesGetParMeshGetComm(pfes) pfes.GetComm()
 #define SetDiscreteTargetSize SetParDiscreteTargetSize
 #define SetDiscreteTargetAspectRatio SetParDiscreteTargetAspectRatio
 #define GradientClass HypreParMatrix
 #else
-typedef int MPI;
 #define ParMesh Mesh
 #define ParGridFunction GridFunction
 #define ParNonlinearForm NonlinearForm
@@ -862,7 +860,7 @@ static void tmop_tests(int id = 0, bool all = false)
 #ifndef MFEM_TMOP_DEVICE
 TEST_CASE("tmop_pa", "[TMOP_PA], [Parallel]")
 {
-   tmop_tests(GlobalMPISession->WorldRank(), launch_all_non_regression_tests);
+   tmop_tests(MPI::Session().WorldRank(), launch_all_non_regression_tests);
 }
 #else
 TEST_CASE("tmop_pa", "[TMOP_PA], [Parallel]")
@@ -870,7 +868,7 @@ TEST_CASE("tmop_pa", "[TMOP_PA], [Parallel]")
    Device device;
    device.Configure(MFEM_TMOP_DEVICE);
    device.Print();
-   tmop_tests(GlobalMPISession->WorldRank(), launch_all_non_regression_tests);
+   tmop_tests(MPI::Session().WorldRank(), launch_all_non_regression_tests);
 }
 #endif
 #else

--- a/tests/unit/miniapps/test_tmop_pa.cpp
+++ b/tests/unit/miniapps/test_tmop_pa.cpp
@@ -27,13 +27,13 @@
 #endif
 
 #if defined(MFEM_USE_MPI) && defined(MFEM_TMOP_MPI)
-extern mfem::MPI_Session *GlobalMPISession;
+extern mfem::MPI *GlobalMPISession;
 #define PFesGetParMeshGetComm(pfes) pfes.GetComm()
 #define SetDiscreteTargetSize SetParDiscreteTargetSize
 #define SetDiscreteTargetAspectRatio SetParDiscreteTargetAspectRatio
 #define GradientClass HypreParMatrix
 #else
-typedef int MPI_Session;
+typedef int MPI;
 #define ParMesh Mesh
 #define ParGridFunction GridFunction
 #define ParNonlinearForm NonlinearForm

--- a/tests/unit/miniapps/test_tmop_pa.cpp
+++ b/tests/unit/miniapps/test_tmop_pa.cpp
@@ -860,7 +860,7 @@ static void tmop_tests(int id = 0, bool all = false)
 #ifndef MFEM_TMOP_DEVICE
 TEST_CASE("tmop_pa", "[TMOP_PA], [Parallel]")
 {
-   tmop_tests(MPI::Session().WorldRank(), launch_all_non_regression_tests);
+   tmop_tests(Mpi::Session().WorldRank(), launch_all_non_regression_tests);
 }
 #else
 TEST_CASE("tmop_pa", "[TMOP_PA], [Parallel]")
@@ -868,7 +868,7 @@ TEST_CASE("tmop_pa", "[TMOP_PA], [Parallel]")
    Device device;
    device.Configure(MFEM_TMOP_DEVICE);
    device.Print();
-   tmop_tests(MPI::Session().WorldRank(), launch_all_non_regression_tests);
+   tmop_tests(Mpi::Session().WorldRank(), launch_all_non_regression_tests);
 }
 #endif
 #else

--- a/tests/unit/miniapps/test_tmop_pa.cpp
+++ b/tests/unit/miniapps/test_tmop_pa.cpp
@@ -860,7 +860,7 @@ static void tmop_tests(int id = 0, bool all = false)
 #ifndef MFEM_TMOP_DEVICE
 TEST_CASE("tmop_pa", "[TMOP_PA], [Parallel]")
 {
-   tmop_tests(Mpi::Session().WorldRank(), launch_all_non_regression_tests);
+   tmop_tests(Mpi::WorldRank(), launch_all_non_regression_tests);
 }
 #else
 TEST_CASE("tmop_pa", "[TMOP_PA], [Parallel]")
@@ -868,7 +868,7 @@ TEST_CASE("tmop_pa", "[TMOP_PA], [Parallel]")
    Device device;
    device.Configure(MFEM_TMOP_DEVICE);
    device.Print();
-   tmop_tests(Mpi::Session().WorldRank(), launch_all_non_regression_tests);
+   tmop_tests(Mpi::WorldRank(), launch_all_non_regression_tests);
 }
 #endif
 #else

--- a/tests/unit/pcunit_test_main.cpp
+++ b/tests/unit/pcunit_test_main.cpp
@@ -29,6 +29,7 @@ int main(int argc, char *argv[])
    mfem::MPI_Session mpi;
    GlobalMPISession = &mpi;
    bool root = mpi.Root();
+   mfem::HYPRE_Session hypre;
 #else
    bool root = true;
 #endif

--- a/tests/unit/pcunit_test_main.cpp
+++ b/tests/unit/pcunit_test_main.cpp
@@ -29,7 +29,7 @@ int main(int argc, char *argv[])
    mfem::MPI_Session mpi;
    GlobalMPISession = &mpi;
    bool root = mpi.Root();
-   mfem::HYPRE_Session hypre;
+   mfem::Hypre::Init();
 #else
    bool root = true;
 #endif

--- a/tests/unit/pcunit_test_main.cpp
+++ b/tests/unit/pcunit_test_main.cpp
@@ -17,7 +17,7 @@ bool launch_all_non_regression_tests = false;
 std::string mfem_data_dir;
 
 #ifdef MFEM_USE_MPI
-mfem::MPI_Session *GlobalMPISession;
+mfem::MPI *GlobalMPISession;
 #else
 #error "This test should be disabled without MFEM_USE_MPI!"
 #endif
@@ -26,9 +26,9 @@ int main(int argc, char *argv[])
 {
    mfem::Device device("cuda");
 #ifdef MFEM_USE_MPI
-   mfem::MPI_Session mpi;
-   GlobalMPISession = &mpi;
-   bool root = mpi.Root();
+   mfem::MPI::Init();
+   GlobalMPISession = &mfem::MPI::Session();
+   bool root = mfem::MPI::Session().Root();
    mfem::Hypre::Init();
 #else
    bool root = true;

--- a/tests/unit/pcunit_test_main.cpp
+++ b/tests/unit/pcunit_test_main.cpp
@@ -16,9 +16,7 @@
 bool launch_all_non_regression_tests = false;
 std::string mfem_data_dir;
 
-#ifdef MFEM_USE_MPI
-mfem::MPI *GlobalMPISession;
-#else
+#ifndef MFEM_USE_MPI
 #error "This test should be disabled without MFEM_USE_MPI!"
 #endif
 
@@ -27,7 +25,6 @@ int main(int argc, char *argv[])
    mfem::Device device("cuda");
 #ifdef MFEM_USE_MPI
    mfem::MPI::Init();
-   GlobalMPISession = &mfem::MPI::Session();
    bool root = mfem::MPI::Session().Root();
    mfem::Hypre::Init();
 #else

--- a/tests/unit/pcunit_test_main.cpp
+++ b/tests/unit/pcunit_test_main.cpp
@@ -24,8 +24,8 @@ int main(int argc, char *argv[])
 {
    mfem::Device device("cuda");
 #ifdef MFEM_USE_MPI
-   mfem::MPI::Init();
-   bool root = mfem::MPI::Session().Root();
+   mfem::Mpi::Init();
+   bool root = mfem::Mpi::Session().Root();
    mfem::Hypre::Init();
 #else
    bool root = true;

--- a/tests/unit/pcunit_test_main.cpp
+++ b/tests/unit/pcunit_test_main.cpp
@@ -25,7 +25,7 @@ int main(int argc, char *argv[])
    mfem::Device device("cuda");
 #ifdef MFEM_USE_MPI
    mfem::Mpi::Init();
-   bool root = mfem::Mpi::Session().Root();
+   bool root = mfem::Mpi::Root();
    mfem::Hypre::Init();
 #else
    bool root = true;

--- a/tests/unit/punit_test_main.cpp
+++ b/tests/unit/punit_test_main.cpp
@@ -28,6 +28,7 @@ int main(int argc, char *argv[])
    mfem::MPI_Session mpi;
    GlobalMPISession = &mpi;
    bool root = mpi.Root();
+   mfem::HYPRE_Session hypre;
 #else
    bool root = true;
 #endif

--- a/tests/unit/punit_test_main.cpp
+++ b/tests/unit/punit_test_main.cpp
@@ -23,8 +23,8 @@ std::string mfem_data_dir;
 int main(int argc, char *argv[])
 {
 #ifdef MFEM_USE_MPI
-   mfem::MPI::Init();
-   bool root = mfem::MPI::Session().Root();
+   mfem::Mpi::Init();
+   bool root = mfem::Mpi::Session().Root();
    mfem::Hypre::Init();
 #else
    bool root = true;

--- a/tests/unit/punit_test_main.cpp
+++ b/tests/unit/punit_test_main.cpp
@@ -28,7 +28,7 @@ int main(int argc, char *argv[])
    mfem::MPI_Session mpi;
    GlobalMPISession = &mpi;
    bool root = mpi.Root();
-   mfem::HYPRE_Session hypre;
+   mfem::Hypre::Init();
 #else
    bool root = true;
 #endif

--- a/tests/unit/punit_test_main.cpp
+++ b/tests/unit/punit_test_main.cpp
@@ -24,7 +24,7 @@ int main(int argc, char *argv[])
 {
 #ifdef MFEM_USE_MPI
    mfem::Mpi::Init();
-   bool root = mfem::Mpi::Session().Root();
+   bool root = mfem::Mpi::Root();
    mfem::Hypre::Init();
 #else
    bool root = true;

--- a/tests/unit/punit_test_main.cpp
+++ b/tests/unit/punit_test_main.cpp
@@ -17,7 +17,7 @@ bool launch_all_non_regression_tests = false;
 std::string mfem_data_dir;
 
 #ifdef MFEM_USE_MPI
-mfem::MPI_Session *GlobalMPISession;
+mfem::MPI *GlobalMPISession;
 #else
 #error "This test should be disabled without MFEM_USE_MPI!"
 #endif
@@ -25,9 +25,9 @@ mfem::MPI_Session *GlobalMPISession;
 int main(int argc, char *argv[])
 {
 #ifdef MFEM_USE_MPI
-   mfem::MPI_Session mpi;
-   GlobalMPISession = &mpi;
-   bool root = mpi.Root();
+   mfem::MPI::Init();
+   GlobalMPISession = &mfem::MPI::Session();
+   bool root = mfem::MPI::Session().Root();
    mfem::Hypre::Init();
 #else
    bool root = true;

--- a/tests/unit/punit_test_main.cpp
+++ b/tests/unit/punit_test_main.cpp
@@ -16,9 +16,7 @@
 bool launch_all_non_regression_tests = false;
 std::string mfem_data_dir;
 
-#ifdef MFEM_USE_MPI
-mfem::MPI *GlobalMPISession;
-#else
+#ifndef MFEM_USE_MPI
 #error "This test should be disabled without MFEM_USE_MPI!"
 #endif
 
@@ -26,7 +24,6 @@ int main(int argc, char *argv[])
 {
 #ifdef MFEM_USE_MPI
    mfem::MPI::Init();
-   GlobalMPISession = &mfem::MPI::Session();
    bool root = mfem::MPI::Session().Root();
    mfem::Hypre::Init();
 #else


### PR DESCRIPTION
Add a simple `HYPRE_Session` class to support *hypre*'s global settings, particularly a number of GPU-relevant options.

- The idea of the class is similar to `MPI_Session` but I decided it to keep it separate, because applications may choose to use `HYPRE_Session` without `MPI_Session` (or a combined `MFEM_Session` in the future).
 
- The implementation is in `linalg/hypre.hpp` and `linalg/hypre.cpp`. We need to decide what global options we'd like to set in `HYPRE_Session::SetGlobalOptions`.

- Most examples and miniapps were updated to define a single object of the class, typically right after `MPI_Session` or `MPI_Init(...)`.

Resolves #2871
Resolves #1276
Resolves #1750

<!--GHEX{"author":"tzanio","assignment":"2022-03-07T23:22:07","editor":"tzanio","id":2873,"reviewers":["jandrej","camierjs","pazner","v-dobrev"],"merge":"2022-03-17T03:05:42","approval":"2022-03-15T23:58:53"}XEHG-->
<!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge|
 | --- | --- | --- | --- | --- | --- | --- |
| [#2873](https://github.com/mfem/mfem/pull/2873) | @tzanio | @tzanio | @jandrej + @camierjs + @pazner + @v-dobrev | 3/7/22 | 3/15/22 | 3/16/22 | |
<!--ELBATXEHG-->