### PR TITLE
Support map type INTEGRAL in device DomainLFIntegrator

### DIFF
--- a/fem/linearform.cpp
+++ b/fem/linearform.cpp
@@ -133,7 +133,6 @@ bool LinearForm::SupportsDevice()
    for (int e = 0; e < fes->GetNE(); ++e)
    {
       const FiniteElement *fe = fes->GetFE(e);
-      if (fe->GetMapType() != FiniteElement::VALUE) { return false; }
       if (!dynamic_cast<const TensorBasisElement*>(fe)) { return false; }
    }
 

--- a/fem/lininteg_domain.cpp
+++ b/fem/lininteg_domain.cpp
@@ -18,8 +18,9 @@ namespace mfem
 
 template<int T_D1D = 0, int T_Q1D = 0> static
 void DLFEvalAssemble2D(const int vdim, const int ne, const int d, const int q,
-                       const int *markers, const double *b, const double *j,
-                       const double *weights, const Vector &coeff, double *y)
+                       const int map_type, const int *markers, const double *b,
+                       const double *j, const double *weights,
+                       const Vector &coeff, double *y)
 {
    const auto F = coeff.Read();
    const auto M = Reshape(markers, ne);
@@ -54,11 +55,19 @@ void DLFEvalAssemble2D(const int vdim, const int ne, const int d, const int q,
          {
             MFEM_FOREACH_THREAD(y,y,q)
             {
-               const double J11 = J(x,y,0,0,e);
-               const double J21 = J(x,y,1,0,e);
-               const double J12 = J(x,y,0,1,e);
-               const double J22 = J(x,y,1,1,e);
-               const double detJ = J11 * J22 - J21 * J12;
+               double detJ;
+               if (map_type == FiniteElement::VALUE)
+               {
+                  const double J11 = J(x,y,0,0,e);
+                  const double J21 = J(x,y,1,0,e);
+                  const double J12 = J(x,y,0,1,e);
+                  const double J22 = J(x,y,1,1,e);
+                  detJ = J11 * J22 - J21 * J12;
+               }
+               else
+               {
+                  detJ = 1.0;
+               }
                const double coeff_val = cst ? cst_val : C(c,x,y,e);
                QQ(y,x) = W(x,y) * coeff_val * detJ;
             }
@@ -90,8 +99,9 @@ void DLFEvalAssemble2D(const int vdim, const int ne, const int d, const int q,
 
 template<int T_D1D = 0, int T_Q1D = 0> static
 void DLFEvalAssemble3D(const int vdim, const int ne, const int d, const int q,
-                       const int *markers, const double *b, const double *j,
-                       const double *weights, const Vector &coeff, double *y)
+                       const int map_type, const int *markers, const double *b,
+                       const double *j, const double *weights,
+                       const Vector &coeff, double *y)
 {
    const auto F = coeff.Read();
    const auto M = Reshape(markers, ne);
@@ -128,18 +138,26 @@ void DLFEvalAssemble3D(const int vdim, const int ne, const int d, const int q,
             {
                for (int z = 0; z < q; ++z)
                {
-                  const double J11 = J(x,y,z,0,0,e);
-                  const double J21 = J(x,y,z,1,0,e);
-                  const double J31 = J(x,y,z,2,0,e);
-                  const double J12 = J(x,y,z,0,1,e);
-                  const double J22 = J(x,y,z,1,1,e);
-                  const double J32 = J(x,y,z,2,1,e);
-                  const double J13 = J(x,y,z,0,2,e);
-                  const double J23 = J(x,y,z,1,2,e);
-                  const double J33 = J(x,y,z,2,2,e);
-                  const double detJ = J11 * (J22 * J33 - J32 * J23) -
-                  /* */               J21 * (J12 * J33 - J32 * J13) +
-                  /* */               J31 * (J12 * J23 - J22 * J13);
+                  double detJ;
+                  if (map_type == FiniteElement::VALUE)
+                  {
+                     const double J11 = J(x,y,z,0,0,e);
+                     const double J21 = J(x,y,z,1,0,e);
+                     const double J31 = J(x,y,z,2,0,e);
+                     const double J12 = J(x,y,z,0,1,e);
+                     const double J22 = J(x,y,z,1,1,e);
+                     const double J32 = J(x,y,z,2,1,e);
+                     const double J13 = J(x,y,z,0,2,e);
+                     const double J23 = J(x,y,z,1,2,e);
+                     const double J33 = J(x,y,z,2,2,e);
+                     detJ = J11 * (J22 * J33 - J32 * J23) -
+                     /* */  J21 * (J12 * J33 - J32 * J13) +
+                     /* */  J31 * (J12 * J23 - J22 * J13);
+                  }
+                  else
+                  {
+                     detJ = 1.0;
+                  }
                   const double coeff_val = cst_coeff ? cst_val : C(c,x,y,z,e);
                   QQQ(z,y,x) = W(x,y,z) * coeff_val * detJ;
                }
@@ -206,6 +224,7 @@ static void DLFEvalAssemble(const FiniteElementSpace &fes,
    const int d = maps.ndof, q = maps.nqpt;
    constexpr int flags = GeometricFactors::JACOBIANS;
    const GeometricFactors *geom = mesh->GetGeometricFactors(*ir, flags, mt);
+   const int map_type = fes.GetFE(0)->GetMapType();
    decltype(&DLFEvalAssemble2D<>) ker =
       dim == 2 ? DLFEvalAssemble2D<> : DLFEvalAssemble3D<>;
 
@@ -244,7 +263,7 @@ static void DLFEvalAssemble(const FiniteElementSpace &fes,
    const double *J = geom->J.Read();
    const double *W = ir->GetWeights().Read();
    double *Y = y.ReadWrite();
-   ker(vdim, ne, d, q, M, B, J, W, coeff, Y);
+   ker(vdim, ne, d, q, map_type, M, B, J, W, coeff, Y);
 }
 
 void DomainLFIntegrator::AssembleDevice(const FiniteElementSpace &fes,


### PR DESCRIPTION
Adds support for map type `INTEGRAL` for L2 spaces for the device version of `DomainLFIntegrator`, with accompanying unit test.