### PR TITLE
Switch to flux on corona

### DIFF
--- a/.gitlab/configs/corona-config.yml
+++ b/.gitlab/configs/corona-config.yml
@@ -52,8 +52,9 @@ variables:
     # THREADS is used by 'tests/gitlab/build_and_test', run below
     - export THREADS=12
     - echo ${ALLOC_NAME}
-    - export JOBID=$(squeue -h --name=${ALLOC_NAME} --format=%A)
-    - echo ${JOBID}
     - echo ${MFEM_DATA_DIR}
     - echo ${SPEC}
-    - srun $( [[ -n "${JOBID}" ]] && echo "--jobid=${JOBID}" ) -t 15 -N 1 tests/gitlab/build_and_test --spec "${SPEC}" --data-dir "${MFEM_DATA_DIR}" --data
+    - |
+      URI=$(flux jobs -o "{uri} {name}" | grep ${ALLOC_NAME} | awk '{print $1}') || echo "Empty URI"
+      if [[ -n "$URI" ]]; then export FLUX_URI=$URI; fi
+      flux mini run --time-limit=15 --nodes=1 tests/gitlab/build_and_test --spec "${SPEC}" --data-dir "${MFEM_DATA_DIR}" --data

--- a/.gitlab/corona-build-and-test.yml
+++ b/.gitlab/corona-build-and-test.yml
@@ -22,8 +22,10 @@ allocate_resource:
   extends: .on_corona
   stage: allocate_resource
   script:
-    - echo ${ALLOC_NAME}
-    - salloc --exclusive --nodes=1 --partition=mi60 --time=45 --no-shell --job-name=${ALLOC_NAME}
+    - |
+      set -x
+      echo "Shared allocation disabled: runs slowly, needs a fix"
+      #flux mini batch --time-limit=45m --nodes=1 --job-name=${ALLOC_NAME} --wrap sleep inf
   timeout: 6h
   needs: [setup]
 
@@ -41,10 +43,11 @@ release_resource:
   extends: .on_corona
   stage: release_resource_and_report
   script:
-    - echo ${ALLOC_NAME}
-    - export JOBID=$(squeue -h --name=${ALLOC_NAME} --format=%A)
-    - echo ${JOBID}
-    - ([[ -n "${JOBID}" ]] && scancel ${JOBID})
+    - |
+      set -x
+      echo "Shared allocation disabled: runs slowly, needs a fix"
+      #export JOBID=$(flux jobs -o "{id} {name}" | grep ${ALLOC_NAME} | awk '{print $1}')
+      #([[ -n "${JOBID}" ]] && flux job kill ${JOBID})
   needs: [rocm_gcc_8.3.1]
 
 # Jobs report


### PR DESCRIPTION
This is a fix to adapt corona jobs to flux. The porting is not complete (shared allocation is temporarily disabled because inefficient at the moment) but working as-is.