### PR TITLE
Add support for shared builds on Windows with MSVC using CMake

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -49,14 +49,20 @@ install:
 
 # MFEM
 before_build:
-- cmake -H. -DCMAKE_INSTALL_PREFIX=install -Bbuild_parallel -DMFEM_USE_MPI=TRUE -DMFEM_USE_METIS_5=TRUE -DHYPRE_DIR=%cd%\..\hypre-2.19.0\src\hypre -DMETIS_LIBRARIES=%METIS_PATH%\build\libmetis\Debug\metis.lib -DMETIS_INCLUDE_DIRS=%METIS_PATH%\include
-- cmake -H. -DCMAKE_INSTALL_PREFIX=install -Bbuild_serial -DMFEM_USE_MPI=FALSE
+- cmake . -Bbuild_parallel -DMFEM_USE_MPI=TRUE -DMFEM_USE_METIS_5=TRUE -DHYPRE_DIR=%cd%\..\hypre-2.19.0\src\hypre -DMETIS_LIBRARIES=%METIS_PATH%\build\libmetis\Debug\metis.lib -DMETIS_INCLUDE_DIRS=%METIS_PATH%\include
+- cmake . -Bbuild_serial -DMFEM_USE_MPI=FALSE
+- cmake . -Bbuild_shared_serial -DMFEM_USE_MPI=FALSE -DBUILD_SHARED_LIBS=ON
 
 build_script:
 - cmake --build build_parallel --config Release -j 4
 - cmake --build build_serial --config Release -j 4
 - cmake --build build_serial --target exec --config Release -j 4
+- cmake --build build_shared_serial --config Release -j 4
+- cmake --build build_shared_serial --target exec --config Release -j 4
 
 after_build:
 - cd build_serial
+- ctest -C Release --output-on-failure
+- cd ..
+- cd build_shared_serial
 - ctest -C Release --output-on-failure

--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,9 @@ CMakeFiles/
 # Default install location
 /mfem/
 
+# Typical build directory
+/build/
+
 # Generated files in main directory, config/ and docs/
 /deps.mk
 config/_config.hpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,7 @@
 # Version 3.8 fixes the handling of CMAKE_CXX_STANDARD for try_compile.
 # Version 3.8 or newer is required for direct CUDA support.
 cmake_minimum_required(VERSION 3.8)
+message(STATUS "CMake version: ${CMAKE_VERSION}")
 set(USER_CONFIG "${CMAKE_CURRENT_SOURCE_DIR}/config/user.cmake" CACHE PATH
   "Path to optional user configuration file.")
 
@@ -24,8 +25,11 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 # Load user settings before the defaults - this way the defaults will not
 # overwrite the user set options. If the user has not set all options, we still
 # have the defaults.
-message(STATUS "(optional) USER_CONFIG = ${USER_CONFIG}")
-include("${USER_CONFIG}" OPTIONAL)
+include("${USER_CONFIG}" OPTIONAL RESULT_VARIABLE USER_CONFIG_LOADED)
+if (USER_CONFIG_LOADED)
+  set(USER_CONFIG_LOADED "LOADED")
+endif()
+message(STATUS "Loading USER_CONFIG = ${USER_CONFIG} (${USER_CONFIG_LOADED})")
 include("${CMAKE_CURRENT_SOURCE_DIR}/config/defaults.cmake")
 
 # Allow overwriting of the compiler by setting CXX/MPICXX on the command line or
@@ -181,6 +185,23 @@ if (CMAKE_BUILD_TYPE MATCHES "Debug|debug|DEBUG")
   set(MFEM_DEBUG ON)
 else()
   set(MFEM_DEBUG OFF)
+endif()
+
+# Shared build on Windows
+if (WIN32 AND BUILD_SHARED_LIBS)
+  # CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS works only with MSVC?
+  set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON CACHE BOOL
+      "Automatically export symbols for shared Windows DLL build")
+  # Place all .dll and .exe files in the same sub-directory, 'bin/<config>', of
+  # the build directory, so that the .exe files can find the .dll files at
+  # runtime:
+  set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin")
+  # Note: CMake tests are run from the build-tree sub-directory where the test
+  # is defined, e.g. <build-dir>/tests/unit, so hard coded paths to meshes still
+  # work fine.
+  # Not strictly necessary:
+  # set(CMAKE_LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib")
+  # set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib")
 endif()
 
 # AMD HIP
