### PR TITLE
Check for consistent diagonal policy in `FABilinearFormExtension::EliminateBC`

### DIFF
--- a/fem/bilinearform.cpp
+++ b/fem/bilinearform.cpp
@@ -970,9 +970,6 @@ void BilinearForm::EliminateVDofs(const Array<int> &vdofs_,
                                   DiagonalPolicy dpolicy)
 {
    vdofs_.HostRead();
-   mat->HostReadWriteI();
-   mat->HostReadWriteJ();
-   mat->HostReadWriteData();
    for (int i = 0; i < vdofs_.Size(); i++)
    {
       int vdof = vdofs_[i];
@@ -996,9 +993,6 @@ void BilinearForm::EliminateVDofs(const Array<int> &vdofs_,
    }
 
    vdofs_.HostRead();
-   mat->HostReadWriteI();
-   mat->HostReadWriteJ();
-   mat->HostReadWriteData();
    for (int i = 0; i < vdofs_.Size(); i++)
    {
       int vdof = vdofs_[i];

--- a/fem/bilinearform.cpp
+++ b/fem/bilinearform.cpp
@@ -970,6 +970,9 @@ void BilinearForm::EliminateVDofs(const Array<int> &vdofs_,
                                   DiagonalPolicy dpolicy)
 {
    vdofs_.HostRead();
+   mat->HostReadI();
+   mat->HostReadJ();
+   mat->HostReadData();
    for (int i = 0; i < vdofs_.Size(); i++)
    {
       int vdof = vdofs_[i];
@@ -992,6 +995,10 @@ void BilinearForm::EliminateVDofs(const Array<int> &vdofs_,
       mat_e = new SparseMatrix(height);
    }
 
+   vdofs_.HostRead();
+   mat->HostReadI();
+   mat->HostReadJ();
+   mat->HostReadData();
    for (int i = 0; i < vdofs_.Size(); i++)
    {
       int vdof = vdofs_[i];

--- a/fem/bilinearform.cpp
+++ b/fem/bilinearform.cpp
@@ -970,9 +970,9 @@ void BilinearForm::EliminateVDofs(const Array<int> &vdofs_,
                                   DiagonalPolicy dpolicy)
 {
    vdofs_.HostRead();
-   mat->HostReadI();
-   mat->HostReadJ();
-   mat->HostReadData();
+   mat->HostReadWriteI();
+   mat->HostReadWriteJ();
+   mat->HostReadWriteData();
    for (int i = 0; i < vdofs_.Size(); i++)
    {
       int vdof = vdofs_[i];
@@ -996,9 +996,9 @@ void BilinearForm::EliminateVDofs(const Array<int> &vdofs_,
    }
 
    vdofs_.HostRead();
-   mat->HostReadI();
-   mat->HostReadJ();
-   mat->HostReadData();
+   mat->HostReadWriteI();
+   mat->HostReadWriteJ();
+   mat->HostReadWriteData();
    for (int i = 0; i < vdofs_.Size(); i++)
    {
       int vdof = vdofs_[i];

--- a/fem/bilinearform_ext.cpp
+++ b/fem/bilinearform_ext.cpp
@@ -975,6 +975,9 @@ void FABilinearFormExtension::RAP(OperatorHandle &A)
 void FABilinearFormExtension::EliminateBC(const Array<int> &ess_dofs,
                                           OperatorHandle &A)
 {
+   MFEM_VERIFY(a->diag_policy == DiagonalPolicy::DIAG_ONE,
+               "Only DiagonalPolicy::DIAG_ONE supported with"
+               " FABilinearFormExtension.");
 #ifdef MFEM_USE_MPI
    if ( dynamic_cast<ParBilinearForm*>(a) )
    {

--- a/linalg/sparsemat.cpp
+++ b/linalg/sparsemat.cpp
@@ -1772,6 +1772,9 @@ void SparseMatrix::EliminateRowCol(int rc, const double sol, Vector &rhs,
 {
    MFEM_ASSERT(rc < height && rc >= 0,
                "Row " << rc << " not in matrix of height " << height);
+   HostReadWriteI();
+   HostReadWriteJ();
+   HostReadWriteData();
 
    if (Rows == NULL)
    {

--- a/tests/unit/fem/test_assembly_levels.cpp
+++ b/tests/unit/fem/test_assembly_levels.cpp
@@ -413,6 +413,7 @@ TEST_CASE("Serial H1 Full Assembly", "[AssemblyLevel], [CUDA]")
    a_fa.AddDomainIntegrator(new DiffusionIntegrator);
    a_legacy.AddDomainIntegrator(new DiffusionIntegrator);
 
+   a_fa.SetDiagonalPolicy(Operator::DIAG_ONE);
    a_fa.Assemble();
 
    a_legacy.SetDiagonalPolicy(Operator::DIAG_ONE);
@@ -473,7 +474,9 @@ TEST_CASE("Parallel H1 Full Assembly", "[AssemblyLevel], [Parallel], [CUDA]")
    ParBilinearForm a_legacy(&fespace);
 
    a_fa.SetAssemblyLevel(AssemblyLevel::FULL);
+   a_fa.SetDiagonalPolicy(Operator::DIAG_ONE);
    a_legacy.SetAssemblyLevel(AssemblyLevel::LEGACY);
+   a_legacy.SetDiagonalPolicy(Operator::DIAG_ONE);
 
    a_fa.AddDomainIntegrator(new DiffusionIntegrator);
    a_legacy.AddDomainIntegrator(new DiffusionIntegrator);


### PR DESCRIPTION
This PR adds:
- a runtime check in `FABilinearFormExtension::EliminateBC` to make sure the diagonal policy used in the `BilinearForm` is consistent with the `DIAG_ONE` policy assumed in `Operator::FormConstrainedSystemOperator`.
- Host reads for the `SparseMatrix` in `BilinearForm::EliminateVDofs`.<!--GHEX{"author":"YohannDudouit","assignment":"2022-08-16T15:59:54","editor":"pazner","id":3127,"reviewers":["camierjs","pazner"],"merge":"2022-09-06T15:59:54","approval":"2022-09-06T15:27:55"}XEHG-->
<!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge|
 | --- | --- | --- | --- | --- | --- | --- |
| [#3127](https://github.com/mfem/mfem/pull/3127) | @YohannDudouit | @pazner | @camierjs + @pazner | 8/16/22 | 9/6/22 | ⌛due 9/6/22 | |
<!--ELBATXEHG-->
<details>
<summary>PR Checklist</summary>
    
- [ ] Code builds.
- [ ] Code passes `make style`.
- [ ] Update `CHANGELOG`:
    - [ ] Is this a new feature users need to be aware of? New or updated example or miniapp?
    - [ ] Does it make sense to create a new section in the `CHANGELOG` to group with other related features?
- [ ] Update `INSTALL`:
    - [ ] Had a new optional library been added? If so, what range of versions of this library are required? (*Make sure the external library is compatible with our BSD license, e.g. it is not licensed under GPL!*)
    - [ ] Have the version ranges for any required or optional libraries changed?
    - [ ] Does `make` or `cmake` have a new target?
    - [ ] Did the requirements or the installation process change? *(rare)*
- [ ] Update continuous integration server configurations if necessary (e.g. with new version requirements for each of MFEM's dependencies)
    - [ ] `.github`
    - [ ] `.appveyor.yml`
- [ ] Update `.gitignore`:
    - [ ] Check if `make distclean; git status` shows any files that were generated from the source by the project (not an IDE) but we don't want to track in the repository.
    - [ ] Add new patterns (just for the new files above) and re-run the above test.
- [ ] New examples:
    - [ ] All sample runs at the top of the example source file work.
    - [ ] Update `examples/makefile`:
      - [ ] Add the example code to the appropriate `SEQ_EXAMPLES` and `PAR_EXAMPLES` variables.
      - [ ] Add any files generated by it to the `clean` target.
      - [ ] Add the example binary and any files generated by it to the top-level `.gitignore` file.
    - [ ] Update `examples/CMakeLists.txt`:
      - [ ] Add the example code to the `ALL_EXE_SRCS` variable.
      - [ ] Make sure `THIS_TEST_OPTIONS` is set correctly for the new example.
   - [ ] List the new example in `doc/CodeDocumentation.dox`.
   - [ ] If new examples directory (e.g.`examples/pumi`), list it in `doc/CodeDocumentation.conf.in`
   - [ ] Companion pull request for documentation in [mfem/web](https://github.com/mfem/web) repo:
      - [ ] Update or add example-specific documentation, see e.g. the `src/examples.md`.
      - [ ] Add the description, labels and screenshots in `src/examples.md` and `src/img`.
      - [ ] In `examples.md`, list the example under the appropriate categories, add new categories if necessary.
      - [ ] Add a short description of the example in the "Extensive Examples" section of `features.md`.
- [ ] New miniapps:
   - [ ] All sample runs at the top of the miniapp source file work.
   - [ ] Update top-level `makefile` and `makefile` in corresponding miniapp directory.
   - [ ] Add the miniapp binary and any files generated by it to the top-level `.gitignore` file.
   - [ ] Update CMake build system:
      - [ ] Update the `CMakeLists.txt` file in the `miniapps` directory, if the new miniapp is in a new directory.
      - [ ] Add/update the `CMakeLists.txt` file in the new miniapp directory.
      - [ ] Consider adding a new test for the new miniapp.
   - [ ] List the new miniapp in `doc/CodeDocumentation.dox`
   - [ ] If new miniapps directory (e.g.`miniapps/nurbs`), add it to `MINIAPP_SUBDIRS` in the `makefile`.
   - [ ] If new miniapps directory (e.g.`miniapps/nurbs`), list it in `doc/CodeDocumentation.conf.in`
   - [ ] Companion pull request for documentation in [mfem/web](https://github.com/mfem/web) repo:
     - [ ] Update or add miniapp-specific documentation, see e.g. the `src/meshing.md` and `src/electromagnetics.md` files.
     - [ ] Add the description, labels and screenshots in `src/examples.md` and `src/img`.
     - [ ] The miniapps go at the end of the page, and are usually listed only under a specific "Application (PDE)" category.
     - [ ] Add a short description of the miniapp in the "Extensive Examples" section of `features.md`.
- [ ] New capability:
   - [ ] All new public, protected, and private classes, methods, data members, and functions have full Doxygen-style documentation in source comments. Documentation should include descriptions of member data, function arguments and return values, template parameters, and prerequisites for calling new functions.
   - [ ] Pointer arguments and return values must specify whether ownership is being transferred or lent with the call.
   - [ ] Any new functions should include descriptions of their intended use e.g. for internal use only, user-facing, etc., along with references to example code whenever possible/appropriate.
   - [ ] Consider adding new sample runs in existing examples to highlight the new capability.
   - [ ] Consider saving cool simulation pictures with the new capability in the Confluence gallery (LLNL only) or submitting them, via pull request, to the gallery section of the `mfem/web` repo.
   - [ ] If this is a major new feature, consider mentioning it in the short summary inside `README` *(rare)*.
   - [ ] List major new classes in `doc/CodeDocumentation.dox` *(rare)*.
- [ ] Update this checklist, if the new pull request affects it.
- [ ] Run `make unittest` to make sure all unit tests pass.
- [ ] Run the tests in `tests/scripts`.
- [ ] (LLNL only) After merging:
   - [ ] Update internal tests to include the new features.
</details>
