### PR TITLE
Fix some clang 14 warnings

### DIFF
--- a/fem/pfespace.cpp
+++ b/fem/pfespace.cpp
@@ -2606,7 +2606,7 @@ int ParFiniteElementSpace
       if (dump < 10)
       {
          char fname[100];
-         sprintf(fname, "dofs%02d.txt", MyRank);
+         snprintf(fname, 100, "dofs%02d.txt", MyRank);
          std::ofstream f(fname);
          DebugDumpDOFs(f, deps, dof_group, dof_owner, finalized);
          dump++;

--- a/general/mem_manager.cpp
+++ b/general/mem_manager.cpp
@@ -310,10 +310,11 @@ inline uintptr_t MmuLengthP(const void *ptr, const size_t bytes)
 /// The protected access error, used for the host
 static void MmuError(int, siginfo_t *si, void*)
 {
+   constexpr size_t buf_size = 64;
    fflush(0);
-   char str[64];
+   char str[buf_size];
    const void *ptr = si->si_addr;
-   sprintf(str, "Error while accessing address %p!", ptr);
+   snprintf(str, buf_size, "Error while accessing address %p!", ptr);
    mfem::out << std::endl << "An illegal memory access was made!";
    MFEM_ABORT(str);
 }

--- a/general/zstr.hpp
+++ b/general/zstr.hpp
@@ -60,9 +60,9 @@ namespace strict_fstream
 {
 
 // Overloaded error checks to handle POSIX and GNU strerror_r
-inline char* check_strerror_r(int r, char* buff, int err)
+inline char* check_strerror_r(int r, char* buff, size_t buff_size)
 {
-   if (r) { sprintf(buff, "unknown error: %d", err); }
+   if (r) { snprintf(buff, buff_size, "unknown error: %d", r); }
    return buff;
 }
 

--- a/mesh/mesh.cpp
+++ b/mesh/mesh.cpp
@@ -10504,8 +10504,8 @@ void Mesh::PrintVTU(std::ostream &os, int ref, VTKFormat format,
    };
 
    int ne = bdr_elements ? GetNBE() : GetNE();
-   // count the points, cells, size
-   int np = 0, nc_ref = 0, size = 0;
+   // count the number of points and cells
+   int np = 0, nc_ref = 0;
    for (int i = 0; i < ne; i++)
    {
       Geometry::Type geom = get_geom(i);
@@ -10513,7 +10513,6 @@ void Mesh::PrintVTU(std::ostream &os, int ref, VTKFormat format,
       RefG = GlobGeometryRefiner.Refine(geom, ref, 1);
       np += RefG->RefPts.GetNPoints();
       nc_ref += RefG->RefGeoms.Size() / nv;
-      size += (RefG->RefGeoms.Size() / nv) * (nv + 1);
    }
 
    os << "<Piece NumberOfPoints=\"" << np << "\" NumberOfCells=\""

--- a/mesh/mesh_readers.cpp
+++ b/mesh/mesh_readers.cpp
@@ -2851,9 +2851,10 @@ void Mesh::ReadCubit(const char *filename, int &curved, int &read_gf)
    int retval;
 
    // dummy string
-   char str_dummy[256];
+   constexpr size_t buf_size = 256;
+   char str_dummy[buf_size];
 
-   char temp_str[256];
+   char temp_str[buf_size];
    int temp_id;
 
    // open the file.
@@ -2897,14 +2898,14 @@ void Mesh::ReadCubit(const char *filename, int &curved, int &read_gf)
    int previous_num_node_per_el = 0;
    for (int i = 0; i < (int) num_el_blk; i++)
    {
-      sprintf(temp_str, "num_el_in_blk%d", i+1);
+      snprintf(temp_str, buf_size, "num_el_in_blk%d", i+1);
       if ((retval = nc_inq_dimid(ncid, temp_str, &temp_id)) ||
           (retval = nc_inq_dim(ncid, temp_id, str_dummy, &num_el_in_blk[i])))
       {
          MFEM_ABORT("Fatal NetCDF error: " << nc_strerror(retval));
       }
 
-      sprintf(temp_str, "num_nod_per_el%d", i+1);
+      snprintf(temp_str, buf_size, "num_nod_per_el%d", i+1);
       if ((retval = nc_inq_dimid(ncid, temp_str, &temp_id)) ||
           (retval = nc_inq_dim(ncid, temp_id, str_dummy, &num_node_per_el)))
       {
@@ -3051,7 +3052,7 @@ void Mesh::ReadCubit(const char *filename, int &curved, int &read_gf)
    size_t *num_side_in_ss  = new size_t[num_side_sets];
    for (int i = 0; i < (int) num_side_sets; i++)
    {
-      sprintf(temp_str, "num_side_ss%d", i+1);
+      snprintf(temp_str, buf_size, "num_side_ss%d", i+1);
       if ((retval = nc_inq_dimid(ncid, temp_str, &temp_id)) ||
           (retval = nc_inq_dim(ncid, temp_id, str_dummy, &num_side_in_ss[i])))
       {
@@ -3086,7 +3087,7 @@ void Mesh::ReadCubit(const char *filename, int &curved, int &read_gf)
    for (int i = 0; i < (int) num_el_blk; i++)
    {
       elem_blk[i] = new int[num_el_in_blk[i] * num_node_per_el];
-      sprintf(temp_str, "connect%d", i+1);
+      snprintf(temp_str, buf_size, "connect%d", i+1);
       if ((retval = nc_inq_varid(ncid, temp_str, &temp_id)) ||
           (retval = nc_get_var_int(ncid, temp_id, elem_blk[i])))
       {
@@ -3110,14 +3111,14 @@ void Mesh::ReadCubit(const char *filename, int &curved, int &read_gf)
       elem_ss[i] = new int[num_side_in_ss[i]];
       side_ss[i] = new int[num_side_in_ss[i]];
 
-      sprintf(temp_str, "elem_ss%d", i+1);
+      snprintf(temp_str, buf_size, "elem_ss%d", i+1);
       if ((retval = nc_inq_varid(ncid, temp_str, &temp_id)) ||
           (retval = nc_get_var_int(ncid, temp_id, elem_ss[i])))
       {
          MFEM_ABORT("Fatal NetCDF error: " << nc_strerror(retval));
       }
 
-      sprintf(temp_str,"side_ss%d",i+1);
+      snprintf(temp_str, buf_size,"side_ss%d",i+1);
       if ((retval = nc_inq_varid(ncid, temp_str, &temp_id)) ||
           (retval = nc_get_var_int(ncid, temp_id, side_ss[i])))
       {

--- a/mesh/ncmesh.cpp
+++ b/mesh/ncmesh.cpp
@@ -1556,6 +1556,8 @@ void NCMesh::Refine(const Array<Refinement>& refinements)
 #if defined(MFEM_DEBUG) && !defined(MFEM_USE_MPI)
    mfem::out << "Refined " << refinements.Size() << " + " << nforced
              << " elements" << std::endl;
+#else
+   MFEM_CONTRACT_VAR(nforced);
 #endif
 
    ref_stack.DeleteAll();

--- a/mesh/pncmesh.cpp
+++ b/mesh/pncmesh.cpp
@@ -2798,14 +2798,6 @@ static std::size_t arrays_memory_usage(const Array<Type> (&arrays)[Size])
 
 std::size_t ParNCMesh::MemoryUsage(bool with_base) const
 {
-   std::size_t total_groups_owners = 0;
-   for (int i = 0; i < 3; i++)
-   {
-      total_groups_owners += entity_owner[i].MemoryUsage() +
-                             entity_pmat_group[i].MemoryUsage() +
-                             entity_index_rank[i].MemoryUsage();
-   }
-
    return (with_base ? NCMesh::MemoryUsage() : 0) +
           GroupsMemoryUsage() +
           arrays_memory_usage(entity_owner) +

--- a/tests/unit/catch.hpp
+++ b/tests/unit/catch.hpp
@@ -15790,7 +15790,7 @@ namespace Catch {
 #ifdef _MSC_VER
         sprintf_s(buffer, "%.3f", duration);
 #else
-        std::sprintf(buffer, "%.3f", duration);
+        std::snprintf(buffer, maxDoubleSize, "%.3f", duration);
 #endif
         return std::string(buffer);
     }
@@ -17969,4 +17969,3 @@ using Catch::Detail::Approx;
 // end catch_reenable_warnings.h
 // end catch.hpp
 #endif // TWOBLUECUBES_SINGLE_INCLUDE_CATCH_HPP_INCLUDED
-

--- a/tests/unit/miniapps/test_tmop_pa.cpp
+++ b/tests/unit/miniapps/test_tmop_pa.cpp
@@ -578,15 +578,17 @@ static void tmop_require(int id, const char *args[])
    REQUIRE(res[0].diag == MFEM_Approx(res[1].diag));
 }
 
+static constexpr size_t sz = 16;
+
 static inline const char *itoa(const int i, char *buf)
 {
-   std::sprintf(buf, "%d", i);
+   std::snprintf(buf, sz, "%d", i);
    return buf;
 }
 
 static inline const char *dtoa(const double d, char *buf)
 {
-   std::sprintf(buf, "%.4f", d);
+   std::snprintf(buf, sz, "%.4f", d);
    return buf;
 }
 
@@ -652,7 +654,7 @@ public:
    {
       if ((id==0) && name) { mfem::out << "[" << name << "]" << std::endl; }
       DEFAULT_ARGS;
-      char ni[8] {}, rs[8] {}, li[8] {}, lc[16] {}, ji[16] {}, cmb[8] {};
+      char ni[sz] {}, rs[sz] {}, li[sz] {}, lc[sz] {}, ji[sz] {}, cmb[sz] {};
       args[MSH] = mesh;
       args[RS] = itoa(REFINE,rs);
       args[NI] = itoa(NEWTON_ITERATIONS,ni);
@@ -663,31 +665,31 @@ public:
       args[NOR] = NORMALIZATION ? "1" : "0";
       for (int p : P_ORDERS)
       {
-         char por[2] {};
+         char por[sz] {};
          args[POR] = itoa(p, por);
          for (int t : TARGET_IDS)
          {
-            char tid[2] {};
+            char tid[sz] {};
             args[TID] = itoa(t, tid);
             for (int m : METRIC_IDS)
             {
-               char mid[4] {};
+               char mid[sz] {};
                args[MID] = itoa(m, mid);
                for (int q : Q_ORDERS)
                {
                   if (q <= p) { continue; }
-                  char qor[2] {};
+                  char qor[sz] {};
                   args[QOR] = itoa(q, qor);
                   for (int ls : LINEAR_SOLVERS)
                   {
                      // skip some linear solver & metric combinations
                      // that lead to non positive definite operators
                      if (ls == 1 && m != 1) { continue; }
-                     char lsb[2] {};
+                     char lsb[sz] {};
                      args[LS] = itoa(ls, lsb);
                      for (int n : NEWTON_LOOPS)
                      {
-                        char nl[2] {};
+                        char nl[sz] {};
                         args[NL] = itoa(n, nl);
                         tmop_require(id, args);
                         if (!nr) { break; }


### PR DESCRIPTION
Replace `sprintf` with the safer version `snprintf`. Recent versions of clang warn about this:

> warning: 'sprintf' is deprecated: This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead. [-Wdeprecated-declarations]

Also remove some unused variables (fixing "set but not used" warnings).<!--GHEX{"author":"pazner","assignment":"2022-11-06T20:42:36","editor":"tzanio","id":3304,"reviewers":["camierjs","tzanio"],"merge":"2022-11-16T00:20:36","approval":"2022-11-13T19:42:55"}XEHG-->
<!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge|
 | --- | --- | --- | --- | --- | --- | --- |
| [#3304](https://github.com/mfem/mfem/pull/3304) | @pazner | @tzanio | @camierjs + @tzanio | 11/6/22 | 11/13/22 | 11/15/22 | |
<!--ELBATXEHG-->
<details>
<summary>PR Checklist</summary>
    
- [ ] Code builds.
- [ ] Code passes `make style`.
- [ ] Update `CHANGELOG`:
    - [ ] Is this a new feature users need to be aware of? New or updated example or miniapp?
    - [ ] Does it make sense to create a new section in the `CHANGELOG` to group with other related features?
- [ ] Update `INSTALL`:
    - [ ] Had a new optional library been added? If so, what range of versions of this library are required? (*Make sure the external library is compatible with our BSD license, e.g. it is not licensed under GPL!*)
    - [ ] Have the version ranges for any required or optional libraries changed?
    - [ ] Does `make` or `cmake` have a new target?
    - [ ] Did the requirements or the installation process change? *(rare)*
- [ ] Update continuous integration server configurations if necessary (e.g. with new version requirements for each of MFEM's dependencies)
    - [ ] `.github`
    - [ ] `.appveyor.yml`
- [ ] Update `.gitignore`:
    - [ ] Check if `make distclean; git status` shows any files that were generated from the source by the project (not an IDE) but we don't want to track in the repository.
    - [ ] Add new patterns (just for the new files above) and re-run the above test.
- [ ] New examples:
    - [ ] All sample runs at the top of the example source file work.
    - [ ] Update `examples/makefile`:
      - [ ] Add the example code to the appropriate `SEQ_EXAMPLES` and `PAR_EXAMPLES` variables.
      - [ ] Add any files generated by it to the `clean` target.
      - [ ] Add the example binary and any files generated by it to the top-level `.gitignore` file.
    - [ ] Update `examples/CMakeLists.txt`:
      - [ ] Add the example code to the `ALL_EXE_SRCS` variable.
      - [ ] Make sure `THIS_TEST_OPTIONS` is set correctly for the new example.
   - [ ] List the new example in `doc/CodeDocumentation.dox`.
   - [ ] If new examples directory (e.g.`examples/pumi`), list it in `doc/CodeDocumentation.conf.in`
   - [ ] Companion pull request for documentation in [mfem/web](https://github.com/mfem/web) repo:
      - [ ] Update or add example-specific documentation, see e.g. the `src/examples.md`.
      - [ ] Add the description, labels and screenshots in `src/examples.md` and `src/img`.
      - [ ] In `examples.md`, list the example under the appropriate categories, add new categories if necessary.
      - [ ] Add a short description of the example in the "Extensive Examples" section of `features.md`.
- [ ] New miniapps:
   - [ ] All sample runs at the top of the miniapp source file work.
   - [ ] Update top-level `makefile` and `makefile` in corresponding miniapp directory.
   - [ ] Add the miniapp binary and any files generated by it to the top-level `.gitignore` file.
   - [ ] Update CMake build system:
      - [ ] Update the `CMakeLists.txt` file in the `miniapps` directory, if the new miniapp is in a new directory.
      - [ ] Add/update the `CMakeLists.txt` file in the new miniapp directory.
      - [ ] Consider adding a new test for the new miniapp.
   - [ ] List the new miniapp in `doc/CodeDocumentation.dox`
   - [ ] If new miniapps directory (e.g.`miniapps/nurbs`), add it to `MINIAPP_SUBDIRS` in the `makefile`.
   - [ ] If new miniapps directory (e.g.`miniapps/nurbs`), list it in `doc/CodeDocumentation.conf.in`
   - [ ] Companion pull request for documentation in [mfem/web](https://github.com/mfem/web) repo:
     - [ ] Update or add miniapp-specific documentation, see e.g. the `src/meshing.md` and `src/electromagnetics.md` files.
     - [ ] Add the description, labels and screenshots in `src/examples.md` and `src/img`.
     - [ ] The miniapps go at the end of the page, and are usually listed only under a specific "Application (PDE)" category.
     - [ ] Add a short description of the miniapp in the "Extensive Examples" section of `features.md`.
- [ ] New capability:
   - [ ] All new public, protected, and private classes, methods, data members, and functions have full Doxygen-style documentation in source comments. Documentation should include descriptions of member data, function arguments and return values, template parameters, and prerequisites for calling new functions.
   - [ ] Pointer arguments and return values must specify whether ownership is being transferred or lent with the call.
   - [ ] Any new functions should include descriptions of their intended use e.g. for internal use only, user-facing, etc., along with references to example code whenever possible/appropriate.
   - [ ] Consider adding new sample runs in existing examples to highlight the new capability.
   - [ ] Consider saving cool simulation pictures with the new capability in the Confluence gallery (LLNL only) or submitting them, via pull request, to the gallery section of the `mfem/web` repo.
   - [ ] If this is a major new feature, consider mentioning it in the short summary inside `README` *(rare)*.
   - [ ] List major new classes in `doc/CodeDocumentation.dox` *(rare)*.
- [ ] Update this checklist, if the new pull request affects it.
- [ ] Run `make unittest` to make sure all unit tests pass.
- [ ] Run the tests in `tests/scripts`.
- [ ] (LLNL only) After merging:
   - [ ] Update internal tests to include the new features.
</details>
