### PR TITLE
Add support for ParaView output of linear pyramid elements

### DIFF
--- a/mesh/vtk.cpp
+++ b/mesh/vtk.cpp
@@ -20,26 +20,27 @@ namespace mfem
 
 const int VTKGeometry::Map[Geometry::NUM_GEOMETRIES] =
 {
-   POINT, SEGMENT, TRIANGLE, SQUARE, TETRAHEDRON, CUBE, PRISM
+   POINT, SEGMENT, TRIANGLE, SQUARE, TETRAHEDRON, CUBE, PRISM, PYRAMID
 };
 
 const int VTKGeometry::QuadraticMap[Geometry::NUM_GEOMETRIES] =
 {
    POINT, QUADRATIC_SEGMENT, QUADRATIC_TRIANGLE, BIQUADRATIC_SQUARE,
-   QUADRATIC_TETRAHEDRON, TRIQUADRATIC_CUBE, BIQUADRATIC_QUADRATIC_PRISM
+   QUADRATIC_TETRAHEDRON, TRIQUADRATIC_CUBE, BIQUADRATIC_QUADRATIC_PRISM,
+   QUADRATIC_PYRAMID
 };
 
 const int VTKGeometry::HighOrderMap[Geometry::NUM_GEOMETRIES] =
 {
    POINT, LAGRANGE_SEGMENT, LAGRANGE_TRIANGLE, LAGRANGE_SQUARE,
-   LAGRANGE_TETRAHEDRON, LAGRANGE_CUBE, LAGRANGE_PRISM
+   LAGRANGE_TETRAHEDRON, LAGRANGE_CUBE, LAGRANGE_PRISM, LAGRANGE_PYRAMID
 };
 
 const int VTKGeometry::PrismMap[6] = {0, 2, 1, 3, 5, 4};
 
 const int *VTKGeometry::VertexPermutation[Geometry::NUM_GEOMETRIES] =
 {
-   NULL, NULL, NULL, NULL, NULL, NULL, VTKGeometry::PrismMap
+   NULL, NULL, NULL, NULL, NULL, NULL, VTKGeometry::PrismMap, NULL
 };
 
 Geometry::Type VTKGeometry::GetMFEMGeometry(int vtk_geom)
@@ -72,6 +73,10 @@ Geometry::Type VTKGeometry::GetMFEMGeometry(int vtk_geom)
       case BIQUADRATIC_QUADRATIC_PRISM:
       case LAGRANGE_PRISM:
          return Geometry::PRISM;
+      case PYRAMID:
+      case QUADRATIC_PYRAMID:
+      case LAGRANGE_PYRAMID:
+         return Geometry::PYRAMID;
       default:
          return Geometry::INVALID;
    }
@@ -79,7 +84,7 @@ Geometry::Type VTKGeometry::GetMFEMGeometry(int vtk_geom)
 
 bool VTKGeometry::IsLagrange(int vtk_geom)
 {
-   return vtk_geom >= LAGRANGE_SEGMENT && vtk_geom <= LAGRANGE_PRISM;
+   return vtk_geom >= LAGRANGE_SEGMENT && vtk_geom <= LAGRANGE_PYRAMID;
 }
 
 bool VTKGeometry::IsQuadratic(int vtk_geom)
@@ -145,6 +150,9 @@ int VTKGeometry::GetOrder(int vtk_geom, int npoints)
                          - twentyseventh);
             return std::round(term + ninth / term - 4*third);
          }
+         case LAGRANGE_PYRAMID:
+            MFEM_ABORT("Lagrange pyramids not currently supported in VTK.");
+            return 0;
       }
    }
    return 1;
@@ -534,6 +542,10 @@ void CreateVTKElementConnectivity(Array<int> &con, Geometry::Type geom, int ref)
             }
          }
       }
+   }
+   else if (geom == Geometry::PYRAMID)
+   {
+      MFEM_ABORT("Lagrange pyramid elements not currently supported in VTK.");
    }
    else
    {

--- a/mesh/vtk.hpp
+++ b/mesh/vtk.hpp
@@ -37,6 +37,7 @@ struct VTKGeometry
    static const int TETRAHEDRON = 10;
    static const int CUBE = 12;
    static const int PRISM = 13;
+   static const int PYRAMID = 14;
    ///@}
 
    /// @name Legacy quadratic VTK geometric types
@@ -48,6 +49,7 @@ struct VTKGeometry
    static const int TRIQUADRATIC_CUBE = 29;
    static const int QUADRATIC_PRISM = 26;
    static const int BIQUADRATIC_QUADRATIC_PRISM = 32;
+   static const int QUADRATIC_PYRAMID = 27;
    ///@}
 
    /// @name Arbitrary-order VTK geometric types
@@ -58,6 +60,7 @@ struct VTKGeometry
    static const int LAGRANGE_TETRAHEDRON = 71;
    static const int LAGRANGE_CUBE = 72;
    static const int LAGRANGE_PRISM = 73;
+   static const int LAGRANGE_PYRAMID = 74;
    ///@}
    ///@}
 


### PR DESCRIPTION
Resolves #2926.

Lagrange pyramid elements don't appear to be currently supported in VTK (and MFEM is limited to lowest-order pyramid elements anyway).

![pyramid](https://user-images.githubusercontent.com/11493037/159969869-bbcbbada-fb3d-4a16-9ed9-0b25d9713b0f.png)
<!--GHEX{"author":"pazner","assignment":"2022-03-27T20:38:07","editor":"tzanio","id":2932,"reviewers":["tzanio","mlstowell"],"merge":"2022-04-12T14:18:07","approval":"2022-04-11T20:07:18"}XEHG-->
<!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge|
 | --- | --- | --- | --- | --- | --- | --- |
| [#2932](https://github.com/mfem/mfem/pull/2932) | @pazner | @tzanio | @tzanio + @mlstowell | 3/27/22 | 4/11/22 | 4/12/22 | |
<!--ELBATXEHG-->

PR Checklist:
    
- [x] Code builds
- [x] Code passes `make style`
- [x] Update `CHANGELOG` 👈 I didn't update the CHANGELOG, this can probably be considered a bugfix rather than new feature.
