### PR TITLE
Add a function to `HypreParMatrix` to sort rows.

### DIFF
--- a/fem/bilinearform_ext.cpp
+++ b/fem/bilinearform_ext.cpp
@@ -963,6 +963,7 @@ void FABilinearFormExtension::RAP(OperatorHandle &A)
    if ( auto pa = dynamic_cast<ParBilinearForm*>(a) )
    {
       pa->ParallelRAP(*pa->mat, A);
+      A.As<HypreParMatrix>()->SortRows();
    }
    else
 #endif

--- a/fem/bilinearform_ext.cpp
+++ b/fem/bilinearform_ext.cpp
@@ -954,6 +954,7 @@ void FABilinearFormExtension::Assemble()
       }
       a->mat = mat;
    }
+   a->mat->SortColumnIndices();
 }
 
 
@@ -963,7 +964,6 @@ void FABilinearFormExtension::RAP(OperatorHandle &A)
    if ( auto pa = dynamic_cast<ParBilinearForm*>(a) )
    {
       pa->ParallelRAP(*pa->mat, A);
-      A.As<HypreParMatrix>()->SortRows();
    }
    else
 #endif

--- a/linalg/hypre.hpp
+++ b/linalg/hypre.hpp
@@ -848,6 +848,13 @@ public:
    /// Read a matrix saved as a HYPRE_IJMatrix
    void Read_IJMatrix(MPI_Comm comm, const char *fname);
 
+   void SortRows()
+   {
+#if defined(HYPRE_USING_CUSPARSE) || defined(HYPRE_USING_ROCSPARSE)
+      hypre_CSRMatrixSortRow(A);
+#endif
+   }
+
    /// Print information about the hypre_ParCSRCommPkg of the HypreParMatrix.
    void PrintCommPkg(std::ostream &out = mfem::out) const;
 

--- a/linalg/hypre.hpp
+++ b/linalg/hypre.hpp
@@ -851,7 +851,8 @@ public:
    void SortRows()
    {
 #if defined(HYPRE_USING_CUSPARSE) || defined(HYPRE_USING_ROCSPARSE)
-      hypre_CSRMatrixSortRow(A);
+      hypre_CSRMatrixSortRow( hypre_ParCSRMatrixDiag(A) );
+      hypre_CSRMatrixSortRow( hypre_ParCSRMatrixOffd(A) );
 #endif
    }
 

--- a/linalg/sparsemat.cpp
+++ b/linalg/sparsemat.cpp
@@ -472,7 +472,7 @@ void SparseMatrix::SortColumnIndices()
 
       const int n = Height();
       const int m = Width();
-      const int nnzA = J.Size();
+      const int nnzA = J.Capacity();
       double * d_a_sorted = A.ReadWrite();
       const int * d_ia = I.Read();
       int * d_ja_sorted = J.ReadWrite();

--- a/linalg/sparsemat.cpp
+++ b/linalg/sparsemat.cpp
@@ -478,6 +478,11 @@ void SparseMatrix::SortColumnIndices()
       int * d_ja_sorted = ReadWriteJ();
       csru2csrInfo_t sortInfoA;
 
+      cusparseMatDescr_t matA_descr;
+      cusparseCreateMatDescr( &matA_descr );
+      cusparseSetMatIndexBase( matA_descr, CUSPARSE_INDEX_BASE_ZERO );
+      cusparseSetMatType( matA_descr, CUSPARSE_MATRIX_TYPE_GENERAL );
+
       cusparseCreateCsru2csrInfo( &sortInfoA );
 
       cusparseDcsru2csr_bufferSizeExt( handle, n, m, nnzA, d_a_sorted, d_ia,

--- a/linalg/sparsemat.cpp
+++ b/linalg/sparsemat.cpp
@@ -15,6 +15,7 @@
 #include "../general/forall.hpp"
 #include "../general/table.hpp"
 #include "../general/sort_pairs.hpp"
+#include "../general/backends.hpp"
 
 #include <iostream>
 #include <iomanip>
@@ -462,28 +463,108 @@ void SparseMatrix::SortColumnIndices()
       return;
    }
 
