### PR TITLE
Bug fix for VisItDataCollection name parsing

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -11,6 +11,15 @@
 Version 4.5.1 (development)
 ===========================
 
+Miscellaneous
+-------------
+- VisItDataCollection now correctly handles collection names containing
+  underscores.
+
+- VisItDataCollection::SetPadDigits() no longer alters the number of digits
+  used to represent the MPI rank because VisIt seems to require 6 digits.
+  This parameter can still be explicitly overridden with
+  VisItDataCollection::SetPadDigitsRank().
 
 Version 4.5, released on October 22, 2022
 =========================================

--- a/fem/datacollection.cpp
+++ b/fem/datacollection.cpp
@@ -724,7 +724,7 @@ void VisItDataCollection::ParseVisItRootString(const std::string& json)
 
    // Set the DataCollection::name using the mesh path
    std::string path = mesh.get("path").get<std::string>();
-   size_t right_sep = path.find('_');
+   size_t right_sep = path.rfind('_');
    if (right_sep == std::string::npos)
    {
       error = READ_ERROR;

--- a/fem/datacollection.hpp
+++ b/fem/datacollection.hpp
@@ -338,11 +338,12 @@ public:
    /// Set the precision (number of digits) used for the text output of doubles
    void SetPrecision(int prec) { precision = prec; }
    /// Set the number of digits used for both the cycle and the MPI rank
-   void SetPadDigits(int digits) { pad_digits_cycle=pad_digits_rank = digits; }
+   virtual void SetPadDigits(int digits)
+   { pad_digits_cycle=pad_digits_rank = digits; }
    /// Set the number of digits used for the cycle
-   void SetPadDigitsCycle(int digits) { pad_digits_cycle = digits; }
+   virtual void SetPadDigitsCycle(int digits) { pad_digits_cycle = digits; }
    /// Set the number of digits used for the MPI rank in filenames
-   void SetPadDigitsRank(int digits) { pad_digits_rank = digits; }
+   virtual void SetPadDigitsRank(int digits) { pad_digits_rank = digits; }
    /// Set the desired output mesh and data format.
    /** See the enumeration #Format for valid options. Derived classes can define
        their own format enumerations and override this method to perform input

--- a/fem/datacollection.hpp
+++ b/fem/datacollection.hpp
@@ -442,27 +442,29 @@ public:
 #endif
 
    /// Set/change the mesh associated with the collection
-   virtual void SetMesh(Mesh *new_mesh);
+   virtual void SetMesh(Mesh *new_mesh) override;
 
 #ifdef MFEM_USE_MPI
    /// Set/change the mesh associated with the collection.
-   virtual void SetMesh(MPI_Comm comm, Mesh *new_mesh);
+   virtual void SetMesh(MPI_Comm comm, Mesh *new_mesh) override;
 #endif
 
    /// Add a grid function to the collection and update the root file
-   virtual void RegisterField(const std::string& field_name, GridFunction *gf);
+   virtual void RegisterField(const std::string& field_name,
+                              GridFunction *gf) override;
 
    /// Add a quadrature function to the collection and update the root file.
    /** Visualization of quadrature function is not supported in VisIt(3.12).
        A patch has been sent to VisIt developers in June 2020. */
    virtual void RegisterQField(const std::string& q_field_name,
-                               QuadratureFunction *qf);
+                               QuadratureFunction *qf) override;
 
    /// Set the number of digits used for both the cycle and the MPI rank
    /// @note VisIt seems to require 6 pad digits for the MPI rank. Therefore,
    /// this function uses this default value. This behavior can be overridden
    /// by calling SetPadDigitsCycle() and SetPadDigitsRank() instead.
-   void SetPadDigits(int digits) { pad_digits_cycle=digits; pad_digits_rank=6; }
+   virtual void SetPadDigits(int digits) override
+   { pad_digits_cycle=digits; pad_digits_rank=6; }
 
    /// Set VisIt parameter: default levels of detail for the MultiresControl
    void SetLevelsOfDetail(int levels_of_detail);
