### PR TITLE
Fix double-free of HypreParVector after move with hypre+GPU

### DIFF
--- a/general/mem_manager.hpp
+++ b/general/mem_manager.hpp
@@ -211,6 +211,8 @@ public:
        validity flags of @a *this to those of @a other. Resets @a other. */
    Memory &operator=(Memory &&orig)
    {
+      // Guard self-assignment:
+      if (this == &orig) { return *this; }
       *this = orig;
       orig.Reset();
       return *this;

--- a/linalg/hypre.cpp
+++ b/linalg/hypre.cpp
@@ -292,13 +292,11 @@ HypreParVector& HypreParVector::operator=(const HypreParVector &y)
 
 HypreParVector& HypreParVector::operator=(HypreParVector &&y)
 {
-   // If the argument vector owns its data, then the calling vector will as well
-   WrapHypreParVector(static_cast<hypre_ParVector*>(y), y.own_ParVector);
-   // Either way the argument vector will no longer own its data
+   Vector::operator=(std::move(y));
+   own_ParVector = y.own_ParVector;
+   x = y.x;
    y.own_ParVector = 0;
    y.x = nullptr;
-   y.data.Delete();
-   y.size = 0;
    return *this;
 }
 

--- a/linalg/hypre.cpp
+++ b/linalg/hypre.cpp
@@ -293,10 +293,13 @@ HypreParVector& HypreParVector::operator=(const HypreParVector &y)
 HypreParVector& HypreParVector::operator=(HypreParVector &&y)
 {
    Vector::operator=(std::move(y));
-   own_ParVector = y.own_ParVector;
-   x = y.x;
+   // Self-assignment-safe way to move for 'own_ParVector' and 'x':
+   const auto own_tmp = y.own_ParVector;
    y.own_ParVector = 0;
+   own_ParVector = own_tmp;
+   const auto x_tmp = y.x;
    y.x = nullptr;
+   x = x_tmp;
    return *this;
 }
 

--- a/linalg/hypre.cpp
+++ b/linalg/hypre.cpp
@@ -297,7 +297,7 @@ HypreParVector& HypreParVector::operator=(HypreParVector &&y)
    // Either way the argument vector will no longer own its data
    y.own_ParVector = 0;
    y.x = nullptr;
-   y.data.Reset();
+   y.data.Delete();
    y.size = 0;
    return *this;
 }

--- a/linalg/vector.cpp
+++ b/linalg/vector.cpp
@@ -149,9 +149,10 @@ Vector &Vector::operator=(const Vector &v)
 Vector &Vector::operator=(Vector &&v)
 {
    data = std::move(v.data);
-   size = v.size;
-   // v.data.Reset(); // now done by the move assignment of 'v.data' -> 'data'
+   // Self-assignment-safe way to move v.size to size:
+   const auto size_tmp = v.size;
    v.size = 0;
+   size = size_tmp;
    return *this;
 }
 

--- a/linalg/vector.cpp
+++ b/linalg/vector.cpp
@@ -150,7 +150,7 @@ Vector &Vector::operator=(Vector &&v)
 {
    data = std::move(v.data);
    size = v.size;
-   v.data.Reset();
+   // v.data.Reset(); // now done by the move assignment of 'v.data' -> 'data'
    v.size = 0;
    return *this;
 }


### PR DESCRIPTION
Fix double-free of `HypreParVector` device memory after `move` when mfem is built with hypre+gpu
* 2 `Memory`s (different host pointer, same device pointer) will be registered, one will be freed when the moved-to `HypreParVector` is destroyed and `MemoryManager::Destroy` will try to free the other; double-free
* Use `Delete` instead of `Reset` to make sure only one `Memory` is registered

