### PR TITLE
Bug fixes for PA in H(curl)

### DIFF
--- a/fem/bilininteg_vectorfe.cpp
+++ b/fem/bilininteg_vectorfe.cpp
@@ -253,7 +253,7 @@ void PAHcurlHdivSetup3D(const int Q1D,
 
                if (coeffDim == 6 || coeffDim == 9) // Matrix coefficient version
                {
-                  // First compute entries of R = MJ
+                  // First compute entries of R = M^T J
                   const double M11 = (!symmetric) ? coeff(i11,qx,qy,qz,e) : coeff(0,qx,qy,qz,e);
                   const double M12 = (!symmetric) ? coeff(i12,qx,qy,qz,e) : coeff(1,qx,qy,qz,e);
                   const double M13 = (!symmetric) ? coeff(i13,qx,qy,qz,e) : coeff(2,qx,qy,qz,e);
@@ -264,25 +264,25 @@ void PAHcurlHdivSetup3D(const int Q1D,
                   const double M32 = (!symmetric) ? coeff(i32,qx,qy,qz,e) : M23;
                   const double M33 = (!symmetric) ? coeff(i33,qx,qy,qz,e) : coeff(5,qx,qy,qz,e);
 
-                  const double R11 = M11*J11 + M12*J12 + M13*J13;
-                  const double R12 = M11*J21 + M12*J22 + M13*J23;
-                  const double R13 = M11*J31 + M12*J32 + M13*J33;
-                  const double R21 = M21*J11 + M22*J12 + M23*J13;
-                  const double R22 = M21*J21 + M22*J22 + M23*J23;
-                  const double R23 = M21*J31 + M22*J32 + M23*J33;
-                  const double R31 = M31*J11 + M32*J12 + M33*J13;
-                  const double R32 = M31*J21 + M32*J22 + M33*J23;
-                  const double R33 = M31*J31 + M32*J32 + M33*J33;
+                  const double R11 = M11*J11 + M21*J21 + M31*J31;
+                  const double R12 = M11*J12 + M21*J22 + M31*J32;
+                  const double R13 = M11*J13 + M21*J23 + M31*J33;
+                  const double R21 = M12*J11 + M22*J21 + M32*J31;
+                  const double R22 = M12*J12 + M22*J22 + M32*J32;
+                  const double R23 = M12*J13 + M22*J23 + M32*J33;
+                  const double R31 = M13*J11 + M23*J21 + M33*J31;
+                  const double R32 = M13*J12 + M23*J22 + M33*J32;
+                  const double R33 = M13*J13 + M23*J23 + M33*J33;
 
-                  // Now set y to detJ J^{-1} R = adj(J) R
+                  // y = (J^{-1} M^T J)^T
                   y(i11,qx,qy,qz,e) = w_detJ * (A11*R11 + A12*R21 + A13*R31); // 1,1
-                  y(i12,qx,qy,qz,e) = w_detJ * (A11*R12 + A12*R22 + A13*R32); // 1,2
-                  y(i13,qx,qy,qz,e) = w_detJ * (A11*R13 + A12*R23 + A13*R33); // 1,3
-                  y(i21,qx,qy,qz,e) = w_detJ * (A21*R11 + A22*R21 + A23*R31); // 2,1
+                  y(i21,qx,qy,qz,e) = w_detJ * (A11*R12 + A12*R22 + A13*R32); // 1,2
+                  y(i31,qx,qy,qz,e) = w_detJ * (A11*R13 + A12*R23 + A13*R33); // 1,3
+                  y(i12,qx,qy,qz,e) = w_detJ * (A21*R11 + A22*R21 + A23*R31); // 2,1
                   y(i22,qx,qy,qz,e) = w_detJ * (A21*R12 + A22*R22 + A23*R32); // 2,2
-                  y(i23,qx,qy,qz,e) = w_detJ * (A21*R13 + A22*R23 + A23*R33); // 2,3
-                  y(i31,qx,qy,qz,e) = w_detJ * (A31*R11 + A32*R21 + A33*R31); // 3,1
-                  y(i32,qx,qy,qz,e) = w_detJ * (A31*R12 + A32*R22 + A33*R32); // 3,2
+                  y(i32,qx,qy,qz,e) = w_detJ * (A21*R13 + A22*R23 + A23*R33); // 2,3
+                  y(i13,qx,qy,qz,e) = w_detJ * (A31*R11 + A32*R21 + A33*R31); // 3,1
+                  y(i23,qx,qy,qz,e) = w_detJ * (A31*R12 + A32*R22 + A33*R32); // 3,2
                   y(i33,qx,qy,qz,e) = w_detJ * (A31*R13 + A32*R23 + A33*R33); // 3,3
                }
                else if (coeffDim == 3)  // Vector coefficient version
@@ -291,14 +291,15 @@ void PAHcurlHdivSetup3D(const int Q1D,
                   const double D2 = coeff(1,qx,qy,qz,e);
                   const double D3 = coeff(2,qx,qy,qz,e);
                   // detJ J^{-1} DJ = adj(J) DJ
+                  // transpose
                   y(i11,qx,qy,qz,e) = w_detJ * (D1*A11*J11 + D2*A12*J21 + D3*A13*J31); // 1,1
-                  y(i12,qx,qy,qz,e) = w_detJ * (D1*A11*J12 + D2*A12*J22 + D3*A13*J32); // 1,2
-                  y(i13,qx,qy,qz,e) = w_detJ * (D1*A11*J13 + D2*A12*J23 + D3*A13*J33); // 1,3
-                  y(i21,qx,qy,qz,e) = w_detJ * (D1*A21*J11 + D2*A22*J21 + D3*A23*J31); // 2,1
+                  y(i21,qx,qy,qz,e) = w_detJ * (D1*A11*J12 + D2*A12*J22 + D3*A13*J32); // 1,2
+                  y(i31,qx,qy,qz,e) = w_detJ * (D1*A11*J13 + D2*A12*J23 + D3*A13*J33); // 1,3
+                  y(i12,qx,qy,qz,e) = w_detJ * (D1*A21*J11 + D2*A22*J21 + D3*A23*J31); // 2,1
                   y(i22,qx,qy,qz,e) = w_detJ * (D1*A21*J12 + D2*A22*J22 + D3*A23*J32); // 2,2
-                  y(i23,qx,qy,qz,e) = w_detJ * (D1*A21*J13 + D2*A22*J23 + D3*A23*J33); // 2,3
-                  y(i31,qx,qy,qz,e) = w_detJ * (D1*A31*J11 + D2*A32*J21 + D3*A33*J31); // 3,1
-                  y(i32,qx,qy,qz,e) = w_detJ * (D1*A31*J12 + D2*A32*J22 + D3*A33*J32); // 3,2
+                  y(i32,qx,qy,qz,e) = w_detJ * (D1*A21*J13 + D2*A22*J23 + D3*A23*J33); // 2,3
+                  y(i13,qx,qy,qz,e) = w_detJ * (D1*A31*J11 + D2*A32*J21 + D3*A33*J31); // 3,1
+                  y(i23,qx,qy,qz,e) = w_detJ * (D1*A31*J12 + D2*A32*J22 + D3*A33*J32); // 3,2
                   y(i33,qx,qy,qz,e) = w_detJ * (D1*A31*J13 + D2*A32*J23 + D3*A33*J33); // 3,3
                }
             }
@@ -340,7 +341,7 @@ void PAHcurlHdivSetup2D(const int Q1D,
             const double J21 = J(qx,qy,1,0,e);
             const double J12 = J(qx,qy,0,1,e);
             const double J22 = J(qx,qy,1,1,e);
-            const double w_detJ = W(qx,qy) / (J11*J22) - (J21*J12);
+            const double w_detJ = W(qx,qy) / ((J11*J22) - (J21*J12));
 
             if (coeffDim == 3 || coeffDim == 4) // Matrix coefficient version
             {
@@ -350,16 +351,17 @@ void PAHcurlHdivSetup2D(const int Q1D,
                const double M21 = (!symmetric) ? coeff(i21,qx,qy,e) : M12;
                const double M22 = (!symmetric) ? coeff(i22,qx,qy,e) : coeff(2,qx,qy,e);
 
-               const double R11 = M11*J11 + M12*J21;
-               const double R12 = M11*J12 + M12*J22;
-               const double R21 = M21*J11 + M22*J21;
-               const double R22 = M21*J12 + M22*J22;
+               // J^{-1} M^T
+               const double R11 = ( J22*M11 - J12*M12); // 1,1
+               const double R12 = ( J22*M21 - J12*M22); // 1,2
+               const double R21 = (-J21*M11 + J11*M12); // 2,1
+               const double R22 = (-J21*M21 + J11*M22); // 2,2
 
-               // Now set y to J^{-1} R
-               y(i11,qx,qy,e) = w_detJ * ( J22*R11 - J12*R21); // 1,1
-               y(i12,qx,qy,e) = w_detJ * ( J22*R12 - J12*R22); // 1,2
-               y(i21,qx,qy,e) = w_detJ * (-J21*R11 + J11*R21); // 2,1
-               y(i22,qx,qy,e) = w_detJ * (-J21*R12 + J11*R22); // 2,2
+               // (RJ)^T
+               y(i11,qx,qy,e) = w_detJ * (R11*J11 + R12*J21); // 1,1
+               y(i21,qx,qy,e) = w_detJ * (R11*J12 + R12*J22); // 1,2 (transpose)
+               y(i12,qx,qy,e) = w_detJ * (R21*J11 + R22*J21); // 2,1 (transpose)
+               y(i22,qx,qy,e) = w_detJ * (R21*J12 + R22*J22); // 2,2
             }
             else if (coeffDim == 2) // Vector coefficient version
             {

--- a/tests/unit/fem/test_pa_coeff.cpp
+++ b/tests/unit/fem/test_pa_coeff.cpp
@@ -19,6 +19,29 @@ namespace pa_coeff
 
 int dimension;
 
+Mesh MakeCartesianNonaligned(const int dim, const int ne)
+{
+   Mesh mesh;
+   if (dim == 2)
+   {
+      mesh = Mesh::MakeCartesian2D(ne, ne, Element::QUADRILATERAL, 1, 1.0, 1.0);
+   }
+   else
+   {
+      mesh = Mesh::MakeCartesian3D(ne, ne, ne, Element::HEXAHEDRON, 1.0, 1.0, 1.0);
+   }
+
+   // Remap vertices so that the mesh is not aligned with axes.
+   for (int i=0; i<mesh.GetNV(); ++i)
+   {
+      double *vcrd = mesh.GetVertex(i);
+      vcrd[1] += 0.2 * vcrd[0];
+      if (dim == 3) { vcrd[2] += 0.3 * vcrd[0]; }
+   }
+
+   return mesh;
+}
+
 double coeffFunction(const Vector& x)
 {
    if (dimension == 2)
@@ -141,17 +164,8 @@ TEST_CASE("H1 pa_coeff")
                       << "integrator " << integrator << std::endl;
             for (int order = 1; order < 4; ++order)
             {
-               Mesh mesh;
-               if (dimension == 2)
-               {
-                  mesh = Mesh::MakeCartesian2D(
-                            ne, ne, Element::QUADRILATERAL, 1, 1.0, 1.0);
-               }
-               else
-               {
-                  mesh = Mesh::MakeCartesian3D(
-                            ne, ne, ne, Element::HEXAHEDRON, 1.0, 1.0, 1.0);
-               }
+               Mesh mesh = MakeCartesianNonaligned(dimension, ne);
+
                FiniteElementCollection* h1_fec =
                   new H1_FECollection(order, dimension);
                FiniteElementSpace h1_fespace(&mesh, h1_fec);
@@ -292,18 +306,8 @@ TEST_CASE("Hcurl/Hdiv pa_coeff",
 {
    for (dimension = 2; dimension < 4; ++dimension)
    {
-      Mesh mesh;
       const int ne = 3;
-      if (dimension == 2)
-      {
-         mesh = Mesh::MakeCartesian2D(
-                   ne, ne, Element::QUADRILATERAL, 1, 1.0, 1.0);
-      }
-      else
-      {
-         mesh = Mesh::MakeCartesian3D(
-                   ne, ne, ne, Element::HEXAHEDRON, 1.0, 1.0, 1.0);
-      }
+      Mesh mesh = MakeCartesianNonaligned(dimension, ne);
 
       for (int coeffType = 3; coeffType < 5; ++coeffType)
       {
@@ -635,18 +639,8 @@ TEST_CASE("Hcurl/Hdiv mixed pa_coeff",
 {
    for (dimension = 2; dimension < 4; ++dimension)
    {
-      Mesh mesh;
       const int ne = 3;
-      if (dimension == 2)
-      {
-         mesh = Mesh::MakeCartesian2D(
-                   ne, ne, Element::QUADRILATERAL, 1, 1.0, 1.0);
-      }
-      else
-      {
-         mesh = Mesh::MakeCartesian3D(
-                   ne, ne, ne, Element::HEXAHEDRON, 1.0, 1.0, 1.0);
-      }
+      Mesh mesh = MakeCartesianNonaligned(dimension, ne);
 
       for (int coeffType = 0; coeffType < 3; ++coeffType)
       {

--- a/tests/unit/fem/test_pa_grad.cpp
+++ b/tests/unit/fem/test_pa_grad.cpp
@@ -15,6 +15,29 @@
 
 using namespace mfem;
 
+Mesh MakeCartesianNonaligned(const int dim, const int ne)
+{
+   Mesh mesh;
+   if (dim == 2)
+   {
+      mesh = Mesh::MakeCartesian2D(ne, ne, Element::QUADRILATERAL, 1, 1.0, 1.0);
+   }
+   else
+   {
+      mesh = Mesh::MakeCartesian3D(ne, ne, ne, Element::HEXAHEDRON, 1.0, 1.0, 1.0);
+   }
+
+   // Remap vertices so that the mesh is not aligned with axes.
+   for (int i=0; i<mesh.GetNV(); ++i)
+   {
+      double *vcrd = mesh.GetVertex(i);
+      vcrd[1] += 0.2 * vcrd[0];
+      if (dim == 3) { vcrd[2] += 0.3 * vcrd[0]; }
+   }
+
+   return mesh;
+}
+
 double compare_pa_assembly(int dim, int num_elements, int order, bool transpose)
 {
    Mesh mesh;
@@ -31,17 +54,9 @@ double compare_pa_assembly(int dim, int num_elements, int order, bool transpose)
    }
    else
    {
-      if (dim == 2)
-      {
-         mesh = Mesh::MakeCartesian2D(num_elements, num_elements, Element::QUADRILATERAL,
-                                      true);
-      }
-      else
-      {
-         mesh = Mesh::MakeCartesian3D(num_elements, num_elements, num_elements,
-                                      Element::HEXAHEDRON);
-      }
+      mesh = MakeCartesianNonaligned(dim, num_elements);
    }
+
    FiniteElementCollection *h1_fec = new H1_FECollection(order, dim);
    FiniteElementCollection *nd_fec = new ND_FECollection(order, dim);
    FiniteElementSpace h1_fespace(&mesh, h1_fec);
@@ -120,17 +135,7 @@ double par_compare_pa_assembly(int dim, int num_elements, int order,
    int size;
    MPI_Comm_size(MPI_COMM_WORLD, &size);
 
-   Mesh smesh;
-   if (dim == 2)
-   {
-      smesh = Mesh::MakeCartesian2D(
-                 num_elements, num_elements, Element::QUADRILATERAL, true);
-   }
-   else
-   {
-      smesh = Mesh::MakeCartesian3D(
-                 num_elements, num_elements, num_elements, Element::HEXAHEDRON);
-   }
+   Mesh smesh = MakeCartesianNonaligned(dim, num_elements);
    ParMesh * mesh = new ParMesh(MPI_COMM_WORLD, smesh);
    smesh.Clear();
    FiniteElementCollection *h1_fec = new H1_FECollection(order, dim);

--- a/tests/unit/fem/test_pa_kernels.cpp
+++ b/tests/unit/fem/test_pa_kernels.cpp
@@ -25,6 +25,29 @@ using namespace mfem;
 namespace pa_kernels
 {
 
+Mesh MakeCartesianNonaligned(const int dim, const int ne)
+{
+   Mesh mesh;
+   if (dim == 2)
+   {
+      mesh = Mesh::MakeCartesian2D(ne, ne, Element::QUADRILATERAL, 1, 1.0, 1.0);
+   }
+   else
+   {
+      mesh = Mesh::MakeCartesian3D(ne, ne, ne, Element::HEXAHEDRON, 1.0, 1.0, 1.0);
+   }
+
+   // Remap vertices so that the mesh is not aligned with axes.
+   for (int i=0; i<mesh.GetNV(); ++i)
+   {
+      double *vcrd = mesh.GetVertex(i);
+      vcrd[1] += 0.2 * vcrd[0];
+      if (dim == 3) { vcrd[2] += 0.3 * vcrd[0]; }
+   }
+
+   return mesh;
+}
+
 double zero_field(const Vector &x)
 {
    MFEM_CONTRACT_VAR(x);
@@ -71,16 +94,7 @@ double pa_divergence_testnd(int dim,
                             void (*f1)(const Vector &, Vector &),
                             double (*divf1)(const Vector &))
 {
-   Mesh mesh;
-   if (dim == 2)
-   {
-      mesh = Mesh::MakeCartesian2D(2, 2, Element::QUADRILATERAL, 0, 1.0, 1.0);
-   }
-   if (dim == 3)
-   {
-      mesh = Mesh::MakeCartesian3D(2, 2, 2, Element::HEXAHEDRON, 1.0, 1.0, 1.0);
-   }
-
+   Mesh mesh = MakeCartesianNonaligned(dim, 2);
    int order = 4;
 
    // Vector valued
@@ -163,16 +177,7 @@ double pa_gradient_testnd(int dim,
                           double (*f1)(const Vector &),
                           void (*gradf1)(const Vector &, Vector &))
 {
-   Mesh mesh;
-   if (dim == 2)
-   {
-      mesh = Mesh::MakeCartesian2D(2, 2, Element::QUADRILATERAL, 0, 1.0, 1.0);
-   }
-   if (dim == 3)
-   {
-      mesh = Mesh::MakeCartesian3D(2, 2, 2, Element::HEXAHEDRON, 1.0, 1.0, 1.0);
-   }
-
+   Mesh mesh = MakeCartesianNonaligned(dim, 2);
    int order = 4;
 
    // Scalar
@@ -222,17 +227,7 @@ TEST_CASE("PA Gradient", "[PartialAssembly]")
 
 double test_nl_convection_nd(int dim)
 {
-   Mesh mesh;
-
-   if (dim == 2)
-   {
-      mesh = Mesh::MakeCartesian2D(2, 2, Element::QUADRILATERAL, 0, 1.0, 1.0);
-   }
-   if (dim == 3)
-   {
-      mesh = Mesh::MakeCartesian3D(2, 2, 2, Element::HEXAHEDRON, 1.0, 1.0, 1.0);
-   }
-
+   Mesh mesh = MakeCartesianNonaligned(dim, 2);
    int order = 2;
    H1_FECollection fec(order, dim);
    FiniteElementSpace fes(&mesh, &fec, dim);
@@ -273,11 +268,7 @@ TEST_CASE("Nonlinear Convection", "[PartialAssembly], [NonlinearPA]")
 template <typename INTEGRATOR>
 double test_vector_pa_integrator(int dim)
 {
-   Mesh mesh =
-      (dim == 2) ?
-      Mesh::MakeCartesian2D(2, 2, Element::QUADRILATERAL, 0, 1.0, 1.0):
-      Mesh::MakeCartesian3D(2, 2, 2, Element::HEXAHEDRON, 1.0, 1.0, 1.0);
-
+   Mesh mesh = MakeCartesianNonaligned(dim, 2);
    int order = 2;
    H1_FECollection fec(order, dim);
    FiniteElementSpace fes(&mesh, &fec, dim);


### PR DESCRIPTION
The unit tests for PA in H(curl) were defined on Cartesian meshes aligned with the axes, which have been generalized to be non-aligned. This exposed some bugs, which are now fixed. The Smem PA kernels are also fixed, so that unit tests succeed with a CUDA build.