-   const int * Ip=HostReadI();
-   HostReadWriteJ();
-   HostReadWriteData();
-
-   Array<Pair<int,double> > row;
-   for (int j = 0, i = 0; i < height; i++)
+#ifdef MFEM_USE_CUDA_OR_HIP
+   if ( Device::Allows( Backend::CUDA_MASK ))
    {
-      int end = Ip[i+1];
-      row.SetSize(end - j);
-      for (int k = 0; k < row.Size(); k++)
-      {
-         row[k].one = J[j+k];
-         row[k].two = A[j+k];
-      }
-      row.Sort();
-      for (int k = 0; k < row.Size(); k++, j++)
-      {
-         J[j] = row[k].one;
-         A[j] = row[k].two;
-      }
+#if defined(MFEM_USE_CUDA)
+      size_t pBufferSizeInBytes = 0;
+      void *pBuffer = NULL;
+
+      const int n = Height();
+      const int m = Width();
+      const int nnzA = J.Size();
+      double * d_a_sorted = A.ReadWrite();
+      const int * d_ia = I.Read();
+      int * d_ja_sorted = J.ReadWrite();
+      csru2csrInfo_t sortInfoA;
+
+      cusparseCreateCsru2csrInfo( &sortInfoA );
+
+      cusparseDcsru2csr_bufferSizeExt( handle, n, m, nnzA, d_a_sorted, d_ia,
+                                       d_ja_sorted, sortInfoA,
+                                       &pBufferSizeInBytes);
+
+      Memory< char > buffer( pBufferSizeInBytes );
+      pBuffer = buffer.Write();
+
+      cusparseDcsru2csr( handle, n, m, nnzA, matA_descr, d_a_sorted, d_ia,
+                         d_ja_sorted, sortInfoA, pBuffer);
+
+      buffer.Delete();
+      cusparseDestroyCsru2csrInfo( sortInfoA );
+      isSorted = true;
+#endif
    }
-   isSorted = true;
+   else if ( Device::Allows( Backend::HIP_MASK ))
+   {
+#if defined(MFEM_USE_HIP)
+      size_t pBufferSizeInBytes = 0;
+      void *pBuffer = NULL;
+      int *P = NULL;
+
+      const int n = Height();
+      const int m = Width();
+      const int nnzA = J.Size();
+      double * d_a_sorted = A.ReadWrite();
+      const int * d_ia = I.Read();
+      int * d_ja_sorted = J.ReadWrite();
+
+      // FIXME: There is not in-place version of csr sort in rocSPARSE currently, so we make
+      //        a temporary copy of the data for gthr, sort that, and then copy the sorted values
+      //        back to the array being returned. Where there is an in-place version available,
+      //        we should use it.
+      Memory< double > a_tmp( nnzA );
+      double *d_a_tmp = a_tmp.Write();
+
+      rocsparse_csrsort_buffer_size(handle, n, m, nnzA, d_ia, d_ja_sorted,
+                                    &pBufferSizeInBytes);
+
+      Memory< char > buffer( pBufferSizeInBytes );
+      pBuffer = buffer.Write();
+      Memory< int > P_mem( nnzA );
+      P       = P_mem.Write();
+
+      rocsparse_create_identity_permutation(handle, nnzA, P);
+      rocsparse_csrsort(handle, n, m, nnzA, descrA, d_ia, d_ja_sorted, P, pBuffer);
+
+      rocsparse_dgthr(handle, nnzA, d_a_sorted, d_a_tmp, P,
+                      rocsparse_index_base_zero);
+
+      buffer.Delete();
+      P_mem.Delete();
+
+      a_sorted = std::move( d_a_tmp );
+
+      a_tmp.Delete();
+      isSorted = true;
+#endif
+   }
+   else
+#endif // MFEM_USE_CUDA_OR_HIP
+   {
+      const int * Ip=HostReadI();
+      HostReadWriteJ();
+      HostReadWriteData();
+
+      Array<Pair<int,double> > row;
+      for (int j = 0, i = 0; i < height; i++)
+      {
+         int end = Ip[i+1];
+         row.SetSize(end - j);
+         for (int k = 0; k < row.Size(); k++)
+         {
+            row[k].one = J[j+k];
+            row[k].two = A[j+k];
+         }
+         row.Sort();
+         for (int k = 0; k < row.Size(); k++, j++)
+         {
+            J[j] = row[k].one;
+            A[j] = row[k].two;
+         }
+      }
+      isSorted = true;
+   }
 }
 
 void SparseMatrix::MoveDiagonalFirst()