Here is a reproducer based on https://github.com/mfem/mfem/blob/master/tests/unit/linalg/test_hypre_vector.cpp:
(I also added debug prints in `MemoryManager::Destroy` and `MemoryManager::Register_`, which you will see in the output)
```cpp
#include <mfem.hpp>
#include <stdlib.h>
#include <vector>

using namespace mfem;

std::vector<HYPRE_BigInt> GenerateColumnPartitioning(const int nproc, const int rank, const int size_per_rank)
{
   std::vector<HYPRE_BigInt> col;
   if (HYPRE_AssumedPartitionCheck())
   {
      int offset = rank*size_per_rank;
      col = {offset, offset + size_per_rank};
   }
   else
   {
      col.resize(nproc + 1);
      for (int i=0; i<=nproc; ++i)
      {
         col[i] = i*size_per_rank;
      }
   }
   return col;
}

int main(int argc, char ** argv)
{
   MPI_Init(&argc, &argv);
   Hypre::Init();
   constexpr const char * device_name =
#ifdef __NVCC__
      "cuda";
#else
      "hip";
#endif
   Device device(device_name);

   MPI_Comm comm = MPI_COMM_WORLD;
   int nproc, rank;
   MPI_Comm_size(comm, &nproc);
   MPI_Comm_rank(comm, &rank);
   const int size_per_rank = 2;

   HYPRE_BigInt glob_size = nproc * size_per_rank;
   std::vector<HYPRE_BigInt> col = GenerateColumnPartitioning(nproc, rank, size_per_rank);

   HypreParVector a(comm, glob_size, col.data()); // registers (h_ptr_1, d_ptr)
   HypreParVector b = std::move(a);               // registers (h_ptr_2, d_ptr) but does not deregister (h_ptr_1, d_ptr) 

   MPI_Finalize();

   return 0;
}
```


Here is the output with cuda:

```
insert device: h_ptr 0x26c4f8d0, d_ptr 0x2000a0000000
insert device: h_ptr 0x26c4f8b0, d_ptr 0x2000a0000000

==============================
known pointers:

key 0x26c4f8d0, h_ptr 0x26c4f8d0, d_ptr 0x2000a0000000
==============================

terminate called after throwing an instance of 'umpire::util::Exception'
  what():  ! Umpire Exception [umpire-6bf231b/src/umpire/alloc/CudaMallocAllocator.hpp:54]:  deallocate cudaFree( ptr = 0x2000a0000000 ) failed with error: invalid argument
```

And hip:

```
insert device: h_ptr 0x59b8bd0, d_ptr 0x154bbd000000
insert device: h_ptr 0x59f6fe0, d_ptr 0x154bbd000000

==============================
known pointers:

key 0x59b8bd0, h_ptr 0x59b8bd0, d_ptr 0x154bbd000000
==============================

terminate called after throwing an instance of 'umpire::util::Exception'
  what():  ! Umpire Exception [umpire-6bf231b/src/umpire/alloc/HipMallocAllocator.hpp:54]:  deallocate hipFree( ptr = 0x154bbd000000 ) failed with error: invalid argument
```

With the change there are no known pointers in `MemoryManager::Destroy`.<!--GHEX{"author":"tomstitt","assignment":"2022-12-13T17:56:29","editor":"pazner","id":3364,"reviewers":["v-dobrev","camierjs","joshessman-llnl"],"merge":"2023-01-03T17:56:29","approval":"2023-01-31T19:55:10"}XEHG-->
<!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge|
 | --- | --- | --- | --- | --- | --- | --- |
