### PR TITLE
Fix bug for markers in `LinearFormExtension::Assemble`

### DIFF
--- a/fem/linearform_ext.cpp
+++ b/fem/linearform_ext.cpp
@@ -25,7 +25,8 @@ void LinearFormExtension::Assemble()
                "match the number of vector dofs!");
 
    const Array<Array<int>*> &domain_integs_marker = *lf->GetDLFI_Marker();
-   const int mesh_attributes_max = fes.GetMesh()->attributes.Max();
+   const int mesh_attributes_max = fes.GetMesh()->attributes.Size() ?
+                                   fes.GetMesh()->attributes.Max() : 0;
    const Array<LinearFormIntegrator*> &domain_integs = *lf->GetDLFI();
 
    for (int k = 0; k < domain_integs.Size(); ++k)
@@ -64,7 +65,8 @@ void LinearFormExtension::Assemble()
    }
 
    const Array<Array<int>*> &boundary_integs_marker = lf->boundary_integs_marker;
-   const int bdr_attributes_max = fes.GetMesh()->bdr_attributes.Max();
+   const int bdr_attributes_max = fes.GetMesh()->bdr_attributes.Size() ?
+                                  fes.GetMesh()->bdr_attributes.Max() : 0;
    const Array<LinearFormIntegrator*> &boundary_integs = lf->boundary_integs;
 
    for (int k = 0; k < boundary_integs.Size(); ++k)

--- a/fem/linearform_ext.cpp
+++ b/fem/linearform_ext.cpp
@@ -25,7 +25,7 @@ void LinearFormExtension::Assemble()
                "match the number of vector dofs!");
 
    const Array<Array<int>*> &domain_integs_marker = *lf->GetDLFI_Marker();
-   const int mesh_attributes_size = fes.GetMesh()->attributes.Size();
+   const int mesh_attributes_max = fes.GetMesh()->attributes.Max();
    const Array<LinearFormIntegrator*> &domain_integs = *lf->GetDLFI();
 
    for (int k = 0; k < domain_integs.Size(); ++k)
@@ -39,7 +39,7 @@ void LinearFormExtension::Assemble()
       if (has_markers_k)
       {
          // Element attribute marker should be of length mesh->attributes
-         MFEM_VERIFY(mesh_attributes_size == domain_integs_marker_k->Size(),
+         MFEM_VERIFY(mesh_attributes_max == domain_integs_marker_k->Size(),
                      "invalid element marker for domain linear form "
                      "integrator #" << k << ", counting from zero");
       }
@@ -64,7 +64,7 @@ void LinearFormExtension::Assemble()
    }
 
    const Array<Array<int>*> &boundary_integs_marker = lf->boundary_integs_marker;
-   const int bdr_attributes_size = fes.GetMesh()->bdr_attributes.Size();
+   const int bdr_attributes_max = fes.GetMesh()->bdr_attributes.Max();
    const Array<LinearFormIntegrator*> &boundary_integs = lf->boundary_integs;
 
    for (int k = 0; k < boundary_integs.Size(); ++k)
