### PR TITLE
Adding support for empty partitions in AMS and ADS

### DIFF
--- a/linalg/hypre.cpp
+++ b/linalg/hypre.cpp
@@ -5345,20 +5345,9 @@ void HypreAMS::MakeGradientAndInterpolation(
    rt_trace_space = dynamic_cast<const RT_Trace_FECollection*>(edge_fec);
    trace_space = trace_space || rt_trace_space;
 
-   int p = 1;
-   if (edge_fespace->GetNE() > 0)
-   {
-      MFEM_VERIFY(!edge_fespace->IsVariableOrder(), "");
-      if (trace_space)
-      {
-         p = edge_fespace->GetFaceOrder(0);
-         if (dim == 2) { p++; }
-      }
-      else
-      {
-         p = edge_fespace->GetElementOrder(0);
-      }
-   }
+   MFEM_VERIFY(!edge_fespace->IsVariableOrder(), "");
+   int p = edge_fec->GetOrder();
+   if (trace_space && dim == 2) { p++; }
 
    ParMesh *pmesh = edge_fespace->GetParMesh();
    if (rt_trace_space)
@@ -5747,19 +5736,8 @@ void HypreADS::MakeDiscreteMatrices(ParFiniteElementSpace *face_fespace)
    const FiniteElementCollection *face_fec = face_fespace->FEColl();
    bool trace_space =
       (dynamic_cast<const RT_Trace_FECollection*>(face_fec) != NULL);
-   int p = 1;
-   if (face_fespace->GetNE() > 0)
-   {
-      MFEM_VERIFY(!face_fespace->IsVariableOrder(), "");
-      if (trace_space)
-      {
-         p = face_fespace->GetFaceOrder(0) + 1;
-      }
-      else
-      {
-         p = face_fespace->GetElementOrder(0);
-      }
-   }
+   int p = face_fec->GetOrder();
+   if (trace_space) { p++; }
 
    // define the nodal and edge finite element spaces associated with face_fespace
    ParMesh *pmesh = (ParMesh *) face_fespace->GetMesh();

--- a/linalg/hypre.cpp
+++ b/linalg/hypre.cpp
@@ -5347,7 +5347,6 @@ void HypreAMS::MakeGradientAndInterpolation(
 
    MFEM_VERIFY(!edge_fespace->IsVariableOrder(), "");
    int p = edge_fec->GetOrder();
-   if (trace_space && dim == 2) { p++; }
 
    ParMesh *pmesh = edge_fespace->GetParMesh();
    if (rt_trace_space)
@@ -5737,7 +5736,6 @@ void HypreADS::MakeDiscreteMatrices(ParFiniteElementSpace *face_fespace)
    bool trace_space =
       (dynamic_cast<const RT_Trace_FECollection*>(face_fec) != NULL);
    int p = face_fec->GetOrder();
-   if (trace_space) { p++; }
 
    // define the nodal and edge finite element spaces associated with face_fespace
    ParMesh *pmesh = (ParMesh *) face_fespace->GetMesh();

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -27,6 +27,7 @@ set(UNIT_TESTS_SRCS
   linalg/test_constrainedsolver.cpp
   linalg/test_direct_solvers.cpp
   linalg/test_hypre_ilu.cpp
+  linalg/test_hypre_prec.cpp
   linalg/test_hypre_vector.cpp
   linalg/test_ilu.cpp
   linalg/test_matrix_block.cpp

--- a/tests/unit/linalg/test_hypre_prec.cpp
+++ b/tests/unit/linalg/test_hypre_prec.cpp
@@ -1,0 +1,264 @@
+// Copyright (c) 2010-2022, Lawrence Livermore National Security, LLC. Produced
+// at the Lawrence Livermore National Laboratory. All Rights reserved. See files
+// LICENSE and NOTICE for details. LLNL-CODE-806117.
+//
+// This file is part of the MFEM library. For more information and source code
+// availability visit https://mfem.org.
+//
+// MFEM is free software; you can redistribute it and/or modify it under the
+// terms of the BSD-3 license. We welcome feedback and contributions, see file
+// CONTRIBUTING.md for details.
+
+#include "unit_tests.hpp"
+#include "mfem.hpp"
+
+namespace mfem
+{
+
+#ifdef MFEM_USE_MPI
+
+enum PartType {ALL, FIRST, LAST, ALL_BUT_LAST, ALL_BUT_FIRST};
+
+double sin3d(const Vector &x)
+{
+   return sin(x[0]) * sin(x[1]) * sin(x[2]);
+}
+
+void sin3d_vec(const Vector &x, Vector &v)
+{
+   v.SetSize(3);
+   v[0] = cos(x[0]) * sin(x[1]) * sin(x[2]);
+   v[1] = sin(x[0]) * cos(x[1]) * sin(x[2]);
+   v[2] = sin(x[0]) * sin(x[1]) * cos(x[2]);
+}
+
+void GeneratePart(PartType part_type, int nelems, int world_size,
+                  int *partitioning)
+{
+   switch (part_type)
+   {
+      case ALL:
+         for (int i=0; i<nelems; i++)
+         {
+            partitioning[i] = i % world_size;
+         }
+         break;
+      case FIRST:
+         for (int i=0; i<nelems; i++)
+         {
+            partitioning[i] = 0;
+         }
+         break;
+      case LAST:
+         for (int i=0; i<nelems; i++)
+         {
+            partitioning[i] = world_size - 1;
+         }
+         break;
+      case ALL_BUT_LAST:
+         for (int i=0; i<nelems; i++)
+         {
+            partitioning[i] = i % (world_size-1);
+         }
+         break;
+      case ALL_BUT_FIRST:
+         for (int i=0; i<nelems; i++)
+         {
+            partitioning[i] = i % (world_size-1) + 1;
+         }
+         break;
+   }
+}
+
+TEST_CASE("HypreBoomerAMG", "[Parallel], [HypreBoomerAMG]")
+{
+   int world_size, rank;
+   MPI_Comm_size(MPI_COMM_WORLD, &world_size);
+   MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+
+   int n = 3;
+   int dim = 3;
+   int order = 2;
+
+   Mesh mesh = Mesh::MakeCartesian3D(n, n, n, Element::HEXAHEDRON);
+
+   int nelems = mesh.GetNE();
+   int *partitioning = new int[nelems];
+
+   auto part_type = GENERATE(ALL, FIRST, LAST, ALL_BUT_LAST, ALL_BUT_FIRST);
+
+   GeneratePart(part_type, nelems, world_size, partitioning);
+
+   ParMesh pmesh(MPI_COMM_WORLD, mesh, partitioning);
+
+   H1_FECollection fec(order, dim);
+   ParFiniteElementSpace fespace(&pmesh, &fec);
+
+   ParBilinearForm a(&fespace);
+   a.AddDomainIntegrator(new DiffusionIntegrator);
+   a.AddDomainIntegrator(new MassIntegrator);
+   a.Assemble();
+
+   ParGridFunction x(&fespace);
+   FunctionCoefficient sin3dCoef(sin3d);
+   x.ProjectCoefficient(sin3dCoef);
+   double err0 = x.ComputeL2Error(sin3dCoef);
+
+   ParLinearForm b(&fespace);
+   a.Mult(x, b);
+   x = 0.0;
+
+   OperatorPtr A;
+   Vector B, X;
+   Array<int> ess_tdof_list;
+   a.FormLinearSystem(ess_tdof_list, x, b, A, X, B);
+
+   HypreBoomerAMG amg;
+   amg.SetPrintLevel(0);
+
+   HyprePCG pcg(MPI_COMM_WORLD);
+   pcg.SetTol(1e-10);
+   pcg.SetMaxIter(2000);
+   pcg.SetPrintLevel(3);
+   pcg.SetPreconditioner(amg);
+   pcg.SetOperator(*A);
+   pcg.Mult(B, X);
+
+   int its = -1;
+   pcg.GetNumIterations(its);
+
+   a.RecoverFEMSolution(X, b, x);
+
+   double err = x.ComputeL2Error(sin3dCoef);
+   REQUIRE(fabs(err - err0) < 1e-6 * err0);
+}
+
+TEST_CASE("HypreAMS", "[Parallel], [HypreAMS]")
+{
+   int world_size, rank;
+   MPI_Comm_size(MPI_COMM_WORLD, &world_size);
+   MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+
+   int n = 3;
+   int dim = 3;
+   int order = 2;
+
+   Mesh mesh = Mesh::MakeCartesian3D(n, n, n, Element::HEXAHEDRON);
+
+   int nelems = mesh.GetNE();
+   int *partitioning = new int[nelems];
+
+   auto part_type = GENERATE(ALL, FIRST, LAST, ALL_BUT_LAST, ALL_BUT_FIRST);
+
+   GeneratePart(part_type, nelems, world_size, partitioning);
+
+   ParMesh pmesh(MPI_COMM_WORLD, mesh, partitioning);
+
+   ND_FECollection fec(order, dim);
+   ParFiniteElementSpace fespace(&pmesh, &fec);
+
+   ParBilinearForm a(&fespace);
+   a.AddDomainIntegrator(new CurlCurlIntegrator);
+   a.AddDomainIntegrator(new VectorFEMassIntegrator);
+   a.Assemble();
+
+   ParGridFunction x(&fespace);
+   VectorFunctionCoefficient sin3dCoef(3, sin3d_vec);
+   x.ProjectCoefficient(sin3dCoef);
+   double err0 = x.ComputeL2Error(sin3dCoef);
+
+   ParLinearForm b(&fespace);
+   a.Mult(x, b);
+   x = 0.0;
+
+   OperatorPtr A;
+   Vector B, X;
+   Array<int> ess_tdof_list;
+   a.FormLinearSystem(ess_tdof_list, x, b, A, X, B);
+
+   HypreAMS ams(*A.As<HypreParMatrix>(), &fespace);
+   ams.SetPrintLevel(0);
+
+   HyprePCG pcg(MPI_COMM_WORLD);
+   pcg.SetTol(1e-10);
+   pcg.SetMaxIter(2000);
+   pcg.SetPrintLevel(3);
+   pcg.SetPreconditioner(ams);
+   pcg.SetOperator(*A);
+   pcg.Mult(B, X);
+
+   int its = -1;
+   pcg.GetNumIterations(its);
+
+   a.RecoverFEMSolution(X, b, x);
+
+   double err = x.ComputeL2Error(sin3dCoef);
+   REQUIRE(fabs(err - err0) < 1e-6 * err0);
+}
+
+TEST_CASE("HypreADS", "[Parallel], [HypreADS]")
+{
+   int world_size, rank;
+   MPI_Comm_size(MPI_COMM_WORLD, &world_size);
+   MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+
+   int n = 3;
+   int dim = 3;
+   int order = 2;
+
+   Mesh mesh = Mesh::MakeCartesian3D(n, n, n, Element::HEXAHEDRON);
+
+   int nelems = mesh.GetNE();
+   int *partitioning = new int[nelems];
+
+   auto part_type = GENERATE(ALL, FIRST, LAST, ALL_BUT_LAST, ALL_BUT_FIRST);
+
+   GeneratePart(part_type, nelems, world_size, partitioning);
+
+   ParMesh pmesh(MPI_COMM_WORLD, mesh, partitioning);
+
+   RT_FECollection fec(order, dim);
+   ParFiniteElementSpace fespace(&pmesh, &fec);
+
+   ParBilinearForm a(&fespace);
+   a.AddDomainIntegrator(new DivDivIntegrator);
+   a.AddDomainIntegrator(new VectorFEMassIntegrator);
+   a.Assemble();
+
+   ParGridFunction x(&fespace);
+   VectorFunctionCoefficient sin3dCoef(3, sin3d_vec);
+   x.ProjectCoefficient(sin3dCoef);
+   double err0 = x.ComputeL2Error(sin3dCoef);
+
+   ParLinearForm b(&fespace);
+   a.Mult(x, b);
+   x = 0.0;
+
+   OperatorPtr A;
+   Vector B, X;
+   Array<int> ess_tdof_list;
+   a.FormLinearSystem(ess_tdof_list, x, b, A, X, B);
+
+   HypreADS ads(*A.As<HypreParMatrix>(), &fespace);
+   ads.SetPrintLevel(0);
+
+   HyprePCG pcg(MPI_COMM_WORLD);
+   pcg.SetTol(1e-10);
+   pcg.SetMaxIter(2000);
+   pcg.SetPrintLevel(3);
+   pcg.SetPreconditioner(ads);
+   pcg.SetOperator(*A);
+   pcg.Mult(B, X);
+
+   int its = -1;
+   pcg.GetNumIterations(its);
+
+   a.RecoverFEMSolution(X, b, x);
+
+   double err = x.ComputeL2Error(sin3dCoef);
+   REQUIRE(fabs(err - err0) < 1e-6 * err0);
+}
+
+#endif // MFEM_USE_MPI
+
+} // namespace mfem


### PR DESCRIPTION
Setup methods for HypreAMS and HyperADS require the basis function order. This cannot be obtained from the `FiniteElement` when a partition has no elements. As a result empty partitions use an order of 1 regardless of the true order. This then leads to the setup methods hanging in collective MPI calls when the true order is greater than 1.

This PR obtains the order from the `FiniteElementCollection` instead. 