### PR TITLE
Changing expected size of gradient [bugfix/mixed-integ-vdim]

### DIFF
--- a/fem/bilininteg.cpp
+++ b/fem/bilininteg.cpp
@@ -659,6 +659,9 @@ void MixedScalarVectorIntegrator::AssembleElementMatrix2(
    MFEM_ASSERT(this->VerifyFiniteElementTypes(trial_fe, test_fe),
                this->FiniteElementTypeFailureMessage());
 
+   MFEM_VERIFY(VQ, "MixedScalarVectorIntegrator: "
+               "VectorCoefficient must be set");
+
    const FiniteElement * vec_fe = transpose?&trial_fe:&test_fe;
    const FiniteElement * sca_fe = transpose?&test_fe:&trial_fe;
 
@@ -669,13 +672,17 @@ void MixedScalarVectorIntegrator::AssembleElementMatrix2(
    int vdim = GetVDim(*vec_fe);
    double vtmp;
 
+   MFEM_VERIFY(VQ->GetVDim() == vdim, "MixedScalarVectorIntegrator: "
+               "Dimensions of VectorCoefficient and Vector-valued basis "
+               "functions must match");
+
 #ifdef MFEM_THREAD_SAFE
-   Vector V(VQ ? VQ->GetVDim() : 0);
+   Vector V(vdim);
    DenseMatrix vshape(vec_nd, vdim);
    Vector      shape(sca_nd);
    Vector      vshape_tmp(vec_nd);
 #else
-   V.SetSize(VQ ? VQ->GetVDim() : 0);
+   V.SetSize(vdim);
    vshape.SetSize(vec_nd, vdim);
    shape.SetSize(sca_nd);
    vshape_tmp.SetSize(vec_nd);

--- a/fem/bilininteg.hpp
+++ b/fem/bilininteg.hpp
@@ -1091,7 +1091,7 @@ public:
    }
 
    inline virtual int GetTestVDim(const FiniteElement & test_fe)
-   { return test_fe.GetDim(); }
+   { return space_dim; }
 
    inline virtual void CalcTestShape(const FiniteElement & test_fe,
                                      ElementTransformation &Trans,
@@ -1141,7 +1141,7 @@ public:
    }
 
    inline virtual int GetTrialVDim(const FiniteElement & trial_fe)
-   { return trial_fe.GetDim(); }
+   { return space_dim; }
 
    inline virtual void CalcTrialShape(const FiniteElement & trial_fe,
                                       ElementTransformation &Trans,
@@ -1149,7 +1149,7 @@ public:
    { trial_fe.CalcPhysDShape(Trans, shape); }
 
    inline virtual int GetTestVDim(const FiniteElement & test_fe)
-   { return test_fe.GetDim(); }
+   { return space_dim; }
 
    inline virtual void CalcTestShape(const FiniteElement & test_fe,
                                      ElementTransformation &Trans,
@@ -1183,7 +1183,7 @@ public:
    }
 
    inline virtual int GetTrialVDim(const FiniteElement & trial_fe)
-   { return trial_fe.GetDim(); }
+   { return space_dim; }
 
    inline virtual void CalcTrialShape(const FiniteElement & trial_fe,
                                       ElementTransformation &Trans,
@@ -1191,7 +1191,7 @@ public:
    { trial_fe.CalcPhysDShape(Trans, shape); }
 
    inline virtual int GetTestVDim(const FiniteElement & test_fe)
-   { return test_fe.GetDim(); }
+   { return space_dim; }
 
    inline virtual void CalcTestShape(const FiniteElement & test_fe,
                                      ElementTransformation &Trans,
@@ -1327,7 +1327,7 @@ public:
    { trial_fe.CalcPhysCurlShape(Trans, shape); }
 
    inline virtual int GetTestVDim(const FiniteElement & test_fe)
-   { return test_fe.GetDim(); }
+   { return space_dim; }
 
    inline virtual void CalcTestShape(const FiniteElement & test_fe,
                                      ElementTransformation &Trans,
@@ -1362,7 +1362,7 @@ public:
    }
 
    inline virtual int GetTrialVDim(const FiniteElement & trial_fe)
-   { return trial_fe.GetDim(); }
+   { return space_dim; }
 
    inline virtual void CalcTrialShape(const FiniteElement & trial_fe,
                                       ElementTransformation &Trans,
@@ -1475,7 +1475,7 @@ public:
    }
 
    inline virtual int GetTrialVDim(const FiniteElement & trial_fe)
-   { return trial_fe.GetDim(); }
+   { return space_dim; }
 
    inline virtual void CalcTrialShape(const FiniteElement & trial_fe,
                                       ElementTransformation &Trans,
@@ -1584,7 +1584,7 @@ public:
    }
 
    inline int GetVDim(const FiniteElement & vector_fe)
-   { return vector_fe.GetDim(); }
+   { return space_dim; }
 
    inline virtual void CalcVShape(const FiniteElement & vector_fe,
                                   ElementTransformation &Trans,
@@ -1672,7 +1672,7 @@ public:
    }
 
    inline virtual int GetVDim(const FiniteElement & vector_fe)
-   { return vector_fe.GetDim(); }
+   { return space_dim; }
 
    inline virtual void CalcVShape(const FiniteElement & vector_fe,
                                   ElementTransformation &Trans,
@@ -1706,7 +1706,7 @@ public:
    }
 
    inline virtual int GetVDim(const FiniteElement & vector_fe)
-   { return vector_fe.GetDim(); }
+   { return space_dim; }
 
    inline virtual void CalcVShape(const FiniteElement & vector_fe,
                                   ElementTransformation &Trans,
@@ -1746,7 +1746,7 @@ public:
    }
 
    inline virtual int GetVDim(const FiniteElement & vector_fe)
-   { return vector_fe.GetDim(); }
+   { return space_dim; }
 
    inline virtual void CalcVShape(const FiniteElement & vector_fe,
                                   ElementTransformation &Trans,
@@ -1784,7 +1784,7 @@ public:
    }
 
    inline int GetVDim(const FiniteElement & vector_fe)
-   { return vector_fe.GetDim(); }
+   { return space_dim; }
 
    inline virtual void CalcVShape(const FiniteElement & vector_fe,
                                   ElementTransformation &Trans,
@@ -1826,7 +1826,7 @@ protected:
    }
 
    inline virtual int GetTrialVDim(const FiniteElement & trial_fe)
-   { return trial_fe.GetDim(); }
+   { return space_dim; }
 
    inline virtual void CalcTrialShape(const FiniteElement & trial_fe,
                                       ElementTransformation &Trans,
@@ -1998,7 +1998,7 @@ protected:
    }
 
    inline virtual int GetTestVDim(const FiniteElement & test_fe)
-   { return test_fe.GetDim(); }
+   { return space_dim; }
 
    inline virtual void CalcTestShape(const FiniteElement & test_fe,
                                      ElementTransformation &Trans,


### PR DESCRIPTION
In the classes derived from `MixedScalarVectorIntegrator` which use the gradient of a scalar basis function we must set the size of the gradient in physical space to match the dimension of physical space. Previously the size defaulted to the dimension of reference space which led to problems on boundary integrals.

This PR is meant to address issue #2890.

<!--GHEX{"author":"mlstowell","assignment":"2022-03-15T22:36:31","editor":"tzanio","id":2895,"reviewers":["psocratis","tzanio"],"merge":"2022-03-17T03:05:24","approval":"2022-03-16T00:02:38"}XEHG--><!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge|
 | --- | --- | --- | --- | --- | --- | --- |
| [#2895](https://github.com/mfem/mfem/pull/2895) | @mlstowell | @tzanio | @psocratis + @tzanio | 3/15/22 | 3/15/22 | 3/16/22 | |
<!--ELBATXEHG-->