### PR TITLE
Mesh rvalue dev

### DIFF
--- a/general/array.hpp
+++ b/general/array.hpp
@@ -477,6 +477,8 @@ public:
    BlockArray(int block_size = 16*1024);
    BlockArray(const BlockArray<T> &other); // deep copy
    BlockArray& operator=(const BlockArray&) = delete; // not supported
+   BlockArray(BlockArray<T> &&other) = default;
+   BlockArray& operator=(BlockArray&&) = delete; // not supported
    ~BlockArray() { Destroy(); }
 
    /// Allocate and construct a new item in the array, return its index.

--- a/general/communication.hpp
+++ b/general/communication.hpp
@@ -548,8 +548,8 @@ struct VarMessage
    }
 
 protected:
-   virtual void Encode(int rank) {}
-   virtual void Decode(int rank) {}
+   virtual void Encode(int rank) = 0;
+   virtual void Decode(int rank) = 0;
 };
 
 

--- a/general/hash.hpp
+++ b/general/hash.hpp
@@ -95,6 +95,10 @@ public:
    HashTable(const HashTable& other);
    /// @brief Copy assignment not supported
    HashTable& operator=(const HashTable&) = delete;
+
+   HashTable(HashTable&& other) = default;
+   /// @brief Move assignment not supported
+   HashTable& operator=(HashTable&&) = delete;
    ~HashTable();
 
    /** @brief Item accessor with key (or parents) the pair 'p1', 'p2'. Default

--- a/mesh/ncmesh.cpp
+++ b/mesh/ncmesh.cpp
@@ -208,24 +208,6 @@ NCMesh::NCMesh(const Mesh *mesh)
    Update();
 }
 
-NCMesh::NCMesh(const NCMesh &other)
-   : Dim(other.Dim)
-   , spaceDim(other.spaceDim)
-   , MyRank(other.MyRank)
-   , Iso(other.Iso)
-   , Geoms(other.Geoms)
-   , Legacy(other.Legacy)
-   , nodes(other.nodes)
-   , faces(other.faces)
-   , elements(other.elements)
-   , shadow(1024, 2048)
-{
-   other.free_element_ids.Copy(free_element_ids);
-   other.root_state.Copy(root_state);
-   other.coordinates.Copy(coordinates);
-   Update();
-}
-
 void NCMesh::InitGeomFlags()
 {
    Geoms = 0;

--- a/mesh/ncmesh.hpp
+++ b/mesh/ncmesh.hpp
@@ -133,10 +133,12 @@ public:
    NCMesh(std::istream &input, int version, int &curved, int &is_nc);
 
    /// Deep copy of another instance.
-   NCMesh(const NCMesh &other);
+   NCMesh(const NCMesh &other) = default;
+   NCMesh(NCMesh &&other) = default;
 
    /// Copy assignment not supported
-   NCMesh& operator=(NCMesh&) = delete;
+   NCMesh& operator=(const NCMesh&) = delete;
+   NCMesh& operator=(NCMesh&&) = delete;
 
    virtual ~NCMesh();
 

--- a/mesh/pmesh.cpp
+++ b/mesh/pmesh.cpp
@@ -107,7 +107,7 @@ ParMesh& ParMesh::operator=(ParMesh &&mesh)
 
 ParMesh::ParMesh(MPI_Comm comm, Mesh &&mesh, int *partitioning_,
                  int part_method)
-: Mesh(mesh), face_nbr_el_to_face(NULL)
+   : Mesh(mesh), face_nbr_el_to_face(NULL)
    , glob_elem_offset(-1)
    , glob_offset_sequence(-1)
    , gtopo(comm)
@@ -117,7 +117,7 @@ ParMesh::ParMesh(MPI_Comm comm, Mesh &&mesh, int *partitioning_,
 
 ParMesh::ParMesh(MPI_Comm comm, const Mesh &mesh, int *partitioning_,
                  int part_method)
-: Mesh(mesh), face_nbr_el_to_face(NULL)
+   : Mesh(mesh), face_nbr_el_to_face(NULL)
    , glob_elem_offset(-1)
    , glob_offset_sequence(-1)
    , gtopo(comm)
@@ -125,7 +125,8 @@ ParMesh::ParMesh(MPI_Comm comm, const Mesh &mesh, int *partitioning_,
    DelegatedConstructionParMesh(comm, partitioning_, part_method);
 }
 
-void ParMesh::DelegatedConstructionParMesh(MPI_Comm comm,int *partitioning_, int part_method)
+void ParMesh::DelegatedConstructionParMesh(MPI_Comm comm,int *partitioning_,
+                                           int part_method)
 {
 
 

--- a/mesh/pmesh.hpp
+++ b/mesh/pmesh.hpp
@@ -298,8 +298,15 @@ public:
        meshes and quick space-filling curve equipartitioning for nonconforming
        meshes (elements of nonconforming meshes should ideally be ordered as a
        sequence of face-neighbors). */
