### PR TITLE
Fix typos

### DIFF
--- a/general/mem_manager.hpp
+++ b/general/mem_manager.hpp
@@ -119,9 +119,9 @@ MemoryClass operator*(MemoryClass mc1, MemoryClass mc2);
     - Pointer arithmetic is not supported, MakeAlias() should be used instead.
     - Const Memory object does not allow modification of the content
       (unlike e.g. a const pointer).
-    - Move constructor and assignement will transfer ownership flags, and
+    - Move constructor and assignment will transfer ownership flags, and
       Reset() the moved Memory object.
-    - Copy constructor and assignement copy flags. This may result in two Memory
+    - Copy constructor and assignment copy flags. This may result in two Memory
       objects owning the data which is an invalid state. This invalid state MUST
       be resolved by users manually using SetHostPtrOwner(),
       SetDevicePtrOwner(), or ClearOwnerFlags(). It is also possible to call

--- a/linalg/complex_densemat.cpp
+++ b/linalg/complex_densemat.cpp
@@ -271,7 +271,7 @@ ComplexDenseMatrix * Mult(const ComplexDenseMatrix &A,
    int h = A.Height()/2;
    int w = B.Width()/2;
 
-   MFEM_VERIFY(A.Width() == B.Height(), "Incompatible matrix dimenions");
+   MFEM_VERIFY(A.Width() == B.Height(), "Incompatible matrix dimensions");
 
    //only real case (imag is null)
    DenseMatrix * C_r = nullptr;
@@ -334,7 +334,7 @@ ComplexDenseMatrix * MultAtB(const ComplexDenseMatrix &A,
    int h = A.Width()/2;
    int w = B.Width()/2;
 
-   MFEM_VERIFY(A.Height() == B.Height(), "Incompatible matrix dimenions");
+   MFEM_VERIFY(A.Height() == B.Height(), "Incompatible matrix dimensions");
 
    //only real case (imag is null)
    DenseMatrix * C_r = nullptr;

--- a/linalg/densemat.hpp
+++ b/linalg/densemat.hpp
@@ -577,11 +577,11 @@ void AddMult_a_VWt(const double a, const Vector &v, const Vector &w,
 void AddMult_a_VVt(const double a, const Vector &v, DenseMatrix &VVt);
 
 /** Computes matrix P^t * A * P. Note: The @a RAP matrix will be resized
-    to accomodate the data */
+    to accommodate the data */
 void RAP(const DenseMatrix &A, const DenseMatrix &P, DenseMatrix & RAP);
 
 /** Computes the matrix Rt^t * A * P. Note: The @a RAP matrix will be resized
-    to accomodate the data */
+    to accommodate the data */
 void RAP(const DenseMatrix &Rt, const DenseMatrix &A,
          const DenseMatrix &P, DenseMatrix & RAP);
 

--- a/mesh/mesh.cpp
+++ b/mesh/mesh.cpp
@@ -2417,7 +2417,7 @@ void Mesh::MarkForRefinement()
 
 void Mesh::MarkTriMeshForRefinement()
 {
-   // Mark the longest triangle edge by rotating the indeces so that
+   // Mark the longest triangle edge by rotating the indices so that
    // vertex 0 - vertex 1 is the longest edge in the triangle.
    DenseMatrix pmat;
    for (int i = 0; i < NumOfElements; i++)
@@ -9799,7 +9799,7 @@ void Mesh::UniformRefinement(int i, const DSTable &v_to_v,
       Triangle *tri0 = (Triangle*) elements[i];
       tri0->GetVertices(v);
 
-      // 1. Get the indeces for the new vertices in array v_new
+      // 1. Get the indices for the new vertices in array v_new
       bisect[0] = v_to_v(v[0],v[1]);
       bisect[1] = v_to_v(v[1],v[2]);
       bisect[2] = v_to_v(v[0],v[2]);
@@ -9834,7 +9834,7 @@ void Mesh::UniformRefinement(int i, const DSTable &v_to_v,
          }
       }
 
-      // 2. Set the node indeces for the new elements in v1, v2, v3 & v4 so that
+      // 2. Set the node indices for the new elements in v1, v2, v3 & v4 so that
       //    the edges marked for refinement be between the first two nodes.
       v1[0] =     v[0]; v1[1] = v_new[0]; v1[2] = v_new[2];
       v2[0] = v_new[0]; v2[1] =     v[1]; v2[2] = v_new[1];


### PR DESCRIPTION
Found via `codespell -q 3 -L allright,ba,bu,childs,equil,esy,fo,fom,hda,localy,lod,mone,nd,ned,nnumber,numer,ot,pres,ro,seh,shat,solfes,strat,tbe,te,tthe,warmup`