### PR TITLE
Adds a QuadratureFunction constructor from external data

### DIFF
--- a/fem/qfunction.hpp
+++ b/fem/qfunction.hpp
@@ -47,6 +47,15 @@ public:
    QuadratureFunction(QuadratureSpaceBase *qspace_, int vdim_ = 1)
       : QuadratureFunction(*qspace_, vdim_) { }
 
+   /** @brief Create a QuadratureFunction based on the given QuadratureSpaceBase,
+       using the external data, @a qf_data. */
+   /** The QuadratureFunction does not assume ownership of the
+       QuadratureSpaceBase or the external data.
+       @warning @a qspace_ may not be NULL. */
+   QuadratureFunction(QuadratureSpaceBase *qspace_, double *qf_data, int vdim_ = 1)
+      : Vector(qf_data, vdim_*qspace_->GetSize()),
+        qspace(qspace_), own_qspace(false), vdim(vdim_) { }
+
    /** @brief Copy constructor. The QuadratureSpace ownership flag, #own_qspace,
        in the new object is set to false. */
    QuadratureFunction(const QuadratureFunction &orig)

--- a/fem/qfunction.hpp
+++ b/fem/qfunction.hpp
@@ -48,10 +48,12 @@ public:
       : QuadratureFunction(*qspace_, vdim_) { }
 
    /** @brief Create a QuadratureFunction based on the given QuadratureSpaceBase,
-       using the external data, @a qf_data. */
+       using the external (host) data, @a qf_data. */
    /** The QuadratureFunction does not assume ownership of the
        QuadratureSpaceBase or the external data.
-       @warning @a qspace_ may not be NULL. */
+       @warning @a qspace_ may not be NULL.
+       @note @a qf_data must be a valid **host** pointer (see the constructor
+       Vector::Vector(double *, int)). */
    QuadratureFunction(QuadratureSpaceBase *qspace_, double *qf_data, int vdim_ = 1)
       : Vector(qf_data, vdim_*qspace_->GetSize()),
         qspace(qspace_), own_qspace(false), vdim(vdim_) { }


### PR DESCRIPTION
This constructor was present in `mfem@4.4`, but is (inadvertently) missing in `mfem@4.5`.

Given:
```cpp
QuadratureSpace* qs = ...;
double* qf_data = ...;
int vdim = ...;
```
The following call: 
```cpp
QuadratureFunction qf(qspace, qf_data, vdim);
```
is equivalent to: 
```cpp
QuadratureFunction qf; 
qf.SetSpace(qspace, qf_data, vdim);
```

The missing constructor makes it a bit more awkward to register quadrature functions within axom's `MFEMSidreDataCollection`, where we want Sidre to allocate memory for the underlying quadrature function.
Also, the following sequence will allocate an unnecessary array:
```cpp
QuadratureFunction qf(qspace, vdim); // note: missing qf_data; qf will allocate a possibly large array
qf.NewDataAndSize(qf_data,qspace->GetSize()*vdim);
```

See: https://github.com/LLNL/axom/pull/975 which works around this when updating axom from mfem@4.4 to mfem@4.5
w/ associated usage:
* https://github.com/LLNL/axom/pull/975/files#diff-0ff57c00c54c7deef680ed6a99d4007c62add9a3cf3d0bfd73b68da4875cf3aa
* https://github.com/LLNL/axom/pull/975/files#diff-b2c20c1fc33599f25c590932ce8e1896728424b325e1e757ecc8d689fdf8f648
* https://github.com/LLNL/axom/pull/975/files#diff-de5333eee363ab8999f793591a2900d1d2e4a5e57cb883892b84c7a11727eeb6<!--GHEX{"author":"kennyweiss","assignment":"2022-12-13T20:46:02","editor":"pazner","id":3362,"reviewers":["rcarson3","pazner"],"merge":"2023-01-03T19:16:56","approval":"2022-12-28T02:02:23"}XEHG-->
<!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge|
 | --- | --- | --- | --- | --- | --- | --- |
