### PR TITLE
Fix the cmake generate error when target_include_directories while linking cmake in another project [cmaketargetincludeerror-dev]

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -575,7 +575,7 @@ target_include_directories(mfem
   PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
-    ${TPL_INCLUDE_DIRS})
+    "$<BUILD_INTERFACE:${TPL_INCLUDE_DIRS}>")
 set_target_properties(mfem PROPERTIES VERSION "${mfem_VERSION}")
 set_target_properties(mfem PROPERTIES SOVERSION "${mfem_VERSION}")
 


### PR DESCRIPTION
fix #3413 
This has already be tested on windows whether mfem is built separately or embedded in other cmake projects.
Hope someone could test in linux.