### PR TITLE
Initial support for `Operator::Mult` with multiple RHS

### DIFF
--- a/fem/bilinearform_ext.hpp
+++ b/fem/bilinearform_ext.hpp
@@ -199,10 +199,6 @@ public:
                                             Vector &x, Vector &b,
                                             OperatorHandle &A, Vector &X, Vector &B) = 0;
 
-   virtual void AddMult(const Vector &x, Vector &y, const double c=1.0) const = 0;
-   virtual void AddMultTranspose(const Vector &x, Vector &y,
-                                 const double c=1.0) const = 0;
-
    virtual void AssembleDiagonal_ADAt(const Vector &D, Vector &diag) const = 0;
 
    virtual void Update() = 0;
@@ -278,7 +274,7 @@ public:
    /// Partial assembly of all internal integrators
    void Assemble();
 
-   void AddMult(const Vector &x, Vector &y, const double c) const;
+   void AddMult(const Vector &x, Vector &y, const double c=1.0) const;
 
    void AddMultTranspose(const Vector &x, Vector &y, const double c=1.0) const;
 

--- a/fem/ceed/interface/operator.cpp
+++ b/fem/ceed/interface/operator.cpp
@@ -69,9 +69,11 @@ void Operator::Mult(const mfem::Vector &x, mfem::Vector &y) const
 #endif
 }
 
-void Operator::AddMult(const mfem::Vector &x, mfem::Vector &y) const
+void Operator::AddMult(const mfem::Vector &x, mfem::Vector &y,
+                       const double a) const
 {
 #ifdef MFEM_USE_CEED
+   MFEM_VERIFY(a == 1.0, "General coefficient case is not yet supported!");
    const CeedScalar *x_ptr;
    CeedScalar *y_ptr;
    CeedMemType mem;

--- a/fem/ceed/interface/operator.hpp
+++ b/fem/ceed/interface/operator.hpp
@@ -38,7 +38,8 @@ public:
    Operator(CeedOperator op);
 #endif
    void Mult(const mfem::Vector &x, mfem::Vector &y) const override;
-   void AddMult(const mfem::Vector &x, mfem::Vector &y) const;
+   void AddMult(const mfem::Vector &x, mfem::Vector &y,
+                const double a = 1.0) const override;
    void GetDiagonal(mfem::Vector &diag) const;
    using mfem::Operator::SetupRAP;
    virtual ~Operator()

--- a/fem/fespace.cpp
+++ b/fem/fespace.cpp
@@ -1960,7 +1960,7 @@ FiniteElementSpace::DerefinementOperator::DerefinementOperator(
          DenseMatrix &lM = localM[g](mi[s]);
          DenseMatrix &lR = localR[g](lR_offset+s);
          MultAtB(lP, lM, lR); // lR = lP^T lM
-         AddMult(lR, lP, lPtMP); // lPtMP += lP^T lM lP
+         mfem::AddMult(lR, lP, lPtMP); // lPtMP += lP^T lM lP
       }
       DenseMatrixInverse lPtMP_inv(lPtMP);
       for (int s = 0; s < nm; s++)
@@ -2007,7 +2007,7 @@ void FiniteElementSpace::DerefinementOperator
          x.GetSubVector(f_vdofs, loc_x);
          loc_x_mat.UseExternalData(loc_x.GetData(), f_vdofs.Size()/fine_vdim,
                                    fine_vdim);
-         AddMult(lR, loc_x_mat, loc_y_mat);
+         mfem::AddMult(lR, loc_x_mat, loc_y_mat);
       }
       y.SetSubVector(c_vdofs, loc_y);
    }

--- a/fem/prestriction.cpp
+++ b/fem/prestriction.cpp
@@ -124,8 +124,10 @@ void ParNCH1FaceRestriction::Mult(const Vector &x, Vector &y) const
    }
 }
 
-void ParNCH1FaceRestriction::AddMultTranspose(const Vector &x, Vector &y) const
+void ParNCH1FaceRestriction::AddMultTranspose(const Vector &x, Vector &y,
+                                              const double a) const
 {
+   MFEM_VERIFY(a == 1.0, "General coefficient case is not yet supported!");
    if (nf==0) { return; }
    if (x_interp.Size()==0)
    {
@@ -906,8 +908,10 @@ void ParNCL2FaceRestriction::Mult(const Vector& x, Vector& y) const
    }
 }
 