@@ -475,13 +477,13 @@ public:
    void DeleteAll();
 
    /// Save the collection and a VisIt root file
-   virtual void Save();
+   virtual void Save() override;
 
    /// Save a VisIt root file for the collection
    void SaveRootFile();
 
    /// Load the collection based on its VisIt data (described in its root file)
-   virtual void Load(int cycle_ = 0);
+   virtual void Load(int cycle_ = 0) override;
 
    /// We will delete the mesh and fields if we own them
    virtual ~VisItDataCollection() {}

--- a/fem/datacollection.hpp
+++ b/fem/datacollection.hpp
@@ -457,6 +457,12 @@ public:
    virtual void RegisterQField(const std::string& q_field_name,
                                QuadratureFunction *qf);
 
+   /// Set the number of digits used for both the cycle and the MPI rank
+   /// @note VisIt seems to require 6 pad digits for the MPI rank. Therefore,
+   /// this function uses this default value. This behavior can be overridden
+   /// by calling SetPadDigitsCycle() and SetPadDigitsRank() instead.
+   void SetPadDigits(int digits) { pad_digits_cycle=digits; pad_digits_rank=6; }
+
    /// Set VisIt parameter: default levels of detail for the MultiresControl
    void SetLevelsOfDetail(int levels_of_detail);
 

--- a/miniapps/tools/convert-dc.cpp
+++ b/miniapps/tools/convert-dc.cpp
@@ -116,8 +116,12 @@ int main(int argc, char *argv[])
    const char *src_coll_name = NULL;
    const char *src_coll_type = "visit";
    int src_cycle = 0;
+   int src_pad_digits_cycle = 6;
+   int src_pad_digits_rank = 6;
    const char *out_coll_name = NULL;
    const char *out_coll_type = "visit";
+   int out_pad_digits_cycle = -1;
+   int out_pad_digits_rank = -1;
 
    OptionsParser args(argc, argv);
    args.AddOption(&src_coll_name, "-s", "--source-root-prefix",
@@ -126,6 +130,16 @@ int main(int argc, char *argv[])
                   "Set the source data collection root file prefix.", true);
    args.AddOption(&src_cycle, "-c", "--cycle",
                   "Set the source cycle index to read.");
+   args.AddOption(&src_pad_digits_cycle, "-pdc", "--pad-digits-cycle",
+                  "Number of digits in source cycle.");
+   args.AddOption(&out_pad_digits_cycle, "-opdc", "--out-pad-digits-cycle",
+                  "Number of digits in output cycle.");
+#ifdef MFEM_USE_MPI
+   args.AddOption(&src_pad_digits_rank, "-pdr", "--pad-digits-rank",
+                  "Number of digits in source MPI rank.");
+   args.AddOption(&out_pad_digits_rank, "-opdr", "--out-pad-digits-rank",
+                  "Number of digits in output MPI rank.");
+#endif
    args.AddOption(&src_coll_type, "-st", "--source-type",
                   "Set the source data collection type. Options:\n"
                   "\t   visit:                VisItDataCollection (default)\n"
@@ -156,6 +170,14 @@ int main(int argc, char *argv[])
       args.PrintUsage(mfem::out);
       return 1;
    }
