### PR TITLE
Clean up base `ElementRestrictionOperator` interface

### DIFF
--- a/fem/bilinearform_ext.hpp
+++ b/fem/bilinearform_ext.hpp
@@ -71,7 +71,7 @@ protected:
    mutable Vector localX, localY;
    mutable Vector int_face_X, int_face_Y;
    mutable Vector bdr_face_X, bdr_face_Y;
-   const Operator *elem_restrict; // Not owned
+   const ElementRestriction *elem_restrict; // Not owned
    const FaceRestriction *int_face_restrict_lex; // Not owned
    const FaceRestriction *bdr_face_restrict_lex; // Not owned
 
@@ -151,7 +151,7 @@ protected:
    mutable Vector localX, localY;
    mutable Vector int_face_X, int_face_Y;
    mutable Vector bdr_face_X, bdr_face_Y;
-   const Operator *elem_restrict; // Not owned
+   const ElementRestriction *elem_restrict; // Not owned
    const FaceRestriction *int_face_restrict_lex; // Not owned
    const FaceRestriction *bdr_face_restrict_lex; // Not owned
 
@@ -219,13 +219,13 @@ class PAMixedBilinearFormExtension : public MixedBilinearFormExtension
 protected:
    const FiniteElementSpace *trial_fes, *test_fes; // Not owned
    mutable Vector localTrial, localTest, tempY;
-   const Operator *elem_restrict_trial; // Not owned
-   const Operator *elem_restrict_test;  // Not owned
+   const ElementRestriction *elem_restrict_trial; // Not owned
+   const ElementRestriction *elem_restrict_test;  // Not owned
 
    /// Helper function to set up inputs/outputs for Mult or MultTranspose
-   void SetupMultInputs(const Operator *elem_restrict_x,
+   void SetupMultInputs(const ElementRestriction *elem_restrict_x,
                         const Vector &x, Vector &localX,
-                        const Operator *elem_restrict_y,
+                        const ElementRestriction *elem_restrict_y,
                         Vector &y, Vector &localY, const double c) const;
 
 public:

--- a/fem/fespace.cpp
+++ b/fem/fespace.cpp
@@ -1256,7 +1256,7 @@ int FiniteElementSpace::GetNConformingDofs() const
    return P ? (P->Width() / vdim) : ndofs;
 }
 
