### PR TITLE
PA transpose for MixedVectorCurlIntegrator

### DIFF
--- a/fem/bilininteg.hpp
+++ b/fem/bilininteg.hpp
@@ -1899,6 +1899,7 @@ protected:
                            const FiniteElementSpace &test_fes);
 
    virtual void AddMultPA(const Vector&, Vector&) const;
+   virtual void AddMultTransposePA(const Vector&, Vector&) const;
 
 private:
    // PA extension
@@ -2655,6 +2656,7 @@ public:
    virtual void AssemblePA(const FiniteElementSpace &trial_fes,
                            const FiniteElementSpace &test_fes);
    virtual void AddMultPA(const Vector &x, Vector &y) const;
+   virtual void AddMultTransposePA(const Vector &x, Vector &y) const;
    virtual void AssembleDiagonalPA(Vector& diag);
 };
 

--- a/fem/bilininteg.hpp
+++ b/fem/bilininteg.hpp
@@ -1958,6 +1958,7 @@ protected:
                            const FiniteElementSpace &test_fes);
 
    virtual void AddMultPA(const Vector&, Vector&) const;
+   virtual void AddMultTransposePA(const Vector&, Vector&) const;
 
 private:
    // PA extension

--- a/fem/bilininteg_hcurl.cpp
+++ b/fem/bilininteg_hcurl.cpp
@@ -4679,6 +4679,362 @@ static void PAHcurlHdivApply3D(const int D1D,
    }); // end of element loop
 }
 