@@ -519,6 +540,7 @@ list(REVERSE TPL_LIBRARIES)
 list(REMOVE_DUPLICATES TPL_INCLUDE_DIRS)
 # message(STATUS "TPL_INCLUDE_DIRS = ${TPL_INCLUDE_DIRS}")
 
+message(STATUS "MFEM shared library: BUILD_SHARED_LIBS = ${BUILD_SHARED_LIBS}")
 message(STATUS "MFEM build type: CMAKE_BUILD_TYPE = ${CMAKE_BUILD_TYPE}")
 message(STATUS "MFEM version: v${MFEM_VERSION_STRING}")
 message(STATUS "MFEM git string: ${MFEM_GIT_STRING}")
@@ -586,6 +608,7 @@ if (NOT ("${PROJECT_SOURCE_DIR}" STREQUAL "${PROJECT_BINARY_DIR}"))
 endif()
 
 # Generate configuration file in the build directory: config/_config.hpp.
+set(MFEM_SHARED_BUILD ${BUILD_SHARED_LIBS})
 configure_file(
   "${PROJECT_SOURCE_DIR}/config/cmake/config.hpp.in"
   "${PROJECT_BINARY_DIR}/config/_config.hpp")
@@ -757,10 +780,8 @@ endif()
 
 # Install the configuration header files
 install(FILES ${PROJECT_BINARY_DIR}/config/_config.hpp
-  DESTINATION ${INSTALL_INCLUDE_DIR}/mfem/config
-  RENAME config.hpp)
-
-install(FILES ${PROJECT_SOURCE_DIR}/config/tconfig.hpp
+  ${PROJECT_SOURCE_DIR}/config/config.hpp
+  ${PROJECT_SOURCE_DIR}/config/tconfig.hpp
   DESTINATION ${INSTALL_INCLUDE_DIR}/mfem/config)
 
 # Package the whole thing up nicely

--- a/config/cmake/config.hpp.in
+++ b/config/cmake/config.hpp.in
@@ -39,6 +39,9 @@
 // Description of the git commit used to build MFEM.
 #cmakedefine MFEM_GIT_STRING "@MFEM_GIT_STRING@"
 
+// Enable shared library build of MFEM.
+#cmakedefine MFEM_SHARED_BUILD
+
 // Build the parallel MFEM library.
 // Requires an MPI compiler, and the libraries HYPRE and METIS.
 #cmakedefine MFEM_USE_MPI

--- a/config/config.hpp
+++ b/config/config.hpp
@@ -30,11 +30,18 @@
 #endif
 
 // Windows specific options
-#ifdef _WIN32
-#ifndef _USE_MATH_DEFINES
+#if defined(_WIN32) && !defined(_USE_MATH_DEFINES)
 // Macro needed to get defines like M_PI from <cmath>. (Visual Studio C++ only?)
 #define _USE_MATH_DEFINES
 #endif
+#if defined(_WIN32) && defined(MFEM_SHARED_BUILD)
+#ifdef mfem_EXPORTS
+#define MFEM_EXPORT __declspec(dllexport)
+#else
+#define MFEM_EXPORT __declspec(dllimport)
+#endif
+#else
+#define MFEM_EXPORT
 #endif
 // On Cygwin the option -std=c++11 prevents the definition of M_PI. Defining
 // the following macro allows us to get M_PI and some needed functions, e.g.

--- a/config/config.hpp.in
+++ b/config/config.hpp.in
@@ -39,6 +39,9 @@
 // Description of the git commit used to build MFEM.
 // #define MFEM_GIT_STRING "@MFEM_GIT_STRING@"
 
+// Enable shared library build of MFEM.
+// #define MFEM_SHARED_BUILD
+
 // Build the parallel MFEM library.
 // Requires an MPI compiler, and the libraries HYPRE and METIS.
 // #define MFEM_USE_MPI

