### PR TITLE
Reproduce bug for nc meshes and face quadrature space

### DIFF
--- a/examples/ex9p.cpp
+++ b/examples/ex9p.cpp
@@ -1,4 +1,4 @@
-//                       MFEttM Example 9 - Parallel Version
+//                       MFEM Example 9 - Parallel Version
 //
 // Compile with: make ex9p
 //

--- a/fem/bilininteg.cpp
+++ b/fem/bilininteg.cpp
@@ -3355,6 +3355,8 @@ const IntegrationRule &DGTraceIntegrator::GetRule(
    Geometry::Type geom, int order, FaceElementTransformations &T)
 {
    int int_order = T.Elem1->OrderW() + 2*order;
+
+   std::cout<<"int order = "<<int_order<<std::endl;
    return IntRules.Get(geom, int_order);
 }
 

--- a/fem/qspace.cpp
+++ b/fem/qspace.cpp
@@ -120,6 +120,8 @@ void FaceQuadratureSpace::ConstructOffsets()
    offsets.SetSize(num_faces + 1);
    int offset = 0;
    int f_idx = 0;
+   std::cout<<"ref - mesh.GetNumFacesWithGhost() = "<<mesh.GetNumFacesWithGhost()
+            <<std::endl;
    for (int i = 0; i < mesh.GetNumFacesWithGhost(); i++)
    {
       const Mesh::FaceInformation face = mesh.GetFaceInformation(i);


### PR DESCRIPTION
`mpirun -n 2 ./ex9p -pa ` will give the following error in debug mode

```
ref - mesh.GetNumFacesWithGhost() = 120
ref - mesh.GetNumFacesWithGhost() = 105


Assertion failed: (i>=0 && i<size) is false:
 --> Access element 79 of array, size = 60
 ... in function: const T &mfem::Array<mfem::Element *>::operator[](int) const [T = mfem::Element *]
 ... in file: mesh/../general/array.hpp:746
```