+   if (out_pad_digits_cycle < 0)
+   {
+      out_pad_digits_cycle = src_pad_digits_cycle;
+   }
+   if (out_pad_digits_rank < 0)
+   {
+      out_pad_digits_rank = src_pad_digits_rank;
+   }
    args.PrintOptions(mfem::out);
 
    DataCollection *src_dc = create_data_collection(std::string(src_coll_name),
@@ -164,6 +186,12 @@ int main(int argc, char *argv[])
    DataCollection *out_dc = create_data_collection(std::string(out_coll_name),
                                                    std::string(out_coll_type));
 
+#ifdef MFEM_USE_MPI
+   out_dc->SetPadDigitsRank(out_pad_digits_rank);
+   src_dc->SetPadDigitsRank(src_pad_digits_rank);
+#endif
+   out_dc->SetPadDigitsCycle(out_pad_digits_cycle);
+   src_dc->SetPadDigitsCycle(src_pad_digits_cycle);
    src_dc->Load(src_cycle);
 
    if (src_dc->Error() != DataCollection::NO_ERROR)

--- a/miniapps/tools/convert-dc.cpp
+++ b/miniapps/tools/convert-dc.cpp
@@ -134,12 +134,10 @@ int main(int argc, char *argv[])
                   "Number of digits in source cycle.");
    args.AddOption(&out_pad_digits_cycle, "-opdc", "--out-pad-digits-cycle",
                   "Number of digits in output cycle.");
-#ifdef MFEM_USE_MPI
    args.AddOption(&src_pad_digits_rank, "-pdr", "--pad-digits-rank",
                   "Number of digits in source MPI rank.");
    args.AddOption(&out_pad_digits_rank, "-opdr", "--out-pad-digits-rank",
                   "Number of digits in output MPI rank.");
