### PR TITLE
[WIP] Move assignment bugfix [move-assignment-fix]

### DIFF
--- a/linalg/vector.cpp
+++ b/linalg/vector.cpp
@@ -51,7 +51,8 @@ Vector::Vector(const Vector &v)
 
 Vector::Vector(Vector&& v) { Move(std::move(v)); }
 
-void Vector::Move(Vector &&v) {
+void Vector::Move(Vector &&v)
+{
    data = std::move(v.data);
    // Self-assignment-safe way to move v.size to size:
    const auto size_tmp = v.size;
@@ -156,9 +157,12 @@ Vector &Vector::operator=(Vector &&v)
    // Move assignments are only safe if we own the underlying data.
    // If we don't, we could be breaking ownership contracts. This could happen during
    // third party library calls, e.g. Sundials N vector operations.
-   if (OwnsData()) {
+   if (OwnsData())
+   {
       Move(std::move(v));
-   } else {
+   }
+   else
+   {
       // If we don't own the data, force use of the copy assignment operator instead.
       this->operator=(const_cast<const mfem::Vector&>(v));
    }

--- a/linalg/vector.hpp
+++ b/linalg/vector.hpp
@@ -65,12 +65,12 @@ protected:
    int size;
 
    /// @brief Move the contents of @a v into the calling vector.
-   /** This is needed in addition to the move constructor/assignment operators since  
-       ownership flags must be checked before completing standard move assignment operations. 
+   /** This is needed in addition to the move constructor/assignment operators since
+       ownership flags must be checked before completing standard move assignment operations.
        We also want to keep the move workflow centralized in a single call. */
    void Move(Vector&& v);
 
- public:
+public:
 
    /** Default constructor for Vector. Sets size = 0, and calls Memory::Reset on
        data through Memory<double>'s default constructor. */

--- a/linalg/vector.hpp
+++ b/linalg/vector.hpp
@@ -64,7 +64,13 @@ protected:
    Memory<double> data;
    int size;
 
-public:
+   /// @brief Move the contents of @a v into the calling vector.
+   /** This is needed in addition to the move constructor/assignment operators since  
+       ownership flags must be checked before completing standard move assignment operations. 
+       We also want to keep the move workflow centralized in a single call. */
+   void Move(Vector&& v);
+
+ public:
 
    /** Default constructor for Vector. Sets size = 0, and calls Memory::Reset on
        data through Memory<double>'s default constructor. */


### PR DESCRIPTION
If move assignment operators are used on a `Vector` that does not own it's own data, memory shadowing (e.g. `SundialsNVector`) strategies can be broken. This adds a check to only perform move operations if the `Vector` owns its own data.

I don't particularly like this solution, so other ideas are welcome.