### PR TITLE
Support boundary linear forms on device

### DIFF
--- a/fem/CMakeLists.txt
+++ b/fem/CMakeLists.txt
@@ -72,6 +72,7 @@ set(SRCS
   linearform.cpp
   linearform_ext.cpp
   lininteg.cpp
+  lininteg_boundary.cpp
   lininteg_domain.cpp
   lininteg_domain_grad.cpp
   lor/lor.cpp

--- a/fem/coefficient.hpp
+++ b/fem/coefficient.hpp
@@ -491,7 +491,7 @@ public:
                      const IntegrationPoint &ip) { V = vec; }
 
    /// Return a reference to the constant vector in this class.
-   const Vector& GetVec() { return vec; }
+   const Vector& GetVec() const { return vec; }
 };
 
 /** @brief A piecewise vector-valued coefficient with the pieces keyed off the

--- a/fem/linearform.cpp
+++ b/fem/linearform.cpp
@@ -106,18 +106,20 @@ bool LinearForm::SupportsDevice()
    // through Assemble, AssembleDevice, GetGeometricFactors and EnsureNodes
    if (fes->GetMesh()->NURBSext != nullptr) { return false; }
 
-   // scan domain integrator to verify that all can use device assembly
-   if (domain_integs.Size() > 0)
+   // scan integrators to verify that all can use device assembly
+   auto IntegratorsSupportDevice = [](const Array<LinearFormIntegrator*> &integ)
    {
-      for (int k = 0; k < domain_integs.Size(); k++)
+      for (int k = 0; k < integ.Size(); k++)
       {
-         if (!domain_integs[k]->SupportsDevice()) { return false; }
+         if (!integ[k]->SupportsDevice()) { return false; }
       }
-   }
+      return true;
+   };
 
-   // boundary, delta and face integrators are not supported yet
-   if (GetBLFI()->Size() > 0 || GetFLFI()->Size() > 0 ||
-       GetDLFI_Delta()->Size() > 0 || GetIFLFI()->Size() > 0) { return false; }
+   if (!IntegratorsSupportDevice(domain_integs)) { return false; }
+   if (!IntegratorsSupportDevice(boundary_integs)) { return false; }
+   if (boundary_face_integs.Size() > 0 || interior_face_integs.Size() > 0 ||
+       domain_delta_integs.Size() > 0) { return false; }
 
    const Mesh &mesh = *fes->GetMesh();
 

--- a/fem/linearform_ext.hpp
+++ b/fem/linearform_ext.hpp
@@ -25,10 +25,10 @@ class LinearForm;
 class LinearFormExtension
 {
    /// Attributes of all mesh elements.
-   Array<int> attributes;
+   Array<int> attributes, bdr_attributes;
 
    /// Temporary markers for device kernels.
-   Array<int> markers;
+   Array<int> markers, bdr_markers;
 
    /// Linear form from which this extension depends. Not owned.
    LinearForm *lf;
@@ -36,8 +36,11 @@ class LinearFormExtension
    /// Operator that converts FiniteElementSpace L-vectors to E-vectors.
    const Operator *elem_restrict_lex; // Not owned
 
+   /// Operator that converts L-vectors to boundary E-vectors.
+   const Operator *bdr_restrict_lex; // Not owned
+
    /// Internal E-vectors.
-   mutable Vector b;
+   mutable Vector b, bdr_b;
 
 public:
 

--- a/fem/lininteg.hpp
+++ b/fem/lininteg.hpp
@@ -217,6 +217,13 @@ public:
    BoundaryNormalLFIntegrator(VectorCoefficient &QG, int a = 1, int b = 1)
       : Q(QG), oa(a), ob(b) { }
 
+   virtual bool SupportsDevice() { return true; }
+
+   /// Method defining assembly on device
+   virtual void AssembleDevice(const FiniteElementSpace &fes,
+                               const Array<int> &markers,
+                               Vector &b);
+
    virtual void AssembleRHSElementVect(const FiniteElement &el,
                                        ElementTransformation &Tr,
                                        Vector &elvect);

--- a/fem/lininteg.hpp
+++ b/fem/lininteg.hpp
@@ -187,6 +187,13 @@ public:
    BoundaryLFIntegrator(Coefficient &QG, int a = 1, int b = 1)
       : Q(QG), oa(a), ob(b) { }
 
+   virtual bool SupportsDevice() { return true; }
+
+   /// Method defining assembly on device
+   virtual void AssembleDevice(const FiniteElementSpace &fes,
+                               const Array<int> &markers,
+                               Vector &b);
+
    /** Given a particular boundary Finite Element and a transformation (Tr)
        computes the element boundary vector, elvect. */
    virtual void AssembleRHSElementVect(const FiniteElement &el,

--- a/fem/lininteg_boundary.cpp
+++ b/fem/lininteg_boundary.cpp
@@ -1,0 +1,219 @@
+// Copyright (c) 2010-2022, Lawrence Livermore National Security, LLC. Produced
+// at the Lawrence Livermore National Laboratory. All Rights reserved. See files
+// LICENSE and NOTICE for details. LLNL-CODE-806117.
+//
+// This file is part of the MFEM library. For more information and source code
+// availability visit https://mfem.org.
+//
+// MFEM is free software; you can redistribute it and/or modify it under the
+// terms of the BSD-3 license. We welcome feedback and contributions, see file
+// CONTRIBUTING.md for details.
+
+#include "fem.hpp"
+#include "../fem/kernels.hpp"
+#include "../general/forall.hpp"
+
+namespace mfem
+{
+
+template<int T_D1D = 0, int T_Q1D = 0> static
+void BLFEvalAssemble2D(const int vdim, const int nbe, const int d, const int q,
+                       const int *markers, const double *b,
+                       const double *detj, const double *weights,
+                       const Vector &coeff, double *y)
+{
+   const auto F = coeff.Read();
+   const auto M = Reshape(markers, nbe);
+   const auto B = Reshape(b, q, d);
+   const auto detJ = Reshape(detj, q, nbe);
+   const auto W = Reshape(weights, q);
+   const bool cst = coeff.Size() == vdim;
+   const auto C = cst ? Reshape(F,vdim,1,1) : Reshape(F,vdim,q,nbe);
+   auto Y = Reshape(y, d, vdim, nbe);
+
+   MFEM_FORALL(e, nbe,
+   {
+      if (M(e) == 0) { return; } // ignore
+
+      constexpr int Q = T_Q1D ? T_Q1D : MAX_Q1D;
+      double QQ[Q];
+
+      for (int c = 0; c < vdim; ++c)
+      {
+         const double cst_val = C(c,0,0);
+         for (int qx = 0; qx < q; ++qx)
+         {
+            const double coeff_val = cst ? cst_val : C(c,qx,e);
+            QQ[qx] = W(qx) * coeff_val * detJ(qx,e);
+         }
+         for (int dx = 0; dx < d; ++dx)
+         {
+            double u = 0;
+            for (int qx = 0; qx < q; ++qx) { u += QQ[qx] * B(qx,dx); }
+            Y(dx,c,e) += u;
+         }
+      }
+   });
+}
+
+template<int T_D1D = 0, int T_Q1D = 0> static
+void BLFEvalAssemble3D(const int vdim, const int nbe, const int d, const int q,
+                       const int *markers, const double *b,
+                       const double *detj, const double *weights,
+                       const Vector &coeff, double *y)
+{
+   const auto F = coeff.Read();
+   const auto M = Reshape(markers, nbe);
+   const auto B = Reshape(b, q, d);
+   const auto detJ = Reshape(detj, q, q, nbe);
+   const auto W = Reshape(weights, q, q);
+   const bool cst = coeff.Size() == vdim;
+   const auto C = cst ? Reshape(F,vdim,1,1,1) : Reshape(F,vdim,q,q,nbe);
+   auto Y = Reshape(y, d, d, vdim, nbe);
+
+
+   MFEM_FORALL_2D(e, nbe, q, q, 1,
+   {
+      if (M(e) == 0) { return; } // ignore
+
+      constexpr int Q = T_Q1D ? T_Q1D : MAX_Q1D;
+      constexpr int D = T_D1D ? T_D1D : MAX_D1D;
+
+      MFEM_SHARED double sBt[Q*D];
+      MFEM_SHARED double sQQ[Q*Q];
+      MFEM_SHARED double sQD[Q*D];
+
+      const DeviceMatrix Bt(sBt, d, q);
+      kernels::internal::LoadB<D,Q>(d, q, B, sBt);
+
+      const DeviceMatrix QQ(sQQ, q, q);
+      const DeviceMatrix QD(sQD, q, d);
+
+      for (int c = 0; c < vdim; ++c)
+      {
+         const double cst_val = C(c,0,0,0);
+         MFEM_FOREACH_THREAD(x,x,q)
+         {
+            MFEM_FOREACH_THREAD(y,y,q)
+            {
+               const double coeff_val = cst ? cst_val : C(c,x,y,e);
+               QQ(y,x) = W(x,y) * coeff_val * detJ(x,y,e);
+            }
+         }
+         MFEM_SYNC_THREAD;
+         MFEM_FOREACH_THREAD(qy,y,q)
+         {
+            MFEM_FOREACH_THREAD(dx,x,d)
+            {
+               double u = 0.0;
+               for (int qx = 0; qx < q; ++qx) { u += QQ(qy,qx) * Bt(dx,qx); }
+               QD(qy,dx) = u;
+            }
+         }
+         MFEM_SYNC_THREAD;
+         MFEM_FOREACH_THREAD(dy,y,d)
+         {
+            MFEM_FOREACH_THREAD(dx,x,d)
+            {
+               double u = 0.0;
+               for (int qy = 0; qy < q; ++qy) { u += QD(qy,dx) * Bt(dy,qy); }
+               Y(dx,dy,c,e) += u;
+            }
+         }
+         MFEM_SYNC_THREAD;
+      }
+   });
+}
+
+static void BLFEvalAssemble(const FiniteElementSpace &fes,
+                            const IntegrationRule &ir,
+                            const Array<int> &markers,
+                            const Vector &coeff,
+                            Vector &y)
+{
+   Mesh &mesh = *fes.GetMesh();
+   const int dim = mesh.Dimension();
+   const FiniteElement &el = *fes.GetBE(0);
+   const MemoryType mt = Device::GetDeviceMemoryType();
+   const DofToQuad &maps = el.GetDofToQuad(ir, DofToQuad::TENSOR);
+   const int d = maps.ndof, q = maps.nqpt;
+   constexpr int flags = FaceGeometricFactors::DETERMINANTS;
+   const FaceGeometricFactors *geom = mesh.GetFaceGeometricFactors(
+                                         ir, flags, FaceType::Boundary, mt);
+   auto ker = (dim == 2) ? BLFEvalAssemble2D<> : BLFEvalAssemble3D<>;
+
+   if (dim==2)
+   {
+      if (d==1 && q==1) { ker=BLFEvalAssemble2D<1,1>; }
+      if (d==2 && q==2) { ker=BLFEvalAssemble2D<2,2>; }
+      if (d==3 && q==3) { ker=BLFEvalAssemble2D<3,3>; }
+      if (d==4 && q==4) { ker=BLFEvalAssemble2D<4,4>; }
+      if (d==5 && q==5) { ker=BLFEvalAssemble2D<5,5>; }
+      if (d==2 && q==3) { ker=BLFEvalAssemble2D<2,3>; }
+      if (d==3 && q==4) { ker=BLFEvalAssemble2D<3,4>; }
+      if (d==4 && q==5) { ker=BLFEvalAssemble2D<4,5>; }
+      if (d==5 && q==6) { ker=BLFEvalAssemble2D<5,6>; }
+   }
+
+   if (dim==3)
+   {
+      if (d==1 && q==1) { ker=BLFEvalAssemble3D<1,1>; }
+      if (d==2 && q==2) { ker=BLFEvalAssemble3D<2,2>; }
+      if (d==3 && q==3) { ker=BLFEvalAssemble3D<3,3>; }
+      if (d==4 && q==4) { ker=BLFEvalAssemble3D<4,4>; }
+      if (d==5 && q==5) { ker=BLFEvalAssemble3D<5,5>; }
+      if (d==2 && q==3) { ker=BLFEvalAssemble3D<2,3>; }
+      if (d==3 && q==4) { ker=BLFEvalAssemble3D<3,4>; }
+      if (d==4 && q==5) { ker=BLFEvalAssemble3D<4,5>; }
+      if (d==5 && q==6) { ker=BLFEvalAssemble3D<5,6>; }
+   }
+
+   MFEM_VERIFY(ker, "No kernel ndof " << d << " nqpt " << q);
+
+   const int vdim = fes.GetVDim();
+   const int nbe = fes.GetMesh()->GetNBE();
+   const int *M = markers.Read();
+   const double *B = maps.B.Read();
+   const double *detJ = geom->detJ.Read();
+   const double *W = ir.GetWeights().Read();
+   double *Y = y.ReadWrite();
+   ker(vdim, nbe, d, q, M, B, detJ, W, coeff, Y);
+}
+
+void BoundaryLFIntegrator::AssembleDevice(const FiniteElementSpace &fes,
+                                          const Array<int> &markers,
+                                          Vector &b)
+{
+   const FiniteElement &fe = *fes.GetBE(0);
+   const int qorder = oa * fe.GetOrder() + ob;
+   const Geometry::Type gtype = fe.GetGeomType();
+   const IntegrationRule &ir = IntRule ? *IntRule : IntRules.Get(gtype, qorder);
+   const int nq = ir.GetNPoints();
+   const int nbe = fes.GetMesh()->GetNBE();
+
+   Vector coeff;
+   if (ConstantCoefficient *cQ =
+          dynamic_cast<ConstantCoefficient*>(&Q))
+   {
+      coeff.SetSize(1);
+      coeff(0) = cQ->constant;
+   }
+   else
+   {
+      coeff.SetSize(nq * nbe);
+      auto C = Reshape(coeff.HostWrite(), nq, nbe);
+      for (int e = 0; e < nbe; ++e)
+      {
+         ElementTransformation& Tr = *fes.GetBdrElementTransformation(e);
+         for (int q = 0; q < nq; ++q)
+         {
+            const IntegrationPoint &ip = ir.IntPoint(q);
+            Tr.SetIntPoint(&ip);
+            C(q,e) = Q.Eval(Tr, ip);
+         }
+      }
+   }
+   BLFEvalAssemble(fes, ir, markers, coeff, b);
+}
+
+} // namespace mfem

--- a/fem/lininteg_boundary.cpp
+++ b/fem/lininteg_boundary.cpp
@@ -18,17 +18,19 @@ namespace mfem
 
 template<int T_D1D = 0, int T_Q1D = 0> static
 void BLFEvalAssemble2D(const int vdim, const int nbe, const int d, const int q,
-                       const int *markers, const double *b,
-                       const double *detj, const double *weights,
+                       const bool normals, const int *markers, const double *b,
+                       const double *detj, const double *n, const double *weights,
                        const Vector &coeff, double *y)
 {
    const auto F = coeff.Read();
    const auto M = Reshape(markers, nbe);
    const auto B = Reshape(b, q, d);
    const auto detJ = Reshape(detj, q, nbe);
+   const auto N = Reshape(n, q, 2, nbe);
    const auto W = Reshape(weights, q);
-   const bool cst = coeff.Size() == vdim;
-   const auto C = cst ? Reshape(F,vdim,1,1) : Reshape(F,vdim,q,nbe);
+   const int cvdim = normals ? 2 : 1;
+   const bool cst = coeff.Size() == cvdim;
+   const auto C = cst ? Reshape(F,cvdim,1,1) : Reshape(F,cvdim,q,nbe);
    auto Y = Reshape(y, d, vdim, nbe);
 
    MFEM_FORALL(e, nbe,
@@ -40,10 +42,21 @@ void BLFEvalAssemble2D(const int vdim, const int nbe, const int d, const int q,
 
       for (int c = 0; c < vdim; ++c)
       {
-         const double cst_val = C(c,0,0);
          for (int qx = 0; qx < q; ++qx)
          {
-            const double coeff_val = cst ? cst_val : C(c,qx,e);
+            double coeff_val = 0.0;
+            if (normals)
+            {
+               for (int cd = 0; cd < 2; ++cd)
+               {
+                  const double cval = cst ? C(cd,0,0) : C(cd,qx,e);
+                  coeff_val += cval * N(qx, cd, e);
+               }
+            }
+            else
+            {
+               coeff_val = cst ? C(0,0,0) : C(0,qx,e);
+            }
             QQ[qx] = W(qx) * coeff_val * detJ(qx,e);
          }
          for (int dx = 0; dx < d; ++dx)
@@ -58,19 +71,20 @@ void BLFEvalAssemble2D(const int vdim, const int nbe, const int d, const int q,
 
 template<int T_D1D = 0, int T_Q1D = 0> static
 void BLFEvalAssemble3D(const int vdim, const int nbe, const int d, const int q,
-                       const int *markers, const double *b,
-                       const double *detj, const double *weights,
+                       const bool normals, const int *markers, const double *b,
+                       const double *detj, const double *n, const double *weights,
                        const Vector &coeff, double *y)
 {
    const auto F = coeff.Read();
    const auto M = Reshape(markers, nbe);
    const auto B = Reshape(b, q, d);
    const auto detJ = Reshape(detj, q, q, nbe);
+   const auto N = Reshape(n, q, q, 3, nbe);
    const auto W = Reshape(weights, q, q);
-   const bool cst = coeff.Size() == vdim;
-   const auto C = cst ? Reshape(F,vdim,1,1,1) : Reshape(F,vdim,q,q,nbe);
+   const int cvdim = normals ? 3 : 1;
+   const bool cst = coeff.Size() == cvdim;
+   const auto C = cst ? Reshape(F,cvdim,1,1,1) : Reshape(F,cvdim,q,q,nbe);
    auto Y = Reshape(y, d, d, vdim, nbe);
-
 
    MFEM_FORALL_2D(e, nbe, q, q, 1,
    {
@@ -91,12 +105,23 @@ void BLFEvalAssemble3D(const int vdim, const int nbe, const int d, const int q,
 
       for (int c = 0; c < vdim; ++c)
       {
-         const double cst_val = C(c,0,0,0);
          MFEM_FOREACH_THREAD(x,x,q)
          {
             MFEM_FOREACH_THREAD(y,y,q)
             {
-               const double coeff_val = cst ? cst_val : C(c,x,y,e);
+               double coeff_val = 0.0;
+               if (normals)
+               {
+                  for (int cd = 0; cd < 3; ++cd)
+                  {
+                     double cval = cst ? C(cd,0,0,0) : C(cd,x,y,e);
+                     coeff_val += cval * N(x,y,cd,e);
+                  }
+               }
+               else
+               {
+                  coeff_val = cst ? C(0,0,0,0) : C(0,x,y,e);
+               }
                QQ(y,x) = W(x,y) * coeff_val * detJ(x,y,e);
             }
          }
@@ -129,6 +154,7 @@ static void BLFEvalAssemble(const FiniteElementSpace &fes,
                             const IntegrationRule &ir,
                             const Array<int> &markers,
                             const Vector &coeff,
+                            const bool normals,
                             Vector &y)
 {
    Mesh &mesh = *fes.GetMesh();
@@ -137,7 +163,8 @@ static void BLFEvalAssemble(const FiniteElementSpace &fes,
    const MemoryType mt = Device::GetDeviceMemoryType();
    const DofToQuad &maps = el.GetDofToQuad(ir, DofToQuad::TENSOR);
    const int d = maps.ndof, q = maps.nqpt;
-   constexpr int flags = FaceGeometricFactors::DETERMINANTS;
+   // can we make this optional (depending on normals)?
+   int flags = FaceGeometricFactors::DETERMINANTS | FaceGeometricFactors::NORMALS;
    const FaceGeometricFactors *geom = mesh.GetFaceGeometricFactors(
                                          ir, flags, FaceType::Boundary, mt);
    auto ker = (dim == 2) ? BLFEvalAssemble2D<> : BLFEvalAssemble3D<>;
@@ -175,9 +202,10 @@ static void BLFEvalAssemble(const FiniteElementSpace &fes,
    const int *M = markers.Read();
    const double *B = maps.B.Read();
    const double *detJ = geom->detJ.Read();
+   const double *n = geom->normal.Read();
    const double *W = ir.GetWeights().Read();
    double *Y = y.ReadWrite();
-   ker(vdim, nbe, d, q, M, B, detJ, W, coeff, Y);
+   ker(vdim, nbe, d, q, normals, M, B, detJ, n, W, coeff, Y);
 }
 
 void BoundaryLFIntegrator::AssembleDevice(const FiniteElementSpace &fes,
@@ -213,7 +241,45 @@ void BoundaryLFIntegrator::AssembleDevice(const FiniteElementSpace &fes,
          }
       }
    }
-   BLFEvalAssemble(fes, ir, markers, coeff, b);
+   BLFEvalAssemble(fes, ir, markers, coeff, false, b);
+}
+
+void BoundaryNormalLFIntegrator::AssembleDevice(const FiniteElementSpace &fes,
+                                                const Array<int> &markers,
+                                                Vector &b)
+{
+   const FiniteElement &fe = *fes.GetBE(0);
+   const int qorder = oa * fe.GetOrder() + ob;
+   const Geometry::Type gtype = fe.GetGeomType();
+   const IntegrationRule &ir = IntRule ? *IntRule : IntRules.Get(gtype, qorder);
+   const int nq = ir.GetNPoints();
+   const int nbe = fes.GetMesh()->GetNBE();
+   const int dim = fes.GetMesh()->Dimension();
+
+   Vector coeff;
+   if (const auto *cQ = dynamic_cast<VectorConstantCoefficient*>(&Q))
+   {
+      coeff = cQ->GetVec();
+   }
+   else
+   {
+
+      Vector coeff_val(dim);
+      coeff.SetSize(dim * nq * nbe);
+      auto C = Reshape(coeff.HostWrite(), dim, nq, nbe);
+      for (int e = 0; e < nbe; ++e)
+      {
+         ElementTransformation& Tr = *fes.GetBdrElementTransformation(e);
+         for (int q = 0; q < nq; ++q)
+         {
+            const IntegrationPoint &ip = ir[q];
+            Tr.SetIntPoint(&ip);
+            Q.Eval(coeff_val, Tr, ip);
+            for (int d=0; d<dim; ++d) { C(d,q,e) = coeff_val[d]; }
+         }
+      }
+   }
+   BLFEvalAssemble(fes, ir, markers, coeff, true, b);
 }
 
 } // namespace mfem


### PR DESCRIPTION
Supports assembly of boundary linear forms on device. `BoundaryLFIntegrator` and `BoundaryNormalLFIntegrator` are currently support. This should be enough for the linear forms needed by the Navier miniapp. #3143 has some fixes that should be incorporated here too.