### PR TITLE
Remove `tmp` `IntegrationRule` in `SegmentIntegrationRule`.

### DIFF
--- a/fem/intrules.cpp
+++ b/fem/intrules.cpp
@@ -1081,8 +1081,7 @@ IntegrationRule *IntegrationRules::SegmentIntegrationRule(int Order)
    // Order is one of {RealOrder-1,RealOrder}
    AllocIntRule(SegmentIntRules, RealOrder);
 
-   IntegrationRule tmp, *ir;
-   ir = refined ? &tmp : new IntegrationRule;
+   IntegrationRule *ir = new IntegrationRule;
 
    int n = 0;
    // n is the number of points to achieve the exact integral of a
@@ -1132,14 +1131,16 @@ IntegrationRule *IntegrationRules::SegmentIntegrationRule(int Order)
    if (refined)
    {
       // Effectively passing memory management to SegmentIntegrationRules
-      ir = new IntegrationRule(2*n);
+      IntegrationRule *refined_ir = new IntegrationRule(2*n);
       for (int j = 0; j < n; j++)
       {
-         ir->IntPoint(j).x = tmp.IntPoint(j).x/2.0;
-         ir->IntPoint(j).weight = tmp.IntPoint(j).weight/2.0;
-         ir->IntPoint(j+n).x = 0.5 + tmp.IntPoint(j).x/2.0;
-         ir->IntPoint(j+n).weight = tmp.IntPoint(j).weight/2.0;
+         refined_ir->IntPoint(j).x = ir->IntPoint(j).x/2.0;
+         refined_ir->IntPoint(j).weight = ir->IntPoint(j).weight/2.0;
+         refined_ir->IntPoint(j+n).x = 0.5 + ir->IntPoint(j).x/2.0;
+         refined_ir->IntPoint(j+n).weight = ir->IntPoint(j).weight/2.0;
       }
+      delete ir;
+      ir = refined_ir;
    }
    SegmentIntRules[RealOrder-1] = SegmentIntRules[RealOrder] = ir;
    return ir;


### PR DESCRIPTION
Attempt to remove the warning:
```
fem/intrules.cpp: In member function 'mfem::IntegrationRule* mfem::IntegrationRules::SegmentIntegrationRule(int)':
fem/intrules.cpp:1145:11: warning: function may return address of local variable [-Wreturn-local-addr]
 1145 |    return ir;
      |           ^~
fem/intrules.cpp:1084:20: note: declared here
 1084 |    IntegrationRule tmp, *ir;
      |                    ^~~
```