### PR TITLE
[Discuss] Passing q-data to the DG trace integrator

### DIFF
--- a/fem/bilininteg.hpp
+++ b/fem/bilininteg.hpp
@@ -2932,6 +2932,7 @@ protected:
    const DofToQuad *maps;             ///< Not owned
    const FaceGeometricFactors *geom;  ///< Not owned
    int dim, nf, nq, dofs1D, quad1D;
+   Vector *external_vel = nullptr;
 
 private:
    Vector shape1, shape2;
@@ -2942,12 +2943,13 @@ public:
    { rho = NULL; u = &u_; alpha = a; beta = 0.5*a; }
 
    /// Construct integrator with rho = 1.
-   DGTraceIntegrator(VectorCoefficient &u_, double a, double b)
-   { rho = NULL; u = &u_; alpha = a; beta = b; }
+   DGTraceIntegrator(VectorCoefficient &u_, double a, double b,
+                     Vector *external_vel_ = nullptr)
+   { rho = NULL; u = &u_; alpha = a; beta = b; external_vel = external_vel_;}
 
    DGTraceIntegrator(Coefficient &rho_, VectorCoefficient &u_,
                      double a, double b)
-   { rho = &rho_; u = &u_; alpha = a; beta = b; }
+   { rho = &rho_; u = &u_; alpha = a; beta = b;}
 
    using BilinearFormIntegrator::AssembleFaceMatrix;
    virtual void AssembleFaceMatrix(const FiniteElement &el1,

--- a/fem/bilininteg_dgtrace_pa.cpp
+++ b/fem/bilininteg_dgtrace_pa.cpp
@@ -291,9 +291,21 @@ void DGTraceIntegrator::SetupPA(const FiniteElementSpace &fes, FaceType type)
       }
       MFEM_VERIFY(f_ind==nf, "Incorrect number of faces.");
    }
-   PADGTraceSetup(dim, dofs1D, quad1D, nf, ir->GetWeights(),
-                  geom->detJ, geom->normal, r, vel,
-                  alpha, beta, pa_data);
+
+   if (external_vel)
+   {
+
+      PADGTraceSetup(dim, dofs1D, quad1D, nf, ir->GetWeights(),
+                     geom->detJ, geom->normal, r, *external_vel,
+                     alpha, beta, pa_data);
+   }
+   else
+   {
+
+      PADGTraceSetup(dim, dofs1D, quad1D, nf, ir->GetWeights(),
+                     geom->detJ, geom->normal, r, vel,
+                     alpha, beta, pa_data);
+   }
 }
 
 void DGTraceIntegrator::AssemblePAInteriorFaces(const FiniteElementSpace& fes)


### PR DESCRIPTION
Hi folks, 

Currently there isn't a way to pass in custom quadrature data to the DG trace integrator, so in my application I have a small hack in MFEM so I can pass in a custom velocity. 

Could the work in the following PR's be used to address this issue? 

https://github.com/mfem/mfem/pull/2891
https://github.com/mfem/mfem/pull/1656
 