### PR TITLE
Draft: Add support for RelWithDebInfo builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -178,7 +178,7 @@ endif()
 #-------------------------------------------------------------------------------
 
 # MFEM_DEBUG
-if (CMAKE_BUILD_TYPE MATCHES "Debug|debug|DEBUG")
+if (CMAKE_BUILD_TYPE MATCHES "Debug|debug|DEBUG|RelWithDebInfo|relwithdebinfo|RELWITHDEBINFO")
   set(MFEM_DEBUG ON)
 else()
   set(MFEM_DEBUG OFF)


### PR DESCRIPTION
This PR adds CMake support for the `RelWithDebInfo` build type, the alternative to `Debug` and `Release`.