### PR TITLE
Add Array move constructor, make [Par]TransferMap movable

### DIFF
--- a/general/array.hpp
+++ b/general/array.hpp
@@ -92,6 +92,9 @@ public:
    template <typename CT, int N>
    explicit inline Array(const CT (&values)[N]);
 
+   /// Move constructor ("steals" data from 'src')
+   inline Array(Array<T> &&src) { Swap(src, *this); }
+
    /// Destructor
    inline ~Array() { TypeAssert(); data.Delete(); }
 

--- a/mesh/submesh/ptransfermap.cpp
+++ b/mesh/submesh/ptransfermap.cpp
@@ -41,9 +41,9 @@ ParTransferMap::ParTransferMap(const ParGridFunction &src,
 
       category_ = TransferCategory::SubMeshToSubMesh;
 
-      root_fes_ = new ParFiniteElementSpace(
-         *src.ParFESpace(),
-         *const_cast<ParMesh *>(SubMeshUtils::GetRootParent(*src_sm)));
+      root_fes_.reset(new ParFiniteElementSpace(
+                         *src.ParFESpace(),
+                         *const_cast<ParMesh *>(SubMeshUtils::GetRootParent(*src_sm))));
       subfes1 = src.ParFESpace();
       subfes2 = dst.ParFESpace();
 
@@ -212,11 +212,6 @@ void ParTransferMap::CommunicateSharedVdofs(Vector &f) const
    }
 
    root_gc_->Bcast<double>(f.HostReadWrite());
-}
-
-ParTransferMap::~ParTransferMap()
-{
-   delete root_fes_;
 }
 
 #endif // MFEM_USE_MPI

