### PR TITLE
Change intersect algorithm to not use goto

### DIFF
--- a/mesh/ncmesh.cpp
+++ b/mesh/ncmesh.cpp
@@ -3706,19 +3706,27 @@ void NCMesh::FindSetNeighbors(const Array<char> &elem_set,
 
 static bool sorted_lists_intersect(const int* a, const int* b, int na, int nb)
 {
-   if (!na || !nb) { return false; }
-   int a_last = a[na-1], b_last = b[nb-1];
-   if (*b < *a) { goto l2; }  // woo-hoo! I always wanted to use a goto! :)
-l1:
-   if (a_last < *b) { return false; }
-   while (*a < *b) { a++; }
-   if (*a == *b) { return true; }
-l2:
-   if (b_last < *a) { return false; }
-   while (*b < *a) { b++; }
-   if (*a == *b) { return true; }
-   goto l1;
+   // pointers to "end" sentinel, not last entry. Not for dereferencing.
+   const int * const a_end = a + na;
+   const int * const b_end = b + nb;
+   while (a != a_end && b != b_end)
+   {
+      if (*a < *b)
+      {
+         ++a;
+      }
+      else
+      {
+         if (!(*b < *a))
+         {
+            return true; // neither *a < *b nor *b < *a thus a == b
+         }
+         ++b;
+      }
+   }
+   return false; // no common element found
 }
+
 
 void NCMesh::FindNeighbors(int elem, Array<int> &neighbors,
                            const Array<int> *search_set)


### PR DESCRIPTION
The intersect algorithm in `ncmesh.cpp` uses `goto` which is non-ideal. This pr switches to an adaptation of the standard algorithm for computing an intersection coming from [cppreference](https://en.cppreference.com/w/cpp/algorithm/set_intersection).