-   ParMesh(MPI_Comm comm, Mesh &mesh, int *partitioning_ = NULL,
+   ParMesh(MPI_Comm comm, Mesh &&mesh, int *partitioning_ = NULL,
            int part_method = 1);
+    ParMesh(MPI_Comm comm, const Mesh &mesh, int *partitioning_ = NULL,
+           int part_method = 1);
+
+protected:
+    /// helper method for delegated construction
+    void DelegatedConstructionParMesh(MPI_Comm comm, int *partitioning_ = NULL, int part_method = 1);
+public:
 
    /** Copy constructor. Performs a deep copy of (almost) all data, so that the
        source mesh can be modified (e.g. deleted, refined) without affecting the

--- a/mesh/pmesh.hpp
+++ b/mesh/pmesh.hpp
@@ -300,12 +300,13 @@ public:
        sequence of face-neighbors). */
    ParMesh(MPI_Comm comm, Mesh &&mesh, int *partitioning_ = NULL,
            int part_method = 1);
-    ParMesh(MPI_Comm comm, const Mesh &mesh, int *partitioning_ = NULL,
+   ParMesh(MPI_Comm comm, const Mesh &mesh, int *partitioning_ = NULL,
            int part_method = 1);
 
 protected:
-    /// helper method for delegated construction
-    void DelegatedConstructionParMesh(MPI_Comm comm, int *partitioning_ = NULL, int part_method = 1);
+   /// helper method for delegated construction
+   void DelegatedConstructionParMesh(MPI_Comm comm, int *partitioning_ = NULL,
+                                     int part_method = 1);
 public:
 
    /** Copy constructor. Performs a deep copy of (almost) all data, so that the

--- a/mesh/pmesh.hpp
+++ b/mesh/pmesh.hpp
@@ -304,9 +304,16 @@ public:
            int part_method = 1);
 
 protected:
-   /// helper method for delegated construction
-   void DelegatedConstructionParMesh(MPI_Comm comm, int *partitioning_ = NULL,
-                                     int part_method = 1);
+   /**
+    * @brief Helper function for performing delegated construction from const
+    * references and rvalue references.
+    *
+    * @param comm The MPI communicator
+    * @param partitioning_ an optional partitioning of the mesh
+    * @param part_method the method to use in the partitioning.
+    */
+   void DelegatedConstructionParMesh(MPI_Comm comm, int *partitioning_,
+                                     int part_method);
 public:
 
    /** Copy constructor. Performs a deep copy of (almost) all data, so that the

--- a/mesh/pncmesh.hpp
+++ b/mesh/pncmesh.hpp
@@ -82,23 +82,23 @@ public:
    /** An override of NCMesh::Refine, which is called eventually, after making
        sure that refinements that occur on the processor boundary are sent to
        the neighbor processors so they can keep their ghost layers up to date.*/
-   virtual void Refine(const Array<Refinement> &refinements);
+   void Refine(const Array<Refinement> &refinements) override;
 
    /// Parallel version of NCMesh::LimitNCLevel.
-   virtual void LimitNCLevel(int max_nc_level);
+   void LimitNCLevel(int max_nc_level) override;
 
    /** Parallel version of NCMesh::CheckDerefinementNCLevel. */
-   virtual void CheckDerefinementNCLevel(const Table &deref_table,
-                                         Array<int> &level_ok, int max_nc_level);
+   void CheckDerefinementNCLevel(const Table &deref_table,
+                                 Array<int> &level_ok, int max_nc_level) override;
 
    /** Parallel reimplementation of NCMesh::Derefine, keeps ghost layers
        in sync. The interface is identical. */
-   virtual void Derefine(const Array<int> &derefs);
+   void Derefine(const Array<int> &derefs) override;
 
    /** Gets partitioning for the coarse mesh if the current fine mesh were to
        be derefined. */
-   virtual void GetFineToCoarsePartitioning(const Array<int> &derefs,
-                                            Array<int> &new_ranks) const;
+   void GetFineToCoarsePartitioning(const Array<int> &derefs,
+                                    Array<int> &new_ranks) const;
 
    /** Migrate leaf elements of the global refinement hierarchy (including ghost
        elements) so that each processor owns the same number of leaves (+-1).
@@ -116,7 +116,7 @@ public:
    int GetNGhostVertices() const { return NGhostVertices; }
    int GetNGhostEdges() const { return NGhostEdges; }
    int GetNGhostFaces() const { return NGhostFaces; }
-   int GetNGhostElements() const { return NGhostElements; }
+   int GetNGhostElements() const override { return NGhostElements; }
 
    // Return a list of vertices/edges/faces shared by this processor and at
    // least one other processor. These are subsets of NCMesh::<entity>_list. */
@@ -232,12 +232,12 @@ public:
 
    /** Extension of NCMesh::GetBoundaryClosure. Filters out ghost vertices and
        ghost edges from 'bdr_vertices' and 'bdr_edges'. */
-   virtual void GetBoundaryClosure(const Array<int> &bdr_attr_is_ess,
-                                   Array<int> &bdr_vertices,
-                                   Array<int> &bdr_edges);
+   void GetBoundaryClosure(const Array<int> &bdr_attr_is_ess,
+                           Array<int> &bdr_vertices,
+                           Array<int> &bdr_edges) override;
 
    /// Save memory by releasing all non-essential and cached data.
-   virtual void Trim();
+   void Trim() override;
 
    /// Return total number of bytes allocated.
    std::size_t MemoryUsage(bool with_base = true) const;
@@ -299,7 +299,7 @@ protected: // implementation
    Array<int> ghost_layer;    ///< list of elements whose 'element_type' == 2.
    Array<int> boundary_layer; ///< list of type 3 elements
 
-   virtual void Update();
+   void Update() override;
 
    /// Return the processor number for a global element number.
    int Partition(long index, long total_elements) const
@@ -313,13 +313,13 @@ protected: // implementation
    long PartitionFirstIndex(int rank, long total_elements) const
    { return (rank * total_elements + NRanks-1) / NRanks; }
 
-   virtual void BuildFaceList();
-   virtual void BuildEdgeList();
-   virtual void BuildVertexList();
+   void BuildFaceList() override;
+   void BuildEdgeList() override;
+   void BuildVertexList() override;
 
-   virtual void ElementSharesFace(int elem, int local, int face);
-   virtual void ElementSharesEdge(int elem, int local, int enode);
-   virtual void ElementSharesVertex(int elem, int local, int vnode);
+   void ElementSharesFace(int elem, int local, int face) override;
+   void ElementSharesEdge(int elem, int local, int enode) override;
+   void ElementSharesVertex(int elem, int local, int vnode) override;
 
    GroupId GetGroupId(const CommGroup &group);
    GroupId GetSingletonGroup(int rank);
@@ -451,8 +451,8 @@ protected: // implementation
    protected:
       ParNCMesh* pncmesh;
 
-      virtual void Encode(int);
-      virtual void Decode(int);
+      void Encode(int) override;
+      void Decode(int) override;
    };
 
    /** Used by ParNCMesh::Refine() to inform neighbors about refinements at
@@ -513,8 +513,8 @@ protected: // implementation
    protected:
       ElementSet eset;
 
-      virtual void Encode(int);
-      virtual void Decode(int);
+      void Encode(int) override;
+      void Decode(int) override;
    };
 
    /** Assign new Element::rank to leaf elements and send them to their new


### PR DESCRIPTION
Changes to allow consuming `Mesh` from an rvalue reference during construction of a `ParMesh`, should marginally reduce the total memory required during partitioning.