-#endif
    args.AddOption(&src_coll_type, "-st", "--source-type",
                   "Set the source data collection type. Options:\n"
                   "\t   visit:                VisItDataCollection (default)\n"
@@ -186,12 +184,10 @@ int main(int argc, char *argv[])
    DataCollection *out_dc = create_data_collection(std::string(out_coll_name),
                                                    std::string(out_coll_type));
 
-#ifdef MFEM_USE_MPI
-   out_dc->SetPadDigitsRank(out_pad_digits_rank);
-   src_dc->SetPadDigitsRank(src_pad_digits_rank);
-#endif
    out_dc->SetPadDigitsCycle(out_pad_digits_cycle);
+   out_dc->SetPadDigitsRank(out_pad_digits_rank);
    src_dc->SetPadDigitsCycle(src_pad_digits_cycle);
+   src_dc->SetPadDigitsRank(src_pad_digits_rank);
    src_dc->Load(src_cycle);
 
    if (src_dc->Error() != DataCollection::NO_ERROR)

--- a/miniapps/tools/get-values.cpp
+++ b/miniapps/tools/get-values.cpp
@@ -74,6 +74,8 @@ int main(int argc, char *argv[])
    // Parse command-line options.
    const char *coll_name = NULL;
    int cycle = 0;
+   int pad_digits_cycle = 6;
+   int pad_digits_rank = 6;
 
    const char *field_name_c_str = "ALL";
    const char *pts_file_c_str = "";
@@ -85,6 +87,12 @@ int main(int argc, char *argv[])
    args.AddOption(&coll_name, "-r", "--root-file",
                   "Set the VisIt data collection root file prefix.", true);
    args.AddOption(&cycle, "-c", "--cycle", "Set the cycle index to read.");
+   args.AddOption(&pad_digits_cycle, "-pdc", "--pad-digits-cycle",
+                  "Number of digits in cycle.");
+#ifdef MFEM_USE_MPI
+   args.AddOption(&pad_digits_rank, "-pdr", "--pad-digits-rank",
+                  "Number of digits in MPI rank.");
+#endif
    args.AddOption(&pts, "-p", "--points", "List of points.");
    args.AddOption(&field_name_c_str, "-fn", "--field-names",
                   "List of field names to get values from.");
@@ -102,9 +110,11 @@ int main(int argc, char *argv[])
 
 #ifdef MFEM_USE_MPI
    VisItDataCollection dc(MPI_COMM_WORLD, coll_name);
+   dc.SetPadDigitsRank(pad_digits_rank);
 #else
    VisItDataCollection dc(coll_name);
 #endif
+   dc.SetPadDigitsCycle(pad_digits_cycle);
    dc.Load(cycle);
 
    if (dc.Error() != DataCollection::NO_ERROR)

--- a/miniapps/tools/get-values.cpp
+++ b/miniapps/tools/get-values.cpp
@@ -89,10 +89,8 @@ int main(int argc, char *argv[])
    args.AddOption(&cycle, "-c", "--cycle", "Set the cycle index to read.");
    args.AddOption(&pad_digits_cycle, "-pdc", "--pad-digits-cycle",
                   "Number of digits in cycle.");
-#ifdef MFEM_USE_MPI
    args.AddOption(&pad_digits_rank, "-pdr", "--pad-digits-rank",
                   "Number of digits in MPI rank.");
-#endif
    args.AddOption(&pts, "-p", "--points", "List of points.");
    args.AddOption(&field_name_c_str, "-fn", "--field-names",
                   "List of field names to get values from.");
@@ -110,11 +108,11 @@ int main(int argc, char *argv[])
 
 #ifdef MFEM_USE_MPI
    VisItDataCollection dc(MPI_COMM_WORLD, coll_name);
-   dc.SetPadDigitsRank(pad_digits_rank);
 #else
    VisItDataCollection dc(coll_name);
 #endif
    dc.SetPadDigitsCycle(pad_digits_cycle);
+   dc.SetPadDigitsRank(pad_digits_rank);
    dc.Load(cycle);
 
    if (dc.Error() != DataCollection::NO_ERROR)

--- a/miniapps/tools/load-dc.cpp
+++ b/miniapps/tools/load-dc.cpp
@@ -41,12 +41,20 @@ int main(int argc, char *argv[])
    // Parse command-line options.
    const char *coll_name = NULL;
    int cycle = 0;
+   int pad_digits_cycle = 6;
+   int pad_digits_rank = 6;
    bool visualization = true;
 
    OptionsParser args(argc, argv);
    args.AddOption(&coll_name, "-r", "--root-file",
                   "Set the VisIt data collection root file prefix.", true);
    args.AddOption(&cycle, "-c", "--cycle", "Set the cycle index to read.");
+   args.AddOption(&pad_digits_cycle, "-pdc", "--pad-digits-cycle",
+                  "Number of digits in cycle.");
+#ifdef MFEM_USE_MPI
+   args.AddOption(&pad_digits_rank, "-pdr", "--pad-digits-rank",
+                  "Number of digits in MPI rank.");
+#endif
    args.AddOption(&visualization, "-vis", "--visualization", "-no-vis",
                   "--no-visualization",
                   "Enable or disable GLVis visualization.");
@@ -60,9 +68,11 @@ int main(int argc, char *argv[])
 
 #ifdef MFEM_USE_MPI
    VisItDataCollection dc(MPI_COMM_WORLD, coll_name);
+   dc.SetPadDigitsRank(pad_digits_rank);
 #else
    VisItDataCollection dc(coll_name);
 #endif
+   dc.SetPadDigitsCycle(pad_digits_cycle);
    dc.Load(cycle);
 
    if (dc.Error() != DataCollection::NO_ERROR)

--- a/miniapps/tools/load-dc.cpp
+++ b/miniapps/tools/load-dc.cpp
@@ -51,10 +51,8 @@ int main(int argc, char *argv[])
    args.AddOption(&cycle, "-c", "--cycle", "Set the cycle index to read.");
    args.AddOption(&pad_digits_cycle, "-pdc", "--pad-digits-cycle",
                   "Number of digits in cycle.");
-#ifdef MFEM_USE_MPI
    args.AddOption(&pad_digits_rank, "-pdr", "--pad-digits-rank",
                   "Number of digits in MPI rank.");
-#endif
    args.AddOption(&visualization, "-vis", "--visualization", "-no-vis",
                   "--no-visualization",
                   "Enable or disable GLVis visualization.");
@@ -68,11 +66,11 @@ int main(int argc, char *argv[])
 
 #ifdef MFEM_USE_MPI
    VisItDataCollection dc(MPI_COMM_WORLD, coll_name);
-   dc.SetPadDigitsRank(pad_digits_rank);
 #else
    VisItDataCollection dc(coll_name);
 #endif
    dc.SetPadDigitsCycle(pad_digits_cycle);
+   dc.SetPadDigitsRank(pad_digits_rank);
    dc.Load(cycle);
 
    if (dc.Error() != DataCollection::NO_ERROR)

--- a/tests/unit/fem/test_datacollection.cpp
+++ b/tests/unit/fem/test_datacollection.cpp
@@ -79,11 +79,13 @@ TEST_CASE("Save and load from collections", "[DataCollection]")
          REQUIRE(dc.GetTime() == 8.0);
 
          // Save the DataCollection and load it into a new DataCollection for comparison
-         dc.SetPadDigits(5);
+         dc.SetPadDigitsCycle(5);
+         dc.SetPadDigitsRank(5);
          dc.Save();
 
          VisItDataCollection dc_new("base");
-         dc_new.SetPadDigits(5);
+         dc_new.SetPadDigitsCycle(5);
+         dc_new.SetPadDigitsRank(5);
          dc_new.Load(dc.GetCycle());
          Mesh* mesh_new = dc_new.GetMesh();
          GridFunction *u_new = dc_new.GetField("u");
@@ -165,12 +167,14 @@ TEST_CASE("Save and load from collections", "[DataCollection]")
          REQUIRE(dc.GetTime() == 8.0);
 
          // Save the DataCollection and load it into a new DataCollection for comparison
-         dc.SetPadDigits(5);
+         dc.SetPadDigitsCycle(5);
+         dc.SetPadDigitsRank(5);
          dc.SetCompression(true);
          dc.Save();
 
          VisItDataCollection dc_new("base");
-         dc_new.SetPadDigits(5);
+         dc_new.SetPadDigitsCycle(5);
+         dc_new.SetPadDigitsRank(5);
          dc_new.Load(dc.GetCycle());
          Mesh *mesh_new = dc_new.GetMesh();
          GridFunction *u_new = dc_new.GetField("u");


### PR DESCRIPTION
When a `VisItDataCollection` name contains underscores it cannot be loaded by applications such as `miniapps/tools/get-values`. This is due to the fact that `VisItDataCollection::ParseVisItRootString` uses `string::find` rather than `string::rfind` to separate the `name` portion of the string from the cycle number.

This PR resolves the bug mentioned in issue #3328.
<!--GHEX{"author":"mlstowell","assignment":"2022-11-17T02:03:05","editor":"tzanio","id":3329,"reviewers":["termi-official","tzanio"],"merge":"2022-11-30T16:02:02","approval":"2022-11-28T22:32:42"}XEHG-->
<!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge|
 | --- | --- | --- | --- | --- | --- | --- |
| [#3329](https://github.com/mfem/mfem/pull/3329) | @mlstowell | @tzanio | @termi-official + @tzanio | 11/16/22 | 11/28/22 | 11/30/22 | |
<!--ELBATXEHG-->
<details>
<summary>PR Checklist</summary>
    
- [ ] Code builds.
- [ ] Code passes `make style`.
- [ ] Update `CHANGELOG`:
    - [ ] Is this a new feature users need to be aware of? New or updated example or miniapp?
    - [ ] Does it make sense to create a new section in the `CHANGELOG` to group with other related features?
- [ ] Update `INSTALL`:
    - [ ] Had a new optional library been added? If so, what range of versions of this library are required? (*Make sure the external library is compatible with our BSD license, e.g. it is not licensed under GPL!*)
    - [ ] Have the version ranges for any required or optional libraries changed?
    - [ ] Does `make` or `cmake` have a new target?
    - [ ] Did the requirements or the installation process change? *(rare)*
- [ ] Update continuous integration server configurations if necessary (e.g. with new version requirements for each of MFEM's dependencies)
    - [ ] `.github`
    - [ ] `.appveyor.yml`
- [ ] Update `.gitignore`:
    - [ ] Check if `make distclean; git status` shows any files that were generated from the source by the project (not an IDE) but we don't want to track in the repository.
    - [ ] Add new patterns (just for the new files above) and re-run the above test.
- [ ] New examples:
    - [ ] All sample runs at the top of the example source file work.
    - [ ] Update `examples/makefile`:
      - [ ] Add the example code to the appropriate `SEQ_EXAMPLES` and `PAR_EXAMPLES` variables.
      - [ ] Add any files generated by it to the `clean` target.
      - [ ] Add the example binary and any files generated by it to the top-level `.gitignore` file.
    - [ ] Update `examples/CMakeLists.txt`:
      - [ ] Add the example code to the `ALL_EXE_SRCS` variable.
      - [ ] Make sure `THIS_TEST_OPTIONS` is set correctly for the new example.
   - [ ] List the new example in `doc/CodeDocumentation.dox`.
   - [ ] If new examples directory (e.g.`examples/pumi`), list it in `doc/CodeDocumentation.conf.in`
   - [ ] Companion pull request for documentation in [mfem/web](https://github.com/mfem/web) repo:
      - [ ] Update or add example-specific documentation, see e.g. the `src/examples.md`.
      - [ ] Add the description, labels and screenshots in `src/examples.md` and `src/img`.
      - [ ] In `examples.md`, list the example under the appropriate categories, add new categories if necessary.
      - [ ] Add a short description of the example in the "Extensive Examples" section of `features.md`.
- [ ] New miniapps:
   - [ ] All sample runs at the top of the miniapp source file work.
   - [ ] Update top-level `makefile` and `makefile` in corresponding miniapp directory.
   - [ ] Add the miniapp binary and any files generated by it to the top-level `.gitignore` file.
   - [ ] Update CMake build system:
      - [ ] Update the `CMakeLists.txt` file in the `miniapps` directory, if the new miniapp is in a new directory.
      - [ ] Add/update the `CMakeLists.txt` file in the new miniapp directory.
      - [ ] Consider adding a new test for the new miniapp.
   - [ ] List the new miniapp in `doc/CodeDocumentation.dox`
   - [ ] If new miniapps directory (e.g.`miniapps/nurbs`), add it to `MINIAPP_SUBDIRS` in the `makefile`.
   - [ ] If new miniapps directory (e.g.`miniapps/nurbs`), list it in `doc/CodeDocumentation.conf.in`
   - [ ] Companion pull request for documentation in [mfem/web](https://github.com/mfem/web) repo:
     - [ ] Update or add miniapp-specific documentation, see e.g. the `src/meshing.md` and `src/electromagnetics.md` files.
     - [ ] Add the description, labels and screenshots in `src/examples.md` and `src/img`.
     - [ ] The miniapps go at the end of the page, and are usually listed only under a specific "Application (PDE)" category.
     - [ ] Add a short description of the miniapp in the "Extensive Examples" section of `features.md`.
- [ ] New capability:
   - [ ] All new public, protected, and private classes, methods, data members, and functions have full Doxygen-style documentation in source comments. Documentation should include descriptions of member data, function arguments and return values, template parameters, and prerequisites for calling new functions.
   - [ ] Pointer arguments and return values must specify whether ownership is being transferred or lent with the call.
   - [ ] Any new functions should include descriptions of their intended use e.g. for internal use only, user-facing, etc., along with references to example code whenever possible/appropriate.
   - [ ] Consider adding new sample runs in existing examples to highlight the new capability.
   - [ ] Consider saving cool simulation pictures with the new capability in the Confluence gallery (LLNL only) or submitting them, via pull request, to the gallery section of the `mfem/web` repo.
   - [ ] If this is a major new feature, consider mentioning it in the short summary inside `README` *(rare)*.
   - [ ] List major new classes in `doc/CodeDocumentation.dox` *(rare)*.
- [ ] Update this checklist, if the new pull request affects it.
- [ ] Run `make unittest` to make sure all unit tests pass.
- [ ] Run the tests in `tests/scripts`.
- [ ] (LLNL only) After merging:
   - [ ] Update internal tests to include the new features.
</details>