| [#3362](https://github.com/mfem/mfem/pull/3362) | @kennyweiss | @pazner | @rcarson3 + @pazner | 12/13/22 | 12/27/22 | 1/3/23 | |
<!--ELBATXEHG-->
<details>
<summary>PR Checklist</summary>
    
- [ ] Code builds.
- [ ] Code passes `make style`.
- [ ] Update `CHANGELOG`:
    - [ ] Is this a new feature users need to be aware of? New or updated example or miniapp?
    - [ ] Does it make sense to create a new section in the `CHANGELOG` to group with other related features?
- [ ] Update `INSTALL`:
    - [ ] Had a new optional library been added? If so, what range of versions of this library are required? (*Make sure the external library is compatible with our BSD license, e.g. it is not licensed under GPL!*)
    - [ ] Have the version ranges for any required or optional libraries changed?
    - [ ] Does `make` or `cmake` have a new target?
    - [ ] Did the requirements or the installation process change? *(rare)*
- [ ] Update continuous integration server configurations if necessary (e.g. with new version requirements for each of MFEM's dependencies)
    - [ ] `.github`
    - [ ] `.appveyor.yml`
- [ ] Update `.gitignore`:
    - [ ] Check if `make distclean; git status` shows any files that were generated from the source by the project (not an IDE) but we don't want to track in the repository.
    - [ ] Add new patterns (just for the new files above) and re-run the above test.
- [ ] New examples:
    - [ ] All sample runs at the top of the example source file work.
    - [ ] Update `examples/makefile`:
      - [ ] Add the example code to the appropriate `SEQ_EXAMPLES` and `PAR_EXAMPLES` variables.
      - [ ] Add any files generated by it to the `clean` target.
      - [ ] Add the example binary and any files generated by it to the top-level `.gitignore` file.
    - [ ] Update `examples/CMakeLists.txt`:
      - [ ] Add the example code to the `ALL_EXE_SRCS` variable.
      - [ ] Make sure `THIS_TEST_OPTIONS` is set correctly for the new example.
   - [ ] List the new example in `doc/CodeDocumentation.dox`.
   - [ ] If new examples directory (e.g.`examples/pumi`), list it in `doc/CodeDocumentation.conf.in`
   - [ ] Companion pull request for documentation in [mfem/web](https://github.com/mfem/web) repo:
      - [ ] Update or add example-specific documentation, see e.g. the `src/examples.md`.
      - [ ] Add the description, labels and screenshots in `src/examples.md` and `src/img`.
      - [ ] In `examples.md`, list the example under the appropriate categories, add new categories if necessary.
      - [ ] Add a short description of the example in the "Extensive Examples" section of `features.md`.
- [ ] New miniapps:
   - [ ] All sample runs at the top of the miniapp source file work.
   - [ ] Update top-level `makefile` and `makefile` in corresponding miniapp directory.
   - [ ] Add the miniapp binary and any files generated by it to the top-level `.gitignore` file.
   - [ ] Update CMake build system:
      - [ ] Update the `CMakeLists.txt` file in the `miniapps` directory, if the new miniapp is in a new directory.
      - [ ] Add/update the `CMakeLists.txt` file in the new miniapp directory.
      - [ ] Consider adding a new test for the new miniapp.
   - [ ] List the new miniapp in `doc/CodeDocumentation.dox`
   - [ ] If new miniapps directory (e.g.`miniapps/nurbs`), add it to `MINIAPP_SUBDIRS` in the `makefile`.
   - [ ] If new miniapps directory (e.g.`miniapps/nurbs`), list it in `doc/CodeDocumentation.conf.in`
   - [ ] Companion pull request for documentation in [mfem/web](https://github.com/mfem/web) repo:
     - [ ] Update or add miniapp-specific documentation, see e.g. the `src/meshing.md` and `src/electromagnetics.md` files.
     - [ ] Add the description, labels and screenshots in `src/examples.md` and `src/img`.
     - [ ] The miniapps go at the end of the page, and are usually listed only under a specific "Application (PDE)" category.
     - [ ] Add a short description of the miniapp in the "Extensive Examples" section of `features.md`.
- [ ] New capability:
   - [ ] All new public, protected, and private classes, methods, data members, and functions have full Doxygen-style documentation in source comments. Documentation should include descriptions of member data, function arguments and return values, template parameters, and prerequisites for calling new functions.
   - [ ] Pointer arguments and return values must specify whether ownership is being transferred or lent with the call.
   - [ ] Any new functions should include descriptions of their intended use e.g. for internal use only, user-facing, etc., along with references to example code whenever possible/appropriate.
   - [ ] Consider adding new sample runs in existing examples to highlight the new capability.
   - [ ] Consider saving cool simulation pictures with the new capability in the Confluence gallery (LLNL only) or submitting them, via pull request, to the gallery section of the `mfem/web` repo.
   - [ ] If this is a major new feature, consider mentioning it in the short summary inside `README` *(rare)*.
   - [ ] List major new classes in `doc/CodeDocumentation.dox` *(rare)*.
- [ ] Update this checklist, if the new pull request affects it.
- [ ] Run `make unittest` to make sure all unit tests pass.
- [ ] Run the tests in `tests/scripts`.
- [ ] (LLNL only) After merging:
   - [ ] Update internal tests to include the new features.
</details>
