### PR TITLE
Update conduit include path to follow standard build system practices

### DIFF
--- a/config/defaults.mk
+++ b/config/defaults.mk
@@ -426,7 +426,9 @@ endif
 # Sidre and required libraries configuration
 # Be sure to check the HDF5_DIR (set above) is correct
 SIDRE_DIR = @MFEM_DIR@/../axom
-SIDRE_OPT = -I$(SIDRE_DIR)/include -I$(CONDUIT_DIR)/include\
+# Sidre requires the compiler include paths to include the inner 'include/conduit'
+# sub-directory.
+SIDRE_OPT = -I$(SIDRE_DIR)/include -I$(CONDUIT_DIR)/include -I$(CONDUIT_DIR)/include/conduit
  -I$(HDF5_DIR)/include
 SIDRE_LIB = \
    $(XLINKER)-rpath,$(SIDRE_DIR)/lib -L$(SIDRE_DIR)/lib \

--- a/config/defaults.mk
+++ b/config/defaults.mk
@@ -409,7 +409,7 @@ FMS_LIB = -Wl,-rpath,$(FMS_DIR)/lib -L$(FMS_DIR)/lib -lfms
 
 # Conduit and required libraries configuration
 CONDUIT_DIR = @MFEM_DIR@/../conduit
-CONDUIT_OPT = -I$(CONDUIT_DIR)/include/conduit
+CONDUIT_OPT = -I$(CONDUIT_DIR)/include
 CONDUIT_LIB = \
    $(XLINKER)-rpath,$(CONDUIT_DIR)/lib -L$(CONDUIT_DIR)/lib \
    -lconduit -lconduit_relay -lconduit_blueprint  -ldl
@@ -426,7 +426,7 @@ endif
 # Sidre and required libraries configuration
 # Be sure to check the HDF5_DIR (set above) is correct
 SIDRE_DIR = @MFEM_DIR@/../axom
-SIDRE_OPT = -I$(SIDRE_DIR)/include -I$(CONDUIT_DIR)/include/conduit\
+SIDRE_OPT = -I$(SIDRE_DIR)/include -I$(CONDUIT_DIR)/include\
  -I$(HDF5_DIR)/include
 SIDRE_LIB = \
    $(XLINKER)-rpath,$(SIDRE_DIR)/lib -L$(SIDRE_DIR)/lib \

--- a/fem/conduitdatacollection.hpp
+++ b/fem/conduitdatacollection.hpp
@@ -17,7 +17,7 @@
 #ifdef MFEM_USE_CONDUIT
 
 #include "datacollection.hpp"
-#include <conduit.hpp>
+#include <conduit/conduit.hpp>
 
 namespace mfem
 {


### PR DESCRIPTION
The fem/conduitdatacollection class is currently referencing an inner directory in the conduit include path.  This trips up most build systems, as they have to make allowances for adding an additional include path into the conduit install location to fix it.

Can we update this to follow the typical norm, ie:

#include "conduit/conduit.hpp"
and have the build system have:
"-I/path/to/conduit/include"

The spack mfem package is an example of something that breaks with this currently, because it expects to include the top of the conduit include path, not a sub-directory inside it. (https://github.com/spack/spack)