### PR TITLE
Replace `MPI_Session` with `Mpi::Init`

### DIFF
--- a/miniapps/navier/navier_turbchan.cpp
+++ b/miniapps/navier/navier_turbchan.cpp
@@ -89,7 +89,8 @@ void vel_wall(const Vector &x, double t, Vector &u)
 
 int main(int argc, char *argv[])
 {
-   MPI_Session mpi(argc, argv);
+   Mpi::Init();
+   Hypre::Init();
 
    double Lx = 2.0 * M_PI;
    double Ly = 1.0;
@@ -121,7 +122,7 @@ int main(int argc, char *argv[])
    Mesh periodic_mesh = Mesh::MakePeriodic(mesh,
                                            mesh.CreatePeriodicVertexMapping(translations));
 
-   if (mpi.Root())
+   if (Mpi::Root())
    {
       printf("NL=%d NX=%d NY=%d NZ=%d dx+=%f\n", NL, NX, NY, NZ, LC * ctx.Re_tau);
       std::cout << "Number of elements: " << mesh.GetNE() << std::endl;
@@ -193,7 +194,7 @@ int main(int argc, char *argv[])
          dt = 1e-2;
       }
 
-      if (mpi.Root())
+      if (Mpi::Root())
       {
          printf("%11s %11s\n", "Time", "dt");
          printf("%.5E %.5E\n", t, dt);


### PR DESCRIPTION
In `navier_turbchan.cpp`, switch to `Mpi::Init()` instead of `MPI_Session` similar to all other examples and miniapps.

This should resolve #2957.<!--GHEX{"author":"v-dobrev","assignment":"2022-05-25T02:58:41","editor":"tzanio","id":3040,"reviewers":["jandrej","tzanio"],"merge":"2022-05-27T16:20:32","approval":"2022-05-25T18:50:09"}XEHG-->
<!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge|
 | --- | --- | --- | --- | --- | --- | --- |
| [#3040](https://github.com/mfem/mfem/pull/3040) | @v-dobrev | @tzanio | @jandrej + @tzanio | 5/24/22 | 5/25/22 | 5/27/22 | |
<!--ELBATXEHG-->

# PR Checklist
    
- [x] Code builds.
- [x] Code passes `make style`.
