### PR TITLE
Support map type INTEGRAL in PA VectorFEDivergenceIntegrator

### DIFF
--- a/fem/bilininteg.hpp
+++ b/fem/bilininteg.hpp
@@ -2423,6 +2423,7 @@ private:
    const DofToQuad *mapsO;         ///< Not owned. DOF-to-quad map, open.
    const DofToQuad *L2mapsO;       ///< Not owned. DOF-to-quad map, open.
    const DofToQuad *mapsC;         ///< Not owned. DOF-to-quad map, closed.
+   const GeometricFactors *geom;   ///< Not owned.
    int dim, ne, dofs1D, L2dofs1D, quad1D;
 
 public:

--- a/fem/bilininteg_hdiv.cpp
+++ b/fem/bilininteg_hdiv.cpp
@@ -1209,6 +1209,19 @@ VectorFEDivergenceIntegrator::AssemblePA(const FiniteElementSpace &trial_fes,
       }
    }
 
+   if (test_el->GetMapType() == FiniteElement::INTEGRAL)
+   {
+      geom = mesh->GetGeometricFactors(*ir, GeometricFactors::DETERMINANTS);
+      for (int i=0; i<ne*nq; ++i)
+      {
+         coeff[i] /= geom->detJ[i];
+      }
+   }
+   else
+   {
+      geom = nullptr;
+   }
+
    if (trial_el->GetDerivType() == mfem::FiniteElement::DIV && dim == 3)
    {
       PADivL2Setup3D(quad1D, ne, ir->GetWeights(), coeff, pa_data);

--- a/tests/unit/fem/test_pa_coeff.cpp
+++ b/tests/unit/fem/test_pa_coeff.cpp
@@ -606,6 +606,8 @@ TEST_CASE("Hcurl/Hdiv PA Coefficient",
 TEST_CASE("Hcurl/Hdiv Mixed PA Coefficient",
           "[CUDA][PartialAssembly][Coefficient]")
 {
+   const double tol = 2e-12;
+
    for (dimension = 2; dimension < 4; ++dimension)
    {
       const int ne = 3;
@@ -628,10 +630,18 @@ TEST_CASE("Hcurl/Hdiv Mixed PA Coefficient",
             dcoeff = new VectorFunctionCoefficient(dimension, &vectorCoeffFunction);
          }
 
-         enum MixedSpaces {HcurlH1, HcurlL2, HdivL2, HcurlH1_2D, NumSpaceTypes};
+         enum MixedSpaces
+         {
+            HcurlH1,
+            HcurlL2,
+            HdivL2,
+            HdivL2_Integral,
+            HcurlH1_2D,
+            NumSpaceTypes
+         };
          for (int spaceType = 0; spaceType < NumSpaceTypes; ++spaceType)
          {
-            if (spaceType == HdivL2 && coeffType == 1)
+            if ((spaceType == HdivL2 || spaceType == HdivL2_Integral) && coeffType == 1)
             {
                continue;  // This case fails, maybe because of insufficient quadrature.
             }
@@ -657,22 +667,27 @@ TEST_CASE("Hcurl/Hdiv Mixed PA Coefficient",
                   FiniteElementCollection* vec_fec = nullptr;
                   if (spaceType == HcurlH1 || spaceType == HcurlL2 || spaceType == HcurlH1_2D)
                   {
-                     vec_fec = (FiniteElementCollection*) new ND_FECollection(order, dimension);
+                     vec_fec = new ND_FECollection(order, dimension);
                   }
                   else
                   {
-                     vec_fec = (FiniteElementCollection*) new RT_FECollection(order-1, dimension);
+                     vec_fec = new RT_FECollection(order-1, dimension);
                   }
 
                   FiniteElementCollection* scalar_fec = nullptr;
                   if (spaceType == HcurlH1 || spaceType == HcurlH1_2D)
                   {
-                     scalar_fec = (FiniteElementCollection*) new H1_FECollection(order, dimension);
+                     scalar_fec = new H1_FECollection(order, dimension);
+                  }
+                  else if (spaceType == HdivL2_Integral)
+                  {
+                     const int map_type = FiniteElement::INTEGRAL;
+                     scalar_fec = new L2_FECollection(
+                        order-1, dimension, BasisType::GaussLegendre, map_type);
                   }
                   else
                   {
-                     scalar_fec = (FiniteElementCollection*) new L2_FECollection(order-1,
-                                                                                 dimension);
+                     scalar_fec = new L2_FECollection(order-1, dimension);
                   }
 
                   FiniteElementSpace v_fespace(&mesh, vec_fec);
@@ -751,10 +766,12 @@ TEST_CASE("Hcurl/Hdiv Mixed PA Coefficient",
 
                   const SparseMatrix& A_explicit = assemblyform->SpMat();
 
-                  Vector *xin = new Vector((spaceType == HcurlH1) ? s_fespace.GetTrueVSize() :
-                                           v_fespace.GetTrueVSize());
-                  xin->Randomize();
-                  Vector y_mat((spaceType == HdivL2 || spaceType == HcurlH1_2D ||
+                  Vector xin((spaceType == HcurlH1) ?
+                             s_fespace.GetTrueVSize() :
+                             v_fespace.GetTrueVSize());
+                  xin.Randomize();
+                  Vector y_mat((spaceType == HdivL2 || spaceType == HdivL2_Integral ||
+                                spaceType == HcurlH1_2D ||
                                 (spaceType == HcurlL2 &&
                                  dimension == 2)) ? s_fespace.GetTrueVSize() :
                                v_fespace.GetTrueVSize());
@@ -764,26 +781,26 @@ TEST_CASE("Hcurl/Hdiv Mixed PA Coefficient",
                   Vector y_pa(y_mat.Size());
                   y_pa = 0.0;
 
-                  paform->Mult(*xin, y_pa);
-                  assemblyform->Mult(*xin, y_assembly);
-                  A_explicit.Mult(*xin, y_mat);
+                  paform->Mult(xin, y_pa);
+                  assemblyform->Mult(xin, y_assembly);
+                  A_explicit.Mult(xin, y_mat);
 
                   y_pa -= y_mat;
                   double pa_error = y_pa.Norml2();
-                  REQUIRE(pa_error < 1.e-12);
+                  REQUIRE(pa_error == MFEM_Approx(0, tol, tol));
 
                   y_assembly -= y_mat;
                   double assembly_error = y_assembly.Norml2();
-                  REQUIRE(assembly_error < 1.e-12);
+                  REQUIRE(assembly_error == MFEM_Approx(0, tol, tol));
 
-                  delete xin;
-                  if (spaceType == HdivL2 || spaceType == HcurlH1_2D ||
+                  if (spaceType == HdivL2 || spaceType == HdivL2_Integral ||
+                      spaceType == HcurlH1_2D ||
                       spaceType == HcurlH1 || (spaceType == HcurlL2 && dimension == 2))
                   {
                      // Test the transpose.
-                     xin = new Vector(spaceType == HcurlH1 ? v_fespace.GetTrueVSize() :
-                                      s_fespace.GetTrueVSize());
-                     xin->Randomize();
+                     xin.SetSize(spaceType == HcurlH1 ? v_fespace.GetTrueVSize() :
+                                 s_fespace.GetTrueVSize());
+                     xin.Randomize();
 
                      y_mat.SetSize(spaceType == HcurlH1 ? s_fespace.GetTrueVSize() :
                                    v_fespace.GetTrueVSize());
@@ -791,19 +808,17 @@ TEST_CASE("Hcurl/Hdiv Mixed PA Coefficient",
                      y_pa.SetSize(y_mat.Size());
 
                      A_explicit.EnsureMultTranspose();
-                     paform->MultTranspose(*xin, y_pa);
-                     assemblyform->MultTranspose(*xin, y_assembly);
-                     A_explicit.MultTranspose(*xin, y_mat);
-
-                     delete xin;
+                     paform->MultTranspose(xin, y_pa);
+                     assemblyform->MultTranspose(xin, y_assembly);
+                     A_explicit.MultTranspose(xin, y_mat);
 
                      y_pa -= y_mat;
                      pa_error = y_pa.Norml2();
-                     REQUIRE(pa_error < 1.e-12);
+                     REQUIRE(pa_error == MFEM_Approx(0, tol, tol));
 
                      y_assembly -= y_mat;
                      assembly_error = y_assembly.Norml2();
-                     REQUIRE(assembly_error < 1.e-12);
+                     REQUIRE(assembly_error == MFEM_Approx(0, tol, tol));
                   }
 
                   delete paform;

--- a/tests/unit/fem/test_pa_coeff.cpp
+++ b/tests/unit/fem/test_pa_coeff.cpp
@@ -606,7 +606,7 @@ TEST_CASE("Hcurl/Hdiv PA Coefficient",
 TEST_CASE("Hcurl/Hdiv Mixed PA Coefficient",
           "[CUDA][PartialAssembly][Coefficient]")
 {
-   const double tol = 2e-12;
+   const double tol = 4e-12;
 
    for (dimension = 2; dimension < 4; ++dimension)
    {


### PR DESCRIPTION
Continuing on the theme of #3077, this PR adds support for map type `INTEGRAL` in partial assembly for `VectorFEDivergenceIntegrator`. The unit tests are extended to test this case.<!--GHEX{"author":"pazner","assignment":"2022-06-19T21:47:58","editor":"tzanio","id":3080,"reviewers":["tzanio","dylan-copeland","YohannDudouit"],"merge":"2022-07-13T19:13:43","approval":"2022-07-10T23:51:58"}XEHG-->
<!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge|
 | --- | --- | --- | --- | --- | --- | --- |
| [#3080](https://github.com/mfem/mfem/pull/3080) | @pazner | @tzanio | @tzanio + @dylan-copeland + @YohannDudouit | 6/19/22 | 7/10/22 | 7/13/22 | |
<!--ELBATXEHG-->
<details>
<summary>PR Checklist</summary>
    
- [ ] Code builds.
- [ ] Code passes `make style`.
- [ ] Update `CHANGELOG`:
    - [ ] Is this a new feature users need to be aware of? New or updated example or miniapp?
    - [ ] Does it make sense to create a new section in the `CHANGELOG` to group with other related features?
- [ ] Update `INSTALL`:
    - [ ] Had a new optional library been added? If so, what range of versions of this library are required? (*Make sure the external library is compatible with our BSD license, e.g. it is not licensed under GPL!*)
    - [ ] Have the version ranges for any required or optional libraries changed?
    - [ ] Does `make` or `cmake` have a new target?
    - [ ] Did the requirements or the installation process change? *(rare)*
- [ ] Update continuous integration server configurations if necessary (e.g. with new version requirements for each of MFEM's dependencies)
    - [ ] `.github`
    - [ ] `.appveyor.yml`
- [ ] Update `.gitignore`:
    - [ ] Check if `make distclean; git status` shows any files that were generated from the source by the project (not an IDE) but we don't want to track in the repository.
    - [ ] Add new patterns (just for the new files above) and re-run the above test.
- [ ] New examples:
    - [ ] All sample runs at the top of the example source file work.
    - [ ] Update `examples/makefile`:
      - [ ] Add the example code to the appropriate `SEQ_EXAMPLES` and `PAR_EXAMPLES` variables.
      - [ ] Add any files generated by it to the `clean` target.
      - [ ] Add the example binary and any files generated by it to the top-level `.gitignore` file.
    - [ ] Update `examples/CMakeLists.txt`:
      - [ ] Add the example code to the `ALL_EXE_SRCS` variable.
      - [ ] Make sure `THIS_TEST_OPTIONS` is set correctly for the new example.
   - [ ] List the new example in `doc/CodeDocumentation.dox`.
   - [ ] If new examples directory (e.g.`examples/pumi`), list it in `doc/CodeDocumentation.conf.in`
   - [ ] Companion pull request for documentation in [mfem/web](https://github.com/mfem/web) repo:
      - [ ] Update or add example-specific documentation, see e.g. the `src/examples.md`.
      - [ ] Add the description, labels and screenshots in `src/examples.md` and `src/img`.
      - [ ] In `examples.md`, list the example under the appropriate categories, add new categories if necessary.
      - [ ] Add a short description of the example in the "Extensive Examples" section of `features.md`.
- [ ] New miniapps:
   - [ ] All sample runs at the top of the miniapp source file work.
   - [ ] Update top-level `makefile` and `makefile` in corresponding miniapp directory.
   - [ ] Add the miniapp binary and any files generated by it to the top-level `.gitignore` file.
   - [ ] Update CMake build system:
      - [ ] Update the `CMakeLists.txt` file in the `miniapps` directory, if the new miniapp is in a new directory.
      - [ ] Add/update the `CMakeLists.txt` file in the new miniapp directory.
      - [ ] Consider adding a new test for the new miniapp.
   - [ ] List the new miniapp in `doc/CodeDocumentation.dox`
   - [ ] If new miniapps directory (e.g.`miniapps/nurbs`), add it to `MINIAPP_SUBDIRS` in the `makefile`.
   - [ ] If new miniapps directory (e.g.`miniapps/nurbs`), list it in `doc/CodeDocumentation.conf.in`
   - [ ] Companion pull request for documentation in [mfem/web](https://github.com/mfem/web) repo:
     - [ ] Update or add miniapp-specific documentation, see e.g. the `src/meshing.md` and `src/electromagnetics.md` files.
     - [ ] Add the description, labels and screenshots in `src/examples.md` and `src/img`.
     - [ ] The miniapps go at the end of the page, and are usually listed only under a specific "Application (PDE)" category.
     - [ ] Add a short description of the miniapp in the "Extensive Examples" section of `features.md`.
- [ ] New capability:
   - [ ] All new public, protected, and private classes, methods, data members, and functions have full Doxygen-style documentation in source comments. Documentation should include descriptions of member data, function arguments and return values, template parameters, and prerequisites for calling new functions.
   - [ ] Pointer arguments and return values must specify whether ownership is being transferred or lent with the call.
   - [ ] Any new functions should include descriptions of their intended use e.g. for internal use only, user-facing, etc., along with references to example code whenever possible/appropriate.
   - [ ] Consider adding new sample runs in existing examples to highlight the new capability.
   - [ ] Consider saving cool simulation pictures with the new capability in the Confluence gallery (LLNL only) or submitting them, via pull request, to the gallery section of the `mfem/web` repo.
   - [ ] If this is a major new feature, consider mentioning it in the short summary inside `README` *(rare)*.
   - [ ] List major new classes in `doc/CodeDocumentation.dox` *(rare)*.
- [ ] Update this checklist, if the new pull request affects it.
- [ ] Run `make unittest` to make sure all unit tests pass.
- [ ] Run the tests in `tests/scripts`.
- [ ] (LLNL only) After merging:
   - [ ] Update internal tests to include the new features.
</details>