-const ElementRestrictionOperator *FiniteElementSpace::GetElementRestriction(
+const Operator *FiniteElementSpace::GetElementRestriction(
    ElementDofOrdering e_ordering) const
 {
    // Check if we have a discontinuous space using the FE collection:
@@ -1271,7 +1271,7 @@ const ElementRestrictionOperator *FiniteElementSpace::GetElementRestriction(
          // The output E-vector layout is: ND x VDIM x NE.
          L2E_nat.Reset(new L2ElementRestriction(*this));
       }
-      return L2E_nat.Is<ElementRestrictionOperator>();
+      return L2E_nat.Ptr();
    }
    if (e_ordering == ElementDofOrdering::LEXICOGRAPHIC)
    {
@@ -1279,14 +1279,14 @@ const ElementRestrictionOperator *FiniteElementSpace::GetElementRestriction(
       {
          L2E_lex.Reset(new ElementRestriction(*this, e_ordering));
       }
-      return L2E_lex.Is<ElementRestrictionOperator>();
+      return L2E_lex.Ptr();
    }
    // e_ordering == ElementDofOrdering::NATIVE
    if (L2E_nat.Ptr() == NULL)
    {
       L2E_nat.Reset(new ElementRestriction(*this, e_ordering));
    }
-   return L2E_nat.Is<ElementRestrictionOperator>();
+   return L2E_nat.Ptr();
 }
 
 const FaceRestriction *FiniteElementSpace::GetFaceRestriction(

--- a/fem/fespace.cpp
+++ b/fem/fespace.cpp
@@ -1256,7 +1256,7 @@ int FiniteElementSpace::GetNConformingDofs() const
    return P ? (P->Width() / vdim) : ndofs;
 }
 
-const Operator *FiniteElementSpace::GetElementRestriction(
+const ElementRestriction *FiniteElementSpace::GetElementRestriction(
    ElementDofOrdering e_ordering) const
 {
    // Check if we have a discontinuous space using the FE collection:
@@ -1271,22 +1271,22 @@ const Operator *FiniteElementSpace::GetElementRestriction(
          // The output E-vector layout is: ND x VDIM x NE.
          L2E_nat.Reset(new L2ElementRestriction(*this));
       }
-      return L2E_nat.Ptr();
+      return L2E_nat.Is<ElementRestriction>();
    }
    if (e_ordering == ElementDofOrdering::LEXICOGRAPHIC)
    {
       if (L2E_lex.Ptr() == NULL)
       {
-         L2E_lex.Reset(new ElementRestriction(*this, e_ordering));
+         L2E_lex.Reset(new ConformingElementRestriction(*this, e_ordering));
       }
-      return L2E_lex.Ptr();
+      return L2E_lex.Is<ElementRestriction>();
    }
    // e_ordering == ElementDofOrdering::NATIVE
    if (L2E_nat.Ptr() == NULL)
    {
-      L2E_nat.Reset(new ElementRestriction(*this, e_ordering));
+      L2E_nat.Reset(new ConformingElementRestriction(*this, e_ordering));
    }
-   return L2E_nat.Ptr();
+   return L2E_nat.Is<ElementRestriction>();
 }
 
 const FaceRestriction *FiniteElementSpace::GetFaceRestriction(

--- a/fem/fespace.hpp
+++ b/fem/fespace.hpp
@@ -639,7 +639,7 @@ public:
        L2ElementRestriction class.
 
        The returned Operator is owned by the FiniteElementSpace. */
-   const ElementRestrictionOperator *GetElementRestriction(
+   const Operator *GetElementRestriction(
       ElementDofOrdering e_ordering) const;
 
    /// Return an Operator that converts L-vectors to E-vectors on each face.

--- a/fem/fespace.hpp
+++ b/fem/fespace.hpp
@@ -639,7 +639,7 @@ public:
        L2ElementRestriction class.
 
        The returned Operator is owned by the FiniteElementSpace. */
-   const Operator *GetElementRestriction(
+   const ElementRestriction *GetElementRestriction(
       ElementDofOrdering e_ordering) const;
 
    /// Return an Operator that converts L-vectors to E-vectors on each face.

--- a/fem/linearform_ext.cpp
+++ b/fem/linearform_ext.cpp
@@ -164,10 +164,8 @@ void LinearFormExtension::Update()
          }
       }
 
-      bdr_restrict_lex =
-         dynamic_cast<const FaceRestriction*>(
-            fes.GetFaceRestriction(ordering, FaceType::Boundary,
-                                   L2FaceValues::SingleValued));
+      bdr_restrict_lex = fes.GetFaceRestriction(ordering, FaceType::Boundary,
+                                                L2FaceValues::SingleValued);
       MFEM_VERIFY(bdr_restrict_lex, "Face restriction not available");
       bdr_b.SetSize(bdr_restrict_lex->Height(), Device::GetMemoryType());
       bdr_b.UseDevice(true);

--- a/fem/linearform_ext.hpp
+++ b/fem/linearform_ext.hpp
@@ -34,7 +34,7 @@ class LinearFormExtension
    LinearForm *lf;
 
    /// Operator that converts FiniteElementSpace L-vectors to E-vectors.
-   const ElementRestrictionOperator *elem_restrict_lex; // Not owned
+   const Operator *elem_restrict_lex; // Not owned
 
    /// Operator that converts L-vectors to boundary E-vectors.
    const FaceRestriction *bdr_restrict_lex; // Not owned

--- a/fem/linearform_ext.hpp
+++ b/fem/linearform_ext.hpp
@@ -34,7 +34,7 @@ class LinearFormExtension
    LinearForm *lf;
 
    /// Operator that converts FiniteElementSpace L-vectors to E-vectors.
-   const Operator *elem_restrict_lex; // Not owned
+   const ElementRestriction *elem_restrict_lex; // Not owned
 
    /// Operator that converts L-vectors to boundary E-vectors.
    const FaceRestriction *bdr_restrict_lex; // Not owned

--- a/fem/lor/lor_ads.cpp
+++ b/fem/lor/lor_ads.cpp
@@ -103,9 +103,9 @@ void BatchedLOR_ADS::FormCurlMatrix()
    Form3DFaceToEdge(face2edge);
 
    ElementDofOrdering ordering = ElementDofOrdering::LEXICOGRAPHIC;
-   const auto *R_f = dynamic_cast<const ElementRestriction*>(
+   const auto *R_f = dynamic_cast<const ConformingElementRestriction*>(
                         face_fes.GetElementRestriction(ordering));
-   const auto *R_e = dynamic_cast<const ElementRestriction*>(
+   const auto *R_e = dynamic_cast<const ConformingElementRestriction*>(
                         edge_fes.GetElementRestriction(ordering));
    MFEM_VERIFY(R_f != NULL && R_e != NULL, "");
 

--- a/fem/lor/lor_ams.cpp
+++ b/fem/lor/lor_ams.cpp
@@ -163,9 +163,9 @@ void BatchedLOR_AMS::FormGradientMatrix()
    else { Form3DEdgeToVertex(edge2vertex); }
 
    ElementDofOrdering ordering = ElementDofOrdering::LEXICOGRAPHIC;
-   const auto *R_v = dynamic_cast<const ElementRestriction*>(
+   const auto *R_v = dynamic_cast<const ConformingElementRestriction*>(
                         vert_fes.GetElementRestriction(ordering));
-   const auto *R_e = dynamic_cast<const ElementRestriction*>(
+   const auto *R_e = dynamic_cast<const ConformingElementRestriction*>(
                         edge_fes.GetElementRestriction(ordering));
    MFEM_VERIFY(R_v != NULL && R_e != NULL, "");
 
@@ -268,7 +268,7 @@ void BatchedLOR_AMS::FormCoordinateVectors(const Vector &X_vert)
    // Create the H1 vertex space and get the element restriction
    ElementDofOrdering ordering = ElementDofOrdering::LEXICOGRAPHIC;
    const Operator *op = vert_fes.GetElementRestriction(ordering);
-   const auto *el_restr = dynamic_cast<const ElementRestriction*>(op);
+   const auto *el_restr = dynamic_cast<const ConformingElementRestriction*>(op);
    MFEM_VERIFY(el_restr != NULL, "");
    const SparseMatrix *R = vert_fes.GetRestrictionMatrix();
 

--- a/fem/lor/lor_batched.cpp
+++ b/fem/lor/lor_batched.cpp
@@ -145,8 +145,8 @@ int BatchedLORAssembly::FillI(SparseMatrix &A) const
 
    const ElementDofOrdering ordering = ElementDofOrdering::LEXICOGRAPHIC;
    const Operator *op = fes_ho.GetElementRestriction(ordering);
-   const ElementRestriction *el_restr =
-      dynamic_cast<const ElementRestriction*>(op);
+   const auto *el_restr =
+      dynamic_cast<const ConformingElementRestriction*>(op);
    MFEM_VERIFY(el_restr != nullptr, "Bad element restriction");
 
    const Array<int> &el_dof_lex_ = el_restr->GatherMap();
@@ -235,8 +235,8 @@ void BatchedLORAssembly::FillJAndData(SparseMatrix &A) const
 
    const ElementDofOrdering ordering = ElementDofOrdering::LEXICOGRAPHIC;
    const Operator *op = fes_ho.GetElementRestriction(ordering);
-   const ElementRestriction *el_restr =
-      dynamic_cast<const ElementRestriction*>(op);
+   const auto *el_restr =
+      dynamic_cast<const ConformingElementRestriction*>(op);
    MFEM_VERIFY(el_restr != nullptr, "Bad element restriction");
 
    const Array<int> &el_dof_lex_ = el_restr->GatherMap();

--- a/fem/restriction.cpp
+++ b/fem/restriction.cpp
@@ -233,12 +233,10 @@ void ElementRestriction::MultLeftInverse(const Vector& x, Vector& y) const
       const int next_offset = d_offsets[i + 1];
       for (int c = 0; c < vd; ++c)
       {
-         double dof_value = 0;
          const int j = next_offset - 1;
          const int idx_j = (d_indices[j] >= 0) ? d_indices[j] : -1 - d_indices[j];
-         dof_value = (d_indices[j] >= 0) ? d_x(idx_j % nd, c, idx_j / nd) :
-                     -d_x(idx_j % nd, c, idx_j / nd);
-         d_y(t?c:i,t?i:c) = dof_value;
+         d_y(t?c:i,t?i:c) = ((d_indices[j] >= 0) ? d_x(idx_j % nd, c, idx_j / nd) :
+                             -d_x(idx_j % nd, c, idx_j / nd));
       }
    });
 }
@@ -1137,7 +1135,7 @@ void L2FaceRestriction::SingleValuedConformingAddMultTranspose(
          for (int j = offset; j < next_offset; ++j)
          {
             int idx_j = d_indices[j];
-            dof_value +=  d_x(idx_j % nface_dofs, c, idx_j / nface_dofs);
+            dof_value += d_x(idx_j % nface_dofs, c, idx_j / nface_dofs);
          }
          d_y(t?c:i,t?i:c) += dof_value;
       }
@@ -1168,9 +1166,8 @@ void L2FaceRestriction::DoubleValuedConformingAddMultTranspose(
             int idx_j = d_indices[j];
             bool isE1 = idx_j < dofs;
             idx_j = isE1 ? idx_j : idx_j - dofs;
-            dof_value +=  isE1 ?
-                          d_x(idx_j % nface_dofs, c, 0, idx_j / nface_dofs)
-                          :d_x(idx_j % nface_dofs, c, 1, idx_j / nface_dofs);
+            dof_value += (isE1 ? d_x(idx_j % nface_dofs, c, 0, idx_j / nface_dofs)
+                          : d_x(idx_j % nface_dofs, c, 1, idx_j / nface_dofs));
          }
          d_y(t?c:i,t?i:c) += dof_value;
       }

--- a/fem/restriction.hpp
+++ b/fem/restriction.hpp
@@ -21,20 +21,10 @@ namespace mfem
 class FiniteElementSpace;
 enum class ElementDofOrdering;
 
-/// Abstract base class that defines an interface for element restrictions.
-class ElementRestrictionOperator : public Operator
-{
-public:
-   /// @brief Add the E-vector degrees of freedom @a x to the L-vector degrees
-   /// of freedom @a y.
-   void AddMultTranspose(const Vector &x, Vector &y,
-                         const double a = 1.0) const override = 0;
-};
-
 /// Operator that converts FiniteElementSpace L-vectors to E-vectors.
 /** Objects of this type are typically created and owned by FiniteElementSpace
     objects, see FiniteElementSpace::GetElementRestriction(). */
-class ElementRestriction : public ElementRestrictionOperator
+class ElementRestriction : public Operator
 {
 private:
    /** This number defines the maximum number of elements any dof can belong to
@@ -109,7 +99,7 @@ public:
     objects, see FiniteElementSpace::GetElementRestriction(). L-vectors
     corresponding to grid functions in L2 finite element spaces differ from
     E-vectors only in the ordering of the degrees of freedom. */
-class L2ElementRestriction : public ElementRestrictionOperator
+class L2ElementRestriction : public Operator
 {
    const int ne;
    const int vdim;

--- a/fem/restriction.hpp
+++ b/fem/restriction.hpp
@@ -21,10 +21,45 @@ namespace mfem
 class FiniteElementSpace;
 enum class ElementDofOrdering;
 
+/// Abstract base class that defines an interface for element restrictions.
+class ElementRestriction : public Operator
+{
+public:
+   /** @brief Extract the degrees of freedom from @a x into @a y. */
+   void Mult(const Vector &x, Vector &y) const override = 0;
+
+   /** @brief Set the degrees of freedom in the element degrees of freedom
+       @a y to the values given in @a x. */
+   void MultTranspose(const Vector &x, Vector &y) const override
+   {
+      y = 0.0;
+      AddMultTranspose(x, y);
+   }
+
+   /** @brief Add the degrees of freedom @a x to the element degrees of
+       freedom @a y. */
+   void AddMultTranspose(const Vector &x, Vector &y,
+                         const double a = 1.0) const override = 0;
+
+   /** @brief Add the degrees of freedom @a x to the element degrees of
+       freedom @a y ignoring the signs from DOF orientation. */
+   virtual void MultUnsigned(const Vector &x, Vector &y) const
+   {
+      Mult(x, y);
+   }
+
+   /** @brief Add the degrees of freedom @a x to the element degrees of
+       freedom @a y ignoring the signs from DOF orientation. */
+   virtual void MultTransposeUnsigned(const Vector &x, Vector &y) const
+   {
+      MultTranspose(x, y);
+   }
+};
+
 /// Operator that converts FiniteElementSpace L-vectors to E-vectors.
 /** Objects of this type are typically created and owned by FiniteElementSpace
     objects, see FiniteElementSpace::GetElementRestriction(). */
-class ElementRestriction : public Operator
+class ConformingElementRestriction : public ElementRestriction
 {
 private:
    /** This number defines the maximum number of elements any dof can belong to
@@ -55,16 +90,18 @@ protected:
    ///@}
 
 public:
-   ElementRestriction(const FiniteElementSpace&, ElementDofOrdering);
+   ConformingElementRestriction(const FiniteElementSpace&, ElementDofOrdering);
+
    void Mult(const Vector &x, Vector &y) const override;
+
    void MultTranspose(const Vector &x, Vector &y) const override;
+
    void AddMultTranspose(const Vector &x, Vector &y,
                          const double a = 1.0) const override;
 
-   /// Compute Mult without applying signs based on DOF orientations.
-   void MultUnsigned(const Vector &x, Vector &y) const;
-   /// Compute MultTranspose without applying signs based on DOF orientations.
-   void MultTransposeUnsigned(const Vector &x, Vector &y) const;
+   void MultUnsigned(const Vector &x, Vector &y) const override;
+
+   void MultTransposeUnsigned(const Vector &x, Vector &y) const override;
 
    /// Compute MultTranspose by setting (rather than adding) element
    /// contributions; this is a left inverse of the Mult() operation
@@ -82,16 +119,13 @@ public:
    void FillSparseMatrix(const Vector &mat_ea, SparseMatrix &mat) const;
 
    /** Fill the I array of SparseMatrix corresponding to the sparsity pattern
-       given by this ElementRestriction. */
+       given by this ConformingElementRestriction. */
    int FillI(SparseMatrix &mat) const;
+
    /** Fill the J and Data arrays of SparseMatrix corresponding to the sparsity
-       pattern given by this ElementRestriction, and the values of ea_data. */
+       pattern given by this ConformingElementRestriction, and the values of
+       ea_data. */
    void FillJAndData(const Vector &ea_data, SparseMatrix &mat) const;
-   /// @private Not part of the public interface (device kernel limitation).
-   ///
-   /// Performs either MultTranspose or AddMultTranspose depending on the
-   /// boolean template parameter @a ADD.
-   template <bool ADD> void TAddMultTranspose(const Vector &x, Vector &y) const;
 };
 
 /// Operator that converts L2 FiniteElementSpace L-vectors to E-vectors.
@@ -99,37 +133,39 @@ public:
     objects, see FiniteElementSpace::GetElementRestriction(). L-vectors
     corresponding to grid functions in L2 finite element spaces differ from
     E-vectors only in the ordering of the degrees of freedom. */
-class L2ElementRestriction : public Operator
+class L2ElementRestriction : public ElementRestriction
 {
+private:
    const int ne;
    const int vdim;
    const bool byvdim;
    const int ndof;
    const int ndofs;
+
 public:
    L2ElementRestriction(const FiniteElementSpace&);
+
    void Mult(const Vector &x, Vector &y) const override;
+
    void MultTranspose(const Vector &x, Vector &y) const override;
+
    void AddMultTranspose(const Vector &x, Vector &y,
                          const double a = 1.0) const override;
+
    /** Fill the I array of SparseMatrix corresponding to the sparsity pattern
        given by this ElementRestriction. */
    void FillI(SparseMatrix &mat) const;
+
    /** Fill the J and Data arrays of SparseMatrix corresponding to the sparsity
        pattern given by this L2FaceRestriction, and the values of ea_data. */
    void FillJAndData(const Vector &ea_data, SparseMatrix &mat) const;
-   /// @private Not part of the public interface (device kernel limitation).
-   ///
-   /// Performs either MultTranspose or AddMultTranspose depending on the
-   /// boolean template parameter @a ADD.
-   template <bool ADD> void TAddMultTranspose(const Vector &x, Vector &y) const;
 };
 
 /** An enum type to specify if only e1 value is requested (SingleValued) or both
     e1 and e2 (DoubleValued). */
 enum class L2FaceValues : bool {SingleValued, DoubleValued};
 
-/** @brief Base class for operators that extracts Face degrees of freedom.
+/** @brief Abstract base class for operators that extracts Face degrees of freedom.
 
     In order to compute quantities on the faces of a mesh, it is often useful to
     extract the degrees of freedom on the faces of the elements. This class
@@ -167,6 +203,19 @@ public:
    */
    void Mult(const Vector &x, Vector &y) const override = 0;
 
+   /** @brief Set the face degrees of freedom in the element degrees of freedom
+       @a y to the values given in @a x.
+
+       @param[in]     x The face degrees of freedom on the face.
+       @param[in,out] y The L-vector of degrees of freedom to which we add the
+                        face degrees of freedom.
+   */
+   void MultTranspose(const Vector &x, Vector &y) const override
+   {
+      y = 0.0;
+      AddMultTranspose(x, y);
+   }
+
    /** @brief Add the face degrees of freedom @a x to the element degrees of
        freedom @a y.
 
@@ -175,8 +224,8 @@ public:
                         face degrees of freedom.
        @param[in]     a Scalar coefficient for addition.
    */
-   virtual void AddMultTranspose(const Vector &x, Vector &y,
-                                 const double a = 1.0) const override = 0;
+   void AddMultTranspose(const Vector &x, Vector &y,
+                         const double a = 1.0) const override = 0;
 
    /** @brief Add the face degrees of freedom @a x to the element degrees of
        freedom @a y. Perform the same computation as AddMultTranspose, but
@@ -191,19 +240,6 @@ public:
    */
    virtual void AddMultTransposeInPlace(Vector &x, Vector &y) const
    {
-      AddMultTranspose(x, y);
-   }
-
-   /** @brief Set the face degrees of freedom in the element degrees of freedom
-       @a y to the values given in @a x.
-
-       @param[in]     x The face degrees of freedom on the face.
-       @param[in,out] y The L-vector of degrees of freedom to which we add the
-                        face degrees of freedom.
-   */
-   void MultTranspose(const Vector &x, Vector &y) const override
-   {
-      y = 0.0;
       AddMultTranspose(x, y);
    }
 };
@@ -242,6 +278,7 @@ protected:
                              const ElementDofOrdering f_ordering,
                              const FaceType type,
                              bool build);
+
 public:
    /** @brief Construct a ConformingFaceRestriction.
 
@@ -800,6 +837,7 @@ protected:
                        const FaceType type,
                        const L2FaceValues m,
                        bool build);
+
 public:
    /** @brief Constructs an NCL2FaceRestriction, this is a specialization of a
        L2FaceRestriction for nonconforming meshes.

--- a/fem/transfer.cpp
+++ b/fem/transfer.cpp
@@ -1159,12 +1159,12 @@ TensorProductPRefinementTransferOperator(
    localL.UseDevice(true);
    localH.UseDevice(true);
 
-   MFEM_VERIFY(dynamic_cast<const ElementRestriction*>(elem_restrict_lex_h),
+   const auto *elem_restrict =
+      dynamic_cast<const ConformingElementRestriction*>(elem_restrict_lex_h);
+   MFEM_VERIFY(elem_restrict,
                "High order element restriction is of unsupported type");
-
    mask.SetSize(localH.Size(), Device::GetMemoryType());
-   static_cast<const ElementRestriction*>(elem_restrict_lex_h)
-   ->BooleanMask(mask);
+   elem_restrict->BooleanMask(mask);
    mask.UseDevice(true);
 }
 


### PR DESCRIPTION
EDIT: 

Following @v-dobrev's [comment below](https://github.com/mfem/mfem/pull/3599#issuecomment-1504921131), I have adjusted the idea of this PR to provide a minor cleanup in a different way.

This PR now renames the abstract base class `ElementRestrictionOperator` to `ElementRestriction` to be consistent with `FaceRestriction` (likewise for the derived `ConformingElementRestriction` class to be similar to `ConformingFaceRestriction`). It makes more use of this abstract base class in order to make the interface cleaner and removes the need for a lot of `dynamic_cast`s in usage of `ElementRestriction` objects.

Previous heading:

This is a minor change from the discussion [here](https://github.com/mfem/mfem/pull/3526#discussion_r1163532449), which recognizes that there is no need for the intermediate `ElementRestrictionOperator` abstract base class after #3075. 

In the future we may want a common base class for all element restriction classes which have specific functionality, for example for mixed meshes or variable orders. However adding these features will require substantial other code additions and changes and so I propose removing this for now in an effort to simplify and reduce unnecessary abstraction layers until such a larger project is undertaken in the future.

@v-dobrev @pazner 
