### PR TITLE
fix VTK ASCII output

### DIFF
--- a/mesh/vtk.hpp
+++ b/mesh/vtk.hpp
@@ -145,7 +145,7 @@ template <typename T>
 void WriteBinaryOrASCII(std::ostream &os, std::vector<char> &buf, const T &val,
                         const char *suffix, VTKFormat format)
 {
-   if (format == VTKFormat::ASCII) { out << val << suffix; }
+   if (format == VTKFormat::ASCII) { os << val << suffix; }
    else { bin_io::AppendBytes(buf, val); }
 }
 


### PR DESCRIPTION
Fixes small bug in ASCII VTK output.<!--GHEX{"author":"ebchin","assignment":"2022-05-04T21:39:13","editor":"tzanio","id":2996,"reviewers":["tzanio","pazner","mlstowell"],"merge":"2022-05-08T21:12:22","approval":"2022-05-04T22:17:42"}XEHG-->
<!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge|
 | --- | --- | --- | --- | --- | --- | --- |
| [#2996](https://github.com/mfem/mfem/pull/2996) | @ebchin | @tzanio | @tzanio + @pazner + @mlstowell | 5/4/22 | 5/4/22 | 5/8/22 | |
<!--ELBATXEHG-->

**PR Checklist**
    
- [x] Code builds.
- [x] Code passes `make style`.