| [#3364](https://github.com/mfem/mfem/pull/3364) | @tomstitt | @pazner | @v-dobrev + @camierjs + @joshessman-llnl | 12/13/22 | 1/31/23 | ⌛due 1/3/23 | |
<!--ELBATXEHG-->
<details>
<summary>PR Checklist</summary>
    
- [ ] Code builds.
- [ ] Code passes `make style`.
- [ ] Update `CHANGELOG`:
    - [ ] Is this a new feature users need to be aware of? New or updated example or miniapp?
    - [ ] Does it make sense to create a new section in the `CHANGELOG` to group with other related features?
- [ ] Update `INSTALL`:
    - [ ] Had a new optional library been added? If so, what range of versions of this library are required? (*Make sure the external library is compatible with our BSD license, e.g. it is not licensed under GPL!*)
    - [ ] Have the version ranges for any required or optional libraries changed?
    - [ ] Does `make` or `cmake` have a new target?
    - [ ] Did the requirements or the installation process change? *(rare)*
- [ ] Update continuous integration server configurations if necessary (e.g. with new version requirements for each of MFEM's dependencies)
    - [ ] `.github`
    - [ ] `.appveyor.yml`
- [ ] Update `.gitignore`:
    - [ ] Check if `make distclean; git status` shows any files that were generated from the source by the project (not an IDE) but we don't want to track in the repository.
    - [ ] Add new patterns (just for the new files above) and re-run the above test.
- [ ] New examples:
    - [ ] All sample runs at the top of the example source file work.
    - [ ] Update `examples/makefile`:
      - [ ] Add the example code to the appropriate `SEQ_EXAMPLES` and `PAR_EXAMPLES` variables.
      - [ ] Add any files generated by it to the `clean` target.
      - [ ] Add the example binary and any files generated by it to the top-level `.gitignore` file.
    - [ ] Update `examples/CMakeLists.txt`:
      - [ ] Add the example code to the `ALL_EXE_SRCS` variable.
      - [ ] Make sure `THIS_TEST_OPTIONS` is set correctly for the new example.
   - [ ] List the new example in `doc/CodeDocumentation.dox`.
   - [ ] If new examples directory (e.g.`examples/pumi`), list it in `doc/CodeDocumentation.conf.in`
   - [ ] Companion pull request for documentation in [mfem/web](https://github.com/mfem/web) repo:
      - [ ] Update or add example-specific documentation, see e.g. the `src/examples.md`.
      - [ ] Add the description, labels and screenshots in `src/examples.md` and `src/img`.
      - [ ] In `examples.md`, list the example under the appropriate categories, add new categories if necessary.
      - [ ] Add a short description of the example in the "Extensive Examples" section of `features.md`.
- [ ] New miniapps:
   - [ ] All sample runs at the top of the miniapp source file work.
   - [ ] Update top-level `makefile` and `makefile` in corresponding miniapp directory.
   - [ ] Add the miniapp binary and any files generated by it to the top-level `.gitignore` file.
   - [ ] Update CMake build system:
      - [ ] Update the `CMakeLists.txt` file in the `miniapps` directory, if the new miniapp is in a new directory.
      - [ ] Add/update the `CMakeLists.txt` file in the new miniapp directory.
      - [ ] Consider adding a new test for the new miniapp.
   - [ ] List the new miniapp in `doc/CodeDocumentation.dox`
   - [ ] If new miniapps directory (e.g.`miniapps/nurbs`), add it to `MINIAPP_SUBDIRS` in the `makefile`.
   - [ ] If new miniapps directory (e.g.`miniapps/nurbs`), list it in `doc/CodeDocumentation.conf.in`
   - [ ] Companion pull request for documentation in [mfem/web](https://github.com/mfem/web) repo:
     - [ ] Update or add miniapp-specific documentation, see e.g. the `src/meshing.md` and `src/electromagnetics.md` files.
     - [ ] Add the description, labels and screenshots in `src/examples.md` and `src/img`.
     - [ ] The miniapps go at the end of the page, and are usually listed only under a specific "Application (PDE)" category.
     - [ ] Add a short description of the miniapp in the "Extensive Examples" section of `features.md`.
- [ ] New capability:
   - [ ] All new public, protected, and private classes, methods, data members, and functions have full Doxygen-style documentation in source comments. Documentation should include descriptions of member data, function arguments and return values, template parameters, and prerequisites for calling new functions.
   - [ ] Pointer arguments and return values must specify whether ownership is being transferred or lent with the call.
   - [ ] Any new functions should include descriptions of their intended use e.g. for internal use only, user-facing, etc., along with references to example code whenever possible/appropriate.
   - [ ] Consider adding new sample runs in existing examples to highlight the new capability.
   - [ ] Consider saving cool simulation pictures with the new capability in the Confluence gallery (LLNL only) or submitting them, via pull request, to the gallery section of the `mfem/web` repo.
   - [ ] If this is a major new feature, consider mentioning it in the short summary inside `README` *(rare)*.
   - [ ] List major new classes in `doc/CodeDocumentation.dox` *(rare)*.
- [ ] Update this checklist, if the new pull request affects it.
- [ ] Run `make unittest` to make sure all unit tests pass.
- [ ] Run the tests in `tests/scripts`.
- [ ] (LLNL only) After merging:
   - [ ] Update internal tests to include the new features.
</details>
