### PR TITLE
Extrapolate

### DIFF
--- a/fem/gridfunc.hpp
+++ b/fem/gridfunc.hpp
@@ -475,23 +475,30 @@ public:
                                              Array<int> &bdr_attr);
 
 
-   virtual double ComputeL2Error(Coefficient &exsol,
+  /*  virtual double ComputeL2Error(Coefficient &exsol,
                                  const IntegrationRule *irs[] = NULL) const
    { return ComputeLpError(2.0, exsol, NULL, irs); }
-
+*/
+  /*   virtual double ComputeL2Error(Coefficient *exsol[],
+       const IntegrationRule *irs[] = NULL) const;*/
    virtual double ComputeL2Error(Coefficient *exsol[],
-                                 const IntegrationRule *irs[] = NULL) const;
-
-   virtual double ComputeL2Error(VectorCoefficient &exsol,
                                  const IntegrationRule *irs[] = NULL,
-                                 Array<int> *elems = NULL) const;
+				 Array<int> *elems = NULL) const;
 
-   /// Returns ||grad u_ex - grad u_h||_L2 for H1 or L2 elements
-   virtual double ComputeGradError(VectorCoefficient *exgrad,
+  virtual double ComputeL2Error(Coefficient &exsol,
+                                 const IntegrationRule *irs[] = NULL,
+				 Array<int> *elems = NULL) const;
+
+  virtual double ComputeL2Error(VectorCoefficient &exsol,
+				const IntegrationRule *irs[] = NULL,
+				Array<int> *elems = NULL) const;
+  
+  /// Returns ||grad u_ex - grad u_h||_L2 for H1 or L2 elements
+  virtual double ComputeGradError(VectorCoefficient *exgrad,
                                    const IntegrationRule *irs[] = NULL) const;
-
-   /// Returns ||curl u_ex - curl u_h||_L2 for ND elements
-   virtual double ComputeCurlError(VectorCoefficient *excurl,
+  
+  /// Returns ||curl u_ex - curl u_h||_L2 for ND elements
+  virtual double ComputeCurlError(VectorCoefficient *excurl,
                                    const IntegrationRule *irs[] = NULL) const;
 
    /// Returns ||div u_ex - div u_h||_L2 for RT elements

--- a/fem/pgridfunc.hpp
+++ b/fem/pgridfunc.hpp
@@ -278,16 +278,31 @@ public:
                                  const IntegrationRule *irs[] = NULL) const
    { return ComputeLpError(1.0, exsol, NULL, NULL, irs); }
 
-   virtual double ComputeL2Error(Coefficient *exsol[],
+  /* virtual double ComputeL2Error(Coefficient *exsol[],
                                  const IntegrationRule *irs[] = NULL) const
    {
       return GlobalLpNorm(2.0, GridFunction::ComputeL2Error(exsol, irs),
                           pfes->GetComm());
+   }*/
+   virtual double ComputeL2Error(Coefficient *exsol[],
+                                 const IntegrationRule *irs[] = NULL,
+                                 Array<int> *elems = NULL) const
+   {
+      return GlobalLpNorm(2.0, GridFunction::ComputeL2Error(exsol, irs, elems),
+                          pfes->GetComm());
    }
 
-   virtual double ComputeL2Error(Coefficient &exsol,
+  virtual double ComputeL2Error(Coefficient &exsol,
+				const IntegrationRule *irs[] = NULL,
+				Array<int> *elems = NULL) const
+   {
+      return GlobalLpNorm(2.0, GridFunction::ComputeL2Error(exsol, irs, elems),
+                          pfes->GetComm());
+   }
+
+  /*  virtual double ComputeL2Error(Coefficient &exsol,
                                  const IntegrationRule *irs[] = NULL) const
-   { return ComputeLpError(2.0, exsol, NULL, irs); }
+				 { return ComputeLpError(2.0, exsol, NULL, irs); }*/
 
    virtual double ComputeL2Error(VectorCoefficient &exsol,
                                  const IntegrationRule *irs[] = NULL,

--- a/miniapps/shifted/makefile
+++ b/miniapps/shifted/makefile
@@ -55,7 +55,7 @@ COMMON_LIB += $(if $(MFEM_SHARED:YES=),,\
 %: %.cpp
 %.o: %.cpp
 
-%.o: $(SRC)%.cpp $(wildcard $(SRC)%.hpp) $(MFEM_LIB_FILE) $(CONFIG_MK) | lib-common
+%.o: $(SRC)%.cpp $(wildcard $(SRC)%.hpp) sbm_aux.hpp $(MFEM_LIB_FILE) $(CONFIG_MK) | lib-common
 	$(MFEM_CXX) $(MFEM_FLAGS) -c $< -o $@
 
 all: $(MINIAPPS)


### PR DESCRIPTION
Modified the ComputeL2Error functions by adding an element array as an input. The L2 error will be only computed on those select elements.