### PR TITLE
GSLIB support for p-refined meshes.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -14,6 +14,8 @@ Version 4.5.3 (development)
 - Added new methods in the Mesh class to set and get attributes on NURBS patches
   and patch boundaries.
 
+- Added support for p-refined meshes in FindPointsGSLIB.
+
 Version 4.5.2, released on March 23, 2023
 =========================================
 

--- a/fem/gridfunc.hpp
+++ b/fem/gridfunc.hpp
@@ -680,6 +680,10 @@ public:
    /// Transform by the Space UpdateMatrix (e.g., on Mesh change).
    virtual void Update();
 
+   /** Return update counter, similar to Mesh::GetSequence(). Used to
+       check if it is up to date with the space. */
+   long GetSequence() const { return fes_sequence; }
+
    FiniteElementSpace *FESpace() { return fes; }
    const FiniteElementSpace *FESpace() const { return fes; }
 

--- a/fem/gslib.cpp
+++ b/fem/gslib.cpp
@@ -1151,31 +1151,31 @@ void OversetFindPointsGSLIB::Setup(Mesh &m, const int meshid,
    SetupSplitMeshes();
    if (dim == 2)
    {
-       if (ir_split[0]) { delete ir_split[0]; ir_split[0] = NULL; }
-       ir_split[0] = new IntegrationRule(3*pow(dof1D, dim));
-       SetupIntegrationRuleForSplitMesh(mesh_split[0], ir_split[0], meshOrder);
+      if (ir_split[0]) { delete ir_split[0]; ir_split[0] = NULL; }
+      ir_split[0] = new IntegrationRule(3*pow(dof1D, dim));
+      SetupIntegrationRuleForSplitMesh(mesh_split[0], ir_split[0], meshOrder);
 
-       if (ir_split[1]) { delete ir_split[1]; ir_split[1] = NULL; }
-       ir_split[1] = new IntegrationRule(pow(dof1D, dim));
-       SetupIntegrationRuleForSplitMesh(mesh_split[1], ir_split[1], meshOrder);
+      if (ir_split[1]) { delete ir_split[1]; ir_split[1] = NULL; }
+      ir_split[1] = new IntegrationRule(pow(dof1D, dim));
+      SetupIntegrationRuleForSplitMesh(mesh_split[1], ir_split[1], meshOrder);
    }
    else if (dim == 3)
    {
-       if (ir_split[0]) { delete ir_split[0]; ir_split[0] = NULL; }
-       ir_split[0] = new IntegrationRule(pow(dof1D, dim));
-       SetupIntegrationRuleForSplitMesh(mesh_split[0], ir_split[0], meshOrder);
+      if (ir_split[0]) { delete ir_split[0]; ir_split[0] = NULL; }
+      ir_split[0] = new IntegrationRule(pow(dof1D, dim));
+      SetupIntegrationRuleForSplitMesh(mesh_split[0], ir_split[0], meshOrder);
 
-       if (ir_split[1]) { delete ir_split[1]; ir_split[1] = NULL; }
-       ir_split[1] = new IntegrationRule(4*pow(dof1D, dim));
-       SetupIntegrationRuleForSplitMesh(mesh_split[1], ir_split[1], meshOrder);
+      if (ir_split[1]) { delete ir_split[1]; ir_split[1] = NULL; }
+      ir_split[1] = new IntegrationRule(4*pow(dof1D, dim));
+      SetupIntegrationRuleForSplitMesh(mesh_split[1], ir_split[1], meshOrder);
 
-       if (ir_split[2]) { delete ir_split[2]; ir_split[2] = NULL; }
-       ir_split[2] = new IntegrationRule(3*pow(dof1D, dim));
-       SetupIntegrationRuleForSplitMesh(mesh_split[2], ir_split[2], meshOrder);
+      if (ir_split[2]) { delete ir_split[2]; ir_split[2] = NULL; }
+      ir_split[2] = new IntegrationRule(3*pow(dof1D, dim));
+      SetupIntegrationRuleForSplitMesh(mesh_split[2], ir_split[2], meshOrder);
 
-       if (ir_split[3]) { delete ir_split[3]; ir_split[3] = NULL; }
-       ir_split[3] = new IntegrationRule(8*pow(dof1D, dim));
-       SetupIntegrationRuleForSplitMesh(mesh_split[3], ir_split[3], meshOrder);
+      if (ir_split[3]) { delete ir_split[3]; ir_split[3] = NULL; }
+      ir_split[3] = new IntegrationRule(8*pow(dof1D, dim));
+      SetupIntegrationRuleForSplitMesh(mesh_split[3], ir_split[3], meshOrder);
    }
 
    GetNodalValues(mesh->GetNodes(), gsl_mesh);

--- a/fem/gslib.cpp
+++ b/fem/gslib.cpp
@@ -1137,8 +1137,7 @@ void OversetFindPointsGSLIB::Setup(Mesh &m, const int meshid,
                                    const int npt_max)
 {
    MFEM_VERIFY(m.GetNodes() != NULL, "Mesh nodes are required.");
-   MFEM_VERIFY(!(m.GetNodes()->FESpace()->IsVariableOrder()),
-               "Variable order mesh is not currently supported.");
+   const int meshOrder = m.GetNodes()->FESpace()->GetMaxElementOrder();
 
    // FreeData if OversetFindPointsGSLIB::Setup has been called already
    if (setupflag) { FreeData(); }
@@ -1152,23 +1151,31 @@ void OversetFindPointsGSLIB::Setup(Mesh &m, const int meshid,
    SetupSplitMeshes();
    if (dim == 2)
    {
-      if (ir_split[0]) { delete ir_split[0]; ir_split[0] = NULL; }
-      ir_split[0] = new IntegrationRule(3*pow(dof1D, dim));
-      SetupIntegrationRuleForSplitMesh(mesh_split[0], ir_split[0], fe->GetOrder());
+       if (ir_split[0]) { delete ir_split[0]; ir_split[0] = NULL; }
+       ir_split[0] = new IntegrationRule(3*pow(dof1D, dim));
+       SetupIntegrationRuleForSplitMesh(mesh_split[0], ir_split[0], meshOrder);
+
+       if (ir_split[1]) { delete ir_split[1]; ir_split[1] = NULL; }
+       ir_split[1] = new IntegrationRule(pow(dof1D, dim));
+       SetupIntegrationRuleForSplitMesh(mesh_split[1], ir_split[1], meshOrder);
    }
    else if (dim == 3)
    {
-      if (ir_split[1]) { delete ir_split[1]; ir_split[1] = NULL; }
-      ir_split[1] = new IntegrationRule(4*pow(dof1D, dim));
-      SetupIntegrationRuleForSplitMesh(mesh_split[1], ir_split[1], fe->GetOrder());
+       if (ir_split[0]) { delete ir_split[0]; ir_split[0] = NULL; }
+       ir_split[0] = new IntegrationRule(pow(dof1D, dim));
+       SetupIntegrationRuleForSplitMesh(mesh_split[0], ir_split[0], meshOrder);
 
-      if (ir_split[2]) { delete ir_split[2]; ir_split[2] = NULL; }
-      ir_split[2] = new IntegrationRule(3*pow(dof1D, dim));
-      SetupIntegrationRuleForSplitMesh(mesh_split[2], ir_split[2], fe->GetOrder());
+       if (ir_split[1]) { delete ir_split[1]; ir_split[1] = NULL; }
+       ir_split[1] = new IntegrationRule(4*pow(dof1D, dim));
+       SetupIntegrationRuleForSplitMesh(mesh_split[1], ir_split[1], meshOrder);
 
-      if (ir_split[3]) { delete ir_split[3]; ir_split[3] = NULL; }
-      ir_split[3] = new IntegrationRule(8*pow(dof1D, dim));
-      SetupIntegrationRuleForSplitMesh(mesh_split[3], ir_split[3], fe->GetOrder());
+       if (ir_split[2]) { delete ir_split[2]; ir_split[2] = NULL; }
+       ir_split[2] = new IntegrationRule(3*pow(dof1D, dim));
+       SetupIntegrationRuleForSplitMesh(mesh_split[2], ir_split[2], meshOrder);
+
+       if (ir_split[3]) { delete ir_split[3]; ir_split[3] = NULL; }
+       ir_split[3] = new IntegrationRule(8*pow(dof1D, dim));
+       SetupIntegrationRuleForSplitMesh(mesh_split[3], ir_split[3], meshOrder);
    }
 
    GetNodalValues(mesh->GetNodes(), gsl_mesh);

--- a/fem/gslib.cpp
+++ b/fem/gslib.cpp
@@ -108,8 +108,7 @@ void FindPointsGSLIB::Setup(Mesh &m, const double bb_t, const double newt_tol,
                             const int npt_max)
 {
    MFEM_VERIFY(m.GetNodes() != NULL, "Mesh nodes are required.");
-   MFEM_VERIFY(!(m.GetNodes()->FESpace()->IsVariableOrder()),
-               "Variable order mesh is not currently supported.");
+   const int meshOrder = m.GetNodes()->FESpace()->GetMaxElementOrder();
 
    // call FreeData if FindPointsGSLIB::Setup has been called already
    if (setupflag) { FreeData(); }
@@ -117,30 +116,36 @@ void FindPointsGSLIB::Setup(Mesh &m, const double bb_t, const double newt_tol,
    crystal_init(cr, gsl_comm);
    mesh = &m;
    dim  = mesh->Dimension();
-   const FiniteElement *fe = mesh->GetNodalFESpace()->GetFE(0);
-   unsigned dof1D = fe->GetOrder() + 1;
+   unsigned dof1D = meshOrder + 1;
 
    SetupSplitMeshes();
    if (dim == 2)
    {
       if (ir_split[0]) { delete ir_split[0]; ir_split[0] = NULL; }
       ir_split[0] = new IntegrationRule(3*pow(dof1D, dim));
-      SetupIntegrationRuleForSplitMesh(mesh_split[0], ir_split[0], fe->GetOrder());
+      SetupIntegrationRuleForSplitMesh(mesh_split[0], ir_split[0], meshOrder);
+
+      if (ir_split[1]) { delete ir_split[1]; ir_split[1] = NULL; }
+      ir_split[1] = new IntegrationRule(pow(dof1D, dim));
+      SetupIntegrationRuleForSplitMesh(mesh_split[1], ir_split[1], meshOrder);
    }
    else if (dim == 3)
    {
+      if (ir_split[0]) { delete ir_split[0]; ir_split[0] = NULL; }
+      ir_split[0] = new IntegrationRule(pow(dof1D, dim));
+      SetupIntegrationRuleForSplitMesh(mesh_split[0], ir_split[0], meshOrder);
 
       if (ir_split[1]) { delete ir_split[1]; ir_split[1] = NULL; }
       ir_split[1] = new IntegrationRule(4*pow(dof1D, dim));
-      SetupIntegrationRuleForSplitMesh(mesh_split[1], ir_split[1], fe->GetOrder());
+      SetupIntegrationRuleForSplitMesh(mesh_split[1], ir_split[1], meshOrder);
 
       if (ir_split[2]) { delete ir_split[2]; ir_split[2] = NULL; }
       ir_split[2] = new IntegrationRule(3*pow(dof1D, dim));
-      SetupIntegrationRuleForSplitMesh(mesh_split[2], ir_split[2], fe->GetOrder());
+      SetupIntegrationRuleForSplitMesh(mesh_split[2], ir_split[2], meshOrder);
 
       if (ir_split[3]) { delete ir_split[3]; ir_split[3] = NULL; }
       ir_split[3] = new IntegrationRule(8*pow(dof1D, dim));
-      SetupIntegrationRuleForSplitMesh(mesh_split[3], ir_split[3], fe->GetOrder());
+      SetupIntegrationRuleForSplitMesh(mesh_split[3], ir_split[3], meshOrder);
    }
 
    GetNodalValues(mesh->GetNodes(), gsl_mesh);
@@ -333,9 +338,14 @@ void FindPointsGSLIB::SetupSplitMeshes()
             (*gf_rst_map[0])(j+k*npt) = quad_v[j][k];
          }
       }
+
+      mesh_split[1] = new Mesh(Mesh::MakeCartesian2D(1, 1,
+                                                     Element::QUADRILATERAL));
    }
    else if (mesh->Dimension() == 3)
    {
+      mesh_split[0] = new Mesh(Mesh::MakeCartesian3D(1, 1, 1,
+                                                     Element::HEXAHEDRON));
       // Tetrahedron
       {
          int Nvert = 15;
@@ -565,11 +575,12 @@ void FindPointsGSLIB::GetNodalValues(const GridFunction *gf_in,
    const GridFunction *nodes     = gf_in;
    const FiniteElementSpace *fes = nodes->FESpace();
    const int NE                  = mesh->GetNE();
-   const int vdim                = gf_in->FESpace()->GetVDim();
+   const int vdim                = fes->GetVDim();
 
    IntegrationRule *ir_split_temp = NULL;
 
-   const int dof_1D =  nodes->FESpace()->GetFE(0)->GetOrder()+1;
+   const int maxOrder = fes->GetMaxElementOrder();
+   const int dof_1D =  maxOrder+1;
    const int pts_el = std::pow(dof_1D, dim);
    const int pts_cnt = NE_split_total * pts_el;
    node_vals.SetSize(vdim * pts_cnt);
@@ -579,7 +590,7 @@ void FindPointsGSLIB::GetNodalValues(const GridFunction *gf_in,
 
    for (int e = 0; e < NE; e++)
    {
-      const FiniteElement *fe   = nodes->FESpace()->GetFE(e);
+      const FiniteElement *fe   = fes->GetFE(e);
       const Geometry::Type gt   = fe->GetGeomType();
       bool el_to_split = true;
       if (gt == Geometry::TRIANGLE)
@@ -598,16 +609,22 @@ void FindPointsGSLIB::GetNodalValues(const GridFunction *gf_in,
       {
          ir_split_temp = ir_split[3];
       }
-      else if (gt == Geometry::SQUARE || gt == Geometry::CUBE)
+      else if (gt == Geometry::SQUARE)
       {
-         el_to_split = false;
+         ir_split_temp = ir_split[1];
+         el_to_split = gf_in->FESpace()->IsVariableOrder();
+      }
+      else if (gt == Geometry::CUBE)
+      {
+         ir_split_temp = ir_split[0];
+         el_to_split = gf_in->FESpace()->IsVariableOrder();
       }
       else
       {
          MFEM_ABORT("Unsupported geometry type.");
       }
 
-      if (el_to_split) // Triangle/Tet/Prism
+      if (el_to_split) // Triangle/Tet/Prism or Quads/Hex but variable order
       {
          // Fill gsl_mesh with location of split points.
          Vector locval(vdim);
@@ -622,7 +639,7 @@ void FindPointsGSLIB::GetNodalValues(const GridFunction *gf_in,
             gsl_mesh_pt_index++;
          }
       }
-      else // Quad/Hex
+      else // Quad/Hex and constant polyomial order
       {
          const int dof_cnt_split = fe->GetDof();
 
@@ -803,8 +820,8 @@ void FindPointsGSLIB::MapRefPosAndElemIndices()
 void FindPointsGSLIB::Interpolate(const GridFunction &field_in,
                                   Vector &field_out)
 {
-   const int  gf_order   = field_in.FESpace()->GetFE(0)->GetOrder(),
-              mesh_order = mesh->GetNodalFESpace()->GetFE(0)->GetOrder();
+   const int  gf_order   = field_in.FESpace()->GetMaxElementOrder(),
+              mesh_order = mesh->GetNodalFESpace()->GetMaxElementOrder();
 
    const FiniteElementCollection *fec_in =  field_in.FESpace()->FEColl();
    const H1_FECollection *fec_h1 = dynamic_cast<const H1_FECollection *>(fec_in);
@@ -812,7 +829,8 @@ void FindPointsGSLIB::Interpolate(const GridFunction &field_in,
 
    if (fec_h1 && gf_order == mesh_order &&
        fec_h1->GetBasisType() == BasisType::GaussLobatto &&
-       !field_in.FESpace()->IsVariableOrder())
+       field_in.FESpace()->IsVariableOrder() ==
+       mesh->GetNodalFESpace()->IsVariableOrder())
    {
       InterpolateH1(field_in, field_out);
       return;
@@ -886,6 +904,14 @@ void FindPointsGSLIB::InterpolateH1(const GridFunction &field_in,
                                     Vector &field_out)
 {
    FiniteElementSpace ind_fes(mesh, field_in.FESpace()->FEColl());
+   if (field_in.FESpace()->IsVariableOrder())
+   {
+      for (int e = 0; e < ind_fes.GetMesh()->GetNE(); e++)
+      {
+         ind_fes.SetElementOrder(e, field_in.FESpace()->GetElementOrder(e));
+      }
+      ind_fes.Update(false);
+   }
    GridFunction field_in_scalar(&ind_fes);
    Vector node_vals;
 

--- a/fem/gslib.cpp
+++ b/fem/gslib.cpp
@@ -639,7 +639,7 @@ void FindPointsGSLIB::GetNodalValues(const GridFunction *gf_in,
             gsl_mesh_pt_index++;
          }
       }
-      else // Quad/Hex and constant polyomial order
+      else // Quad/Hex and constant polynomial order
       {
          const int dof_cnt_split = fe->GetDof();
 

--- a/fem/gslib.hpp
+++ b/fem/gslib.hpp
@@ -57,6 +57,8 @@ public:
 protected:
    Mesh *mesh;
    Array<Mesh *> mesh_split;  // Meshes used to split simplices.
+   // IntegrationRules for simplex->Quad/Hex and to project to highest polynomial
+   // order in-case of p-refinement.
    Array<IntegrationRule *> ir_split; // IntegrationRules for simplex->Quad/Hex
    Array<FiniteElementSpace *>
    fes_rst_map; // FESpaces to map info Quad/Hex->Simplex

--- a/fem/gslib.hpp
+++ b/fem/gslib.hpp
@@ -59,7 +59,7 @@ protected:
    Array<Mesh *> mesh_split;  // Meshes used to split simplices.
    // IntegrationRules for simplex->Quad/Hex and to project to highest polynomial
    // order in-case of p-refinement.
-   Array<IntegrationRule *> ir_split; // IntegrationRules for simplex->Quad/Hex
+   Array<IntegrationRule *> ir_split;
    Array<FiniteElementSpace *>
    fes_rst_map; // FESpaces to map info Quad/Hex->Simplex
    Array<GridFunction *> gf_rst_map; // GridFunctions to map info Quad/Hex->Simplex

--- a/miniapps/gslib/findpts.cpp
+++ b/miniapps/gslib/findpts.cpp
@@ -40,7 +40,7 @@
 //    findpts -m ../../data/amr-quad.mesh -o 2
 //    findpts -m ../../data/rt-2d-q3.mesh -o 3 -mo 4 -ft 2
 //    findpts -m ../../data/square-mixed.mesh -o 2 -mo 2
-//    findpts -m ../../data/square-mixed.mesh -o 2 -mo 2 -hr -pr
+//    findpts -m ../../data/square-mixed.mesh -o 2 -mo 2 -hr -pr -mpr
 //    findpts -m ../../data/square-mixed.mesh -o 2 -mo 3 -ft 2
 //    findpts -m ../../data/fichera-mixed.mesh -o 3 -mo 2
 //    findpts -m ../../data/inline-pyramid.mesh -o 1 -mo 1
@@ -67,6 +67,10 @@ public:
    /// Destructor
    ~PRefinementGFUpdate();
 
+   /// Update source FiniteElementSpace used to construct the
+   /// PRefinementTransfer operator.
+   void SetSourceFESpace(const FiniteElementSpace& src_);
+
    /// @brief Update GridFunction using PRefinementTransferOperator.
    /// Do not use GridFunction->Update() prior to this method as it is
    /// handled internally.
@@ -81,6 +85,12 @@ PRefinementGFUpdate::PRefinementGFUpdate(const FiniteElementSpace &src_)
 PRefinementGFUpdate::~PRefinementGFUpdate()
 {
    delete src;
+}
+
+void PRefinementGFUpdate::SetSourceFESpace(const FiniteElementSpace &src_)
+{
+   if (src) { delete src; }
+   src = new FiniteElementSpace(src_);
 }
 
 void PRefinementGFUpdate::GridFunctionUpdate(GridFunction &targf)

--- a/miniapps/gslib/findpts.cpp
+++ b/miniapps/gslib/findpts.cpp
@@ -33,6 +33,7 @@
 //    findpts -m ../../data/inline-quad.mesh -o 3 -po 1
 //    findpts -m ../../data/inline-quad.mesh -o 3 -po 1 -fo 1 -nc 2
 //    findpts -m ../../data/inline-quad.mesh -o 3 -hr -pr -mpr -mo 2
+//    findpts -m ../../data/inline-quad.mesh -o 3 -hr -pr -mpr -mo 3
 //    findpts -m ../../data/inline-tet.mesh -o 3
 //    findpts -m ../../data/inline-hex.mesh -o 3
 //    findpts -m ../../data/inline-wedge.mesh -o 3
@@ -47,8 +48,6 @@
 
 #include "mfem.hpp"
 #include "../common/mfem-common.hpp"
-#include <fstream>
-#include <iostream>
 
 using namespace mfem;
 using namespace std;
@@ -163,7 +162,7 @@ void VisualizeFESpacePolynomialOrder(FiniteElementSpace &fespace,
 
    socketstream vis1;
    common::VisualizeField(vis1, "localhost", 19916, order_gf, title,
-                          500, 0, 400, 400, "RjmAcp");
+                          400, 0, 400, 400, "RjmAcp");
 }
 
 double func_order;
@@ -474,6 +473,7 @@ int main (int argc, char *argv[])
    // Free the internal gslib data.
    finder.FreeData();
 
+   if (mesh_prefinement) { delete mesh_nodes_pref; }
    if (prefinement) { delete field_vals_pref; }
    delete fec;
 

--- a/miniapps/gslib/makefile
+++ b/miniapps/gslib/makefile
@@ -35,6 +35,13 @@ else
    MINIAPPS = $(PAR_MINIAPPS) $(SEQ_MINIAPPS)
 endif
 
+COMMON_LIB = -L$(MFEM_BUILD_DIR)/miniapps/common -lmfem-common
+
+# If MFEM_SHARED is set, add the ../common rpath
+COMMON_LIB += $(if $(MFEM_SHARED:YES=),,\
+   $(if $(MFEM_USE_CUDA:YES=),$(CXX_XLINKER),$(CUDA_XLINKER))-rpath,$(abspath\
+   $(MFEM_BUILD_DIR)/miniapps/common))
+
 .SUFFIXES:
 .SUFFIXES: .o .cpp .mk
 .PHONY: all clean clean-build clean-exec
@@ -43,10 +50,14 @@ endif
 %: %.cpp
 
 # Replace the default implicit rule for *.cpp files
-%: $(SRC)%.cpp $(MFEM_LIB_FILE) $(CONFIG_MK)
-	$(MFEM_CXX) $(MFEM_FLAGS) $< -o $@ $(MFEM_LIBS)
+%: $(SRC)%.cpp $(MFEM_LIB_FILE) $(CONFIG_MK) | lib-common
+	$(MFEM_CXX) $(MFEM_FLAGS) $< -o $@ $(COMMON_LIB) $(MFEM_LIBS)
 
 all: $(MINIAPPS)
+
+# Rule for building lib-common
+lib-common:
+	$(MAKE) -C $(MFEM_BUILD_DIR)/miniapps/common
 
 # For out-of-source builds, link the data files from the source tree:
 ifneq ($(SRC),)


### PR DESCRIPTION
Output from updated sample run that uses GSLIB to find points over a randomly hp-refined mesh and solution:

<img width="1197" alt="gslib-p-ref" src="https://user-images.githubusercontent.com/12035999/226415370-a930e8a0-a83b-49b6-83a6-96b93c8adc37.png">

```
Searched points:     625
Found points:        625
Max interp error:    2.220446049250313e-15
Max dist (of found): 1.885870601543981e-30
Points not found:    0
Points on faces:     40
```

<!--GHEX{"author":"kmittal2","assignment":"2023-03-24T23:53:29","editor":"tzanio","id":3548,"reviewers":["dylan-copeland","jakubcerveny"],"merge":"2023-04-14T23:53:29","approval":"2023-04-14T13:57:42"}XEHG-->
<!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge|
 | --- | --- | --- | --- | --- | --- | --- |
| [#3548](https://github.com/mfem/mfem/pull/3548) | @kmittal2 | @tzanio | @dylan-copeland + @jakubcerveny | 3/24/23 | 4/14/23 | ⌛due 4/14/23 | |
<!--ELBATXEHG-->
<details>
<summary>PR Checklist</summary>
    
- [ ] Code builds.
- [ ] Code passes `make style`.
- [ ] Update `CHANGELOG`:
    - [ ] Is this a new feature users need to be aware of? New or updated example or miniapp?
    - [ ] Does it make sense to create a new section in the `CHANGELOG` to group with other related features?
- [ ] Update `INSTALL`:
    - [ ] Had a new optional library been added? If so, what range of versions of this library are required? (*Make sure the external library is compatible with our BSD license, e.g. it is not licensed under GPL!*)
    - [ ] Have the version ranges for any required or optional libraries changed?
    - [ ] Does `make` or `cmake` have a new target?
    - [ ] Did the requirements or the installation process change? *(rare)*
- [ ] Update continuous integration server configurations if necessary (e.g. with new version requirements for each of MFEM's dependencies)
    - [ ] `.github`
    - [ ] `.appveyor.yml`
- [ ] Update `.gitignore`:
    - [ ] Check if `make distclean; git status` shows any files that were generated from the source by the project (not an IDE) but we don't want to track in the repository.
    - [ ] Add new patterns (just for the new files above) and re-run the above test.
- [ ] New examples:
    - [ ] All sample runs at the top of the example source file work.
    - [ ] Update `examples/makefile`:
      - [ ] Add the example code to the appropriate `SEQ_EXAMPLES` and `PAR_EXAMPLES` variables.
      - [ ] Add any files generated by it to the `clean` target.
      - [ ] Add the example binary and any files generated by it to the top-level `.gitignore` file.
    - [ ] Update `examples/CMakeLists.txt`:
      - [ ] Add the example code to the `ALL_EXE_SRCS` variable.
      - [ ] Make sure `THIS_TEST_OPTIONS` is set correctly for the new example.
   - [ ] List the new example in `doc/CodeDocumentation.dox`.
   - [ ] If new examples directory (e.g.`examples/pumi`), list it in `doc/CodeDocumentation.conf.in`
   - [ ] Companion pull request for documentation in [mfem/web](https://github.com/mfem/web) repo:
      - [ ] Update or add example-specific documentation, see e.g. the `src/examples.md`.
      - [ ] Add the description, labels and screenshots in `src/examples.md` and `src/img`.
      - [ ] In `examples.md`, list the example under the appropriate categories, add new categories if necessary.
      - [ ] Add a short description of the example in the "Extensive Examples" section of `features.md`.
- [ ] New miniapps:
   - [ ] All sample runs at the top of the miniapp source file work.
   - [ ] Update top-level `makefile` and `makefile` in corresponding miniapp directory.
   - [ ] Add the miniapp binary and any files generated by it to the top-level `.gitignore` file.
   - [ ] Update CMake build system:
      - [ ] Update the `CMakeLists.txt` file in the `miniapps` directory, if the new miniapp is in a new directory.
      - [ ] Add/update the `CMakeLists.txt` file in the new miniapp directory.
      - [ ] Consider adding a new test for the new miniapp.
   - [ ] List the new miniapp in `doc/CodeDocumentation.dox`
   - [ ] If new miniapps directory (e.g.`miniapps/nurbs`), add it to `MINIAPP_SUBDIRS` in the `makefile`.
   - [ ] If new miniapps directory (e.g.`miniapps/nurbs`), list it in `doc/CodeDocumentation.conf.in`
   - [ ] Companion pull request for documentation in [mfem/web](https://github.com/mfem/web) repo:
     - [ ] Update or add miniapp-specific documentation, see e.g. the `src/meshing.md` and `src/electromagnetics.md` files.
     - [ ] Add the description, labels and screenshots in `src/examples.md` and `src/img`.
     - [ ] The miniapps go at the end of the page, and are usually listed only under a specific "Application (PDE)" category.
     - [ ] Add a short description of the miniapp in the "Extensive Examples" section of `features.md`.
- [ ] New capability:
   - [ ] All new public, protected, and private classes, methods, data members, and functions have full Doxygen-style documentation in source comments. Documentation should include descriptions of member data, function arguments and return values, template parameters, and prerequisites for calling new functions.
   - [ ] Pointer arguments and return values must specify whether ownership is being transferred or lent with the call.
   - [ ] Any new functions should include descriptions of their intended use e.g. for internal use only, user-facing, etc., along with references to example code whenever possible/appropriate.
   - [ ] Consider adding new sample runs in existing examples to highlight the new capability.
   - [ ] Consider saving cool simulation pictures with the new capability in the Confluence gallery (LLNL only) or submitting them, via pull request, to the gallery section of the `mfem/web` repo.
   - [ ] If this is a major new feature, consider mentioning it in the short summary inside `README` *(rare)*.
   - [ ] List major new classes in `doc/CodeDocumentation.dox` *(rare)*.
- [ ] Update this checklist, if the new pull request affects it.
- [ ] Run `make unittest` to make sure all unit tests pass.
- [ ] Run the tests in `tests/scripts`.
- [ ] (LLNL only) After merging:
   - [ ] Update internal tests to include the new features.
</details>
