### PR TITLE
Adding DataCollection output to mesh-explorer [mesh-explorer-datacollection-dev]

### DIFF
--- a/miniapps/meshing/mesh-explorer.cpp
+++ b/miniapps/meshing/mesh-explorer.cpp
@@ -384,6 +384,7 @@ int main (int argc, char *argv[])
            "o) Reorder elements\n"
            "S) Save in MFEM format\n"
            "V) Save in VTK format (only linear and quadratic meshes)\n"
+           "D) Save as a DataCollection\n"
            "q) Quit\n"
 #ifdef MFEM_USE_ZLIB
            "Z) Save in MFEM format with compression\n"
@@ -1188,6 +1189,33 @@ int main (int argc, char *argv[])
          omesh.precision(14);
          mesh->PrintVTK(omesh);
          cout << "New VTK mesh file: " << omesh_file << endl;
+      }
+
+      if (mk == 'D')
+      {
+         cout << "What type of DataCollection?\n"
+              "p) ParaView Data Collection\n"
+              "v) VisIt Data Collection\n"
+              "--> " << flush;
+         char dk;
+         cin >> dk;
+         if (dk == 'p')
+         {
+            const char omesh_file[] = "mesh-explorer-paraview";
+            ParaViewDataCollection dc(omesh_file, mesh);
+            dc.SetPrecision(14);
+            dc.Save();
+            cout << "New ParaView mesh file: " << omesh_file << endl;
+         }
+         else if (dk == 'v')
+         {
+            const char omesh_file[] = "mesh-explorer-visit";
+            VisItDataCollection dc(omesh_file, mesh);
+            dc.SetPrecision(14);
+            dc.Save();
+            cout << "New VisIt mesh file: " << omesh_file << "_000000.mfem_root"
+                 << endl;
+         }
       }
 
 #ifdef MFEM_USE_ZLIB


### PR DESCRIPTION
This PR adds a new main menu item 'D' to select DataCollection output. A submenu then offers VisIt and ParaView output options.

We could potentially add additional user input to change various DataCollection settings if this would be useful.

This PR is related to discussion #3397.