### PR TITLE
Fix TODO item in MixedBilinearForm::FormRectangularSystemMatrix

### DIFF
--- a/fem/bilinearform.cpp
+++ b/fem/bilinearform.cpp
@@ -1763,9 +1763,21 @@ void MixedBilinearForm::FormRectangularSystemMatrix(
 
    mat->Finalize();
 
-   if (test_P) // TODO: Must actually check for trial_P too
+   if (test_P && trial_P)
    {
       SparseMatrix *m = RAP(*test_P, *mat, *trial_P);
+      delete mat;
+      mat = m;
+   }
+   else if (test_P)
+   {
+      SparseMatrix *m = mfem::Mult(*test_P, *mat);
+      delete mat;
+      mat = m;
+   }
+   else if (trial_P)
+   {
+      SparseMatrix *m = mfem::Mult(*mat, *trial_P);
       delete mat;
       mat = m;
    }

--- a/fem/bilinearform.cpp
+++ b/fem/bilinearform.cpp
@@ -1771,7 +1771,7 @@ void MixedBilinearForm::FormRectangularSystemMatrix(
    }
    else if (test_P)
    {
-      SparseMatrix *m = mfem::Mult(*test_P, *mat);
+      SparseMatrix *m = TransposeMult(*test_P, *mat);
       delete mat;
       mat = m;
    }


### PR DESCRIPTION
This fixes `MixedBilinearForm::FormRectangularSystemMatrix` in the case where one space has a prolongation matrix, but the other one doesn't.<!--GHEX{"author":"pazner","assignment":"2022-04-15T16:35:13","editor":"tzanio","id":2968,"reviewers":["tzanio","psocratis"],"merge":"2022-04-17T22:42:11","approval":"2022-04-15T18:44:56"}XEHG-->
<!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge|
 | --- | --- | --- | --- | --- | --- | --- |
| [#2968](https://github.com/mfem/mfem/pull/2968) | @pazner | @tzanio | @tzanio + @psocratis | 4/15/22 | 4/15/22 | 4/17/22 | |
<!--ELBATXEHG-->

PR Checklist
    
- [x] Code builds.
- [x] Code passes `make style`.