--- a/config/defaults.cmake
+++ b/config/defaults.cmake
@@ -19,6 +19,7 @@ if (NOT CMAKE_BUILD_TYPE)
 endif()
 
 # MFEM options. Set to mimic the default "defaults.mk" file.
+option(BUILD_SHARED_LIBS "Enable shared library build of MFEM" OFF)
 option(MFEM_USE_MPI "Enable MPI parallel build" OFF)
 option(MFEM_USE_METIS "Enable METIS usage" ${MFEM_USE_MPI})
 option(MFEM_USE_EXCEPTIONS "Enable the use of exceptions" OFF)

--- a/examples/ex25.cpp
+++ b/examples/ex25.cpp
@@ -469,7 +469,7 @@ int main(int argc, char *argv[])
 
       Operator *pc_r = nullptr;
       Operator *pc_i = nullptr;
-      int s = (conv == ComplexOperator::HERMITIAN) ? -1.0 : 1.0;
+      double s = (conv == ComplexOperator::HERMITIAN) ? -1.0 : 1.0;
       if (pa)
       {
          // Jacobi Smoother

--- a/examples/ex30.cpp
+++ b/examples/ex30.cpp
@@ -90,7 +90,7 @@ int main(int argc, char *argv[])
    const char *mesh_file = "../data/star.mesh";
    int order = 1;
    int nc_limit = 1;
-   int max_elems = 1e5;
+   int max_elems = 100*1000;
    double double_max_elems = double(max_elems);
    bool visualization = true;
    double osc_threshold = 1e-3;

--- a/examples/ex33.cpp
+++ b/examples/ex33.cpp
@@ -123,7 +123,7 @@ int main(int argc, char *argv[])
 
    // 2. Compute the rational expansion coefficients that define the
    //    integer-order PDEs.
-   const int power_of_laplace = floor(alpha);
+   const int power_of_laplace = (int)floor(alpha);
    double exponent_to_approximate = alpha - power_of_laplace;
    bool integer_order = false;
    // Check if alpha is an integer or not.

--- a/fem/ceed/interface/util.cpp
+++ b/fem/ceed/interface/util.cpp
@@ -19,11 +19,11 @@
 
 #include <sys/types.h>
 #include <sys/stat.h>
-#ifndef _WIN32
+#if !defined(_WIN32) || !defined(_MSC_VER)
 typedef struct stat struct_stat;
 #else
 #define stat(dir, buf) _stat(dir, buf)
-#define S_ISDIR(mode) _S_IFDIR(mode)
+#define S_ISDIR(mode) (((mode) & _S_IFMT) == _S_IFDIR)
 typedef struct _stat struct_stat;
 #endif
 

--- a/fem/fe/fe_base.hpp
+++ b/fem/fe/fe_base.hpp
@@ -1154,7 +1154,7 @@ public:
    ~Poly_1D();
 };
 
-extern Poly_1D poly1d;
+extern MFEM_EXPORT Poly_1D poly1d;
 
 /// An element defined as an ND tensor product of 1D elements on a segment,
 /// square, or cube

--- a/fem/geom.hpp
+++ b/fem/geom.hpp
@@ -29,7 +29,7 @@ namespace mfem
     Geometry::PRISM - w/ vert. (0,0,0),(1,0,0),(0,1,0),(0,0,1),(1,0,1),(0,1,1)
     Geometry::PYRAMID - w/ vert. (0,0,0),(1,0,0),(1,1,0),(0,1,0),(0,0,1)
 */
-class Geometry
+class MFEM_EXPORT Geometry
 {
 public:
    enum Type
@@ -126,7 +126,7 @@ public:
    int NumBdr(int GeomType) { return NumBdrArray[GeomType]; }
 };
 
-template <> struct Geometry::Constants<Geometry::POINT>
+template <> struct MFEM_EXPORT Geometry::Constants<Geometry::POINT>
 {
    static const int Dimension = 0;
    static const int NumVert = 1;
@@ -136,7 +136,7 @@ template <> struct Geometry::Constants<Geometry::POINT>
    static const int InvOrient[NumOrient];
 };
 