--- a/mesh/submesh/ptransfermap.cpp
+++ b/mesh/submesh/ptransfermap.cpp
@@ -33,17 +33,17 @@ ParTransferMap::ParTransferMap(const ParGridFunction &src,
 
       // There is no immediate relation and both src and dst come from a
       // SubMesh, check if they have an equivalent root parent.
-      if (SubMeshUtils::GetRootParent<ParSubMesh, ParMesh>(*src_sm) !=
-          SubMeshUtils::GetRootParent<ParSubMesh, ParMesh>(*dst_sm))
+      if (SubMeshUtils::GetRootParent(*src_sm) !=
+          SubMeshUtils::GetRootParent(*dst_sm))
       {
          MFEM_ABORT("Can't find a relation between the two GridFunctions");
       }
 
       category_ = TransferCategory::SubMeshToSubMesh;
 
-      root_fes_ = new ParFiniteElementSpace(*src.ParFESpace(),
-                                            *const_cast<ParMesh *>(SubMeshUtils::GetRootParent<ParSubMesh, ParMesh>
-                                                                   (*src_sm)));
+      root_fes_ = new ParFiniteElementSpace(
+         *src.ParFESpace(),
+         *const_cast<ParMesh *>(SubMeshUtils::GetRootParent(*src_sm)));
       subfes1 = src.ParFESpace();
       subfes2 = dst.ParFESpace();
 

--- a/mesh/submesh/ptransfermap.hpp
+++ b/mesh/submesh/ptransfermap.hpp
@@ -14,6 +14,7 @@
 
 #include "../../fem/pgridfunc.hpp"
 #include "transfer_category.hpp"
+#include <memory>
 
 namespace mfem
 {
@@ -51,8 +52,6 @@ public:
     * @param dst The destination ParGridFunction
     */
    void Transfer(const ParGridFunction &src, ParGridFunction &dst) const;
-
-   ~ParTransferMap();
 
 private:
    /**
@@ -97,7 +96,7 @@ private:
    /// Pointer to the supplemental ParFiniteElementSpace on the common root
    /// parent ParMesh. This is only used if this ParTransferMap represents a
    /// ParSubMesh to ParSubMesh transfer.
-   const ParFiniteElementSpace *root_fes_ = nullptr;
+   std::unique_ptr<const ParFiniteElementSpace> root_fes_;
 
    const GroupCommunicator *root_gc_ = nullptr;
 

--- a/mesh/submesh/submesh_utils.hpp
+++ b/mesh/submesh/submesh_utils.hpp
@@ -118,14 +118,8 @@ RT GetRootParent(const T &m)
    while (true)
    {
       const T* next = dynamic_cast<const T*>(parent);
-      if (next == nullptr)
-      {
-         return static_cast<RT>(parent);
-      }
-      else
-      {
-         parent = next->GetParent();
-      }
+      if (next == nullptr) { return parent; }
+      else { parent = next->GetParent(); }
    }
 }
 

--- a/mesh/submesh/submesh_utils.hpp
+++ b/mesh/submesh/submesh_utils.hpp
@@ -111,16 +111,16 @@ void BuildVdofToVdofMap(const FiniteElementSpace& subfes,
  * @tparam T The type of the input object which has to fulfill the
  * SubMesh::GetParent() interface.
  */
-template <class T, class RT>
-const RT* GetRootParent(const T &m)
+template <class T, class RT = decltype(std::declval<T>().GetParent())>
+RT GetRootParent(const T &m)
 {
-   const RT* parent = m.GetParent();
+   RT parent = m.GetParent();
    while (true)
    {
       const T* next = dynamic_cast<const T*>(parent);
       if (next == nullptr)
       {
-         return static_cast<const RT *>(parent);
+         return static_cast<RT>(parent);
       }
       else
       {

--- a/mesh/submesh/transfermap.cpp
+++ b/mesh/submesh/transfermap.cpp
@@ -29,17 +29,17 @@ TransferMap::TransferMap(const GridFunction &src,
 
       // There is no immediate relation and both src and dst come from a
       // SubMesh, check if they have an equivalent root parent.
-      if (SubMeshUtils::GetRootParent<SubMesh, Mesh>(*src_sm) !=
-          SubMeshUtils::GetRootParent<SubMesh, Mesh>(*dst_sm))
+      if (SubMeshUtils::GetRootParent(*src_sm) !=
+          SubMeshUtils::GetRootParent(*dst_sm))
       {
          MFEM_ABORT("Can't find a relation between the two GridFunctions");
       }
 
       category_ = TransferCategory::SubMeshToSubMesh;
 
-      root_fes_ = new FiniteElementSpace(*src.FESpace(),
-                                         const_cast<Mesh *>(SubMeshUtils::GetRootParent<SubMesh, Mesh>
-                                                            (*src_sm)));
+      root_fes_ = new FiniteElementSpace(
+         *src.FESpace(),
+         const_cast<Mesh *>(SubMeshUtils::GetRootParent(*src_sm)));
       subfes1 = src.FESpace();
       subfes2 = dst.FESpace();
 

--- a/mesh/submesh/transfermap.cpp
+++ b/mesh/submesh/transfermap.cpp
@@ -37,9 +37,9 @@ TransferMap::TransferMap(const GridFunction &src,
 
       category_ = TransferCategory::SubMeshToSubMesh;
 
-      root_fes_ = new FiniteElementSpace(
-         *src.FESpace(),
-         const_cast<Mesh *>(SubMeshUtils::GetRootParent(*src_sm)));
+      root_fes_.reset(new FiniteElementSpace(
+                         *src.FESpace(),
+                         const_cast<Mesh *>(SubMeshUtils::GetRootParent(*src_sm))));
       subfes1 = src.FESpace();
       subfes2 = dst.FESpace();
 
@@ -137,9 +137,4 @@ void TransferMap::Transfer(const GridFunction &src,
    {
       MFEM_ABORT("unknown TransferCategory: " << category_);
    }
-}
-
-TransferMap::~TransferMap()
-{
-   delete root_fes_;
 }

--- a/mesh/submesh/transfermap.hpp
+++ b/mesh/submesh/transfermap.hpp
@@ -14,6 +14,7 @@
 
 #include "../../fem/gridfunc.hpp"
 #include "transfer_category.hpp"
+#include <memory>
 
 namespace mfem
 {
@@ -50,8 +51,6 @@ public:
     */
    void Transfer(const GridFunction &src, GridFunction &dst) const;
 
-   ~TransferMap();
-
 private:
    TransferCategory category_;
 
@@ -67,7 +66,7 @@ private:
    /// Pointer to the supplemental FiniteElementSpace on the common root parent
    /// Mesh. This is only used if this TransferMap represents a SubMesh to
    /// SubMesh transfer.
-   const FiniteElementSpace *root_fes_ = nullptr;
+   std::unique_ptr<const FiniteElementSpace> root_fes_;
 
    /// Temporary vector
    mutable Vector z_;


### PR DESCRIPTION
* Adds move constructor for `Array<T>`
* Make `TransferMap` and `ParTransferMap` implicitly movable (resolves #3401)
* Slight change to `SubMeshUtils::GetRootParent` to improve type deduction (no longer need to explicitly specify template parameters)<!--GHEX{"author":"pazner","assignment":"2023-01-09T15:30:21","editor":"tzanio","id":3402,"reviewers":["sshiraiwa","jandrej"],"merge":"2023-01-10T20:11:56","approval":"2023-01-10T01:36:21"}XEHG-->
<!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge|
 | --- | --- | --- | --- | --- | --- | --- |
| [#3402](https://github.com/mfem/mfem/pull/3402) | @pazner | @tzanio | @sshiraiwa + @jandrej | 1/9/23 | 1/9/23 | 1/10/23 | |
<!--ELBATXEHG-->
<details>
<summary>PR Checklist</summary>
    
- [ ] Code builds.
- [ ] Code passes `make style`.
- [ ] Update `CHANGELOG`:
    - [ ] Is this a new feature users need to be aware of? New or updated example or miniapp?
    - [ ] Does it make sense to create a new section in the `CHANGELOG` to group with other related features?
- [ ] Update `INSTALL`:
    - [ ] Had a new optional library been added? If so, what range of versions of this library are required? (*Make sure the external library is compatible with our BSD license, e.g. it is not licensed under GPL!*)
    - [ ] Have the version ranges for any required or optional libraries changed?
    - [ ] Does `make` or `cmake` have a new target?
    - [ ] Did the requirements or the installation process change? *(rare)*
- [ ] Update continuous integration server configurations if necessary (e.g. with new version requirements for each of MFEM's dependencies)
    - [ ] `.github`
    - [ ] `.appveyor.yml`
- [ ] Update `.gitignore`:
    - [ ] Check if `make distclean; git status` shows any files that were generated from the source by the project (not an IDE) but we don't want to track in the repository.
    - [ ] Add new patterns (just for the new files above) and re-run the above test.
- [ ] New examples:
    - [ ] All sample runs at the top of the example source file work.
    - [ ] Update `examples/makefile`:
      - [ ] Add the example code to the appropriate `SEQ_EXAMPLES` and `PAR_EXAMPLES` variables.
      - [ ] Add any files generated by it to the `clean` target.
      - [ ] Add the example binary and any files generated by it to the top-level `.gitignore` file.
    - [ ] Update `examples/CMakeLists.txt`:
      - [ ] Add the example code to the `ALL_EXE_SRCS` variable.
      - [ ] Make sure `THIS_TEST_OPTIONS` is set correctly for the new example.
   - [ ] List the new example in `doc/CodeDocumentation.dox`.
   - [ ] If new examples directory (e.g.`examples/pumi`), list it in `doc/CodeDocumentation.conf.in`
   - [ ] Companion pull request for documentation in [mfem/web](https://github.com/mfem/web) repo:
      - [ ] Update or add example-specific documentation, see e.g. the `src/examples.md`.
      - [ ] Add the description, labels and screenshots in `src/examples.md` and `src/img`.
      - [ ] In `examples.md`, list the example under the appropriate categories, add new categories if necessary.
      - [ ] Add a short description of the example in the "Extensive Examples" section of `features.md`.
- [ ] New miniapps:
   - [ ] All sample runs at the top of the miniapp source file work.
   - [ ] Update top-level `makefile` and `makefile` in corresponding miniapp directory.
   - [ ] Add the miniapp binary and any files generated by it to the top-level `.gitignore` file.
   - [ ] Update CMake build system:
      - [ ] Update the `CMakeLists.txt` file in the `miniapps` directory, if the new miniapp is in a new directory.
      - [ ] Add/update the `CMakeLists.txt` file in the new miniapp directory.
      - [ ] Consider adding a new test for the new miniapp.
   - [ ] List the new miniapp in `doc/CodeDocumentation.dox`
   - [ ] If new miniapps directory (e.g.`miniapps/nurbs`), add it to `MINIAPP_SUBDIRS` in the `makefile`.
   - [ ] If new miniapps directory (e.g.`miniapps/nurbs`), list it in `doc/CodeDocumentation.conf.in`
   - [ ] Companion pull request for documentation in [mfem/web](https://github.com/mfem/web) repo:
     - [ ] Update or add miniapp-specific documentation, see e.g. the `src/meshing.md` and `src/electromagnetics.md` files.
     - [ ] Add the description, labels and screenshots in `src/examples.md` and `src/img`.
     - [ ] The miniapps go at the end of the page, and are usually listed only under a specific "Application (PDE)" category.
     - [ ] Add a short description of the miniapp in the "Extensive Examples" section of `features.md`.
- [ ] New capability:
   - [ ] All new public, protected, and private classes, methods, data members, and functions have full Doxygen-style documentation in source comments. Documentation should include descriptions of member data, function arguments and return values, template parameters, and prerequisites for calling new functions.
   - [ ] Pointer arguments and return values must specify whether ownership is being transferred or lent with the call.
   - [ ] Any new functions should include descriptions of their intended use e.g. for internal use only, user-facing, etc., along with references to example code whenever possible/appropriate.
   - [ ] Consider adding new sample runs in existing examples to highlight the new capability.
   - [ ] Consider saving cool simulation pictures with the new capability in the Confluence gallery (LLNL only) or submitting them, via pull request, to the gallery section of the `mfem/web` repo.
   - [ ] If this is a major new feature, consider mentioning it in the short summary inside `README` *(rare)*.
   - [ ] List major new classes in `doc/CodeDocumentation.dox` *(rare)*.
- [ ] Update this checklist, if the new pull request affects it.
- [ ] Run `make unittest` to make sure all unit tests pass.
- [ ] Run the tests in `tests/scripts`.
- [ ] (LLNL only) After merging:
   - [ ] Update internal tests to include the new features.
</details>
