### PR TITLE
Change the behavior of `GetNodalFESpace` to always return a `FiniteElementSpace`.

### DIFF
--- a/mesh/mesh.cpp
+++ b/mesh/mesh.cpp
@@ -5344,7 +5344,7 @@ void Mesh::SetNodalGridFunction(GridFunction *nodes, bool make_owner)
 
 const FiniteElementSpace *Mesh::GetNodalFESpace() const
 {
-   const_cast< Mesh* >(this)->EnsureNodes();
+   if (Nodes == nullptr) { const_cast<Mesh*>(this)->EnsureNodes(); }
    return Nodes->FESpace();
 }
 

--- a/mesh/mesh.cpp
+++ b/mesh/mesh.cpp
@@ -5344,7 +5344,8 @@ void Mesh::SetNodalGridFunction(GridFunction *nodes, bool make_owner)
 
 const FiniteElementSpace *Mesh::GetNodalFESpace() const
 {
-   return ((Nodes) ? Nodes->FESpace() : NULL);
+   const_cast< Mesh* >(this)->EnsureNodes();
+   return Nodes->FESpace();
 }
 
 void Mesh::SetCurvature(int order, bool discont, int space_dim, int ordering)

--- a/mesh/mesh.hpp
+++ b/mesh/mesh.hpp
@@ -1623,7 +1623,9 @@ public:
        from the current nodes/vertices. */
    void SetNodalGridFunction(GridFunction *nodes, bool make_owner = false);
    /** Return the FiniteElementSpace on which the current mesh nodes are
-       defined or NULL if the mesh does not have nodes. */
+       defined.
+       NOTE: despite being const this method will create the nodal finite
+             element space if necessary. */
    const FiniteElementSpace *GetNodalFESpace() const;
    /** @brief Make sure that the mesh has valid nodes, i.e. its geometry is
        described by a vector finite element grid function (even if it is a


### PR DESCRIPTION
The current behavior of `Mesh::GetNodalFESpace` is extremely bug prone, and results in relatively hard to track bugs. This PR modifies the behavior of the `GetNodalFESpace` method to never return a `null` pointer, and always return a valid `FiniteElementSpace`.<!--GHEX{"author":"YohannDudouit","assignment":"2023-02-08T22:26:06","editor":"pazner","id":3450,"reviewers":["v-dobrev","tzanio","mlstowell"],"merge":"2023-03-01T22:26:06","approval":"2023-02-22T22:26:06"}XEHG-->
<!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge|
 | --- | --- | --- | --- | --- | --- | --- |
| [#3450](https://github.com/mfem/mfem/pull/3450) | @YohannDudouit | @pazner | @v-dobrev + @tzanio + @mlstowell | 2/8/23 | ⌛due 2/22/23 | ⌛due 3/1/23 | |
<!--ELBATXEHG-->
<details>
<summary>PR Checklist</summary>
    
- [ ] Code builds.
- [ ] Code passes `make style`.
- [ ] Update `CHANGELOG`:
    - [ ] Is this a new feature users need to be aware of? New or updated example or miniapp?
    - [ ] Does it make sense to create a new section in the `CHANGELOG` to group with other related features?
- [ ] Update `INSTALL`:
    - [ ] Had a new optional library been added? If so, what range of versions of this library are required? (*Make sure the external library is compatible with our BSD license, e.g. it is not licensed under GPL!*)
    - [ ] Have the version ranges for any required or optional libraries changed?
    - [ ] Does `make` or `cmake` have a new target?
    - [ ] Did the requirements or the installation process change? *(rare)*
- [ ] Update continuous integration server configurations if necessary (e.g. with new version requirements for each of MFEM's dependencies)
    - [ ] `.github`
    - [ ] `.appveyor.yml`
- [ ] Update `.gitignore`:
    - [ ] Check if `make distclean; git status` shows any files that were generated from the source by the project (not an IDE) but we don't want to track in the repository.
    - [ ] Add new patterns (just for the new files above) and re-run the above test.
- [ ] New examples:
    - [ ] All sample runs at the top of the example source file work.
    - [ ] Update `examples/makefile`:
      - [ ] Add the example code to the appropriate `SEQ_EXAMPLES` and `PAR_EXAMPLES` variables.
      - [ ] Add any files generated by it to the `clean` target.
      - [ ] Add the example binary and any files generated by it to the top-level `.gitignore` file.
    - [ ] Update `examples/CMakeLists.txt`:
      - [ ] Add the example code to the `ALL_EXE_SRCS` variable.
      - [ ] Make sure `THIS_TEST_OPTIONS` is set correctly for the new example.
   - [ ] List the new example in `doc/CodeDocumentation.dox`.
   - [ ] If new examples directory (e.g.`examples/pumi`), list it in `doc/CodeDocumentation.conf.in`
   - [ ] Companion pull request for documentation in [mfem/web](https://github.com/mfem/web) repo:
      - [ ] Update or add example-specific documentation, see e.g. the `src/examples.md`.
      - [ ] Add the description, labels and screenshots in `src/examples.md` and `src/img`.
      - [ ] In `examples.md`, list the example under the appropriate categories, add new categories if necessary.
      - [ ] Add a short description of the example in the "Extensive Examples" section of `features.md`.
- [ ] New miniapps:
   - [ ] All sample runs at the top of the miniapp source file work.
   - [ ] Update top-level `makefile` and `makefile` in corresponding miniapp directory.
   - [ ] Add the miniapp binary and any files generated by it to the top-level `.gitignore` file.
   - [ ] Update CMake build system:
      - [ ] Update the `CMakeLists.txt` file in the `miniapps` directory, if the new miniapp is in a new directory.
      - [ ] Add/update the `CMakeLists.txt` file in the new miniapp directory.
      - [ ] Consider adding a new test for the new miniapp.
   - [ ] List the new miniapp in `doc/CodeDocumentation.dox`
   - [ ] If new miniapps directory (e.g.`miniapps/nurbs`), add it to `MINIAPP_SUBDIRS` in the `makefile`.
   - [ ] If new miniapps directory (e.g.`miniapps/nurbs`), list it in `doc/CodeDocumentation.conf.in`
   - [ ] Companion pull request for documentation in [mfem/web](https://github.com/mfem/web) repo:
     - [ ] Update or add miniapp-specific documentation, see e.g. the `src/meshing.md` and `src/electromagnetics.md` files.
     - [ ] Add the description, labels and screenshots in `src/examples.md` and `src/img`.
     - [ ] The miniapps go at the end of the page, and are usually listed only under a specific "Application (PDE)" category.
     - [ ] Add a short description of the miniapp in the "Extensive Examples" section of `features.md`.
- [ ] New capability:
   - [ ] All new public, protected, and private classes, methods, data members, and functions have full Doxygen-style documentation in source comments. Documentation should include descriptions of member data, function arguments and return values, template parameters, and prerequisites for calling new functions.
   - [ ] Pointer arguments and return values must specify whether ownership is being transferred or lent with the call.
   - [ ] Any new functions should include descriptions of their intended use e.g. for internal use only, user-facing, etc., along with references to example code whenever possible/appropriate.
   - [ ] Consider adding new sample runs in existing examples to highlight the new capability.
   - [ ] Consider saving cool simulation pictures with the new capability in the Confluence gallery (LLNL only) or submitting them, via pull request, to the gallery section of the `mfem/web` repo.
   - [ ] If this is a major new feature, consider mentioning it in the short summary inside `README` *(rare)*.
   - [ ] List major new classes in `doc/CodeDocumentation.dox` *(rare)*.
- [ ] Update this checklist, if the new pull request affects it.
- [ ] Run `make unittest` to make sure all unit tests pass.
- [ ] Run the tests in `tests/scripts`.
- [ ] (LLNL only) After merging:
   - [ ] Update internal tests to include the new features.
</details>