-template <> struct Geometry::Constants<Geometry::SEGMENT>
+template <> struct MFEM_EXPORT Geometry::Constants<Geometry::SEGMENT>
 {
    static const int Dimension = 1;
    static const int NumVert = 2;
@@ -148,7 +148,7 @@ template <> struct Geometry::Constants<Geometry::SEGMENT>
    static const int InvOrient[NumOrient];
 };
 
-template <> struct Geometry::Constants<Geometry::TRIANGLE>
+template <> struct MFEM_EXPORT Geometry::Constants<Geometry::TRIANGLE>
 {
    static const int Dimension = 2;
    static const int NumVert = 3;
@@ -174,7 +174,7 @@ template <> struct Geometry::Constants<Geometry::TRIANGLE>
    static const int InvOrient[NumOrient];
 };
 
-template <> struct Geometry::Constants<Geometry::SQUARE>
+template <> struct MFEM_EXPORT Geometry::Constants<Geometry::SQUARE>
 {
    static const int Dimension = 2;
    static const int NumVert = 4;
@@ -194,7 +194,7 @@ template <> struct Geometry::Constants<Geometry::SQUARE>
    static const int InvOrient[NumOrient];
 };
 
-template <> struct Geometry::Constants<Geometry::TETRAHEDRON>
+template <> struct MFEM_EXPORT Geometry::Constants<Geometry::TETRAHEDRON>
 {
    static const int Dimension = 3;
    static const int NumVert = 4;
@@ -216,7 +216,7 @@ template <> struct Geometry::Constants<Geometry::TETRAHEDRON>
    static const int InvOrient[NumOrient];
 };
 
-template <> struct Geometry::Constants<Geometry::CUBE>
+template <> struct MFEM_EXPORT Geometry::Constants<Geometry::CUBE>
 {
    static const int Dimension = 3;
    static const int NumVert = 8;
@@ -234,7 +234,7 @@ template <> struct Geometry::Constants<Geometry::CUBE>
    };
 };
 
-template <> struct Geometry::Constants<Geometry::PRISM>
+template <> struct MFEM_EXPORT Geometry::Constants<Geometry::PRISM>
 {
    static const int Dimension = 3;
    static const int NumVert = 6;
@@ -252,7 +252,7 @@ template <> struct Geometry::Constants<Geometry::PRISM>
    };
 };
 
-template <> struct Geometry::Constants<Geometry::PYRAMID>
+template <> struct MFEM_EXPORT Geometry::Constants<Geometry::PYRAMID>
 {
    static const int Dimension = 3;
    static const int NumVert = 5;
@@ -272,7 +272,7 @@ template <> struct Geometry::Constants<Geometry::PYRAMID>
 
 // Defined in fe.cpp to ensure construction after 'mfem::TriangleFE' and
 // `mfem::TetrahedronFE`.
-extern Geometry Geometries;
+extern MFEM_EXPORT Geometry Geometries;
 
 
 class RefinedGeometry
@@ -321,7 +321,7 @@ public:
    ~GeometryRefiner();
 };
 
-extern GeometryRefiner GlobGeometryRefiner;
+extern MFEM_EXPORT GeometryRefiner GlobGeometryRefiner;
 
 }
 

--- a/fem/intrules.hpp
+++ b/fem/intrules.hpp
@@ -376,10 +376,10 @@ public:
 };
 
 /// A global object with all integration rules (defined in intrules.cpp)
-extern IntegrationRules IntRules;
+extern MFEM_EXPORT IntegrationRules IntRules;
 
 /// A global object with all refined integration rules
-extern IntegrationRules RefinedIntRules;
+extern MFEM_EXPORT IntegrationRules RefinedIntRules;
 
 }
 

--- a/general/device.hpp
+++ b/general/device.hpp
@@ -125,7 +125,7 @@ private:
    enum MODES {SEQUENTIAL, ACCELERATED};
 
    static bool device_env, mem_host_env, mem_device_env, mem_types_set;
-   static Device device_singleton;
+   static MFEM_EXPORT Device device_singleton;
 
    MODES mode = Device::SEQUENTIAL;
    int dev = 0;   ///< Device ID of the configured device.