-void ParNCL2FaceRestriction::AddMultTranspose(const Vector &x, Vector &y) const
+void ParNCL2FaceRestriction::AddMultTranspose(const Vector &x, Vector &y,
+                                              const double a) const
 {
+   MFEM_VERIFY(a == 1.0, "General coefficient case is not yet supported!");
    if (nf==0) { return; }
    if (type==FaceType::Interior)
    {

--- a/fem/prestriction.hpp
+++ b/fem/prestriction.hpp
@@ -65,8 +65,10 @@ public:
                      requested by @a type in the constructor.
                      The face_dofs should be ordered according to the given
                      ElementDofOrdering.
-       @param[in,out] y The L-vector degrees of freedom. */
-   void AddMultTranspose(const Vector &x, Vector &y) const override;
+       @param[in,out] y The L-vector degrees of freedom.
+       @param[in]  a Scalar coefficient for addition. */
+   void AddMultTranspose(const Vector &x, Vector &y,
+                         const double a = 1.0) const override;
 
 private:
    /** @brief Compute the scatter indices: L-vector to E-vector, the offsets
@@ -262,8 +264,10 @@ public:
                      requested by @a type in the constructor.
                      The face_dofs should be ordered according to the given
                      ElementDofOrdering
-       @param[in,out] y The L-vector degrees of freedom. */
-   void AddMultTranspose(const Vector &x, Vector &y) const override;
+       @param[in,out] y The L-vector degrees of freedom.
+       @param[in]  a Scalar coefficient for addition. */
+   void AddMultTranspose(const Vector &x, Vector &y,
+                         const double a = 1.0) const override;
 
    /** @brief Fill the I array of SparseMatrix corresponding to the sparsity
        pattern given by this ParNCL2FaceRestriction.

--- a/fem/restriction.cpp
+++ b/fem/restriction.cpp
@@ -732,8 +732,10 @@ void H1FaceRestriction::Mult(const Vector& x, Vector& y) const
    });
 }
 
-void H1FaceRestriction::AddMultTranspose(const Vector& x, Vector& y) const
+void H1FaceRestriction::AddMultTranspose(const Vector& x, Vector& y,
+                                         const double a) const
 {
+   MFEM_VERIFY(a == 1.0, "General coefficient case is not yet supported!");
    if (nf==0) { return; }
    // Assumes all elements have the same number of dofs
    const int nface_dofs = face_dofs;
@@ -1238,8 +1240,10 @@ void L2FaceRestriction::DoubleValuedConformingAddMultTranspose(
    });
 }
 
-void L2FaceRestriction::AddMultTranspose(const Vector& x, Vector& y) const
+void L2FaceRestriction::AddMultTranspose(const Vector& x, Vector& y,
+                                         const double a) const
 {
+   MFEM_VERIFY(a == 1.0, "General coefficient case is not yet supported!");
    if (nf==0) { return; }
    if (m == L2FaceValues::DoubleValued)
    {
@@ -1987,8 +1991,10 @@ void NCL2FaceRestriction::DoubleValuedNonconformingTransposeInterpolation(
    });
 }
 
-void NCL2FaceRestriction::AddMultTranspose(const Vector& x, Vector& y) const
+void NCL2FaceRestriction::AddMultTranspose(const Vector& x, Vector& y,
+                                           const double a) const
 {
+   MFEM_VERIFY(a == 1.0, "General coefficient case is not yet supported!");
    if (nf==0) { return; }
    if (type==FaceType::Interior)
    {

--- a/fem/restriction.hpp
+++ b/fem/restriction.hpp
@@ -159,8 +159,10 @@ public:
        @param[in]     x The face degrees of freedom on the face.
        @param[in,out] y The L-vector of degrees of freedom to which we add the
                         face degrees of freedom.
+       @param[in]     a Scalar coefficient for addition.
    */
-   virtual void AddMultTranspose(const Vector &x, Vector &y) const = 0;
+   virtual void AddMultTranspose(const Vector &x, Vector &y,
+                                 const double a = 1.0) const override = 0;
 
    /** @brief Set the face degrees of freedom in the element degrees of freedom
        @a y to the values given in @a x.
@@ -238,8 +240,10 @@ public:
                      requested by @a type in the constructor.
                      The face_dofs should be ordered according to the given
                      ElementDofOrdering
-       @param[in,out] y The L-vector degrees of freedom. */
-   void AddMultTranspose(const Vector &x, Vector &y) const override;
+       @param[in,out] y The L-vector degrees of freedom.
+       @param[in]  a Scalar coefficient for addition. */
+   void AddMultTranspose(const Vector &x, Vector &y,
+                         const double a = 1.0) const override;
 
 private:
    /** @brief Compute the scatter indices: L-vector to E-vector, and the offsets
@@ -368,8 +372,10 @@ public:
                      requested by @a type in the constructor.
                      The face_dofs should be ordered according to the given
                      ElementDofOrdering
-       @param[in,out] y The L-vector degrees of freedom. */
-   void AddMultTranspose(const Vector &x, Vector &y) const override;
+       @param[in,out] y The L-vector degrees of freedom.
+       @param[in]  a Scalar coefficient for addition. */
+   void AddMultTranspose(const Vector &x, Vector &y,
+                         const double a = 1.0) const override;
 
    /** @brief Fill the I array of SparseMatrix corresponding to the sparsity
        pattern given by this L2FaceRestriction.
@@ -746,8 +752,10 @@ public:
                      requested by @a type in the constructor.
                      The face_dofs should be ordered according to the given
                      ElementDofOrdering
-       @param[in,out] y The L-vector degrees of freedom. */
-   void AddMultTranspose(const Vector &x, Vector &y) const override;
+       @param[in,out] y The L-vector degrees of freedom.
+       @param[in]  a Scalar coefficient for addition. */
+   void AddMultTranspose(const Vector &x, Vector &y,
+                         const double a = 1.0) const override;
 
    /** @brief Fill the I array of SparseMatrix corresponding to the sparsity
        pattern given by this NCL2FaceRestriction.

--- a/fem/tbilinearform.hpp
+++ b/fem/tbilinearform.hpp
@@ -615,6 +615,7 @@ public:
          solFES.VectorAssemble(y_dof.layout, y_dof, solVecLayoutLoc, y);
       }
    }
+   using Operator::AddMult;
 };
 
 } // namespace mfem

--- a/linalg/complex_operator.hpp
+++ b/linalg/complex_operator.hpp
@@ -111,6 +111,9 @@ public:
    virtual void Mult(const Vector &x, Vector &y) const;
    virtual void MultTranspose(const Vector &x, Vector &y) const;
 
+   using Operator::Mult;
+   using Operator::MultTranspose;
+
    virtual Type GetType() const { return Complex_Operator; }
 
    Convention GetConvention() const { return convention_; }

--- a/linalg/densemat.cpp
+++ b/linalg/densemat.cpp
@@ -221,8 +221,13 @@ void DenseMatrix::MultTranspose(const Vector &x, Vector &y) const
    MultTranspose((const double *)x, (double *)y);
 }
 
-void DenseMatrix::AddMult(const Vector &x, Vector &y) const
+void DenseMatrix::AddMult(const Vector &x, Vector &y, const double a) const
 {
+   if (a != 1.0)
+   {
+      AddMult_a(a, x, y);
+      return;
+   }
    MFEM_ASSERT(height == y.Size() && width == x.Size(),
                "incompatible dimensions");
 
@@ -239,8 +244,14 @@ void DenseMatrix::AddMult(const Vector &x, Vector &y) const
    }
 }
 
-void DenseMatrix::AddMultTranspose(const Vector &x, Vector &y) const
+void DenseMatrix::AddMultTranspose(const Vector &x, Vector &y,
+                                   const double a) const
 {
+   if (a != 1.0)
+   {
+      AddMultTranspose_a(a, x, y);
+      return;
+   }
    MFEM_ASSERT(height == x.Size() && width == y.Size(),
                "incompatible dimensions");
 

--- a/linalg/densemat.hpp
+++ b/linalg/densemat.hpp
@@ -150,11 +150,15 @@ public:
    /// Multiply a vector with the transpose matrix.
    virtual void MultTranspose(const Vector &x, Vector &y) const;
 
+   using Operator::Mult;
+   using Operator::MultTranspose;
+
    /// y += A.x
-   void AddMult(const Vector &x, Vector &y) const;
+   virtual void AddMult(const Vector &x, Vector &y, const double a = 1.0) const;
 
    /// y += A^t x
-   void AddMultTranspose(const Vector &x, Vector &y) const;
+   virtual void AddMultTranspose(const Vector &x, Vector &y,
+                                 const double a = 1.0) const;
 
    /// y += a * A.x
    void AddMult_a(double a, const Vector &x, Vector &y) const;
@@ -772,6 +776,8 @@ public:
 
    /// Multiply the inverse matrix by another matrix: X <- A^{-1} X.
    void Mult(DenseMatrix &X) const {factors->Solve(width, X.Width(), X.Data());}
+
+   using Operator::Mult;
 
    /// Compute and return the inverse matrix in Ainv.
    void GetInverseMatrix(DenseMatrix &Ainv) const;

--- a/linalg/hypre.hpp
+++ b/linalg/hypre.hpp
@@ -676,6 +676,11 @@ public:
    virtual void MultTranspose(const Vector &x, Vector &y) const
    { MultTranspose(1.0, x, 0.0, y); }
 
+   virtual void AddMult(const Vector &x, Vector &y, const double a = 1.0) const
+   { Mult(a, x, 1.0, y); }
+   virtual void AddMultTranspose(const Vector &x, Vector &y, const double a = 1.0) const
+   { MultTranspose(a, x, 1.0, y); }
+
    /** @brief Computes y = a * |A| * x + b * y, using entry-wise absolute values
        of the matrix A. */
    void AbsMult(double a, const Vector &x, double b, Vector &y) const;

--- a/linalg/hypre.hpp
+++ b/linalg/hypre.hpp
@@ -678,8 +678,12 @@ public:
 
    virtual void AddMult(const Vector &x, Vector &y, const double a = 1.0) const
    { Mult(a, x, 1.0, y); }
-   virtual void AddMultTranspose(const Vector &x, Vector &y, const double a = 1.0) const
+   virtual void AddMultTranspose(const Vector &x, Vector &y,
+                                 const double a = 1.0) const
    { MultTranspose(a, x, 1.0, y); }
+
+   using Operator::Mult;
+   using Operator::MultTranspose;
 
    /** @brief Computes y = a * |A| * x + b * y, using entry-wise absolute values
        of the matrix A. */
@@ -1040,6 +1044,7 @@ public:
    /// Relax the linear system Ax=b
    virtual void Mult(const HypreParVector &b, HypreParVector &x) const;
    virtual void Mult(const Vector &b, Vector &x) const;
+   using Operator::Mult;
 
    /// Apply transpose of the smoother to relax the linear system Ax=b
    virtual void MultTranspose(const Vector &b, Vector &x) const;
@@ -1116,6 +1121,7 @@ public:
    virtual void Mult(const HypreParVector &b, HypreParVector &x) const;
    /// Solve the linear system Ax=b
    virtual void Mult(const Vector &b, Vector &x) const;
+   using Operator::Mult;
 
    ///@}
 

--- a/linalg/operator.cpp
+++ b/linalg/operator.cpp
@@ -48,6 +48,66 @@ void Operator::InitTVectors(const Operator *Po, const Operator *Ri,
    }
 }
 
+void Operator::AddMult(const Vector &x, Vector &y, const double a) const
+{
+   mfem::Vector z(y.Size());
+   Mult(x, z);
+   y.Add(a, z);
+}
+
+void Operator::AddMultTranspose(const Vector &x, Vector &y, const double a) const
+{
+   mfem::Vector z(y.Size());
+   MultTranspose(x, z);
+   y.Add(a, z);
+}
+
+void Operator::Mult(const Array<Vector *> &X, Array<Vector *> &Y) const
+{
+   MFEM_ASSERT(X.Size() == Y.Size(),
+               "Number of columns mismatch in Operator::Mult!");
+   for (int i = 0; i < X.Size(); i++)
+   {
+      MFEM_ASSERT(X[i] && Y[i], "Missing Vector in Operator::Mult!");
+      Mult(*X[i], *Y[i]);
+   }
+}
+
+void Operator::MultTranspose(const Array<Vector *> &X, Array<Vector *> &Y) const
+{
+   MFEM_ASSERT(X.Size() == Y.Size(),
+               "Number of columns mismatch in Operator::MultTranspose!");
+   for (int i = 0; i < X.Size(); i++)
+   {
+      MFEM_ASSERT(X[i] && Y[i], "Missing Vector in Operator::Mult!");
+      MultTranspose(*X[i], *Y[i]);
+   }
+}
+
+void Operator::AddMult(const Array<Vector *> &X, Array<Vector *> &Y,
+                       const double a) const
+{
+   MFEM_ASSERT(X.Size() == Y.Size(),
+               "Number of columns mismatch in Operator::Mult!");
+   for (int i = 0; i < X.Size(); i++)
+   {
+      MFEM_ASSERT(X[i] && Y[i], "Missing Vector in Operator::Mult!");
+      AddMult(*X[i], *Y[i], a);
+   }
+}
+
+void Operator::AddMultTranspose(const Array<Vector *> &X, Array<Vector *> &Y,
+                                const double a) const
+{
+   MFEM_ASSERT(X.Size() == Y.Size(),
+               "Number of columns mismatch in Operator::MultTranspose!");
+   for (int i = 0; i < X.Size(); i++)
+   {
+      MFEM_ASSERT(X[i] && Y[i], "Missing Vector in Operator::Mult!");
+      AddMultTranspose(*X[i], *Y[i], a);
+   }
+}
+
 void Operator::FormLinearSystem(const Array<int> &ess_tdof_list,
                                 Vector &x, Vector &b,
                                 Operator* &Aout, Vector &X, Vector &B,

--- a/linalg/operator.cpp
+++ b/linalg/operator.cpp
@@ -55,7 +55,8 @@ void Operator::AddMult(const Vector &x, Vector &y, const double a) const
    y.Add(a, z);
 }
 
-void Operator::AddMultTranspose(const Vector &x, Vector &y, const double a) const
+void Operator::AddMultTranspose(const Vector &x, Vector &y,
+                                const double a) const
 {
    mfem::Vector z(y.Size());
    MultTranspose(x, z);

--- a/linalg/operator.hpp
+++ b/linalg/operator.hpp
@@ -93,6 +93,26 @@ public:
    virtual void MultTranspose(const Vector &x, Vector &y) const
    { mfem_error("Operator::MultTranspose() is not overloaded!"); }
 
+   /// y += A(x) (default)  or  y += a * A(x)
+   virtual void AddMult(const Vector &x, Vector &y, const double a = 1.0) const;
+
+   /// y += A^t(x) (default)  or  y += a * A^t(x)
+   virtual void AddMultTranspose(const Vector &x, Vector &y, const double a = 1.0) const;
+
+   /// Operator application on a matrix: `Y=A(X)`.
+   virtual void Mult(const Array<Vector *> &X, Array<Vector *> &Y) const;
+
+   /// Action of the transpose operator on a matrix: `Y=A^t(X)`.
+   virtual void MultTranspose(const Array<Vector *> &X, Array<Vector *> &Y) const;
+
+   /// Y += A(X) (default)  or  Y += a * A(X)
+   virtual void AddMult(const Array<Vector *> &X, Array<Vector *> &Y,
+                        const double a = 1.0) const;
+
+   /// Y += A^t(X) (default)  or  Y += a * A^t(X)
+   virtual void AddMultTranspose(const Array<Vector *> &X, Array<Vector *> &Y,
+                                 const double a = 1.0) const;
+
    /** @brief Evaluate the gradient operator at the point @a x. The default
        behavior in class Operator is to generate an error. */
    virtual Operator &GetGradient(const Vector &x) const

--- a/linalg/operator.hpp
+++ b/linalg/operator.hpp
@@ -91,13 +91,14 @@ public:
    /** @brief Action of the transpose operator: `y=A^t(x)`. The default behavior
        in class Operator is to generate an error. */
    virtual void MultTranspose(const Vector &x, Vector &y) const
-   { mfem_error("Operator::MultTranspose() is not overloaded!"); }
+   { mfem_error("Operator::MultTranspose() is not overridden!"); }
 
-   /// y += A(x) (default)  or  y += a * A(x)
+   /// y += A(x) (default) or y += a * A(x)
    virtual void AddMult(const Vector &x, Vector &y, const double a = 1.0) const;
 
-   /// y += A^t(x) (default)  or  y += a * A^t(x)
-   virtual void AddMultTranspose(const Vector &x, Vector &y, const double a = 1.0) const;
+   /// y += A^t(x) (default) or y += a * A^t(x)
+   virtual void AddMultTranspose(const Vector &x, Vector &y,
+                                 const double a = 1.0) const;
 
    /// Operator application on a matrix: `Y=A(X)`.
    virtual void Mult(const Array<Vector *> &X, Array<Vector *> &Y) const;
@@ -117,7 +118,7 @@ public:
        behavior in class Operator is to generate an error. */
    virtual Operator &GetGradient(const Vector &x) const
    {
-      mfem_error("Operator::GetGradient() is not overloaded!");
+      mfem_error("Operator::GetGradient() is not overridden!");
       return const_cast<Operator &>(*this);
    }
 

--- a/linalg/petsc.hpp
+++ b/linalg/petsc.hpp
@@ -439,6 +439,12 @@ public:
    virtual void MultTranspose(const Vector &x, Vector &y) const
    { MultTranspose(1.0, x, 0.0, y); }
 
+   virtual void AddMult(const Vector &x, Vector &y, const double a = 1.0) const
+   { Mult(a, x, 1.0, y); }
+
+   virtual void AddMultTranspose(const Vector &x, Vector &y, const double a = 1.0) const
+   { MultTranspose(a, x, 1.0, y); }
+
    /// Get the associated MPI communicator
    MPI_Comm GetComm() const;
 

--- a/linalg/petsc.hpp
+++ b/linalg/petsc.hpp
@@ -442,7 +442,8 @@ public:
    virtual void AddMult(const Vector &x, Vector &y, const double a = 1.0) const
    { Mult(a, x, 1.0, y); }
 
-   virtual void AddMultTranspose(const Vector &x, Vector &y, const double a = 1.0) const
+   virtual void AddMultTranspose(const Vector &x, Vector &y,
+                                 const double a = 1.0) const
    { MultTranspose(a, x, 1.0, y); }
 
    /// Get the associated MPI communicator

--- a/linalg/solvers.hpp
+++ b/linalg/solvers.hpp
@@ -1145,6 +1145,7 @@ public:
    virtual void MultTranspose(const Vector &x, Vector &y) const { Mult(x, y, true); }
    virtual void SetOperator(const Operator &op) { }
    HypreSmoother& GetSmoother() { return *aux_smoother_.As<HypreSmoother>(); }
+   using Operator::Mult;
 };
 #endif // MFEM_USE_MPI
 

--- a/linalg/sparsemat.hpp
+++ b/linalg/sparsemat.hpp
@@ -345,14 +345,14 @@ public:
    virtual void Mult(const Vector &x, Vector &y) const;
 
    /// y += A * x (default)  or  y += a * A * x
-   void AddMult(const Vector &x, Vector &y, const double a = 1.0) const;
+   virtual void AddMult(const Vector &x, Vector &y, const double a = 1.0) const;
 
    /// Multiply a vector with the transposed matrix. y = At * x
-   void MultTranspose(const Vector &x, Vector &y) const;
+   virtual void MultTranspose(const Vector &x, Vector &y) const;
 
    /// y += At * x (default)  or  y += a * At * x
-   void AddMultTranspose(const Vector &x, Vector &y,
-                         const double a = 1.0) const;
+   virtual void AddMultTranspose(const Vector &x, Vector &y,
+                                 const double a = 1.0) const;
 
    /** @brief Build and store internally the transpose of this matrix which will
        be used in the methods AddMultTranspose(), MultTranspose(), and

--- a/linalg/sparsemat.hpp
+++ b/linalg/sparsemat.hpp
@@ -345,7 +345,8 @@ public:
    virtual void Mult(const Vector &x, Vector &y) const;
 
    /// y += A * x (default)  or  y += a * A * x
-   virtual void AddMult(const Vector &x, Vector &y, const double a = 1.0) const;
+   virtual void AddMult(const Vector &x, Vector &y,
+                        const double a = 1.0) const;
 
    /// Multiply a vector with the transposed matrix. y = At * x
    virtual void MultTranspose(const Vector &x, Vector &y) const;


### PR DESCRIPTION
Interface upgrades for #3072, which is based on this branch.

Includes:
- `Operator::Mult(const Array<Vector *> &X, Array<Vector *> &Y)` overload for application to multiple RHS. Base class implementation just loops over columns of the input and calls `Mult` on each Vector.
- `Operator::AddMult` and `Operator::AddMultTranspose` methods to the base `Operator` class for derived classes which already implement this.
<!--GHEX{"author":"sebastiangrimberg","assignment":"2022-06-16T23:49:23","editor":"mlstowell","id":3073,"reviewers":["psocratis","jandrej"],"merge":"2022-07-07T23:49:23","approval":"2022-06-30T23:49:23"}XEHG-->
<!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge|
 | --- | --- | --- | --- | --- | --- | --- |
| [#3073](https://github.com/mfem/mfem/pull/3073) | @sebastiangrimberg | @mlstowell | @psocratis + @jandrej | 6/16/22 | ⌛due 6/30/22 | ⌛due 7/7/22 | |
<!--ELBATXEHG-->