### PR TITLE
Fix memory leak in FA assembly

### DIFF
--- a/fem/bilinearform_ext.cpp
+++ b/fem/bilinearform_ext.cpp
@@ -903,7 +903,8 @@ void FABilinearFormExtension::Assemble()
    }
    else // We create, compute the sparsity, and fill the sparse matrix
    {
-      mat = new SparseMatrix(height, width, 0);
+      mat = new SparseMatrix;
+      mat->OverrideSize(height, width);
       if (fes.IsDGSpace())
       {
          const L2ElementRestriction *restE =

--- a/linalg/sparsemat.cpp
+++ b/linalg/sparsemat.cpp
@@ -292,6 +292,12 @@ SparseMatrix::SparseMatrix(const Vector &v)
    InitGPUSparse();
 }
 
+void SparseMatrix::OverrideSize(int height_, int width_)
+{
+   height = height_;
+   width = width_;
+}
+
 SparseMatrix& SparseMatrix::operator=(const SparseMatrix &rhs)
 {
    Clear();

--- a/linalg/sparsemat.hpp
+++ b/linalg/sparsemat.hpp
@@ -170,6 +170,15 @@ public:
    /// Create a SparseMatrix with diagonal @a v, i.e. A = Diag(v)
    SparseMatrix(const Vector & v);
 
+   /// @brief Sets the height and width of the matrix.
+   /** @warning This does not modify in any way the underlying CSR or LIL
+       representation of the matrix.
+
+       This function should generally be called when manually constructing the
+       CSR #I, #J, and #A arrays in conjunction with the
+       SparseMatrix::SparseMatrix() constructor. */
+   void OverrideSize(int height_, int width_);
+
    /** @brief Runtime option to use cuSPARSE or hipSPARSE. Only valid when using
        a CUDA or HIP backend.
 


### PR DESCRIPTION
The `FULL` assembly mode has a memory leak since the initial pointers for the `I`, `J`, and `A` arrays are overwritten (`J` and `A` are allocated but are actually zero-length, `I` has nonzero length).

This PR adds a new "expert function" `SparseMatrix::OverrideSize` that lets one change the `width` and `height` of a `SparseMatrix` after it has already been constructed (e.g. with the default constructor).

The use-case here is creating an "empty" `SparseMatrix` (but with the correct dimensions), and letting the user handle allocating and filling the CSR arrays.