### PR TITLE
[Draft] Refactoring NCMesh

### DIFF
--- a/fem/geom.hpp
+++ b/fem/geom.hpp
@@ -32,7 +32,7 @@ namespace mfem
 class Geometry
 {
 public:
-   enum Type
+   enum Type : char
    {
       INVALID = -1,
       POINT = 0, SEGMENT, TRIANGLE, SQUARE, TETRAHEDRON, CUBE, PRISM, PYRAMID,

--- a/general/hash.hpp
+++ b/general/hash.hpp
@@ -106,6 +106,10 @@ public:
 
        @warning This method should only be called if T inherits from Hashed2. */
    T* Get(int p1, int p2);
+   /// @brief Reference equivalent of the Get(int, int) method
+   T& At(int p1, int p2);
+   /// @brief Const reference equivalent of the Get(int, int) method
+   const T& At(int p1, int p2) const;
 
    /** @brief Item accessor with key (or parents) the quadruplet 'p1', 'p2',
        'p3', 'p4'. The key 'p4' is optional. Default construct an item of type T
@@ -119,6 +123,8 @@ public:
 
       @warning This method should only be called if T inherits from Hashed4. */
    T* Get(int p1, int p2, int p3, int p4 = -1 /* p4 optional */);
+   T& At(int p1, int p2, int p3, int p4 = -1 /* p4 optional */);
+   const T& At(int p1, int p2, int p3, int p4 = -1 /* p4 optional */) const;
 
    /// Get id of item whose parents are p1, p2... Create it if it doesn't exist.
    /** @brief Get the "id" of an item, this "id" corresponding to the index of the
@@ -599,9 +605,34 @@ inline T* HashTable<T>::Get(int p1, int p2)
 }
 
 template<typename T>
+inline T& HashTable<T>::At(int p1, int p2)
+{
+   return Base::At(GetId(p1, p2));
+}
+
+template<typename T>
+inline const T& HashTable<T>::At(int p1, int p2) const
+{
+   return Base::At(GetId(p1, p2));
+}
+
+template<typename T>
 inline T* HashTable<T>::Get(int p1, int p2, int p3, int p4)
 {
    return &(Base::At(GetId(p1, p2, p3, p4)));
+}
+
+
+template<typename T>
+inline T& HashTable<T>::At(int p1, int p2, int p3, int p4)
+{
+   return Base::At(GetId(p1, p2, p3, p4));
+}
+
+template<typename T>
+inline const T& HashTable<T>::At(int p1, int p2, int p3, int p4) const
+{
+   return Base::At(GetId(p1, p2, p3, p4));
 }
 
 template<typename T>

--- a/mesh/ncmesh.cpp
+++ b/mesh/ncmesh.cpp
@@ -3145,7 +3145,7 @@ void NCMesh::BuildFaceList()
          if (processed_faces[face]) { continue; }
          processed_faces[face] = 1;
 
-         int fgeom = (node[3] >= 0) ? Geometry::SQUARE : Geometry::TRIANGLE;
+         Geometry::Type fgeom = (node[3] >= 0) ? Geometry::SQUARE : Geometry::TRIANGLE;
 
          Face &fa = faces[face];
          if (fa.elem[0] >= 0 && fa.elem[1] >= 0)

--- a/mesh/ncmesh.cpp
+++ b/mesh/ncmesh.cpp
@@ -2411,7 +2411,8 @@ mfem::Element* NCMesh::NewMeshElement(int geom) const
    return NULL;
 }
 
-const double* NCMesh::CalcVertexPos(int node, std::unordered_map<int, TmpVertex> &tmp_vertex) const
+const double* NCMesh::CalcVertexPos(int node,
+                                    std::unordered_map<int, TmpVertex> &tmp_vertex) const
 {
    const Node &nd = nodes[node];
    if (nd.p1 == nd.p2) // top-level vertex
@@ -2424,7 +2425,9 @@ const double* NCMesh::CalcVertexPos(int node, std::unordered_map<int, TmpVertex>
    if (search != tmp_vertex.end())
    {
       if (search->second.valid)
+      {
          return search->second.pos;
+      }
 
       // it's invalid check it's not been seen before
       MFEM_VERIFY(search->second.visited == false, "cycle vertex dependency");
@@ -2455,7 +2458,8 @@ void NCMesh::GetMeshComponents(Mesh &mesh) const
       std::unordered_map<int, TmpVertex> tmp_vertices;
       for (int i = 0; i < mesh.vertices.Size(); i++)
       {
-         mesh.vertices[i].SetCoords(spaceDim, CalcVertexPos(vertex_nodeId[i], tmp_vertices));
+         mesh.vertices[i].SetCoords(spaceDim, CalcVertexPos(vertex_nodeId[i],
+                                                            tmp_vertices));
       }
    }
    // NOTE: if the mesh is curved ('coordinates' is empty), mesh.vertices are
@@ -5268,7 +5272,8 @@ int NCMesh::TriFaceSplitLevel(int vn1, int vn2, int vn3) const
    }
 }
 
-std::array<int, 2> NCMesh::QuadFaceSplitLevel(int vn1, int vn2, int vn3, int vn4) const
+std::array<int, 2> NCMesh::QuadFaceSplitLevel(int vn1, int vn2, int vn3,
+                                              int vn4) const
 {
    int mid[5];
    switch (QuadFaceSplitType(vn1, vn2, vn3, vn4, mid))
@@ -5277,17 +5282,17 @@ std::array<int, 2> NCMesh::QuadFaceSplitLevel(int vn1, int vn2, int vn3, int vn4
          return {0,0};
 
       case 1: // vertical
-         {
-            const auto sub0 = QuadFaceSplitLevel(vn1, mid[0], mid[2], vn4);
-            const auto sub1 = QuadFaceSplitLevel(mid[0], vn2, vn3, mid[2]);
-            return {std::max(sub0[0], sub1[0]), std::max(sub0[2], sub1[1]) + 1};
-         }
+      {
+         const auto sub0 = QuadFaceSplitLevel(vn1, mid[0], mid[2], vn4);
+         const auto sub1 = QuadFaceSplitLevel(mid[0], vn2, vn3, mid[2]);
+         return {std::max(sub0[0], sub1[0]), std::max(sub0[2], sub1[1]) + 1};
+      }
       default: // horizontal
-         {
-            const auto sub0 = QuadFaceSplitLevel(vn1, vn2, mid[1], mid[3]);
-            const auto sub1 = QuadFaceSplitLevel(mid[3], mid[1], vn3, vn4);
-            return {std::max(sub0[0], sub1[0]) + 1, std::max(sub0[2], sub1[1])};
-         }
+      {
+         const auto sub0 = QuadFaceSplitLevel(vn1, vn2, mid[1], mid[3]);
+         const auto sub1 = QuadFaceSplitLevel(mid[3], mid[1], vn3, vn4);
+         return {std::max(sub0[0], sub1[0]) + 1, std::max(sub0[2], sub1[1])};
+      }
    }
 }
 
@@ -5328,30 +5333,30 @@ std::array<int, 3> NCMesh::CountSplits(int elem) const
    if (el.Geom() == Geometry::CUBE)
    {
       return { std::max({flevel[0][0], flevel[1][0], flevel[3][0], flevel[5][0],
-                   elevel[0], elevel[2], elevel[4], elevel[6]}),
+                         elevel[0], elevel[2], elevel[4], elevel[6]}),
                std::max({flevel[0][1], flevel[2][0], flevel[4][0], flevel[5][1],
-                   elevel[1], elevel[3], elevel[5], elevel[7]}),
+                         elevel[1], elevel[3], elevel[5], elevel[7]}),
                std::max({flevel[1][1], flevel[2][1], flevel[3][1], flevel[4][1],
-                   elevel[8], elevel[9], elevel[10], elevel[11]})};
+                         elevel[8], elevel[9], elevel[10], elevel[11]})};
    }
    else if (el.Geom() == Geometry::PRISM)
    {
       const auto x = std::max({flevel[0][0], flevel[1][0], 0,
                                flevel[2][0], flevel[3][0], flevel[4][0],
                                elevel[0], elevel[1], elevel[2],
-                              elevel[3], elevel[4], elevel[5]});
+                               elevel[3], elevel[4], elevel[5]});
 
       const auto y = std::max({flevel[2][1], flevel[3][1], flevel[4][1],
-                          elevel[6], elevel[7], elevel[8]});
+                               elevel[6], elevel[7], elevel[8]});
       return {x, x, y};
    }
    else if (el.Geom() == Geometry::PYRAMID)
    {
       const auto x = std::max({flevel[0][0], flevel[1][0], 0,
-                          flevel[2][0], flevel[3][0], flevel[4][0],
-                          elevel[0], elevel[1], elevel[2],
-                          elevel[3], elevel[4], elevel[5],
-                          elevel[6], elevel[7]});
+                               flevel[2][0], flevel[3][0], flevel[4][0],
+                               elevel[0], elevel[1], elevel[2],
+                               elevel[3], elevel[4], elevel[5],
+                               elevel[6], elevel[7]});
       return {x, x, x};
    }
    else if (el.Geom() == Geometry::TETRAHEDRON)

--- a/mesh/ncmesh.cpp
+++ b/mesh/ncmesh.cpp
@@ -487,7 +487,7 @@ int NCMesh::NewHexahedron(int n0, int n1, int n2, int n3,
    {
       const auto &fv = gi_hex.faces[i];
       f[i] = faces.At(el.node[fv[0]], el.node[fv[1]],
-                       el.node[fv[2]], el.node[fv[3]]);
+                      el.node[fv[2]], el.node[fv[3]]);
    }
 
    f[0].attribute = fattr0,  f[1].attribute = fattr1;
@@ -517,7 +517,7 @@ int NCMesh::NewWedge(int n0, int n1, int n2,
    {
       const auto &fv = gi_wedge.faces[i];
       f[i] = faces.At(el.node[fv[0]], el.node[fv[1]],
-                       el.node[fv[2]], el.node[fv[3]]);
+                      el.node[fv[2]], el.node[fv[3]]);
    }
 
    f[0].attribute = fattr0;
@@ -601,7 +601,7 @@ int NCMesh::NewQuadrilateral(int n0, int n1, int n2, int n3,
    {
       const auto &fv = gi_quad.faces[i];
       f[i] = faces.At(el.node[fv[0]], el.node[fv[1]],
-                       el.node[fv[2]], el.node[fv[3]]);
+                      el.node[fv[2]], el.node[fv[3]]);
    }
 
    f[0].attribute = eattr0,  f[1].attribute = eattr1;
@@ -626,7 +626,7 @@ int NCMesh::NewTriangle(int n0, int n1, int n2,
    {
       const auto &fv = gi_tri.faces[i];
       f[i] = faces.At(el.node[fv[0]], el.node[fv[1]],
-                       el.node[fv[2]], el.node[fv[3]]);
+                      el.node[fv[2]], el.node[fv[3]]);
    }
 
    f[0].attribute = eattr0;

--- a/mesh/ncmesh.cpp
+++ b/mesh/ncmesh.cpp
@@ -334,14 +334,14 @@ void NCMesh::ReferenceElement(int elem)
    // reference all edges (possibly creating their nodes)
    for (int i = 0; i < gi.ne; i++)
    {
-      const int* ev = gi.edges[i];
+      const auto &ev = gi.edges[i];
       nodes.Get(node[ev[0]], node[ev[1]])->edge_refc++;
    }
 
    // get all faces (possibly creating them)
    for (int i = 0; i < gi.nf; i++)
    {
-      const int* fv = gi.faces[i];
+      const auto &fv = gi.faces[i];
       faces.GetId(node[fv[0]], node[fv[1]], node[fv[2]], node[fv[3]]);
 
       // NOTE: face->RegisterElement called separately to avoid having
@@ -359,7 +359,7 @@ void NCMesh::UnreferenceElement(int elem, Array<int> &elemFaces)
    // unreference all faces
    for (int i = 0; i < gi.nf; i++)
    {
-      const int* fv = gi.faces[i];
+      const auto &fv = gi.faces[i];
       int face = faces.FindId(node[fv[0]], node[fv[1]],
                               node[fv[2]], node[fv[3]]);
       MFEM_ASSERT(face >= 0, "face not found.");
@@ -373,7 +373,7 @@ void NCMesh::UnreferenceElement(int elem, Array<int> &elemFaces)
    // unreference all edges (possibly destroying them)
    for (int i = 0; i < gi.ne; i++)
    {
-      const int* ev = gi.edges[i];
+      const auto &ev = gi.edges[i];
       int enode = FindMidEdgeNode(node[ev[0]], node[ev[1]]);
       MFEM_ASSERT(enode >= 0, "edge not found.");
       MFEM_ASSERT(nodes.IdExists(enode), "edge does not exist.");
@@ -432,11 +432,11 @@ void NCMesh::Face::ForgetElement(int e)
    else { MFEM_ABORT("element " << e << " not found in Face::elem[]."); }
 }
 
-NCMesh::Face* NCMesh::GetFace(Element &elem, int face_no)
+NCMesh::Face* NCMesh::GetFace(const Element &elem, int face_no)
 {
    GeomInfo& gi = GI[(int) elem.geom];
-   const int* fv = gi.faces[face_no];
-   auto &node = elem.node;
+   const auto &fv = gi.faces[face_no];
+   const auto &node = elem.node;
    return faces.Find(node[fv[0]], node[fv[1]], node[fv[2]], node[fv[3]]);
 }
 
@@ -485,7 +485,7 @@ int NCMesh::NewHexahedron(int n0, int n1, int n2, int n3,
    const GeomInfo &gi_hex = GI[Geometry::CUBE];
    for (int i = 0; i < gi_hex.nf; i++)
    {
-      const int* fv = gi_hex.faces[i];
+      const auto &fv = gi_hex.faces[i];
       f[i] = faces.Get(el.node[fv[0]], el.node[fv[1]],
                        el.node[fv[2]], el.node[fv[3]]);
    }
@@ -515,7 +515,7 @@ int NCMesh::NewWedge(int n0, int n1, int n2,
    const GeomInfo &gi_wedge = GI[Geometry::PRISM];
    for (int i = 0; i < gi_wedge.nf; i++)
    {
-      const int* fv = gi_wedge.faces[i];
+      const auto &fv = gi_wedge.faces[i];
       f[i] = faces.Get(el.node[fv[0]], el.node[fv[1]],
                        el.node[fv[2]], el.node[fv[3]]);
    }
@@ -543,7 +543,7 @@ int NCMesh::NewTetrahedron(int n0, int n1, int n2, int n3, int attr,
    const GeomInfo &gi_tet = GI[Geometry::TETRAHEDRON];
    for (int i = 0; i < gi_tet.nf; i++)
    {
-      const int* fv = gi_tet.faces[i];
+      const auto &fv = gi_tet.faces[i];
       f[i] = faces.Get(el.node[fv[0]], el.node[fv[1]], el.node[fv[2]]);
    }
 
@@ -570,7 +570,7 @@ int NCMesh::NewPyramid(int n0, int n1, int n2, int n3, int n4, int attr,
    const GeomInfo &gi_pyr = GI[Geometry::PYRAMID];
    for (int i = 0; i < gi_pyr.nf; i++)
    {
-      const int* fv = gi_pyr.faces[i];
+      const auto &fv = gi_pyr.faces[i];
       f[i] = faces.Get(el.node[fv[0]], el.node[fv[1]],
                        el.node[fv[2]], el.node[fv[3]]);
    }
@@ -599,7 +599,7 @@ int NCMesh::NewQuadrilateral(int n0, int n1, int n2, int n3,
    const GeomInfo &gi_quad = GI[Geometry::SQUARE];
    for (int i = 0; i < gi_quad.nf; i++)
    {
-      const int* fv = gi_quad.faces[i];
+      const auto &fv = gi_quad.faces[i];
       f[i] = faces.Get(el.node[fv[0]], el.node[fv[1]],
                        el.node[fv[2]], el.node[fv[3]]);
    }
@@ -624,7 +624,7 @@ int NCMesh::NewTriangle(int n0, int n1, int n2,
    const GeomInfo &gi_tri = GI[Geometry::TRIANGLE];
    for (int i = 0; i < gi_tri.nf; i++)
    {
-      const int* fv = gi_tri.faces[i];
+      const auto &fv = gi_tri.faces[i];
       f[i] = faces.Get(el.node[fv[0]], el.node[fv[1]],
                        el.node[fv[2]], el.node[fv[3]]);
    }
@@ -962,7 +962,7 @@ void NCMesh::RefineElement(int elem, char ref_type)
    GeomInfo& gi = GI[el.Geom()];
    for (int i = 0; i < gi.nf; i++)
    {
-      const int* fv = gi.faces[i];
+      const auto &fv = gi.faces[i];
       Face* face = faces.Find(no[fv[0]], no[fv[1]], no[fv[2]], no[fv[3]]);
       fa[i] = face->attribute;
    }
@@ -1754,7 +1754,7 @@ void NCMesh::DerefineElement(int elem)
                                        [i + nb_cube_childs];
          const int child_global_index = child[child_local_index];
          Element &ch = elements[child_global_index];
-         const int* fv = GI[el.Geom()].faces[i];
+         const auto &fv = GI[el.Geom()].faces[i];
          faces_attribute[i] = faces.Find(ch.node[fv[0]], ch.node[fv[1]],
                                          ch.node[fv[2]], ch.node[fv[3]])
                               ->attribute;
@@ -1781,7 +1781,7 @@ void NCMesh::DerefineElement(int elem)
                                        [i + nb_prism_childs];
          const int child_global_index = child[child_local_index];
          Element &ch = elements[child_global_index];
-         const int* fv = GI[el.Geom()].faces[i];
+         const auto &fv = GI[el.Geom()].faces[i];
          faces_attribute[i] = faces.Find(ch.node[fv[0]], ch.node[fv[1]],
                                          ch.node[fv[2]], ch.node[fv[3]])
                               ->attribute;
@@ -1809,7 +1809,7 @@ void NCMesh::DerefineElement(int elem)
                                        [i + nb_pyramid_childs];
          const int child_global_index = child[child_local_index];
          Element &ch = elements[child_global_index];
-         const int* fv = GI[el.Geom()].faces[i];
+         const auto &fv = GI[el.Geom()].faces[i];
          faces_attribute[i] = faces.Find(ch.node[fv[0]], ch.node[fv[1]],
                                          ch.node[fv[2]], ch.node[fv[3]])
                               ->attribute;
@@ -1822,7 +1822,7 @@ void NCMesh::DerefineElement(int elem)
          Element& ch1 = elements[child[i]];
          Element& ch2 = elements[child[(i+1) & 0x3]];
          el.node[i] = ch1.node[i];
-         const int* fv = GI[el.Geom()].faces[i];
+         const auto &fv = GI[el.Geom()].faces[i];
          faces_attribute[i] = faces.Find(ch2.node[fv[0]], ch2.node[fv[1]],
                                          ch2.node[fv[2]], ch2.node[fv[3]])
                               ->attribute;
@@ -1845,7 +1845,7 @@ void NCMesh::DerefineElement(int elem)
                                        [i + nb_square_childs];
          const int child_global_index = child[child_local_index];
          Element &ch = elements[child_global_index];
-         const int* fv = GI[el.Geom()].faces[i];
+         const auto &fv = GI[el.Geom()].faces[i];
          faces_attribute[i] = faces.Find(ch.node[fv[0]], ch.node[fv[1]],
                                          ch.node[fv[2]], ch.node[fv[3]])
                               ->attribute;
@@ -1858,7 +1858,7 @@ void NCMesh::DerefineElement(int elem)
       {
          Element& ch = elements[child[i]];
          el.node[i] = ch.node[i];
-         const int* fv = GI[el.Geom()].faces[i];
+         const auto &fv = GI[el.Geom()].faces[i];
          faces_attribute[i] = faces.Find(ch.node[fv[0]], ch.node[fv[1]],
                                          ch.node[fv[2]], ch.node[fv[3]])
                               ->attribute;
@@ -2060,7 +2060,7 @@ void NCMesh::CollectLeafElements(int elem, int state, Array<int> &ghosts,
                                  int &counter)
 {
    Element &el = elements[elem];
-   if (!el.ref_type)
+   if (el.ref_type == Refinement::UNREFINED)
    {
       if (el.rank >= 0) // skip elements beyond the ghost layer in parallel
       {
@@ -2113,11 +2113,11 @@ void NCMesh::CollectLeafElements(int elem, int state, Array<int> &ghosts,
       }
       else // no space filling curve tables yet for remaining cases
       {
-         for (int i = 0; i < MaxElemChildren; i++)
+         for (const auto &e : el.child)
          {
-            if (el.child[i] >= 0)
+            if (e >= 0)
             {
-               CollectLeafElements(el.child[i], state, ghosts, counter);
+               CollectLeafElements(e, state, ghosts, counter);
             }
          }
       }
@@ -2367,8 +2367,8 @@ void NCMesh::InitRootState(int root_count)
       if (v_in < 0) { v_in = 0; }
 
       // determine which nodes are shared with the next element
-      bool shared[MaxElemNodes];
-      for (int ni = 0; ni < MaxElemNodes; ++ni) { shared[ni] = 0; }
+      std::array<bool, MaxElemNodes> shared;
+      shared.fill(false); // Initialize all nodes to unshared
       if (i+1 < root_count)
       {
          Element &next = elements[i+1];
@@ -2487,7 +2487,7 @@ void NCMesh::GetMeshComponents(Mesh &mesh) const
       // TODO: use boundary_faces?
       for (int k = 0; k < gi.nf; k++)
       {
-         const int* fv = gi.faces[k];
+         const auto &fv = gi.faces[k];
          const int nfv = gi.nfv[k];
          const Face* face = faces.Find(node[fv[0]], node[fv[1]],
                                        node[fv[2]], node[fv[3]]);
@@ -2577,7 +2577,7 @@ void NCMesh::OnMeshUpdated(Mesh *mesh)
    face_geom.SetSize(NFaces);
    for (int i = 0; i < NFaces; i++)
    {
-      const int* fv = mesh->GetFace(i)->GetVertices();
+      const auto &fv = mesh->GetFace(i)->GetVertices();
       const int nfv = mesh->GetFace(i)->GetNVertices();
 
       Face* face;
@@ -2655,7 +2655,7 @@ void NCMesh::OnMeshUpdated(Mesh *mesh)
 
       for (int j = 0; j < gi.nf; j++)
       {
-         const int *fv = gi.faces[j];
+         const auto &fv = gi.faces[j];
          Face* face = faces.Find(el.node[fv[0]], el.node[fv[1]],
                                  el.node[fv[2]], el.node[fv[3]]);
          MFEM_ASSERT(face, "face not found!");
@@ -2777,7 +2777,7 @@ int NCMesh::find_element_edge(const Element &el, int vn0, int vn1, bool abort)
    GeomInfo &gi = GI[el.Geom()];
    for (int i = 0; i < gi.ne; i++)
    {
-      const int* ev = gi.edges[i];
+      const auto &ev = gi.edges[i];
       int n0 = el.node[ev[0]];
       int n1 = el.node[ev[1]];
       if ((n0 == vn0 && n1 == vn1) ||
@@ -2793,7 +2793,7 @@ int NCMesh::find_local_face(int geom, int a, int b, int c)
    GeomInfo &gi = GI[geom];
    for (int i = 0; i < gi.nf; i++)
    {
-      const int* fv = gi.faces[i];
+      const auto &fv = gi.faces[i];
       if ((a == fv[0] || a == fv[1] || a == fv[2] || a == fv[3]) &&
           (b == fv[0] || b == fv[1] || b == fv[2] || b == fv[3]) &&
           (c == fv[0] || c == fv[1] || c == fv[2] || c == fv[3]))
@@ -2879,7 +2879,7 @@ int NCMesh::ReorderFacePointMat(int v0, int v1, int v2, int v3,
    int nfv = (v3 >= 0) ? 4 : 3;
 
    int local = find_local_face(el.Geom(), master[0], master[1], master[2]);
-   const int* fv = GI[el.Geom()].faces[local];
+   const auto &fv = GI[el.Geom()].faces[local];
 
    reordered.np = pm.np;
    for (int i = 0, j; i < nfv; i++)
@@ -3257,7 +3257,7 @@ void NCMesh::BuildEdgeList()
       for (int j = 0; j < gi.ne; j++)
       {
          // get nodes for this edge
-         const int* ev = gi.edges[j];
+         const auto &ev = gi.edges[j];
          int node[2] = { el.node[ev[0]], el.node[ev[1]] };
 
          int enode = nodes.FindId(node[0], node[1]);
@@ -3584,7 +3584,7 @@ void NCMesh::BuildElementToVertexTable()
       indices.SetSize(0);
       for (int j = 0; j < gi.ne; j++)
       {
-         const int* ev = gi.edges[j];
+         const auto &ev = gi.edges[j];
          CollectEdgeVertices(node[ev[0]], node[ev[1]], indices);
       }
 
@@ -3592,7 +3592,7 @@ void NCMesh::BuildElementToVertexTable()
       {
          for (int j = 0; j < gi.nf; j++)
          {
-            const int* fv = gi.faces[j];
+            const auto &fv = gi.faces[j];
             if (gi.nfv[j] == 4)
             {
                CollectQuadFaceVertices(node[fv[0]], node[fv[1]],
@@ -5012,7 +5012,7 @@ void NCMesh::GetEdgeVertices(const MeshId &edge_id, int vert_index[2],
 {
    const Element &el = elements[edge_id.element];
    const GeomInfo& gi = GI[el.Geom()];
-   const int* ev = gi.edges[(int) edge_id.local];
+   const auto &ev = gi.edges[(int) edge_id.local];
 
    int n0 = el.node[ev[0]], n1 = el.node[ev[1]];
    if (n0 > n1) { std::swap(n0, n1); }
@@ -5030,7 +5030,7 @@ int NCMesh::GetEdgeNCOrientation(const NCMesh::MeshId &edge_id) const
 {
    const Element &el = elements[edge_id.element];
    const GeomInfo& gi = GI[el.Geom()];
-   const int* ev = gi.edges[(int) edge_id.local];
+   const auto &ev = gi.edges[(int) edge_id.local];
 
    int v0 = nodes[el.node[ev[0]]].vert_index;
    int v1 = nodes[el.node[ev[1]]].vert_index;
@@ -5047,7 +5047,7 @@ int NCMesh::GetFaceVerticesEdges(const MeshId &face_id,
    const Element &el = elements[face_id.element];
    const GeomInfo& gi = GI[el.Geom()];
 
-   const int *fv = gi.faces[(int) face_id.local];
+   const auto &fv = gi.faces[(int) face_id.local];
    const int nfv = gi.nfv[(int) face_id.local];
 
    vert_index[3] = edge_index[3] = -1;
@@ -5155,7 +5155,7 @@ void NCMesh::GetElementFacesAttributes(int leaf_elem,
 
    for (int i = 0; i < gi.nf; i++)
    {
-      const int* fv = gi.faces[i];
+      const auto &fv = gi.faces[i];
       const Face *face = faces.Find(el.node[fv[0]], el.node[fv[1]],
                                     el.node[fv[2]], el.node[fv[3]]);
       MFEM_ASSERT(face, "face not found");
@@ -5181,8 +5181,8 @@ std::array<int, 4> NCMesh::FindFaceNodes(int face)
                            find_node(el, fa.p2),
                            find_node(el, fa.p3));
 
-   const int* fv = GI[el.Geom()].faces[f];
-   return {el.node[fv[1]], el.node[fv[2]], el.node[fv[3]], el.node[fv[4]]}
+   const auto &fv = GI[el.Geom()].faces[f];
+   return {el.node[fv[1]], el.node[fv[2]], el.node[fv[3]], el.node[fv[4]]};
 }
 
 void NCMesh::GetBoundaryClosure(const Array<int> &bdr_attr_is_ess,
@@ -5300,7 +5300,7 @@ std::array<int, 3> NCMesh::CountSplits(int elem) const
    int elevel[MaxElemEdges];
    for (int i = 0; i < gi.ne; i++)
    {
-      const int* ev = gi.edges[i];
+      const auto &ev = gi.edges[i];
       elevel[i] = EdgeSplitLevel(node[ev[0]], node[ev[1]]);
    }
 
@@ -5491,7 +5491,7 @@ int NCMesh::PrintBoundary(std::ostream *os) const
       GeomInfo& gi = GI[el.Geom()];
       for (int k = 0; k < gi.nf; k++)
       {
-         const int* fv = gi.faces[k];
+         const auto &fv = gi.faces[k];
          const int nfv = gi.nfv[k];
          const Face* face = faces.Find(el.node[fv[0]], el.node[fv[1]],
                                        el.node[fv[2]], el.node[fv[3]]);
@@ -6351,7 +6351,7 @@ void NCMesh::DebugDump(std::ostream &os) const
                                find_node(el, face->p2),
                                find_node(el, face->p3));
 
-      const int* fv = GI[el.Geom()].faces[lf];
+      const auto &fv = GI[el.Geom()].faces[lf];
       const int nfv = GI[el.Geom()].nfv[lf];
 
       os << nfv;

--- a/mesh/ncmesh.cpp
+++ b/mesh/ncmesh.cpp
@@ -4582,10 +4582,10 @@ const CoarseFineTransformations& NCMesh::GetRefinementTransforms()
       std::string ref_path;
       ref_path.reserve(100);
 
-      RefPathMap path_map[Geometry::NumGeom];
-      for (int g = 0; g < Geometry::NumGeom; g++)
+      std::array<RefPathMap, Geometry::NumGeom> path_map;
+      for (auto &p : path_map)
       {
-         path_map[g][ref_path] = 1; // empty path == identity
+         p[ref_path] = 1; // empty path == identity
       }
 
       int used_geoms = 0;
@@ -4603,15 +4603,13 @@ const CoarseFineTransformations& NCMesh::GetRefinementTransforms()
             Geometry::Type geom = Geometry::Type(g);
             const PointMatrix &identity = GetGeomIdentity(geom);
 
-            transforms.point_matrices[g]
-            .SetSize(Dim, identity.np, path_map[g].size());
+            transforms.point_matrices[g].SetSize(Dim, identity.np, path_map[g].size());
 
             // calculate the point matrices
-            RefPathMap::iterator it;
-            for (it = path_map[g].begin(); it != path_map[g].end(); ++it)
+            for (auto const &kv : path_map[g])
             {
-               GetPointMatrix(geom, it->first.c_str(),
-                              transforms.point_matrices[g](it->second-1));
+               GetPointMatrix(geom, kv.first.c_str(),
+                              transforms.point_matrices[g](kv.second-1));
             }
          }
       }

--- a/mesh/ncmesh.cpp
+++ b/mesh/ncmesh.cpp
@@ -539,18 +539,18 @@ int NCMesh::NewTetrahedron(int n0, int n1, int n2, int n3, int attr,
    el.node[0] = n0, el.node[1] = n1, el.node[2] = n2, el.node[3] = n3;
 
    // get faces and assign face attributes
-   Face* f[4];
+   std::array<Face, 4> f;
    const GeomInfo &gi_tet = GI[Geometry::TETRAHEDRON];
    for (int i = 0; i < gi_tet.nf; i++)
    {
       const auto &fv = gi_tet.faces[i];
-      f[i] = faces.Get(el.node[fv[0]], el.node[fv[1]], el.node[fv[2]]);
+      f[i] = faces.At(el.node[fv[0]], el.node[fv[1]], el.node[fv[2]]);
    }
 
-   f[0]->attribute = fattr0;
-   f[1]->attribute = fattr1;
-   f[2]->attribute = fattr2;
-   f[3]->attribute = fattr3;
+   f[0].attribute = fattr0;
+   f[1].attribute = fattr1;
+   f[2].attribute = fattr2;
+   f[3].attribute = fattr3;
 
    return new_id;
 }

--- a/mesh/ncmesh.cpp
+++ b/mesh/ncmesh.cpp
@@ -481,18 +481,18 @@ int NCMesh::NewHexahedron(int n0, int n1, int n2, int n3,
    el.node[4] = n4, el.node[5] = n5, el.node[6] = n6, el.node[7] = n7;
 
    // get faces and assign face attributes
-   Face* f[MaxElemFaces];
+   std::array<Face, 8> f;
    const GeomInfo &gi_hex = GI[Geometry::CUBE];
    for (int i = 0; i < gi_hex.nf; i++)
    {
       const auto &fv = gi_hex.faces[i];
-      f[i] = faces.Get(el.node[fv[0]], el.node[fv[1]],
+      f[i] = faces.At(el.node[fv[0]], el.node[fv[1]],
                        el.node[fv[2]], el.node[fv[3]]);
    }
 
-   f[0]->attribute = fattr0,  f[1]->attribute = fattr1;
-   f[2]->attribute = fattr2,  f[3]->attribute = fattr3;
-   f[4]->attribute = fattr4,  f[5]->attribute = fattr5;
+   f[0].attribute = fattr0,  f[1].attribute = fattr1;
+   f[2].attribute = fattr2,  f[3].attribute = fattr3;
+   f[4].attribute = fattr4,  f[5].attribute = fattr5;
 
    return new_id;
 }
@@ -511,20 +511,20 @@ int NCMesh::NewWedge(int n0, int n1, int n2,
    el.node[3] = n3, el.node[4] = n4, el.node[5] = n5;
 
    // get faces and assign face attributes
-   Face* f[5];
+   std::array<Face, 5> f;
    const GeomInfo &gi_wedge = GI[Geometry::PRISM];
    for (int i = 0; i < gi_wedge.nf; i++)
    {
       const auto &fv = gi_wedge.faces[i];
-      f[i] = faces.Get(el.node[fv[0]], el.node[fv[1]],
+      f[i] = faces.At(el.node[fv[0]], el.node[fv[1]],
                        el.node[fv[2]], el.node[fv[3]]);
    }
 
-   f[0]->attribute = fattr0;
-   f[1]->attribute = fattr1;
-   f[2]->attribute = fattr2;
-   f[3]->attribute = fattr3;
-   f[4]->attribute = fattr4;
+   f[0].attribute = fattr0;
+   f[1].attribute = fattr1;
+   f[2].attribute = fattr2;
+   f[3].attribute = fattr3;
+   f[4].attribute = fattr4;
 
    return new_id;
 }
@@ -566,20 +566,20 @@ int NCMesh::NewPyramid(int n0, int n1, int n2, int n3, int n4, int attr,
    el.node[4] = n4;
 
    // get faces and assign face attributes
-   Face* f[5];
+   std::array<Face, 5> f;
    const GeomInfo &gi_pyr = GI[Geometry::PYRAMID];
    for (int i = 0; i < gi_pyr.nf; i++)
    {
       const auto &fv = gi_pyr.faces[i];
-      f[i] = faces.Get(el.node[fv[0]], el.node[fv[1]],
-                       el.node[fv[2]], el.node[fv[3]]);
+      f[i] = faces.At(el.node[fv[0]], el.node[fv[1]],
+                      el.node[fv[2]], el.node[fv[3]]);
    }
 
-   f[0]->attribute = fattr0;
-   f[1]->attribute = fattr1;
-   f[2]->attribute = fattr2;
-   f[3]->attribute = fattr3;
-   f[4]->attribute = fattr4;
+   f[0].attribute = fattr0;
+   f[1].attribute = fattr1;
+   f[2].attribute = fattr2;
+   f[3].attribute = fattr3;
+   f[4].attribute = fattr4;
 
    return new_id;
 }
@@ -595,17 +595,17 @@ int NCMesh::NewQuadrilateral(int n0, int n1, int n2, int n3,
    el.node[0] = n0, el.node[1] = n1, el.node[2] = n2, el.node[3] = n3;
 
    // get (degenerate) faces and assign face attributes
-   Face* f[4];
+   std::array<Face, 4> f;
    const GeomInfo &gi_quad = GI[Geometry::SQUARE];
    for (int i = 0; i < gi_quad.nf; i++)
    {
       const auto &fv = gi_quad.faces[i];
-      f[i] = faces.Get(el.node[fv[0]], el.node[fv[1]],
+      f[i] = faces.At(el.node[fv[0]], el.node[fv[1]],
                        el.node[fv[2]], el.node[fv[3]]);
    }
 
-   f[0]->attribute = eattr0,  f[1]->attribute = eattr1;
-   f[2]->attribute = eattr2,  f[3]->attribute = eattr3;
+   f[0].attribute = eattr0,  f[1].attribute = eattr1;
+   f[2].attribute = eattr2,  f[3].attribute = eattr3;
 
    return new_id;
 }
@@ -620,18 +620,18 @@ int NCMesh::NewTriangle(int n0, int n1, int n2,
    el.node[0] = n0, el.node[1] = n1, el.node[2] = n2;
 
    // get (degenerate) faces and assign face attributes
-   Face* f[3];
+   std::array<Face, 3> f;
    const GeomInfo &gi_tri = GI[Geometry::TRIANGLE];
    for (int i = 0; i < gi_tri.nf; i++)
    {
       const auto &fv = gi_tri.faces[i];
-      f[i] = faces.Get(el.node[fv[0]], el.node[fv[1]],
+      f[i] = faces.At(el.node[fv[0]], el.node[fv[1]],
                        el.node[fv[2]], el.node[fv[3]]);
    }
 
-   f[0]->attribute = eattr0;
-   f[1]->attribute = eattr1;
-   f[2]->attribute = eattr2;
+   f[0].attribute = eattr0;
+   f[1].attribute = eattr1;
+   f[2].attribute = eattr2;
 
    return new_id;
 }

--- a/mesh/ncmesh.hpp
+++ b/mesh/ncmesh.hpp
@@ -189,12 +189,12 @@ public:
       int index;   ///< Mesh number
       int element; ///< NCMesh::Element containing this vertex/edge/face
       signed char local; ///< local number within 'element'
-      signed char geom;  ///< Geometry::Type (faces only) (char to save RAM)
+      Geometry::Type geom;  ///< Geometry::Type (faces only) (char to save RAM)
 
-      Geometry::Type Geom() const { return Geometry::Type(geom); }
+      Geometry::Type Geom() const { return geom; }
 
       MeshId() = default;
-      MeshId(int index, int element, int local, int geom = -1)
+      MeshId(int index, int element, int local, Geometry::Type geom = Geometry::Type::INVALID)
          : index(index), element(element), local(local), geom(geom) {}
    };
 
@@ -205,7 +205,7 @@ public:
       int slaves_begin, slaves_end; ///< slave faces
 
       Master() = default;
-      Master(int index, int element, int local, int geom, int sb, int se)
+      Master(int index, int element, int local, Geometry::Type geom, int sb, int se)
          : MeshId(index, element, local, geom)
          , slaves_begin(sb), slaves_end(se) {}
    };
@@ -218,7 +218,7 @@ public:
       unsigned edge_flags : 8; ///< orientation flags, see OrientedPointMatrix
 
       Slave() = default;
-      Slave(int index, int element, int local, int geom)
+      Slave(int index, int element, int local, Geometry::Type geom)
          : MeshId(index, element, local, geom)
          , master(-1), matrix(0), edge_flags(0) {}
    };

--- a/mesh/ncmesh.hpp
+++ b/mesh/ncmesh.hpp
@@ -226,9 +226,9 @@ public:
    /// Lists all edges/faces in the nonconforming mesh.
    struct NCList
    {
-      Array<MeshId> conforming;
-      Array<Master> masters;
-      Array<Slave> slaves;
+      Array<MeshId> conforming; ///< MeshIds that are conforming
+      Array<Master> masters; ///< MeshIds that are masters
+      Array<Slave> slaves; ///< MeshIds that are slaves (receive geometry information from masters)
 
       /// List of unique point matrices for each slave geometry.
       Array<DenseMatrix*> point_matrices[Geometry::NumGeom];
@@ -237,16 +237,27 @@ public:
       void OrientedPointMatrix(const Slave &slave,
                                DenseMatrix &oriented_matrix) const;
 
-      void Clear();
+      void Clear(); ///< Call DeleteAll on member Arrays
+      /// Check if this NCList contains data
       bool Empty() const { return !conforming.Size() && !masters.Size(); }
+      /// Combined Size call of all member arrays
       long TotalSize() const;
+      /// Combined Memory Usage of member arrays
       long MemoryUsage() const;
 
+      /// Given an index corresponding to an element number within Mesh, find
+      /// the corresponding mesh element, from within the @a conforming, @a
+      /// masters and @a slaves arrays, optionally return the @a type of the
+      /// returned MeshId.
       const MeshId& LookUp(int index, int *type = NULL) const;
-
-      ~NCList() { Clear(); }
    private:
-      mutable Array<int> inv_index;
+      /// @brief Which array is this element stored in
+      enum class ElementType : char { INVALID, CONFORMING, MASTER, SLAVE };
+      /// @brief Convenience struct storing which array, and the index into it.
+      struct TypeIndex { ElementType t; int index; };
+      /// inv_index goes from a Mesh index number to the entry in one of the
+      /// three member arrays: conforming, masters and slaves.
+      mutable Array<TypeIndex> inv_index;
    };
 
    /// Return the current list of conforming and nonconforming faces.

--- a/mesh/ncmesh.hpp
+++ b/mesh/ncmesh.hpp
@@ -256,6 +256,7 @@ public:
       enum class ElementType : char { INVALID, CONFORMING, MASTER, SLAVE };
       /// @brief Convenience struct storing which array, and the index into it.
       struct TypeIndex { ElementType t; int index; };
+
       /// inv_index goes from a Mesh index number to the entry in one of the
       /// three member arrays: conforming, masters and slaves.
       mutable Array<TypeIndex> inv_index;

--- a/mesh/ncmesh.hpp
+++ b/mesh/ncmesh.hpp
@@ -194,7 +194,8 @@ public:
       Geometry::Type Geom() const { return geom; }
 
       MeshId() = default;
-      MeshId(int index, int element, int local, Geometry::Type geom = Geometry::Type::INVALID)
+      MeshId(int index, int element, int local,
+             Geometry::Type geom = Geometry::Type::INVALID)
          : index(index), element(element), local(local), geom(geom) {}
    };
 
@@ -228,7 +229,7 @@ public:
    {
       Array<MeshId> conforming; ///< MeshIds that are conforming
       Array<Master> masters; ///< MeshIds that are masters
-      Array<Slave> slaves; ///< MeshIds that are slaves (receive geometry information from masters)
+      Array<Slave> slaves; ///< MeshIds that are slaves
 
       /// List of unique point matrices for each slave geometry.
       Array<DenseMatrix*> point_matrices[Geometry::NumGeom];
@@ -948,9 +949,8 @@ protected: // implementation
 
    struct TmpVertex
    {
-      bool valid, visited;
+      bool valid = false, visited = false;
       double pos[3];
-      TmpVertex() : valid(false), visited(false) {}
    };
 
    mutable TmpVertex* tmp_vertex;

--- a/mesh/ncmesh.hpp
+++ b/mesh/ncmesh.hpp
@@ -491,8 +491,8 @@ protected: // implementation
       int attribute;
       union
       {
-         int node[MaxElemNodes];  ///< element corners (if ref_type == 0)
-         int child[MaxElemChildren]; ///< 2-10 children (if ref_type != 0)
+         std::array<int, MaxElemNodes> node;  ///< element corners (if ref_type == 0)
+         std::array<int, MaxElemChildren> child; ///< 2-10 children (if ref_type != 0)
       };
       int parent; ///< parent element, -1 if this is a root element, -2 if free'd
 

--- a/mesh/ncmesh.hpp
+++ b/mesh/ncmesh.hpp
@@ -960,7 +960,8 @@ protected: // implementation
 
    /// Calculate the vertex position of @a node, using the @a tmp_vertex map to
    /// store those values calculated on demand.
-   const double *CalcVertexPos(int node, std::unordered_map<int, TmpVertex> &tmp_vertex) const;
+   const double *CalcVertexPos(int node,
+                               std::unordered_map<int, TmpVertex> &tmp_vertex) const;
 
    // utility
 
@@ -1057,8 +1058,10 @@ protected: // implementation
    struct GeomInfo
    {
       int nv, ne, nf;   ///< number of: vertices, edges, faces
-      std::array<std::array<int, 2>, MaxElemEdges> edges; ///< edge vertices (up to 12 edges)
-      std::array<std::array<int, 4>, MaxElemFaces> faces; ///< face vertices (up to 6 faces)
+      /// edge vertices (up to 12 edges)
+      std::array<std::array<int, 2>, MaxElemEdges> edges;
+      /// face vertices (up to 6 faces)
+      std::array<std::array<int, 4>, MaxElemFaces> faces;
       std::array<int, MaxElemFaces> nfv; ///< number of face vertices
 
       bool initialized;

--- a/mesh/ncmesh.hpp
+++ b/mesh/ncmesh.hpp
@@ -554,6 +554,8 @@ protected: // implementation
 
    /// Coordinates of top-level vertices (organized as triples). If empty,
    /// the Mesh is curved (Nodes != NULL) and NCMesh is topology-only.
+   /// These are vertices that have not been introduced by a refinement, namely
+   /// are from the initial root mesh.
    Array<double> coordinates;
 
    // secondary data
@@ -676,30 +678,134 @@ protected: // implementation
       elements[id].parent = -2; // mark the element as free
    }
 
+
+   /**
+    * @brief Introduce a new hexahedron to the elements array
+    *
+    * @param n0 A node number of the introduced hexahedron
+    * @param n1 A node number of the introduced hexahedron
+    * @param n2 A node number of the introduced hexahedron
+    * @param n3 A node number of the introduced hexahedron
+    * @param n4 A node number of the introduced hexahedron
+    * @param n5 A node number of the introduced hexahedron
+    * @param n6 A node number of the introduced hexahedron
+    * @param n7 A node number of the introduced hexahedron
+    * @param attr The attribute of the hexahedron
+    * @param fattr0 A face attribute of the introduced hexahedron
+    * @param fattr1 A face attribute of the introduced hexahedron
+    * @param fattr2 A face attribute of the introduced hexahedron
+    * @param fattr3 A face attribute of the introduced hexahedron
+    * @param fattr4 A face attribute of the introduced hexahedron
+    * @param fattr5 A face attribute of the introduced hexahedron
+    * @return int Index into `elements` for the new hexahedron
+    */
    int NewHexahedron(int n0, int n1, int n2, int n3,
                      int n4, int n5, int n6, int n7, int attr,
                      int fattr0, int fattr1, int fattr2,
                      int fattr3, int fattr4, int fattr5);
 
+   /**
+    * @brief Introduce a new wedge to the elements array
+    *
+    * @param n0 A node number of the introduced wedge
+    * @param n1 A node number of the introduced wedge
+    * @param n2 A node number of the introduced wedge
+    * @param n3 A node number of the introduced wedge
+    * @param n4 A node number of the introduced wedge
+    * @param n5 A node number of the introduced wedge
+    * @param attr The attribute of the wedge
+    * @param fattr0 A face attribute of the introduced wedge
+    * @param fattr1 A face attribute of the introduced wedge
+    * @param fattr2 A face attribute of the introduced wedge
+    * @param fattr3 A face attribute of the introduced wedge
+    * @param fattr4 A face attribute of the introduced wedge
+    * @return int Index into `elements` for the new wedge
+    */
    int NewWedge(int n0, int n1, int n2,
                 int n3, int n4, int n5, int attr,
                 int fattr0, int fattr1,
                 int fattr2, int fattr3, int fattr4);
 
+   /**
+    * @brief Introduce a new tetrahedron to the elements array
+    *
+    * @param n0 A node number of the introduced tetrahedron
+    * @param n1 A node number of the introduced tetrahedron
+    * @param n2 A node number of the introduced tetrahedron
+    * @param n3 A node number of the introduced tetrahedron
+    * @param attr The attribute of the tetrahedron
+    * @param fattr0 A face attribute of the introduced tetrahedron
+    * @param fattr1 A face attribute of the introduced tetrahedron
+    * @param fattr2 A face attribute of the introduced tetrahedron
+    * @param fattr3 A face attribute of the introduced tetrahedron
+    * @return int Index into `elements` for the new tetrahedron
+    */
    int NewTetrahedron(int n0, int n1, int n2, int n3, int attr,
                       int fattr0, int fattr1, int fattr2, int fattr3);
 
+   /**
+    * @brief Introduce a new pyramid to the elements array
+    *
+    * @param n0 A node number of the introduced pyramid
+    * @param n1 A node number of the introduced pyramid
+    * @param n2 A node number of the introduced pyramid
+    * @param n3 A node number of the introduced pyramid
+    * @param n4 A node number of the introduced pyramid
+    * @param attr The attribute of the pyramid
+    * @param fattr0 A face attribute of the introduced pyramid
+    * @param fattr1 A face attribute of the introduced pyramid
+    * @param fattr2 A face attribute of the introduced pyramid
+    * @param fattr3 A face attribute of the introduced pyramid
+    * @param fattr4 A face attribute of the introduced pyramid
+    * @return int Index into `elements` for the new pyramid
+    */
    int NewPyramid(int n0, int n1, int n2, int n3, int n4, int attr,
                   int fattr0, int fattr1, int fattr2, int fattr3,
                   int fattr4);
 
+   /**
+    * @brief Introduce a new quadrilateral to the elements array
+    *
+    * @param n0 A node number of the introduced quadrilateral
+    * @param n1 A node number of the introduced quadrilateral
+    * @param n2 A node number of the introduced quadrilateral
+    * @param n3 A node number of the introduced quadrilateral
+    * @param attr The attribute of the quadrilateral
+    * @param eattr0 An edge attribute of the introduced quadrilateral
+    * @param eattr1 An edge attribute of the introduced quadrilateral
+    * @param eattr2 An edge attribute of the introduced quadrilateral
+    * @param eattr3 An edge attribute of the introduced quadrilateral
+    * @return int Index into `elements` for the new quadrilateral
+    */
    int NewQuadrilateral(int n0, int n1, int n2, int n3, int attr,
                         int eattr0, int eattr1, int eattr2, int eattr3);
 
+   /**
+    * @brief Introduce a new triangle to the elements array
+    *
+    * @param n0 A node number of the introduced triangle
+    * @param n1 A node number of the introduced triangle
+    * @param n2 A node number of the introduced triangle
+    * @param attr The attribute of the triangle
+    * @param eattr0 An edge attribute of the introduced triangle
+    * @param eattr1 An edge attribute of the introduced triangle
+    * @param eattr2 An edge attribute of the introduced triangle
+    * @return int Index into `elements` for the new triangle
+    */
    int NewTriangle(int n0, int n1, int n2,
                    int attr, int eattr0, int eattr1, int eattr2);
 
-   int NewSegment(int n0, int n1, int attr, int vattr1, int vattr2);
+   /**
+    * @brief Introduce a new segment to the elements array
+    *
+    * @param n0 A node number of the introduced segment
+    * @param n1 A node number of the introduced segment
+    * @param attr The attribute of the segment
+    * @param vattr0 A vertex attribute of the introduced segment
+    * @param vattr1 A vertex attribute of the introduced segment
+    * @return int Index into `elements` for the new segment
+    */
+   int NewSegment(int n0, int n1, int attr, int vattr0, int vattr1);
 
    mfem::Element* NewMeshElement(int geom) const;
 

--- a/mesh/ncmesh.hpp
+++ b/mesh/ncmesh.hpp
@@ -541,6 +541,15 @@ protected: // implementation
    /// Initial traversal state (~ element orientation) for each root element
    /// NOTE: M = root_state.Size() is the number of root elements.
    /// NOTE: the first M items of 'elements' is the coarse mesh.
+
+   /**
+    * @brief nitial traversal state (~ element orientation) for each root element
+    * @details This is zero for most element types, but for quadrilaterals and
+    * hexahedra this is modified from an array of zeroes, to assign an ordering
+    * of the root elements that will give a space filling curve.
+    * @note M = root_state.Size() is the number of root elements, and the first
+    * M items of 'elements' is the coarse mesh.
+    */
    Array<int> root_state;
 
    /// Coordinates of top-level vertices (organized as triples). If empty,

--- a/mesh/ncmesh.hpp
+++ b/mesh/ncmesh.hpp
@@ -466,6 +466,13 @@ protected: // implementation
       int vert_index = -1, edge_index = -1;
 
       ~Node();
+      /// non-default dtor means all implicit constructors and operators need
+      /// definining
+      Node() = default;
+      Node(const Node&) = default;
+      Node& operator=(const Node&) = default;
+      Node(Node&&) = default;
+      Node& operator=(Node&&) = default;
 
       /// True if this Node has an associated vertex reference.
       bool HasVertex() const { return vert_refc > 0; }
@@ -490,7 +497,7 @@ protected: // implementation
       bool Boundary() const { return attribute >= 0; }
       bool Unused() const { return elem[0] < 0 && elem[1] < 0; }
 
-      // add or remove an element from the 'elem[2]' array
+      // add or remove an element from the elem array
       void RegisterElement(int e);
       void ForgetElement(int e);
 

--- a/mesh/ncmesh.hpp
+++ b/mesh/ncmesh.hpp
@@ -22,6 +22,7 @@
 #include "../fem/geom.hpp"
 
 #include <vector>
+#include <unordered_map>
 #include <map>
 #include <iostream>
 

--- a/mesh/ncmesh.hpp
+++ b/mesh/ncmesh.hpp
@@ -810,12 +810,15 @@ protected: // implementation
 
    struct Point
    {
-      int dim;
+      int dim = 0;
       double coord[3];
 
-      Point() { dim = 0; }
+      Point() = default;
+      Point(const Point&) = default;
+      Point(Point&&) = default;
 
-      Point(const Point &) = default;
+      Point& operator=(const Point&) = default;
+      Point& operator=(Point&&) = default;
 
       Point(double x)
       { dim = 1; coord[0] = x; }
@@ -844,13 +847,6 @@ protected: // implementation
             coord[i] = (p0.coord[i] + p1.coord[i] + p2.coord[i] + p3.coord[i])
                        * 0.25;
          }
-      }
-
-      Point& operator=(const Point& src)
-      {
-         dim = src.dim;
-         for (int i = 0; i < dim; i++) { coord[i] = src.coord[i]; }
-         return *this;
       }
    };
 
