### PR TITLE
Mesh and DataCollection upgrades

### DIFF
--- a/fem/datacollection.cpp
+++ b/fem/datacollection.cpp
@@ -210,6 +210,11 @@ void DataCollection::Save()
    {
       SaveOneQField(it);
    }
+
+   MFEM_VERIFY(coeff_field_map.begin() == coeff_field_map.end() &&
+               vcoeff_field_map.begin() == vcoeff_field_map.end(),
+               "Coefficient/VectorCoefficient output is not supported for "
+               "DataCollection class!");
 }
 
 void DataCollection::SaveMesh()
@@ -309,9 +314,9 @@ void DataCollection::SaveField(const std::string &field_name)
    }
 }
 
-void DataCollection::SaveQField(const std::string &q_field_name)
+void DataCollection::SaveQField(const std::string &field_name)
 {
-   QFieldMapIterator it = q_field_map.find(q_field_name);
+   QFieldMapIterator it = q_field_map.find(field_name);
    if (it != q_field_map.end())
    {
       SaveOneQField(it);
@@ -765,7 +770,9 @@ ParaViewDataCollection::ParaViewDataCollection(const std::string&
      levels_of_detail(1),
      pv_data_format(VTKFormat::BINARY),
      high_order_output(false),
-     restart_mode(false)
+     restart_mode(false),
+     bdr(false),
+     lscale(1.0)
 {
    cycle = 0; // always include a valid cycle index in file names
 
@@ -910,16 +917,19 @@ void ParaViewDataCollection::Save()
    std::string vtu_prefix = col_path + "/" + GenerateVTUPath() + "/";
 
    // Save the local part of the mesh and grid functions fields to the local
-   // VTU file
+   // VTU file. Also save coefficient fields.
    {
       std::ofstream os(vtu_prefix + GenerateVTUFileName("proc", myid));
       os.precision(precision);
       SaveDataVTU(os, levels_of_detail);
    }
 
-   // Save the local part of the quadrature function fields
+   // Save the local part of the quadrature function fields.
    for (const auto &qfield : q_field_map)
    {
+      MFEM_VERIFY(!bdr,
+                  "QuadratureFunction output is not supported for "
+                  "ParaViewDataCollection on domain boundary!");
       const std::string &field_name = qfield.first;
       std::ofstream os(vtu_prefix + GenerateVTUFileName(field_name, myid));
       qfield.second->SaveVTU(os, pv_data_format, GetCompressionLevel());
@@ -935,7 +945,7 @@ void ParaViewDataCollection::Save()
          std::ofstream pvtu_out(vtu_prefix + GeneratePVTUFileName("data"));
          WritePVTUHeader(pvtu_out);
 
-         // Grid function fields
+         // Grid function fields and coefficient fields
          pvtu_out << "<PPointData>\n";
          for (auto &field_it : field_map)
          {
@@ -945,7 +955,24 @@ void ParaViewDataCollection::Save()
                      << "\" NumberOfComponents=\"" << vec_dim << "\" "
                      << "format=\"" << GetDataFormatString() << "\" />\n";
          }
+         for (auto &field_it : coeff_field_map)
+         {
+            int vec_dim = 1;
+            pvtu_out << "<PDataArray type=\"" << GetDataTypeString()
+                     << "\" Name=\"" << field_it.first
+                     << "\" NumberOfComponents=\"" << vec_dim << "\" "
+                     << "format=\"" << GetDataFormatString() << "\" />\n";
+         }
+         for (auto &field_it : vcoeff_field_map)
+         {
+            int vec_dim = field_it.second->GetVDim();
+            pvtu_out << "<PDataArray type=\"" << GetDataTypeString()
+                     << "\" Name=\"" << field_it.first
+                     << "\" NumberOfComponents=\"" << vec_dim << "\" "
+                     << "format=\"" << GetDataFormatString() << "\" />\n";
+         }
          pvtu_out << "</PPointData>\n";
+
          // Element attributes
          pvtu_out << "<PCellData>\n";
          pvtu_out << "\t<PDataArray type=\"Int32\" Name=\"" << "attribute"
@@ -1042,7 +1069,7 @@ void ParaViewDataCollection::SaveDataVTU(std::ostream &os, int ref)
    }
    os << " version=\"0.1\" byte_order=\"" << VTKByteOrder() << "\">\n";
    os << "<UnstructuredGrid>\n";
-   mesh->PrintVTU(os,ref,pv_data_format,high_order_output,GetCompressionLevel());
+   mesh->PrintVTU(os,ref,pv_data_format,high_order_output,GetCompressionLevel(),bdr,lscale);
 
    // dump out the grid functions as point data
    os << "<PointData >\n";
@@ -1050,7 +1077,22 @@ void ParaViewDataCollection::SaveDataVTU(std::ostream &os, int ref)
    // iterate over all grid functions
    for (FieldMapIterator it=field_map.begin(); it!=field_map.end(); ++it)
    {
+      MFEM_VERIFY(!bdr,
+                  "GridFunction output is not supported for "
+                  "ParaViewDataCollection on domain boundary!");
       SaveGFieldVTU(os,ref,it);
+   }
+   // save the coefficient functions
+   // iterate over all Coefficient and VectorCoefficient functions
+   for (CoeffFieldMapIterator it=coeff_field_map.begin();
+        it!=coeff_field_map.end(); ++it)
+   {
+      SaveCoeffFieldVTU(os,ref,it);
+   }
+   for (VCoeffFieldMapIterator it=vcoeff_field_map.begin();
+        it!=vcoeff_field_map.end(); ++it)
+   {
+      SaveVCoeffFieldVTU(os,ref,it);
    }
    os << "</PointData>\n";
    // close the mesh
@@ -1073,7 +1115,6 @@ void ParaViewDataCollection::SaveGFieldVTU(std::ostream &os, int ref_,
       << " format=\"" << GetDataFormatString() << "\" >" << '\n';
    if (vec_dim == 1)
    {
-      // scalar data
       for (int i = 0; i < mesh->GetNE(); i++)
       {
          RefG = GlobGeometryRefiner.Refine(
@@ -1103,11 +1144,131 @@ void ParaViewDataCollection::SaveGFieldVTU(std::ostream &os, int ref_,
          }
       }
    }
-
-   if (IsBinaryFormat())
+   if (pv_data_format != VTKFormat::ASCII)
    {
-      WriteVTKEncodedCompressed(os,buf.data(),buf.size(),GetCompressionLevel());
-      os << '\n';
+      WriteBase64WithSizeAndClear(os, buf, GetCompressionLevel());
+   }
+   os << "</DataArray>" << std::endl;
+}
+
+void ParaViewDataCollection::SaveCoeffFieldVTU(std::ostream &os, int ref_,
+                                               const CoeffFieldMapIterator &it)
+{
+   RefinedGeometry *RefG;
+   double val;
+   std::vector<char> buf;
+   int vec_dim = 1;
+   os << "<DataArray type=\"" << GetDataTypeString()
+      << "\" Name=\"" << it->first
+      << "\" NumberOfComponents=\"" << vec_dim << "\""
+      << " format=\"" << GetDataFormatString() << "\" >" << '\n';
+   {
+      // scalar data
+      if (!bdr)
+      {
+         for (int i = 0; i < mesh->GetNE(); i++)
+         {
+            RefG = GlobGeometryRefiner.Refine(
+                      mesh->GetElementBaseGeometry(i), ref_, 1);
+
+            ElementTransformation *eltrans = mesh->GetElementTransformation(i);
+            const IntegrationRule *ir = &RefG->RefPts;
+            for (int j = 0; j < ir->GetNPoints(); j++)
+            {
+               const IntegrationPoint &ip = ir->IntPoint(j);
+               eltrans->SetIntPoint(&ip);
+               val = it->second->Eval(*eltrans, ip);
+               WriteBinaryOrASCII(os, buf, val, "\n", pv_data_format);
+            }
+         }
+      }
+      else
+      {
+         for (int i = 0; i < mesh->GetNBE(); i++)
+         {
+            RefG = GlobGeometryRefiner.Refine(
+                      mesh->GetBdrElementBaseGeometry(i), ref_, 1);
+
+            ElementTransformation *eltrans = mesh->GetBdrElementTransformation(i);
+            const IntegrationRule *ir = &RefG->RefPts;
+            for (int j = 0; j < ir->GetNPoints(); j++)
+            {
+               const IntegrationPoint &ip = ir->IntPoint(j);
+               eltrans->SetIntPoint(&ip);
+               val = it->second->Eval(*eltrans, ip);
+               WriteBinaryOrASCII(os, buf, val, "\n", pv_data_format);
+            }
+         }
+      }
+   }
+   if (pv_data_format != VTKFormat::ASCII)
+   {
+      WriteBase64WithSizeAndClear(os, buf, compression);
+   }
+   os << "</DataArray>" << std::endl;
+}
+
+void ParaViewDataCollection::SaveVCoeffFieldVTU(std::ostream &os, int ref_,
+                                                const VCoeffFieldMapIterator &it)
+{
+   RefinedGeometry *RefG;
+   Vector val;
+   std::vector<char> buf;
+   int vec_dim = it->second->GetVDim();
+   os << "<DataArray type=\"" << GetDataTypeString()
+      << "\" Name=\"" << it->first
+      << "\" NumberOfComponents=\"" << vec_dim << "\""
+      << " format=\"" << GetDataFormatString() << "\" >" << '\n';
+   {
+      // vector data
+      if (!bdr)
+      {
+         for (int i = 0; i < mesh->GetNE(); i++)
+         {
+            RefG = GlobGeometryRefiner.Refine(
+                      mesh->GetElementBaseGeometry(i), ref_, 1);
+
+            ElementTransformation *eltrans = mesh->GetElementTransformation(i);
+            const IntegrationRule *ir = &RefG->RefPts;
+            for (int j = 0; j < ir->GetNPoints(); j++)
+            {
+               const IntegrationPoint &ip = ir->IntPoint(j);
+               eltrans->SetIntPoint(&ip);
+               it->second->Eval(val, *eltrans, ip);
+               for (int jj = 0; jj < val.Size(); jj++)
+               {
+                  WriteBinaryOrASCII(os, buf, val(jj), " ", pv_data_format);
+               }
+               if (pv_data_format == VTKFormat::ASCII) { os << '\n'; }
+            }
+         }
+      }
+      else
+      {
+         for (int i = 0; i < mesh->GetNBE(); i++)
+         {
+            RefG = GlobGeometryRefiner.Refine(
+                      mesh->GetBdrElementBaseGeometry(i), ref_, 1);
+
+            ElementTransformation *eltrans = mesh->GetBdrElementTransformation(i);
+            const IntegrationRule *ir = &RefG->RefPts;
+            for (int j = 0; j < ir->GetNPoints(); j++)
+            {
+               const IntegrationPoint &ip = ir->IntPoint(j);
+               eltrans->SetIntPoint(&ip);
+               it->second->Eval(val, *eltrans, ip);
+               for (int jj = 0; jj < val.Size(); jj++)
+               {
+                  WriteBinaryOrASCII(os, buf, val(jj), " ", pv_data_format);
+               }
+               if (pv_data_format == VTKFormat::ASCII) { os << '\n'; }
+            }
+         }
+      }
+   }
+   if (pv_data_format != VTKFormat::ASCII)
+   {
+      WriteBase64WithSizeAndClear(os, buf, GetCompressionLevel());
    }
    os << "</DataArray>" << std::endl;
 }
@@ -1138,6 +1299,16 @@ void ParaViewDataCollection::SetCompressionLevel(int compression_level_)
 void ParaViewDataCollection::SetCompression(bool compression_)
 {
    compression = compression_;
+}
+
+void ParaViewDataCollection::SetBoundaryOutput(bool bdr_)
+{
+   bdr = bdr_;
+}
+
+void ParaViewDataCollection::SetLengthScale(double lscale_)
+{
+   lscale = lscale_;
 }
 
 void ParaViewDataCollection::UseRestartMode(bool restart_mode_)

--- a/fem/datacollection.hpp
+++ b/fem/datacollection.hpp
@@ -133,6 +133,10 @@ private:
 
    /// A collection of named QuadratureFunctions
    typedef NamedFieldsMap<QuadratureFunction> QFieldMap;
+
+   /// A collection of named Coefficients and VectorCoefficients
+   typedef NamedFieldsMap<Coefficient> CoeffFieldMap;
+   typedef NamedFieldsMap<VectorCoefficient> VCoeffFieldMap;
 public:
    typedef GFieldMap::MapType FieldMapType;
    typedef GFieldMap::iterator FieldMapIterator;
@@ -141,6 +145,14 @@ public:
    typedef QFieldMap::MapType QFieldMapType;
    typedef QFieldMap::iterator QFieldMapIterator;
    typedef QFieldMap::const_iterator QFieldMapConstIterator;
+
+   typedef CoeffFieldMap::MapType CoeffFieldMapType;
+   typedef CoeffFieldMap::iterator CoeffFieldMapIterator;
+   typedef CoeffFieldMap::const_iterator CoeffFieldMapConstIterator;
+
+   typedef VCoeffFieldMap::MapType VCoeffFieldMapType;
+   typedef VCoeffFieldMap::iterator VCoeffFieldMapIterator;
+   typedef VCoeffFieldMap::const_iterator VCoeffFieldMapConstIterator;
 
    /// Format constants to be used with SetFormat().
    /** Derived classes can define their own format enumerations and override the
@@ -168,6 +180,11 @@ protected:
 
    /** A FieldMap mapping registered names to QuadratureFunction pointers. */
    QFieldMap q_field_map;
+
+   /** A FieldMap mapping registered names to Coefficient and VectorCoefficient
+       pointers. */
+   CoeffFieldMap coeff_field_map;
+   VCoeffFieldMap vcoeff_field_map;
 
    /// The (common) mesh for the collected fields
    Mesh *mesh;
@@ -249,14 +266,27 @@ public:
    { field_map.Deregister(field_name, own_data); }
 
    /// Add a QuadratureFunction to the collection.
-   virtual void RegisterQField(const std::string& q_field_name,
+   virtual void RegisterQField(const std::string& field_name,
                                QuadratureFunction *qf)
-   { q_field_map.Register(q_field_name, qf, own_data); }
-
+   { q_field_map.Register(field_name, qf, own_data); }
 
    /// Remove a QuadratureFunction from the collection
    virtual void DeregisterQField(const std::string& field_name)
    { q_field_map.Deregister(field_name, own_data); }
+
+   /// Add a Coefficient or VectorCoefficient to the collection.
+   virtual void RegisterCoeffField(const std::string& field_name,
+                                   Coefficient *coeff)
+   { coeff_field_map.Register(field_name, coeff, own_data); }
+   virtual void RegisterVCoeffField(const std::string& field_name,
+                                    VectorCoefficient *vcoeff)
+   { vcoeff_field_map.Register(field_name, vcoeff, own_data); }
+
+   /// Remove a Coefficient or VectorCoefficient from the collection
+   virtual void DeregisterCoeffField(const std::string& field_name)
+   { coeff_field_map.Deregister(field_name, own_data); }
+   virtual void DeregisterVCoeffField(const std::string& field_name)
+   { vcoeff_field_map.Deregister(field_name, own_data); }
 
    /// Check if a grid function is part of the collection
    bool HasField(const std::string& field_name) const
@@ -280,13 +310,27 @@ public:
 #endif
 
    /// Check if a QuadratureFunction with the given name is in the collection.
-   bool HasQField(const std::string& q_field_name) const
-   { return q_field_map.Has(q_field_name); }
+   bool HasQField(const std::string& field_name) const
+   { return q_field_map.Has(field_name); }
 
    /// Get a pointer to a QuadratureFunction in the collection.
    /** Returns NULL if @a field_name is not in the collection. */
-   QuadratureFunction *GetQField(const std::string& q_field_name)
-   { return q_field_map.Get(q_field_name); }
+   QuadratureFunction *GetQField(const std::string& field_name)
+   { return q_field_map.Get(field_name); }
+
+   /** Check if a Coefficient or VectorCoefficient with the given name is in
+       the collection. */
+   bool HasCoeffField(const std::string& field_name) const
+   { return coeff_field_map.Has(field_name); }
+   bool HasVCoeffField(const std::string& field_name) const
+   { return vcoeff_field_map.Has(field_name); }
+
+   /// Get a pointer to a Coefficient or VectorCoefficient in the collection.
+   /** Returns NULL if @a field_name is not in the collection. */
+   Coefficient *GetCoeffField(const std::string& field_name)
+   { return coeff_field_map.Get(field_name); }
+   VectorCoefficient *GetVCoeffField(const std::string& field_name)
+   { return vcoeff_field_map.Get(field_name); }
 
    /// Get a const reference to the internal field map.
    /** The keys in the map are the field names and the values are pointers to
@@ -300,13 +344,23 @@ public:
    const QFieldMapType &GetQFieldMap() const
    { return q_field_map.GetMap(); }
 
+   /// Get a const reference to the internal coefficient-field map.
+   /** The keys in the map are the coefficient-field names and the values are
+       pointers to Coefficient%s or VectorCoefficient%s. */
+   const CoeffFieldMapType &GetCoeffFieldMap() const
+   { return coeff_field_map.GetMap(); }
+   const VCoeffFieldMapType &GetVCoeffFieldMap() const
+   { return vcoeff_field_map.GetMap(); }
+
    /// Get a pointer to the mesh in the collection
    Mesh *GetMesh() { return mesh; }
+
    /// Set/change the mesh associated with the collection
    /** When passed a Mesh, assumes the serial case: MPI rank id is set to 0 and
        MPI num_procs is set to 1.  When passed a ParMesh, MPI info from the
        ParMesh is used to set the DataCollection's MPI rank and num_procs. */
    virtual void SetMesh(Mesh *new_mesh);
+
 #ifdef MFEM_USE_MPI
    /// Set/change the mesh associated with the collection.
    /** For this case, @a comm is used to set the DataCollection's MPI rank id
@@ -369,7 +423,19 @@ public:
    /// Save one field, assuming the collection directory already exists.
    virtual void SaveField(const std::string &field_name);
    /// Save one q-field, assuming the collection directory already exists.
-   virtual void SaveQField(const std::string &q_field_name);
+   virtual void SaveQField(const std::string &field_name);
+   /** Save one coefficient-field, assuming the collection directory already
+       exists. */
+   virtual void SaveCoeffField(const std::string &field_name)
+   {
+      MFEM_ABORT("SaveCoeffField not implemented for DataCollection class!");
+   }
+   /** Save one coefficient-field, assuming the collection directory already
+       exists. */
+   virtual void SaveVCoeffField(const std::string &field_name)
+   {
+      MFEM_ABORT("SaveVCoeffField not implemented for DataCollection class!");
+   }
 
    /// Load the collection. Not implemented in the base class DataCollection.
    virtual void Load(int cycle_ = 0);
@@ -500,12 +566,18 @@ private:
    VTKFormat pv_data_format;
    bool high_order_output;
    bool restart_mode;
+   bool bdr;
+   double lscale;
 
 protected:
    void WritePVTUHeader(std::ostream &out);
    void WritePVTUFooter(std::ostream &out, const std::string &vtu_prefix);
    void SaveDataVTU(std::ostream &out, int ref);
    void SaveGFieldVTU(std::ostream& out, int ref_, const FieldMapIterator& it);
+   void SaveCoeffFieldVTU(std::ostream& out, int ref_,
+                          const CoeffFieldMapIterator& it);
+   void SaveVCoeffFieldVTU(std::ostream& out, int ref_,
+                           const VCoeffFieldMapIterator& it);
    const char *GetDataFormatString() const;
    const char *GetDataTypeString() const;
    /// @brief If compression is enabled, return the compression level, otherwise
@@ -518,7 +590,6 @@ protected:
    std::string GeneratePVDFileName();
    std::string GeneratePVTUFileName(const std::string &prefix);
    std::string GeneratePVTUPath();
-
 
 public:
    /// Constructor. The collection name is used when saving the data.
@@ -569,6 +640,14 @@ public:
    /// Sets whether or not to output the data as high-order elements (false
    /// by default). Reading high-order data requires ParaView 5.5 or later.
    void SetHighOrderOutput(bool high_order_output_);
+
+   /// Configures collection to save only fields evaluated on boundaries of
+   /// the mesh.
+   void SetBoundaryOutput(bool bdr_);
+
+   /// Sets length scale used to scale mesh point coordinates on output.
+   /// The default if unset is 1.0 (unscaled).
+   void SetLengthScale(double lscale_);
 
    /// Enable or disable restart mode. If restart is enabled, new writes will
    /// preserve timestep metadata for any solutions prior to the currently

--- a/mesh/mesh.cpp
+++ b/mesh/mesh.cpp
@@ -10513,7 +10513,8 @@ void Mesh::PrintVTU(std::string fname,
                     VTKFormat format,
                     bool high_order_output,
                     int compression_level,
-                    bool bdr)
+                    bool bdr,
+                    double sf)
 {
    int ref = (high_order_output && Nodes)
              ? Nodes->FESpace()->GetMaxElementOrder() : 1;
@@ -10527,7 +10528,7 @@ void Mesh::PrintVTU(std::string fname,
    }
    os << " byte_order=\"" << VTKByteOrder() << "\">\n";
    os << "<UnstructuredGrid>\n";
-   PrintVTU(os, ref, format, high_order_output, compression_level, bdr);
+   PrintVTU(os, ref, format, high_order_output, compression_level, bdr, sf);
    os << "</Piece>\n"; // need to close the piece open in the PrintVTU method
    os << "</UnstructuredGrid>\n";
    os << "</VTKFile>" << std::endl;
@@ -10538,14 +10539,15 @@ void Mesh::PrintVTU(std::string fname,
 void Mesh::PrintBdrVTU(std::string fname,
                        VTKFormat format,
                        bool high_order_output,
-                       int compression_level)
+                       int compression_level,
+                       double sf)
 {
-   PrintVTU(fname, format, high_order_output, compression_level, true);
+   PrintVTU(fname, format, high_order_output, compression_level, true, sf);
 }
 
 void Mesh::PrintVTU(std::ostream &os, int ref, VTKFormat format,
                     bool high_order_output, int compression_level,
-                    bool bdr_elements)
+                    bool bdr_elements, double sf)
 {
    RefinedGeometry *RefG;
    DenseMatrix pmat;
@@ -10590,6 +10592,11 @@ void Mesh::PrintVTU(std::ostream &os, int ref, VTKFormat format,
       else
       {
          GetElementTransformation(i)->Transform(RefG->RefPts, pmat);
+      }
+
+      if (sf != 1.0)
+      {
+         pmat *= sf;
       }
 
       for (int j = 0; j < pmat.Width(); j++)

--- a/mesh/mesh.hpp
+++ b/mesh/mesh.hpp
@@ -1768,25 +1768,29 @@ public:
    /** Print the mesh in VTU format. The parameter ref > 0 specifies an element
        subdivision number (useful for high order fields and curved meshes).
        If @a bdr_elements is true, then output (only) the boundary elements,
-       otherwise output only the non-boundary elements. */
+       otherwise output only the non-boundary elements. The parameter @a sf sets
+       a scale factor for the output mesh point coordinates. */
    void PrintVTU(std::ostream &os,
                  int ref=1,
                  VTKFormat format=VTKFormat::ASCII,
                  bool high_order_output=false,
                  int compression_level=0,
-                 bool bdr_elements=false);
+                 bool bdr_elements=false,
+                 double sf=1.0);
    /** Print the mesh in VTU format with file name fname. */
    virtual void PrintVTU(std::string fname,
                          VTKFormat format=VTKFormat::ASCII,
                          bool high_order_output=false,
                          int compression_level=0,
-                         bool bdr=false);
+                         bool bdr=false,
+                         double sf=1.0);
    /** Print the boundary elements of the mesh in VTU format, and output the
        boundary attributes as a data array (useful for boundary conditions). */
    void PrintBdrVTU(std::string fname,
                     VTKFormat format=VTKFormat::ASCII,
                     bool high_order_output=false,
-                    int compression_level=0);
+                    int compression_level=0,
+                    double sf=1.0);
 
    void GetElementColoring(Array<int> &colors, int el0 = 0);
 

--- a/mesh/pmesh.cpp
+++ b/mesh/pmesh.cpp
@@ -6393,7 +6393,8 @@ void ParMesh::PrintVTU(std::string pathname,
                        VTKFormat format,
                        bool high_order_output,
                        int compression_level,
-                       bool bdr)
+                       bool bdr,
+                       double sf)
 {
    int pad_digits_rank = 6;
    DataCollection::create_directory(pathname, this, MyRank);
@@ -6453,7 +6454,7 @@ void ParMesh::PrintVTU(std::string pathname,
 
    std::string vtu_fname = pathname + "/" + fname + ".proc"
                            + to_padded_string(MyRank, pad_digits_rank);
-   Mesh::PrintVTU(vtu_fname, format, high_order_output, compression_level, bdr);
+   Mesh::PrintVTU(vtu_fname, format, high_order_output, compression_level, bdr, sf);
 }
 
 int ParMesh::FindPoints(DenseMatrix& point_mat, Array<int>& elem_id,

--- a/mesh/pmesh.hpp
+++ b/mesh/pmesh.hpp
@@ -630,7 +630,8 @@ public:
                  VTKFormat format=VTKFormat::ASCII,
                  bool high_order_output=false,
                  int compression_level=0,
-                 bool bdr=false) override;
+                 bool bdr=false,
+                 double sf=1.0) override;
 
    /// Parallel version of Mesh::Load().
    void Load(std::istream &input, int generate_edges = 0,


### PR DESCRIPTION
- Adds `DataCollection` option to visualize a `Coefficient` or `VectorCoefficient` to disk.
- Adds capability for a `ParaViewDataCollection` to be constructed for all the mesh boundaries rather than the domain.
- Adds option for printing a `Mesh` or `ParMesh` with a scale factor applied to the node coordinates.