### PR TITLE
Fix logic for points near but outside domain boundary

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -16,6 +16,9 @@ Meshing improvements
 - Added support for pyramids in non-conforming meshes. Currently only isotropic
   refinement is supported in this case.
 
+- Updated logic in FindPointsGSLIB to ignore points found near (but outside) the
+  domain boundary.
+
 Discretization improvements
 ---------------------------
 - TBD

--- a/fem/gslib.cpp
+++ b/fem/gslib.cpp
@@ -37,7 +37,7 @@ FindPointsGSLIB::FindPointsGSLIB()
      fec_map_lin(NULL),
      fdata2D(NULL), fdata3D(NULL), cr(NULL), gsl_comm(NULL),
      dim(-1), points_cnt(0), setupflag(false), default_interp_value(0),
-     avgtype(AvgType::ARITHMETIC)
+     avgtype(AvgType::ARITHMETIC), bdr_tol(1e-8)
 {
    mesh_split.SetSize(4);
    ir_split.SetSize(4);
@@ -84,7 +84,7 @@ FindPointsGSLIB::FindPointsGSLIB(MPI_Comm comm_)
      fec_map_lin(NULL),
      fdata2D(NULL), fdata3D(NULL), cr(NULL), gsl_comm(NULL),
      dim(-1), points_cnt(0), setupflag(false), default_interp_value(0),
-     avgtype(AvgType::ARITHMETIC)
+     avgtype(AvgType::ARITHMETIC), bdr_tol(1e-8)
 {
    mesh_split.SetSize(4);
    ir_split.SetSize(4);
@@ -223,10 +223,12 @@ void FindPointsGSLIB::FindPoints(const Vector &point_pos,
    // Set the element number and reference position to 0 for points not found
    for (int i = 0; i < points_cnt; i++)
    {
-      if (gsl_code[i] == 2)
+      if (gsl_code[i] == 2 ||
+          (gsl_code[i] == 1 && gsl_dist(i) > bdr_tol))
       {
          gsl_elem[i] = 0;
          for (int d = 0; d < dim; d++) { gsl_ref(i*dim + d) = -1.; }
+         gsl_code[i] = 2;
       }
    }
 
@@ -1248,10 +1250,12 @@ void OversetFindPointsGSLIB::FindPoints(const Vector &point_pos,
    // Set the element number and reference position to 0 for points not found
    for (int i = 0; i < points_cnt; i++)
    {
-      if (gsl_code[i] == 2)
+      if (gsl_code[i] == 2 ||
+          (gsl_code[i] == 1 && gsl_dist(i) > bdr_tol))
       {
          gsl_elem[i] = 0;
          for (int d = 0; d < dim; d++) { gsl_ref(i*dim + d) = -1.; }
+         gsl_code[i] = 2;
       }
    }
 

--- a/fem/gslib.hpp
+++ b/fem/gslib.hpp
@@ -38,6 +38,11 @@ namespace mfem
  *     coordinates inside the element that each point is located in. gslib also
  *     returns a code that indicates whether the point was found inside an
  *     element, on element border, or not found in the domain.
+ *     For points returned as found on `element border`, the point is either
+ *     on an element edge/face or near the domain boundary, and gslib also
+ *     returns a distance to the border. Points near (but outside) the domain
+ *     boundary must then be marked as not found using the distance returned
+ *     by gslib.
  *
  *  3. Interpolate - Interpolates any grid function at the points found using 2.
  *
@@ -70,6 +75,8 @@ protected:
    Array<int> split_element_map;
    Array<int> split_element_index;
    int        NE_split_total;
+   // Tolerance to ignore points just outside elements at the boundary.
+   double     bdr_tol;
 
    /// Use GSLIB for communication and interpolation
    virtual void InterpolateH1(const GridFunction &field_in, Vector &field_out);
@@ -179,6 +186,14 @@ public:
    virtual void SetDefaultInterpolationValue(double interp_value_)
    {
       default_interp_value = interp_value_;
+   }
+
+   /// Set the tolerance for detecting points outside the 'curvilinear' boundary
+   /// that gslib may return as found on the boundary. Points found on boundary
+   /// with distance greater than @ bdr_tol are marked as not found.
+   virtual void SetDistanceToleranceForPointsFoundOnBoundary(double bdr_tol_)
+   {
+      bdr_tol = bdr_tol_;
    }
 
    /** Cleans up memory allocated internally by gslib.

--- a/fem/tmop.cpp
+++ b/fem/tmop.cpp
@@ -4011,6 +4011,12 @@ void TMOP_Integrator::EnableFiniteDifferences(const ParGridFunction &x)
    ComputeFDh(x,*pfes);
    if (discr_tc)
    {
+      const AdaptivityEvaluator *ae = discr_tc->GetAdaptivityEvaluator();
+      if (dynamic_cast<const InterpolatorFP *>(ae))
+      {
+         MFEM_ABORT("Using GSLIB-based interpolation with finite differences"
+                    "requires careful consideration. Contact TMOP team.");
+      }
       discr_tc->UpdateTargetSpecification(x, false, pfes->GetOrdering());
       discr_tc->UpdateGradientTargetSpecification(x, dx, false, pfes->GetOrdering());
       discr_tc->UpdateHessianTargetSpecification(x, dx, false, pfes->GetOrdering());

--- a/fem/tmop.cpp
+++ b/fem/tmop.cpp
@@ -3997,6 +3997,14 @@ void TMOP_Integrator::EnableFiniteDifferences(const GridFunction &x)
    ComputeFDh(x,*fes);
    if (discr_tc)
    {
+#ifdef MFEM_USE_GSLIB
+      const AdaptivityEvaluator *ae = discr_tc->GetAdaptivityEvaluator();
+      if (dynamic_cast<const InterpolatorFP *>(ae))
+      {
+         MFEM_ABORT("Using GSLIB-based interpolation with finite differences"
+                    "requires careful consideration. Contact TMOP team.");
+      }
+#endif
       discr_tc->UpdateTargetSpecification(x, false, fes->GetOrdering());
       discr_tc->UpdateGradientTargetSpecification(x, dx, false, fes->GetOrdering());
       discr_tc->UpdateHessianTargetSpecification(x, dx, false, fes->GetOrdering());
@@ -4011,12 +4019,14 @@ void TMOP_Integrator::EnableFiniteDifferences(const ParGridFunction &x)
    ComputeFDh(x,*pfes);
    if (discr_tc)
    {
+#ifdef MFEM_USE_GSLIB
       const AdaptivityEvaluator *ae = discr_tc->GetAdaptivityEvaluator();
       if (dynamic_cast<const InterpolatorFP *>(ae))
       {
          MFEM_ABORT("Using GSLIB-based interpolation with finite differences"
                     "requires careful consideration. Contact TMOP team.");
       }
+#endif
       discr_tc->UpdateTargetSpecification(x, false, pfes->GetOrdering());
       discr_tc->UpdateGradientTargetSpecification(x, dx, false, pfes->GetOrdering());
       discr_tc->UpdateHessianTargetSpecification(x, dx, false, pfes->GetOrdering());

--- a/fem/tmop.hpp
+++ b/fem/tmop.hpp
@@ -1551,6 +1551,11 @@ public:
       adapt_eval = ae;
    }
 
+   const AdaptivityEvaluator *GetAdaptivityEvaluator() const
+   {
+      return adapt_eval;
+   }
+
    const Vector &GetTspecPert1H()   { return tspec_pert1h; }
    const Vector &GetTspecPert2H()   { return tspec_pert2h; }
    const Vector &GetTspecPertMixH() { return tspec_pertmix; }

--- a/fem/tmop_tools.hpp
+++ b/fem/tmop_tools.hpp
@@ -68,6 +68,11 @@ public:
                                      Vector &new_field,
                                      int new_nodes_ordering = Ordering::byNODES);
 
+   const FindPointsGSLIB *GetFindPointsGSLIB() const
+   {
+      return finder;
+   }
+
    ~InterpolatorFP()
    {
       finder->FreeData();

--- a/miniapps/meshing/mesh-optimizer.cpp
+++ b/miniapps/meshing/mesh-optimizer.cpp
@@ -57,10 +57,8 @@
 //   Adapted discrete size+aspect_ratio:
 //     mesh-optimizer -m square01.mesh -o 2 -rs 2 -mid 7 -tid 6 -ni 100
 //     mesh-optimizer -m square01.mesh -o 2 -rs 2 -mid 7 -tid 6 -ni 100 -qo 6 -ex -st 1 -nor
-//   Adapted discrete size+orientation (requires GSLIB):
-//   * mesh-optimizer -m square01.mesh -o 2 -rs 2 -mid 36 -tid 8 -qo 4 -fd -ae 1 -nor
-//   Adapted discrete aspect-ratio+orientation (requires GSLIB):
-//   * mesh-optimizer -m square01.mesh -o 2 -rs 2 -mid 85 -tid 8 -ni 10 -bnd -qt 1 -qo 8 -fd -ae 1
+//   Adapted discrete size+orientation:
+//   * mesh-optimizer -m square01.mesh -o 2 -rs 2 -mid 36 -tid 8 -qo 4 -fd -nor
 //   Adapted discrete aspect ratio (3D):
 //     mesh-optimizer -m cube.mesh -o 2 -rs 2 -mid 302 -tid 7 -ni 20 -bnd -qt 1 -qo 8
 //
@@ -740,20 +738,9 @@ int main(int argc, char *argv[])
 #endif
          }
 
-         if (metric_id == 14 || metric_id == 36)
-         {
-            ConstantCoefficient size_coeff(0.1*0.1);
-            size.ProjectCoefficient(size_coeff);
-            tc->SetSerialDiscreteTargetSize(size);
-         }
-
-         if (metric_id == 85)
-         {
-            FunctionCoefficient aspr_coeff(discrete_aspr_2d);
-            aspr.ProjectCoefficient(aspr_coeff);
-            DiffuseField(aspr,2);
-            tc->SetSerialDiscreteTargetAspectRatio(aspr);
-         }
+         ConstantCoefficient size_coeff(0.1*0.1);
+         size.ProjectCoefficient(size_coeff);
+         tc->SetSerialDiscreteTargetSize(size);
 
          FunctionCoefficient ori_coeff(discrete_ori_2d);
          ori.ProjectCoefficient(ori_coeff);

--- a/miniapps/meshing/mesh-optimizer.cpp
+++ b/miniapps/meshing/mesh-optimizer.cpp
@@ -58,7 +58,7 @@
 //     mesh-optimizer -m square01.mesh -o 2 -rs 2 -mid 7 -tid 6 -ni 100
 //     mesh-optimizer -m square01.mesh -o 2 -rs 2 -mid 7 -tid 6 -ni 100 -qo 6 -ex -st 1 -nor
 //   Adapted discrete size+orientation:
-//   * mesh-optimizer -m square01.mesh -o 2 -rs 2 -mid 36 -tid 8 -qo 4 -fd -nor
+//      mesh-optimizer -m square01.mesh -o 2 -rs 2 -mid 36 -tid 8 -qo 4 -fd -nor
 //   Adapted discrete aspect ratio (3D):
 //     mesh-optimizer -m cube.mesh -o 2 -rs 2 -mid 302 -tid 7 -ni 20 -bnd -qt 1 -qo 8
 //

--- a/miniapps/meshing/mesh-optimizer.hpp
+++ b/miniapps/meshing/mesh-optimizer.hpp
@@ -84,24 +84,6 @@ double discrete_ori_2d(const Vector &x)
    return M_PI * x(1) * (1.0 - x(1)) * cos(2 * M_PI * x(0));
 }
 
-double discrete_aspr_2d(const Vector &x)
-{
-   double xc = x(0)-0.5, yc = x(1)-0.5;
-   double th = 22.5*M_PI/180.;
-   double xn =  cos(th)*xc + sin(th)*yc;
-   double yn = -sin(th)*xc + cos(th)*yc;
-   xc = xn; yc = yn;
-
-   double tfac = 20;
-   double s1 = 3;
-   double s2 = 2;
-   double wgt = std::tanh((tfac*(yc) + s2*std::sin(s1*M_PI*xc)) + 1)
-                - std::tanh((tfac*(yc) + s2*std::sin(s1*M_PI*xc)) - 1);
-   if (wgt > 1) { wgt = 1; }
-   if (wgt < 0) { wgt = 0; }
-   return 0.1 + 1*(1-wgt)*(1-wgt);
-}
-
 void discrete_aspr_3d(const Vector &x, Vector &v)
 {
    int dim = x.Size();

--- a/miniapps/meshing/pmesh-optimizer.cpp
+++ b/miniapps/meshing/pmesh-optimizer.cpp
@@ -57,10 +57,8 @@
 //   Adapted discrete size+aspect_ratio:
 //     mpirun -np 4 pmesh-optimizer -m square01.mesh -o 2 -rs 2 -mid 7 -tid 6 -ni 100
 //     mpirun -np 4 pmesh-optimizer -m square01.mesh -o 2 -rs 2 -mid 7 -tid 6 -ni 100 -qo 6 -ex -st 1 -nor
-//   Adapted discrete size+orientation (requires GSLIB):
-//   * mpirun -np 4 pmesh-optimizer -m square01.mesh -o 2 -rs 2 -mid 36 -tid 8 -qo 4 -fd -ae 1 -nor
-//   Adapted discrete aspect-ratio+orientation (requires GSLIB):
-//   * mpirun -np 4 pmesh-optimizer -m square01.mesh -o 2 -rs 2 -mid 85 -tid 8 -ni 10 -bnd -qt 1 -qo 8 -fd -ae 1
+//   Adapted discrete size+orientation:
+//     mpirun -np 4 pmesh-optimizer -m square01.mesh -o 2 -rs 2 -mid 36 -tid 8 -qo 4 -fd -nor
 //   Adapted discrete aspect ratio (3D):
 //     mpirun -np 4 pmesh-optimizer -m cube.mesh -o 2 -rs 2 -mid 302 -tid 7 -ni 20 -bnd -qt 1 -qo 8
 //
@@ -774,20 +772,9 @@ int main (int argc, char *argv[])
 #endif
          }
 
-         if (metric_id == 14 || metric_id == 36)
-         {
-            ConstantCoefficient size_coeff(0.1*0.1);
-            size.ProjectCoefficient(size_coeff);
-            tc->SetParDiscreteTargetSize(size);
-         }
-
-         if (metric_id == 85)
-         {
-            FunctionCoefficient aspr_coeff(discrete_aspr_2d);
-            aspr.ProjectCoefficient(aspr_coeff);
-            DiffuseField(aspr,2);
-            tc->SetParDiscreteTargetAspectRatio(aspr);
-         }
+         ConstantCoefficient size_coeff(0.1*0.1);
+         size.ProjectCoefficient(size_coeff);
+         tc->SetParDiscreteTargetSize(size);
 
          FunctionCoefficient ori_coeff(discrete_ori_2d);
          ori.ProjectCoefficient(ori_coeff);


### PR DESCRIPTION
When a point is outside the domain but near the boundary, gslib can return the point as found on the boundary (with a finite distance to the boundary). This happens when the boundary is curvilinear and the point happens to be within the bounding box gslib constructs internally to search for points.
I have now added logic to ignore such points that are beyond a certain distance from the boundary.<!--GHEX{"author":"kmittal2","assignment":"2023-02-09T19:02:04","editor":"tzanio","id":3427,"reviewers":["tzanio","vladotomov"],"merge":"2023-03-07T20:45:15","approval":"2023-02-23T15:41:08"}XEHG-->
<!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge|
 | --- | --- | --- | --- | --- | --- | --- |
| [#3427](https://github.com/mfem/mfem/pull/3427) | @kmittal2 | @tzanio | @tzanio + @vladotomov | 2/9/23 | 2/23/23 | 3/7/23 | |
<!--ELBATXEHG-->
<details>
<summary>PR Checklist</summary>
    
- [ ] Code builds.
- [ ] Code passes `make style`.
- [ ] Update `CHANGELOG`:
    - [ ] Is this a new feature users need to be aware of? New or updated example or miniapp?
    - [ ] Does it make sense to create a new section in the `CHANGELOG` to group with other related features?
- [ ] Update `INSTALL`:
    - [ ] Had a new optional library been added? If so, what range of versions of this library are required? (*Make sure the external library is compatible with our BSD license, e.g. it is not licensed under GPL!*)
    - [ ] Have the version ranges for any required or optional libraries changed?
    - [ ] Does `make` or `cmake` have a new target?
    - [ ] Did the requirements or the installation process change? *(rare)*
- [ ] Update continuous integration server configurations if necessary (e.g. with new version requirements for each of MFEM's dependencies)
    - [ ] `.github`
    - [ ] `.appveyor.yml`
- [ ] Update `.gitignore`:
    - [ ] Check if `make distclean; git status` shows any files that were generated from the source by the project (not an IDE) but we don't want to track in the repository.
    - [ ] Add new patterns (just for the new files above) and re-run the above test.
- [ ] New examples:
    - [ ] All sample runs at the top of the example source file work.
    - [ ] Update `examples/makefile`:
      - [ ] Add the example code to the appropriate `SEQ_EXAMPLES` and `PAR_EXAMPLES` variables.
      - [ ] Add any files generated by it to the `clean` target.
      - [ ] Add the example binary and any files generated by it to the top-level `.gitignore` file.
    - [ ] Update `examples/CMakeLists.txt`:
      - [ ] Add the example code to the `ALL_EXE_SRCS` variable.
      - [ ] Make sure `THIS_TEST_OPTIONS` is set correctly for the new example.
   - [ ] List the new example in `doc/CodeDocumentation.dox`.
   - [ ] If new examples directory (e.g.`examples/pumi`), list it in `doc/CodeDocumentation.conf.in`
   - [ ] Companion pull request for documentation in [mfem/web](https://github.com/mfem/web) repo:
      - [ ] Update or add example-specific documentation, see e.g. the `src/examples.md`.
      - [ ] Add the description, labels and screenshots in `src/examples.md` and `src/img`.
      - [ ] In `examples.md`, list the example under the appropriate categories, add new categories if necessary.
      - [ ] Add a short description of the example in the "Extensive Examples" section of `features.md`.
- [ ] New miniapps:
   - [ ] All sample runs at the top of the miniapp source file work.
   - [ ] Update top-level `makefile` and `makefile` in corresponding miniapp directory.
   - [ ] Add the miniapp binary and any files generated by it to the top-level `.gitignore` file.
   - [ ] Update CMake build system:
      - [ ] Update the `CMakeLists.txt` file in the `miniapps` directory, if the new miniapp is in a new directory.
      - [ ] Add/update the `CMakeLists.txt` file in the new miniapp directory.
      - [ ] Consider adding a new test for the new miniapp.
   - [ ] List the new miniapp in `doc/CodeDocumentation.dox`
   - [ ] If new miniapps directory (e.g.`miniapps/nurbs`), add it to `MINIAPP_SUBDIRS` in the `makefile`.
   - [ ] If new miniapps directory (e.g.`miniapps/nurbs`), list it in `doc/CodeDocumentation.conf.in`
   - [ ] Companion pull request for documentation in [mfem/web](https://github.com/mfem/web) repo:
     - [ ] Update or add miniapp-specific documentation, see e.g. the `src/meshing.md` and `src/electromagnetics.md` files.
     - [ ] Add the description, labels and screenshots in `src/examples.md` and `src/img`.
     - [ ] The miniapps go at the end of the page, and are usually listed only under a specific "Application (PDE)" category.
     - [ ] Add a short description of the miniapp in the "Extensive Examples" section of `features.md`.
- [ ] New capability:
   - [ ] All new public, protected, and private classes, methods, data members, and functions have full Doxygen-style documentation in source comments. Documentation should include descriptions of member data, function arguments and return values, template parameters, and prerequisites for calling new functions.
   - [ ] Pointer arguments and return values must specify whether ownership is being transferred or lent with the call.
   - [ ] Any new functions should include descriptions of their intended use e.g. for internal use only, user-facing, etc., along with references to example code whenever possible/appropriate.
   - [ ] Consider adding new sample runs in existing examples to highlight the new capability.
   - [ ] Consider saving cool simulation pictures with the new capability in the Confluence gallery (LLNL only) or submitting them, via pull request, to the gallery section of the `mfem/web` repo.
   - [ ] If this is a major new feature, consider mentioning it in the short summary inside `README` *(rare)*.
   - [ ] List major new classes in `doc/CodeDocumentation.dox` *(rare)*.
- [ ] Update this checklist, if the new pull request affects it.
- [ ] Run `make unittest` to make sure all unit tests pass.
- [ ] Run the tests in `tests/scripts`.
- [ ] (LLNL only) After merging:
   - [ ] Update internal tests to include the new features.
</details>