@@ -78,7 +78,7 @@ void LinearFormExtension::Assemble()
       if (has_markers_k)
       {
          // Element attribute marker should be of length mesh->attributes
-         MFEM_VERIFY(bdr_attributes_size == boundary_integs_marker_k->Size(),
+         MFEM_VERIFY(bdr_attributes_max == boundary_integs_marker_k->Size(),
                      "invalid boundary marker for boundary linear form "
                      "integrator #" << k << ", counting from zero");
       }


### PR DESCRIPTION
The checks on lines 28 and 66 of `LinearFormExtension::Assemble`:

```
const int mesh_attributes_size = fes.GetMesh()->attributes.Size();
```

and:

```
const int bdr_attributes_size = fes.GetMesh()->bdr_attributes.Size();
```

should use `Max()` I think. This is done correctly in `LinearForm::Assemble`. This bug shows up when mesh attributes are not contiguous and because the `use_device` parameter to `Assemble` is `true`. This would also show up once the default assembly level is set to `FULL` as per https://github.com/mfem/mfem/pull/3235.

I'm not sure if there are corresponding changes required for `BilinearFormExtension` classes. I'm not very familiar but these appear to potentially disregard the markers entirely? This should be considered before changing defaults to `AssemblyLevel::FULL` I think. As an additional aside, from my experience using `FULL` for vector FE spaces is unsupported because the element assembly integrators are not yet implemented.<!--GHEX{"author":"sebastiangrimberg","assignment":"2022-09-30T21:29:08","editor":"pazner","id":3240,"reviewers":["pazner","camierjs"],"merge":"2022-10-21T21:29:08","approval":"2022-10-04T16:00:47"}XEHG-->
<!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge|
 | --- | --- | --- | --- | --- | --- | --- |
| [#3240](https://github.com/mfem/mfem/pull/3240) | @sebastiangrimberg | @pazner | @pazner + @camierjs | 9/30/22 | 10/4/22 | ⌛due 10/21/22 | |
<!--ELBATXEHG-->
<details>
<summary>PR Checklist</summary>
    
- [ ] Code builds.
- [ ] Code passes `make style`.
- [ ] Update `CHANGELOG`:
    - [ ] Is this a new feature users need to be aware of? New or updated example or miniapp?
    - [ ] Does it make sense to create a new section in the `CHANGELOG` to group with other related features?
- [ ] Update `INSTALL`:
    - [ ] Had a new optional library been added? If so, what range of versions of this library are required? (*Make sure the external library is compatible with our BSD license, e.g. it is not licensed under GPL!*)
    - [ ] Have the version ranges for any required or optional libraries changed?
    - [ ] Does `make` or `cmake` have a new target?
    - [ ] Did the requirements or the installation process change? *(rare)*
- [ ] Update continuous integration server configurations if necessary (e.g. with new version requirements for each of MFEM's dependencies)
    - [ ] `.github`
    - [ ] `.appveyor.yml`
- [ ] Update `.gitignore`:
    - [ ] Check if `make distclean; git status` shows any files that were generated from the source by the project (not an IDE) but we don't want to track in the repository.
    - [ ] Add new patterns (just for the new files above) and re-run the above test.
- [ ] New examples:
    - [ ] All sample runs at the top of the example source file work.
    - [ ] Update `examples/makefile`:
      - [ ] Add the example code to the appropriate `SEQ_EXAMPLES` and `PAR_EXAMPLES` variables.
      - [ ] Add any files generated by it to the `clean` target.
      - [ ] Add the example binary and any files generated by it to the top-level `.gitignore` file.
    - [ ] Update `examples/CMakeLists.txt`:
      - [ ] Add the example code to the `ALL_EXE_SRCS` variable.
      - [ ] Make sure `THIS_TEST_OPTIONS` is set correctly for the new example.
   - [ ] List the new example in `doc/CodeDocumentation.dox`.
   - [ ] If new examples directory (e.g.`examples/pumi`), list it in `doc/CodeDocumentation.conf.in`
   - [ ] Companion pull request for documentation in [mfem/web](https://github.com/mfem/web) repo:
      - [ ] Update or add example-specific documentation, see e.g. the `src/examples.md`.
      - [ ] Add the description, labels and screenshots in `src/examples.md` and `src/img`.
      - [ ] In `examples.md`, list the example under the appropriate categories, add new categories if necessary.
      - [ ] Add a short description of the example in the "Extensive Examples" section of `features.md`.
- [ ] New miniapps:
   - [ ] All sample runs at the top of the miniapp source file work.
   - [ ] Update top-level `makefile` and `makefile` in corresponding miniapp directory.
   - [ ] Add the miniapp binary and any files generated by it to the top-level `.gitignore` file.
   - [ ] Update CMake build system:
      - [ ] Update the `CMakeLists.txt` file in the `miniapps` directory, if the new miniapp is in a new directory.
      - [ ] Add/update the `CMakeLists.txt` file in the new miniapp directory.
      - [ ] Consider adding a new test for the new miniapp.
   - [ ] List the new miniapp in `doc/CodeDocumentation.dox`
   - [ ] If new miniapps directory (e.g.`miniapps/nurbs`), add it to `MINIAPP_SUBDIRS` in the `makefile`.
   - [ ] If new miniapps directory (e.g.`miniapps/nurbs`), list it in `doc/CodeDocumentation.conf.in`
   - [ ] Companion pull request for documentation in [mfem/web](https://github.com/mfem/web) repo:
     - [ ] Update or add miniapp-specific documentation, see e.g. the `src/meshing.md` and `src/electromagnetics.md` files.
     - [ ] Add the description, labels and screenshots in `src/examples.md` and `src/img`.
     - [ ] The miniapps go at the end of the page, and are usually listed only under a specific "Application (PDE)" category.
     - [ ] Add a short description of the miniapp in the "Extensive Examples" section of `features.md`.
- [ ] New capability:
   - [ ] All new public, protected, and private classes, methods, data members, and functions have full Doxygen-style documentation in source comments. Documentation should include descriptions of member data, function arguments and return values, template parameters, and prerequisites for calling new functions.
   - [ ] Pointer arguments and return values must specify whether ownership is being transferred or lent with the call.
   - [ ] Any new functions should include descriptions of their intended use e.g. for internal use only, user-facing, etc., along with references to example code whenever possible/appropriate.
   - [ ] Consider adding new sample runs in existing examples to highlight the new capability.
   - [ ] Consider saving cool simulation pictures with the new capability in the Confluence gallery (LLNL only) or submitting them, via pull request, to the gallery section of the `mfem/web` repo.
   - [ ] If this is a major new feature, consider mentioning it in the short summary inside `README` *(rare)*.
   - [ ] List major new classes in `doc/CodeDocumentation.dox` *(rare)*.
- [ ] Update this checklist, if the new pull request affects it.
- [ ] Run `make unittest` to make sure all unit tests pass.
- [ ] Run the tests in `tests/scripts`.
- [ ] (LLNL only) After merging:
   - [ ] Update internal tests to include the new features.
</details>