--- a/linalg/sparsemat.cpp
+++ b/linalg/sparsemat.cpp
@@ -484,13 +484,12 @@ void SparseMatrix::SortColumnIndices()
                                        d_ja_sorted, sortInfoA,
                                        &pBufferSizeInBytes);
 
-      Memory< char > buffer( pBufferSizeInBytes );
+      Array< char > buffer( pBufferSizeInBytes );
       pBuffer = buffer.Write();
 
       cusparseDcsru2csr( handle, n, m, nnzA, matA_descr, d_a_sorted, d_ia,
                          d_ja_sorted, sortInfoA, pBuffer);
 
-      buffer.Delete();
       cusparseDestroyCsru2csrInfo( sortInfoA );
       isSorted = true;
 #endif
@@ -513,15 +512,15 @@ void SparseMatrix::SortColumnIndices()
       //        a temporary copy of the data for gthr, sort that, and then copy the sorted values
       //        back to the array being returned. Where there is an in-place version available,
       //        we should use it.
-      Memory< double > a_tmp( nnzA );
+      Array< double > a_tmp( nnzA );
       double *d_a_tmp = a_tmp.Write();
 
       rocsparse_csrsort_buffer_size(handle, n, m, nnzA, d_ia, d_ja_sorted,
                                     &pBufferSizeInBytes);
 
-      Memory< char > buffer( pBufferSizeInBytes );
+      Array< char > buffer( pBufferSizeInBytes );
       pBuffer = buffer.Write();
-      Memory< int > P_mem( nnzA );
+      Array< int > P_mem( nnzA );
       P       = P_mem.Write();
 
       rocsparse_create_identity_permutation(handle, nnzA, P);
@@ -530,12 +529,8 @@ void SparseMatrix::SortColumnIndices()
       rocsparse_dgthr(handle, nnzA, d_a_sorted, d_a_tmp, P,
                       rocsparse_index_base_zero);
 
-      buffer.Delete();
-      P_mem.Delete();
+      a_sorted = d_a_tmp;
 
-      a_sorted = std::move( d_a_tmp );
-
-      a_tmp.Delete();
       isSorted = true;
 #endif
    }

--- a/linalg/sparsemat.cpp
+++ b/linalg/sparsemat.cpp
@@ -473,9 +473,9 @@ void SparseMatrix::SortColumnIndices()
       const int n = Height();
       const int m = Width();
       const int nnzA = J.Capacity();
-      double * d_a_sorted = A.ReadWrite();
-      const int * d_ia = I.Read();
-      int * d_ja_sorted = J.ReadWrite();
+      double * d_a_sorted = ReadWriteData();
+      const int * d_ia = ReadI();
+      int * d_ja_sorted = ReadWriteJ();
       csru2csrInfo_t sortInfoA;
 
       cusparseCreateCsru2csrInfo( &sortInfoA );
@@ -504,10 +504,10 @@ void SparseMatrix::SortColumnIndices()
 
       const int n = Height();
       const int m = Width();
-      const int nnzA = J.Size();
-      double * d_a_sorted = A.ReadWrite();
-      const int * d_ia = I.Read();
-      int * d_ja_sorted = J.ReadWrite();
+      const int nnzA = J.Capacity();
+      double * d_a_sorted = ReadWriteData();
+      const int * d_ia = ReadI();
+      int * d_ja_sorted = ReadWriteJ();
 
       // FIXME: There is not in-place version of csr sort in rocSPARSE currently, so we make
       //        a temporary copy of the data for gthr, sort that, and then copy the sorted values


### PR DESCRIPTION
Use `hypre_CSRMatrixSortRow` from Hypre to sort `HypreParMatrix` on device (exclusively). MFEM would remain non-deterministic if Hypre is compiled for CPU and MFEM for GPU.