### PR TITLE
Don't duplicate unit test output in parallel

### DIFF
--- a/tests/unit/pcunit_test_main.cpp
+++ b/tests/unit/pcunit_test_main.cpp
@@ -9,6 +9,7 @@
 // terms of the BSD-3 license. We welcome feedback and contributions, see file
 // CONTRIBUTING.md for details.
 
+#define CATCH_CONFIG_NOSTDOUT
 #define CATCH_CONFIG_RUNNER
 #include "mfem.hpp"
 #include "run_unit_tests.hpp"
@@ -25,12 +26,9 @@ int main(int argc, char *argv[])
    mfem::Device device("cuda");
 #ifdef MFEM_USE_MPI
    mfem::Mpi::Init();
-   bool root = mfem::Mpi::Root();
    mfem::Hypre::Init();
-#else
-   bool root = true;
 #endif
 
    // Include only tests that are labeled with both CUDA and Parallel.
-   return RunCatchSession(argc, argv, {"[CUDA]","[Parallel]"}, root);
+   return RunCatchSession(argc, argv, {"[CUDA]","[Parallel]"}, Root());
 }

--- a/tests/unit/punit_test_main.cpp
+++ b/tests/unit/punit_test_main.cpp
@@ -9,6 +9,7 @@
 // terms of the BSD-3 license. We welcome feedback and contributions, see file
 // CONTRIBUTING.md for details.
 
+#define CATCH_CONFIG_NOSTDOUT
 #define CATCH_CONFIG_RUNNER
 #include "mfem.hpp"
 #include "run_unit_tests.hpp"
@@ -24,12 +25,9 @@ int main(int argc, char *argv[])
 {
 #ifdef MFEM_USE_MPI
    mfem::Mpi::Init();
-   bool root = mfem::Mpi::Root();
    mfem::Hypre::Init();
-#else
-   bool root = true;
 #endif
 
    // Only run tests that are labeled with Parallel.
-   return RunCatchSession(argc, argv, {"[Parallel]"}, root);
+   return RunCatchSession(argc, argv, {"[Parallel]"}, Root());
 }

--- a/tests/unit/run_unit_tests.hpp
+++ b/tests/unit/run_unit_tests.hpp
@@ -58,4 +58,40 @@ static int RunCatchSession(int argc, char *argv[],
    return result;
 }
 
+static inline bool Root()
+{
+#ifdef MFEM_USE_MPI
+   return mfem::Mpi::IsInitialized() ? mfem::Mpi::Root() : true;
+#else
+   return true;
+#endif
+}
+
+#ifdef CATCH_CONFIG_NOSTDOUT
+
+namespace Catch
+{
+
+std::ofstream null_stream;
+
+std::ostream& cout()
+{
+   if (Root()) { return std::cout; }
+   else { return null_stream; }
+}
+std::ostream& cerr()
+{
+   if (Root()) { return std::cerr; }
+   else { return null_stream; }
+}
+std::ostream& clog()
+{
+   if (Root()) { return std::clog; }
+   else { return null_stream; }
+}
+
+} // namespace Catch
+
+#endif
+
 #endif


### PR DESCRIPTION
Small change to the unit tests so that Catch will only write to `cout`, `cerr`, and `clog` from MPI rank 0 when running in parallel. This should avoid duplicating messages such as "All tests passed".<!--GHEX{"author":"pazner","assignment":"2022-03-24T15:16:29","editor":"tzanio","id":2918,"reviewers":["jandrej","acfisher"],"merge":"2022-03-30T15:02:34","approval":"2022-03-28T19:03:44"}XEHG-->
<!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge|
 | --- | --- | --- | --- | --- | --- | --- |
| [#2918](https://github.com/mfem/mfem/pull/2918) | @pazner | @tzanio | @jandrej + @acfisher | 3/24/22 | 3/28/22 | 3/30/22 | |
<!--ELBATXEHG-->

PR Checklist
    
- [x] Code builds.
- [x] Code passes `make style`.