--- a/general/globals.hpp
+++ b/general/globals.hpp
@@ -63,12 +63,12 @@ public:
 /** @brief Global stream used by the library for standard output. Initially it
     uses the same std::streambuf as std::cout, however that can be changed.
     @sa OutStream. */
-extern OutStream out;
+extern MFEM_EXPORT OutStream out;
 /** @brief Global stream used by the library for standard error output.
     Initially it uses the same std::streambuf as std::cerr, however that can be
     changed.
     @sa OutStream. */
-extern OutStream err;
+extern MFEM_EXPORT OutStream err;
 
 
 /** @brief Construct a string of the form "<prefix><myid><suffix>" where the

--- a/general/isockstream.cpp
+++ b/general/isockstream.cpp
@@ -25,11 +25,11 @@
 #include <winsock.h>
 #ifdef _MSC_VER
 typedef int ssize_t;
+// Link with ws2_32.lib
+#pragma comment(lib, "ws2_32.lib")
 #endif
 typedef int socklen_t;
 #define close closesocket
-// Link with ws2_32.lib
-#pragma comment(lib, "ws2_32.lib")
 #endif
 
 using namespace std;

--- a/general/mem_manager.hpp
+++ b/general/mem_manager.hpp
@@ -64,7 +64,7 @@ constexpr int DeviceMemoryType = static_cast<int>(MemoryType::MANAGED);
 constexpr int DeviceMemoryTypeSize = MemoryTypeSize - DeviceMemoryType;
 
 /// Memory type names, used during Device:: configuration.
-extern const char *MemoryTypeName[MemoryTypeSize];
+extern MFEM_EXPORT const char *MemoryTypeName[MemoryTypeSize];
 
 /// Memory classes identify sets of memory types.
 /** This type is used by kernels that can work with multiple MemoryType%s.
@@ -580,7 +580,7 @@ private:
 /** The MFEM memory manager class. Host-side pointers are inserted into this
     manager which keeps track of the associated device pointer, and where the
     data currently resides. */
-class MemoryManager
+class MFEM_EXPORT MemoryManager
 {
 private:
 
@@ -1273,7 +1273,7 @@ inline int Memory<T>::CompareHostAndDevice(int size) const
 
 
 /// The (single) global memory manager object
-extern MemoryManager mm;
+extern MFEM_EXPORT MemoryManager mm;
 
 } // namespace mfem
 

--- a/general/socketstream.cpp
+++ b/general/socketstream.cpp
@@ -30,9 +30,9 @@
 #include <winsock.h>
 #ifdef _MSC_VER
 typedef int ssize_t;
-#endif
 // Link with ws2_32.lib
 #pragma comment(lib, "ws2_32.lib")
+#endif
 #endif
 
 #ifdef MFEM_USE_GNUTLS

--- a/general/tic_toc.hpp
+++ b/general/tic_toc.hpp
@@ -66,7 +66,7 @@ public:
 };
 
 
-extern StopWatch tic_toc;
+extern MFEM_EXPORT StopWatch tic_toc;
 
 /// Start the tic_toc timer
 extern void tic();

--- a/general/tinyxml2.cpp
+++ b/general/tinyxml2.cpp
@@ -21,6 +21,8 @@ must not be misrepresented as being the original software.
 distribution.
 */
 
+// This file was modified by the MFEM team.
+
 #include "tinyxml2.h"
 
 #include <new>		// yes, this one new style header, is in the Android SDK.
@@ -106,7 +108,7 @@ distribution.
 #elif defined(__APPLE__) || (__FreeBSD__)
 	#define TIXML_FSEEK fseeko
 	#define TIXML_FTELL ftello
-#elif defined(__unix__) && defined(__x86_64__)
+#elif defined(__unix__) && defined(__x86_64__) && !defined(__CYGWIN__)
 	#define TIXML_FSEEK fseeko64
 	#define TIXML_FTELL ftello64
 #else