@@ -944,19 +940,20 @@ protected: // implementation
    void InitDerefTransforms();
    void SetDerefMatrixCodes(int parent, Array<int> &fine_coarse);
 
-
-   // vertex temporary data, used by GetMeshComponents
-
+   /**
+    * @brief Storage for vertices calculated on demand for nodes in the mesh
+    */
    struct TmpVertex
    {
-      bool valid = false, visited = false;
-      double pos[3];
+      bool valid = false; ///< Is the data in pos valid?
+      /// Used for checking for circular dependencies and invalid meshes.
+      bool visited = false;
+      double pos[3]; ///< storage for the vertex position.
    };
 
-   mutable TmpVertex* tmp_vertex;
-
-   const double *CalcVertexPos(int node) const;
-
+   /// Calculate the vertex position of @a node, using the @a tmp_vertex map to
+   /// store those values calculated on demand.
+   const double *CalcVertexPos(int node, std::unordered_map<int, TmpVertex> &tmp_vertex) const;
 
    // utility
 

--- a/mesh/pncmesh.cpp
+++ b/mesh/pncmesh.cpp
@@ -558,7 +558,7 @@ int ParNCMesh::get_face_orientation(Face &face, Element &e1, Element &e2,
       if (local) { local[i] = lf; }
 
       // get node IDs for the face as seen from e[i]
-      const int* fv = GI[e[i]->Geom()].faces[lf];
+      const auto &fv = GI[e[i]->Geom()].faces[lf];
       for (int j = 0; j < 4; j++)
       {
          ids[i][j] = e[i]->node[fv[j]];
@@ -2369,7 +2369,7 @@ void ParNCMesh::ChangeVertexMeshIdElement(NCMesh::MeshId &id, int elem)
 void ParNCMesh::ChangeEdgeMeshIdElement(NCMesh::MeshId &id, int elem)
 {
    Element &old = elements[id.element];
-   const int *old_ev = GI[old.Geom()].edges[(int) id.local];
+   const auto &old_ev = GI[old.Geom()].edges[(int) id.local];
    Node* node = nodes.Find(old.node[old_ev[0]], old.node[old_ev[1]]);
    MFEM_ASSERT(node != NULL, "Edge not found.");
 
@@ -2379,7 +2379,7 @@ void ParNCMesh::ChangeEdgeMeshIdElement(NCMesh::MeshId &id, int elem)
    GeomInfo& gi = GI[el.Geom()];
    for (int i = 0; i < gi.ne; i++)
    {
-      const int* ev = gi.edges[i];
+      const auto &ev = gi.edges[i];
       if ((el.node[ev[0]] == node->p1 && el.node[ev[1]] == node->p2) ||
           (el.node[ev[1]] == node->p1 && el.node[ev[0]] == node->p2))
       {
@@ -2485,7 +2485,7 @@ void ParNCMesh::DecodeMeshIds(std::istream &is, Array<MeshId> ids[])
             }
             case 1:
             {
-               const int* ev = gi.edges[(int) id.local];
+               const auto &ev = gi.edges[(int) id.local];
                Node* node = nodes.Find(el.node[ev[0]], el.node[ev[1]]);
                MFEM_ASSERT(node && node->HasEdge(), "edge not found.");
                id.index = node->edge_index;
@@ -2493,7 +2493,7 @@ void ParNCMesh::DecodeMeshIds(std::istream &is, Array<MeshId> ids[])
             }
             default:
             {
-               const int* fv = gi.faces[(int) id.local];
+               const auto &fv = gi.faces[(int) id.local];
                Face* face = faces.Find(el.node[fv[0]], el.node[fv[1]],
                                        el.node[fv[2]], el.node[fv[3]]);
                MFEM_ASSERT(face, "face not found.");

--- a/mesh/pncmesh.cpp
+++ b/mesh/pncmesh.cpp
@@ -997,16 +997,15 @@ void ParNCMesh::GetFaceNeighbors(ParMesh &pmesh)
 
    // create vertices in 'face_nbr_vertices'
    {
+      std::unordered_map<int, TmpVertex> tmp_vertices;
       pmesh.face_nbr_vertices.SetSize(vert_map.size());
       if (coordinates.Size())
       {
-         tmp_vertex = new TmpVertex[nodes.NumIds()]; // TODO: something cheaper?
          for (auto it = vert_map.begin(); it != vert_map.end(); ++it)
          {
             pmesh.face_nbr_vertices[it->second-1].SetCoords(
-               spaceDim, CalcVertexPos(it->first));
+               spaceDim, CalcVertexPos(it->first, tmp_vertices));
          }
-         delete [] tmp_vertex;
       }
    }
 

--- a/mesh/vertex.hpp
+++ b/mesh/vertex.hpp
@@ -15,6 +15,8 @@
 #include "../config/config.hpp"
 #include "../general/globals.hpp"
 
+#include <array>
+
 namespace mfem
 {
 

--- a/mesh/vertex.hpp
+++ b/mesh/vertex.hpp
@@ -22,20 +22,25 @@ namespace mfem
 class Vertex
 {
 protected:
-   double coord[3];
+   std::array<double, 3> coord;
 
 public:
    Vertex() = default;
+   Vertex(const Vertex&) = default;
+   Vertex(Vertex&&) = default;
+
+   Vertex& operator=(const Vertex&) = default;
+   Vertex& operator=(Vertex&&) = default;
 
    // Trivial copy constructor and trivial copy assignment operator
-
-   Vertex (double *xx, int dim);
-   Vertex( double x, double y) { coord[0] = x; coord[1] = y; coord[2] = 0.; }
-   Vertex( double x, double y, double z)
+   Vertex(double *xx, int dim);
+   Vertex(double x, double y) { coord[0] = x; coord[1] = y; coord[2] = 0.; }
+   Vertex(double x, double y, double z)
    { coord[0] = x; coord[1] = y; coord[2] = z; }
 
    /// Returns pointer to the coordinates of the vertex.
-   inline double * operator() () const { return (double*)coord; }
+   inline const double * operator() () const { return coord.data(); }
+   inline double * operator() () { return coord.data(); }
 
    /// Returns the i'th coordinate of the vertex.
    inline double & operator() (int i) { return coord[i]; }
@@ -51,6 +56,9 @@ public:
    /// Sets vertex location based on given point p
    void SetCoords(int dim, const double *p)
    { for (int i = 0; i < dim; i++) { coord[i] = p[i]; } }
+
+   void SetCoords(const std::array<double, 3>& x) { coord = x; }
+   void SetCoords(std::array<double, 3>&& x) { coord = x; }
 
    // Trivial destructor
 };


### PR DESCRIPTION
Was investigating modifications to `NCMesh` to allow distribution of the root mesh. In the process made some modifications:
* Added doxygen comments on a few methods
* Added reference accessors to a few upstream classes
* Changed Cstyle arrays to std::array in some places, mainly to allow binding references
* Addressed a source of a potential bug in NCList where usage of a bitshift meant that overflow would be achieved with 4x fewer elements than expected
* Changed the underlying type of some enums to char, to avoid the need for casting back and forth.

The plan to modify `NCMesh` has been put on hold, but I thought I would submit the modifications I made to a branch, in case of returning to them later. Consider it a WIP.
