### PR TITLE
Fix indices of face with in `SmemPADGTraceApply3D` and `SmemPADGTraceApplyTranspose3D`.

### DIFF
--- a/fem/bilininteg_dgtrace_pa.cpp
+++ b/fem/bilininteg_dgtrace_pa.cpp
@@ -579,8 +579,8 @@ void SmemPADGTraceApply3D(const int NF,
       {
          MFEM_FOREACH_THREAD(d2,y,D1D)
          {
-            u0[tidz][d1][d2] = x(d1,d2,0,f+tidz);
-            u1[tidz][d1][d2] = x(d1,d2,1,f+tidz);
+            u0[tidz][d1][d2] = x(d1,d2,0,f);
+            u1[tidz][d1][d2] = x(d1,d2,1,f);
          }
       }
       MFEM_SYNC_THREAD;
@@ -627,8 +627,8 @@ void SmemPADGTraceApply3D(const int NF,
       {
          MFEM_FOREACH_THREAD(q2,y,Q1D)
          {
-            DBBu[tidz][q1][q2] = op(q1,q2,0,0,f+tidz)*BBu0[tidz][q1][q2] +
-                                 op(q1,q2,1,0,f+tidz)*BBu1[tidz][q1][q2];
+            DBBu[tidz][q1][q2] = op(q1,q2,0,0,f)*BBu0[tidz][q1][q2] +
+                                 op(q1,q2,1,0,f)*BBu1[tidz][q1][q2];
          }
       }
       MFEM_SYNC_THREAD;
@@ -657,8 +657,8 @@ void SmemPADGTraceApply3D(const int NF,
                const double b = Bt(d1,q1);
                BBDBBu_ += b*BDBBu[tidz][q1][d2];
             }
-            y(d1,d2,0,f+tidz) +=  BBDBBu_;
-            y(d1,d2,1,f+tidz) += -BBDBBu_;
+            y(d1,d2,0,f) +=  BBDBBu_;
+            y(d1,d2,1,f) += -BBDBBu_;
          }
       }
    });
@@ -995,8 +995,8 @@ void SmemPADGTraceApplyTranspose3D(const int NF,
       {
          MFEM_FOREACH_THREAD(d2,y,D1D)
          {
-            u0[tidz][d1][d2] = x(d1,d2,0,f+tidz);
-            u1[tidz][d1][d2] = x(d1,d2,1,f+tidz);
+            u0[tidz][d1][d2] = x(d1,d2,0,f);
+            u1[tidz][d1][d2] = x(d1,d2,1,f);
          }
       }
       MFEM_SYNC_THREAD;
@@ -1044,10 +1044,10 @@ void SmemPADGTraceApplyTranspose3D(const int NF,
       {
          MFEM_FOREACH_THREAD(q2,y,Q1D)
          {
-            const double D00 = op(q1,q2,0,0,f+tidz);
-            const double D01 = op(q1,q2,0,1,f+tidz);
-            const double D10 = op(q1,q2,1,0,f+tidz);
-            const double D11 = op(q1,q2,1,1,f+tidz);
+            const double D00 = op(q1,q2,0,0,f);
+            const double D01 = op(q1,q2,0,1,f);
+            const double D10 = op(q1,q2,1,0,f);
+            const double D11 = op(q1,q2,1,1,f);
             const double u0q = BBu0[tidz][q1][q2];
             const double u1q = BBu1[tidz][q1][q2];
             DBBu0[tidz][q1][q2] = D00*u0q + D01*u1q;
@@ -1086,8 +1086,8 @@ void SmemPADGTraceApplyTranspose3D(const int NF,
                BBDBBu0_ += b*BDBBu0[tidz][q1][d2];
                BBDBBu1_ += b*BDBBu1[tidz][q1][d2];
             }
-            y(d1,d2,0,f+tidz) += BBDBBu0_;
-            y(d1,d2,1,f+tidz) += BBDBBu1_;
+            y(d1,d2,0,f) += BBDBBu0_;
+            y(d1,d2,1,f) += BBDBBu1_;
          }
       }
    });

--- a/tests/unit/fem/test_pa_kernels.cpp
+++ b/tests/unit/fem/test_pa_kernels.cpp
@@ -413,6 +413,7 @@ void test_pa_convection(const std::string &meshname, int order, int prob,
 
    k_fa.Assemble();
    k_fa.Finalize();
+   k_fa.SpMat().EnsureMultTranspose();
 
    k_pa.SetAssemblyLevel(AssemblyLevel::PARTIAL);
    k_pa.Assemble();
@@ -443,7 +444,7 @@ void test_pa_convection(const std::string &meshname, int order, int prob,
 }
 
 // Basic unit tests for convection
-TEST_CASE("PA Convection", "[PartialAssembly]")
+TEST_CASE("PA Convection", "[PartialAssembly][CUDA]")
 {
    // prob:
    // - 0: CG,
@@ -469,7 +470,7 @@ TEST_CASE("PA Convection", "[PartialAssembly]")
 } // test case
 
 // Advanced unit tests for convection
-TEST_CASE("PA Convection advanced", "[PartialAssembly][MFEMData]")
+TEST_CASE("PA Convection advanced", "[PartialAssembly][MFEMData][CUDA]")
 {
    if (launch_all_non_regression_tests)
    {


### PR DESCRIPTION
There is a bug in the face index using `MFEM_FORALL_2D`, this PR fixes it.<!--GHEX{"author":"YohannDudouit","assignment":"2022-03-15T01:34:56","editor":"tzanio","id":2883,"reviewers":["v-dobrev","artv3"],"merge":"2022-03-17T03:06:14","approval":"2022-03-15T22:43:36"}XEHG-->
<!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge|
 | --- | --- | --- | --- | --- | --- | --- |
| [#2883](https://github.com/mfem/mfem/pull/2883) | @YohannDudouit | @tzanio | @v-dobrev + @artv3 | 3/14/22 | 3/15/22 | 3/16/22 | |
<!--ELBATXEHG-->
<details>
<summary>PR Checklist</summary>
    
- [x] Code builds.
- [x] Code passes `make style`.

</details>