--- a/linalg/ode.hpp
+++ b/linalg/ode.hpp
@@ -204,7 +204,7 @@ public:
 class RK6Solver : public ExplicitRKSolver
 {
 private:
-   static const double a[28], b[8], c[7];
+   static MFEM_EXPORT const double a[28], b[8], c[7];
 
 public:
    RK6Solver() : ExplicitRKSolver(8, a, b, c) { }
@@ -258,7 +258,7 @@ public:
 class AB1Solver : public AdamsBashforthSolver
 {
 private:
-   static const double a[1];
+   static MFEM_EXPORT const double a[1];
 
 public:
    AB1Solver() : AdamsBashforthSolver(1, a) { }
@@ -268,7 +268,7 @@ public:
 class AB2Solver : public AdamsBashforthSolver
 {
 private:
-   static const double a[2];
+   static MFEM_EXPORT const double a[2];
 
 public:
    AB2Solver() : AdamsBashforthSolver(2, a) { }
@@ -278,7 +278,7 @@ public:
 class AB3Solver : public AdamsBashforthSolver
 {
 private:
-   static const double a[3];
+   static MFEM_EXPORT const double a[3];
 
 public:
    AB3Solver() : AdamsBashforthSolver(3, a) { }
@@ -288,7 +288,7 @@ public:
 class AB4Solver : public AdamsBashforthSolver
 {
 private:
-   static const double a[4];
+   static MFEM_EXPORT const double a[4];
 
 public:
    AB4Solver() : AdamsBashforthSolver(4, a) { }
@@ -298,7 +298,7 @@ public:
 class AB5Solver : public AdamsBashforthSolver
 {
 private:
-   static const double a[5];
+   static MFEM_EXPORT const double a[5];
 
 public:
    AB5Solver() : AdamsBashforthSolver(5, a) { }
@@ -339,7 +339,7 @@ public:
 class AM0Solver : public AdamsMoultonSolver
 {
 private:
-   static const double a[1];
+   static MFEM_EXPORT const double a[1];
 
 public:
    AM0Solver() : AdamsMoultonSolver(0, a) { }
@@ -350,7 +350,7 @@ public:
 class AM1Solver : public AdamsMoultonSolver
 {
 private:
-   static const double a[2];
+   static MFEM_EXPORT const double a[2];
 
 public:
    AM1Solver() : AdamsMoultonSolver(1, a) { }
@@ -360,7 +360,7 @@ public:
 class AM2Solver : public AdamsMoultonSolver
 {
 private:
-   static const double a[3];
+   static MFEM_EXPORT const double a[3];
 
 public:
    AM2Solver() : AdamsMoultonSolver(2, a) { }
@@ -370,7 +370,7 @@ public:
 class AM3Solver : public AdamsMoultonSolver
 {
 private:
-   static const double a[4];
+   static MFEM_EXPORT const double a[4];
 
 public:
    AM3Solver() : AdamsMoultonSolver(3, a) { }
@@ -380,7 +380,7 @@ public:
 class AM4Solver : public AdamsMoultonSolver
 {
 private:
-   static const double a[5];
+   static MFEM_EXPORT const double a[5];
 
 public:
    AM4Solver() : AdamsMoultonSolver(4, a) { }

--- a/makefile
+++ b/makefile
@@ -198,6 +198,7 @@ ALL_LIBS =
 # Building static and/or shared libraries:
 MFEM_STATIC ?= $(STATIC)
 MFEM_SHARED ?= $(SHARED)
+MFEM_SHARED_BUILD = $(MFEM_SHARED)
 
 # Internal shortcuts
 override static = $(if $(MFEM_STATIC:YES=),,YES)
@@ -346,7 +347,7 @@ MFEM_DEFINES = MFEM_VERSION MFEM_VERSION_STRING MFEM_GIT_STRING MFEM_USE_MPI\
  MFEM_USE_SIMD MFEM_USE_ADIOS2 MFEM_USE_MKL_CPARDISO MFEM_USE_AMGX\
  MFEM_USE_MUMPS MFEM_USE_ADFORWARD MFEM_USE_CODIPACK MFEM_USE_CALIPER\
  MFEM_USE_BENCHMARK MFEM_USE_PARELAG MFEM_USE_ALGOIM MFEM_USE_ENZYME\
- MFEM_SOURCE_DIR MFEM_INSTALL_DIR
+ MFEM_SOURCE_DIR MFEM_INSTALL_DIR MFEM_SHARED_BUILD
 
 # List of makefile variables that will be written to config.mk:
 MFEM_CONFIG_VARS = MFEM_CXX MFEM_HOST_CXX MFEM_CPPFLAGS MFEM_CXXFLAGS\
@@ -589,7 +590,8 @@ install: $(if $(static),$(BLD)libmfem.a) $(if $(shared),$(BLD)libmfem.$(SO_EXT))
 	      > $(PREFIX_INC)/$$hdr && chmod 640 $(PREFIX_INC)/$$hdr; done
 # install config include
 	mkdir -p $(PREFIX_INC)/mfem/config
-	$(INSTALL) -m 640 $(BLD)config/_config.hpp $(PREFIX_INC)/mfem/config/config.hpp
+	$(INSTALL) -m 640 $(BLD)config/_config.hpp $(PREFIX_INC)/mfem/config/_config.hpp
+	$(INSTALL) -m 640 $(SRC)config/config.hpp $(PREFIX_INC)/mfem/config/config.hpp
 	$(INSTALL) -m 640 $(SRC)config/tconfig.hpp $(PREFIX_INC)/mfem/config
 # install remaining includes in each subdirectory
 	for dir in $(DIRS); do \

--- a/mesh/hexahedron.hpp
+++ b/mesh/hexahedron.hpp
@@ -68,7 +68,7 @@ public:
    virtual ~Hexahedron() { }
 };
 
-extern class TriLinear3DFiniteElement HexahedronFE;
+extern MFEM_EXPORT class TriLinear3DFiniteElement HexahedronFE;
 
 }
 

--- a/mesh/point.hpp
+++ b/mesh/point.hpp
@@ -63,7 +63,7 @@ public:
 };
 
 class PointFiniteElement;
-extern PointFiniteElement PointFE;
+extern MFEM_EXPORT PointFiniteElement PointFE;
 
 }
 

--- a/mesh/quadrilateral.hpp
+++ b/mesh/quadrilateral.hpp
@@ -69,7 +69,7 @@ public:
    virtual ~Quadrilateral() { }
 };
 
-extern class BiLinear2DFiniteElement QuadrilateralFE;
+extern MFEM_EXPORT class BiLinear2DFiniteElement QuadrilateralFE;
 
 }
 

--- a/mesh/segment.hpp
+++ b/mesh/segment.hpp
@@ -69,7 +69,7 @@ public:
 };
 
 class Linear1DFiniteElement;
-extern Linear1DFiniteElement SegmentFE;
+extern MFEM_EXPORT Linear1DFiniteElement SegmentFE;
 
 }
 

--- a/mesh/tetrahedron.hpp
+++ b/mesh/tetrahedron.hpp
@@ -117,7 +117,7 @@ public:
 };
 
 // Defined in fe.cpp to ensure construction before 'mfem::Geometries'.
-extern class Linear3DFiniteElement TetrahedronFE;
+extern MFEM_EXPORT class Linear3DFiniteElement TetrahedronFE;
 
 }
 

--- a/mesh/triangle.hpp
+++ b/mesh/triangle.hpp
@@ -98,7 +98,7 @@ public:
 };
 
 // Defined in fe.cpp to ensure construction before 'mfem::Geometries'.
-extern Linear2DFiniteElement TriangleFE;
+extern MFEM_EXPORT Linear2DFiniteElement TriangleFE;
 
 }
 

--- a/mesh/wedge.hpp
+++ b/mesh/wedge.hpp
@@ -71,7 +71,7 @@ public:
    virtual ~Wedge() { }
 };
 
-extern class LinearWedgeFiniteElement WedgeFE;
+extern MFEM_EXPORT class LinearWedgeFiniteElement WedgeFE;
 
 }
 


### PR DESCRIPTION
This branch is largely based on PR #1401.

It removes the use of the `mfem_export.h` header, adds a few tweaks to CMake, fixes a few MSVC warnings, and fixes some issues with Cygwin and MinGW builds.
