### PR TITLE
Switching to single point Dirichlet BC in IrrotationalProjector

### DIFF
--- a/miniapps/common/pfem_extras.cpp
+++ b/miniapps/common/pfem_extras.cpp
@@ -115,9 +115,15 @@ IrrotationalProjector
      ownsWeakDiv_(weakDiv == NULL),
      ownsGrad_(grad == NULL)
 {
+   int myid = H1FESpace_->GetMyRank();
+
    ess_bdr_.SetSize(H1FESpace_->GetParMesh()->bdr_attributes.Max());
-   ess_bdr_ = 1;
-   H1FESpace_->GetEssentialTrueDofs(ess_bdr_, ess_bdr_tdofs_);
+   ess_bdr_ = 0;
+   ess_bdr_tdofs_.SetSize((myid == 0) ? 1 : 0);
+   if (myid == 0)
+   {
+      ess_bdr_tdofs_[0] = 0;
+   }
 
    int geom = H1FESpace_->GetFE(0)->GetGeomType();
    const IntegrationRule * ir = &IntRules.Get(geom, irOrder);


### PR DESCRIPTION
Only a single point is required to make the diffusion operator non-singular and the results are usually much better.

This improvement was noticed in connection with discussion #3523.
