### PR TITLE
Bug Fix thread safe version of RT_WedgeElement [bugfix/thread-safe-rt-wedge]

### DIFF
--- a/fem/fe/fe_rt.cpp
+++ b/fem/fe/fe_rt.cpp
@@ -1177,7 +1177,7 @@ void RT_WedgeElement::CalcDivShape(const IntegrationPoint &ip,
                                    Vector &divshape) const
 {
 #ifdef MFEM_THREAD_SAFE
-   Vector      trt_dshape(RTSegmentFE.GetDof());
+   Vector      trt_dshape(RTTriangleFE.GetDof());
    Vector      tl2_shape(L2TriangleFE.GetDof());
    Vector      sl2_shape(L2SegmentFE.GetDof());
    DenseMatrix sh1_dshape(H1SegmentFE.GetDof(), 1);


### PR DESCRIPTION
Bug Fix copy-and-paste error in thread safe version of RT_WedgeElement.

This PR should address issue #2914.