+// Apply to x corresponding to DOF's in H(div) (test), integrated against the
+// curl of H(curl) trial functions corresponding to y.
+template<int MAX_D1D = HCURL_MAX_D1D, int MAX_Q1D = HCURL_MAX_Q1D>
+static void PAHcurlHdivApply3DTranspose(const int D1D,
+                                        const int D1Dtest,
+                                        const int Q1D,
+                                        const int NE,
+                                        const Array<double> &bo,
+                                        const Array<double> &bc,
+                                        const Array<double> &bot,
+                                        const Array<double> &bct,
+                                        const Array<double> &gct,
+                                        const Vector &pa_data,
+                                        const Vector &x,
+                                        Vector &y)
+{
+   MFEM_VERIFY(D1D <= MAX_D1D, "Error: D1D > MAX_D1D");
+   MFEM_VERIFY(Q1D <= MAX_Q1D, "Error: Q1D > MAX_Q1D");
+   // Using Piola transformations (\nabla\times u) F = 1/det(dF) dF \hat{\nabla}\times\hat{u}
+   // for u in H(curl) and w = (1 / det (dF)) dF \hat{w} for w in H(div), we get
+   // (\nabla\times u) \cdot w = 1/det(dF)^2 \hat{\nabla}\times\hat{u}^T dF^T dF \hat{w}
+   // If c = 0, \hat{\nabla}\times\hat{u} reduces to [0, (u_0)_{x_2}, -(u_0)_{x_1}]
+   // If c = 1, \hat{\nabla}\times\hat{u} reduces to [-(u_1)_{x_2}, 0, (u_1)_{x_0}]
+   // If c = 2, \hat{\nabla}\times\hat{u} reduces to [(u_2)_{x_1}, -(u_2)_{x_0}, 0]
+
+   constexpr static int VDIM = 3;
+
+   auto Bo = Reshape(bo.Read(), Q1D, D1D-1);
+   auto Bc = Reshape(bc.Read(), Q1D, D1D);
+   auto Bot = Reshape(bot.Read(), D1Dtest-1, Q1D);
+   auto Bct = Reshape(bct.Read(), D1Dtest, Q1D);
+   auto Gct = Reshape(gct.Read(), D1D, Q1D);
+   auto op = Reshape(pa_data.Read(), Q1D, Q1D, Q1D, 6, NE);
+   auto X = Reshape(x.Read(), 3*(D1Dtest-1)*(D1Dtest-1)*D1D, NE);
+   auto Y = Reshape(y.ReadWrite(), 3*(D1D-1)*D1D*D1D, NE);
+
+   MFEM_FORALL(e, NE,
+   {
+      double mass[MAX_Q1D][MAX_Q1D][MAX_Q1D][VDIM];  // Assuming HDIV_MAX_D1D <= HCURL_MAX_D1D
+
+      for (int qz = 0; qz < Q1D; ++qz)
+      {
+         for (int qy = 0; qy < Q1D; ++qy)
+         {
+            for (int qx = 0; qx < Q1D; ++qx)
+            {
+               for (int c = 0; c < VDIM; ++c)
+               {
+                  mass[qz][qy][qx][c] = 0.0;
+               }
+            }
+         }
+      }
+
+      int osc = 0;
+
+      for (int c = 0; c < VDIM; ++c)  // loop over x, y, z components
+      {
+         const int D1Dz = (c == 2) ? D1D : D1D - 1;
+         const int D1Dy = (c == 1) ? D1D : D1D - 1;
+         const int D1Dx = (c == 0) ? D1D : D1D - 1;
+
+         for (int dz = 0; dz < D1Dz; ++dz)
+         {
+            double massXY[HDIV_MAX_Q1D][HDIV_MAX_Q1D];
+            for (int qy = 0; qy < Q1D; ++qy)
+            {
+               for (int qx = 0; qx < Q1D; ++qx)
+               {
+                  massXY[qy][qx] = 0.0;
+               }
+            }
+
+            for (int dy = 0; dy < D1Dy; ++dy)
+            {
+               double massX[HDIV_MAX_Q1D];
+               for (int qx = 0; qx < Q1D; ++qx)
+               {
+                  massX[qx] = 0.0;
+               }
+
+               for (int dx = 0; dx < D1Dx; ++dx)
+               {
+                  const double t = X(dx + ((dy + (dz * D1Dy)) * D1Dx) + osc, e);
+                  for (int qx = 0; qx < Q1D; ++qx)
+                  {
+                     massX[qx] += t * ((c == 0) ? Bc(qx,dx) : Bo(qx,dx));
+                  }
+               }
+
+               for (int qy = 0; qy < Q1D; ++qy)
+               {
+                  const double wy = (c == 1) ? Bc(qy,dy) : Bo(qy,dy);
+                  for (int qx = 0; qx < Q1D; ++qx)
+                  {
+                     const double wx = massX[qx];
+                     massXY[qy][qx] += wx * wy;
+                  }
+               }
+            }
+
+            for (int qz = 0; qz < Q1D; ++qz)
+            {
+               const double wz = (c == 2) ? Bc(qz,dz) : Bo(qz,dz);
+               for (int qy = 0; qy < Q1D; ++qy)
+               {
+                  for (int qx = 0; qx < Q1D; ++qx)
+                  {
+                     mass[qz][qy][qx][c] += massXY[qy][qx] * wz;
+                  }
+               }
+            }
+         }
+
+         osc += D1Dx * D1Dy * D1Dz;
+      }  // loop (c) over components
+
+      // Apply D operator.
+      for (int qz = 0; qz < Q1D; ++qz)
+      {
+         for (int qy = 0; qy < Q1D; ++qy)
+         {
+            for (int qx = 0; qx < Q1D; ++qx)
+            {
+               const double O11 = op(qx,qy,qz,0,e);
+               const double O12 = op(qx,qy,qz,1,e);
+               const double O13 = op(qx,qy,qz,2,e);
+               const double O22 = op(qx,qy,qz,3,e);
+               const double O23 = op(qx,qy,qz,4,e);
+               const double O33 = op(qx,qy,qz,5,e);
+               const double massX = mass[qz][qy][qx][0];
+               const double massY = mass[qz][qy][qx][1];
+               const double massZ = mass[qz][qy][qx][2];
+               mass[qz][qy][qx][0] = (O11*massX)+(O12*massY)+(O13*massZ);
+               mass[qz][qy][qx][1] = (O12*massX)+(O22*massY)+(O23*massZ);
+               mass[qz][qy][qx][2] = (O13*massX)+(O23*massY)+(O33*massZ);
+            }
+         }
+      }
+
+      // x component
+      osc = 0;
+      {
+         const int D1Dz = D1D;
+         const int D1Dy = D1D;
+         const int D1Dx = D1D - 1;
+
+         for (int qz = 0; qz < Q1D; ++qz)
+         {
+            double gradXY12[MAX_D1D][MAX_D1D];
+            double gradXY21[MAX_D1D][MAX_D1D];
+
+            for (int dy = 0; dy < D1Dy; ++dy)
+            {
+               for (int dx = 0; dx < D1Dx; ++dx)
+               {
+                  gradXY12[dy][dx] = 0.0;
+                  gradXY21[dy][dx] = 0.0;
+               }
+            }
+            for (int qy = 0; qy < Q1D; ++qy)
+            {
+               double massX[MAX_D1D][2];
+               for (int dx = 0; dx < D1Dx; ++dx)
+               {
+                  for (int n = 0; n < 2; ++n)
+                  {
+                     massX[dx][n] = 0.0;
+                  }
+               }
+               for (int qx = 0; qx < Q1D; ++qx)
+               {
+                  for (int dx = 0; dx < D1Dx; ++dx)
+                  {
+                     const double wx = Bot(dx,qx);
+
+                     massX[dx][0] += wx * mass[qz][qy][qx][1];
+                     massX[dx][1] += wx * mass[qz][qy][qx][2];
+                  }
+               }
+               for (int dy = 0; dy < D1Dy; ++dy)
+               {
+                  const double wy = Bct(dy,qy);
+                  const double wDy = Gct(dy,qy);
+
+                  for (int dx = 0; dx < D1Dx; ++dx)
+                  {
+                     gradXY21[dy][dx] += massX[dx][0] * wy;
+                     gradXY12[dy][dx] += massX[dx][1] * wDy;
+                  }
+               }
+            }
+
+            for (int dz = 0; dz < D1Dz; ++dz)
+            {
+               const double wz = Bct(dz,qz);
+               const double wDz = Gct(dz,qz);
+               for (int dy = 0; dy < D1Dy; ++dy)
+               {
+                  for (int dx = 0; dx < D1Dx; ++dx)
+                  {
+                     // \hat{\nabla}\times\hat{u} is [0, (u_0)_{x_2}, -(u_0)_{x_1}]
+                     // (u_0)_{x_2} * (op * curl)_1 - (u_0)_{x_1} * (op * curl)_2
+                     Y(dx + ((dy + (dz * D1Dy)) * D1Dx) + osc,
+                       e) += (gradXY21[dy][dx] * wDz) - (gradXY12[dy][dx] * wz);
+                  }
+               }
+            }
+         }  // loop qz
+
+         osc += D1Dx * D1Dy * D1Dz;
+      }
+
+      // y component
+      {
+         const int D1Dz = D1D;
+         const int D1Dy = D1D - 1;
+         const int D1Dx = D1D;
+
+         for (int qz = 0; qz < Q1D; ++qz)
+         {
+            double gradXY02[MAX_D1D][MAX_D1D];
+            double gradXY20[MAX_D1D][MAX_D1D];
+
+            for (int dy = 0; dy < D1Dy; ++dy)
+            {
+               for (int dx = 0; dx < D1Dx; ++dx)
+               {
+                  gradXY02[dy][dx] = 0.0;
+                  gradXY20[dy][dx] = 0.0;
+               }
+            }
+            for (int qx = 0; qx < Q1D; ++qx)
+            {
+               double massY[MAX_D1D][2];
+               for (int dy = 0; dy < D1Dy; ++dy)
+               {
+                  massY[dy][0] = 0.0;
+                  massY[dy][1] = 0.0;
+               }
+               for (int qy = 0; qy < Q1D; ++qy)
+               {
+                  for (int dy = 0; dy < D1Dy; ++dy)
+                  {
+                     const double wy = Bot(dy,qy);
+
+                     massY[dy][0] += wy * mass[qz][qy][qx][2];
+                     massY[dy][1] += wy * mass[qz][qy][qx][0];
+                  }
+               }
+               for (int dx = 0; dx < D1Dx; ++dx)
+               {
+                  const double wx = Bct(dx,qx);
+                  const double wDx = Gct(dx,qx);
+
+                  for (int dy = 0; dy < D1Dy; ++dy)
+                  {
+                     gradXY02[dy][dx] += massY[dy][0] * wDx;
+                     gradXY20[dy][dx] += massY[dy][1] * wx;
+                  }
+               }
+            }
+
+            for (int dz = 0; dz < D1Dz; ++dz)
+            {
+               const double wz = Bct(dz,qz);
+               const double wDz = Gct(dz,qz);
+               for (int dy = 0; dy < D1Dy; ++dy)
+               {
+                  for (int dx = 0; dx < D1Dx; ++dx)
+                  {
+                     // \hat{\nabla}\times\hat{u} is [-(u_1)_{x_2}, 0, (u_1)_{x_0}]
+                     // -(u_1)_{x_2} * (op * curl)_0 + (u_1)_{x_0} * (op * curl)_2
+                     Y(dx + ((dy + (dz * D1Dy)) * D1Dx) + osc,
+                       e) += (-gradXY20[dy][dx] * wDz) + (gradXY02[dy][dx] * wz);
+                  }
+               }
+            }
+         }  // loop qz
+
+         osc += D1Dx * D1Dy * D1Dz;
+      }
+
+      // z component
+      {
+         const int D1Dz = D1D - 1;
+         const int D1Dy = D1D;
+         const int D1Dx = D1D;
+
+         for (int qx = 0; qx < Q1D; ++qx)
+         {
+            double gradYZ01[MAX_D1D][MAX_D1D];
+            double gradYZ10[MAX_D1D][MAX_D1D];
+
+            for (int dy = 0; dy < D1Dy; ++dy)
+            {
+               for (int dz = 0; dz < D1Dz; ++dz)
+               {
+                  gradYZ01[dz][dy] = 0.0;
+                  gradYZ10[dz][dy] = 0.0;
+               }
+            }
+            for (int qy = 0; qy < Q1D; ++qy)
+            {
+               double massZ[MAX_D1D][2];
+               for (int dz = 0; dz < D1Dz; ++dz)
+               {
+                  for (int n = 0; n < 2; ++n)
+                  {
+                     massZ[dz][n] = 0.0;
+                  }
+               }
+               for (int qz = 0; qz < Q1D; ++qz)
+               {
+                  for (int dz = 0; dz < D1Dz; ++dz)
+                  {
+                     const double wz = Bot(dz,qz);
+
+                     massZ[dz][0] += wz * mass[qz][qy][qx][0];
+                     massZ[dz][1] += wz * mass[qz][qy][qx][1];
+                  }
+               }
+               for (int dy = 0; dy < D1Dy; ++dy)
+               {
+                  const double wy = Bct(dy,qy);
+                  const double wDy = Gct(dy,qy);
+
+                  for (int dz = 0; dz < D1Dz; ++dz)
+                  {
+                     gradYZ01[dz][dy] += wy * massZ[dz][1];
+                     gradYZ10[dz][dy] += wDy * massZ[dz][0];
+                  }
+               }
+            }
+
+            for (int dx = 0; dx < D1Dx; ++dx)
+            {
+               const double wx = Bct(dx,qx);
+               const double wDx = Gct(dx,qx);
+
+               for (int dy = 0; dy < D1Dy; ++dy)
+               {
+                  for (int dz = 0; dz < D1Dz; ++dz)
+                  {
+                     // \hat{\nabla}\times\hat{u} is [(u_2)_{x_1}, -(u_2)_{x_0}, 0]
+                     // (u_2)_{x_1} * (op * curl)_0 - (u_2)_{x_0} * (op * curl)_1
+                     Y(dx + ((dy + (dz * D1Dy)) * D1Dx) + osc,
+                       e) += (gradYZ10[dz][dy] * wx) - (gradYZ01[dz][dy] * wDx);
+                  }
+               }
+            }
+         }  // loop qx
+      }
+   }); // end of element loop
+}
+
 void MixedVectorCurlIntegrator::AddMultPA(const Vector &x, Vector &y) const
 {
    if (testType == mfem::FiniteElement::CURL &&
@@ -4717,6 +5073,20 @@ void MixedVectorCurlIntegrator::AddMultPA(const Vector &x, Vector &y) const
       PAHcurlHdivApply3D(dofs1D, dofs1Dtest, quad1D, ne, mapsO->B,
                          mapsC->B, mapsOtest->Bt, mapsCtest->Bt, mapsC->G,
                          pa_data, x, y);
+   else
+   {
+      MFEM_ABORT("Unsupported dimension or space!");
+   }
+}
+
+void MixedVectorCurlIntegrator::AddMultTransposePA(const Vector &x,
+                                                   Vector &y) const
+{
+   if (testType == mfem::FiniteElement::DIV &&
+       trialType == mfem::FiniteElement::CURL && dim == 3)
+      PAHcurlHdivApply3DTranspose(dofs1D, dofs1Dtest, quad1D, ne, mapsO->B,
+                                  mapsC->B, mapsOtest->Bt, mapsCtest->Bt,
+                                  mapsC->Gt, pa_data, x, y);
    else
    {
       MFEM_ABORT("Unsupported dimension or space!");

--- a/fem/bilininteg_vectorfe.cpp
+++ b/fem/bilininteg_vectorfe.cpp
@@ -1094,7 +1094,7 @@ void VectorFEMassIntegrator::AddMultTransposePA(const Vector &x,
 
    if (dim == 3 && ((trial_div && test_curl) || (trial_curl && test_div)))
    {
-      const bool scalarCoeff = !(DQ || MQ || SMQ);
+      const bool scalarCoeff = !(DQ || MQ);
       PAHcurlHdivMassApply3D(dofs1D, dofs1Dtest, quad1D, ne, scalarCoeff,
                              trial_div, true, mapsO->B, mapsC->B, mapsOtest->Bt,
                              mapsCtest->Bt, pa_data, x, y);
@@ -1102,7 +1102,7 @@ void VectorFEMassIntegrator::AddMultTransposePA(const Vector &x,
    }
    else if (dim == 2 && ((trial_curl && test_div) || (trial_div && test_curl)))
    {
-      const bool scalarCoeff = !(DQ || MQ || SMQ);
+      const bool scalarCoeff = !(DQ || MQ);
       PAHcurlHdivMassApply2D(dofs1D, dofs1Dtest, quad1D, ne, scalarCoeff,
                              !trial_curl, true, mapsO->B, mapsC->B, mapsOtest->Bt,
                              mapsCtest->Bt, pa_data, x, y);

--- a/fem/bilininteg_vectorfe.cpp
+++ b/fem/bilininteg_vectorfe.cpp
@@ -372,8 +372,8 @@ void PAHcurlHdivSetup2D(const int Q1D,
                const double R21 = D2*J21;
                const double R22 = D2*J22;
                y(i11,qx,qy,e) = w_detJ * ( J22*R11 - J12*R21); // 1,1
-               y(i12,qx,qy,e) = w_detJ * ( J22*R12 - J12*R22); // 1,2
-               y(i21,qx,qy,e) = w_detJ * (-J21*R11 + J11*R21); // 2,1
+               y(i21,qx,qy,e) = w_detJ * ( J22*R12 - J12*R22); // 1,2 (transpose)
+               y(i12,qx,qy,e) = w_detJ * (-J21*R11 + J11*R21); // 2,1 (transpose)
                y(i22,qx,qy,e) = w_detJ * (-J21*R12 + J11*R22); // 2,2
             }
          }
@@ -389,6 +389,7 @@ void PAHcurlHdivMassApply3D(const int D1D,
                             const int NE,
                             const bool scalarCoeff,
                             const bool trialHcurl,
+                            const bool transpose,
                             const Array<double> &Bo_,
                             const Array<double> &Bc_,
                             const Array<double> &Bot_,
@@ -412,6 +413,13 @@ void PAHcurlHdivMassApply3D(const int D1D,
    auto x = Reshape(x_.Read(), 3*(D1D-1)*D1D*(trialHcurl ? D1D : D1D-1), NE);
    auto y = Reshape(y_.ReadWrite(), 3*(D1Dtest-1)*D1Dtest*
                     (trialHcurl ? D1Dtest-1 : D1Dtest), NE);
+
+   const int i12 = transpose ? 3 : 1;
+   const int i13 = transpose ? 6 : 2;
+   const int i21 = transpose ? 1 : 3;
+   const int i23 = transpose ? 7 : 5;
+   const int i31 = transpose ? 2 : 6;
+   const int i32 = transpose ? 5 : 7;
 
    MFEM_FORALL(e, NE,
    {
@@ -507,13 +515,13 @@ void PAHcurlHdivMassApply3D(const int D1D,
             for (int qx = 0; qx < Q1D; ++qx)
             {
                const double O11 = op(0,qx,qy,qz,e);
-               const double O12 = scalarCoeff ? 0.0 : op(1,qx,qy,qz,e);
-               const double O13 = scalarCoeff ? 0.0 : op(2,qx,qy,qz,e);
-               const double O21 = scalarCoeff ? 0.0 : op(3,qx,qy,qz,e);
+               const double O12 = scalarCoeff ? 0.0 : op(i12,qx,qy,qz,e);
+               const double O13 = scalarCoeff ? 0.0 : op(i13,qx,qy,qz,e);
+               const double O21 = scalarCoeff ? 0.0 : op(i21,qx,qy,qz,e);
                const double O22 = scalarCoeff ? O11 : op(4,qx,qy,qz,e);
-               const double O23 = scalarCoeff ? 0.0 : op(5,qx,qy,qz,e);
-               const double O31 = scalarCoeff ? 0.0 : op(6,qx,qy,qz,e);
-               const double O32 = scalarCoeff ? 0.0 : op(7,qx,qy,qz,e);
+               const double O23 = scalarCoeff ? 0.0 : op(i23,qx,qy,qz,e);
+               const double O31 = scalarCoeff ? 0.0 : op(i31,qx,qy,qz,e);
+               const double O32 = scalarCoeff ? 0.0 : op(i32,qx,qy,qz,e);
                const double O33 = scalarCoeff ? O11 : op(8,qx,qy,qz,e);
                const double massX = mass[qz][qy][qx][0];
                const double massY = mass[qz][qy][qx][1];
@@ -601,6 +609,7 @@ void PAHcurlHdivMassApply2D(const int D1D,
                             const int NE,
                             const bool scalarCoeff,
                             const bool trialHcurl,
+                            const bool transpose,
                             const Array<double> &Bo_,
                             const Array<double> &Bc_,
                             const Array<double> &Bot_,
@@ -623,6 +632,9 @@ void PAHcurlHdivMassApply2D(const int D1D,
    auto op = Reshape(op_.Read(), scalarCoeff ? 1 : 4, Q1D, Q1D, NE);
    auto x = Reshape(x_.Read(), 2*(D1D-1)*D1D, NE);
    auto y = Reshape(y_.ReadWrite(), 2*(D1Dtest-1)*D1Dtest, NE);
+
+   const int i12 = transpose ? 2 : 1;
+   const int i21 = transpose ? 1 : 2;
 
    MFEM_FORALL(e, NE,
    {
@@ -685,8 +697,8 @@ void PAHcurlHdivMassApply2D(const int D1D,
          for (int qx = 0; qx < Q1D; ++qx)
          {
             const double O11 = op(0,qx,qy,e);
-            const double O12 = scalarCoeff ? 0.0 : op(1,qx,qy,e);
-            const double O21 = scalarCoeff ? 0.0 : op(2,qx,qy,e);
+            const double O12 = scalarCoeff ? 0.0 : op(i12,qx,qy,e);
+            const double O21 = scalarCoeff ? 0.0 : op(i21,qx,qy,e);
             const double O22 = scalarCoeff ? O11 : op(3,qx,qy,e);
             const double massX = mass[qy][qx][0];
             const double massY = mass[qy][qx][1];
@@ -1026,14 +1038,14 @@ void VectorFEMassIntegrator::AddMultPA(const Vector &x, Vector &y) const
       {
          const bool scalarCoeff = !(DQ || MQ || SMQ);
          PAHcurlHdivMassApply3D(dofs1D, dofs1Dtest, quad1D, ne, scalarCoeff,
-                                true, mapsO->B, mapsC->B, mapsOtest->Bt,
+                                true, false, mapsO->B, mapsC->B, mapsOtest->Bt,
                                 mapsCtest->Bt, pa_data, x, y);
       }
       else if (trial_div && test_curl)
       {
          const bool scalarCoeff = !(DQ || MQ || SMQ);
          PAHcurlHdivMassApply3D(dofs1D, dofs1Dtest, quad1D, ne, scalarCoeff,
-                                false, mapsO->B, mapsC->B, mapsOtest->Bt,
+                                false, false, mapsO->B, mapsC->B, mapsOtest->Bt,
                                 mapsCtest->Bt, pa_data, x, y);
       }
       else
@@ -1057,13 +1069,46 @@ void VectorFEMassIntegrator::AddMultPA(const Vector &x, Vector &y) const
       {
          const bool scalarCoeff = !(DQ || MQ || SMQ);
          PAHcurlHdivMassApply2D(dofs1D, dofs1Dtest, quad1D, ne, scalarCoeff,
-                                trial_curl, mapsO->B, mapsC->B, mapsOtest->Bt,
-                                mapsCtest->Bt, pa_data, x, y);
+                                trial_curl, false, mapsO->B, mapsC->B,
+                                mapsOtest->Bt, mapsCtest->Bt, pa_data, x, y);
       }
       else
       {
          MFEM_ABORT("Unknown kernel.");
       }
+   }
+}
+
+void VectorFEMassIntegrator::AddMultTransposePA(const Vector &x,
+                                                Vector &y) const
+{
+   const bool trial_curl = (trial_fetype == mfem::FiniteElement::CURL);
+   const bool trial_div = (trial_fetype == mfem::FiniteElement::DIV);
+   const bool test_curl = (test_fetype == mfem::FiniteElement::CURL);
+   const bool test_div = (test_fetype == mfem::FiniteElement::DIV);
+
+   bool symmetricSpaces = true;
+
+   if (dim == 3 && ((trial_div && test_curl) || (trial_curl && test_div)))
+   {
+      const bool scalarCoeff = !(DQ || MQ || SMQ);
+      PAHcurlHdivMassApply3D(dofs1D, dofs1Dtest, quad1D, ne, scalarCoeff,
+                             trial_div, true, mapsO->B, mapsC->B, mapsOtest->Bt,
+                             mapsCtest->Bt, pa_data, x, y);
+      symmetricSpaces = false;
+   }
+   else if (dim == 2 && ((trial_curl && test_div) || (trial_div && test_curl)))
+   {
+      const bool scalarCoeff = !(DQ || MQ || SMQ);
+      PAHcurlHdivMassApply2D(dofs1D, dofs1Dtest, quad1D, ne, scalarCoeff,
+                             !trial_curl, true, mapsO->B, mapsC->B, mapsOtest->Bt,
+                             mapsCtest->Bt, pa_data, x, y);
+      symmetricSpaces = false;
+   }
+
+   if (symmetricSpaces)
+   {
+      this->AddMultPA(x, y);
    }
 }
 

--- a/tests/unit/fem/test_pa_coeff.cpp
+++ b/tests/unit/fem/test_pa_coeff.cpp
@@ -309,7 +309,7 @@ TEST_CASE("Hcurl/Hdiv pa_coeff",
       const int ne = 3;
       Mesh mesh = MakeCartesianNonaligned(dimension, ne);
 
-      for (int coeffType = 3; coeffType < 5; ++coeffType)
+      for (int coeffType = 0; coeffType < 5; ++coeffType)
       {
          Coefficient* coeff = nullptr;
          Coefficient* coeff2 = nullptr;
@@ -348,7 +348,7 @@ TEST_CASE("Hcurl/Hdiv pa_coeff",
 
          enum MixedSpaces {Hcurl, Hdiv, HcurlHdiv, HdivHcurl, NumSpaceTypes};
 
-         for (int spaceType = 2; spaceType < NumSpaceTypes; ++spaceType)
+         for (int spaceType = 0; spaceType < NumSpaceTypes; ++spaceType)
          {
             if (spaceType == Hdiv && coeffType >= 2)
             {
@@ -507,12 +507,47 @@ TEST_CASE("Hcurl/Hdiv pa_coeff",
                      paform->FormRectangularSystemMatrix(ess_tdof_list, empty_ess, paopr);
 
                      assemblyform->Assemble();
+                     assemblyform->Finalize();
+
                      OperatorPtr A_explicit;
                      assemblyform->FormRectangularSystemMatrix(ess_tdof_list, empty_ess, A_explicit);
 
                      paopr->Mult(xin, y_pa);
                      assemblyform->Mult(xin, y_assembly);
                      A_explicit->Mult(xin, y_mat);
+
+                     // Test the transpose
+                     if (spaceType == HcurlHdiv && dimension == 3)
+                     {
+                        Vector u(testSize);
+                        u.Randomize();
+
+                        Vector v_mat(fespace.GetTrueVSize());
+                        v_mat = 0.0;
+                        Vector v_assembly(fespace.GetTrueVSize());
+                        v_assembly = 0.0;
+                        Vector v_pa(fespace.GetTrueVSize());
+                        v_pa = 0.0;
+
+                        const SparseMatrix& A_spmat = assemblyform->SpMat();
+                        A_spmat.EnsureMultTranspose();
+                        paopr->MultTranspose(u, v_pa);
+                        assemblyform->MultTranspose(u, v_assembly);
+                        A_spmat.MultTranspose(u, v_mat);
+
+                        v_pa -= v_mat;
+                        double pa_error = v_pa.Norml2();
+                        std::cout << "  order: " << order
+                                  << ", pa transpose error norm: " << pa_error << std::endl;
+                        REQUIRE(pa_error < 1.e-12);
+
+                        v_assembly -= v_mat;
+                        double assembly_error = v_assembly.Norml2();
+                        std::cout << "  order: " << order
+                                  << ", assembly transpose error norm: " << assembly_error
+                                  << std::endl;
+                        REQUIRE(assembly_error < 1.e-12);
+                     }
 
                      delete paform;
                      delete assemblyform;

--- a/tests/unit/fem/test_pa_coeff.cpp
+++ b/tests/unit/fem/test_pa_coeff.cpp
@@ -486,17 +486,33 @@ TEST_CASE("Hcurl/Hdiv pa_coeff",
                         assemblyform->AddDomainIntegrator(new VectorFEMassIntegrator(*coeff));
                      }
 
-                     if (spaceType == HcurlHdiv && dimension == 3)
+                     if (dimension == 3 && (spaceType == HcurlHdiv || spaceType == HdivHcurl))
                      {
                         if (coeffType == 2)
                         {
-                           paform->AddDomainIntegrator(new MixedVectorCurlIntegrator(*vcoeff));
-                           assemblyform->AddDomainIntegrator(new MixedVectorCurlIntegrator(*vcoeff));
+                           if (spaceType == HcurlHdiv)
+                           {
+                              paform->AddDomainIntegrator(new MixedVectorCurlIntegrator(*vcoeff));
+                              assemblyform->AddDomainIntegrator(new MixedVectorCurlIntegrator(*vcoeff));
+                           }
+                           else
+                           {
+                              paform->AddDomainIntegrator(new MixedVectorWeakCurlIntegrator(*vcoeff));
+                              assemblyform->AddDomainIntegrator(new MixedVectorWeakCurlIntegrator(*vcoeff));
+                           }
                         }
                         else if (coeffType < 2)
                         {
-                           paform->AddDomainIntegrator(new MixedVectorCurlIntegrator(*coeff));
-                           assemblyform->AddDomainIntegrator(new MixedVectorCurlIntegrator(*coeff));
+                           if (spaceType == HcurlHdiv)
+                           {
+                              paform->AddDomainIntegrator(new MixedVectorCurlIntegrator(*coeff));
+                              assemblyform->AddDomainIntegrator(new MixedVectorCurlIntegrator(*coeff));
+                           }
+                           else
+                           {
+                              paform->AddDomainIntegrator(new MixedVectorWeakCurlIntegrator(*coeff));
+                              assemblyform->AddDomainIntegrator(new MixedVectorWeakCurlIntegrator(*coeff));
+                           }
                         }
                      }
 
@@ -517,7 +533,8 @@ TEST_CASE("Hcurl/Hdiv pa_coeff",
                      A_explicit->Mult(xin, y_mat);
 
                      // Test the transpose
-                     if (spaceType == HcurlHdiv && dimension == 3)
+                     if ((spaceType == HcurlHdiv || spaceType == HdivHcurl) &&
+                         dimension == 3)
                      {
                         Vector u(testSize);
                         u.Randomize();


### PR DESCRIPTION
- [x] Expanded the unit tests (some were excluded by a previous PR).
- [x] Fixed a bug in `PAHcurlHdivSetup2D` revealed by the unit tests.
- [x] Implemented `AddMultTransposePA` for `VectorFEMassIntegrator`.
- [x] Implemented `AddMultTransposePA` for `MixedVectorCurlIntegrator`.
- [x] Implemented `AddMultTransposePA` for `MixedVectorWeakCurlIntegrator` for H(curl) x H(div).
- [x] Tested with CUDA.

Note that some of these integrators do not have shared memory versions, so they will run out of memory quickly (with respect to polynomial order), especially in 3D.  <!--GHEX{"author":"dylan-copeland","assignment":"2022-03-24T14:32:59","editor":"tzanio","id":2921,"reviewers":["mlstowell","v-dobrev","YohannDudouit","tzanio"],"merge":"2022-04-15T16:27:29","approval":"2022-04-11T22:57:37"}XEHG-->
<!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge|
 | --- | --- | --- | --- | --- | --- | --- |
| [#2921](https://github.com/mfem/mfem/pull/2921) | @dylan-copeland | @tzanio | @mlstowell + @v-dobrev + @YohannDudouit + @tzanio | 3/24/22 | 4/11/22 | 4/15/22 | |
<!--ELBATXEHG-->

PR Checklist
    
- [x] Code builds.
- [x] Code passes `make style`.
