### PR TITLE
Init j and resid

### DIFF
--- a/linalg/solvers.cpp
+++ b/linalg/solvers.cpp
@@ -1028,6 +1028,8 @@ void GMRESSolver::Mult(const Vector &b, Vector &x) const
       final_norm = beta;
       final_iter = 0;
       converged = true;
+      j = 0;
+      resid = beta;
       goto finish;
    }
 


### PR DESCRIPTION
This PR sets j and resid. They are not initialized if beta <= final_norm, while they are printed later.