### PR TITLE
libCEED interface: Support for vector and matrix coefficients and boundary integrator partial/matrix-free assembly

### DIFF
--- a/fem/CMakeLists.txt
+++ b/fem/CMakeLists.txt
@@ -77,13 +77,13 @@ set(SRCS
   hybridization.cpp
   intrules.cpp
   ceed/interface/basis.cpp
-  ceed/interface/restriction.cpp
   ceed/interface/operator.cpp
+  ceed/interface/restriction.cpp
   ceed/interface/util.cpp
+  ceed/integrators/mass/mass.cpp
   ceed/integrators/convection/convection.cpp
   ceed/integrators/diffusion/diffusion.cpp
   ceed/integrators/nlconvection/nlconvection.cpp
-  ceed/integrators/mass/mass.cpp
   ceed/solvers/algebraic.cpp
   ceed/solvers/full-assembly.cpp
   ceed/solvers/solvers-atpmg.cpp
@@ -185,16 +185,23 @@ set(HDRS
   hybridization.hpp
   intrules.hpp
   ceed/interface/basis.hpp
+  ceed/interface/ceed.hpp
+  ceed/interface/coefficient.hpp
   ceed/interface/integrator.hpp
   ceed/interface/interface.hpp
+  ceed/interface/mixed_integrator.hpp
   ceed/interface/operator.hpp
   ceed/interface/restriction.hpp
   ceed/interface/util.hpp
-  ceed/integrators/convection/convection.hpp
-  ceed/integrators/diffusion/diffusion.hpp
   ceed/integrators/mass/mass.hpp
+  ceed/integrators/mass/mass_qf.h
+  ceed/integrators/convection/convection.hpp
+  ceed/integrators/convection/convection_qf.h
+  ceed/integrators/diffusion/diffusion.hpp
+  ceed/integrators/diffusion/diffusion_qf.h
   ceed/integrators/nlconvection/nlconvection.hpp
-  ceed/interface/coefficient.hpp
+  ceed/integrators/nlconvection/nlconvection_qf.h
+  ceed/integrators/util/util_qf.h
   ceed/solvers/algebraic.hpp
   ceed/solvers/full-assembly.hpp
   ceed/solvers/solvers-atpmg.hpp

--- a/fem/bilininteg.hpp
+++ b/fem/bilininteg.hpp
@@ -2196,6 +2196,8 @@ public:
    using BilinearFormIntegrator::AssemblePA;
    virtual void AssemblePA(const FiniteElementSpace &fes);
 
+   virtual void AssemblePABoundary(const FiniteElementSpace &fes);
+
    virtual void AssembleDiagonalPA(Vector &diag);
 
    virtual void AddMultPA(const Vector &x, Vector &y) const;
@@ -2204,6 +2206,8 @@ public:
 
    using BilinearFormIntegrator::AssembleMF;
    virtual void AssembleMF(const FiniteElementSpace &fes);
+
+   virtual void AssembleMFBoundary(const FiniteElementSpace &fes);
 
    virtual void AssembleDiagonalMF(Vector &diag);
 
@@ -2281,6 +2285,8 @@ public:
    using BilinearFormIntegrator::AssembleMF;
    virtual void AssembleMF(const FiniteElementSpace &fes);
 
+   virtual void AssembleMFBoundary(const FiniteElementSpace &fes);
+
    virtual void AssembleDiagonalMF(Vector &diag);
 
    virtual void AddMultMF(const Vector &x, Vector &y) const;
@@ -2345,6 +2351,8 @@ public:
    using BilinearFormIntegrator::AssemblePA;
    virtual void AssemblePA(const FiniteElementSpace &fes);
 
+   virtual void AssemblePABoundary(const FiniteElementSpace &fes);
+
    virtual void AssembleDiagonalPA(Vector &diag);
 
    virtual void AddMultPA(const Vector &x, Vector &y) const;
@@ -2353,6 +2361,8 @@ public:
 
    using BilinearFormIntegrator::AssembleMF;
    virtual void AssembleMF(const FiniteElementSpace &fes);
+
+   virtual void AssembleMFBoundary(const FiniteElementSpace &fes);
 
    virtual void AssembleDiagonalMF(Vector &diag);
 
@@ -2496,12 +2506,16 @@ public:
    using BilinearFormIntegrator::AssemblePA;
    virtual void AssemblePA(const FiniteElementSpace &fes);
 
+   virtual void AssemblePABoundary(const FiniteElementSpace &fes);
+
    virtual void AssembleDiagonalPA(Vector &diag);
 
    virtual void AddMultPA(const Vector &x, Vector &y) const;
 
    using BilinearFormIntegrator::AssembleMF;
    virtual void AssembleMF(const FiniteElementSpace &fes);
+
+   virtual void AssembleMFBoundary(const FiniteElementSpace &fes);
 
    virtual void AssembleDiagonalMF(Vector &diag);
 
@@ -2573,12 +2587,16 @@ public:
    using BilinearFormIntegrator::AssemblePA;
    virtual void AssemblePA(const FiniteElementSpace &fes);
 
+   virtual void AssemblePABoundary(const FiniteElementSpace &fes);
+
    virtual void AssembleDiagonalPA(Vector &diag);
 
    virtual void AddMultPA(const Vector &x, Vector &y) const;
 
    using BilinearFormIntegrator::AssembleMF;
    virtual void AssembleMF(const FiniteElementSpace &fes);
+
+   virtual void AssembleMFBoundary(const FiniteElementSpace &fes);
 
    virtual void AssembleDiagonalMF(Vector &diag);
 

--- a/fem/ceed/integrators/convection/convection.cpp
+++ b/fem/ceed/integrators/convection/convection.cpp
@@ -27,26 +27,12 @@ struct ConvectionOperatorInfo : public OperatorInfo
 {
    ConvectionContext ctx;
    ConvectionOperatorInfo(const mfem::FiniteElementSpace &fes,
-                          mfem::VectorCoefficient *VQ, double alpha)
+                          mfem::VectorCoefficient *VQ, double alpha,
+                          bool use_bdr)
    {
-      header = "/integrators/convection/convection_qf.h";
-      build_func_const = ":f_build_conv_const";
-      build_qf_const = &f_build_conv_const;
-      build_func_quad = ":f_build_conv_quad";
-      build_qf_quad = &f_build_conv_quad;
-      apply_func = ":f_apply_conv";
-      apply_qf = &f_apply_conv;
-      apply_func_mf_const = ":f_apply_conv_mf_const";
-      apply_qf_mf_const = &f_apply_conv_mf_const;
-      apply_func_mf_quad = ":f_apply_conv_mf_quad";
-      apply_qf_mf_quad = &f_apply_conv_mf_quad;
-      trial_op = EvalMode::Grad;
-      test_op = EvalMode::Interp;
-      qdatasize = fes.GetMesh()->Dimension();
-
       MFEM_VERIFY(VQ && VQ->GetVDim() == fes.GetMesh()->SpaceDimension(),
                   "Incorrect coefficient dimensions in ceed::ConvectionOperatorInfo!");
-      ctx.dim = fes.GetMesh()->Dimension();
+      ctx.dim = fes.GetMesh()->Dimension() - (use_bdr * 1);
       ctx.space_dim = fes.GetMesh()->SpaceDimension();
       if (VectorConstantCoefficient *const_coeff =
              dynamic_cast<VectorConstantCoefficient *>(VQ))
@@ -61,63 +47,50 @@ struct ConvectionOperatorInfo : public OperatorInfo
          }
       }
       ctx.alpha = alpha;
+
+      header = "/integrators/convection/convection_qf.h";
+      build_func_const = ":f_build_conv_const";
+      build_qf_const = &f_build_conv_const;
+      build_func_quad = ":f_build_conv_quad";
+      build_qf_quad = &f_build_conv_quad;
+      apply_func = ":f_apply_conv";
+      apply_qf = &f_apply_conv;
+      apply_func_mf_const = ":f_apply_conv_mf_const";
+      apply_qf_mf_const = &f_apply_conv_mf_const;
+      apply_func_mf_quad = ":f_apply_conv_mf_quad";
+      apply_qf_mf_quad = &f_apply_conv_mf_quad;
+      trial_op = EvalMode::Grad;
+      test_op = EvalMode::Interp;
+      qdatasize = ctx.dim;
    }
 };
 #endif
 
 PAConvectionIntegrator::PAConvectionIntegrator(
-   const mfem::FiniteElementSpace &fes,
-   const mfem::IntegrationRule &irm,
-   mfem::VectorCoefficient *VQ,
-   const double alpha)
-   : PAIntegrator()
-{
-#ifdef MFEM_USE_CEED
-   ConvectionOperatorInfo info(fes, VQ, alpha);
-   Assemble(info, fes, irm, VQ);
-#else
-   MFEM_ABORT("MFEM must be built with MFEM_USE_CEED=YES to use libCEED.");
-#endif
-}
-
-MixedPAConvectionIntegrator::MixedPAConvectionIntegrator(
-   const ConvectionIntegrator &integ,
+   const mfem::ConvectionIntegrator &integ,
    const mfem::FiniteElementSpace &fes,
    mfem::VectorCoefficient *VQ,
-   const double alpha)
+   const double alpha,
+   const bool use_bdr)
 {
 #ifdef MFEM_USE_CEED
-   ConvectionOperatorInfo info(fes, VQ, alpha);
-   Assemble(integ, info, fes, VQ);
+   ConvectionOperatorInfo info(fes, VQ, alpha, use_bdr);
+   Assemble(integ, info, fes, VQ, use_bdr);
 #else
    MFEM_ABORT("MFEM must be built with MFEM_USE_CEED=YES to use libCEED.");
 #endif
 }
 
 MFConvectionIntegrator::MFConvectionIntegrator(
-   const mfem::FiniteElementSpace &fes,
-   const mfem::IntegrationRule &irm,
-   mfem::VectorCoefficient *VQ,
-   const double alpha)
-   : MFIntegrator()
-{
-#ifdef MFEM_USE_CEED
-   ConvectionOperatorInfo info(fes, VQ, alpha);
-   Assemble(info, fes, irm, VQ);
-#else
-   MFEM_ABORT("MFEM must be built with MFEM_USE_CEED=YES to use libCEED.");
-#endif
-}
-
-MixedMFConvectionIntegrator::MixedMFConvectionIntegrator(
-   const ConvectionIntegrator &integ,
+   const mfem::ConvectionIntegrator &integ,
    const mfem::FiniteElementSpace &fes,
    mfem::VectorCoefficient *VQ,
-   const double alpha)
+   const double alpha,
+   const bool use_bdr)
 {
 #ifdef MFEM_USE_CEED
-   ConvectionOperatorInfo info(fes, VQ, alpha);
-   Assemble(integ, info, fes, VQ);
+   ConvectionOperatorInfo info(fes, VQ, alpha, use_bdr);
+   Assemble(integ, info, fes, VQ, use_bdr, true);
 #else
    MFEM_ABORT("MFEM must be built with MFEM_USE_CEED=YES to use libCEED.");
 #endif

--- a/fem/ceed/integrators/convection/convection.cpp
+++ b/fem/ceed/integrators/convection/convection.cpp
@@ -32,7 +32,7 @@ struct ConvectionOperatorInfo : public OperatorInfo
    {
       MFEM_VERIFY(VQ && VQ->GetVDim() == fes.GetMesh()->SpaceDimension(),
                   "Incorrect coefficient dimensions in ceed::ConvectionOperatorInfo!");
-      ctx.dim = fes.GetMesh()->Dimension() - (use_bdr * 1);
+      ctx.dim = fes.GetMesh()->Dimension() - use_bdr;
       ctx.space_dim = fes.GetMesh()->SpaceDimension();
       if (VectorConstantCoefficient *const_coeff =
              dynamic_cast<VectorConstantCoefficient *>(VQ))

--- a/fem/ceed/integrators/convection/convection.hpp
+++ b/fem/ceed/integrators/convection/convection.hpp
@@ -12,7 +12,6 @@
 #ifndef MFEM_LIBCEED_CONV_HPP
 #define MFEM_LIBCEED_CONV_HPP
 
-#include "../../interface/integrator.hpp"
 #include "../../interface/mixed_integrator.hpp"
 #include "../../../fespace.hpp"
 
@@ -23,41 +22,25 @@ namespace ceed
 {
 
 /// Represent a ConvectionIntegrator with AssemblyLevel::Partial using libCEED.
-class PAConvectionIntegrator : public PAIntegrator
+class PAConvectionIntegrator : public MixedIntegrator
 {
 public:
-   PAConvectionIntegrator(const mfem::FiniteElementSpace &fes,
-                          const mfem::IntegrationRule &ir,
+   PAConvectionIntegrator(const mfem::ConvectionIntegrator &integ,
+                          const mfem::FiniteElementSpace &fes,
                           mfem::VectorCoefficient *VQ,
-                          const double alpha);
-};
-
-class MixedPAConvectionIntegrator : public MixedIntegrator<PAIntegrator>
-{
-public:
-   MixedPAConvectionIntegrator(const ConvectionIntegrator &integ,
-                               const mfem::FiniteElementSpace &fes,
-                               mfem::VectorCoefficient *VQ,
-                               const double alpha);
+                          const double alpha,
+                          const bool use_bdr = false);
 };
 
 /// Represent a ConvectionIntegrator with AssemblyLevel::None using libCEED.
-class MFConvectionIntegrator : public MFIntegrator
+class MFConvectionIntegrator : public MixedIntegrator
 {
 public:
-   MFConvectionIntegrator(const mfem::FiniteElementSpace &fes,
-                          const mfem::IntegrationRule &ir,
+   MFConvectionIntegrator(const mfem::ConvectionIntegrator &integ,
+                          const mfem::FiniteElementSpace &fes,
                           mfem::VectorCoefficient *VQ,
-                          const double alpha);
-};
-
-class MixedMFConvectionIntegrator : public MixedIntegrator<MFIntegrator>
-{
-public:
-   MixedMFConvectionIntegrator(const ConvectionIntegrator &integ,
-                               const mfem::FiniteElementSpace &fes,
-                               mfem::VectorCoefficient *VQ,
-                               const double alpha);
+                          const double alpha,
+                          const bool use_bdr = false);
 };
 
 }

--- a/fem/ceed/integrators/convection/convection.hpp
+++ b/fem/ceed/integrators/convection/convection.hpp
@@ -28,7 +28,7 @@ class PAConvectionIntegrator : public PAIntegrator
 public:
    PAConvectionIntegrator(const mfem::FiniteElementSpace &fes,
                           const mfem::IntegrationRule &ir,
-                          mfem::VectorCoefficient *Q,
+                          mfem::VectorCoefficient *VQ,
                           const double alpha);
 };
 
@@ -37,7 +37,7 @@ class MixedPAConvectionIntegrator : public MixedIntegrator<PAIntegrator>
 public:
    MixedPAConvectionIntegrator(const ConvectionIntegrator &integ,
                                const mfem::FiniteElementSpace &fes,
-                               mfem::VectorCoefficient *Q,
+                               mfem::VectorCoefficient *VQ,
                                const double alpha);
 };
 
@@ -47,7 +47,7 @@ class MFConvectionIntegrator : public MFIntegrator
 public:
    MFConvectionIntegrator(const mfem::FiniteElementSpace &fes,
                           const mfem::IntegrationRule &ir,
-                          mfem::VectorCoefficient *Q,
+                          mfem::VectorCoefficient *VQ,
                           const double alpha);
 };
 
@@ -56,7 +56,7 @@ class MixedMFConvectionIntegrator : public MixedIntegrator<MFIntegrator>
 public:
    MixedMFConvectionIntegrator(const ConvectionIntegrator &integ,
                                const mfem::FiniteElementSpace &fes,
-                               mfem::VectorCoefficient *Q,
+                               mfem::VectorCoefficient *VQ,
                                const double alpha);
 };
 

--- a/fem/ceed/integrators/convection/convection_qf.h
+++ b/fem/ceed/integrators/convection/convection_qf.h
@@ -17,7 +17,8 @@
 #define LIBCEED_CONV_COEFF_COMP_MAX 3
 
 /// A structure used to pass additional data to f_build_conv and f_apply_conv
-struct ConvectionContext {
+struct ConvectionContext
+{
    CeedInt dim, space_dim;
    CeedScalar coeff[LIBCEED_CONV_COEFF_COMP_MAX];
    CeedScalar alpha;

--- a/fem/ceed/integrators/convection/convection_qf.h
+++ b/fem/ceed/integrators/convection/convection_qf.h
@@ -12,7 +12,7 @@
 #ifndef MFEM_LIBCEED_CONV_QF_H
 #define MFEM_LIBCEED_CONV_QF_H
 
-#include "../qf_utils.h"
+#include "../util/util_qf.h"
 
 #define LIBCEED_CONV_COEFF_COMP_MAX 3
 

--- a/fem/ceed/integrators/convection/convection_qf.h
+++ b/fem/ceed/integrators/convection/convection_qf.h
@@ -41,32 +41,32 @@ CEED_QFUNCTION(f_build_conv_const)(void *ctx, CeedInt Q,
    switch (10 * bc->space_dim + bc->dim)
    {
       case 11:
-         for (CeedInt i = 0; i < Q; i++)
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
             const CeedScalar coeff0 = coeff[0];
             qd[i] = alpha * coeff0 * qw[i] * J[i];
          }
          break;
       case 21:
-         for (CeedInt i = 0; i < Q; i++)
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
             MultCtAdjJt21(J + i, Q, coeff, 1, alpha * qw[i], Q, qd + i);
          }
          break;
       case 22:
-         for (CeedInt i = 0; i < Q; i++)
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
             MultCtAdjJt22(J + i, Q, coeff, 1, alpha * qw[i], Q, qd + i);
          }
          break;
       case 32:
-         for (CeedInt i = 0; i < Q; i++)
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
             MultCtAdjJt32(J + i, Q, coeff, 1, alpha * qw[i], Q, qd + i);
          }
          break;
       case 33:
-         for (CeedInt i = 0; i < Q; i++)
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
             MultCtAdjJt33(J + i, Q, coeff, 1, alpha * qw[i], Q, qd + i);
          }
@@ -93,32 +93,32 @@ CEED_QFUNCTION(f_build_conv_quad)(void *ctx, CeedInt Q,
    switch (10 * bc->space_dim + bc->dim)
    {
       case 11:
-         for (CeedInt i = 0; i < Q; i++)
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
             const CeedScalar coeff = c[i];
             qd[i] = alpha * coeff * qw[i] * J[i];
          }
          break;
       case 21:
-         for (CeedInt i = 0; i < Q; i++)
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
             MultCtAdjJt21(J + i, Q, c + i, Q, alpha * qw[i], Q, qd + i);
          }
          break;
       case 22:
-         for (CeedInt i = 0; i < Q; i++)
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
             MultCtAdjJt22(J + i, Q, c + i, Q, alpha * qw[i], Q, qd + i);
          }
          break;
       case 32:
-         for (CeedInt i = 0; i < Q; i++)
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
             MultCtAdjJt32(J + i, Q, c + i, Q, alpha * qw[i], Q, qd + i);
          }
          break;
       case 33:
-         for (CeedInt i = 0; i < Q; i++)
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
             MultCtAdjJt33(J + i, Q, c + i, Q, alpha * qw[i], Q, qd + i);
          }
@@ -140,13 +140,13 @@ CEED_QFUNCTION(f_apply_conv)(void *ctx, CeedInt Q,
    switch (bc->dim)
    {
       case 1:
-         for (CeedInt i = 0; i < Q; i++)
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
             vg[i] = ug[i] * qd[i];
          }
          break;
       case 2:
-         for (CeedInt i = 0; i < Q; i++)
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
             const CeedScalar ug0 = ug[i + Q * 0];
             const CeedScalar ug1 = ug[i + Q * 1];
@@ -154,7 +154,7 @@ CEED_QFUNCTION(f_apply_conv)(void *ctx, CeedInt Q,
          }
          break;
       case 3:
-         for (CeedInt i = 0; i < Q; i++)
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
             const CeedScalar ug0 = ug[i + Q * 0];
             const CeedScalar ug1 = ug[i + Q * 1];
@@ -185,7 +185,7 @@ CEED_QFUNCTION(f_apply_conv_mf_const)(void *ctx, CeedInt Q,
    switch (10 * bc->space_dim + bc->dim)
    {
       case 11:
-         for (CeedInt i = 0; i < Q; i++)
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
             const CeedScalar coeff0 = coeff[0];
             const CeedScalar qd = alpha * coeff0 * qw[i] * J[i];
@@ -193,7 +193,7 @@ CEED_QFUNCTION(f_apply_conv_mf_const)(void *ctx, CeedInt Q,
          }
          break;
       case 21:
-         for (CeedInt i = 0; i < Q; i++)
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
             CeedScalar qd;
             MultCtAdjJt21(J + i, Q, coeff, 1, alpha * qw[i], 1, &qd);
@@ -201,7 +201,7 @@ CEED_QFUNCTION(f_apply_conv_mf_const)(void *ctx, CeedInt Q,
          }
          break;
       case 22:
-         for (CeedInt i = 0; i < Q; i++)
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
             CeedScalar qd[2];
             MultCtAdjJt22(J + i, Q, coeff, 1, alpha * qw[i], 1, qd);
@@ -211,7 +211,7 @@ CEED_QFUNCTION(f_apply_conv_mf_const)(void *ctx, CeedInt Q,
          }
          break;
       case 32:
-         for (CeedInt i = 0; i < Q; i++)
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
             CeedScalar qd[2];
             MultCtAdjJt32(J + i, Q, coeff, 1, alpha * qw[i], 1, qd);
@@ -221,7 +221,7 @@ CEED_QFUNCTION(f_apply_conv_mf_const)(void *ctx, CeedInt Q,
          }
          break;
       case 33:
-         for (CeedInt i = 0; i < Q; i++)
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
             CeedScalar qd[3];
             MultCtAdjJt33(J + i, Q, coeff, 1, alpha * qw[i], 1, qd);
@@ -253,14 +253,14 @@ CEED_QFUNCTION(f_apply_conv_mf_quad)(void *ctx, CeedInt Q,
    switch (10 * bc->space_dim + bc->dim)
    {
       case 11:
-         for (CeedInt i = 0; i < Q; i++)
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
             const CeedScalar qd = alpha * c[i] * qw[i] * J[i];
             vg[i] = ug[i] * qd;
          }
          break;
       case 21:
-         for (CeedInt i = 0; i < Q; i++)
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
             CeedScalar qd;
             MultCtAdjJt21(J + i, Q, c + i, Q, alpha * qw[i], 1, &qd);
@@ -268,7 +268,7 @@ CEED_QFUNCTION(f_apply_conv_mf_quad)(void *ctx, CeedInt Q,
          }
          break;
       case 22:
-         for (CeedInt i = 0; i < Q; i++)
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
             CeedScalar qd[2];
             MultCtAdjJt22(J + i, Q, c + i, Q, alpha * qw[i], 1, qd);
@@ -278,7 +278,7 @@ CEED_QFUNCTION(f_apply_conv_mf_quad)(void *ctx, CeedInt Q,
          }
          break;
       case 32:
-         for (CeedInt i = 0; i < Q; i++)
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
             CeedScalar qd[2];
             MultCtAdjJt32(J + i, Q, c + i, Q, alpha * qw[i], 1, qd);
@@ -288,7 +288,7 @@ CEED_QFUNCTION(f_apply_conv_mf_quad)(void *ctx, CeedInt Q,
          }
          break;
       case 33:
-         for (CeedInt i = 0; i < Q; i++)
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
             CeedScalar qd[3];
             MultCtAdjJt33(J + i, Q, c + i, Q, alpha * qw[i], 1, qd);

--- a/fem/ceed/integrators/convection/convection_qf.h
+++ b/fem/ceed/integrators/convection/convection_qf.h
@@ -9,10 +9,17 @@
 // terms of the BSD-3 license. We welcome feedback and contributions, see file
 // CONTRIBUTING.md for details.
 
+#ifndef MFEM_LIBCEED_CONV_QF_H
+#define MFEM_LIBCEED_CONV_QF_H
+
+#include "../qf_utils.h"
+
+#define LIBCEED_CONV_COEFF_COMP_MAX 3
+
 /// A structure used to pass additional data to f_build_conv and f_apply_conv
 struct ConvectionContext {
-   CeedInt dim, space_dim, vdim;
-   CeedScalar coeff[3];
+   CeedInt dim, space_dim;
+   CeedScalar coeff[LIBCEED_CONV_COEFF_COMP_MAX];
    CeedScalar alpha;
 };
 
@@ -22,72 +29,46 @@ CEED_QFUNCTION(f_build_conv_const)(void *ctx, CeedInt Q,
                                    const CeedScalar *const *in,
                                    CeedScalar *const *out)
 {
-   ConvectionContext *bc = (ConvectionContext*)ctx;
-   // in[0] is Jacobians with shape [dim, nc=dim, Q]
+   ConvectionContext *bc = (ConvectionContext *)ctx;
+   // in[0] is Jacobians with shape [dim, ncomp=space_dim, Q]
    // in[1] is quadrature weights, size (Q)
    //
-   // At every quadrature point, compute and store qw * adj(J).
-   const CeedScalar coeff0 = bc->coeff[0];
-   const CeedScalar coeff1 = bc->coeff[1];
-   const CeedScalar coeff2 = bc->coeff[2];
+   // At every quadrature point, compute and store qw * α * c^T adj(J)^T.
    const CeedScalar alpha  = bc->alpha;
+   const CeedScalar *coeff = bc->coeff;
    const CeedScalar *J = in[0], *qw = in[1];
    CeedScalar *qd = out[0];
-   switch (bc->dim + 10 * bc->space_dim)
+   switch (10 * bc->space_dim + bc->dim)
    {
       case 11:
          for (CeedInt i = 0; i < Q; i++)
          {
+            const CeedScalar coeff0 = coeff[0];
             qd[i] = alpha * coeff0 * qw[i] * J[i];
+         }
+         break;
+      case 21:
+         for (CeedInt i = 0; i < Q; i++)
+         {
+            MultCtAdjJt21(J + i, Q, coeff, 1, alpha * qw[i], Q, qd + i);
          }
          break;
       case 22:
          for (CeedInt i = 0; i < Q; i++)
          {
-            // J: 0 2   qd: 0 1   adj(J):  J22 -J12
-            //    1 3       1 2           -J21  J11
-            const CeedScalar J11 = J[i + Q * 0];
-            const CeedScalar J21 = J[i + Q * 1];
-            const CeedScalar J12 = J[i + Q * 2];
-            const CeedScalar J22 = J[i + Q * 3];
-            const CeedScalar w = alpha * qw[i];
-            const CeedScalar wx = w * coeff0;
-            const CeedScalar wy = w * coeff1;
-            qd[i + Q * 0] =  wx * J22 - wy * J12;
-            qd[i + Q * 1] = -wx * J21 + wy * J11;
+            MultCtAdjJt22(J + i, Q, coeff, 1, alpha * qw[i], Q, qd + i);
+         }
+         break;
+      case 32:
+         for (CeedInt i = 0; i < Q; i++)
+         {
+            MultCtAdjJt32(J + i, Q, coeff, 1, alpha * qw[i], Q, qd + i);
          }
          break;
       case 33:
          for (CeedInt i = 0; i < Q; i++)
          {
-            // J: 0 3 6   qd: 0 1 2
-            //    1 4 7       1 3 4
-            //    2 5 8       2 4 5
-            const CeedScalar J11 = J[i + Q * 0];
-            const CeedScalar J21 = J[i + Q * 1];
-            const CeedScalar J31 = J[i + Q * 2];
-            const CeedScalar J12 = J[i + Q * 3];
-            const CeedScalar J22 = J[i + Q * 4];
-            const CeedScalar J32 = J[i + Q * 5];
-            const CeedScalar J13 = J[i + Q * 6];
-            const CeedScalar J23 = J[i + Q * 7];
-            const CeedScalar J33 = J[i + Q * 8];
-            const CeedScalar A11 = J22 * J33 - J23 * J32;
-            const CeedScalar A12 = J13 * J32 - J12 * J33;
-            const CeedScalar A13 = J12 * J23 - J13 * J22;
-            const CeedScalar A21 = J23 * J31 - J21 * J33;
-            const CeedScalar A22 = J11 * J33 - J13 * J31;
-            const CeedScalar A23 = J13 * J21 - J11 * J23;
-            const CeedScalar A31 = J21 * J32 - J22 * J31;
-            const CeedScalar A32 = J12 * J31 - J11 * J32;
-            const CeedScalar A33 = J11 * J22 - J12 * J21;
-            const CeedScalar w = alpha * qw[i];
-            const CeedScalar wx = w * coeff0;
-            const CeedScalar wy = w * coeff1;
-            const CeedScalar wz = w * coeff2;
-            qd[i + Q * 0] = wx * A11 + wy * A12 + wz * A13;
-            qd[i + Q * 1] = wx * A21 + wy * A22 + wz * A23;
-            qd[i + Q * 2] = wx * A31 + wy * A32 + wz * A33;
+            MultCtAdjJt33(J + i, Q, coeff, 1, alpha * qw[i], Q, qd + i);
          }
          break;
    }
@@ -101,14 +82,15 @@ CEED_QFUNCTION(f_build_conv_quad)(void *ctx, CeedInt Q,
                                   CeedScalar *const *out)
 {
    ConvectionContext *bc = (ConvectionContext *)ctx;
-   // in[1] is Jacobians with shape [dim, nc=dim, Q]
+   // in[0] is coefficients with shape [ncomp=space_dim, Q]
+   // in[1] is Jacobians with shape [dim, ncomp=space_dim, Q]
    // in[2] is quadrature weights, size (Q)
    //
-   // At every quadrature point, compute and store qw * adj(J).
-   const CeedScalar *c = in[0], *J = in[1], *qw = in[2];
+   // At every quadrature point, compute and store qw * α * c^T adj(J)^T.
    const CeedScalar alpha  = bc->alpha;
+   const CeedScalar *c = in[0], *J = in[1], *qw = in[2];
    CeedScalar *qd = out[0];
-   switch (bc->dim + 10 * bc->space_dim)
+   switch (10 * bc->space_dim + bc->dim)
    {
       case 11:
          for (CeedInt i = 0; i < Q; i++)
@@ -117,53 +99,28 @@ CEED_QFUNCTION(f_build_conv_quad)(void *ctx, CeedInt Q,
             qd[i] = alpha * coeff * qw[i] * J[i];
          }
          break;
+      case 21:
+         for (CeedInt i = 0; i < Q; i++)
+         {
+            MultCtAdjJt21(J + i, Q, c + i, Q, alpha * qw[i], Q, qd + i);
+         }
+         break;
       case 22:
          for (CeedInt i = 0; i < Q; i++)
          {
-            // J: 0 2   qd: 0 1   adj(J):  J22 -J12
-            //    1 3       1 2           -J21  J11
-            const CeedScalar J11 = J[i + Q * 0];
-            const CeedScalar J21 = J[i + Q * 1];
-            const CeedScalar J12 = J[i + Q * 2];
-            const CeedScalar J22 = J[i + Q * 3];
-            const CeedScalar w = alpha * qw[i];
-            const CeedScalar wx = w * c[i + Q * 0];
-            const CeedScalar wy = w * c[i + Q * 1];
-            qd[i + Q * 0] =  wx * J22 - wy * J12;
-            qd[i + Q * 1] = -wx * J21 + wy * J11;
+            MultCtAdjJt22(J + i, Q, c + i, Q, alpha * qw[i], Q, qd + i);
+         }
+         break;
+      case 32:
+         for (CeedInt i = 0; i < Q; i++)
+         {
+            MultCtAdjJt32(J + i, Q, c + i, Q, alpha * qw[i], Q, qd + i);
          }
          break;
       case 33:
          for (CeedInt i = 0; i < Q; i++)
          {
-            // J: 0 3 6   qd: 0 1 2
-            //    1 4 7       1 3 4
-            //    2 5 8       2 4 5
-            const CeedScalar J11 = J[i + Q * 0];
-            const CeedScalar J21 = J[i + Q * 1];
-            const CeedScalar J31 = J[i + Q * 2];
-            const CeedScalar J12 = J[i + Q * 3];
-            const CeedScalar J22 = J[i + Q * 4];
-            const CeedScalar J32 = J[i + Q * 5];
-            const CeedScalar J13 = J[i + Q * 6];
-            const CeedScalar J23 = J[i + Q * 7];
-            const CeedScalar J33 = J[i + Q * 8];
-            const CeedScalar A11 = J22 * J33 - J23 * J32;
-            const CeedScalar A12 = J13 * J32 - J12 * J33;
-            const CeedScalar A13 = J12 * J23 - J13 * J22;
-            const CeedScalar A21 = J23 * J31 - J21 * J33;
-            const CeedScalar A22 = J11 * J33 - J13 * J31;
-            const CeedScalar A23 = J13 * J21 - J11 * J23;
-            const CeedScalar A31 = J21 * J32 - J22 * J31;
-            const CeedScalar A32 = J12 * J31 - J11 * J32;
-            const CeedScalar A33 = J11 * J22 - J12 * J21;
-            const CeedScalar w = alpha * qw[i];
-            const CeedScalar wx = w * c[i + Q * 0];
-            const CeedScalar wy = w * c[i + Q * 1];
-            const CeedScalar wz = w * c[i + Q * 2];
-            qd[i + Q * 0] = wx * A11 + wy * A12 + wz * A13;
-            qd[i + Q * 1] = wx * A21 + wy * A22 + wz * A23;
-            qd[i + Q * 2] = wx * A31 + wy * A32 + wz * A33;
+            MultCtAdjJt33(J + i, Q, c + i, Q, alpha * qw[i], Q, qd + i);
          }
          break;
    }
@@ -176,18 +133,19 @@ CEED_QFUNCTION(f_apply_conv)(void *ctx, CeedInt Q,
                              CeedScalar *const *out)
 {
    ConvectionContext *bc = (ConvectionContext *)ctx;
-   // in[0], out[0] have shape [dim, nc=1, Q]
+   // in[0] has shape [dim, ncomp=1, Q]
+   // out[0] has shape [ncomp=1, Q]
    const CeedScalar *ug = in[0], *qd = in[1];
    CeedScalar *vg = out[0];
-   switch (10*bc->dim + bc->vdim)
+   switch (bc->dim)
    {
-      case 11:
+      case 1:
          for (CeedInt i = 0; i < Q; i++)
          {
             vg[i] = ug[i] * qd[i];
          }
          break;
-      case 21:
+      case 2:
          for (CeedInt i = 0; i < Q; i++)
          {
             const CeedScalar ug0 = ug[i + Q * 0];
@@ -195,41 +153,13 @@ CEED_QFUNCTION(f_apply_conv)(void *ctx, CeedInt Q,
             vg[i] = qd[i + Q * 0] * ug0 + qd[i + Q * 1] * ug1;
          }
          break;
-      case 22:
-         for (CeedInt i = 0; i < Q; i++)
-         {
-            const CeedScalar qd0 = qd[i + Q * 0];
-            const CeedScalar qd1 = qd[i + Q * 1];
-            for (CeedInt c = 0; c < 2; c++)
-            {
-               const CeedScalar ug0 = ug[i + Q * (c+2*0)];
-               const CeedScalar ug1 = ug[i + Q * (c+2*1)];
-               vg[i + Q * c] = qd0 * ug0 + qd1 * ug1;
-            }
-         }
-         break;
-      case 31:
+      case 3:
          for (CeedInt i = 0; i < Q; i++)
          {
             const CeedScalar ug0 = ug[i + Q * 0];
             const CeedScalar ug1 = ug[i + Q * 1];
             const CeedScalar ug2 = ug[i + Q * 2];
             vg[i] = qd[i + Q * 0] * ug0 + qd[i + Q * 1] * ug1 + qd[i + Q * 2] * ug2;
-         }
-         break;
-      case 33:
-         for (CeedInt i = 0; i < Q; i++)
-         {
-            const CeedScalar qd0 = qd[i + Q * 0];
-            const CeedScalar qd1 = qd[i + Q * 1];
-            const CeedScalar qd2 = qd[i + Q * 2];
-            for (CeedInt c = 0; c < 3; c++)
-            {
-               const CeedScalar ug0 = ug[i + Q * (c+3*0)];
-               const CeedScalar ug1 = ug[i + Q * (c+3*1)];
-               const CeedScalar ug2 = ug[i + Q * (c+3*2)];
-               vg[i + Q * c] = qd0 * ug0 + qd1 * ug1 + qd2 * ug2;
-            }
          }
          break;
    }
@@ -241,23 +171,23 @@ CEED_QFUNCTION(f_apply_conv_mf_const)(void *ctx, CeedInt Q,
                                       const CeedScalar *const *in,
                                       CeedScalar *const *out)
 {
-   ConvectionContext *bc = (ConvectionContext*)ctx;
-   // in[0], out[0] have shape [dim, nc=1, Q]
-   // in[1] is Jacobians with shape [dim, nc=dim, Q]
+   ConvectionContext *bc = (ConvectionContext *)ctx;
+   // in[0] has shape [dim, ncomp=1, Q]
+   // in[1] is Jacobians with shape [dim, ncomp=space_dim, Q]
    // in[2] is quadrature weights, size (Q)
+   // out[0] has shape [ncomp=1, Q]
    //
-   // At every quadrature point, compute qw * adj(J).
-   const CeedScalar coeff0 = bc->coeff[0];
-   const CeedScalar coeff1 = bc->coeff[1];
-   const CeedScalar coeff2 = bc->coeff[2];
+   // At every quadrature point, compute qw * α * c^T adj(J)^T.
    const CeedScalar alpha  = bc->alpha;
+   const CeedScalar *coeff = bc->coeff;
    const CeedScalar *ug = in[0], *J = in[1], *qw = in[2];
    CeedScalar *vg = out[0];
-   switch (10 * bc->dim + bc->vdim)
+   switch (10 * bc->space_dim + bc->dim)
    {
       case 11:
          for (CeedInt i = 0; i < Q; i++)
          {
+            const CeedScalar coeff0 = coeff[0];
             const CeedScalar qd = alpha * coeff0 * qw[i] * J[i];
             vg[i] = ug[i] * qd;
          }
@@ -265,119 +195,40 @@ CEED_QFUNCTION(f_apply_conv_mf_const)(void *ctx, CeedInt Q,
       case 21:
          for (CeedInt i = 0; i < Q; i++)
          {
-            // J: 0 2   qd: 0 1   adj(J):  J22 -J12
-            //    1 3       1 2           -J21  J11
-            const CeedScalar J11 = J[i + Q * 0];
-            const CeedScalar J21 = J[i + Q * 1];
-            const CeedScalar J12 = J[i + Q * 2];
-            const CeedScalar J22 = J[i + Q * 3];
-            const CeedScalar w = alpha * qw[i];
-            const CeedScalar wx = w * coeff0;
-            const CeedScalar wy = w * coeff1;
-            const CeedScalar qd0 =  wx * J22 - wy * J12;
-            const CeedScalar qd1 = -wx * J21 + wy * J11;
-            const CeedScalar ug0 = ug[i + Q * 0];
-            const CeedScalar ug1 = ug[i + Q * 1];
-            vg[i] = qd0 * ug0 + qd1 * ug1;
+            CeedScalar qd;
+            MultCtAdjJt21(J + i, Q, coeff, 1, alpha * qw[i], 1, &qd);
+            vg[i] = qd * ug[i];
          }
          break;
       case 22:
          for (CeedInt i = 0; i < Q; i++)
          {
-            // J: 0 2   qd: 0 1   adj(J):  J22 -J12
-            //    1 3       1 2           -J21  J11
-            const CeedScalar J11 = J[i + Q * 0];
-            const CeedScalar J21 = J[i + Q * 1];
-            const CeedScalar J12 = J[i + Q * 2];
-            const CeedScalar J22 = J[i + Q * 3];
-            const CeedScalar w = alpha * qw[i];
-            const CeedScalar wx = w * coeff0;
-            const CeedScalar wy = w * coeff1;
-            const CeedScalar qd0 =  wx * J22 - wy * J12;
-            const CeedScalar qd1 = -wx * J21 + wy * J11;
-            for (CeedInt c = 0; c < 2; c++)
-            {
-               const CeedScalar ug0 = ug[i + Q * (c+2*0)];
-               const CeedScalar ug1 = ug[i + Q * (c+2*1)];
-               vg[i + Q * c] = qd0 * ug0 + qd1 * ug1;
-            }
-         }
-         break;
-      case 31:
-         for (CeedInt i = 0; i < Q; i++)
-         {
-            // J: 0 3 6   qd: 0 1 2
-            //    1 4 7       1 3 4
-            //    2 5 8       2 4 5
-            const CeedScalar J11 = J[i + Q * 0];
-            const CeedScalar J21 = J[i + Q * 1];
-            const CeedScalar J31 = J[i + Q * 2];
-            const CeedScalar J12 = J[i + Q * 3];
-            const CeedScalar J22 = J[i + Q * 4];
-            const CeedScalar J32 = J[i + Q * 5];
-            const CeedScalar J13 = J[i + Q * 6];
-            const CeedScalar J23 = J[i + Q * 7];
-            const CeedScalar J33 = J[i + Q * 8];
-            const CeedScalar A11 = J22 * J33 - J23 * J32;
-            const CeedScalar A12 = J13 * J32 - J12 * J33;
-            const CeedScalar A13 = J12 * J23 - J13 * J22;
-            const CeedScalar A21 = J23 * J31 - J21 * J33;
-            const CeedScalar A22 = J11 * J33 - J13 * J31;
-            const CeedScalar A23 = J13 * J21 - J11 * J23;
-            const CeedScalar A31 = J21 * J32 - J22 * J31;
-            const CeedScalar A32 = J12 * J31 - J11 * J32;
-            const CeedScalar A33 = J11 * J22 - J12 * J21;
-            const CeedScalar w = alpha * qw[i];
-            const CeedScalar wx = w * coeff0;
-            const CeedScalar wy = w * coeff1;
-            const CeedScalar wz = w * coeff2;
-            const CeedScalar qd0 = wx * A11 + wy * A12 + wz * A13;
-            const CeedScalar qd1 = wx * A21 + wy * A22 + wz * A23;
-            const CeedScalar qd2 = wx * A31 + wy * A32 + wz * A33;
+            CeedScalar qd[2];
+            MultCtAdjJt22(J + i, Q, coeff, 1, alpha * qw[i], 1, qd);
             const CeedScalar ug0 = ug[i + Q * 0];
             const CeedScalar ug1 = ug[i + Q * 1];
-            const CeedScalar ug2 = ug[i + Q * 2];
-            vg[i] = qd0 * ug0 + qd1 * ug1 + qd2 * ug2;
+            vg[i] = qd[0] * ug0 + qd[1] * ug1;
+         }
+         break;
+      case 32:
+         for (CeedInt i = 0; i < Q; i++)
+         {
+            CeedScalar qd[2];
+            MultCtAdjJt32(J + i, Q, coeff, 1, alpha * qw[i], 1, qd);
+            const CeedScalar ug0 = ug[i + Q * 0];
+            const CeedScalar ug1 = ug[i + Q * 1];
+            vg[i] = qd[0] * ug0 + qd[1] * ug1;
          }
          break;
       case 33:
          for (CeedInt i = 0; i < Q; i++)
          {
-            // J: 0 3 6   qd: 0 1 2
-            //    1 4 7       1 3 4
-            //    2 5 8       2 4 5
-            const CeedScalar J11 = J[i + Q * 0];
-            const CeedScalar J21 = J[i + Q * 1];
-            const CeedScalar J31 = J[i + Q * 2];
-            const CeedScalar J12 = J[i + Q * 3];
-            const CeedScalar J22 = J[i + Q * 4];
-            const CeedScalar J32 = J[i + Q * 5];
-            const CeedScalar J13 = J[i + Q * 6];
-            const CeedScalar J23 = J[i + Q * 7];
-            const CeedScalar J33 = J[i + Q * 8];
-            const CeedScalar A11 = J22 * J33 - J23 * J32;
-            const CeedScalar A12 = J13 * J32 - J12 * J33;
-            const CeedScalar A13 = J12 * J23 - J13 * J22;
-            const CeedScalar A21 = J23 * J31 - J21 * J33;
-            const CeedScalar A22 = J11 * J33 - J13 * J31;
-            const CeedScalar A23 = J13 * J21 - J11 * J23;
-            const CeedScalar A31 = J21 * J32 - J22 * J31;
-            const CeedScalar A32 = J12 * J31 - J11 * J32;
-            const CeedScalar A33 = J11 * J22 - J12 * J21;
-            const CeedScalar w = alpha * qw[i];
-            const CeedScalar wx = w * coeff0;
-            const CeedScalar wy = w * coeff1;
-            const CeedScalar wz = w * coeff2;
-            const CeedScalar qd0 = wx * A11 + wy * A12 + wz * A13;
-            const CeedScalar qd1 = wx * A21 + wy * A22 + wz * A23;
-            const CeedScalar qd2 = wx * A31 + wy * A32 + wz * A33;
-            for (CeedInt c = 0; c < 3; c++)
-            {
-               const CeedScalar ug0 = ug[i + Q * (c+3*0)];
-               const CeedScalar ug1 = ug[i + Q * (c+3*1)];
-               const CeedScalar ug2 = ug[i + Q * (c+3*2)];
-               vg[i + Q * c] = qd0 * ug0 + qd1 * ug1 + qd2 * ug2;
-            }
+            CeedScalar qd[3];
+            MultCtAdjJt33(J + i, Q, coeff, 1, alpha * qw[i], 1, qd);
+            const CeedScalar ug0 = ug[i + Q * 0];
+            const CeedScalar ug1 = ug[i + Q * 1];
+            const CeedScalar ug2 = ug[i + Q * 2];
+            vg[i] = qd[0] * ug0 + qd[1] * ug1 + qd[2] * ug2;
          }
          break;
    }
@@ -388,16 +239,18 @@ CEED_QFUNCTION(f_apply_conv_mf_quad)(void *ctx, CeedInt Q,
                                      const CeedScalar *const *in,
                                      CeedScalar *const *out)
 {
-   ConvectionContext *bc = (ConvectionContext*)ctx;
-   // in[0], out[0] have shape [dim, nc=1, Q]
-   // in[1] is Jacobians with shape [dim, nc=dim, Q]
-   // in[2] is quadrature weights, size (Q)
+   ConvectionContext *bc = (ConvectionContext *)ctx;
+   // in[0] is coefficients with shape [ncomp=space_dim, Q]
+   // in[1] has shape [dim, ncomp=1, Q]
+   // in[2] is Jacobians with shape [dim, ncomp=space_dim, Q]
+   // in[3] is quadrature weights, size (Q)
+   // out[0] has shape [ncomp=1, Q]
    //
-   // At every quadrature point, compute qw * adj(J).
-   const CeedScalar *c = in[0], *ug = in[1], *J = in[2], *qw = in[3];
+   // At every quadrature point, compute qw * α * c^T adj(J)^T.
    const CeedScalar alpha  = bc->alpha;
+   const CeedScalar *c = in[0], *ug = in[1], *J = in[2], *qw = in[3];
    CeedScalar *vg = out[0];
-   switch (10 * bc->dim + bc->vdim)
+   switch (10 * bc->space_dim + bc->dim)
    {
       case 11:
          for (CeedInt i = 0; i < Q; i++)
@@ -409,121 +262,44 @@ CEED_QFUNCTION(f_apply_conv_mf_quad)(void *ctx, CeedInt Q,
       case 21:
          for (CeedInt i = 0; i < Q; i++)
          {
-            // J: 0 2   qd: 0 1   adj(J):  J22 -J12
-            //    1 3       1 2           -J21  J11
-            const CeedScalar J11 = J[i + Q * 0];
-            const CeedScalar J21 = J[i + Q * 1];
-            const CeedScalar J12 = J[i + Q * 2];
-            const CeedScalar J22 = J[i + Q * 3];
-            const CeedScalar w = alpha * qw[i];
-            const CeedScalar wx = w * c[i + Q * 0];
-            const CeedScalar wy = w * c[i + Q * 1];
-            const CeedScalar qd0 =  wx * J22 - wy * J12;
-            const CeedScalar qd1 = -wx * J21 + wy * J11;
-            const CeedScalar ug0 = ug[i + Q * 0];
-            const CeedScalar ug1 = ug[i + Q * 1];
-            vg[i] = qd0 * ug0 + qd1 * ug1;
+            CeedScalar qd;
+            MultCtAdjJt21(J + i, Q, c + i, Q, alpha * qw[i], 1, &qd);
+            vg[i] = qd * ug[i];
          }
          break;
       case 22:
          for (CeedInt i = 0; i < Q; i++)
          {
-            // J: 0 2   qd: 0 1   adj(J):  J22 -J12
-            //    1 3       1 2           -J21  J11
-            const CeedScalar J11 = J[i + Q * 0];
-            const CeedScalar J21 = J[i + Q * 1];
-            const CeedScalar J12 = J[i + Q * 2];
-            const CeedScalar J22 = J[i + Q * 3];
-            const CeedScalar w = alpha * qw[i];
-            const CeedScalar wx = w * c[i + Q * 0];
-            const CeedScalar wy = w * c[i + Q * 1];
-            const CeedScalar qd0 =  wx * J22 - wy * J12;
-            const CeedScalar qd1 = -wx * J21 + wy * J11;
-            for (CeedInt d = 0; d < 2; d++)
-            {
-               const CeedScalar ug0 = ug[i + Q * (d+2*0)];
-               const CeedScalar ug1 = ug[i + Q * (d+2*1)];
-               vg[i + Q * d] = qd0 * ug0 + qd1 * ug1;
-            }
-         }
-         break;
-      case 31:
-         for (CeedInt i = 0; i < Q; i++)
-         {
-            // J: 0 3 6   qd: 0 1 2
-            //    1 4 7       1 3 4
-            //    2 5 8       2 4 5
-            const CeedScalar J11 = J[i + Q * 0];
-            const CeedScalar J21 = J[i + Q * 1];
-            const CeedScalar J31 = J[i + Q * 2];
-            const CeedScalar J12 = J[i + Q * 3];
-            const CeedScalar J22 = J[i + Q * 4];
-            const CeedScalar J32 = J[i + Q * 5];
-            const CeedScalar J13 = J[i + Q * 6];
-            const CeedScalar J23 = J[i + Q * 7];
-            const CeedScalar J33 = J[i + Q * 8];
-            const CeedScalar A11 = J22 * J33 - J23 * J32;
-            const CeedScalar A12 = J13 * J32 - J12 * J33;
-            const CeedScalar A13 = J12 * J23 - J13 * J22;
-            const CeedScalar A21 = J23 * J31 - J21 * J33;
-            const CeedScalar A22 = J11 * J33 - J13 * J31;
-            const CeedScalar A23 = J13 * J21 - J11 * J23;
-            const CeedScalar A31 = J21 * J32 - J22 * J31;
-            const CeedScalar A32 = J12 * J31 - J11 * J32;
-            const CeedScalar A33 = J11 * J22 - J12 * J21;
-            const CeedScalar w = alpha * qw[i];
-            const CeedScalar wx = w * c[i + Q * 0];
-            const CeedScalar wy = w * c[i + Q * 1];
-            const CeedScalar wz = w * c[i + Q * 2];
-            const CeedScalar qd0 = wx * A11 + wy * A12 + wz * A13;
-            const CeedScalar qd1 = wx * A21 + wy * A22 + wz * A23;
-            const CeedScalar qd2 = wx * A31 + wy * A32 + wz * A33;
+            CeedScalar qd[2];
+            MultCtAdjJt22(J + i, Q, c + i, Q, alpha * qw[i], 1, qd);
             const CeedScalar ug0 = ug[i + Q * 0];
             const CeedScalar ug1 = ug[i + Q * 1];
-            const CeedScalar ug2 = ug[i + Q * 2];
-            vg[i] = qd0 * ug0 + qd1 * ug1 + qd2 * ug2;
+            vg[i] = qd[0] * ug0 + qd[1] * ug1;
+         }
+         break;
+      case 32:
+         for (CeedInt i = 0; i < Q; i++)
+         {
+            CeedScalar qd[2];
+            MultCtAdjJt32(J + i, Q, c + i, Q, alpha * qw[i], 1, qd);
+            const CeedScalar ug0 = ug[i + Q * 0];
+            const CeedScalar ug1 = ug[i + Q * 1];
+            vg[i] = qd[0] * ug0 + qd[1] * ug1;
          }
          break;
       case 33:
          for (CeedInt i = 0; i < Q; i++)
          {
-            // J: 0 3 6   qd: 0 1 2
-            //    1 4 7       1 3 4
-            //    2 5 8       2 4 5
-            const CeedScalar J11 = J[i + Q * 0];
-            const CeedScalar J21 = J[i + Q * 1];
-            const CeedScalar J31 = J[i + Q * 2];
-            const CeedScalar J12 = J[i + Q * 3];
-            const CeedScalar J22 = J[i + Q * 4];
-            const CeedScalar J32 = J[i + Q * 5];
-            const CeedScalar J13 = J[i + Q * 6];
-            const CeedScalar J23 = J[i + Q * 7];
-            const CeedScalar J33 = J[i + Q * 8];
-            const CeedScalar A11 = J22 * J33 - J23 * J32;
-            const CeedScalar A12 = J13 * J32 - J12 * J33;
-            const CeedScalar A13 = J12 * J23 - J13 * J22;
-            const CeedScalar A21 = J23 * J31 - J21 * J33;
-            const CeedScalar A22 = J11 * J33 - J13 * J31;
-            const CeedScalar A23 = J13 * J21 - J11 * J23;
-            const CeedScalar A31 = J21 * J32 - J22 * J31;
-            const CeedScalar A32 = J12 * J31 - J11 * J32;
-            const CeedScalar A33 = J11 * J22 - J12 * J21;
-            const CeedScalar w = alpha * qw[i];
-            const CeedScalar wx = w * c[i + Q * 0];
-            const CeedScalar wy = w * c[i + Q * 1];
-            const CeedScalar wz = w * c[i + Q * 2];
-            const CeedScalar qd0 = wx * A11 + wy * A12 + wz * A13;
-            const CeedScalar qd1 = wx * A21 + wy * A22 + wz * A23;
-            const CeedScalar qd2 = wx * A31 + wy * A32 + wz * A33;
-            for (CeedInt d = 0; d < 3; d++)
-            {
-               const CeedScalar ug0 = ug[i + Q * (d+3*0)];
-               const CeedScalar ug1 = ug[i + Q * (d+3*1)];
-               const CeedScalar ug2 = ug[i + Q * (d+3*2)];
-               vg[i + Q * d] = qd0 * ug0 + qd1 * ug1 + qd2 * ug2;
-            }
+            CeedScalar qd[3];
+            MultCtAdjJt33(J + i, Q, c + i, Q, alpha * qw[i], 1, qd);
+            const CeedScalar ug0 = ug[i + Q * 0];
+            const CeedScalar ug1 = ug[i + Q * 1];
+            const CeedScalar ug2 = ug[i + Q * 2];
+            vg[i] = qd[0] * ug0 + qd[1] * ug1 + qd[2] * ug2;
          }
          break;
    }
    return 0;
 }
+
+#endif // MFEM_LIBCEED_CONV_QF_H

--- a/fem/ceed/integrators/convection/convection_qf.h
+++ b/fem/ceed/integrators/convection/convection_qf.h
@@ -240,15 +240,15 @@ CEED_QFUNCTION(f_apply_conv_mf_quad)(void *ctx, CeedInt Q,
                                      CeedScalar *const *out)
 {
    ConvectionContext *bc = (ConvectionContext *)ctx;
-   // in[0] is coefficients with shape [ncomp=space_dim, Q]
-   // in[1] has shape [dim, ncomp=1, Q]
+   // in[0] has shape [dim, ncomp=1, Q]
+   // in[1] is coefficients with shape [ncomp=space_dim, Q]
    // in[2] is Jacobians with shape [dim, ncomp=space_dim, Q]
    // in[3] is quadrature weights, size (Q)
    // out[0] has shape [ncomp=1, Q]
    //
    // At every quadrature point, compute qw * α * c^T adj(J)^T.
    const CeedScalar alpha  = bc->alpha;
-   const CeedScalar *c = in[0], *ug = in[1], *J = in[2], *qw = in[3];
+   const CeedScalar *ug = in[0], *c = in[1], *J = in[2], *qw = in[3];
    CeedScalar *vg = out[0];
    switch (10 * bc->space_dim + bc->dim)
    {

--- a/fem/ceed/integrators/convection/convection_qf.h
+++ b/fem/ceed/integrators/convection/convection_qf.h
@@ -24,7 +24,7 @@ struct ConvectionContext
    CeedScalar alpha;
 };
 
-/// libCEED Q-function for building quadrature data for a convection operator
+/// libCEED QFunction for building quadrature data for a convection operator
 /// with a constant coefficient
 CEED_QFUNCTION(f_build_conv_const)(void *ctx, CeedInt Q,
                                    const CeedScalar *const *in,
@@ -45,39 +45,39 @@ CEED_QFUNCTION(f_build_conv_const)(void *ctx, CeedInt Q,
          CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
             const CeedScalar coeff0 = coeff[0];
-            qd[i] = alpha * coeff0 * qw[i] * J[i];
+            qd[i] = qw[i] * alpha * coeff0 * J[i];
          }
          break;
       case 21:
          CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
-            MultCtAdjJt21(J + i, Q, coeff, 1, alpha * qw[i], Q, qd + i);
+            MultCtAdjJt21(J + i, Q, coeff, 1, qw[i] * alpha, Q, qd + i);
          }
          break;
       case 22:
          CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
-            MultCtAdjJt22(J + i, Q, coeff, 1, alpha * qw[i], Q, qd + i);
+            MultCtAdjJt22(J + i, Q, coeff, 1, qw[i] * alpha, Q, qd + i);
          }
          break;
       case 32:
          CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
-            MultCtAdjJt32(J + i, Q, coeff, 1, alpha * qw[i], Q, qd + i);
+            MultCtAdjJt32(J + i, Q, coeff, 1, qw[i] * alpha, Q, qd + i);
          }
          break;
       case 33:
          CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
-            MultCtAdjJt33(J + i, Q, coeff, 1, alpha * qw[i], Q, qd + i);
+            MultCtAdjJt33(J + i, Q, coeff, 1, qw[i] * alpha, Q, qd + i);
          }
          break;
    }
    return 0;
 }
 
-/// libCEED Q-function for building quadrature data for a convection operator
-/// coefficient evaluated at quadrature points.
+/// libCEED QFunction for building quadrature data for a convection operator
+/// with a coefficient evaluated at quadrature points.
 CEED_QFUNCTION(f_build_conv_quad)(void *ctx, CeedInt Q,
                                   const CeedScalar *const *in,
                                   CeedScalar *const *out)
@@ -96,39 +96,38 @@ CEED_QFUNCTION(f_build_conv_quad)(void *ctx, CeedInt Q,
       case 11:
          CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
-            const CeedScalar coeff = c[i];
-            qd[i] = alpha * coeff * qw[i] * J[i];
+            qd[i] = qw[i] * alpha * c[i] * J[i];
          }
          break;
       case 21:
          CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
-            MultCtAdjJt21(J + i, Q, c + i, Q, alpha * qw[i], Q, qd + i);
+            MultCtAdjJt21(J + i, Q, c + i, Q, qw[i] * alpha, Q, qd + i);
          }
          break;
       case 22:
          CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
-            MultCtAdjJt22(J + i, Q, c + i, Q, alpha * qw[i], Q, qd + i);
+            MultCtAdjJt22(J + i, Q, c + i, Q, qw[i] * alpha, Q, qd + i);
          }
          break;
       case 32:
          CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
-            MultCtAdjJt32(J + i, Q, c + i, Q, alpha * qw[i], Q, qd + i);
+            MultCtAdjJt32(J + i, Q, c + i, Q, qw[i] * alpha, Q, qd + i);
          }
          break;
       case 33:
          CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
-            MultCtAdjJt33(J + i, Q, c + i, Q, alpha * qw[i], Q, qd + i);
+            MultCtAdjJt33(J + i, Q, c + i, Q, qw[i] * alpha, Q, qd + i);
          }
          break;
    }
    return 0;
 }
 
-/// libCEED Q-function for applying a conv operator
+/// libCEED QFunction for applying a conv operator
 CEED_QFUNCTION(f_apply_conv)(void *ctx, CeedInt Q,
                              const CeedScalar *const *in,
                              CeedScalar *const *out)
@@ -143,7 +142,7 @@ CEED_QFUNCTION(f_apply_conv)(void *ctx, CeedInt Q,
       case 1:
          CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
-            vg[i] = ug[i] * qd[i];
+            vg[i] = qd[i] * ug[i];
          }
          break;
       case 2:
@@ -167,7 +166,7 @@ CEED_QFUNCTION(f_apply_conv)(void *ctx, CeedInt Q,
    return 0;
 }
 
-/// libCEED Q-function for applying a conv operator
+/// libCEED QFunction for applying a conv operator
 CEED_QFUNCTION(f_apply_conv_mf_const)(void *ctx, CeedInt Q,
                                       const CeedScalar *const *in,
                                       CeedScalar *const *out)
@@ -189,15 +188,15 @@ CEED_QFUNCTION(f_apply_conv_mf_const)(void *ctx, CeedInt Q,
          CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
             const CeedScalar coeff0 = coeff[0];
-            const CeedScalar qd = alpha * coeff0 * qw[i] * J[i];
-            vg[i] = ug[i] * qd;
+            const CeedScalar qd = qw[i] * alpha * coeff0 * J[i];
+            vg[i] = qd * ug[i];
          }
          break;
       case 21:
          CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
             CeedScalar qd;
-            MultCtAdjJt21(J + i, Q, coeff, 1, alpha * qw[i], 1, &qd);
+            MultCtAdjJt21(J + i, Q, coeff, 1, qw[i] * alpha, 1, &qd);
             vg[i] = qd * ug[i];
          }
          break;
@@ -205,7 +204,7 @@ CEED_QFUNCTION(f_apply_conv_mf_const)(void *ctx, CeedInt Q,
          CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
             CeedScalar qd[2];
-            MultCtAdjJt22(J + i, Q, coeff, 1, alpha * qw[i], 1, qd);
+            MultCtAdjJt22(J + i, Q, coeff, 1, qw[i] * alpha, 1, qd);
             const CeedScalar ug0 = ug[i + Q * 0];
             const CeedScalar ug1 = ug[i + Q * 1];
             vg[i] = qd[0] * ug0 + qd[1] * ug1;
@@ -215,7 +214,7 @@ CEED_QFUNCTION(f_apply_conv_mf_const)(void *ctx, CeedInt Q,
          CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
             CeedScalar qd[2];
-            MultCtAdjJt32(J + i, Q, coeff, 1, alpha * qw[i], 1, qd);
+            MultCtAdjJt32(J + i, Q, coeff, 1, qw[i] * alpha, 1, qd);
             const CeedScalar ug0 = ug[i + Q * 0];
             const CeedScalar ug1 = ug[i + Q * 1];
             vg[i] = qd[0] * ug0 + qd[1] * ug1;
@@ -225,7 +224,7 @@ CEED_QFUNCTION(f_apply_conv_mf_const)(void *ctx, CeedInt Q,
          CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
             CeedScalar qd[3];
-            MultCtAdjJt33(J + i, Q, coeff, 1, alpha * qw[i], 1, qd);
+            MultCtAdjJt33(J + i, Q, coeff, 1, qw[i] * alpha, 1, qd);
             const CeedScalar ug0 = ug[i + Q * 0];
             const CeedScalar ug1 = ug[i + Q * 1];
             const CeedScalar ug2 = ug[i + Q * 2];
@@ -236,6 +235,7 @@ CEED_QFUNCTION(f_apply_conv_mf_const)(void *ctx, CeedInt Q,
    return 0;
 }
 
+/// libCEED QFunction for applying a conv operator
 CEED_QFUNCTION(f_apply_conv_mf_quad)(void *ctx, CeedInt Q,
                                      const CeedScalar *const *in,
                                      CeedScalar *const *out)
@@ -256,15 +256,15 @@ CEED_QFUNCTION(f_apply_conv_mf_quad)(void *ctx, CeedInt Q,
       case 11:
          CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
-            const CeedScalar qd = alpha * c[i] * qw[i] * J[i];
-            vg[i] = ug[i] * qd;
+            const CeedScalar qd = qw[i] * alpha * c[i] * J[i];
+            vg[i] = qd * ug[i];
          }
          break;
       case 21:
          CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
             CeedScalar qd;
-            MultCtAdjJt21(J + i, Q, c + i, Q, alpha * qw[i], 1, &qd);
+            MultCtAdjJt21(J + i, Q, c + i, Q, qw[i] * alpha, 1, &qd);
             vg[i] = qd * ug[i];
          }
          break;
@@ -272,7 +272,7 @@ CEED_QFUNCTION(f_apply_conv_mf_quad)(void *ctx, CeedInt Q,
          CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
             CeedScalar qd[2];
-            MultCtAdjJt22(J + i, Q, c + i, Q, alpha * qw[i], 1, qd);
+            MultCtAdjJt22(J + i, Q, c + i, Q, qw[i] * alpha, 1, qd);
             const CeedScalar ug0 = ug[i + Q * 0];
             const CeedScalar ug1 = ug[i + Q * 1];
             vg[i] = qd[0] * ug0 + qd[1] * ug1;
@@ -282,7 +282,7 @@ CEED_QFUNCTION(f_apply_conv_mf_quad)(void *ctx, CeedInt Q,
          CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
             CeedScalar qd[2];
-            MultCtAdjJt32(J + i, Q, c + i, Q, alpha * qw[i], 1, qd);
+            MultCtAdjJt32(J + i, Q, c + i, Q, qw[i] * alpha, 1, qd);
             const CeedScalar ug0 = ug[i + Q * 0];
             const CeedScalar ug1 = ug[i + Q * 1];
             vg[i] = qd[0] * ug0 + qd[1] * ug1;
@@ -292,7 +292,7 @@ CEED_QFUNCTION(f_apply_conv_mf_quad)(void *ctx, CeedInt Q,
          CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
             CeedScalar qd[3];
-            MultCtAdjJt33(J + i, Q, c + i, Q, alpha * qw[i], 1, qd);
+            MultCtAdjJt33(J + i, Q, c + i, Q, qw[i] * alpha, 1, qd);
             const CeedScalar ug0 = ug[i + Q * 0];
             const CeedScalar ug1 = ug[i + Q * 1];
             const CeedScalar ug2 = ug[i + Q * 2];

--- a/fem/ceed/integrators/diffusion/diffusion.cpp
+++ b/fem/ceed/integrators/diffusion/diffusion.cpp
@@ -26,7 +26,8 @@ namespace ceed
 struct DiffusionOperatorInfo : public OperatorInfo
 {
    DiffusionContext ctx;
-   DiffusionOperatorInfo(int dim)
+   template <typename CoeffType>
+   DiffusionOperatorInfo(const mfem::FiniteElementSpace &fes, CoeffType *Q)
    {
       header = "/integrators/diffusion/diffusion_qf.h";
       build_func_const = ":f_build_diff_const";
@@ -41,90 +42,224 @@ struct DiffusionOperatorInfo : public OperatorInfo
       apply_qf_mf_quad = &f_apply_diff_mf_quad;
       trial_op = EvalMode::Grad;
       test_op = EvalMode::Grad;
-      qdatasize = dim*(dim+1)/2;
+      qdatasize =
+         fes.GetMesh()->Dimension() * (fes.GetMesh()->Dimension() + 1) / 2;
+
+      ctx.dim = fes.GetMesh()->Dimension();
+      ctx.space_dim = fes.GetMesh()->SpaceDimension();
+      ctx.vdim = fes.GetVDim();
+      InitCoefficient(Q);
+   }
+   void InitCoefficient(mfem::Coefficient *Q)
+   {
+      ctx.coeff_comp = 1;
+      if (Q == nullptr)
+      {
+         ctx.coeff[0] = 1.0;
+      }
+      else if (ConstantCoefficient *const_coeff =
+                  dynamic_cast<ConstantCoefficient *>(Q))
+      {
+         ctx.coeff[0] = const_coeff->constant;
+      }
+   }
+   void InitCoefficient(mfem::VectorCoefficient *VQ)
+   {
+      if (VQ == nullptr)
+      {
+         ctx.coeff_comp = 1;
+         ctx.coeff[0] = 1.0;
+         return;
+      }
+      const int vdim = VQ->GetVDim();
+      ctx.coeff_comp = vdim;
+      if (VectorConstantCoefficient *const_coeff =
+             dynamic_cast<VectorConstantCoefficient *>(VQ))
+      {
+         MFEM_VERIFY(ctx.coeff_comp <= LIBCEED_DIFF_COEFF_COMP_MAX,
+                     "VectorCoefficient dimension exceeds context storage!");
+         const mfem::Vector &val = const_coeff->GetVec();
+         for (int i = 0; i < vdim; i++)
+         {
+            ctx.coeff[i] = val[i];
+         }
+      }
+   }
+   void InitCoefficient(mfem::MatrixCoefficient *MQ)
+   {
+      if (MQ == nullptr)
+      {
+         ctx.coeff_comp = 1;
+         ctx.coeff[0] = 1.0;
+         return;
+      }
+      // Assumes matrix coefficient is symmetric
+      const int vdim = MQ->GetVDim();
+      ctx.coeff_comp = vdim * (vdim + 1) / 2;
+      if (MatrixConstantCoefficient *const_coeff =
+             dynamic_cast<MatrixConstantCoefficient *>(MQ))
+      {
+         MFEM_VERIFY(ctx.coeff_comp <= LIBCEED_DIFF_COEFF_COMP_MAX,
+                     "MatrixCoefficient dimensions exceed context storage!");
+         const mfem::DenseMatrix &val = const_coeff->GetMatrix();
+         for (int j = 0; j < vdim; j++)
+         {
+            for (int i = j; i < vdim; i++)
+            {
+               const int idx = (j * vdim) - (((j - 1) * j) / 2) + i - j;
+               ctx.coeff[idx] = val(i, j);
+            }
+         }
+      }
    }
 };
 #endif
 
+template <typename CoeffType>
 PADiffusionIntegrator::PADiffusionIntegrator(
    const mfem::FiniteElementSpace &fes,
    const mfem::IntegrationRule &irm,
-   mfem::Coefficient *Q)
+   CoeffType *Q)
    : PAIntegrator()
 {
 #ifdef MFEM_USE_CEED
-   DiffusionOperatorInfo info(fes.GetMesh()->Dimension());
+   DiffusionOperatorInfo info(fes, Q);
    Assemble(info, fes, irm, Q);
 #else
    MFEM_ABORT("MFEM must be built with MFEM_USE_CEED=YES to use libCEED.");
 #endif
 }
 
+template <typename CoeffType>
 MixedPADiffusionIntegrator::MixedPADiffusionIntegrator(
    const DiffusionIntegrator &integ,
    const mfem::FiniteElementSpace &fes,
-   mfem::Coefficient *Q)
+   CoeffType *Q)
 {
 #ifdef MFEM_USE_CEED
-   DiffusionOperatorInfo info(fes.GetMesh()->Dimension());
+   DiffusionOperatorInfo info(fes, Q);
    Assemble(integ, info, fes, Q);
 #else
    MFEM_ABORT("MFEM must be built with MFEM_USE_CEED=YES to use libCEED.");
 #endif
 }
 
+template <typename CoeffType>
 MixedPADiffusionIntegrator::MixedPADiffusionIntegrator(
    const VectorDiffusionIntegrator &integ,
    const mfem::FiniteElementSpace &fes,
-   mfem::Coefficient *Q)
+   CoeffType *Q)
 {
 #ifdef MFEM_USE_CEED
-   DiffusionOperatorInfo info(fes.GetMesh()->Dimension());
+   DiffusionOperatorInfo info(fes, Q);
    Assemble(integ, info, fes, Q);
 #else
    MFEM_ABORT("MFEM must be built with MFEM_USE_CEED=YES to use libCEED.");
 #endif
 }
 
+template <typename CoeffType>
 MFDiffusionIntegrator::MFDiffusionIntegrator(
    const mfem::FiniteElementSpace &fes,
    const mfem::IntegrationRule &irm,
-   mfem::Coefficient *Q)
+   CoeffType *Q)
    : MFIntegrator()
 {
 #ifdef MFEM_USE_CEED
-   DiffusionOperatorInfo info(fes.GetMesh()->Dimension());
+   DiffusionOperatorInfo info(fes, Q);
    Assemble(info, fes, irm, Q);
 #else
    MFEM_ABORT("MFEM must be built with MFEM_USE_CEED=YES to use libCEED.");
 #endif
 }
 
+template <typename CoeffType>
 MixedMFDiffusionIntegrator::MixedMFDiffusionIntegrator(
    const DiffusionIntegrator &integ,
    const mfem::FiniteElementSpace &fes,
-   mfem::Coefficient *Q)
+   CoeffType *Q)
 {
 #ifdef MFEM_USE_CEED
-   DiffusionOperatorInfo info(fes.GetMesh()->Dimension());
+   DiffusionOperatorInfo info(fes, Q);
    Assemble(integ, info, fes, Q);
 #else
    MFEM_ABORT("MFEM must be built with MFEM_USE_CEED=YES to use libCEED.");
 #endif
 }
 
+template <typename CoeffType>
 MixedMFDiffusionIntegrator::MixedMFDiffusionIntegrator(
    const VectorDiffusionIntegrator &integ,
    const mfem::FiniteElementSpace &fes,
-   mfem::Coefficient *Q)
+   CoeffType *Q)
 {
 #ifdef MFEM_USE_CEED
-   DiffusionOperatorInfo info(fes.GetMesh()->Dimension());
+   DiffusionOperatorInfo info(fes, Q);
    Assemble(integ, info, fes, Q);
 #else
    MFEM_ABORT("MFEM must be built with MFEM_USE_CEED=YES to use libCEED.");
 #endif
 }
+
+template PADiffusionIntegrator::PADiffusionIntegrator(
+   const mfem::FiniteElementSpace &, const mfem::IntegrationRule &,
+   mfem::Coefficient *);
+template PADiffusionIntegrator::PADiffusionIntegrator(
+   const mfem::FiniteElementSpace &, const mfem::IntegrationRule &,
+   mfem::VectorCoefficient *);
+template PADiffusionIntegrator::PADiffusionIntegrator(
+   const mfem::FiniteElementSpace &, const mfem::IntegrationRule &,
+   mfem::MatrixCoefficient *);
+
+template MixedPADiffusionIntegrator::MixedPADiffusionIntegrator(
+   const DiffusionIntegrator &, const mfem::FiniteElementSpace &,
+   mfem::Coefficient *);
+template MixedPADiffusionIntegrator::MixedPADiffusionIntegrator(
+   const DiffusionIntegrator &, const mfem::FiniteElementSpace &,
+   mfem::VectorCoefficient *);
+template MixedPADiffusionIntegrator::MixedPADiffusionIntegrator(
+   const DiffusionIntegrator &, const mfem::FiniteElementSpace &,
+   mfem::MatrixCoefficient *);
+
+template MixedPADiffusionIntegrator::MixedPADiffusionIntegrator(
+   const VectorDiffusionIntegrator &, const mfem::FiniteElementSpace &,
+   mfem::Coefficient *);
+template MixedPADiffusionIntegrator::MixedPADiffusionIntegrator(
+   const VectorDiffusionIntegrator &, const mfem::FiniteElementSpace &,
+   mfem::VectorCoefficient *);
+template MixedPADiffusionIntegrator::MixedPADiffusionIntegrator(
+   const VectorDiffusionIntegrator &, const mfem::FiniteElementSpace &,
+   mfem::MatrixCoefficient *);
+
+template MFDiffusionIntegrator::MFDiffusionIntegrator(
+   const mfem::FiniteElementSpace &, const mfem::IntegrationRule &,
+   mfem::Coefficient *);
+template MFDiffusionIntegrator::MFDiffusionIntegrator(
+   const mfem::FiniteElementSpace &, const mfem::IntegrationRule &,
+   mfem::VectorCoefficient *);
+template MFDiffusionIntegrator::MFDiffusionIntegrator(
+   const mfem::FiniteElementSpace &, const mfem::IntegrationRule &,
+   mfem::MatrixCoefficient *);
+
+template MixedMFDiffusionIntegrator::MixedMFDiffusionIntegrator(
+   const DiffusionIntegrator &, const mfem::FiniteElementSpace &,
+   mfem::Coefficient *);
+template MixedMFDiffusionIntegrator::MixedMFDiffusionIntegrator(
+   const DiffusionIntegrator &, const mfem::FiniteElementSpace &,
+   mfem::VectorCoefficient *);
+template MixedMFDiffusionIntegrator::MixedMFDiffusionIntegrator(
+   const DiffusionIntegrator &, const mfem::FiniteElementSpace &,
+   mfem::MatrixCoefficient *);
+
+template MixedMFDiffusionIntegrator::MixedMFDiffusionIntegrator(
+   const VectorDiffusionIntegrator &, const mfem::FiniteElementSpace &,
+   mfem::Coefficient *);
+template MixedMFDiffusionIntegrator::MixedMFDiffusionIntegrator(
+   const VectorDiffusionIntegrator &, const mfem::FiniteElementSpace &,
+   mfem::VectorCoefficient *);
+template MixedMFDiffusionIntegrator::MixedMFDiffusionIntegrator(
+   const VectorDiffusionIntegrator &, const mfem::FiniteElementSpace &,
+   mfem::MatrixCoefficient *);
 
 } // namespace ceed
 

--- a/fem/ceed/integrators/diffusion/diffusion.cpp
+++ b/fem/ceed/integrators/diffusion/diffusion.cpp
@@ -30,7 +30,7 @@ struct DiffusionOperatorInfo : public OperatorInfo
    DiffusionOperatorInfo(const mfem::FiniteElementSpace &fes, CoeffType *Q,
                          bool use_bdr)
    {
-      ctx.dim = fes.GetMesh()->Dimension() - (use_bdr * 1);
+      ctx.dim = fes.GetMesh()->Dimension() - use_bdr;
       ctx.space_dim = fes.GetMesh()->SpaceDimension();
       ctx.vdim = fes.GetVDim();
       InitCoefficient(Q);
@@ -48,7 +48,7 @@ struct DiffusionOperatorInfo : public OperatorInfo
       apply_qf_mf_quad = &f_apply_diff_mf_quad;
       trial_op = EvalMode::Grad;
       test_op = EvalMode::Grad;
-      qdatasize = ctx.dim * (ctx.dim + 1) / 2;
+      qdatasize = (ctx.dim * (ctx.dim + 1)) / 2;
    }
    void InitCoefficient(mfem::Coefficient *Q)
    {
@@ -95,7 +95,7 @@ struct DiffusionOperatorInfo : public OperatorInfo
       }
       // Assumes matrix coefficient is symmetric
       const int vdim = MQ->GetVDim();
-      ctx.coeff_comp = vdim * (vdim + 1) / 2;
+      ctx.coeff_comp = (vdim * (vdim + 1)) / 2;
       if (MatrixConstantCoefficient *const_coeff =
              dynamic_cast<MatrixConstantCoefficient *>(MQ))
       {
@@ -188,12 +188,6 @@ template PADiffusionIntegrator::PADiffusionIntegrator(
 template PADiffusionIntegrator::PADiffusionIntegrator(
    const mfem::VectorDiffusionIntegrator &, const mfem::FiniteElementSpace &,
    mfem::Coefficient *, const bool);
-template PADiffusionIntegrator::PADiffusionIntegrator(
-   const mfem::VectorDiffusionIntegrator &, const mfem::FiniteElementSpace &,
-   mfem::VectorCoefficient *, const bool);
-template PADiffusionIntegrator::PADiffusionIntegrator(
-   const mfem::VectorDiffusionIntegrator &, const mfem::FiniteElementSpace &,
-   mfem::MatrixCoefficient *, const bool);
 
 template MFDiffusionIntegrator::MFDiffusionIntegrator(
    const mfem::DiffusionIntegrator &, const mfem::FiniteElementSpace &,
@@ -208,12 +202,6 @@ template MFDiffusionIntegrator::MFDiffusionIntegrator(
 template MFDiffusionIntegrator::MFDiffusionIntegrator(
    const mfem::VectorDiffusionIntegrator &, const mfem::FiniteElementSpace &,
    mfem::Coefficient *, const bool);
-template MFDiffusionIntegrator::MFDiffusionIntegrator(
-   const mfem::VectorDiffusionIntegrator &, const mfem::FiniteElementSpace &,
-   mfem::VectorCoefficient *, const bool);
-template MFDiffusionIntegrator::MFDiffusionIntegrator(
-   const mfem::VectorDiffusionIntegrator &, const mfem::FiniteElementSpace &,
-   mfem::MatrixCoefficient *, const bool);
 
 } // namespace ceed
 

--- a/fem/ceed/integrators/diffusion/diffusion.cpp
+++ b/fem/ceed/integrators/diffusion/diffusion.cpp
@@ -175,6 +175,8 @@ MFDiffusionIntegrator::MFDiffusionIntegrator(
 #endif
 }
 
+// @cond DOXYGEN_SKIP
+
 template PADiffusionIntegrator::PADiffusionIntegrator(
    const mfem::DiffusionIntegrator &, const mfem::FiniteElementSpace &,
    mfem::Coefficient *, const bool);
@@ -202,6 +204,8 @@ template MFDiffusionIntegrator::MFDiffusionIntegrator(
 template MFDiffusionIntegrator::MFDiffusionIntegrator(
    const mfem::VectorDiffusionIntegrator &, const mfem::FiniteElementSpace &,
    mfem::Coefficient *, const bool);
+
+// @endcond
 
 } // namespace ceed
 

--- a/fem/ceed/integrators/diffusion/diffusion.hpp
+++ b/fem/ceed/integrators/diffusion/diffusion.hpp
@@ -12,7 +12,6 @@
 #ifndef MFEM_LIBCEED_DIFF_HPP
 #define MFEM_LIBCEED_DIFF_HPP
 
-#include "../../interface/integrator.hpp"
 #include "../../interface/mixed_integrator.hpp"
 #include "../../../fespace.hpp"
 
@@ -23,51 +22,37 @@ namespace ceed
 {
 
 /// Represent a DiffusionIntegrator with AssemblyLevel::Partial using libCEED.
-class PADiffusionIntegrator : public PAIntegrator
+class PADiffusionIntegrator : public MixedIntegrator
 {
 public:
    template <typename CoeffType>
-   PADiffusionIntegrator(const mfem::FiniteElementSpace &fes,
-                         const mfem::IntegrationRule &ir,
-                         CoeffType *Q);
-};
-
-class MixedPADiffusionIntegrator : public MixedIntegrator<PAIntegrator>
-{
-public:
-   template <typename CoeffType>
-   MixedPADiffusionIntegrator(const DiffusionIntegrator &integ,
-                              const mfem::FiniteElementSpace &fes,
-                              CoeffType *Q);
+   PADiffusionIntegrator(const mfem::DiffusionIntegrator &integ,
+                         const mfem::FiniteElementSpace &fes,
+                         CoeffType *Q,
+                         const bool use_bdr = false);
 
    template <typename CoeffType>
-   MixedPADiffusionIntegrator(const VectorDiffusionIntegrator &integ,
-                              const mfem::FiniteElementSpace &fes,
-                              CoeffType *Q);
+   PADiffusionIntegrator(const mfem::VectorDiffusionIntegrator &integ,
+                         const mfem::FiniteElementSpace &fes,
+                         CoeffType *Q,
+                         const bool use_bdr = false);
 };
 
 /// Represent a DiffusionIntegrator with AssemblyLevel::None using libCEED.
-class MFDiffusionIntegrator : public MFIntegrator
+class MFDiffusionIntegrator : public MixedIntegrator
 {
 public:
    template <typename CoeffType>
-   MFDiffusionIntegrator(const mfem::FiniteElementSpace &fes,
-                         const mfem::IntegrationRule &ir,
-                         CoeffType *Q);
-};
-
-class MixedMFDiffusionIntegrator : public MixedIntegrator<MFIntegrator>
-{
-public:
-   template <typename CoeffType>
-   MixedMFDiffusionIntegrator(const DiffusionIntegrator &integ,
-                              const mfem::FiniteElementSpace &fes,
-                              CoeffType *Q);
+   MFDiffusionIntegrator(const mfem::DiffusionIntegrator &integ,
+                         const mfem::FiniteElementSpace &fes,
+                         CoeffType *Q,
+                         const bool use_bdr = false);
 
    template <typename CoeffType>
-   MixedMFDiffusionIntegrator(const VectorDiffusionIntegrator &integ,
-                              const mfem::FiniteElementSpace &fes,
-                              CoeffType *Q);
+   MFDiffusionIntegrator(const mfem::VectorDiffusionIntegrator &integ,
+                         const mfem::FiniteElementSpace &fes,
+                         CoeffType *Q,
+                         const bool use_bdr = false);
 };
 
 }

--- a/fem/ceed/integrators/diffusion/diffusion.hpp
+++ b/fem/ceed/integrators/diffusion/diffusion.hpp
@@ -26,42 +26,48 @@ namespace ceed
 class PADiffusionIntegrator : public PAIntegrator
 {
 public:
+   template <typename CoeffType>
    PADiffusionIntegrator(const mfem::FiniteElementSpace &fes,
                          const mfem::IntegrationRule &ir,
-                         mfem::Coefficient *Q);
+                         CoeffType *Q);
 };
 
 class MixedPADiffusionIntegrator : public MixedIntegrator<PAIntegrator>
 {
 public:
+   template <typename CoeffType>
    MixedPADiffusionIntegrator(const DiffusionIntegrator &integ,
                               const mfem::FiniteElementSpace &fes,
-                              mfem::Coefficient *Q);
+                              CoeffType *Q);
 
+   template <typename CoeffType>
    MixedPADiffusionIntegrator(const VectorDiffusionIntegrator &integ,
                               const mfem::FiniteElementSpace &fes,
-                              mfem::Coefficient *Q);
+                              CoeffType *Q);
 };
 
 /// Represent a DiffusionIntegrator with AssemblyLevel::None using libCEED.
 class MFDiffusionIntegrator : public MFIntegrator
 {
 public:
+   template <typename CoeffType>
    MFDiffusionIntegrator(const mfem::FiniteElementSpace &fes,
                          const mfem::IntegrationRule &ir,
-                         mfem::Coefficient *Q);
+                         CoeffType *Q);
 };
 
 class MixedMFDiffusionIntegrator : public MixedIntegrator<MFIntegrator>
 {
 public:
+   template <typename CoeffType>
    MixedMFDiffusionIntegrator(const DiffusionIntegrator &integ,
                               const mfem::FiniteElementSpace &fes,
-                              mfem::Coefficient *Q);
+                              CoeffType *Q);
 
+   template <typename CoeffType>
    MixedMFDiffusionIntegrator(const VectorDiffusionIntegrator &integ,
                               const mfem::FiniteElementSpace &fes,
-                              mfem::Coefficient *Q);
+                              CoeffType *Q);
 };
 
 }

--- a/fem/ceed/integrators/diffusion/diffusion_qf.h
+++ b/fem/ceed/integrators/diffusion/diffusion_qf.h
@@ -9,9 +9,19 @@
 // terms of the BSD-3 license. We welcome feedback and contributions, see file
 // CONTRIBUTING.md for details.
 
+#ifndef MFEM_LIBCEED_DIFF_QF_H
+#define MFEM_LIBCEED_DIFF_QF_H
+
+#include "../qf_utils.h"
+
+#define LIBCEED_DIFF_COEFF_COMP_MAX 6
 
 /// A structure used to pass additional data to f_build_diff and f_apply_diff
-struct DiffusionContext { CeedInt dim, space_dim, vdim; CeedScalar coeff; };
+struct DiffusionContext
+{
+   CeedInt dim, space_dim, vdim, coeff_comp;
+   CeedScalar coeff[LIBCEED_DIFF_COEFF_COMP_MAX];
+};
 
 /// libCEED Q-function for building quadrature data for a diffusion operator
 /// with a constant coefficient
@@ -19,69 +29,47 @@ CEED_QFUNCTION(f_build_diff_const)(void *ctx, CeedInt Q,
                                    const CeedScalar *const *in,
                                    CeedScalar *const *out)
 {
-   DiffusionContext *bc = (DiffusionContext*)ctx;
-   // in[0] is Jacobians with shape [dim, nc=dim, Q]
+   DiffusionContext *bc = (DiffusionContext *)ctx;
+   // in[0] is Jacobians with shape [dim, ncomp=space_dim, Q]
    // in[1] is quadrature weights, size (Q)
    //
-   // At every quadrature point, compute qw/det(J).adj(J).adj(J)^T and store
+   // At every quadrature point, compute qw/det(J) adj(J) C adj(J)^T and store
    // the symmetric part of the result.
-   const CeedScalar coeff = bc->coeff;
+   const CeedInt coeff_comp = bc->coeff_comp;
+   const CeedScalar *coeff = bc->coeff;
    const CeedScalar *J = in[0], *qw = in[1];
    CeedScalar *qd = out[0];
-   switch (bc->dim + 10 * bc->space_dim)
+   switch (10 * bc->space_dim + bc->dim)
    {
       case 11:
          for (CeedInt i = 0; i < Q; i++)
          {
-            qd[i] = coeff * qw[i] / J[i];
+            const CeedScalar coeff0 = coeff[0];
+            qd[i] = coeff0 * qw[i] / J[i];
+         }
+         break;
+      case 21:
+         for (CeedInt i = 0; i < Q; i++)
+         {
+            MultAdjJCAdjJt21(J + i, Q, coeff, 1, coeff_comp, qw[i], Q, qd + i);
          }
          break;
       case 22:
          for (CeedInt i = 0; i < Q; i++)
          {
-            // J: 0 2   qd: 0 1   adj(J):  J22 -J12
-            //    1 3       1 2           -J21  J11
-            const CeedScalar J11 = J[i + Q * 0];
-            const CeedScalar J21 = J[i + Q * 1];
-            const CeedScalar J12 = J[i + Q * 2];
-            const CeedScalar J22 = J[i + Q * 3];
-            const CeedScalar w = qw[i] / (J11 * J22 - J21 * J12);
-            qd[i + Q * 0] =   coeff * w * (J12 * J12 + J22 * J22);
-            qd[i + Q * 1] = - coeff * w * (J11 * J12 + J21 * J22);
-            qd[i + Q * 2] =   coeff * w * (J11 * J11 + J21 * J21);
+            MultAdjJCAdjJt22(J + i, Q, coeff, 1, coeff_comp, qw[i], Q, qd + i);
+         }
+         break;
+      case 32:
+         for (CeedInt i = 0; i < Q; i++)
+         {
+            MultAdjJCAdjJt32(J + i, Q, coeff, 1, coeff_comp, qw[i], Q, qd + i);
          }
          break;
       case 33:
          for (CeedInt i = 0; i < Q; i++)
          {
-            // J: 0 3 6   qd: 0 1 2
-            //    1 4 7       1 3 4
-            //    2 5 8       2 4 5
-            const CeedScalar J11 = J[i + Q * 0];
-            const CeedScalar J21 = J[i + Q * 1];
-            const CeedScalar J31 = J[i + Q * 2];
-            const CeedScalar J12 = J[i + Q * 3];
-            const CeedScalar J22 = J[i + Q * 4];
-            const CeedScalar J32 = J[i + Q * 5];
-            const CeedScalar J13 = J[i + Q * 6];
-            const CeedScalar J23 = J[i + Q * 7];
-            const CeedScalar J33 = J[i + Q * 8];
-            const CeedScalar A11 = J22 * J33 - J23 * J32;
-            const CeedScalar A12 = J13 * J32 - J12 * J33;
-            const CeedScalar A13 = J12 * J23 - J13 * J22;
-            const CeedScalar A21 = J23 * J31 - J21 * J33;
-            const CeedScalar A22 = J11 * J33 - J13 * J31;
-            const CeedScalar A23 = J13 * J21 - J11 * J23;
-            const CeedScalar A31 = J21 * J32 - J22 * J31;
-            const CeedScalar A32 = J12 * J31 - J11 * J32;
-            const CeedScalar A33 = J11 * J22 - J12 * J21;
-            const CeedScalar w = qw[i] / (J11 * A11 + J21 * A12 + J31 * A13);
-            qd[i + Q * 0] = coeff * w * (A11 * A11 + A12 * A12 + A13 * A13);
-            qd[i + Q * 1] = coeff * w * (A11 * A21 + A12 * A22 + A13 * A23);
-            qd[i + Q * 2] = coeff * w * (A11 * A31 + A12 * A32 + A13 * A33);
-            qd[i + Q * 3] = coeff * w * (A21 * A21 + A22 * A22 + A23 * A23);
-            qd[i + Q * 4] = coeff * w * (A21 * A31 + A22 * A32 + A23 * A33);
-            qd[i + Q * 5] = coeff * w * (A31 * A31 + A32 * A32 + A33 * A33);
+            MultAdjJCAdjJt33(J + i, Q, coeff, 1, coeff_comp, qw[i], Q, qd + i);
          }
          break;
    }
@@ -95,14 +83,16 @@ CEED_QFUNCTION(f_build_diff_quad)(void *ctx, CeedInt Q,
                                   CeedScalar *const *out)
 {
    DiffusionContext *bc = (DiffusionContext *)ctx;
-   // in[1] is Jacobians with shape [dim, nc=dim, Q]
+   // in[0] is coefficients with shape [ncomp=coeff_comp, Q]
+   // in[1] is Jacobians with shape [dim, ncomp=space_dim, Q]
    // in[2] is quadrature weights, size (Q)
    //
-   // At every quadrature point, compute qw/det(J).adj(J).adj(J)^T and store
+   // At every quadrature point, compute qw/det(J) adj(J) C adj(J)^T and store
    // the symmetric part of the result.
+   const CeedInt coeff_comp = bc->coeff_comp;
    const CeedScalar *c = in[0], *J = in[1], *qw = in[2];
    CeedScalar *qd = out[0];
-   switch (bc->dim + 10 * bc->space_dim)
+   switch (10 * bc->space_dim + bc->dim)
    {
       case 11:
          for (CeedInt i = 0; i < Q; i++)
@@ -110,54 +100,28 @@ CEED_QFUNCTION(f_build_diff_quad)(void *ctx, CeedInt Q,
             qd[i] = c[i] * qw[i] / J[i];
          }
          break;
+      case 21:
+         for (CeedInt i = 0; i < Q; i++)
+         {
+            MultAdjJCAdjJt21(J + i, Q, c + i, Q, coeff_comp, qw[i], Q, qd + i);
+         }
+         break;
       case 22:
          for (CeedInt i = 0; i < Q; i++)
          {
-            // J: 0 2   qd: 0 1   adj(J):  J22 -J12
-            //    1 3       1 2           -J21  J11
-            const CeedScalar coeff = c[i];
-            const CeedScalar J11 = J[i + Q * 0];
-            const CeedScalar J21 = J[i + Q * 1];
-            const CeedScalar J12 = J[i + Q * 2];
-            const CeedScalar J22 = J[i + Q * 3];
-            const CeedScalar w = qw[i] / (J11 * J22 - J21 * J12);
-            qd[i + Q * 0] =   coeff * w * (J12 * J12 + J22 * J22);
-            qd[i + Q * 1] = - coeff * w * (J11 * J12 + J21 * J22);
-            qd[i + Q * 2] =   coeff * w * (J11 * J11 + J21 * J21);
+            MultAdjJCAdjJt22(J + i, Q, c + i, Q, coeff_comp, qw[i], Q, qd + i);
+         }
+         break;
+      case 32:
+         for (CeedInt i = 0; i < Q; i++)
+         {
+            MultAdjJCAdjJt32(J + i, Q, c + i, Q, coeff_comp, qw[i], Q, qd + i);
          }
          break;
       case 33:
          for (CeedInt i = 0; i < Q; i++)
          {
-            // J: 0 3 6   qd: 0 1 2
-            //    1 4 7       1 3 4
-            //    2 5 8       2 4 5
-            const CeedScalar coeff = c[i];
-            const CeedScalar J11 = J[i + Q * 0];
-            const CeedScalar J21 = J[i + Q * 1];
-            const CeedScalar J31 = J[i + Q * 2];
-            const CeedScalar J12 = J[i + Q * 3];
-            const CeedScalar J22 = J[i + Q * 4];
-            const CeedScalar J32 = J[i + Q * 5];
-            const CeedScalar J13 = J[i + Q * 6];
-            const CeedScalar J23 = J[i + Q * 7];
-            const CeedScalar J33 = J[i + Q * 8];
-            const CeedScalar A11 = J22 * J33 - J23 * J32;
-            const CeedScalar A12 = J13 * J32 - J12 * J33;
-            const CeedScalar A13 = J12 * J23 - J13 * J22;
-            const CeedScalar A21 = J23 * J31 - J21 * J33;
-            const CeedScalar A22 = J11 * J33 - J13 * J31;
-            const CeedScalar A23 = J13 * J21 - J11 * J23;
-            const CeedScalar A31 = J21 * J32 - J22 * J31;
-            const CeedScalar A32 = J12 * J31 - J11 * J32;
-            const CeedScalar A33 = J11 * J22 - J12 * J21;
-            const CeedScalar w = qw[i] / (J11 * A11 + J21 * A12 + J31 * A13);
-            qd[i + Q * 0] = coeff * w * (A11 * A11 + A12 * A12 + A13 * A13);
-            qd[i + Q * 1] = coeff * w * (A11 * A21 + A12 * A22 + A13 * A23);
-            qd[i + Q * 2] = coeff * w * (A11 * A31 + A12 * A32 + A13 * A33);
-            qd[i + Q * 3] = coeff * w * (A21 * A21 + A22 * A22 + A23 * A23);
-            qd[i + Q * 4] = coeff * w * (A21 * A31 + A22 * A32 + A23 * A33);
-            qd[i + Q * 5] = coeff * w * (A31 * A31 + A32 * A32 + A33 * A33);
+            MultAdjJCAdjJt33(J + i, Q, c + i, Q, coeff_comp, qw[i], Q, qd + i);
          }
          break;
    }
@@ -170,10 +134,10 @@ CEED_QFUNCTION(f_apply_diff)(void *ctx, CeedInt Q,
                              CeedScalar *const *out)
 {
    DiffusionContext *bc = (DiffusionContext *)ctx;
-   // in[0], out[0] have shape [dim, nc=1, Q]
+   // in[0], out[0] have shape [dim, ncomp=vdim, Q]
    const CeedScalar *ug = in[0], *qd = in[1];
    CeedScalar *vg = out[0];
-   switch (10*bc->dim + bc->vdim)
+   switch (10 * bc->dim + bc->vdim)
    {
       case 11:
          for (CeedInt i = 0; i < Q; i++)
@@ -197,12 +161,12 @@ CEED_QFUNCTION(f_apply_diff)(void *ctx, CeedInt Q,
             const CeedScalar qd01 = qd[i + Q * 1];
             const CeedScalar qd10 = qd01;
             const CeedScalar qd11 = qd[i + Q * 2];
-            for (CeedInt c = 0; c < 2; c++)
+            for (CeedInt d = 0; d < 2; d++)
             {
-               const CeedScalar ug0 = ug[i + Q * (c+2*0)];
-               const CeedScalar ug1 = ug[i + Q * (c+2*1)];
-               vg[i + Q * (c+2*0)] = qd00 * ug0 + qd01 * ug1;
-               vg[i + Q * (c+2*1)] = qd10 * ug0 + qd11 * ug1;
+               const CeedScalar ug0 = ug[i + Q * (d + 2 * 0)];
+               const CeedScalar ug1 = ug[i + Q * (d + 2 * 1)];
+               vg[i + Q * (d + 2 * 0)] = qd00 * ug0 + qd01 * ug1;
+               vg[i + Q * (d + 2 * 1)] = qd10 * ug0 + qd11 * ug1;
             }
          }
          break;
@@ -229,14 +193,14 @@ CEED_QFUNCTION(f_apply_diff)(void *ctx, CeedInt Q,
             const CeedScalar qd20 = qd02;
             const CeedScalar qd21 = qd12;
             const CeedScalar qd22 = qd[i + Q * 5];
-            for (CeedInt c = 0; c < 3; c++)
+            for (CeedInt d = 0; d < 3; d++)
             {
-               const CeedScalar ug0 = ug[i + Q * (c+3*0)];
-               const CeedScalar ug1 = ug[i + Q * (c+3*1)];
-               const CeedScalar ug2 = ug[i + Q * (c+3*2)];
-               vg[i + Q * (c+3*0)] = qd00 * ug0 + qd01 * ug1 + qd02 * ug2;
-               vg[i + Q * (c+3*1)] = qd10 * ug0 + qd11 * ug1 + qd12 * ug2;
-               vg[i + Q * (c+3*2)] = qd20 * ug0 + qd21 * ug1 + qd22 * ug2;
+               const CeedScalar ug0 = ug[i + Q * (d + 3 * 0)];
+               const CeedScalar ug1 = ug[i + Q * (d + 3 * 1)];
+               const CeedScalar ug2 = ug[i + Q * (d + 3 * 2)];
+               vg[i + Q * (d + 3 * 0)] = qd00 * ug0 + qd01 * ug1 + qd02 * ug2;
+               vg[i + Q * (d + 3 * 1)] = qd10 * ug0 + qd11 * ug1 + qd12 * ug2;
+               vg[i + Q * (d + 3 * 2)] = qd20 * ug0 + qd21 * ug1 + qd22 * ug2;
             }
          }
          break;
@@ -249,99 +213,100 @@ CEED_QFUNCTION(f_apply_diff_mf_const)(void *ctx, CeedInt Q,
                                       const CeedScalar *const *in,
                                       CeedScalar *const *out)
 {
-   DiffusionContext *bc = (DiffusionContext*)ctx;
-   // in[0], out[0] have shape [dim, nc=1, Q]
-   // in[1] is Jacobians with shape [dim, nc=dim, Q]
+   DiffusionContext *bc = (DiffusionContext *)ctx;
+   // in[0], out[0] have shape [dim, ncomp=vdim, Q]
+   // in[1] is Jacobians with shape [dim, ncomp=space_dim, Q]
    // in[2] is quadrature weights, size (Q)
    //
-   // At every quadrature point, compute qw/det(J).adj(J).adj(J)^T
-   const CeedScalar coeff = bc->coeff;
+   // At every quadrature point, compute qw/det(J) adj(J) C adj(J)^T
+   const CeedInt coeff_comp = bc->coeff_comp;
+   const CeedScalar *coeff = bc->coeff;
    const CeedScalar *ug = in[0], *J = in[1], *qw = in[2];
    CeedScalar *vg = out[0];
-   switch (10 * bc->dim + bc->vdim)
+   switch (100 * bc->space_dim + 10 * bc->dim + bc->vdim)
    {
-      case 11:
+      case 111:
          for (CeedInt i = 0; i < Q; i++)
          {
-            const CeedScalar qd = coeff * qw[i] / J[i];
+            const CeedScalar coeff0 = coeff[0];
+            const CeedScalar qd = coeff0 * qw[i] / J[i];
             vg[i] = ug[i] * qd;
          }
          break;
-      case 21:
+      case 211:
          for (CeedInt i = 0; i < Q; i++)
          {
-            // J: 0 2   qd: 0 1   adj(J):  J22 -J12
-            //    1 3       1 2           -J21  J11
-            const CeedScalar J11 = J[i + Q * 0];
-            const CeedScalar J21 = J[i + Q * 1];
-            const CeedScalar J12 = J[i + Q * 2];
-            const CeedScalar J22 = J[i + Q * 3];
-            const CeedScalar w = qw[i] / (J11 * J22 - J21 * J12);
+            CeedScalar qd;
+            MultAdjJCAdjJt21(J + i, Q, coeff, 1, coeff_comp, qw[i], 1, &qd);
+            vg[i] = ug[i] * qd;
+         }
+         break;
+      case 212:
+         for (CeedInt i = 0; i < Q; i++)
+         {
+            CeedScalar qd;
+            MultAdjJCAdjJt21(J + i, Q, coeff, 1, coeff_comp, qw[i], 1, &qd);
+            for (CeedInt d = 0; d < 2; d++)
+            {
+               vg[i + Q * d] = ug[i + Q * d] * qd;
+            }
+         }
+         break;
+      case 221:
+         for (CeedInt i = 0; i < Q; i++)
+         {
             CeedScalar qd[3];
-            qd[0] =   coeff * w * (J12 * J12 + J22 * J22);
-            qd[1] = - coeff * w * (J11 * J12 + J21 * J22);
-            qd[2] =   coeff * w * (J11 * J11 + J21 * J21);
+            MultAdjJCAdjJt22(J + i, Q, coeff, 1, coeff_comp, qw[i], 1, qd);
             const CeedScalar ug0 = ug[i + Q * 0];
             const CeedScalar ug1 = ug[i + Q * 1];
             vg[i + Q * 0] = qd[0] * ug0 + qd[1] * ug1;
             vg[i + Q * 1] = qd[1] * ug0 + qd[2] * ug1;
          }
          break;
-      case 22:
+      case 222:
          for (CeedInt i = 0; i < Q; i++)
          {
-            // J: 0 2   qd: 0 1   adj(J):  J22 -J12
-            //    1 3       1 2           -J21  J11
-            const CeedScalar J11 = J[i + Q * 0];
-            const CeedScalar J21 = J[i + Q * 1];
-            const CeedScalar J12 = J[i + Q * 2];
-            const CeedScalar J22 = J[i + Q * 3];
-            const CeedScalar w = qw[i] / (J11 * J22 - J21 * J12);
             CeedScalar qd[3];
-            qd[0] =   coeff * w * (J12 * J12 + J22 * J22);
-            qd[1] = - coeff * w * (J11 * J12 + J21 * J22);
-            qd[2] =   coeff * w * (J11 * J11 + J21 * J21);
-            for (CeedInt c = 0; c < 2; c++)
+            MultAdjJCAdjJt22(J + i, Q, coeff, 1, coeff_comp, qw[i], 1, qd);
+            for (CeedInt d = 0; d < 2; d++)
             {
-               const CeedScalar ug0 = ug[i + Q * (c+2*0)];
-               const CeedScalar ug1 = ug[i + Q * (c+2*1)];
-               vg[i + Q * (c+2*0)] = qd[0] * ug0 + qd[1] * ug1;
-               vg[i + Q * (c+2*1)] = qd[1] * ug0 + qd[2] * ug1;
+               const CeedScalar ug0 = ug[i + Q * (d + 2 * 0)];
+               const CeedScalar ug1 = ug[i + Q * (d + 2 * 1)];
+               vg[i + Q * (d + 2 * 0)] = qd[0] * ug0 + qd[1] * ug1;
+               vg[i + Q * (d + 2 * 1)] = qd[1] * ug0 + qd[2] * ug1;
             }
          }
          break;
-      case 31:
+      case 321:
          for (CeedInt i = 0; i < Q; i++)
          {
-            // J: 0 3 6   qd: 0 1 2
-            //    1 4 7       1 3 4
-            //    2 5 8       2 4 5
-            const CeedScalar J11 = J[i + Q * 0];
-            const CeedScalar J21 = J[i + Q * 1];
-            const CeedScalar J31 = J[i + Q * 2];
-            const CeedScalar J12 = J[i + Q * 3];
-            const CeedScalar J22 = J[i + Q * 4];
-            const CeedScalar J32 = J[i + Q * 5];
-            const CeedScalar J13 = J[i + Q * 6];
-            const CeedScalar J23 = J[i + Q * 7];
-            const CeedScalar J33 = J[i + Q * 8];
-            const CeedScalar A11 = J22 * J33 - J23 * J32;
-            const CeedScalar A12 = J13 * J32 - J12 * J33;
-            const CeedScalar A13 = J12 * J23 - J13 * J22;
-            const CeedScalar A21 = J23 * J31 - J21 * J33;
-            const CeedScalar A22 = J11 * J33 - J13 * J31;
-            const CeedScalar A23 = J13 * J21 - J11 * J23;
-            const CeedScalar A31 = J21 * J32 - J22 * J31;
-            const CeedScalar A32 = J12 * J31 - J11 * J32;
-            const CeedScalar A33 = J11 * J22 - J12 * J21;
-            const CeedScalar w = qw[i] / (J11 * A11 + J21 * A12 + J31 * A13);
+            CeedScalar qd[3];
+            MultAdjJCAdjJt32(J + i, Q, coeff, 1, coeff_comp, qw[i], 1, qd);
+            const CeedScalar ug0 = ug[i + Q * 0];
+            const CeedScalar ug1 = ug[i + Q * 1];
+            vg[i + Q * 0] = qd[0] * ug0 + qd[1] * ug1;
+            vg[i + Q * 1] = qd[1] * ug0 + qd[2] * ug1;
+         }
+         break;
+      case 323:
+         for (CeedInt i = 0; i < Q; i++)
+         {
+            CeedScalar qd[3];
+            MultAdjJCAdjJt32(J + i, Q, coeff, 1, coeff_comp, qw[i], 1, qd);
+            for (CeedInt d = 0; d < 3; d++)
+            {
+               const CeedScalar ug0 = ug[i + Q * (d + 3 * 0)];
+               const CeedScalar ug1 = ug[i + Q * (d + 3 * 1)];
+               vg[i + Q * (d + 3 * 0)] = qd[0] * ug0 + qd[1] * ug1;
+               vg[i + Q * (d + 3 * 1)] = qd[1] * ug0 + qd[2] * ug1;
+            }
+         }
+         break;
+      case 331:
+         for (CeedInt i = 0; i < Q; i++)
+         {
             CeedScalar qd[6];
-            qd[0] = coeff * w * (A11 * A11 + A12 * A12 + A13 * A13);
-            qd[1] = coeff * w * (A11 * A21 + A12 * A22 + A13 * A23);
-            qd[2] = coeff * w * (A11 * A31 + A12 * A32 + A13 * A33);
-            qd[3] = coeff * w * (A21 * A21 + A22 * A22 + A23 * A23);
-            qd[4] = coeff * w * (A21 * A31 + A22 * A32 + A23 * A33);
-            qd[5] = coeff * w * (A31 * A31 + A32 * A32 + A33 * A33);
+            MultAdjJCAdjJt33(J + i, Q, coeff, 1, coeff_comp, qw[i], 1, qd);
             const CeedScalar ug0 = ug[i + Q * 0];
             const CeedScalar ug1 = ug[i + Q * 1];
             const CeedScalar ug2 = ug[i + Q * 2];
@@ -350,49 +315,21 @@ CEED_QFUNCTION(f_apply_diff_mf_const)(void *ctx, CeedInt Q,
             vg[i + Q * 2] = qd[2] * ug0 + qd[4] * ug1 + qd[5] * ug2;
          }
          break;
-      case 33:
+      case 333:
          for (CeedInt i = 0; i < Q; i++)
          {
-            // J: 0 3 6   qd: 0 1 2
-            //    1 4 7       1 3 4
-            //    2 5 8       2 4 5
-            const CeedScalar J11 = J[i + Q * 0];
-            const CeedScalar J21 = J[i + Q * 1];
-            const CeedScalar J31 = J[i + Q * 2];
-            const CeedScalar J12 = J[i + Q * 3];
-            const CeedScalar J22 = J[i + Q * 4];
-            const CeedScalar J32 = J[i + Q * 5];
-            const CeedScalar J13 = J[i + Q * 6];
-            const CeedScalar J23 = J[i + Q * 7];
-            const CeedScalar J33 = J[i + Q * 8];
-            const CeedScalar A11 = J22 * J33 - J23 * J32;
-            const CeedScalar A12 = J13 * J32 - J12 * J33;
-            const CeedScalar A13 = J12 * J23 - J13 * J22;
-            const CeedScalar A21 = J23 * J31 - J21 * J33;
-            const CeedScalar A22 = J11 * J33 - J13 * J31;
-            const CeedScalar A23 = J13 * J21 - J11 * J23;
-            const CeedScalar A31 = J21 * J32 - J22 * J31;
-            const CeedScalar A32 = J12 * J31 - J11 * J32;
-            const CeedScalar A33 = J11 * J22 - J12 * J21;
-            const CeedScalar w = qw[i] / (J11 * A11 + J21 * A12 + J31 * A13);
             CeedScalar qd[6];
-            qd[0] = coeff * w * (A11 * A11 + A12 * A12 + A13 * A13);
-            qd[1] = coeff * w * (A11 * A21 + A12 * A22 + A13 * A23);
-            qd[2] = coeff * w * (A11 * A31 + A12 * A32 + A13 * A33);
-            qd[3] = coeff * w * (A21 * A21 + A22 * A22 + A23 * A23);
-            qd[4] = coeff * w * (A21 * A31 + A22 * A32 + A23 * A33);
-            qd[5] = coeff * w * (A31 * A31 + A32 * A32 + A33 * A33);
-            for (CeedInt c = 0; c < 3; c++)
+            MultAdjJCAdjJt33(J + i, Q, coeff, 1, coeff_comp, qw[i], 1, qd);
+            for (CeedInt d = 0; d < 3; d++)
             {
-               const CeedScalar ug0 = ug[i + Q * (c+3*0)];
-               const CeedScalar ug1 = ug[i + Q * (c+3*1)];
-               const CeedScalar ug2 = ug[i + Q * (c+3*2)];
-               vg[i + Q * (c+3*0)] = qd[0] * ug0 + qd[1] * ug1 + qd[2] * ug2;
-               vg[i + Q * (c+3*1)] = qd[1] * ug0 + qd[3] * ug1 + qd[4] * ug2;
-               vg[i + Q * (c+3*2)] = qd[2] * ug0 + qd[4] * ug1 + qd[5] * ug2;
+               const CeedScalar ug0 = ug[i + Q * (d + 3 * 0)];
+               const CeedScalar ug1 = ug[i + Q * (d + 3 * 1)];
+               const CeedScalar ug2 = ug[i + Q * (d + 3 * 2)];
+               vg[i + Q * (d + 3 * 0)] = qd[0] * ug0 + qd[1] * ug1 + qd[2] * ug2;
+               vg[i + Q * (d + 3 * 1)] = qd[1] * ug0 + qd[3] * ug1 + qd[4] * ug2;
+               vg[i + Q * (d + 3 * 2)] = qd[2] * ug0 + qd[4] * ug1 + qd[5] * ug2;
             }
          }
-         break;
    }
    return 0;
 }
@@ -401,101 +338,98 @@ CEED_QFUNCTION(f_apply_diff_mf_quad)(void *ctx, CeedInt Q,
                                      const CeedScalar *const *in,
                                      CeedScalar *const *out)
 {
-   DiffusionContext *bc = (DiffusionContext*)ctx;
-   // in[0], out[0] have shape [dim, nc=1, Q]
-   // in[1] is Jacobians with shape [dim, nc=dim, Q]
-   // in[2] is quadrature weights, size (Q)
+   DiffusionContext *bc = (DiffusionContext *)ctx;
+   // in[0] is coefficients with shape [ncomp=coeff_comp, Q]
+   // in[1], out[0] have shape [dim, ncomp=vdim, Q]
+   // in[2] is Jacobians with shape [dim, ncomp=space_dim, Q]
+   // in[3] is quadrature weights, size (Q)
    //
-   // At every quadrature point, compute qw/det(J).adj(J).adj(J)^T
+   // At every quadrature point, compute qw/det(J) adj(J) C adj(J)^T
+   const CeedInt coeff_comp = bc->coeff_comp;
    const CeedScalar *c = in[0], *ug = in[1], *J = in[2], *qw = in[3];
    CeedScalar *vg = out[0];
-   switch (10 * bc->dim + bc->vdim)
+   switch (100 * bc->space_dim + 10 * bc->dim + bc->vdim)
    {
-      case 11:
+      case 111:
          for (CeedInt i = 0; i < Q; i++)
          {
             const CeedScalar qd = c[i] * qw[i] / J[i];
             vg[i] = ug[i] * qd;
          }
          break;
-      case 21:
+      case 211:
          for (CeedInt i = 0; i < Q; i++)
          {
-            // J: 0 2   qd: 0 1   adj(J):  J22 -J12
-            //    1 3       1 2           -J21  J11
-            const CeedScalar J11 = J[i + Q * 0];
-            const CeedScalar J21 = J[i + Q * 1];
-            const CeedScalar J12 = J[i + Q * 2];
-            const CeedScalar J22 = J[i + Q * 3];
-            const CeedScalar w = qw[i] / (J11 * J22 - J21 * J12);
+            CeedScalar qd;
+            MultAdjJCAdjJt21(J + i, Q, c + i, Q, coeff_comp, qw[i], 1, &qd);
+            vg[i] = ug[i] * qd;
+         }
+         break;
+      case 212:
+         for (CeedInt i = 0; i < Q; i++)
+         {
+            CeedScalar qd;
+            MultAdjJCAdjJt21(J + i, Q, c + i, Q, coeff_comp, qw[i], 1, &qd);
+            for (CeedInt d = 0; d < 2; d++)
+            {
+               vg[i + Q * d] = ug[i + Q * d] * qd;
+            }
+         }
+      case 221:
+         for (CeedInt i = 0; i < Q; i++)
+         {
             CeedScalar qd[3];
-            const CeedScalar coeff = c[i];
-            qd[0] =   coeff * w * (J12 * J12 + J22 * J22);
-            qd[1] = - coeff * w * (J11 * J12 + J21 * J22);
-            qd[2] =   coeff * w * (J11 * J11 + J21 * J21);
+            MultAdjJCAdjJt22(J + i, Q, c + i, Q, coeff_comp, qw[i], 1, qd);
             const CeedScalar ug0 = ug[i + Q * 0];
             const CeedScalar ug1 = ug[i + Q * 1];
             vg[i + Q * 0] = qd[0] * ug0 + qd[1] * ug1;
             vg[i + Q * 1] = qd[1] * ug0 + qd[2] * ug1;
          }
          break;
-      case 22:
+      case 222:
          for (CeedInt i = 0; i < Q; i++)
          {
-            // J: 0 2   qd: 0 1   adj(J):  J22 -J12
-            //    1 3       1 2           -J21  J11
-            const CeedScalar J11 = J[i + Q * 0];
-            const CeedScalar J21 = J[i + Q * 1];
-            const CeedScalar J12 = J[i + Q * 2];
-            const CeedScalar J22 = J[i + Q * 3];
-            const CeedScalar w = qw[i] / (J11 * J22 - J21 * J12);
             CeedScalar qd[3];
-            const CeedScalar coeff = c[i];
-            qd[0] =   coeff * w * (J12 * J12 + J22 * J22);
-            qd[1] = - coeff * w * (J11 * J12 + J21 * J22);
-            qd[2] =   coeff * w * (J11 * J11 + J21 * J21);
+            MultAdjJCAdjJt22(J + i, Q, c + i, Q, coeff_comp, qw[i], 1, qd);
             for (CeedInt d = 0; d < 2; d++)
             {
-               const CeedScalar ug0 = ug[i + Q * (d+2*0)];
-               const CeedScalar ug1 = ug[i + Q * (d+2*1)];
-               vg[i + Q * (d+2*0)] = qd[0] * ug0 + qd[1] * ug1;
-               vg[i + Q * (d+2*1)] = qd[1] * ug0 + qd[2] * ug1;
+               const CeedScalar ug0 = ug[i + Q * (d + 2 * 0)];
+               const CeedScalar ug1 = ug[i + Q * (d + 2 * 1)];
+               vg[i + Q * (d + 2 * 0)] = qd[0] * ug0 + qd[1] * ug1;
+               vg[i + Q * (d + 2 * 1)] = qd[1] * ug0 + qd[2] * ug1;
             }
          }
          break;
-      case 31:
+      case 321:
          for (CeedInt i = 0; i < Q; i++)
          {
-            // J: 0 3 6   qd: 0 1 2
-            //    1 4 7       1 3 4
-            //    2 5 8       2 4 5
-            const CeedScalar J11 = J[i + Q * 0];
-            const CeedScalar J21 = J[i + Q * 1];
-            const CeedScalar J31 = J[i + Q * 2];
-            const CeedScalar J12 = J[i + Q * 3];
-            const CeedScalar J22 = J[i + Q * 4];
-            const CeedScalar J32 = J[i + Q * 5];
-            const CeedScalar J13 = J[i + Q * 6];
-            const CeedScalar J23 = J[i + Q * 7];
-            const CeedScalar J33 = J[i + Q * 8];
-            const CeedScalar A11 = J22 * J33 - J23 * J32;
-            const CeedScalar A12 = J13 * J32 - J12 * J33;
-            const CeedScalar A13 = J12 * J23 - J13 * J22;
-            const CeedScalar A21 = J23 * J31 - J21 * J33;
-            const CeedScalar A22 = J11 * J33 - J13 * J31;
-            const CeedScalar A23 = J13 * J21 - J11 * J23;
-            const CeedScalar A31 = J21 * J32 - J22 * J31;
-            const CeedScalar A32 = J12 * J31 - J11 * J32;
-            const CeedScalar A33 = J11 * J22 - J12 * J21;
-            const CeedScalar w = qw[i] / (J11 * A11 + J21 * A12 + J31 * A13);
+            CeedScalar qd[3];
+            MultAdjJCAdjJt32(J + i, Q, c + i, Q, coeff_comp, qw[i], 1, qd);
+            const CeedScalar ug0 = ug[i + Q * 0];
+            const CeedScalar ug1 = ug[i + Q * 1];
+            vg[i + Q * 0] = qd[0] * ug0 + qd[1] * ug1;
+            vg[i + Q * 1] = qd[1] * ug0 + qd[2] * ug1;
+         }
+         break;
+      case 323:
+         for (CeedInt i = 0; i < Q; i++)
+         {
+            CeedScalar qd[3];
+            MultAdjJCAdjJt32(J + i, Q, c + i, Q, coeff_comp, qw[i], 1, qd);
+            for (CeedInt d = 0; d < 3; d++)
+            {
+               const CeedScalar ug0 = ug[i + Q * (d + 3 * 0)];
+               const CeedScalar ug1 = ug[i + Q * (d + 3 * 1)];
+               vg[i + Q * (d + 3 * 0)] = qd[0] * ug0 + qd[1] * ug1;
+               vg[i + Q * (d + 3 * 1)] = qd[1] * ug0 + qd[2] * ug1;
+            }
+         }
+         break;
+      case 331:
+         for (CeedInt i = 0; i < Q; i++)
+         {
             CeedScalar qd[6];
-            const CeedScalar coeff = c[i];
-            qd[0] = coeff * w * (A11 * A11 + A12 * A12 + A13 * A13);
-            qd[1] = coeff * w * (A11 * A21 + A12 * A22 + A13 * A23);
-            qd[2] = coeff * w * (A11 * A31 + A12 * A32 + A13 * A33);
-            qd[3] = coeff * w * (A21 * A21 + A22 * A22 + A23 * A23);
-            qd[4] = coeff * w * (A21 * A31 + A22 * A32 + A23 * A33);
-            qd[5] = coeff * w * (A31 * A31 + A32 * A32 + A33 * A33);
+            MultAdjJCAdjJt33(J + i, Q, c + i, Q, coeff_comp, qw[i], 1, qd);
             const CeedScalar ug0 = ug[i + Q * 0];
             const CeedScalar ug1 = ug[i + Q * 1];
             const CeedScalar ug2 = ug[i + Q * 2];
@@ -504,50 +438,24 @@ CEED_QFUNCTION(f_apply_diff_mf_quad)(void *ctx, CeedInt Q,
             vg[i + Q * 2] = qd[2] * ug0 + qd[4] * ug1 + qd[5] * ug2;
          }
          break;
-      case 33:
+      case 333:
          for (CeedInt i = 0; i < Q; i++)
          {
-            // J: 0 3 6   qd: 0 1 2
-            //    1 4 7       1 3 4
-            //    2 5 8       2 4 5
-            const CeedScalar J11 = J[i + Q * 0];
-            const CeedScalar J21 = J[i + Q * 1];
-            const CeedScalar J31 = J[i + Q * 2];
-            const CeedScalar J12 = J[i + Q * 3];
-            const CeedScalar J22 = J[i + Q * 4];
-            const CeedScalar J32 = J[i + Q * 5];
-            const CeedScalar J13 = J[i + Q * 6];
-            const CeedScalar J23 = J[i + Q * 7];
-            const CeedScalar J33 = J[i + Q * 8];
-            const CeedScalar A11 = J22 * J33 - J23 * J32;
-            const CeedScalar A12 = J13 * J32 - J12 * J33;
-            const CeedScalar A13 = J12 * J23 - J13 * J22;
-            const CeedScalar A21 = J23 * J31 - J21 * J33;
-            const CeedScalar A22 = J11 * J33 - J13 * J31;
-            const CeedScalar A23 = J13 * J21 - J11 * J23;
-            const CeedScalar A31 = J21 * J32 - J22 * J31;
-            const CeedScalar A32 = J12 * J31 - J11 * J32;
-            const CeedScalar A33 = J11 * J22 - J12 * J21;
-            const CeedScalar w = qw[i] / (J11 * A11 + J21 * A12 + J31 * A13);
             CeedScalar qd[6];
-            const CeedScalar coeff = c[i];
-            qd[0] = coeff * w * (A11 * A11 + A12 * A12 + A13 * A13);
-            qd[1] = coeff * w * (A11 * A21 + A12 * A22 + A13 * A23);
-            qd[2] = coeff * w * (A11 * A31 + A12 * A32 + A13 * A33);
-            qd[3] = coeff * w * (A21 * A21 + A22 * A22 + A23 * A23);
-            qd[4] = coeff * w * (A21 * A31 + A22 * A32 + A23 * A33);
-            qd[5] = coeff * w * (A31 * A31 + A32 * A32 + A33 * A33);
+            MultAdjJCAdjJt33(J + i, Q, c + i, Q, coeff_comp, qw[i], 1, qd);
             for (CeedInt d = 0; d < 3; d++)
             {
-               const CeedScalar ug0 = ug[i + Q * (d+3*0)];
-               const CeedScalar ug1 = ug[i + Q * (d+3*1)];
-               const CeedScalar ug2 = ug[i + Q * (d+3*2)];
-               vg[i + Q * (d+3*0)] = qd[0] * ug0 + qd[1] * ug1 + qd[2] * ug2;
-               vg[i + Q * (d+3*1)] = qd[1] * ug0 + qd[3] * ug1 + qd[4] * ug2;
-               vg[i + Q * (d+3*2)] = qd[2] * ug0 + qd[4] * ug1 + qd[5] * ug2;
+               const CeedScalar ug0 = ug[i + Q * (d + 3 * 0)];
+               const CeedScalar ug1 = ug[i + Q * (d + 3 * 1)];
+               const CeedScalar ug2 = ug[i + Q * (d + 3 * 2)];
+               vg[i + Q * (d + 3 * 0)] = qd[0] * ug0 + qd[1] * ug1 + qd[2] * ug2;
+               vg[i + Q * (d + 3 * 1)] = qd[1] * ug0 + qd[3] * ug1 + qd[4] * ug2;
+               vg[i + Q * (d + 3 * 2)] = qd[2] * ug0 + qd[4] * ug1 + qd[5] * ug2;
             }
          }
          break;
    }
    return 0;
 }
+
+#endif // MFEM_LIBCEED_DIFF_QF_H

--- a/fem/ceed/integrators/diffusion/diffusion_qf.h
+++ b/fem/ceed/integrators/diffusion/diffusion_qf.h
@@ -42,32 +42,32 @@ CEED_QFUNCTION(f_build_diff_const)(void *ctx, CeedInt Q,
    switch (10 * bc->space_dim + bc->dim)
    {
       case 11:
-         for (CeedInt i = 0; i < Q; i++)
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
             const CeedScalar coeff0 = coeff[0];
             qd[i] = coeff0 * qw[i] / J[i];
          }
          break;
       case 21:
-         for (CeedInt i = 0; i < Q; i++)
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
             MultAdjJCAdjJt21(J + i, Q, coeff, 1, coeff_comp, qw[i], Q, qd + i);
          }
          break;
       case 22:
-         for (CeedInt i = 0; i < Q; i++)
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
             MultAdjJCAdjJt22(J + i, Q, coeff, 1, coeff_comp, qw[i], Q, qd + i);
          }
          break;
       case 32:
-         for (CeedInt i = 0; i < Q; i++)
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
             MultAdjJCAdjJt32(J + i, Q, coeff, 1, coeff_comp, qw[i], Q, qd + i);
          }
          break;
       case 33:
-         for (CeedInt i = 0; i < Q; i++)
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
             MultAdjJCAdjJt33(J + i, Q, coeff, 1, coeff_comp, qw[i], Q, qd + i);
          }
@@ -95,31 +95,31 @@ CEED_QFUNCTION(f_build_diff_quad)(void *ctx, CeedInt Q,
    switch (10 * bc->space_dim + bc->dim)
    {
       case 11:
-         for (CeedInt i = 0; i < Q; i++)
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
             qd[i] = c[i] * qw[i] / J[i];
          }
          break;
       case 21:
-         for (CeedInt i = 0; i < Q; i++)
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
             MultAdjJCAdjJt21(J + i, Q, c + i, Q, coeff_comp, qw[i], Q, qd + i);
          }
          break;
       case 22:
-         for (CeedInt i = 0; i < Q; i++)
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
             MultAdjJCAdjJt22(J + i, Q, c + i, Q, coeff_comp, qw[i], Q, qd + i);
          }
          break;
       case 32:
-         for (CeedInt i = 0; i < Q; i++)
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
             MultAdjJCAdjJt32(J + i, Q, c + i, Q, coeff_comp, qw[i], Q, qd + i);
          }
          break;
       case 33:
-         for (CeedInt i = 0; i < Q; i++)
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
             MultAdjJCAdjJt33(J + i, Q, c + i, Q, coeff_comp, qw[i], Q, qd + i);
          }
@@ -140,13 +140,13 @@ CEED_QFUNCTION(f_apply_diff)(void *ctx, CeedInt Q,
    switch (10 * bc->dim + bc->vdim)
    {
       case 11:
-         for (CeedInt i = 0; i < Q; i++)
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
             vg[i] = ug[i] * qd[i];
          }
          break;
       case 21:
-         for (CeedInt i = 0; i < Q; i++)
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
             const CeedScalar ug0 = ug[i + Q * 0];
             const CeedScalar ug1 = ug[i + Q * 1];
@@ -155,13 +155,13 @@ CEED_QFUNCTION(f_apply_diff)(void *ctx, CeedInt Q,
          }
          break;
       case 22:
-         for (CeedInt i = 0; i < Q; i++)
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
             const CeedScalar qd00 = qd[i + Q * 0];
             const CeedScalar qd01 = qd[i + Q * 1];
             const CeedScalar qd10 = qd01;
             const CeedScalar qd11 = qd[i + Q * 2];
-            for (CeedInt d = 0; d < 2; d++)
+            CeedPragmaSIMD for (CeedInt d = 0; d < 2; d++)
             {
                const CeedScalar ug0 = ug[i + Q * (d + 2 * 0)];
                const CeedScalar ug1 = ug[i + Q * (d + 2 * 1)];
@@ -171,7 +171,7 @@ CEED_QFUNCTION(f_apply_diff)(void *ctx, CeedInt Q,
          }
          break;
       case 31:
-         for (CeedInt i = 0; i < Q; i++)
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
             const CeedScalar ug0 = ug[i + Q * 0];
             const CeedScalar ug1 = ug[i + Q * 1];
@@ -182,7 +182,7 @@ CEED_QFUNCTION(f_apply_diff)(void *ctx, CeedInt Q,
          }
          break;
       case 33:
-         for (CeedInt i = 0; i < Q; i++)
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
             const CeedScalar qd00 = qd[i + Q * 0];
             const CeedScalar qd01 = qd[i + Q * 1];
@@ -193,7 +193,7 @@ CEED_QFUNCTION(f_apply_diff)(void *ctx, CeedInt Q,
             const CeedScalar qd20 = qd02;
             const CeedScalar qd21 = qd12;
             const CeedScalar qd22 = qd[i + Q * 5];
-            for (CeedInt d = 0; d < 3; d++)
+            CeedPragmaSIMD for (CeedInt d = 0; d < 3; d++)
             {
                const CeedScalar ug0 = ug[i + Q * (d + 3 * 0)];
                const CeedScalar ug1 = ug[i + Q * (d + 3 * 1)];
@@ -226,7 +226,7 @@ CEED_QFUNCTION(f_apply_diff_mf_const)(void *ctx, CeedInt Q,
    switch (100 * bc->space_dim + 10 * bc->dim + bc->vdim)
    {
       case 111:
-         for (CeedInt i = 0; i < Q; i++)
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
             const CeedScalar coeff0 = coeff[0];
             const CeedScalar qd = coeff0 * qw[i] / J[i];
@@ -234,7 +234,7 @@ CEED_QFUNCTION(f_apply_diff_mf_const)(void *ctx, CeedInt Q,
          }
          break;
       case 211:
-         for (CeedInt i = 0; i < Q; i++)
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
             CeedScalar qd;
             MultAdjJCAdjJt21(J + i, Q, coeff, 1, coeff_comp, qw[i], 1, &qd);
@@ -242,18 +242,18 @@ CEED_QFUNCTION(f_apply_diff_mf_const)(void *ctx, CeedInt Q,
          }
          break;
       case 212:
-         for (CeedInt i = 0; i < Q; i++)
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
             CeedScalar qd;
             MultAdjJCAdjJt21(J + i, Q, coeff, 1, coeff_comp, qw[i], 1, &qd);
-            for (CeedInt d = 0; d < 2; d++)
+            CeedPragmaSIMD for (CeedInt d = 0; d < 2; d++)
             {
                vg[i + Q * d] = ug[i + Q * d] * qd;
             }
          }
          break;
       case 221:
-         for (CeedInt i = 0; i < Q; i++)
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
             CeedScalar qd[3];
             MultAdjJCAdjJt22(J + i, Q, coeff, 1, coeff_comp, qw[i], 1, qd);
@@ -264,11 +264,11 @@ CEED_QFUNCTION(f_apply_diff_mf_const)(void *ctx, CeedInt Q,
          }
          break;
       case 222:
-         for (CeedInt i = 0; i < Q; i++)
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
             CeedScalar qd[3];
             MultAdjJCAdjJt22(J + i, Q, coeff, 1, coeff_comp, qw[i], 1, qd);
-            for (CeedInt d = 0; d < 2; d++)
+            CeedPragmaSIMD for (CeedInt d = 0; d < 2; d++)
             {
                const CeedScalar ug0 = ug[i + Q * (d + 2 * 0)];
                const CeedScalar ug1 = ug[i + Q * (d + 2 * 1)];
@@ -278,7 +278,7 @@ CEED_QFUNCTION(f_apply_diff_mf_const)(void *ctx, CeedInt Q,
          }
          break;
       case 321:
-         for (CeedInt i = 0; i < Q; i++)
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
             CeedScalar qd[3];
             MultAdjJCAdjJt32(J + i, Q, coeff, 1, coeff_comp, qw[i], 1, qd);
@@ -289,11 +289,11 @@ CEED_QFUNCTION(f_apply_diff_mf_const)(void *ctx, CeedInt Q,
          }
          break;
       case 323:
-         for (CeedInt i = 0; i < Q; i++)
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
             CeedScalar qd[3];
             MultAdjJCAdjJt32(J + i, Q, coeff, 1, coeff_comp, qw[i], 1, qd);
-            for (CeedInt d = 0; d < 3; d++)
+            CeedPragmaSIMD for (CeedInt d = 0; d < 3; d++)
             {
                const CeedScalar ug0 = ug[i + Q * (d + 3 * 0)];
                const CeedScalar ug1 = ug[i + Q * (d + 3 * 1)];
@@ -303,7 +303,7 @@ CEED_QFUNCTION(f_apply_diff_mf_const)(void *ctx, CeedInt Q,
          }
          break;
       case 331:
-         for (CeedInt i = 0; i < Q; i++)
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
             CeedScalar qd[6];
             MultAdjJCAdjJt33(J + i, Q, coeff, 1, coeff_comp, qw[i], 1, qd);
@@ -316,11 +316,11 @@ CEED_QFUNCTION(f_apply_diff_mf_const)(void *ctx, CeedInt Q,
          }
          break;
       case 333:
-         for (CeedInt i = 0; i < Q; i++)
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
             CeedScalar qd[6];
             MultAdjJCAdjJt33(J + i, Q, coeff, 1, coeff_comp, qw[i], 1, qd);
-            for (CeedInt d = 0; d < 3; d++)
+            CeedPragmaSIMD for (CeedInt d = 0; d < 3; d++)
             {
                const CeedScalar ug0 = ug[i + Q * (d + 3 * 0)];
                const CeedScalar ug1 = ug[i + Q * (d + 3 * 1)];
@@ -351,14 +351,14 @@ CEED_QFUNCTION(f_apply_diff_mf_quad)(void *ctx, CeedInt Q,
    switch (100 * bc->space_dim + 10 * bc->dim + bc->vdim)
    {
       case 111:
-         for (CeedInt i = 0; i < Q; i++)
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
             const CeedScalar qd = c[i] * qw[i] / J[i];
             vg[i] = ug[i] * qd;
          }
          break;
       case 211:
-         for (CeedInt i = 0; i < Q; i++)
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
             CeedScalar qd;
             MultAdjJCAdjJt21(J + i, Q, c + i, Q, coeff_comp, qw[i], 1, &qd);
@@ -366,17 +366,17 @@ CEED_QFUNCTION(f_apply_diff_mf_quad)(void *ctx, CeedInt Q,
          }
          break;
       case 212:
-         for (CeedInt i = 0; i < Q; i++)
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
             CeedScalar qd;
             MultAdjJCAdjJt21(J + i, Q, c + i, Q, coeff_comp, qw[i], 1, &qd);
-            for (CeedInt d = 0; d < 2; d++)
+            CeedPragmaSIMD for (CeedInt d = 0; d < 2; d++)
             {
                vg[i + Q * d] = ug[i + Q * d] * qd;
             }
          }
       case 221:
-         for (CeedInt i = 0; i < Q; i++)
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
             CeedScalar qd[3];
             MultAdjJCAdjJt22(J + i, Q, c + i, Q, coeff_comp, qw[i], 1, qd);
@@ -387,11 +387,11 @@ CEED_QFUNCTION(f_apply_diff_mf_quad)(void *ctx, CeedInt Q,
          }
          break;
       case 222:
-         for (CeedInt i = 0; i < Q; i++)
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
             CeedScalar qd[3];
             MultAdjJCAdjJt22(J + i, Q, c + i, Q, coeff_comp, qw[i], 1, qd);
-            for (CeedInt d = 0; d < 2; d++)
+            CeedPragmaSIMD for (CeedInt d = 0; d < 2; d++)
             {
                const CeedScalar ug0 = ug[i + Q * (d + 2 * 0)];
                const CeedScalar ug1 = ug[i + Q * (d + 2 * 1)];
@@ -401,7 +401,7 @@ CEED_QFUNCTION(f_apply_diff_mf_quad)(void *ctx, CeedInt Q,
          }
          break;
       case 321:
-         for (CeedInt i = 0; i < Q; i++)
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
             CeedScalar qd[3];
             MultAdjJCAdjJt32(J + i, Q, c + i, Q, coeff_comp, qw[i], 1, qd);
@@ -412,11 +412,11 @@ CEED_QFUNCTION(f_apply_diff_mf_quad)(void *ctx, CeedInt Q,
          }
          break;
       case 323:
-         for (CeedInt i = 0; i < Q; i++)
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
             CeedScalar qd[3];
             MultAdjJCAdjJt32(J + i, Q, c + i, Q, coeff_comp, qw[i], 1, qd);
-            for (CeedInt d = 0; d < 3; d++)
+            CeedPragmaSIMD for (CeedInt d = 0; d < 3; d++)
             {
                const CeedScalar ug0 = ug[i + Q * (d + 3 * 0)];
                const CeedScalar ug1 = ug[i + Q * (d + 3 * 1)];
@@ -426,7 +426,7 @@ CEED_QFUNCTION(f_apply_diff_mf_quad)(void *ctx, CeedInt Q,
          }
          break;
       case 331:
-         for (CeedInt i = 0; i < Q; i++)
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
             CeedScalar qd[6];
             MultAdjJCAdjJt33(J + i, Q, c + i, Q, coeff_comp, qw[i], 1, qd);
@@ -439,11 +439,11 @@ CEED_QFUNCTION(f_apply_diff_mf_quad)(void *ctx, CeedInt Q,
          }
          break;
       case 333:
-         for (CeedInt i = 0; i < Q; i++)
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
             CeedScalar qd[6];
             MultAdjJCAdjJt33(J + i, Q, c + i, Q, coeff_comp, qw[i], 1, qd);
-            for (CeedInt d = 0; d < 3; d++)
+            CeedPragmaSIMD for (CeedInt d = 0; d < 3; d++)
             {
                const CeedScalar ug0 = ug[i + Q * (d + 3 * 0)];
                const CeedScalar ug1 = ug[i + Q * (d + 3 * 1)];

--- a/fem/ceed/integrators/diffusion/diffusion_qf.h
+++ b/fem/ceed/integrators/diffusion/diffusion_qf.h
@@ -12,7 +12,7 @@
 #ifndef MFEM_LIBCEED_DIFF_QF_H
 #define MFEM_LIBCEED_DIFF_QF_H
 
-#include "../qf_utils.h"
+#include "../util/util_qf.h"
 
 #define LIBCEED_DIFF_COEFF_COMP_MAX 6
 

--- a/fem/ceed/integrators/mass/mass.cpp
+++ b/fem/ceed/integrators/mass/mass.cpp
@@ -26,7 +26,7 @@ namespace ceed
 struct MassOperatorInfo : public OperatorInfo
 {
    MassContext ctx;
-   MassOperatorInfo()
+   MassOperatorInfo(const mfem::FiniteElementSpace &fes, mfem::Coefficient *Q)
    {
       header = "/integrators/mass/mass_qf.h";
       build_func_const = ":f_build_mass_const";
@@ -42,6 +42,19 @@ struct MassOperatorInfo : public OperatorInfo
       trial_op = EvalMode::Interp;
       test_op = EvalMode::Interp;
       qdatasize = 1;
+
+      ctx.dim = fes.GetMesh()->Dimension();
+      ctx.space_dim = fes.GetMesh()->SpaceDimension();
+      ctx.vdim = fes.GetVDim();
+      if (Q == nullptr)
+      {
+         ctx.coeff = 1.0;
+      }
+      else if (ConstantCoefficient *const_coeff =
+                  dynamic_cast<ConstantCoefficient *>(Q))
+      {
+         ctx.coeff = const_coeff->constant;
+      }
    }
 };
 #endif
@@ -52,7 +65,7 @@ PAMassIntegrator::PAMassIntegrator(const mfem::FiniteElementSpace &fes,
    : PAIntegrator()
 {
 #ifdef MFEM_USE_CEED
-   MassOperatorInfo info;
+   MassOperatorInfo info(fes, Q);
    Assemble(info, fes, irm, Q);
 #else
    MFEM_ABORT("MFEM must be built with MFEM_USE_CEED=YES to use libCEED.");
@@ -64,7 +77,7 @@ MixedPAMassIntegrator::MixedPAMassIntegrator(const MassIntegrator &integ,
                                              mfem::Coefficient *Q)
 {
 #ifdef MFEM_USE_CEED
-   MassOperatorInfo info;
+   MassOperatorInfo info(fes, Q);
    Assemble(integ, info, fes, Q);
 #else
    MFEM_ABORT("MFEM must be built with MFEM_USE_CEED=YES to use libCEED.");
@@ -76,7 +89,7 @@ MixedPAMassIntegrator::MixedPAMassIntegrator(const VectorMassIntegrator &integ,
                                              mfem::Coefficient *Q)
 {
 #ifdef MFEM_USE_CEED
-   MassOperatorInfo info;
+   MassOperatorInfo info(fes, Q);
    Assemble(integ, info, fes, Q);
 #else
    MFEM_ABORT("MFEM must be built with MFEM_USE_CEED=YES to use libCEED.");
@@ -89,7 +102,7 @@ MFMassIntegrator::MFMassIntegrator(const mfem::FiniteElementSpace &fes,
    : MFIntegrator()
 {
 #ifdef MFEM_USE_CEED
-   MassOperatorInfo info;
+   MassOperatorInfo info(fes, Q);
    Assemble(info, fes, irm, Q);
 #else
    MFEM_ABORT("MFEM must be built with MFEM_USE_CEED=YES to use libCEED.");
@@ -101,7 +114,7 @@ MixedMFMassIntegrator::MixedMFMassIntegrator(const MassIntegrator &integ,
                                              mfem::Coefficient *Q)
 {
 #ifdef MFEM_USE_CEED
-   MassOperatorInfo info;
+   MassOperatorInfo info(fes, Q);
    Assemble(integ, info, fes, Q);
 #else
    MFEM_ABORT("MFEM must be built with MFEM_USE_CEED=YES to use libCEED.");
@@ -113,7 +126,7 @@ MixedMFMassIntegrator::MixedMFMassIntegrator(const VectorMassIntegrator &integ,
                                              mfem::Coefficient *Q)
 {
 #ifdef MFEM_USE_CEED
-   MassOperatorInfo info;
+   MassOperatorInfo info(fes, Q);
    Assemble(integ, info, fes, Q);
 #else
    MFEM_ABORT("MFEM must be built with MFEM_USE_CEED=YES to use libCEED.");

--- a/fem/ceed/integrators/mass/mass.cpp
+++ b/fem/ceed/integrators/mass/mass.cpp
@@ -29,7 +29,7 @@ struct MassOperatorInfo : public OperatorInfo
    MassOperatorInfo(const mfem::FiniteElementSpace &fes, mfem::Coefficient *Q,
                     bool use_bdr)
    {
-      ctx.dim = fes.GetMesh()->Dimension() - (use_bdr * 1);
+      ctx.dim = fes.GetMesh()->Dimension() - use_bdr;
       ctx.space_dim = fes.GetMesh()->SpaceDimension();
       ctx.vdim = fes.GetVDim();
       if (Q == nullptr)

--- a/fem/ceed/integrators/mass/mass.hpp
+++ b/fem/ceed/integrators/mass/mass.hpp
@@ -12,7 +12,6 @@
 #ifndef MFEM_LIBCEED_MASS_HPP
 #define MFEM_LIBCEED_MASS_HPP
 
-#include "../../interface/integrator.hpp"
 #include "../../interface/mixed_integrator.hpp"
 #include "../../../fespace.hpp"
 
@@ -23,45 +22,33 @@ namespace ceed
 {
 
 /// Represent a MassIntegrator with AssemblyLevel::Partial using libCEED.
-class PAMassIntegrator : public PAIntegrator
+class PAMassIntegrator : public MixedIntegrator
 {
 public:
-   PAMassIntegrator(const mfem::FiniteElementSpace &fes,
-                    const mfem::IntegrationRule &ir,
-                    mfem::Coefficient *Q);
-};
+   PAMassIntegrator(const mfem::MassIntegrator &integ,
+                    const mfem::FiniteElementSpace &fes,
+                    mfem::Coefficient *Q,
+                    const bool use_bdr = false);
 
-class MixedPAMassIntegrator : public MixedIntegrator<PAIntegrator>
-{
-public:
-   MixedPAMassIntegrator(const MassIntegrator &integ,
-                         const mfem::FiniteElementSpace &fes,
-                         mfem::Coefficient *Q);
-
-   MixedPAMassIntegrator(const VectorMassIntegrator &integ,
-                         const mfem::FiniteElementSpace &fes,
-                         mfem::Coefficient *Q);
+   PAMassIntegrator(const mfem::VectorMassIntegrator &integ,
+                    const mfem::FiniteElementSpace &fes,
+                    mfem::Coefficient *Q,
+                    const bool use_bdr = false);
 };
 
 /// Represent a MassIntegrator with AssemblyLevel::None using libCEED.
-class MFMassIntegrator : public MFIntegrator
+class MFMassIntegrator : public MixedIntegrator
 {
 public:
-   MFMassIntegrator(const mfem::FiniteElementSpace &fes,
-                    const mfem::IntegrationRule &ir,
-                    mfem::Coefficient *Q);
-};
+   MFMassIntegrator(const mfem::MassIntegrator &integ,
+                    const mfem::FiniteElementSpace &fes,
+                    mfem::Coefficient *Q,
+                    const bool use_bdr = false);
 
-class MixedMFMassIntegrator : public MixedIntegrator<MFIntegrator>
-{
-public:
-   MixedMFMassIntegrator(const MassIntegrator &integ,
-                         const mfem::FiniteElementSpace &fes,
-                         mfem::Coefficient *Q);
-
-   MixedMFMassIntegrator(const VectorMassIntegrator &integ,
-                         const mfem::FiniteElementSpace &fes,
-                         mfem::Coefficient *Q);
+   MFMassIntegrator(const mfem::VectorMassIntegrator &integ,
+                    const mfem::FiniteElementSpace &fes,
+                    mfem::Coefficient *Q,
+                    const bool use_bdr = false);
 };
 
 }

--- a/fem/ceed/integrators/mass/mass_qf.h
+++ b/fem/ceed/integrators/mass/mass_qf.h
@@ -36,31 +36,31 @@ CEED_QFUNCTION(f_build_mass_const)(void *ctx, CeedInt Q,
    switch (10 * bc->space_dim + bc->dim)
    {
       case 11:
-         for (CeedInt i = 0; i < Q; i++)
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
             qd[i] = coeff * J[i] * qw[i];
          }
          break;
       case 21:
-         for (CeedInt i = 0; i < Q; i++)
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
             qd[i] = coeff * qw[i] * DetJ21(J + i, Q);
          }
          break;
       case 22:
-         for (CeedInt i = 0; i < Q; i++)
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
             qd[i] = coeff * qw[i] * DetJ22(J + i, Q);
          }
          break;
       case 32:
-         for (CeedInt i = 0; i < Q; i++)
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
             qd[i] = coeff * qw[i] * DetJ32(J + i, Q);
          }
          break;
       case 33:
-         for (CeedInt i = 0; i < Q; i++)
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
             qd[i] = coeff * qw[i] * DetJ33(J + i, Q);
          }
@@ -84,31 +84,31 @@ CEED_QFUNCTION(f_build_mass_quad)(void *ctx, CeedInt Q,
    switch (10 * bc->space_dim + bc->dim)
    {
       case 11:
-         for (CeedInt i = 0; i < Q; i++)
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
             qd[i] = c[i] * J[i] * qw[i];
          }
          break;
       case 21:
-         for (CeedInt i = 0; i < Q; i++)
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
             qd[i] = c[i] * qw[i] * DetJ21(J + i, Q);
          }
          break;
       case 22:
-         for (CeedInt i = 0; i < Q; i++)
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
             qd[i] = c[i] * qw[i] * DetJ22(J + i, Q);
          }
          break;
       case 32:
-         for (CeedInt i = 0; i < Q; i++)
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
             qd[i] = c[i] * qw[i] * DetJ32(J + i, Q);
          }
          break;
       case 33:
-         for (CeedInt i = 0; i < Q; i++)
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
             qd[i] = c[i] * qw[i] * DetJ33(J + i, Q);
          }
@@ -128,26 +128,26 @@ CEED_QFUNCTION(f_apply_mass)(void *ctx, CeedInt Q,
    switch (bc->vdim)
    {
       case 1:
-         for (CeedInt i = 0; i < Q; i++)
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
             v[i] = qd[i] * u[i];
          }
          break;
       case 2:
-         for (CeedInt i = 0; i < Q; i++)
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
             const CeedScalar qdi = qd[i];
-            for (CeedInt d = 0; d < 2; d++)
+            CeedPragmaSIMD for (CeedInt d = 0; d < 2; d++)
             {
                v[i + d * Q] = qdi * u[i + d * Q];
             }
          }
          break;
       case 3:
-         for (CeedInt i = 0; i < Q; i++)
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
             const CeedScalar qdi = qd[i];
-            for (CeedInt d = 0; d < 3; d++)
+            CeedPragmaSIMD for (CeedInt d = 0; d < 3; d++)
             {
                v[i + d * Q] = qdi * u[i + d * Q];
             }
@@ -168,75 +168,75 @@ CEED_QFUNCTION(f_apply_mass_mf_const)(void *ctx, CeedInt Q,
    switch (100 * bc->space_dim + 10 * bc->dim + bc->vdim)
    {
       case 111:
-         for (CeedInt i = 0; i < Q; i++)
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
             const CeedScalar qd = coeff * qw[i] * J[i];
             v[i] = qd * u[i];
          }
          break;
       case 211:
-         for (CeedInt i = 0; i < Q; i++)
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
             const CeedScalar qd = coeff * qw[i] * DetJ21(J + i, Q);
             v[i] = qd * u[i];
          }
          break;
       case 212:
-         for (CeedInt i = 0; i < Q; i++)
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
             const CeedScalar qd = coeff * qw[i] * DetJ21(J + i, Q);
-            for (CeedInt d = 0; d < 2; d++)
+            CeedPragmaSIMD for (CeedInt d = 0; d < 2; d++)
             {
                v[i + d * Q] = qd * u[i + d * Q];
             }
          }
          break;
       case 221:
-         for (CeedInt i = 0; i < Q; i++)
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
             const CeedScalar qd = coeff * qw[i] * DetJ22(J + i, Q);
             v[i] = qd * u[i];
          }
          break;
       case 222:
-         for (CeedInt i = 0; i < Q; i++)
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
             const CeedScalar qd = coeff * qw[i] * DetJ22(J + i, Q);
-            for (CeedInt d = 0; d < 2; d++)
+            CeedPragmaSIMD for (CeedInt d = 0; d < 2; d++)
             {
                v[i + d * Q] = qd * u[i + d * Q];
             }
          }
          break;
       case 321:
-         for (CeedInt i = 0; i < Q; i++)
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
             const CeedScalar qd = coeff * qw[i] * DetJ32(J + i, Q);
             v[i] = qd * u[i];
          }
          break;
       case 323:
-         for (CeedInt i = 0; i < Q; i++)
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
             const CeedScalar qd = coeff * qw[i] * DetJ32(J + i, Q);
-            for (CeedInt d = 0; d < 3; d++)
+            CeedPragmaSIMD for (CeedInt d = 0; d < 3; d++)
             {
                v[i + d * Q] = qd * u[i + d * Q];
             }
          }
          break;
       case 331:
-         for (CeedInt i = 0; i < Q; i++)
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
             const CeedScalar qd = coeff * qw[i] * DetJ33(J + i, Q);
             v[i] = qd * u[i];
          }
          break;
       case 333:
-         for (CeedInt i = 0; i < Q; i++)
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
             const CeedScalar qd = coeff * qw[i] * DetJ33(J + i, Q);
-            for (CeedInt d = 0; d < 3; d++)
+            CeedPragmaSIMD for (CeedInt d = 0; d < 3; d++)
             {
                v[i + d * Q] = qd * u[i + d * Q];
             }
@@ -255,75 +255,75 @@ CEED_QFUNCTION(f_apply_mass_mf_quad)(void *ctx, CeedInt Q,
    switch (100 * bc->space_dim + 10 * bc->dim + bc->vdim)
    {
       case 111:
-         for (CeedInt i = 0; i < Q; i++)
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
             const CeedScalar qd = c[i] * J[i] * qw[i];
             v[i] = qd * u[i];
          }
          break;
       case 211:
-         for (CeedInt i = 0; i < Q; i++)
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
             const CeedScalar qd = c[i] * qw[i] * DetJ21(J + i, Q);
             v[i] = qd * u[i];
          }
          break;
       case 212:
-         for (CeedInt i = 0; i < Q; i++)
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
             const CeedScalar qd = c[i] * qw[i] * DetJ21(J + i, Q);
-            for (CeedInt d = 0; d < 2; d++)
+            CeedPragmaSIMD for (CeedInt d = 0; d < 2; d++)
             {
                v[i + d * Q] = qd * u[i + d * Q];
             }
          }
          break;
       case 221:
-         for (CeedInt i = 0; i < Q; i++)
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
             const CeedScalar qd = c[i] * qw[i] * DetJ22(J + i, Q);
             v[i] = qd * u[i];
          }
          break;
       case 222:
-         for (CeedInt i = 0; i < Q; i++)
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
             const CeedScalar qd = c[i] * qw[i] * DetJ22(J + i, Q);
-            for (CeedInt d = 0; d < 2; d++)
+            CeedPragmaSIMD for (CeedInt d = 0; d < 2; d++)
             {
                v[i + d * Q] = qd * u[i + d * Q];
             }
          }
          break;
       case 321:
-         for (CeedInt i = 0; i < Q; i++)
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
             const CeedScalar qd = c[i] * qw[i] * DetJ32(J + i, Q);
             v[i] = qd * u[i];
          }
          break;
       case 323:
-         for (CeedInt i = 0; i < Q; i++)
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
             const CeedScalar qd = c[i] * qw[i] * DetJ32(J + i, Q);
-            for (CeedInt d = 0; d < 3; d++)
+            CeedPragmaSIMD for (CeedInt d = 0; d < 3; d++)
             {
                v[i + d * Q] = qd * u[i + d * Q];
             }
          }
          break;
       case 331:
-         for (CeedInt i = 0; i < Q; i++)
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
             const CeedScalar qd = c[i] * qw[i] * DetJ33(J + i, Q);
             v[i] = qd * u[i];
          }
          break;
       case 333:
-         for (CeedInt i = 0; i < Q; i++)
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
             const CeedScalar qd = c[i] * qw[i] * DetJ33(J + i, Q);
-            for (CeedInt d = 0; d < 3; d++)
+            CeedPragmaSIMD for (CeedInt d = 0; d < 3; d++)
             {
                v[i + d * Q] = qd * u[i + d * Q];
             }

--- a/fem/ceed/integrators/mass/mass_qf.h
+++ b/fem/ceed/integrators/mass/mass_qf.h
@@ -9,9 +9,17 @@
 // terms of the BSD-3 license. We welcome feedback and contributions, see file
 // CONTRIBUTING.md for details.
 
+#ifndef MFEM_LIBCEED_MASS_QF_H
+#define MFEM_LIBCEED_MASS_QF_H
 
-/// A structure used to pass additional data to f_build_diff and f_apply_diff
-struct MassContext { CeedInt dim, space_dim, vdim; CeedScalar coeff; };
+#include "../qf_utils.h"
+
+/// A structure used to pass additional data to f_build_mass and f_apply_mass
+struct MassContext
+{
+   CeedInt dim, space_dim, vdim;
+   CeedScalar coeff;
+};
 
 /// libCEED Q-function for building quadrature data for a mass operator with a
 /// constant coefficient
@@ -19,37 +27,42 @@ CEED_QFUNCTION(f_build_mass_const)(void *ctx, CeedInt Q,
                                    const CeedScalar *const *in,
                                    CeedScalar *const *out)
 {
-   // in[0] is Jacobians with shape [dim, nc=dim, Q]
+   // in[0] is Jacobians with shape [dim, ncomp=space_dim, Q]
    // in[1] is quadrature weights, size (Q)
    MassContext *bc = (MassContext *)ctx;
    const CeedScalar coeff = bc->coeff;
    const CeedScalar *J = in[0], *qw = in[1];
-   CeedScalar *rho = out[0];
-   switch (bc->dim + 10*bc->space_dim)
+   CeedScalar *qd = out[0];
+   switch (10 * bc->space_dim + bc->dim)
    {
       case 11:
-         for (CeedInt i=0; i<Q; i++)
+         for (CeedInt i = 0; i < Q; i++)
          {
-            rho[i] = coeff * J[i] * qw[i];
+            qd[i] = coeff * J[i] * qw[i];
+         }
+         break;
+      case 21:
+         for (CeedInt i = 0; i < Q; i++)
+         {
+            qd[i] = coeff * qw[i] * DetJ21(J + i, Q);
          }
          break;
       case 22:
-         for (CeedInt i=0; i<Q; i++)
+         for (CeedInt i = 0; i < Q; i++)
          {
-            // 0 2
-            // 1 3
-            rho[i] = coeff * (J[i+Q*0]*J[i+Q*3] - J[i+Q*1]*J[i+Q*2]) * qw[i];
+            qd[i] = coeff * qw[i] * DetJ22(J + i, Q);
+         }
+         break;
+      case 32:
+         for (CeedInt i = 0; i < Q; i++)
+         {
+            qd[i] = coeff * qw[i] * DetJ32(J + i, Q);
          }
          break;
       case 33:
-         for (CeedInt i=0; i<Q; i++)
+         for (CeedInt i = 0; i < Q; i++)
          {
-            // 0 3 6
-            // 1 4 7
-            // 2 5 8
-            rho[i] = (J[i+Q*0]*(J[i+Q*4]*J[i+Q*8] - J[i+Q*5]*J[i+Q*7]) -
-                      J[i+Q*1]*(J[i+Q*3]*J[i+Q*8] - J[i+Q*5]*J[i+Q*6]) +
-                      J[i+Q*2]*(J[i+Q*3]*J[i+Q*7] - J[i+Q*4]*J[i+Q*6])) * coeff * qw[i];
+            qd[i] = coeff * qw[i] * DetJ33(J + i, Q);
          }
          break;
    }
@@ -62,36 +75,42 @@ CEED_QFUNCTION(f_build_mass_quad)(void *ctx, CeedInt Q,
                                   const CeedScalar *const *in,
                                   CeedScalar *const *out)
 {
-   // in[0] is Jacobians with shape [dim, nc=dim, Q]
-   // in[1] is quadrature weights, size (Q)
+   // in[0] is coefficients, size (Q)
+   // in[1] is Jacobians with shape [dim, ncomp=space_dim, Q]
+   // in[2] is quadrature weights, size (Q)
    MassContext *bc = (MassContext *)ctx;
    const CeedScalar *c = in[0], *J = in[1], *qw = in[2];
-   CeedScalar *rho = out[0];
-   switch (bc->dim + 10*bc->space_dim)
+   CeedScalar *qd = out[0];
+   switch (10 * bc->space_dim + bc->dim)
    {
       case 11:
-         for (CeedInt i=0; i<Q; i++)
+         for (CeedInt i = 0; i < Q; i++)
          {
-            rho[i] = c[i] * J[i] * qw[i];
+            qd[i] = c[i] * J[i] * qw[i];
+         }
+         break;
+      case 21:
+         for (CeedInt i = 0; i < Q; i++)
+         {
+            qd[i] = c[i] * qw[i] * DetJ21(J + i, Q);
          }
          break;
       case 22:
-         for (CeedInt i=0; i<Q; i++)
+         for (CeedInt i = 0; i < Q; i++)
          {
-            // 0 2
-            // 1 3
-            rho[i] = c[i] * (J[i+Q*0]*J[i+Q*3] - J[i+Q*1]*J[i+Q*2]) * qw[i];
+            qd[i] = c[i] * qw[i] * DetJ22(J + i, Q);
+         }
+         break;
+      case 32:
+         for (CeedInt i = 0; i < Q; i++)
+         {
+            qd[i] = c[i] * qw[i] * DetJ32(J + i, Q);
          }
          break;
       case 33:
-         for (CeedInt i=0; i<Q; i++)
+         for (CeedInt i = 0; i < Q; i++)
          {
-            // 0 3 6
-            // 1 4 7
-            // 2 5 8
-            rho[i] = (J[i+Q*0]*(J[i+Q*4]*J[i+Q*8] - J[i+Q*5]*J[i+Q*7]) -
-                      J[i+Q*1]*(J[i+Q*3]*J[i+Q*8] - J[i+Q*5]*J[i+Q*6]) +
-                      J[i+Q*2]*(J[i+Q*3]*J[i+Q*7] - J[i+Q*4]*J[i+Q*6])) * c[i] * qw[i];
+            qd[i] = c[i] * qw[i] * DetJ33(J + i, Q);
          }
          break;
    }
@@ -104,33 +123,33 @@ CEED_QFUNCTION(f_apply_mass)(void *ctx, CeedInt Q,
                              CeedScalar *const *out)
 {
    MassContext *bc = (MassContext *)ctx;
-   const CeedScalar *u = in[0], *w = in[1];
+   const CeedScalar *u = in[0], *qd = in[1];
    CeedScalar *v = out[0];
    switch (bc->vdim)
    {
       case 1:
-         for (CeedInt i=0; i<Q; i++)
+         for (CeedInt i = 0; i < Q; i++)
          {
-            v[i] = w[i] * u[i];
+            v[i] = qd[i] * u[i];
          }
          break;
       case 2:
-         for (CeedInt i=0; i<Q; i++)
+         for (CeedInt i = 0; i < Q; i++)
          {
-            const CeedScalar W = w[i];
-            for (CeedInt c = 0; c < 2; c++)
+            const CeedScalar qdi = qd[i];
+            for (CeedInt d = 0; d < 2; d++)
             {
-               v[i+c*Q] = W * u[i+c*Q];
+               v[i + d * Q] = qdi * u[i + d * Q];
             }
          }
          break;
       case 3:
-         for (CeedInt i=0; i<Q; i++)
+         for (CeedInt i = 0; i < Q; i++)
          {
-            const CeedScalar W = w[i];
-            for (CeedInt c = 0; c < 3; c++)
+            const CeedScalar qdi = qd[i];
+            for (CeedInt d = 0; d < 3; d++)
             {
-               v[i+c*Q] = W * u[i+c*Q];
+               v[i + d * Q] = qdi * u[i + d * Q];
             }
          }
          break;
@@ -138,63 +157,88 @@ CEED_QFUNCTION(f_apply_mass)(void *ctx, CeedInt Q,
    return 0;
 }
 
-/// libCEED Q-function for applying a diff operator
+/// libCEED Q-function for applying a mass operator
 CEED_QFUNCTION(f_apply_mass_mf_const)(void *ctx, CeedInt Q,
                                       const CeedScalar *const *in, CeedScalar *const *out)
 {
-   MassContext *bc = (MassContext*)ctx;
+   MassContext *bc = (MassContext *)ctx;
    const CeedScalar coeff = bc->coeff;
    const CeedScalar *u = in[0], *J = in[1], *qw = in[2];
    CeedScalar *v = out[0];
-   switch (10 * bc->dim + bc->vdim)
+   switch (100 * bc->space_dim + 10 * bc->dim + bc->vdim)
    {
-      case 11:
+      case 111:
          for (CeedInt i = 0; i < Q; i++)
          {
-            const CeedScalar rho = coeff * qw[i] / J[i];
-            v[i] = rho * u[i];
+            const CeedScalar qd = coeff * qw[i] * J[i];
+            v[i] = qd * u[i];
          }
          break;
-      case 21:
+      case 211:
          for (CeedInt i = 0; i < Q; i++)
          {
-            const CeedScalar rho = coeff * (J[i+Q*0]*J[i+Q*3] - J[i+Q*1]*J[i+Q*2]) * qw[i];
-            v[i] = rho * u[i];
+            const CeedScalar qd = coeff * qw[i] * DetJ21(J + i, Q);
+            v[i] = qd * u[i];
          }
          break;
-      case 22:
-         for (CeedInt i=0; i<Q; i++)
+      case 212:
+         for (CeedInt i = 0; i < Q; i++)
          {
-            // 0 2
-            // 1 3
-            const CeedScalar rho = coeff * (J[i+Q*0]*J[i+Q*3] - J[i+Q*1]*J[i+Q*2]) * qw[i];
-            for (CeedInt c = 0; c < 2; c++)
+            const CeedScalar qd = coeff * qw[i] * DetJ21(J + i, Q);
+            for (CeedInt d = 0; d < 2; d++)
             {
-               v[i+c*Q] = rho * u[i+c*Q];
+               v[i + d * Q] = qd * u[i + d * Q];
             }
          }
          break;
-      case 31:
+      case 221:
          for (CeedInt i = 0; i < Q; i++)
          {
-            const CeedScalar rho = (J[i+Q*0]*(J[i+Q*4]*J[i+Q*8] - J[i+Q*5]*J[i+Q*7]) -
-                                    J[i+Q*1]*(J[i+Q*3]*J[i+Q*8] - J[i+Q*5]*J[i+Q*6]) +
-                                    J[i+Q*2]*(J[i+Q*3]*J[i+Q*7] - J[i+Q*4]*J[i+Q*6])) * coeff * qw[i];
-            v[i] = rho * u[i];
+            const CeedScalar qd = coeff * qw[i] * DetJ22(J + i, Q);
+            v[i] = qd * u[i];
          }
          break;
-      case 33:
-         for (CeedInt i=0; i<Q; i++)
+      case 222:
+         for (CeedInt i = 0; i < Q; i++)
          {
-            // 0 3 6
-            // 1 4 7
-            // 2 5 8
-            const CeedScalar rho = (J[i+Q*0]*(J[i+Q*4]*J[i+Q*8] - J[i+Q*5]*J[i+Q*7]) -
-                                    J[i+Q*1]*(J[i+Q*3]*J[i+Q*8] - J[i+Q*5]*J[i+Q*6]) +
-                                    J[i+Q*2]*(J[i+Q*3]*J[i+Q*7] - J[i+Q*4]*J[i+Q*6])) * coeff * qw[i];
-            for (CeedInt c = 0; c < 3; c++)
+            const CeedScalar qd = coeff * qw[i] * DetJ22(J + i, Q);
+            for (CeedInt d = 0; d < 2; d++)
             {
-               v[i+c*Q] = rho * u[i+c*Q];
+               v[i + d * Q] = qd * u[i + d * Q];
+            }
+         }
+         break;
+      case 321:
+         for (CeedInt i = 0; i < Q; i++)
+         {
+            const CeedScalar qd = coeff * qw[i] * DetJ32(J + i, Q);
+            v[i] = qd * u[i];
+         }
+         break;
+      case 323:
+         for (CeedInt i = 0; i < Q; i++)
+         {
+            const CeedScalar qd = coeff * qw[i] * DetJ32(J + i, Q);
+            for (CeedInt d = 0; d < 3; d++)
+            {
+               v[i + d * Q] = qd * u[i + d * Q];
+            }
+         }
+         break;
+      case 331:
+         for (CeedInt i = 0; i < Q; i++)
+         {
+            const CeedScalar qd = coeff * qw[i] * DetJ33(J + i, Q);
+            v[i] = qd * u[i];
+         }
+         break;
+      case 333:
+         for (CeedInt i = 0; i < Q; i++)
+         {
+            const CeedScalar qd = coeff * qw[i] * DetJ33(J + i, Q);
+            for (CeedInt d = 0; d < 3; d++)
+            {
+               v[i + d * Q] = qd * u[i + d * Q];
             }
          }
          break;
@@ -205,66 +249,88 @@ CEED_QFUNCTION(f_apply_mass_mf_const)(void *ctx, CeedInt Q,
 CEED_QFUNCTION(f_apply_mass_mf_quad)(void *ctx, CeedInt Q,
                                      const CeedScalar *const *in, CeedScalar *const *out)
 {
-   MassContext *bc = (MassContext*)ctx;
+   MassContext *bc = (MassContext *)ctx;
    const CeedScalar *c = in[0], *u = in[1], *J = in[2], *qw = in[3];
    CeedScalar *v = out[0];
-   switch (10 * bc->dim + bc->vdim)
+   switch (100 * bc->space_dim + 10 * bc->dim + bc->vdim)
    {
-      case 11:
-         for (CeedInt i=0; i<Q; i++)
+      case 111:
+         for (CeedInt i = 0; i < Q; i++)
          {
-            const CeedScalar rho = c[i] * J[i] * qw[i];
-            v[i] = rho * u[i];
+            const CeedScalar qd = c[i] * J[i] * qw[i];
+            v[i] = qd * u[i];
          }
          break;
-      case 21:
-         for (CeedInt i=0; i<Q; i++)
+      case 211:
+         for (CeedInt i = 0; i < Q; i++)
          {
-            // 0 2
-            // 1 3
-            const CeedScalar rho = c[i] * (J[i+Q*0]*J[i+Q*3] - J[i+Q*1]*J[i+Q*2]) * qw[i];
-            v[i] = rho * u[i];
+            const CeedScalar qd = c[i] * qw[i] * DetJ21(J + i, Q);
+            v[i] = qd * u[i];
          }
          break;
-      case 22:
-         for (CeedInt i=0; i<Q; i++)
+      case 212:
+         for (CeedInt i = 0; i < Q; i++)
          {
-            // 0 2
-            // 1 3
-            const CeedScalar rho = c[i] * (J[i+Q*0]*J[i+Q*3] - J[i+Q*1]*J[i+Q*2]) * qw[i];
+            const CeedScalar qd = c[i] * qw[i] * DetJ21(J + i, Q);
             for (CeedInt d = 0; d < 2; d++)
             {
-               v[i+d*Q] = rho * u[i+d*Q];
+               v[i + d * Q] = qd * u[i + d * Q];
             }
          }
          break;
-      case 31:
-         for (CeedInt i=0; i<Q; i++)
+      case 221:
+         for (CeedInt i = 0; i < Q; i++)
          {
-            // 0 3 6
-            // 1 4 7
-            // 2 5 8
-            const CeedScalar rho = (J[i+Q*0]*(J[i+Q*4]*J[i+Q*8] - J[i+Q*5]*J[i+Q*7]) -
-                                    J[i+Q*1]*(J[i+Q*3]*J[i+Q*8] - J[i+Q*5]*J[i+Q*6]) +
-                                    J[i+Q*2]*(J[i+Q*3]*J[i+Q*7] - J[i+Q*4]*J[i+Q*6])) * c[i] * qw[i];
-            v[i] = rho * u[i];
+            const CeedScalar qd = c[i] * qw[i] * DetJ22(J + i, Q);
+            v[i] = qd * u[i];
          }
          break;
-      case 33:
-         for (CeedInt i=0; i<Q; i++)
+      case 222:
+         for (CeedInt i = 0; i < Q; i++)
          {
-            // 0 3 6
-            // 1 4 7
-            // 2 5 8
-            const CeedScalar rho = (J[i+Q*0]*(J[i+Q*4]*J[i+Q*8] - J[i+Q*5]*J[i+Q*7]) -
-                                    J[i+Q*1]*(J[i+Q*3]*J[i+Q*8] - J[i+Q*5]*J[i+Q*6]) +
-                                    J[i+Q*2]*(J[i+Q*3]*J[i+Q*7] - J[i+Q*4]*J[i+Q*6])) * c[i] * qw[i];
+            const CeedScalar qd = c[i] * qw[i] * DetJ22(J + i, Q);
+            for (CeedInt d = 0; d < 2; d++)
+            {
+               v[i + d * Q] = qd * u[i + d * Q];
+            }
+         }
+         break;
+      case 321:
+         for (CeedInt i = 0; i < Q; i++)
+         {
+            const CeedScalar qd = c[i] * qw[i] * DetJ32(J + i, Q);
+            v[i] = qd * u[i];
+         }
+         break;
+      case 323:
+         for (CeedInt i = 0; i < Q; i++)
+         {
+            const CeedScalar qd = c[i] * qw[i] * DetJ32(J + i, Q);
             for (CeedInt d = 0; d < 3; d++)
             {
-               v[i+d*Q] = rho * u[i+d*Q];
+               v[i + d * Q] = qd * u[i + d * Q];
+            }
+         }
+         break;
+      case 331:
+         for (CeedInt i = 0; i < Q; i++)
+         {
+            const CeedScalar qd = c[i] * qw[i] * DetJ33(J + i, Q);
+            v[i] = qd * u[i];
+         }
+         break;
+      case 333:
+         for (CeedInt i = 0; i < Q; i++)
+         {
+            const CeedScalar qd = c[i] * qw[i] * DetJ33(J + i, Q);
+            for (CeedInt d = 0; d < 3; d++)
+            {
+               v[i + d * Q] = qd * u[i + d * Q];
             }
          }
          break;
    }
    return 0;
 }
+
+#endif // MFEM_LIBCEED_MASS_QF_H

--- a/fem/ceed/integrators/mass/mass_qf.h
+++ b/fem/ceed/integrators/mass/mass_qf.h
@@ -12,7 +12,7 @@
 #ifndef MFEM_LIBCEED_MASS_QF_H
 #define MFEM_LIBCEED_MASS_QF_H
 
-#include "../qf_utils.h"
+#include "../util/util_qf.h"
 
 /// A structure used to pass additional data to f_build_mass and f_apply_mass
 struct MassContext

--- a/fem/ceed/integrators/mass/mass_qf.h
+++ b/fem/ceed/integrators/mass/mass_qf.h
@@ -250,7 +250,7 @@ CEED_QFUNCTION(f_apply_mass_mf_quad)(void *ctx, CeedInt Q,
                                      const CeedScalar *const *in, CeedScalar *const *out)
 {
    MassContext *bc = (MassContext *)ctx;
-   const CeedScalar *c = in[0], *u = in[1], *J = in[2], *qw = in[3];
+   const CeedScalar *u = in[0], *c = in[1], *J = in[2], *qw = in[3];
    CeedScalar *v = out[0];
    switch (100 * bc->space_dim + 10 * bc->dim + bc->vdim)
    {

--- a/fem/ceed/integrators/nlconvection/nlconvection.cpp
+++ b/fem/ceed/integrators/nlconvection/nlconvection.cpp
@@ -31,7 +31,7 @@ struct NLConvectionOperatorInfo : public OperatorInfo
    {
       MFEM_VERIFY(fes.GetVDim() == fes.GetMesh()->SpaceDimension(),
                   "Missing coefficient in ceed::NLConvectionOperatorInfo!");
-      ctx.dim = fes.GetMesh()->Dimension() - (use_bdr * 1);
+      ctx.dim = fes.GetMesh()->Dimension() - use_bdr;
       ctx.space_dim = fes.GetMesh()->SpaceDimension();
       if (Q == nullptr)
       {

--- a/fem/ceed/integrators/nlconvection/nlconvection.hpp
+++ b/fem/ceed/integrators/nlconvection/nlconvection.hpp
@@ -12,7 +12,6 @@
 #ifndef MFEM_LIBCEED_NLCONV_HPP
 #define MFEM_LIBCEED_NLCONV_HPP
 
-#include "../../interface/integrator.hpp"
 #include "../../interface/mixed_integrator.hpp"
 #include "../../../fespace.hpp"
 
@@ -24,40 +23,26 @@ namespace ceed
 
 /** Represent a VectorConvectionNLFIntegrator with AssemblyLevel::Partial
     using libCEED. */
-class PAVectorConvectionNLFIntegrator : public PAIntegrator
+class PAVectorConvectionNLIntegrator : public MixedIntegrator
 {
 public:
-   PAVectorConvectionNLFIntegrator(const mfem::FiniteElementSpace &fes,
-                                   const mfem::IntegrationRule &irm,
-                                   mfem::Coefficient *Q);
-};
-
-class MixedPAVectorConvectionNLIntegrator : public MixedIntegrator<PAIntegrator>
-{
-public:
-   MixedPAVectorConvectionNLIntegrator(
-      const VectorConvectionNLFIntegrator &integ,
+   PAVectorConvectionNLIntegrator(
+      const mfem::VectorConvectionNLFIntegrator &integ,
       const mfem::FiniteElementSpace &fes,
-      mfem::Coefficient *Q);
+      mfem::Coefficient *Q,
+      const bool use_bdr = false);
 };
 
 /** Represent a VectorConvectionNLFIntegrator with AssemblyLevel::None
     using libCEED. */
-class MFVectorConvectionNLFIntegrator : public MFIntegrator
+class MFVectorConvectionNLIntegrator : public MixedIntegrator
 {
 public:
-   MFVectorConvectionNLFIntegrator(const mfem::FiniteElementSpace &fes,
-                                   const mfem::IntegrationRule &irm,
-                                   mfem::Coefficient *Q);
-};
-
-class MixedMFVectorConvectionNLIntegrator : public MixedIntegrator<MFIntegrator>
-{
-public:
-   MixedMFVectorConvectionNLIntegrator(
-      const VectorConvectionNLFIntegrator &integ,
+   MFVectorConvectionNLIntegrator(
+      const mfem::VectorConvectionNLFIntegrator &integ,
       const mfem::FiniteElementSpace &fes,
-      mfem::Coefficient *Q);
+      mfem::Coefficient *Q,
+      const bool use_bdr = false);
 };
 
 }

--- a/fem/ceed/integrators/nlconvection/nlconvection.hpp
+++ b/fem/ceed/integrators/nlconvection/nlconvection.hpp
@@ -29,7 +29,7 @@ class PAVectorConvectionNLFIntegrator : public PAIntegrator
 public:
    PAVectorConvectionNLFIntegrator(const mfem::FiniteElementSpace &fes,
                                    const mfem::IntegrationRule &irm,
-                                   mfem::Coefficient *coeff);
+                                   mfem::Coefficient *Q);
 };
 
 class MixedPAVectorConvectionNLIntegrator : public MixedIntegrator<PAIntegrator>
@@ -48,7 +48,7 @@ class MFVectorConvectionNLFIntegrator : public MFIntegrator
 public:
    MFVectorConvectionNLFIntegrator(const mfem::FiniteElementSpace &fes,
                                    const mfem::IntegrationRule &irm,
-                                   mfem::Coefficient *coeff);
+                                   mfem::Coefficient *Q);
 };
 
 class MixedMFVectorConvectionNLIntegrator : public MixedIntegrator<MFIntegrator>

--- a/fem/ceed/integrators/nlconvection/nlconvection_qf.h
+++ b/fem/ceed/integrators/nlconvection/nlconvection_qf.h
@@ -381,15 +381,15 @@ CEED_QFUNCTION(f_apply_conv_mf_quad)(void *ctx, CeedInt Q,
                                      CeedScalar *const *out)
 {
    NLConvectionContext *bc = (NLConvectionContext *)ctx;
-   // in[0] is coefficients, size (Q)
-   // in[1] has shape [ncomp=space_dim, Q]
-   // in[2] has shape [dim, ncomp=space_dim, Q]
+   // in[0] has shape [ncomp=space_dim, Q]
+   // in[1] has shape [dim, ncomp=space_dim, Q]
+   // in[2] is coefficients, size (Q)
    // in[3] is Jacobians with shape [dim, ncomp=space_dim, Q]
    // in[4] is quadrature weights, size (Q)
    // out[0] has shape [ncomp=space_dim, Q]
    //
    // At every quadrature point, compute qw * c * adj(J)^T.
-   const CeedScalar *c = in[0], *u = in[1], *ug = in[2], *J = in[3], *qw = in[4];
+   const CeedScalar *u = in[0], *ug = in[1], *c = in[2], *J = in[3], *qw = in[4];
    CeedScalar *vg = out[0];
    switch (10 * bc->space_dim + bc->dim)
    {

--- a/fem/ceed/integrators/nlconvection/nlconvection_qf.h
+++ b/fem/ceed/integrators/nlconvection/nlconvection_qf.h
@@ -12,7 +12,7 @@
 #ifndef MFEM_LIBCEED_NLCONV_QF_H
 #define MFEM_LIBCEED_NLCONV_QF_H
 
-#include "../qf_utils.h"
+#include "../util/util_qf.h"
 
 /// A structure used to pass additional data to f_build_conv and f_apply_conv
 struct NLConvectionContext

--- a/fem/ceed/integrators/nlconvection/nlconvection_qf.h
+++ b/fem/ceed/integrators/nlconvection/nlconvection_qf.h
@@ -38,31 +38,31 @@ CEED_QFUNCTION(f_build_conv_const)(void *ctx, CeedInt Q,
    switch (10 * bc->space_dim + bc->dim)
    {
       case 11:
-         for (CeedInt i = 0; i < Q; i++)
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
             qd[i] = coeff * qw[i] * J[i];
          }
          break;
       case 21:
-         for (CeedInt i = 0; i < Q; i++)
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
             MultAdjJt21(J + i, Q, qw[i] * coeff, Q, qd + i);
          }
          break;
       case 22:
-         for (CeedInt i = 0; i < Q; i++)
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
             MultAdjJt22(J + i, Q, qw[i] * coeff, Q, qd + i);
          }
          break;
       case 32:
-         for (CeedInt i = 0; i < Q; i++)
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
             MultAdjJt32(J + i, Q, qw[i] * coeff, Q, qd + i);
          }
          break;
       case 33:
-         for (CeedInt i = 0; i < Q; i++)
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
             MultAdjJt33(J + i, Q, qw[i] * coeff, Q, qd + i);
          }
@@ -88,32 +88,32 @@ CEED_QFUNCTION(f_build_conv_quad)(void *ctx, CeedInt Q,
    switch (10 * bc->space_dim + bc->dim)
    {
       case 11:
-         for (CeedInt i = 0; i < Q; i++)
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
             const CeedScalar coeff = c[i];
             qd[i] = coeff * qw[i] * J[i];
          }
          break;
       case 21:
-         for (CeedInt i = 0; i < Q; i++)
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
             MultAdjJt21(J + i, Q, qw[i] * c[i], Q, qd + i);
          }
          break;
       case 22:
-         for (CeedInt i = 0; i < Q; i++)
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
             MultAdjJt22(J + i, Q, qw[i] * c[i], Q, qd + i);
          }
          break;
       case 32:
-         for (CeedInt i = 0; i < Q; i++)
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
             MultAdjJt32(J + i, Q, qw[i] * c[i], Q, qd + i);
          }
          break;
       case 33:
-         for (CeedInt i = 0; i < Q; i++)
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
             MultAdjJt33(J + i, Q, qw[i] * c[i], Q, qd + i);
          }
@@ -136,13 +136,13 @@ CEED_QFUNCTION(f_apply_conv)(void *ctx, CeedInt Q,
    switch (10 * bc->space_dim + bc->dim)
    {
       case 11:
-         for (CeedInt i = 0; i < Q; i++)
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
             vg[i] = u[i] * ug[i] * qd[i];
          }
          break;
       case 21:
-         for (CeedInt i = 0; i < Q; i++)
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
             const CeedScalar qd00 = qd[i + Q * 0];
             const CeedScalar qd10 = qd[i + Q * 1];
@@ -159,7 +159,7 @@ CEED_QFUNCTION(f_apply_conv)(void *ctx, CeedInt Q,
          }
          break;
       case 22:
-         for (CeedInt i = 0; i < Q; i++)
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
             const CeedScalar qd00 = qd[i + Q * 0];
             const CeedScalar qd10 = qd[i + Q * 1];
@@ -180,7 +180,7 @@ CEED_QFUNCTION(f_apply_conv)(void *ctx, CeedInt Q,
          }
          break;
       case 32:
-         for (CeedInt i = 0; i < Q; i++)
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
             const CeedScalar qd00 = qd[i + Q * 0];
             const CeedScalar qd10 = qd[i + Q * 1];
@@ -211,7 +211,7 @@ CEED_QFUNCTION(f_apply_conv)(void *ctx, CeedInt Q,
             vg[i + Q * 2] = u0 * Dxu2 + u1 * Dyu2 + u2 * Dzu2;
          }
       case 33:
-         for (CeedInt i = 0; i < Q; i++)
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
             const CeedScalar qd00 = qd[i + Q * 0];
             const CeedScalar qd10 = qd[i + Q * 1];
@@ -271,14 +271,14 @@ CEED_QFUNCTION(f_apply_conv_mf_const)(void *ctx, CeedInt Q,
    switch (10 * bc->space_dim + bc->dim)
    {
       case 11:
-         for (CeedInt i = 0; i < Q; i++)
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
             const CeedScalar qd = coeff * qw[i] * J[i];
             vg[i] = u[i] * ug[i] * qd;
          }
          break;
       case 21:
-         for (CeedInt i = 0; i < Q; i++)
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
             CeedScalar qd[2];
             MultAdjJt21(J + i, Q, qw[i] * coeff, 1, qd);
@@ -295,7 +295,7 @@ CEED_QFUNCTION(f_apply_conv_mf_const)(void *ctx, CeedInt Q,
          }
          break;
       case 22:
-         for (CeedInt i = 0; i < Q; i++)
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
             CeedScalar qd[4];
             MultAdjJt22(J + i, Q, qw[i] * coeff, 1, qd);
@@ -314,7 +314,7 @@ CEED_QFUNCTION(f_apply_conv_mf_const)(void *ctx, CeedInt Q,
          }
          break;
       case 32:
-         for (CeedInt i = 0; i < Q; i++)
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
             CeedScalar qd[6];
             MultAdjJt32(J + i, Q, qw[i] * coeff, 1, qd);
@@ -342,7 +342,7 @@ CEED_QFUNCTION(f_apply_conv_mf_const)(void *ctx, CeedInt Q,
          }
          break;
       case 33:
-         for (CeedInt i = 0; i < Q; i++)
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
             CeedScalar qd[9];
             MultAdjJt33(J + i, Q, qw[i] * coeff, 1, qd);
@@ -394,14 +394,14 @@ CEED_QFUNCTION(f_apply_conv_mf_quad)(void *ctx, CeedInt Q,
    switch (10 * bc->space_dim + bc->dim)
    {
       case 11:
-         for (CeedInt i = 0; i < Q; i++)
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
             const CeedScalar qd = c[i] * qw[i] * J[i];
             vg[i] = u[i] * ug[i] * qd;
          }
          break;
       case 21:
-         for (CeedInt i = 0; i < Q; i++)
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
             CeedScalar qd[2];
             MultAdjJt21(J + i, Q, qw[i] * c[i], 1, qd);
@@ -418,7 +418,7 @@ CEED_QFUNCTION(f_apply_conv_mf_quad)(void *ctx, CeedInt Q,
          }
          break;
       case 22:
-         for (CeedInt i = 0; i < Q; i++)
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
             CeedScalar qd[4];
             MultAdjJt22(J + i, Q, qw[i] * c[i], 1, qd);
@@ -437,7 +437,7 @@ CEED_QFUNCTION(f_apply_conv_mf_quad)(void *ctx, CeedInt Q,
          }
          break;
       case 32:
-         for (CeedInt i = 0; i < Q; i++)
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
             CeedScalar qd[6];
             MultAdjJt32(J + i, Q, qw[i] * c[i], 1, qd);
@@ -465,7 +465,7 @@ CEED_QFUNCTION(f_apply_conv_mf_quad)(void *ctx, CeedInt Q,
          }
          break;
       case 33:
-         for (CeedInt i = 0; i < Q; i++)
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
             CeedScalar qd[9];
             MultAdjJt33(J + i, Q, qw[i] * c[i], 1, qd);

--- a/fem/ceed/integrators/nlconvection/nlconvection_qf.h
+++ b/fem/ceed/integrators/nlconvection/nlconvection_qf.h
@@ -21,7 +21,7 @@ struct NLConvectionContext
    CeedScalar coeff;
 };
 
-/// libCEED Q-function for building quadrature data for a convection operator
+/// libCEED QFunction for building quadrature data for a convection operator
 /// with a constant coefficient
 CEED_QFUNCTION(f_build_conv_const)(void *ctx, CeedInt Q,
                                    const CeedScalar *const *in,
@@ -40,7 +40,7 @@ CEED_QFUNCTION(f_build_conv_const)(void *ctx, CeedInt Q,
       case 11:
          CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
-            qd[i] = coeff * qw[i] * J[i];
+            qd[i] = qw[i] * coeff * J[i];
          }
          break;
       case 21:
@@ -71,8 +71,8 @@ CEED_QFUNCTION(f_build_conv_const)(void *ctx, CeedInt Q,
    return 0;
 }
 
-/// libCEED Q-function for building quadrature data for a convection operator
-/// coefficient evaluated at quadrature points.
+/// libCEED QFunction for building quadrature data for a convection operator
+/// with a coefficient evaluated at quadrature points.
 CEED_QFUNCTION(f_build_conv_quad)(void *ctx, CeedInt Q,
                                   const CeedScalar *const *in,
                                   CeedScalar *const *out)
@@ -90,8 +90,7 @@ CEED_QFUNCTION(f_build_conv_quad)(void *ctx, CeedInt Q,
       case 11:
          CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
-            const CeedScalar coeff = c[i];
-            qd[i] = coeff * qw[i] * J[i];
+            qd[i] = qw[i] * c[i] * J[i];
          }
          break;
       case 21:
@@ -122,7 +121,7 @@ CEED_QFUNCTION(f_build_conv_quad)(void *ctx, CeedInt Q,
    return 0;
 }
 
-/// libCEED Q-function for applying a conv operator
+/// libCEED QFunction for applying a conv operator
 CEED_QFUNCTION(f_apply_conv)(void *ctx, CeedInt Q,
                              const CeedScalar *const *in,
                              CeedScalar *const *out)
@@ -138,7 +137,7 @@ CEED_QFUNCTION(f_apply_conv)(void *ctx, CeedInt Q,
       case 11:
          CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
-            vg[i] = u[i] * ug[i] * qd[i];
+            vg[i] = qd[i] * u[i] * ug[i];
          }
          break;
       case 21:
@@ -150,10 +149,10 @@ CEED_QFUNCTION(f_apply_conv)(void *ctx, CeedInt Q,
             const CeedScalar u1   = u[i + Q * 1];
             const CeedScalar ug00 = ug[i + Q * 0];
             const CeedScalar ug10 = ug[i + Q * 1];
-            const CeedScalar Dxu0 = ug00 * qd00;
-            const CeedScalar Dyu0 = ug00 * qd10;
-            const CeedScalar Dxu1 = ug10 * qd00;
-            const CeedScalar Dyu1 = ug10 * qd10;
+            const CeedScalar Dxu0 = qd00 * ug00;
+            const CeedScalar Dyu0 = qd10 * ug00;
+            const CeedScalar Dxu1 = qd00 * ug10;
+            const CeedScalar Dyu1 = qd10 * ug10;
             vg[i + Q * 0] = u0 * Dxu0 + u1 * Dyu0;
             vg[i + Q * 1] = u0 * Dxu1 + u1 * Dyu1;
          }
@@ -171,10 +170,10 @@ CEED_QFUNCTION(f_apply_conv)(void *ctx, CeedInt Q,
             const CeedScalar ug10 = ug[i + Q * 1];
             const CeedScalar ug01 = ug[i + Q * 2];
             const CeedScalar ug11 = ug[i + Q * 3];
-            const CeedScalar Dxu0 = ug00 * qd00 + ug01 * qd01;
-            const CeedScalar Dyu0 = ug00 * qd10 + ug01 * qd11;
-            const CeedScalar Dxu1 = ug10 * qd00 + ug11 * qd01;
-            const CeedScalar Dyu1 = ug10 * qd10 + ug11 * qd11;
+            const CeedScalar Dxu0 = qd00 * ug00 + qd01 * ug01;
+            const CeedScalar Dyu0 = qd10 * ug00 + qd11 * ug01;
+            const CeedScalar Dxu1 = qd00 * ug10 + qd01 * ug11;
+            const CeedScalar Dyu1 = qd10 * ug10 + qd11 * ug11;
             vg[i + Q * 0] = u0 * Dxu0 + u1 * Dyu0;
             vg[i + Q * 1] = u0 * Dxu1 + u1 * Dyu1;
          }
@@ -197,15 +196,15 @@ CEED_QFUNCTION(f_apply_conv)(void *ctx, CeedInt Q,
             const CeedScalar ug01 = ug[i + Q * 3];
             const CeedScalar ug11 = ug[i + Q * 4];
             const CeedScalar ug21 = ug[i + Q * 5];
-            const CeedScalar Dxu0 = ug00 * qd00 + ug01 * qd01;
-            const CeedScalar Dyu0 = ug00 * qd10 + ug01 * qd11;
-            const CeedScalar Dzu0 = ug00 * qd20 + ug01 * qd21;
-            const CeedScalar Dxu1 = ug10 * qd00 + ug11 * qd01;
-            const CeedScalar Dyu1 = ug10 * qd10 + ug11 * qd11;
-            const CeedScalar Dzu1 = ug10 * qd20 + ug11 * qd21;
-            const CeedScalar Dxu2 = ug20 * qd00 + ug21 * qd01;
-            const CeedScalar Dyu2 = ug20 * qd10 + ug21 * qd11;
-            const CeedScalar Dzu2 = ug20 * qd20 + ug21 * qd21;
+            const CeedScalar Dxu0 = qd00 * ug00 + qd01 * ug01;
+            const CeedScalar Dyu0 = qd10 * ug00 + qd11 * ug01;
+            const CeedScalar Dzu0 = qd20 * ug00 + qd21 * ug01;
+            const CeedScalar Dxu1 = qd00 * ug10 + qd01 * ug11;
+            const CeedScalar Dyu1 = qd10 * ug10 + qd11 * ug11;
+            const CeedScalar Dzu1 = qd20 * ug10 + qd21 * ug11;
+            const CeedScalar Dxu2 = qd00 * ug20 + qd01 * ug21;
+            const CeedScalar Dyu2 = qd10 * ug20 + qd11 * ug21;
+            const CeedScalar Dzu2 = qd20 * ug20 + qd21 * ug21;
             vg[i + Q * 0] = u0 * Dxu0 + u1 * Dyu0 + u2 * Dzu0;
             vg[i + Q * 1] = u0 * Dxu1 + u1 * Dyu1 + u2 * Dzu1;
             vg[i + Q * 2] = u0 * Dxu2 + u1 * Dyu2 + u2 * Dzu2;
@@ -234,15 +233,15 @@ CEED_QFUNCTION(f_apply_conv)(void *ctx, CeedInt Q,
             const CeedScalar ug02 = ug[i + Q * 6];
             const CeedScalar ug12 = ug[i + Q * 7];
             const CeedScalar ug22 = ug[i + Q * 8];
-            const CeedScalar Dxu0 = ug00 * qd00 + ug01 * qd01 + ug02 * qd02;
-            const CeedScalar Dyu0 = ug00 * qd10 + ug01 * qd11 + ug02 * qd12;
-            const CeedScalar Dzu0 = ug00 * qd20 + ug01 * qd21 + ug02 * qd22;
-            const CeedScalar Dxu1 = ug10 * qd00 + ug11 * qd01 + ug12 * qd02;
-            const CeedScalar Dyu1 = ug10 * qd10 + ug11 * qd11 + ug12 * qd12;
-            const CeedScalar Dzu1 = ug10 * qd20 + ug11 * qd21 + ug12 * qd22;
-            const CeedScalar Dxu2 = ug20 * qd00 + ug21 * qd01 + ug22 * qd02;
-            const CeedScalar Dyu2 = ug20 * qd10 + ug21 * qd11 + ug22 * qd12;
-            const CeedScalar Dzu2 = ug20 * qd20 + ug21 * qd21 + ug22 * qd22;
+            const CeedScalar Dxu0 = qd00 * ug00 + qd01 * ug01 + qd02 * ug02;
+            const CeedScalar Dyu0 = qd10 * ug00 + qd11 * ug01 + qd12 * ug02;
+            const CeedScalar Dzu0 = qd20 * ug00 + qd21 * ug01 + qd22 * ug02;
+            const CeedScalar Dxu1 = qd00 * ug10 + qd01 * ug11 + qd02 * ug12;
+            const CeedScalar Dyu1 = qd10 * ug10 + qd11 * ug11 + qd12 * ug12;
+            const CeedScalar Dzu1 = qd20 * ug10 + qd21 * ug11 + qd22 * ug12;
+            const CeedScalar Dxu2 = qd00 * ug20 + qd01 * ug21 + qd02 * ug22;
+            const CeedScalar Dyu2 = qd10 * ug20 + qd11 * ug21 + qd12 * ug22;
+            const CeedScalar Dzu2 = qd20 * ug20 + qd21 * ug21 + qd22 * ug22;
             vg[i + Q * 0] = u0 * Dxu0 + u1 * Dyu0 + u2 * Dzu0;
             vg[i + Q * 1] = u0 * Dxu1 + u1 * Dyu1 + u2 * Dzu1;
             vg[i + Q * 2] = u0 * Dxu2 + u1 * Dyu2 + u2 * Dzu2;
@@ -252,7 +251,7 @@ CEED_QFUNCTION(f_apply_conv)(void *ctx, CeedInt Q,
    return 0;
 }
 
-/// libCEED Q-function for applying a conv operator
+/// libCEED QFunction for applying a conv operator
 CEED_QFUNCTION(f_apply_conv_mf_const)(void *ctx, CeedInt Q,
                                       const CeedScalar *const *in,
                                       CeedScalar *const *out)
@@ -273,8 +272,8 @@ CEED_QFUNCTION(f_apply_conv_mf_const)(void *ctx, CeedInt Q,
       case 11:
          CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
-            const CeedScalar qd = coeff * qw[i] * J[i];
-            vg[i] = u[i] * ug[i] * qd;
+            const CeedScalar qd = qw[i] * coeff * J[i];
+            vg[i] = u[i] * qd * ug[i];
          }
          break;
       case 21:
@@ -286,10 +285,10 @@ CEED_QFUNCTION(f_apply_conv_mf_const)(void *ctx, CeedInt Q,
             const CeedScalar u1   = u[i + Q * 1];
             const CeedScalar ug00 = ug[i + Q * 0];
             const CeedScalar ug10 = ug[i + Q * 1];
-            const CeedScalar Dxu0 = ug00 * qd[0];
-            const CeedScalar Dyu0 = ug00 * qd[1];
-            const CeedScalar Dxu1 = ug10 * qd[0];
-            const CeedScalar Dyu1 = ug10 * qd[1];
+            const CeedScalar Dxu0 = qd[0] * ug00;
+            const CeedScalar Dyu0 = qd[1] * ug00;
+            const CeedScalar Dxu1 = qd[0] * ug10;
+            const CeedScalar Dyu1 = qd[1] * ug10;
             vg[i + Q * 0] = u0 * Dxu0 + u1 * Dyu0;
             vg[i + Q * 1] = u0 * Dxu1 + u1 * Dyu1;
          }
@@ -305,10 +304,10 @@ CEED_QFUNCTION(f_apply_conv_mf_const)(void *ctx, CeedInt Q,
             const CeedScalar ug10 = ug[i + Q * 1];
             const CeedScalar ug01 = ug[i + Q * 2];
             const CeedScalar ug11 = ug[i + Q * 3];
-            const CeedScalar Dxu0 = ug00 * qd[0] + ug01 * qd[2];
-            const CeedScalar Dyu0 = ug00 * qd[1] + ug01 * qd[3];
-            const CeedScalar Dxu1 = ug10 * qd[0] + ug11 * qd[2];
-            const CeedScalar Dyu1 = ug10 * qd[1] + ug11 * qd[3];
+            const CeedScalar Dxu0 = qd[0] * ug00 + qd[2] * ug01;
+            const CeedScalar Dyu0 = qd[1] * ug00 + qd[3] * ug01;
+            const CeedScalar Dxu1 = qd[0] * ug10 + qd[2] * ug11;
+            const CeedScalar Dyu1 = qd[1] * ug10 + qd[3] * ug11;
             vg[i + Q * 0] = u0 * Dxu0 + u1 * Dyu0;
             vg[i + Q * 1] = u0 * Dxu1 + u1 * Dyu1;
          }
@@ -327,15 +326,15 @@ CEED_QFUNCTION(f_apply_conv_mf_const)(void *ctx, CeedInt Q,
             const CeedScalar ug01 = ug[i + Q * 3];
             const CeedScalar ug11 = ug[i + Q * 4];
             const CeedScalar ug21 = ug[i + Q * 5];
-            const CeedScalar Dxu0 = ug00 * qd[0] + ug01 * qd[3];
-            const CeedScalar Dyu0 = ug00 * qd[1] + ug01 * qd[4];
-            const CeedScalar Dzu0 = ug00 * qd[2] + ug01 * qd[5];
-            const CeedScalar Dxu1 = ug10 * qd[0] + ug11 * qd[3];
-            const CeedScalar Dyu1 = ug10 * qd[1] + ug11 * qd[4];
-            const CeedScalar Dzu1 = ug10 * qd[2] + ug11 * qd[5];
-            const CeedScalar Dxu2 = ug20 * qd[0] + ug21 * qd[3];
-            const CeedScalar Dyu2 = ug20 * qd[1] + ug21 * qd[4];
-            const CeedScalar Dzu2 = ug20 * qd[2] + ug21 * qd[5];
+            const CeedScalar Dxu0 = qd[0] * ug00 + qd[3] * ug01;
+            const CeedScalar Dyu0 = qd[1] * ug00 + qd[4] * ug01;
+            const CeedScalar Dzu0 = qd[2] * ug00 + qd[5] * ug01;
+            const CeedScalar Dxu1 = qd[0] * ug10 + qd[3] * ug11;
+            const CeedScalar Dyu1 = qd[1] * ug10 + qd[4] * ug11;
+            const CeedScalar Dzu1 = qd[2] * ug10 + qd[5] * ug11;
+            const CeedScalar Dxu2 = qd[0] * ug20 + qd[3] * ug21;
+            const CeedScalar Dyu2 = qd[1] * ug20 + qd[4] * ug21;
+            const CeedScalar Dzu2 = qd[2] * ug20 + qd[5] * ug21;
             vg[i + Q * 0] = u0 * Dxu0 + u1 * Dyu0 + u2 * Dzu0;
             vg[i + Q * 1] = u0 * Dxu1 + u1 * Dyu1 + u2 * Dzu1;
             vg[i + Q * 2] = u0 * Dxu2 + u1 * Dyu2 + u2 * Dzu2;
@@ -358,15 +357,15 @@ CEED_QFUNCTION(f_apply_conv_mf_const)(void *ctx, CeedInt Q,
             const CeedScalar ug02 = ug[i + Q * 6];
             const CeedScalar ug12 = ug[i + Q * 7];
             const CeedScalar ug22 = ug[i + Q * 8];
-            const CeedScalar Dxu0 = ug00 * qd[0] + ug01 * qd[3] + ug02 * qd[6];
-            const CeedScalar Dyu0 = ug00 * qd[1] + ug01 * qd[4] + ug02 * qd[7];
-            const CeedScalar Dzu0 = ug00 * qd[2] + ug01 * qd[5] + ug02 * qd[8];
-            const CeedScalar Dxu1 = ug10 * qd[0] + ug11 * qd[3] + ug12 * qd[6];
-            const CeedScalar Dyu1 = ug10 * qd[1] + ug11 * qd[4] + ug12 * qd[7];
-            const CeedScalar Dzu1 = ug10 * qd[2] + ug11 * qd[5] + ug12 * qd[8];
-            const CeedScalar Dxu2 = ug20 * qd[0] + ug21 * qd[3] + ug22 * qd[6];
-            const CeedScalar Dyu2 = ug20 * qd[1] + ug21 * qd[4] + ug22 * qd[7];
-            const CeedScalar Dzu2 = ug20 * qd[2] + ug21 * qd[5] + ug22 * qd[8];
+            const CeedScalar Dxu0 = qd[0] * ug00 + qd[3] * ug01 + qd[6] * ug02;
+            const CeedScalar Dyu0 = qd[1] * ug00 + qd[4] * ug01 + qd[7] * ug02;
+            const CeedScalar Dzu0 = qd[2] * ug00 + qd[5] * ug01 + qd[8] * ug02;
+            const CeedScalar Dxu1 = qd[0] * ug10 + qd[3] * ug11 + qd[6] * ug12;
+            const CeedScalar Dyu1 = qd[1] * ug10 + qd[4] * ug11 + qd[7] * ug12;
+            const CeedScalar Dzu1 = qd[2] * ug10 + qd[5] * ug11 + qd[8] * ug12;
+            const CeedScalar Dxu2 = qd[0] * ug20 + qd[3] * ug21 + qd[6] * ug22;
+            const CeedScalar Dyu2 = qd[1] * ug20 + qd[4] * ug21 + qd[7] * ug22;
+            const CeedScalar Dzu2 = qd[2] * ug20 + qd[5] * ug21 + qd[8] * ug22;
             vg[i + Q * 0] = u0 * Dxu0 + u1 * Dyu0 + u2 * Dzu0;
             vg[i + Q * 1] = u0 * Dxu1 + u1 * Dyu1 + u2 * Dzu1;
             vg[i + Q * 2] = u0 * Dxu2 + u1 * Dyu2 + u2 * Dzu2;
@@ -376,6 +375,7 @@ CEED_QFUNCTION(f_apply_conv_mf_const)(void *ctx, CeedInt Q,
    return 0;
 }
 
+/// libCEED QFunction for applying a conv operator
 CEED_QFUNCTION(f_apply_conv_mf_quad)(void *ctx, CeedInt Q,
                                      const CeedScalar *const *in,
                                      CeedScalar *const *out)
@@ -396,8 +396,8 @@ CEED_QFUNCTION(f_apply_conv_mf_quad)(void *ctx, CeedInt Q,
       case 11:
          CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
-            const CeedScalar qd = c[i] * qw[i] * J[i];
-            vg[i] = u[i] * ug[i] * qd;
+            const CeedScalar qd = qw[i] * c[i] * J[i];
+            vg[i] = u[i] * qd * ug[i];
          }
          break;
       case 21:
@@ -409,10 +409,10 @@ CEED_QFUNCTION(f_apply_conv_mf_quad)(void *ctx, CeedInt Q,
             const CeedScalar u1   = u[i + Q * 1];
             const CeedScalar ug00 = ug[i + Q * 0];
             const CeedScalar ug10 = ug[i + Q * 1];
-            const CeedScalar Dxu0 = ug00 * qd[0];
-            const CeedScalar Dyu0 = ug00 * qd[1];
-            const CeedScalar Dxu1 = ug10 * qd[0];
-            const CeedScalar Dyu1 = ug10 * qd[1];
+            const CeedScalar Dxu0 = qd[0] * ug00;
+            const CeedScalar Dyu0 = qd[1] * ug00;
+            const CeedScalar Dxu1 = qd[0] * ug10;
+            const CeedScalar Dyu1 = qd[1] * ug10;
             vg[i + Q * 0] = u0 * Dxu0 + u1 * Dyu0;
             vg[i + Q * 1] = u0 * Dxu1 + u1 * Dyu1;
          }
@@ -428,10 +428,10 @@ CEED_QFUNCTION(f_apply_conv_mf_quad)(void *ctx, CeedInt Q,
             const CeedScalar ug10 = ug[i + Q * 1];
             const CeedScalar ug01 = ug[i + Q * 2];
             const CeedScalar ug11 = ug[i + Q * 3];
-            const CeedScalar Dxu0 = ug00 * qd[0] + ug01 * qd[2];
-            const CeedScalar Dyu0 = ug00 * qd[1] + ug01 * qd[3];
-            const CeedScalar Dxu1 = ug10 * qd[0] + ug11 * qd[2];
-            const CeedScalar Dyu1 = ug10 * qd[1] + ug11 * qd[3];
+            const CeedScalar Dxu0 = qd[0] * ug00 + qd[2] * ug01;
+            const CeedScalar Dyu0 = qd[1] * ug00 + qd[3] * ug01;
+            const CeedScalar Dxu1 = qd[0] * ug10 + qd[2] * ug11;
+            const CeedScalar Dyu1 = qd[1] * ug10 + qd[3] * ug11;
             vg[i + Q * 0] = u0 * Dxu0 + u1 * Dyu0;
             vg[i + Q * 1] = u0 * Dxu1 + u1 * Dyu1;
          }
@@ -450,15 +450,15 @@ CEED_QFUNCTION(f_apply_conv_mf_quad)(void *ctx, CeedInt Q,
             const CeedScalar ug01 = ug[i + Q * 3];
             const CeedScalar ug11 = ug[i + Q * 4];
             const CeedScalar ug21 = ug[i + Q * 5];
-            const CeedScalar Dxu0 = ug00 * qd[0] + ug01 * qd[3];
-            const CeedScalar Dyu0 = ug00 * qd[1] + ug01 * qd[4];
-            const CeedScalar Dzu0 = ug00 * qd[2] + ug01 * qd[5];
-            const CeedScalar Dxu1 = ug10 * qd[0] + ug11 * qd[3];
-            const CeedScalar Dyu1 = ug10 * qd[1] + ug11 * qd[4];
-            const CeedScalar Dzu1 = ug10 * qd[2] + ug11 * qd[5];
-            const CeedScalar Dxu2 = ug20 * qd[0] + ug21 * qd[3];
-            const CeedScalar Dyu2 = ug20 * qd[1] + ug21 * qd[4];
-            const CeedScalar Dzu2 = ug20 * qd[2] + ug21 * qd[5];
+            const CeedScalar Dxu0 = qd[0] * ug00 + qd[3] * ug01;
+            const CeedScalar Dyu0 = qd[1] * ug00 + qd[4] * ug01;
+            const CeedScalar Dzu0 = qd[2] * ug00 + qd[5] * ug01;
+            const CeedScalar Dxu1 = qd[0] * ug10 + qd[3] * ug11;
+            const CeedScalar Dyu1 = qd[1] * ug10 + qd[4] * ug11;
+            const CeedScalar Dzu1 = qd[2] * ug10 + qd[5] * ug11;
+            const CeedScalar Dxu2 = qd[0] * ug20 + qd[3] * ug21;
+            const CeedScalar Dyu2 = qd[1] * ug20 + qd[4] * ug21;
+            const CeedScalar Dzu2 = qd[2] * ug20 + qd[5] * ug21;
             vg[i + Q * 0] = u0 * Dxu0 + u1 * Dyu0 + u2 * Dzu0;
             vg[i + Q * 1] = u0 * Dxu1 + u1 * Dyu1 + u2 * Dzu1;
             vg[i + Q * 2] = u0 * Dxu2 + u1 * Dyu2 + u2 * Dzu2;
@@ -481,15 +481,15 @@ CEED_QFUNCTION(f_apply_conv_mf_quad)(void *ctx, CeedInt Q,
             const CeedScalar ug02 = ug[i + Q * 6];
             const CeedScalar ug12 = ug[i + Q * 7];
             const CeedScalar ug22 = ug[i + Q * 8];
-            const CeedScalar Dxu0 = ug00 * qd[0] + ug01 * qd[3] + ug02 * qd[6];
-            const CeedScalar Dyu0 = ug00 * qd[1] + ug01 * qd[4] + ug02 * qd[7];
-            const CeedScalar Dzu0 = ug00 * qd[2] + ug01 * qd[5] + ug02 * qd[8];
-            const CeedScalar Dxu1 = ug10 * qd[0] + ug11 * qd[3] + ug12 * qd[6];
-            const CeedScalar Dyu1 = ug10 * qd[1] + ug11 * qd[4] + ug12 * qd[7];
-            const CeedScalar Dzu1 = ug10 * qd[2] + ug11 * qd[5] + ug12 * qd[8];
-            const CeedScalar Dxu2 = ug20 * qd[0] + ug21 * qd[3] + ug22 * qd[6];
-            const CeedScalar Dyu2 = ug20 * qd[1] + ug21 * qd[4] + ug22 * qd[7];
-            const CeedScalar Dzu2 = ug20 * qd[2] + ug21 * qd[5] + ug22 * qd[8];
+            const CeedScalar Dxu0 = qd[0] * ug00 + qd[3] * ug01 + qd[6] * ug02;
+            const CeedScalar Dyu0 = qd[1] * ug00 + qd[4] * ug01 + qd[7] * ug02;
+            const CeedScalar Dzu0 = qd[2] * ug00 + qd[5] * ug01 + qd[8] * ug02;
+            const CeedScalar Dxu1 = qd[0] * ug10 + qd[3] * ug11 + qd[6] * ug12;
+            const CeedScalar Dyu1 = qd[1] * ug10 + qd[4] * ug11 + qd[7] * ug12;
+            const CeedScalar Dzu1 = qd[2] * ug10 + qd[5] * ug11 + qd[8] * ug12;
+            const CeedScalar Dxu2 = qd[0] * ug20 + qd[3] * ug21 + qd[6] * ug22;
+            const CeedScalar Dyu2 = qd[1] * ug20 + qd[4] * ug21 + qd[7] * ug22;
+            const CeedScalar Dzu2 = qd[2] * ug20 + qd[5] * ug21 + qd[8] * ug22;
             vg[i + Q * 0] = u0 * Dxu0 + u1 * Dyu0 + u2 * Dzu0;
             vg[i + Q * 1] = u0 * Dxu1 + u1 * Dyu1 + u2 * Dzu1;
             vg[i + Q * 2] = u0 * Dxu2 + u1 * Dyu2 + u2 * Dzu2;

--- a/fem/ceed/integrators/qf_utils.h
+++ b/fem/ceed/integrators/qf_utils.h
@@ -27,7 +27,7 @@ CEED_QFUNCTION_HELPER CeedScalar DetJ21(const CeedScalar *J,
 {
    // J: 0
    //    1
-   return sqrt(J[J_stride * 0] * J[J_stride * 0] - J[J_stride * 1] * J[J_stride * 1]);
+   return sqrt(J[J_stride * 0] * J[J_stride * 0] + J[J_stride * 1] * J[J_stride * 1]);
 }
 
 CEED_QFUNCTION_HELPER CeedScalar DetJ33(const CeedScalar *J,
@@ -94,8 +94,8 @@ CEED_QFUNCTION_HELPER void MultAdjJCAdjJt22(const CeedScalar *J,
    }
    else if (c_comp == 2)  // Vector coefficient
    {
-      qd[qd_stride * 0] =  w * (c[c_stride * 0] * J12 * J12 +
-                                c[c_stride * 1] * J22 * J22);
+      qd[qd_stride * 0] =  w * (c[c_stride * 1] * J12 * J12 +
+                                c[c_stride * 0] * J22 * J22);
       qd[qd_stride * 1] = -w * (c[c_stride * 1] * J11 * J12 +
                                 c[c_stride * 0] * J21 * J22);
       qd[qd_stride * 2] =  w * (c[c_stride * 1] * J11 * J11 +
@@ -307,19 +307,19 @@ CEED_QFUNCTION_HELPER void MultAdjJCAdjJt32(const CeedScalar *J,
                              F * (c[c_stride * 2] * J12 +
                                   c[c_stride * 4] * J22 +
                                   c[c_stride * 5] * J32);
-      const CeedScalar R12 = E * (c[c_stride * 0] * J11 +
+      const CeedScalar R12 = E * (c[c_stride * 0] * J12 +
                                   c[c_stride * 1] * J22 +
                                   c[c_stride * 2] * J32) -
                              F * (c[c_stride * 0] * J11 +
                                   c[c_stride * 1] * J21 +
                                   c[c_stride * 2] * J31);
-      const CeedScalar R22 = E * (c[c_stride * 1] * J11 +
+      const CeedScalar R22 = E * (c[c_stride * 1] * J12 +
                                   c[c_stride * 3] * J22 +
                                   c[c_stride * 4] * J32) -
                              F * (c[c_stride * 1] * J11 +
                                   c[c_stride * 3] * J21 +
                                   c[c_stride * 4] * J31);
-      const CeedScalar R32 = E * (c[c_stride * 2] * J11 +
+      const CeedScalar R32 = E * (c[c_stride * 2] * J12 +
                                   c[c_stride * 4] * J22 +
                                   c[c_stride * 5] * J32) -
                              F * (c[c_stride * 2] * J11 +
@@ -330,7 +330,7 @@ CEED_QFUNCTION_HELPER void MultAdjJCAdjJt32(const CeedScalar *J,
       qd[qd_stride * 1] = w * (G * (J11 * R12 + J21 * R22 + J31 * R32) -
                                F * (J12 * R12 + J22 * R22 + J32 * R32)) / d;
       qd[qd_stride * 2] = w * (E * (J12 * R12 + J22 * R22 + J32 * R32) -
-                               F * (J11 * R12 + J21 * R22 + J32 * R31)) / d;
+                               F * (J11 * R12 + J21 * R22 + J31 * R32)) / d;
    }
    else if (c_comp == 3)  // Vector coefficient
    {
@@ -349,7 +349,7 @@ CEED_QFUNCTION_HELPER void MultAdjJCAdjJt32(const CeedScalar *J,
       qd[qd_stride * 1] = w * (G * (J11 * R12 + J21 * R22 + J31 * R32) -
                                F * (J12 * R12 + J22 * R22 + J32 * R32)) / d;
       qd[qd_stride * 2] = w * (E * (J12 * R12 + J22 * R22 + J32 * R32) -
-                               F * (J11 * R12 + J21 * R22 + J32 * R31)) / d;
+                               F * (J11 * R12 + J21 * R22 + J31 * R32)) / d;
    }
    else  // Scalar coefficient
    {

--- a/fem/ceed/integrators/qf_utils.h
+++ b/fem/ceed/integrators/qf_utils.h
@@ -1,0 +1,583 @@
+// Copyright (c) 2010-2022, Lawrence Livermore National Security, LLC. Produced
+// at the Lawrence Livermore National Laboratory. All Rights reserved. See files
+// LICENSE and NOTICE for details. LLNL-CODE-806117.
+//
+// This file is part of the MFEM library. For more information and source code
+// availability visit https://mfem.org.
+//
+// MFEM is free software; you can redistribute it and/or modify it under the
+// terms of the BSD-3 license. We welcome feedback and contributions, see file
+// CONTRIBUTING.md for details.
+
+#ifndef MFEM_LIBCEED_QF_UTILS_H
+#define MFEM_LIBCEED_QF_UTILS_H
+
+#include <math.h>
+
+CEED_QFUNCTION_HELPER CeedScalar DetJ22(const CeedScalar *J,
+                                        const CeedInt J_stride)
+{
+   // J: 0 2
+   //    1 3
+   return J[J_stride * 0] * J[J_stride * 3] - J[J_stride * 1] * J[J_stride * 2];
+}
+
+CEED_QFUNCTION_HELPER CeedScalar DetJ21(const CeedScalar *J,
+                                        const CeedInt J_stride)
+{
+   // J: 0
+   //    1
+   return sqrt(J[J_stride * 0] * J[J_stride * 0] - J[J_stride * 1] * J[J_stride * 1]);
+}
+
+CEED_QFUNCTION_HELPER CeedScalar DetJ33(const CeedScalar *J,
+                                        const CeedInt J_stride)
+{
+   // J: 0 3 6
+   //    1 4 7
+   //    2 5 8
+   return J[J_stride * 0] * (J[J_stride * 4] * J[J_stride * 8] -
+                             J[J_stride * 5] * J[J_stride * 7]) -
+          J[J_stride * 1] * (J[J_stride * 3] * J[J_stride * 8] -
+                             J[J_stride * 5] * J[J_stride * 6]) +
+          J[J_stride * 2] * (J[J_stride * 3] * J[J_stride * 7] -
+                             J[J_stride * 4] * J[J_stride * 6]);
+}
+
+CEED_QFUNCTION_HELPER CeedScalar DetJ32(const CeedScalar *J,
+                                        const CeedInt J_stride)
+{
+   // J: 0 3
+   //    1 4
+   //    2 5
+   const CeedScalar E = J[J_stride * 0] * J[J_stride * 0] +
+                        J[J_stride * 1] * J[J_stride * 1] +
+                        J[J_stride * 2] * J[J_stride * 2];
+   const CeedScalar G = J[J_stride * 3] * J[J_stride * 3] +
+                        J[J_stride * 4] * J[J_stride * 4] +
+                        J[J_stride * 5] * J[J_stride * 5];
+   const CeedScalar F = J[J_stride * 0] * J[J_stride * 3] +
+                        J[J_stride * 1] * J[J_stride * 4] +
+                        J[J_stride * 2] * J[J_stride * 5];
+   return sqrt(E * G - F * F);
+}
+
+CEED_QFUNCTION_HELPER void MultAdjJCAdjJt22(const CeedScalar *J,
+                                            const CeedInt J_stride,
+                                            const CeedScalar *c,
+                                            const CeedInt c_stride,
+                                            const CeedInt c_comp,
+                                            const CeedScalar qw,
+                                            const CeedInt qd_stride,
+                                            CeedScalar *qd)
+{
+   // compute qw/det(J) adj(J) C adj(J)^T and store the symmetric part of the result.
+   // J: 0 2   adj(J):  J22 -J12   qd: 0 1
+   //    1 3           -J21  J11       1 2
+   const CeedScalar J11 = J[J_stride * 0];
+   const CeedScalar J21 = J[J_stride * 1];
+   const CeedScalar J12 = J[J_stride * 2];
+   const CeedScalar J22 = J[J_stride * 3];
+   const CeedScalar w = qw / (J11 * J22 - J21 * J12);
+   if (c_comp == 3)  // Matrix coefficient (symmetric)
+   {
+      // First compute entries of R = C adj(J)^T
+      // c: 0 1
+      //    1 2
+      const CeedScalar R11 =  c[c_stride * 0] * J22 - c[c_stride * 1] * J12;
+      const CeedScalar R21 =  c[c_stride * 1] * J22 - c[c_stride * 2] * J12;
+      const CeedScalar R12 = -c[c_stride * 0] * J21 + c[c_stride * 1] * J11;
+      const CeedScalar R22 = -c[c_stride * 1] * J21 + c[c_stride * 2] * J11;
+      qd[qd_stride * 0] = w * (J22 * R11 - J12 * R21);
+      qd[qd_stride * 1] = w * (J11 * R21 - J21 * R11);
+      qd[qd_stride * 2] = w * (J11 * R22 - J21 * R12);
+   }
+   else if (c_comp == 2)  // Vector coefficient
+   {
+      qd[qd_stride * 0] =  w * (c[c_stride * 0] * J12 * J12 +
+                                c[c_stride * 1] * J22 * J22);
+      qd[qd_stride * 1] = -w * (c[c_stride * 1] * J11 * J12 +
+                                c[c_stride * 0] * J21 * J22);
+      qd[qd_stride * 2] =  w * (c[c_stride * 1] * J11 * J11 +
+                                c[c_stride * 0] * J21 * J21);
+   }
+   else  // Scalar coefficient
+   {
+      qd[qd_stride * 0] =  w * c[c_stride * 0] * (J12 * J12 + J22 * J22);
+      qd[qd_stride * 1] = -w * c[c_stride * 0] * (J11 * J12 + J21 * J22);
+      qd[qd_stride * 2] =  w * c[c_stride * 0] * (J11 * J11 + J21 * J21);
+   }
+}
+
+CEED_QFUNCTION_HELPER void MultAdjJCAdjJt21(const CeedScalar *J,
+                                            const CeedInt J_stride,
+                                            const CeedScalar *c,
+                                            const CeedInt c_stride,
+                                            const CeedInt c_comp,
+                                            const CeedScalar qw,
+                                            const CeedInt qd_stride,
+                                            CeedScalar *qd)
+{
+   // compute qw/det(J) adj(J) C adj(J)^T and store the symmetric part of the result.
+   // J: 0   adj(J): 1/sqrt(J^T J) J^T   qd: 0
+   //    1
+   const CeedScalar J11 = J[J_stride * 0];
+   const CeedScalar J21 = J[J_stride * 1];
+   const CeedScalar d = J11 * J11 + J21 * J21;
+   const CeedScalar w = qw / sqrt(d);
+   if (c_comp == 3)  // Matrix coefficient (symmetric)
+   {
+      // First compute entries of R = C adj(J)^T
+      // c: 0 1
+      //    1 2
+      const CeedScalar R11 = c[c_stride * 0] * J11 + c[c_stride * 1] * J21;
+      const CeedScalar R21 = c[c_stride * 1] * J11 + c[c_stride * 2] * J21;
+      qd[qd_stride * 0] = w * (J11 * R11 + J21 * R21) / d;
+   }
+   else if (c_comp == 2)  // Vector coefficient
+   {
+      // First compute entries of R = C adj(J)^T
+      // c: 0
+      //      1
+      const CeedScalar R11 = c[c_stride * 0] * J11;
+      const CeedScalar R21 = c[c_stride * 1] * J21;
+      qd[qd_stride * 0] = w * (J11 * R11 + J21 * R21) / d;
+   }
+   else  // Scalar coefficient
+   {
+      qd[qd_stride * 0] = w * c[c_stride * 0];
+   }
+}
+
+CEED_QFUNCTION_HELPER void MultAdjJCAdjJt33(const CeedScalar *J,
+                                            const CeedInt J_stride,
+                                            const CeedScalar *c,
+                                            const CeedInt c_stride,
+                                            const CeedInt c_comp,
+                                            const CeedScalar qw,
+                                            const CeedInt qd_stride,
+                                            CeedScalar *qd)
+{
+   // compute qw/det(J) adj(J) C adj(J)^T and store the symmetric part of the result.
+   // J: 0 3 6   qd: 0 1 2
+   //    1 4 7       1 3 4
+   //    2 5 8       2 4 5
+   const CeedScalar J11 = J[J_stride * 0];
+   const CeedScalar J21 = J[J_stride * 1];
+   const CeedScalar J31 = J[J_stride * 2];
+   const CeedScalar J12 = J[J_stride * 3];
+   const CeedScalar J22 = J[J_stride * 4];
+   const CeedScalar J32 = J[J_stride * 5];
+   const CeedScalar J13 = J[J_stride * 6];
+   const CeedScalar J23 = J[J_stride * 7];
+   const CeedScalar J33 = J[J_stride * 8];
+   const CeedScalar A11 = J22 * J33 - J23 * J32;
+   const CeedScalar A12 = J13 * J32 - J12 * J33;
+   const CeedScalar A13 = J12 * J23 - J13 * J22;
+   const CeedScalar A21 = J23 * J31 - J21 * J33;
+   const CeedScalar A22 = J11 * J33 - J13 * J31;
+   const CeedScalar A23 = J13 * J21 - J11 * J23;
+   const CeedScalar A31 = J21 * J32 - J22 * J31;
+   const CeedScalar A32 = J12 * J31 - J11 * J32;
+   const CeedScalar A33 = J11 * J22 - J12 * J21;
+   const CeedScalar w = qw / (J11 * A11 + J21 * A12 + J31 * A13);
+   if (c_comp == 6)  // Matrix coefficient (symmetric)
+   {
+      // First compute entries of R = C adj(J)^T
+      // c: 0 1 2
+      //    1 3 4
+      //    2 4 5
+      const CeedScalar R11 = c[c_stride * 0] * A11 +
+                             c[c_stride * 1] * A12 +
+                             c[c_stride * 2] * A13;
+      const CeedScalar R12 = c[c_stride * 0] * A21 +
+                             c[c_stride * 1] * A22 +
+                             c[c_stride * 2] * A23;
+      const CeedScalar R13 = c[c_stride * 0] * A31 +
+                             c[c_stride * 1] * A32 +
+                             c[c_stride * 2] * A33;
+      const CeedScalar R21 = c[c_stride * 1] * A11 +
+                             c[c_stride * 3] * A12 +
+                             c[c_stride * 4] * A13;
+      const CeedScalar R22 = c[c_stride * 1] * A21 +
+                             c[c_stride * 3] * A22 +
+                             c[c_stride * 4] * A23;
+      const CeedScalar R23 = c[c_stride * 1] * A31 +
+                             c[c_stride * 3] * A32 +
+                             c[c_stride * 4] * A33;
+      const CeedScalar R31 = c[c_stride * 2] * A11 +
+                             c[c_stride * 4] * A12 +
+                             c[c_stride * 5] * A13;
+      const CeedScalar R32 = c[c_stride * 2] * A21 +
+                             c[c_stride * 4] * A22 +
+                             c[c_stride * 5] * A23;
+      const CeedScalar R33 = c[c_stride * 2] * A31 +
+                             c[c_stride * 4] * A32 +
+                             c[c_stride * 5] * A33;
+      qd[qd_stride * 0] = w * (A11 * R11 + A12 * R21 + A13 * R31);
+      qd[qd_stride * 1] = w * (A11 * R12 + A12 * R22 + A13 * R32);
+      qd[qd_stride * 2] = w * (A11 * R13 + A12 * R23 + A13 * R33);
+      qd[qd_stride * 3] = w * (A21 * R12 + A22 * R22 + A23 * R32);
+      qd[qd_stride * 4] = w * (A21 * R13 + A22 * R23 + A23 * R33);
+      qd[qd_stride * 5] = w * (A31 * R13 + A32 * R23 + A33 * R33);
+   }
+   else if (c_comp == 3)  // Vector coefficient
+   {
+      qd[qd_stride * 0] = w * (c[c_stride * 0] * A11 * A11 +
+                               c[c_stride * 1] * A12 * A12 +
+                               c[c_stride * 2] * A13 * A13);
+      qd[qd_stride * 1] = w * (c[c_stride * 0] * A11 * A21 +
+                               c[c_stride * 1] * A12 * A22 +
+                               c[c_stride * 2] * A13 * A23);
+      qd[qd_stride * 2] = w * (c[c_stride * 0] * A11 * A31 +
+                               c[c_stride * 1] * A12 * A32 +
+                               c[c_stride * 2] * A13 * A33);
+      qd[qd_stride * 3] = w * (c[c_stride * 0] * A21 * A21 +
+                               c[c_stride * 1] * A22 * A22 +
+                               c[c_stride * 2] * A23 * A23);
+      qd[qd_stride * 4] = w * (c[c_stride * 0] * A21 * A31 +
+                               c[c_stride * 1] * A22 * A32 +
+                               c[c_stride * 2] * A23 * A33);
+      qd[qd_stride * 5] = w * (c[c_stride * 0] * A31 * A31 +
+                               c[c_stride * 1] * A32 * A32 +
+                               c[c_stride * 2] * A33 * A33);
+   }
+   else  // Scalar coefficient
+   {
+      qd[qd_stride * 0] =
+         w * c[c_stride * 0] * (A11 * A11 + A12 * A12 + A13 * A13);
+      qd[qd_stride * 1] =
+         w * c[c_stride * 0] * (A11 * A21 + A12 * A22 + A13 * A23);
+      qd[qd_stride * 2] =
+         w * c[c_stride * 0] * (A11 * A31 + A12 * A32 + A13 * A33);
+      qd[qd_stride * 3] =
+         w * c[c_stride * 0] * (A21 * A21 + A22 * A22 + A23 * A23);
+      qd[qd_stride * 4] =
+         w * c[c_stride * 0] * (A21 * A31 + A22 * A32 + A23 * A33);
+      qd[qd_stride * 5] =
+         w * c[c_stride * 0] * (A31 * A31 + A32 * A32 + A33 * A33);
+   }
+}
+
+CEED_QFUNCTION_HELPER void MultAdjJCAdjJt32(const CeedScalar *J,
+                                            const CeedInt J_stride,
+                                            const CeedScalar *c,
+                                            const CeedInt c_stride,
+                                            const CeedInt c_comp,
+                                            const CeedScalar qw,
+                                            const CeedInt qd_stride,
+                                            CeedScalar *qd)
+{
+   // compute qw/det(J) adj(J) C adj(J)^T and store the symmetric part of the result.
+   // J: 0 3   qd: 0 1
+   //    1 4       1 2
+   //    2 5
+   const CeedScalar J11 = J[J_stride * 0];
+   const CeedScalar J21 = J[J_stride * 1];
+   const CeedScalar J31 = J[J_stride * 2];
+   const CeedScalar J12 = J[J_stride * 3];
+   const CeedScalar J22 = J[J_stride * 4];
+   const CeedScalar J32 = J[J_stride * 5];
+   const CeedScalar E = J11 * J11 + J21 * J21 + J31 * J31;
+   const CeedScalar G = J12 * J12 + J22 * J22 + J32 * J32;
+   const CeedScalar F = J11 * J12 + J21 * J22 + J31 * J32;
+   const CeedScalar d = E * G - F * F;
+   const CeedScalar w = qw / sqrt(d);
+   if (c_comp == 6)  // Matrix coefficient (symmetric)
+   {
+      // First compute entries of R = C adj(J)^T
+      // c: 0 1 2
+      //    1 3 4
+      //    2 4 5
+      const CeedScalar R11 = G * (c[c_stride * 0] * J11 +
+                                  c[c_stride * 1] * J21 +
+                                  c[c_stride * 2] * J31) -
+                             F * (c[c_stride * 0] * J12 +
+                                  c[c_stride * 1] * J22 +
+                                  c[c_stride * 2] * J32);
+      const CeedScalar R21 = G * (c[c_stride * 1] * J11 +
+                                  c[c_stride * 3] * J21 +
+                                  c[c_stride * 4] * J31) -
+                             F * (c[c_stride * 1] * J12 +
+                                  c[c_stride * 3] * J22 +
+                                  c[c_stride * 4] * J32);
+      const CeedScalar R31 = G * (c[c_stride * 2] * J11 +
+                                  c[c_stride * 4] * J21 +
+                                  c[c_stride * 5] * J31) -
+                             F * (c[c_stride * 2] * J12 +
+                                  c[c_stride * 4] * J22 +
+                                  c[c_stride * 5] * J32);
+      const CeedScalar R12 = E * (c[c_stride * 0] * J11 +
+                                  c[c_stride * 1] * J22 +
+                                  c[c_stride * 2] * J32) -
+                             F * (c[c_stride * 0] * J11 +
+                                  c[c_stride * 1] * J21 +
+                                  c[c_stride * 2] * J31);
+      const CeedScalar R22 = E * (c[c_stride * 1] * J11 +
+                                  c[c_stride * 3] * J22 +
+                                  c[c_stride * 4] * J32) -
+                             F * (c[c_stride * 1] * J11 +
+                                  c[c_stride * 3] * J21 +
+                                  c[c_stride * 4] * J31);
+      const CeedScalar R32 = E * (c[c_stride * 2] * J11 +
+                                  c[c_stride * 4] * J22 +
+                                  c[c_stride * 5] * J32) -
+                             F * (c[c_stride * 2] * J11 +
+                                  c[c_stride * 4] * J21 +
+                                  c[c_stride * 5] * J31);
+      qd[qd_stride * 0] = w * (G * (J11 * R11 + J21 * R21 + J31 * R31) -
+                               F * (J12 * R11 + J22 * R21 + J32 * R31)) / d;
+      qd[qd_stride * 1] = w * (G * (J11 * R12 + J21 * R22 + J31 * R32) -
+                               F * (J12 * R12 + J22 * R22 + J32 * R32)) / d;
+      qd[qd_stride * 2] = w * (E * (J12 * R12 + J22 * R22 + J32 * R32) -
+                               F * (J11 * R12 + J21 * R22 + J32 * R31)) / d;
+   }
+   else if (c_comp == 3)  // Vector coefficient
+   {
+      // First compute entries of R = C adj(J)^T
+      // c: 0
+      //      1
+      //        2
+      const CeedScalar R11 = c[c_stride * 0] * (G * J11 - F * J12);
+      const CeedScalar R21 = c[c_stride * 1] * (G * J21 - F * J22);
+      const CeedScalar R31 = c[c_stride * 2] * (G * J31 - F * J32);
+      const CeedScalar R12 = c[c_stride * 0] * (E * J12 - F * J11);
+      const CeedScalar R22 = c[c_stride * 1] * (E * J22 - F * J21);
+      const CeedScalar R32 = c[c_stride * 2] * (E * J32 - F * J31);
+      qd[qd_stride * 0] = w * (G * (J11 * R11 + J21 * R21 + J31 * R31) -
+                               F * (J12 * R11 + J22 * R21 + J32 * R31)) / d;
+      qd[qd_stride * 1] = w * (G * (J11 * R12 + J21 * R22 + J31 * R32) -
+                               F * (J12 * R12 + J22 * R22 + J32 * R32)) / d;
+      qd[qd_stride * 2] = w * (E * (J12 * R12 + J22 * R22 + J32 * R32) -
+                               F * (J11 * R12 + J21 * R22 + J32 * R31)) / d;
+   }
+   else  // Scalar coefficient
+   {
+      qd[qd_stride * 0] =  w * c[c_stride * 0] * G;
+      qd[qd_stride * 1] = -w * c[c_stride * 0] * F;
+      qd[qd_stride * 2] =  w * c[c_stride * 0] * E;
+   }
+}
+
+CEED_QFUNCTION_HELPER void MultCtAdjJt22(const CeedScalar *J,
+                                         const CeedInt J_stride,
+                                         const CeedScalar *c,
+                                         const CeedInt c_stride,
+                                         const CeedScalar qw,
+                                         const CeedInt qd_stride,
+                                         CeedScalar *qd)
+{
+   // compute qw c^T adj(J)^T and store the result vector.
+   // J: 0 2   adj(J):  J22 -J12
+   //    1 3           -J21  J11
+   const CeedScalar J11 = J[J_stride * 0];
+   const CeedScalar J21 = J[J_stride * 1];
+   const CeedScalar J12 = J[J_stride * 2];
+   const CeedScalar J22 = J[J_stride * 3];
+   const CeedScalar w1 = qw * c[c_stride * 0];
+   const CeedScalar w2 = qw * c[c_stride * 1];
+   qd[qd_stride * 0] =  w1 * J22 - w2 * J12;
+   qd[qd_stride * 1] = -w1 * J21 + w2 * J11;
+}
+
+CEED_QFUNCTION_HELPER void MultCtAdjJt21(const CeedScalar *J,
+                                         const CeedInt J_stride,
+                                         const CeedScalar *c,
+                                         const CeedInt c_stride,
+                                         const CeedScalar qw,
+                                         const CeedInt qd_stride,
+                                         CeedScalar *qd)
+{
+   // compute qw c^T adj(J)^T and store the result vector.
+   // J: 0   adj(J): 1/sqrt(J^T J) J^T
+   //    1
+   const CeedScalar J11 = J[J_stride * 0];
+   const CeedScalar J21 = J[J_stride * 1];
+   const CeedScalar w = qw / sqrt(J11 * J11 + J21 * J21);
+   const CeedScalar w1 = w * c[c_stride * 0];
+   const CeedScalar w2 = w * c[c_stride * 1];
+   qd[qd_stride * 0] =  w1 * J11 + w2 * J21;
+}
+
+CEED_QFUNCTION_HELPER void MultCtAdjJt33(const CeedScalar *J,
+                                         const CeedInt J_stride,
+                                         const CeedScalar *c,
+                                         const CeedInt c_stride,
+                                         const CeedScalar qw,
+                                         const CeedInt qd_stride,
+                                         CeedScalar *qd)
+{
+   // compute qw c^T adj(J)^T and store the result vector.
+   // J: 0 3 6
+   //    1 4 7
+   //    2 5 8
+   const CeedScalar J11 = J[J_stride * 0];
+   const CeedScalar J21 = J[J_stride * 1];
+   const CeedScalar J31 = J[J_stride * 2];
+   const CeedScalar J12 = J[J_stride * 3];
+   const CeedScalar J22 = J[J_stride * 4];
+   const CeedScalar J32 = J[J_stride * 5];
+   const CeedScalar J13 = J[J_stride * 6];
+   const CeedScalar J23 = J[J_stride * 7];
+   const CeedScalar J33 = J[J_stride * 8];
+   const CeedScalar A11 = J22 * J33 - J23 * J32;
+   const CeedScalar A12 = J13 * J32 - J12 * J33;
+   const CeedScalar A13 = J12 * J23 - J13 * J22;
+   const CeedScalar A21 = J23 * J31 - J21 * J33;
+   const CeedScalar A22 = J11 * J33 - J13 * J31;
+   const CeedScalar A23 = J13 * J21 - J11 * J23;
+   const CeedScalar A31 = J21 * J32 - J22 * J31;
+   const CeedScalar A32 = J12 * J31 - J11 * J32;
+   const CeedScalar A33 = J11 * J22 - J12 * J21;
+   const CeedScalar w1 = qw * c[c_stride * 0];
+   const CeedScalar w2 = qw * c[c_stride * 1];
+   const CeedScalar w3 = qw * c[c_stride * 2];
+   qd[qd_stride * 0] = w1 * A11 + w2 * A12 + w3 * A13;
+   qd[qd_stride * 1] = w1 * A21 + w2 * A22 + w3 * A23;
+   qd[qd_stride * 2] = w1 * A31 + w2 * A32 + w3 * A33;
+}
+
+CEED_QFUNCTION_HELPER void MultCtAdjJt32(const CeedScalar *J,
+                                        const CeedInt J_stride,
+                                        const CeedScalar *c,
+                                        const CeedInt c_stride,
+                                        const CeedScalar qw,
+                                        const CeedInt qd_stride,
+                                        CeedScalar *qd)
+{
+   // compute qw c^T adj(J)^T and store the result vector.
+   // J: 0 3
+   //    1 4
+   //    2 5
+   const CeedScalar J11 = J[J_stride * 0];
+   const CeedScalar J21 = J[J_stride * 1];
+   const CeedScalar J31 = J[J_stride * 2];
+   const CeedScalar J12 = J[J_stride * 3];
+   const CeedScalar J22 = J[J_stride * 4];
+   const CeedScalar J32 = J[J_stride * 5];
+   const CeedScalar E = J11 * J11 + J21 * J21 + J31 * J31;
+   const CeedScalar G = J12 * J12 + J22 * J22 + J32 * J32;
+   const CeedScalar F = J11 * J12 + J21 * J22 + J31 * J32;
+   const CeedScalar A11 = G * J11 - F * J12;
+   const CeedScalar A21 = E * J12 - F * J11;
+   const CeedScalar A12 = G * J21 - F * J22;
+   const CeedScalar A22 = E * J22 - F * J21;
+   const CeedScalar A13 = G * J31 - F * J32;
+   const CeedScalar A23 = E * J32 - F * J31;
+   const CeedScalar w = qw / sqrt(E * G - F * F);
+   const CeedScalar w1 = w * c[c_stride * 0];
+   const CeedScalar w2 = w * c[c_stride * 1];
+   const CeedScalar w3 = w * c[c_stride * 2];
+   qd[qd_stride * 0] = w1 * A11 + w2 * A12 + w3 * A13;
+   qd[qd_stride * 1] = w1 * A21 + w2 * A22 + w3 * A23;
+}
+
+CEED_QFUNCTION_HELPER void MultAdjJt22(const CeedScalar *J,
+                                       const CeedInt J_stride,
+                                       const CeedScalar qw,
+                                       const CeedInt qd_stride,
+                                       CeedScalar *qd)
+{
+   // compute qw adj(J)^T and store the result matrix.
+   // J: 0 2   adj(J):  J22 -J12   qd: 0 2
+   //    1 3           -J21  J11       1 3
+   const CeedScalar J11 = J[J_stride * 0];
+   const CeedScalar J21 = J[J_stride * 1];
+   const CeedScalar J12 = J[J_stride * 2];
+   const CeedScalar J22 = J[J_stride * 3];
+   qd[qd_stride * 0] =  qw * J22;
+   qd[qd_stride * 1] = -qw * J12;
+   qd[qd_stride * 2] = -qw * J21;
+   qd[qd_stride * 3] =  qw * J11;
+}
+
+CEED_QFUNCTION_HELPER void MultAdjJt21(const CeedScalar *J,
+                                       const CeedInt J_stride,
+                                       const CeedScalar qw,
+                                       const CeedInt qd_stride,
+                                       CeedScalar *qd)
+{
+   // compute qw adj(J)^T and store the result matrix.
+   // J: 0   adj(J):  1/sqrt(J^T J) J^T   qd: 0
+   //    1                                    1
+   const CeedScalar J11 = J[J_stride * 0];
+   const CeedScalar J21 = J[J_stride * 1];
+   const CeedScalar w = qw / sqrt(J11 * J11 + J21 * J21);
+   qd[qd_stride * 0] = w * J11;
+   qd[qd_stride * 1] = w * J21;
+}
+
+CEED_QFUNCTION_HELPER void MultAdjJt33(const CeedScalar *J,
+                                       const CeedInt J_stride,
+                                       const CeedScalar qw,
+                                       const CeedInt qd_stride,
+                                       CeedScalar *qd)
+{
+   // compute qw adj(J)^T and store the result matrix.
+   // J: 0 3 6   qd: 0 3 6
+   //    1 4 7       1 4 7
+   //    2 5 8       2 5 8
+   const CeedScalar J11 = J[J_stride * 0];
+   const CeedScalar J21 = J[J_stride * 1];
+   const CeedScalar J31 = J[J_stride * 2];
+   const CeedScalar J12 = J[J_stride * 3];
+   const CeedScalar J22 = J[J_stride * 4];
+   const CeedScalar J32 = J[J_stride * 5];
+   const CeedScalar J13 = J[J_stride * 6];
+   const CeedScalar J23 = J[J_stride * 7];
+   const CeedScalar J33 = J[J_stride * 8];
+   const CeedScalar A11 = J22 * J33 - J23 * J32;
+   const CeedScalar A12 = J13 * J32 - J12 * J33;
+   const CeedScalar A13 = J12 * J23 - J13 * J22;
+   const CeedScalar A21 = J23 * J31 - J21 * J33;
+   const CeedScalar A22 = J11 * J33 - J13 * J31;
+   const CeedScalar A23 = J13 * J21 - J11 * J23;
+   const CeedScalar A31 = J21 * J32 - J22 * J31;
+   const CeedScalar A32 = J12 * J31 - J11 * J32;
+   const CeedScalar A33 = J11 * J22 - J12 * J21;
+   qd[qd_stride * 0] = qw * A11;
+   qd[qd_stride * 1] = qw * A12;
+   qd[qd_stride * 2] = qw * A13;
+   qd[qd_stride * 3] = qw * A21;
+   qd[qd_stride * 4] = qw * A22;
+   qd[qd_stride * 5] = qw * A23;
+   qd[qd_stride * 6] = qw * A31;
+   qd[qd_stride * 7] = qw * A32;
+   qd[qd_stride * 8] = qw * A33;
+}
+
+CEED_QFUNCTION_HELPER void MultAdjJt32(const CeedScalar *J,
+                                       const CeedInt J_stride,
+                                       const CeedScalar qw,
+                                       const CeedInt qd_stride,
+                                       CeedScalar *qd)
+{
+   // compute qw adj(J)^T and store the result matrix.
+   // J: 0 3   qd: 0 3
+   //    1 4       1 4
+   //    2 5       2 5
+   const CeedScalar J11 = J[J_stride * 0];
+   const CeedScalar J21 = J[J_stride * 1];
+   const CeedScalar J31 = J[J_stride * 2];
+   const CeedScalar J12 = J[J_stride * 3];
+   const CeedScalar J22 = J[J_stride * 4];
+   const CeedScalar J32 = J[J_stride * 5];
+   const CeedScalar E = J11 * J11 + J21 * J21 + J31 * J31;
+   const CeedScalar G = J12 * J12 + J22 * J22 + J32 * J32;
+   const CeedScalar F = J11 * J12 + J21 * J22 + J31 * J32;
+   const CeedScalar A11 = G * J11 - F * J12;
+   const CeedScalar A21 = E * J12 - F * J11;
+   const CeedScalar A12 = G * J21 - F * J22;
+   const CeedScalar A22 = E * J22 - F * J21;
+   const CeedScalar A13 = G * J31 - F * J32;
+   const CeedScalar A23 = E * J32 - F * J31;
+   const CeedScalar w = qw / sqrt(E * G - F * F);
+   qd[qd_stride * 0] = w * A11;
+   qd[qd_stride * 1] = w * A12;
+   qd[qd_stride * 2] = w * A13;
+   qd[qd_stride * 3] = w * A21;
+   qd[qd_stride * 4] = w * A22;
+   qd[qd_stride * 5] = w * A23;
+}
+
+#endif // MFEM_LIBCEED_QF_UTILS_H

--- a/fem/ceed/integrators/util/util_qf.h
+++ b/fem/ceed/integrators/util/util_qf.h
@@ -9,8 +9,8 @@
 // terms of the BSD-3 license. We welcome feedback and contributions, see file
 // CONTRIBUTING.md for details.
 
-#ifndef MFEM_LIBCEED_QF_UTILS_H
-#define MFEM_LIBCEED_QF_UTILS_H
+#ifndef MFEM_LIBCEED_UTIL_QF_H
+#define MFEM_LIBCEED_UTIL_QF_H
 
 #include <math.h>
 
@@ -580,4 +580,4 @@ CEED_QFUNCTION_HELPER void MultAdjJt32(const CeedScalar *J,
    qd[qd_stride * 5] = w * A23;
 }
 
-#endif // MFEM_LIBCEED_QF_UTILS_H
+#endif // MFEM_LIBCEED_UTIL_QF_H

--- a/fem/ceed/integrators/util/util_qf.h
+++ b/fem/ceed/integrators/util/util_qf.h
@@ -27,7 +27,8 @@ CEED_QFUNCTION_HELPER CeedScalar DetJ21(const CeedScalar *J,
 {
    // J: 0
    //    1
-   return sqrt(J[J_stride * 0] * J[J_stride * 0] + J[J_stride * 1] * J[J_stride * 1]);
+   return sqrt(J[J_stride * 0] * J[J_stride * 0] +
+               J[J_stride * 1] * J[J_stride * 1]);
 }
 
 CEED_QFUNCTION_HELPER CeedScalar DetJ33(const CeedScalar *J,
@@ -438,12 +439,12 @@ CEED_QFUNCTION_HELPER void MultCtAdjJt33(const CeedScalar *J,
 }
 
 CEED_QFUNCTION_HELPER void MultCtAdjJt32(const CeedScalar *J,
-                                        const CeedInt J_stride,
-                                        const CeedScalar *c,
-                                        const CeedInt c_stride,
-                                        const CeedScalar qw,
-                                        const CeedInt qd_stride,
-                                        CeedScalar *qd)
+                                         const CeedInt J_stride,
+                                         const CeedScalar *c,
+                                         const CeedInt c_stride,
+                                         const CeedScalar qw,
+                                         const CeedInt qd_stride,
+                                         CeedScalar *qd)
 {
    // compute qw c^T adj(J)^T and store the result vector.
    // J: 0 3

--- a/fem/ceed/integrators/util/util_qf.h
+++ b/fem/ceed/integrators/util/util_qf.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2010-2022, Lawrence Livermore National Security, LLC. Produced
+// Copyright (c) 2010-2023, Lawrence Livermore National Security, LLC. Produced
 // at the Lawrence Livermore National Laboratory. All Rights reserved. See files
 // LICENSE and NOTICE for details. LLNL-CODE-806117.
 //
@@ -19,7 +19,8 @@ CEED_QFUNCTION_HELPER CeedScalar DetJ22(const CeedScalar *J,
 {
    // J: 0 2
    //    1 3
-   return J[J_stride * 0] * J[J_stride * 3] - J[J_stride * 1] * J[J_stride * 2];
+   return J[J_stride * 0] * J[J_stride * 3] -
+          J[J_stride * 1] * J[J_stride * 2];
 }
 
 CEED_QFUNCTION_HELPER CeedScalar DetJ21(const CeedScalar *J,
@@ -95,6 +96,8 @@ CEED_QFUNCTION_HELPER void MultAdjJCAdjJt22(const CeedScalar *J,
    }
    else if (c_comp == 2)  // Vector coefficient
    {
+      // c: 0
+      //      1
       qd[qd_stride * 0] =  w * (c[c_stride * 1] * J12 * J12 +
                                 c[c_stride * 0] * J22 * J22);
       qd[qd_stride * 1] = -w * (c[c_stride * 1] * J11 * J12 +
@@ -137,12 +140,10 @@ CEED_QFUNCTION_HELPER void MultAdjJCAdjJt21(const CeedScalar *J,
    }
    else if (c_comp == 2)  // Vector coefficient
    {
-      // First compute entries of R = C adj(J)^T
       // c: 0
       //      1
-      const CeedScalar R11 = c[c_stride * 0] * J11;
-      const CeedScalar R21 = c[c_stride * 1] * J21;
-      qd[qd_stride * 0] = w * (J11 * R11 + J21 * R21) / d;
+      qd[qd_stride * 0] = w * (c[c_stride * 0] * J11 * J11 +
+                               c[c_stride * 1] * J21 * J21) / d;
    }
    else  // Scalar coefficient
    {
@@ -224,6 +225,9 @@ CEED_QFUNCTION_HELPER void MultAdjJCAdjJt33(const CeedScalar *J,
    }
    else if (c_comp == 3)  // Vector coefficient
    {
+      // c: 0
+      //      1
+      //        2
       qd[qd_stride * 0] = w * (c[c_stride * 0] * A11 * A11 +
                                c[c_stride * 1] * A12 * A12 +
                                c[c_stride * 2] * A13 * A13);

--- a/fem/ceed/interface/basis.cpp
+++ b/fem/ceed/interface/basis.cpp
@@ -9,7 +9,8 @@
 // terms of the BSD-3 license. We welcome feedback and contributions, see file
 // CONTRIBUTING.md for details.
 
-#include "../../gridfunc.hpp"
+#include "basis.hpp"
+
 #include "util.hpp"
 
 namespace mfem
@@ -47,25 +48,25 @@ static CeedElemTopology GetCeedTopology(Geometry::Type geom)
 static void InitNonTensorBasis(const mfem::FiniteElementSpace &fes,
                                const mfem::FiniteElement &fe,
                                const mfem::IntegrationRule &ir,
-                               Ceed ceed, CeedBasis *basis)
+                               Ceed ceed,
+                               CeedBasis *basis)
 {
    const mfem::DofToQuad &maps = fe.GetDofToQuad(ir, mfem::DofToQuad::FULL);
-   mfem::Mesh *mesh = fes.GetMesh();
-   const int dim = mesh->Dimension();
-   const int ndofs = maps.ndof;
-   const int nqpts = maps.nqpt;
-   mfem::DenseMatrix qX(dim,nqpts);
-   mfem::Vector qW(nqpts);
-   for (int i = 0; i < nqpts; i++)
+   const int dim = fe.GetDim();
+   const int ncomp = fes.GetVDim();
+   const int P = maps.ndof;
+   const int Q = maps.nqpt;
+   mfem::DenseMatrix qX(dim, Q);
+   mfem::Vector qW(Q);
+   for (int i = 0; i < Q; i++)
    {
       const mfem::IntegrationPoint &ip = ir.IntPoint(i);
-      qX(0,i) = ip.x;
-      if (dim>1) { qX(1,i) = ip.y; }
-      if (dim>2) { qX(2,i) = ip.z; }
+      qX(0, i) = ip.x;
+      if (dim > 1) { qX(1, i) = ip.y; }
+      if (dim > 2) { qX(2, i) = ip.z; }
       qW(i) = ip.weight;
    }
-   CeedBasisCreateH1(ceed, GetCeedTopology(fe.GetGeomType()),
-                     fes.GetVDim(), ndofs, nqpts,
+   CeedBasisCreateH1(ceed, GetCeedTopology(fe.GetGeomType()), ncomp, P, Q,
                      maps.Bt.GetData(), maps.Gt.GetData(),
                      qX.GetData(), qW.GetData(), basis);
 }
@@ -73,49 +74,51 @@ static void InitNonTensorBasis(const mfem::FiniteElementSpace &fes,
 static void InitTensorBasis(const mfem::FiniteElementSpace &fes,
                             const mfem::FiniteElement &fe,
                             const mfem::IntegrationRule &ir,
-                            Ceed ceed, CeedBasis *basis)
+                            Ceed ceed,
+                            CeedBasis *basis)
 {
    const mfem::DofToQuad &maps = fe.GetDofToQuad(ir, mfem::DofToQuad::TENSOR);
-   mfem::Mesh *mesh = fes.GetMesh();
-   const int ndofs = maps.ndof;
-   const int nqpts = maps.nqpt;
-   mfem::Vector qX(nqpts), qW(nqpts);
-   // The x-coordinates of the first `nqpts` points of the integration rule are
+   const int dim = fe.GetDim();
+   const int ncomp = fes.GetVDim();
+   const int P = maps.ndof;
+   const int Q = maps.nqpt;
+   mfem::Vector qX(Q), qW(Q);
+   // The x-coordinates of the first `Q` points of the integration rule are
    // the points of the corresponding 1D rule. We also scale the weights
    // accordingly.
    double w_sum = 0.0;
-   for (int i = 0; i < nqpts; i++)
+   for (int i = 0; i < Q; i++)
    {
       const mfem::IntegrationPoint &ip = ir.IntPoint(i);
       qX(i) = ip.x;
       qW(i) = ip.weight;
       w_sum += ip.weight;
    }
-   qW *= 1.0/w_sum;
-   CeedBasisCreateTensorH1(ceed, mesh->Dimension(), fes.GetVDim(), ndofs,
-                           nqpts, maps.Bt.GetData(),
-                           maps.Gt.GetData(), qX.GetData(),
-                           qW.GetData(), basis);
+   qW *= 1.0 / w_sum;
+   CeedBasisCreateTensorH1(ceed, dim, ncomp, P, Q,
+                           maps.Bt.GetData(), maps.Gt.GetData(),
+                           qX.GetData(), qW.GetData(), basis);
 }
 
 static void InitBasisImpl(const FiniteElementSpace &fes,
                           const FiniteElement &fe,
                           const IntegrationRule &ir,
-                          Ceed ceed, CeedBasis *basis)
+                          Ceed ceed,
+                          CeedBasis *basis)
 {
-   // Check for FES -> basis, restriction in hash tables
+   // Check for fes -> basis in hash table
+   const int ncomp = fes.GetVDim();
    const int P = fe.GetDof();
    const int Q = ir.GetNPoints();
-   const int ncomp = fes.GetVDim();
+   const bool tensor =
+      dynamic_cast<const mfem::TensorBasisElement *>(&fe) != nullptr;
    BasisKey basis_key(&fes, &ir, ncomp, P, Q);
    auto basis_itr = mfem::internal::ceed_basis_map.find(basis_key);
-   const bool tensor = dynamic_cast<const mfem::TensorBasisElement *>
-                       (&fe) != nullptr;
 
    // Init or retrieve key values
    if (basis_itr == mfem::internal::ceed_basis_map.end())
    {
-      if ( tensor )
+      if (tensor)
       {
          InitTensorBasis(fes, fe, ir, ceed, basis);
       }
@@ -133,19 +136,24 @@ static void InitBasisImpl(const FiniteElementSpace &fes,
 
 void InitBasis(const FiniteElementSpace &fes,
                const IntegrationRule &ir,
-               Ceed ceed, CeedBasis *basis)
+               bool use_bdr,
+               Ceed ceed,
+               CeedBasis *basis)
 {
-   const mfem::FiniteElement &fe = *fes.GetFE(0);
+   const mfem::FiniteElement &fe = use_bdr ? *fes.GetBE(0) : *fes.GetFE(0);
    InitBasisImpl(fes, fe, ir, ceed, basis);
 }
 
 void InitBasisWithIndices(const FiniteElementSpace &fes,
                           const IntegrationRule &ir,
+                          bool use_bdr,
                           int nelem,
-                          const int* indices,
-                          Ceed ceed, CeedBasis *basis)
+                          const int *indices,
+                          Ceed ceed,
+                          CeedBasis *basis)
 {
-   const mfem::FiniteElement &fe = *fes.GetFE(indices[0]);
+   const mfem::FiniteElement &fe = use_bdr ? *fes.GetBE(indices[0]) :
+                                   *fes.GetFE(indices[0]);
    InitBasisImpl(fes, fe, ir, ceed, basis);
 }
 

--- a/fem/ceed/interface/basis.hpp
+++ b/fem/ceed/interface/basis.hpp
@@ -12,6 +12,7 @@
 #ifndef MFEM_LIBCEED_BASIS
 #define MFEM_LIBCEED_BASIS
 
+#include "../../fespace.hpp"
 #include "ceed.hpp"
 
 namespace mfem
@@ -24,19 +25,23 @@ namespace ceed
 
 /** @brief Initialize a CeedBasis for non-mixed meshes.
 
-   @param[in] fes Input finite element space.
-   @param[in] ir Input integration rule.
-   @param[in] ceed Input Ceed object.
-   @param[out] basis The address of the initialized CeedBasis object.
+    @param[in] fes Input finite element space.
+    @param[in] ir Input integration rule.
+    @param[in] use_bdr Create the basis for boundary elements.
+    @param[in] ceed Input Ceed object.
+    @param[out] basis The address of the initialized CeedBasis object.
 */
 void InitBasis(const FiniteElementSpace &fes,
                const IntegrationRule &ir,
-               Ceed ceed, CeedBasis *basis);
+               bool use_bdr,
+               Ceed ceed,
+               CeedBasis *basis);
 
 /** @brief Initialize a CeedBasis for mixed meshes.
 
     @param[in] fes The finite element space.
     @param[in] ir is the integration rule for the operator.
+    @param[in] use_bdr Create the basis for boundary elements.
     @param[in] nelem The number of elements.
     @param[in] indices The indices of the elements of same type in the
                        `FiniteElementSpace`.
@@ -44,9 +49,11 @@ void InitBasis(const FiniteElementSpace &fes,
     @param[out] basis The `CeedBasis` to initialize. */
 void InitBasisWithIndices(const FiniteElementSpace &fes,
                           const IntegrationRule &ir,
+                          bool use_bdr,
                           int nelem,
-                          const int* indices,
-                          Ceed ceed, CeedBasis *basis);
+                          const int *indices,
+                          Ceed ceed,
+                          CeedBasis *basis);
 
 #endif
 

--- a/fem/ceed/interface/ceed.hpp
+++ b/fem/ceed/interface/ceed.hpp
@@ -12,6 +12,7 @@
 #ifndef MFEM_LIBCEED_CEED
 #define MFEM_LIBCEED_CEED
 
+#include "../../../config/config.hpp"
 #ifdef MFEM_USE_CEED
 #include <ceed.h>
 #if !CEED_VERSION_GE(0,10,0)
@@ -24,6 +25,7 @@ namespace mfem
 namespace internal
 {
 
+// Definition in general/device.cpp.
 extern Ceed ceed;
 
 } // namespace internal

--- a/fem/ceed/interface/coefficient.hpp
+++ b/fem/ceed/interface/coefficient.hpp
@@ -67,6 +67,7 @@ struct QuadCoefficient : Coefficient
     @param[in] Q is the coefficient from the `Integrator`.
     @param[in] mesh is the mesh.
     @param[in] ir is the integration rule.
+    @param[in] use_bdr is a flag to construct the coefficient on mesh boundaries.
     @param[out] coeff_ptr is the structure to store the coefficient for the
                           `CeedOperator`. */
 inline void InitCoefficient(mfem::Coefficient *Q, mfem::Mesh &mesh,
@@ -93,10 +94,10 @@ inline void InitCoefficient(mfem::Coefficient *Q, mfem::Mesh &mesh,
       QuadCoefficient *ceed_coeff = new QuadCoefficient(1);
       const mfem::QuadratureFunction &qfunc = qf_coeff->GetQuadFunction();
       MFEM_VERIFY(qfunc.Size() == nq * ne,
-                  "Incompatible QuadratureFunction dimension\n");
+                  "Incompatible QuadratureFunction dimension.");
       MFEM_VERIFY(&ir == &qfunc.GetSpace()->GetIntRule(0),
                   "IntegrationRule used within integrator and in"
-                  " QuadratureFunction appear to be different");
+                  " QuadratureFunction appear to be different.");
       qfunc.Read();
       ceed_coeff->vector.MakeRef(const_cast<mfem::QuadratureFunction &>(qfunc), 0);
       InitVector(ceed_coeff->vector, ceed_coeff->coeff_vector);
@@ -132,6 +133,7 @@ inline void InitCoefficient(mfem::Coefficient *Q, mfem::Mesh &mesh,
     @param[in] VQ is the vector coefficient from the `Integrator`.
     @param[in] mesh is the mesh.
     @param[in] ir is the integration rule.
+    @param[in] use_bdr is a flag to construct the coefficient on mesh boundaries.
     @param[out] coeff_ptr is the structure to store the coefficient for the
                           `CeedOperator`. */
 inline void InitCoefficient(mfem::VectorCoefficient *VQ, mfem::Mesh &mesh,
@@ -159,10 +161,10 @@ inline void InitCoefficient(mfem::VectorCoefficient *VQ, mfem::Mesh &mesh,
       QuadCoefficient *ceed_coeff = new QuadCoefficient(vdim);
       const mfem::QuadratureFunction &qfunc = vqf_coeff->GetQuadFunction();
       MFEM_VERIFY(qfunc.Size() == vdim * nq * ne,
-                  "Incompatible QuadratureFunction dimension\n");
+                  "Incompatible QuadratureFunction dimension.");
       MFEM_VERIFY(&ir == &qfunc.GetSpace()->GetIntRule(0),
                   "IntegrationRule used within integrator and in"
-                  " QuadratureFunction appear to be different");
+                  " QuadratureFunction appear to be different.");
       qfunc.Read();
       ceed_coeff->vector.MakeRef(const_cast<mfem::QuadratureFunction &>(qfunc), 0);
       InitVector(ceed_coeff->vector, ceed_coeff->coeff_vector);
@@ -202,6 +204,7 @@ inline void InitCoefficient(mfem::VectorCoefficient *VQ, mfem::Mesh &mesh,
     @param[in] MQ is the matrix coefficient from the `Integrator`.
     @param[in] mesh is the mesh.
     @param[in] ir is the integration rule.
+    @param[in] use_bdr is a flag to construct the coefficient on mesh boundaries.
     @param[out] coeff_ptr is the structure to store the coefficient for the
                           `CeedOperator`. */
 inline void InitCoefficient(mfem::MatrixCoefficient *MQ, mfem::Mesh &mesh,
@@ -255,11 +258,12 @@ inline void InitCoefficient(mfem::MatrixCoefficient *MQ, mfem::Mesh &mesh,
     @param[in] Q is the coefficient from the `Integrator`.
     @param[in] mesh is the mesh.
     @param[in] ir is the integration rule.
-    @param[in] nelem The number of elements.
-    @param[in] indices The indices of the elements of same type in the
+    @param[in] use_bdr is a flag to construct the coefficient on mesh boundaries.
+    @param[in] nelem is the number of elements.
+    @param[in] indices are the indices of the elements of same type in the
                        `FiniteElementSpace`.
     @param[out] coeff_ptr is the structure to store the coefficient for the
-                          `CeedOperator`.  */
+                          `CeedOperator`. */
 inline void InitCoefficientWithIndices(mfem::Coefficient *Q,
                                        mfem::Mesh &mesh,
                                        const mfem::IntegrationRule &ir,
@@ -289,10 +293,10 @@ inline void InitCoefficientWithIndices(mfem::Coefficient *Q,
       ceed_coeff->vector.SetSize(nq * nelem);
       const mfem::QuadratureFunction &qfunc = qf_coeff->GetQuadFunction();
       MFEM_VERIFY(qfunc.Size() == nq * ne,
-                  "Incompatible QuadratureFunction dimension\n");
+                  "Incompatible QuadratureFunction dimension.");
       MFEM_VERIFY(&ir == &qfunc.GetSpace()->GetIntRule(0),
                   "IntegrationRule used within integrator and in"
-                  " QuadratureFunction appear to be different");
+                  " QuadratureFunction appear to be different.");
       Memory<int> m_indices((int*)indices, nelem, false);
       auto in = Reshape(qfunc.Read(), nq, ne);
       auto d_indices = Read(m_indices, nelem);
@@ -338,8 +342,9 @@ inline void InitCoefficientWithIndices(mfem::Coefficient *Q,
     @param[in] VQ is the vector coefficient from the `Integrator`.
     @param[in] mesh is the mesh.
     @param[in] ir is the integration rule.
-    @param[in] nelem The number of elements.
-    @param[in] indices The indices of the elements of same type in the
+    @param[in] use_bdr is a flag to construct the coefficient on mesh boundaries.
+    @param[in] nelem is the number of elements.
+    @param[in] indices are the indices of the elements of same type in the
                        `FiniteElementSpace`.
     @param[out] coeff_ptr is the structure to store the coefficient for the
                           `CeedOperator`. */
@@ -372,10 +377,10 @@ inline void InitCoefficientWithIndices(mfem::VectorCoefficient *VQ,
       ceed_coeff->vector.SetSize(vdim * nq * nelem);
       const mfem::QuadratureFunction &qfunc = vqf_coeff->GetQuadFunction();
       MFEM_VERIFY(qfunc.Size() == vdim * nq * ne,
-                  "Incompatible QuadratureFunction dimension\n");
+                  "Incompatible QuadratureFunction dimension.");
       MFEM_VERIFY(&ir == &qfunc.GetSpace()->GetIntRule(0),
                   "IntegrationRule used within integrator and in"
-                  " QuadratureFunction appear to be different");
+                  " QuadratureFunction appear to be different.");
       Memory<int> m_indices((int*)indices, nelem, false);
       auto in = Reshape(qfunc.Read(), vdim, nq, ne);
       auto d_indices = Read(m_indices, nelem);
@@ -428,8 +433,9 @@ inline void InitCoefficientWithIndices(mfem::VectorCoefficient *VQ,
     @param[in] MQ is the matrix coefficient from the `Integrator`.
     @param[in] mesh is the mesh.
     @param[in] ir is the integration rule.
-    @param[in] nelem The number of elements.
-    @param[in] indices The indices of the elements of same type in the
+    @param[in] use_bdr is a flag to construct the coefficient on mesh boundaries.
+    @param[in] nelem is the number of elements.
+    @param[in] indices are the indices of the elements of same type in the
                        `FiniteElementSpace`.
     @param[out] coeff_ptr is the structure to store the coefficient for the
                           `CeedOperator`. */

--- a/fem/ceed/interface/integrator.hpp
+++ b/fem/ceed/interface/integrator.hpp
@@ -12,7 +12,6 @@
 #ifndef MFEM_LIBCEED_INTEG
 #define MFEM_LIBCEED_INTEG
 
-#include "../../../config/config.hpp"
 #include "../../fespace.hpp"
 #include "../../gridfunc.hpp"
 #include "operator.hpp"
@@ -74,29 +73,29 @@ struct OperatorInfo
 };
 #endif
 
-/** This class represent a partially assembled operator using libCEED. */
-class PAIntegrator : public ceed::Operator
+/** This class represents a matrix-free or partially assembled operator using
+    libCEED. */
+class Integrator : public Operator
 {
 #ifdef MFEM_USE_CEED
 protected:
    CeedBasis trial_basis, test_basis, mesh_basis;
    CeedElemRestriction trial_restr, test_restr, mesh_restr, restr_i;
-   CeedQFunction build_qfunc, apply_qfunc;
+   CeedQFunction apply_qfunc;
+   CeedQFunctionContext apply_ctx;
    CeedVector node_coords, qdata;
    Coefficient *coeff;
-   CeedQFunctionContext build_ctx;
-   CeedOperator build_oper;
 
 public:
-   PAIntegrator()
+   Integrator()
       : Operator(),
         trial_basis(nullptr), test_basis(nullptr), mesh_basis(nullptr),
         trial_restr(nullptr), test_restr(nullptr), mesh_restr(nullptr),
         restr_i(nullptr),
-        build_qfunc(nullptr), apply_qfunc(nullptr), node_coords(nullptr),
-        qdata(nullptr), coeff(nullptr), build_ctx(nullptr), build_oper(nullptr) {}
+        apply_qfunc(nullptr), apply_ctx(nullptr),
+        node_coords(nullptr), qdata(nullptr), coeff(nullptr) {}
 
-   /** @brief This method assembles the `PAIntegrator` with the given
+   /** @brief This method assembles the `Integrator` with the given
        `CeedOperatorInfo` @a info, an `mfem::FiniteElementSpace` @a fes, an
        `mfem::IntegrationRule` @a ir, and `mfem::Coefficient`,
        `mfem::VectorCoefficient`, or `mfem::MatrixCoefficient` @a Q.
@@ -106,17 +105,24 @@ public:
        @param[in] info is the structure describing the CeedOperator to assemble.
        @param[in] fes is the finite element space.
        @param[in] ir is the integration rule for the operator.
-       @param[in] Q is the coefficient from the `Integrator`. */
+       @param[in] Q is the coefficient from the `Integrator`.
+       @param[in] use_bdr controls whether to construct the operator for the domain
+                          or domain boundary.
+       @param[in] use_mf controls whether to construct a matrix-free or partially
+                         assembled operator. */
    template <typename CeedOperatorInfo, typename CoeffType>
    void Assemble(CeedOperatorInfo &info,
                  const mfem::FiniteElementSpace &fes,
                  const mfem::IntegrationRule &ir,
-                 CoeffType *Q)
+                 CoeffType *Q,
+                 const bool use_bdr = false,
+                 const bool use_mf = false)
    {
-      Assemble(info, fes, ir, fes.GetNE(), nullptr, Q);
+      Assemble(info, fes, ir, use_bdr ? fes.GetNBE() : fes.GetNE(),
+               nullptr, Q, use_bdr, use_mf);
    }
 
-   /** @brief This method assembles the `PAIntegrator` with the given
+   /** @brief This method assembles the `Integrator` with the given
        `CeedOperatorInfo` @a info, an `mfem::FiniteElementSpace` @a fes, an
        `mfem::IntegrationRule` @a ir, and `mfem::Coefficient`,
        `mfem::VectorCoefficient`, or `mfem::MatrixCoefficient` @a Q for the
@@ -131,19 +137,25 @@ public:
        @param[in] indices The indices of the elements of same type in the
                           `FiniteElementSpace`. If `indices == nullptr`, assumes
                           that the `FiniteElementSpace` is not mixed.
-       @param[in] Q is the coefficient from the `Integrator`. */
+       @param[in] Q is the coefficient from the `Integrator`.
+       @param[in] use_bdr controls whether to construct the operator for the domain
+                          or domain boundary.
+       @param[in] use_mf controls whether to construct a matrix-free or partially
+                         assembled operator. */
    template <typename CeedOperatorInfo, typename CoeffType>
    void Assemble(CeedOperatorInfo &info,
                  const mfem::FiniteElementSpace &fes,
                  const mfem::IntegrationRule &ir,
                  int nelem,
                  const int *indices,
-                 CoeffType *Q)
+                 CoeffType *Q,
+                 const bool use_bdr = false,
+                 const bool use_mf = false)
    {
-      Assemble(info, fes, fes, ir, nelem, indices, Q);
+      Assemble(info, fes, fes, ir, nelem, indices, Q, use_bdr, use_mf);
    }
 
-   /** This method assembles the PAIntegrator for mixed forms.
+   /** This method assembles the `Integrator` for mixed forms.
 
        @param[in] info the `CeedOperatorInfo` describing the `CeedOperator`,
                        the `CeedOperatorInfo` type is expected to inherit from
@@ -153,18 +165,26 @@ public:
        @param[in] test_fes the test `FiniteElementSpace` for the form,
        @param[in] ir the `IntegrationRule` for the numerical integration,
        @param[in] Q `Coefficient`, `VectorCoefficient`, or
-                    `MatrixCoefficient`. */
+                    `MatrixCoefficient`.
+       @param[in] use_bdr controls whether to construct the operator for the domain
+                          or domain boundary.
+       @param[in] use_mf controls whether to construct a matrix-free or partially
+                         assembled operator. */
    template <typename CeedOperatorInfo, typename CoeffType>
    void Assemble(CeedOperatorInfo &info,
                  const mfem::FiniteElementSpace &trial_fes,
                  const mfem::FiniteElementSpace &test_fes,
                  const mfem::IntegrationRule &ir,
-                 CoeffType *Q)
+                 CoeffType *Q,
+                 const bool use_bdr = false,
+                 const bool use_mf = false)
    {
-      Assemble(info, trial_fes, test_fes, ir, trial_fes.GetNE(), nullptr, Q);
+      Assemble(info, trial_fes, test_fes, ir,
+               use_bdr ? trial_fes.GetNBE() : trial_fes.GetNE(),
+               nullptr, Q, use_bdr, use_mf);
    }
 
-   /** This method assembles the PAIntegrator for mixed forms on mixed meshes.
+   /** This method assembles the `Integrator` for mixed forms on mixed meshes.
 
        @param[in] info the `CeedOperatorInfo` describing the `CeedOperator`,
                        the `CeedOperatorInfo` type is expected to inherit from
@@ -178,7 +198,11 @@ public:
                           `FiniteElementSpace`. If `indices == nullptr`, assumes
                           that the `FiniteElementSpace` is not mixed,
        @param[in] Q `Coefficient`, `VectorCoefficient`, or
-                    `MatrixCoefficient`. */
+                    `MatrixCoefficient`.
+       @param[in] use_bdr controls whether to construct the operator for the domain
+                          or domain boundary.
+       @param[in] use_mf controls whether to construct a matrix-free or partially
+                         assembled operator. */
    template <typename CeedOperatorInfo, typename CoeffType>
    void Assemble(CeedOperatorInfo &info,
                  const mfem::FiniteElementSpace &trial_fes,
@@ -186,48 +210,34 @@ public:
                  const mfem::IntegrationRule &ir,
                  int nelem,
                  const int *indices,
-                 CoeffType *Q)
+                 CoeffType *Q,
+                 const bool use_bdr = false,
+                 const bool use_mf = false)
    {
       Ceed ceed(internal::ceed);
       mfem::Mesh &mesh = *trial_fes.GetMesh();
-      MFEM_VERIFY(!(!indices && mesh.GetNumGeometries(mesh.Dimension()) > 1),
-                  "Use ceed::MixedIntegrator on mixed meshes.");
-      InitCoefficient(Q, mesh, ir, nelem, indices, coeff);
-      std::string build_func = (coeff == nullptr) ? info.build_func_const
-                               : info.build_func_quad;
-      CeedQFunctionUser build_qf = (coeff == nullptr) ? info.build_qf_const
-                                   : info.build_qf_quad;
-      PAOperator op {info.qdatasize, info.header,
-                     build_func, build_qf,
-                     info.apply_func, info.apply_qf,
-                     info.trial_op,
-                     info.test_op
-                    };
-      CeedInt dim = mesh.Dimension();
+      CeedInt dim = mesh.Dimension() - (use_bdr * 1);
       CeedInt space_dim = mesh.SpaceDimension();
       CeedInt trial_vdim = trial_fes.GetVDim();
       CeedInt test_vdim = test_fes.GetVDim();
+      MFEM_VERIFY(!(!indices && mesh.GetNumGeometries(dim) > 1),
+                  "Use ceed::MixedIntegrator on mixed meshes.");
+      InitCoefficient(Q, mesh, ir, use_bdr, nelem, indices, coeff);
 
-      mesh.EnsureNodes();
       if (&trial_fes == &test_fes)
       {
-         InitBasisAndRestriction(trial_fes, ir, nelem, indices,
-                                 ceed, &trial_basis, &trial_restr);
-         test_basis = trial_basis;
-         test_restr = trial_restr;
+         InitBasisAndRestriction(trial_fes, ir, use_bdr, nelem, indices, ceed,
+                                 &trial_basis, &trial_restr);
+         CeedBasisReferenceCopy(trial_basis, &test_basis);
+         CeedElemRestrictionReferenceCopy(trial_restr, &test_restr);
       }
       else
       {
-         InitBasisAndRestriction(trial_fes, ir, nelem, indices,
-                                 ceed, &trial_basis, &trial_restr);
-         InitBasisAndRestriction(test_fes, ir, nelem, indices,
-                                 ceed, &test_basis, &test_restr);
+         InitBasisAndRestriction(trial_fes, ir, use_bdr, nelem, indices, ceed,
+                                 &trial_basis, &trial_restr);
+         InitBasisAndRestriction(test_fes, ir, use_bdr, nelem, indices, ceed,
+                                 &test_basis, &test_restr);
       }
-
-      const mfem::FiniteElementSpace *mesh_fes = mesh.GetNodalFESpace();
-      MFEM_VERIFY(mesh_fes, "the Mesh has no nodal FE space");
-      InitBasisAndRestriction(*mesh_fes, ir, nelem, indices,
-                              ceed, &mesh_basis, &mesh_restr);
 
       CeedInt trial_nqpts, test_nqpts;
       CeedBasisGetNumQuadraturePoints(trial_basis, &trial_nqpts);
@@ -235,372 +245,104 @@ public:
       MFEM_VERIFY(trial_nqpts == test_nqpts,
                   "Trial and test basis must have the same number of quadrature"
                   " points.");
-      CeedInt nqpts = trial_nqpts;
+      const CeedInt nqpts = trial_nqpts;
 
-      const int qdatasize = op.qdatasize;
-      InitStridedRestriction(*mesh_fes, nelem, nqpts, qdatasize,
-                             CEED_STRIDES_BACKEND,
-                             &restr_i);
-
+      mesh.EnsureNodes();
+      const mfem::FiniteElementSpace *mesh_fes = mesh.GetNodalFESpace();
+      MFEM_VERIFY(mesh_fes, "The Mesh has no nodal FE space");
+      InitBasisAndRestriction(*mesh_fes, ir, use_bdr, nelem, indices, ceed,
+                              &mesh_basis, &mesh_restr);
       InitVector(*mesh.GetNodes(), node_coords);
 
-      CeedVectorCreate(ceed, nelem * nqpts * qdatasize, &qdata);
-
-      std::string qf_file = GetCeedPath() + op.header;
-      std::string qf = qf_file + op.build_func;
-      CeedQFunctionCreateInterior(ceed, 1, op.build_qf, qf.c_str(),
-                                  &build_qfunc);
-
-      // Create the Q-function that builds the operator (i.e. computes its
-      // quadrature data) and set its context data.
-      if (coeff)
-      {
-         CeedQFunctionAddInput(build_qfunc, "coeff", coeff->ncomp, coeff->emode);
-      }
-      CeedQFunctionAddInput(build_qfunc, "dx", dim * space_dim, CEED_EVAL_GRAD);
-      CeedQFunctionAddInput(build_qfunc, "weights", 1, CEED_EVAL_WEIGHT);
-      CeedQFunctionAddOutput(build_qfunc, "qdata", qdatasize, CEED_EVAL_NONE);
-
-      CeedQFunctionContextCreate(ceed, &build_ctx);
-      CeedQFunctionContextSetData(build_ctx, CEED_MEM_HOST,
+      CeedQFunctionContextCreate(ceed, &apply_ctx);
+      CeedQFunctionContextSetData(apply_ctx, CEED_MEM_HOST,
                                   CEED_COPY_VALUES,
                                   sizeof(info.ctx),
                                   &info.ctx);
-      CeedQFunctionSetContext(build_qfunc, build_ctx);
 
-      // Create the operator that builds the quadrature data for the operator.
-      CeedOperatorCreate(ceed, build_qfunc, NULL, NULL, &build_oper);
-      if (GridCoefficient *gridCoeff = dynamic_cast<GridCoefficient *>(coeff))
+      if (!use_mf)
       {
-         InitBasisAndRestriction(*gridCoeff->gf.FESpace(), ir,
-                                 nelem, indices, ceed,
-                                 &gridCoeff->basis,
-                                 &gridCoeff->restr);
-         CeedOperatorSetField(build_oper, "coeff", gridCoeff->restr,
-                              gridCoeff->basis, gridCoeff->coeffVector);
-      }
-      else if (QuadCoefficient *quadCoeff = dynamic_cast<QuadCoefficient *>(coeff))
-      {
-         const int ncomp = quadCoeff->ncomp;
-         CeedInt strides[3] = {ncomp, 1, ncomp * nqpts};
-         InitStridedRestriction(*mesh.GetNodalFESpace(),
-                                nelem, nqpts, ncomp, strides,
-                                &quadCoeff->restr);
-         CeedOperatorSetField(build_oper, "coeff", quadCoeff->restr,
-                              CEED_BASIS_COLLOCATED, quadCoeff->coeffVector);
-      }
-      CeedOperatorSetField(build_oper, "dx", mesh_restr,
-                           mesh_basis, CEED_VECTOR_ACTIVE);
-      CeedOperatorSetField(build_oper, "weights", CEED_ELEMRESTRICTION_NONE,
-                           mesh_basis, CEED_VECTOR_NONE);
-      CeedOperatorSetField(build_oper, "qdata", restr_i,
-                           CEED_BASIS_COLLOCATED, CEED_VECTOR_ACTIVE);
+         const int qdatasize = info.qdatasize;
+         InitStridedRestriction(*mesh_fes, nelem, nqpts, qdatasize,
+                                CEED_STRIDES_BACKEND, ceed,
+                                &restr_i);
+         CeedVectorCreate(ceed, nelem * nqpts * qdatasize, &qdata);
 
-      // Compute the quadrature data for the operator.
-      CeedOperatorApply(build_oper, node_coords, qdata, CEED_REQUEST_IMMEDIATE);
+         std::string build_func = coeff ? info.build_func_quad
+                                  : info.build_func_const;
+         CeedQFunctionUser build_qf = coeff ? info.build_qf_quad
+                                      : info.build_qf_const;
+
+         // Create the Q-function that builds the operator (i.e. computes its
+         // quadrature data) and set its context data.
+         CeedQFunction build_qfunc;
+         std::string qf_file = GetCeedPath() + info.header;
+         std::string qf = qf_file + build_func;
+         CeedQFunctionCreateInterior(ceed, 1, build_qf, qf.c_str(),
+                                     &build_qfunc);
+         if (coeff)
+         {
+            CeedQFunctionAddInput(build_qfunc, "coeff", coeff->ncomp, coeff->emode);
+         }
+         CeedQFunctionAddInput(build_qfunc, "dx", dim * space_dim, CEED_EVAL_GRAD);
+         CeedQFunctionAddInput(build_qfunc, "weights", 1, CEED_EVAL_WEIGHT);
+         CeedQFunctionAddOutput(build_qfunc, "qdata", qdatasize, CEED_EVAL_NONE);
+         CeedQFunctionSetContext(build_qfunc, apply_ctx);
+
+         // Create the operator that builds the quadrature data for the operator.
+         CeedOperator build_oper;
+         CeedOperatorCreate(ceed, build_qfunc, NULL, NULL, &build_oper);
+         if (GridCoefficient *gridCoeff = dynamic_cast<GridCoefficient *>(coeff))
+         {
+            InitBasisAndRestriction(*gridCoeff->gf.FESpace(), ir,
+                                    use_bdr, nelem, indices, ceed,
+                                    &gridCoeff->basis, &gridCoeff->restr);
+            CeedOperatorSetField(build_oper, "coeff", gridCoeff->restr,
+                                 gridCoeff->basis, gridCoeff->coeffVector);
+         }
+         else if (QuadCoefficient *quadCoeff = dynamic_cast<QuadCoefficient *>(coeff))
+         {
+            const int ncomp = quadCoeff->ncomp;
+            CeedInt strides[3] = {ncomp, 1, ncomp * nqpts};
+            InitStridedRestriction(*mesh.GetNodalFESpace(),
+                                   nelem, nqpts, ncomp, strides, ceed,
+                                   &quadCoeff->restr);
+            CeedOperatorSetField(build_oper, "coeff", quadCoeff->restr,
+                                 CEED_BASIS_COLLOCATED, quadCoeff->coeffVector);
+         }
+         CeedOperatorSetField(build_oper, "dx", mesh_restr,
+                              mesh_basis, CEED_VECTOR_ACTIVE);
+         CeedOperatorSetField(build_oper, "weights", CEED_ELEMRESTRICTION_NONE,
+                              mesh_basis, CEED_VECTOR_NONE);
+         CeedOperatorSetField(build_oper, "qdata", restr_i,
+                              CEED_BASIS_COLLOCATED, CEED_VECTOR_ACTIVE);
+
+         // Compute the quadrature data for the operator.
+         CeedOperatorApply(build_oper, node_coords, qdata, CEED_REQUEST_IMMEDIATE);
+
+         CeedOperatorDestroy(&build_oper);
+         CeedQFunctionDestroy(&build_qfunc);
+      }
+
+      std::string apply_func = !use_mf ? info.apply_func :
+                               (coeff ? info.apply_func_mf_quad
+                                : info.apply_func_mf_const);
+      CeedQFunctionUser apply_qf = !use_mf ? info.apply_qf :
+                                   (coeff ? info.apply_qf_mf_quad
+                                    : info.apply_qf_mf_const);
 
       // Create the Q-function that defines the action of the operator.
-      qf = qf_file + op.apply_func;
-      CeedQFunctionCreateInterior(ceed, 1, op.apply_qf, qf.c_str(),
+      std::string qf_file = GetCeedPath() + info.header;
+      std::string qf = qf_file + apply_func;
+      CeedQFunctionCreateInterior(ceed, 1, apply_qf, qf.c_str(),
                                   &apply_qfunc);
-      // input
-      switch (op.trial_op)
+      if (use_mf && coeff)
       {
-         case EvalMode::None:
-            CeedQFunctionAddInput(apply_qfunc, "u", trial_vdim, CEED_EVAL_NONE);
-            break;
-         case EvalMode::Interp:
-            CeedQFunctionAddInput(apply_qfunc, "u", trial_vdim, CEED_EVAL_INTERP);
-            break;
-         case EvalMode::Grad:
-            CeedQFunctionAddInput(apply_qfunc, "gu", trial_vdim * dim, CEED_EVAL_GRAD);
-            break;
-         case EvalMode::InterpAndGrad:
-            CeedQFunctionAddInput(apply_qfunc, "u", trial_vdim, CEED_EVAL_INTERP);
-            CeedQFunctionAddInput(apply_qfunc, "gu", trial_vdim * dim, CEED_EVAL_GRAD);
-            break;
-      }
-      // qdata
-      CeedQFunctionAddInput(apply_qfunc, "qdata", qdatasize, CEED_EVAL_NONE);
-      // output
-      switch (op.test_op)
-      {
-         case EvalMode::None:
-            CeedQFunctionAddOutput(apply_qfunc, "v", test_vdim, CEED_EVAL_NONE);
-            break;
-         case EvalMode::Interp:
-            CeedQFunctionAddOutput(apply_qfunc, "v", test_vdim, CEED_EVAL_INTERP);
-            break;
-         case EvalMode::Grad:
-            CeedQFunctionAddOutput(apply_qfunc, "gv", test_vdim * dim, CEED_EVAL_GRAD);
-            break;
-         case EvalMode::InterpAndGrad:
-            CeedQFunctionAddOutput(apply_qfunc, "v", test_vdim, CEED_EVAL_INTERP);
-            CeedQFunctionAddOutput(apply_qfunc, "gv", test_vdim * dim, CEED_EVAL_GRAD);
-            break;
-      }
-      CeedQFunctionSetContext(apply_qfunc, build_ctx);
-
-      // Create the operator.
-      CeedOperatorCreate(ceed, apply_qfunc, NULL, NULL, &oper);
-      // input
-      switch (op.trial_op)
-      {
-         case EvalMode::None:
-            CeedOperatorSetField(oper, "u", trial_restr,
-                                 CEED_BASIS_COLLOCATED, CEED_VECTOR_ACTIVE);
-            break;
-         case EvalMode::Interp:
-            CeedOperatorSetField(oper, "u", trial_restr, trial_basis, CEED_VECTOR_ACTIVE);
-            break;
-         case EvalMode::Grad:
-            CeedOperatorSetField(oper, "gu", trial_restr, trial_basis, CEED_VECTOR_ACTIVE);
-            break;
-         case EvalMode::InterpAndGrad:
-            CeedOperatorSetField(oper, "u", trial_restr, trial_basis, CEED_VECTOR_ACTIVE);
-            CeedOperatorSetField(oper, "gu", trial_restr, trial_basis, CEED_VECTOR_ACTIVE);
-            break;
-      }
-      // qdata
-      CeedOperatorSetField(oper, "qdata", restr_i, CEED_BASIS_COLLOCATED,
-                           qdata);
-      // output
-      switch (op.test_op)
-      {
-         case EvalMode::None:
-            CeedOperatorSetField(oper, "v", test_restr,
-                                 CEED_BASIS_COLLOCATED, CEED_VECTOR_ACTIVE);
-            break;
-         case EvalMode::Interp:
-            CeedOperatorSetField(oper, "v", test_restr, test_basis, CEED_VECTOR_ACTIVE);
-            break;
-         case EvalMode::Grad:
-            CeedOperatorSetField(oper, "gv", test_restr, test_basis, CEED_VECTOR_ACTIVE);
-            break;
-         case EvalMode::InterpAndGrad:
-            CeedOperatorSetField(oper, "v", test_restr, test_basis, CEED_VECTOR_ACTIVE);
-            CeedOperatorSetField(oper, "gv", test_restr, test_basis, CEED_VECTOR_ACTIVE);
-            break;
-      }
-
-      CeedVectorCreate(ceed, trial_vdim * trial_fes.GetNDofs(), &u);
-      CeedVectorCreate(ceed, test_vdim * test_fes.GetNDofs(), &v);
-   }
-
-   virtual ~PAIntegrator()
-   {
-      CeedQFunctionDestroy(&build_qfunc);
-      CeedQFunctionDestroy(&apply_qfunc);
-      CeedQFunctionContextDestroy(&build_ctx);
-      CeedVectorDestroy(&node_coords);
-      CeedVectorDestroy(&qdata);
-      delete coeff;
-      CeedOperatorDestroy(&build_oper);
-   }
-
-private:
-   /** This structure contains the data to assemble a partially assembled
-       operator with libCEED. */
-   struct PAOperator
-   {
-      /** The number of quadrature data at each quadrature point. */
-      int qdatasize;
-      /** The path to the header containing the functions for libCEED. */
-      std::string header;
-      /** The name of the QFunction to build the quadrature data. */
-      std::string build_func;
-      /** The QFunction to build the quadrature data. */
-      CeedQFunctionUser build_qf;
-      /** The name of the QFunction to apply the operator. */
-      std::string apply_func;
-      /** The QFunction to apply the operator. */
-      CeedQFunctionUser apply_qf;
-      /** The evaluation mode to apply to the trial function (CEED_EVAL_INTERP,
-          CEED_EVAL_GRAD, etc.) */
-      EvalMode trial_op;
-      /** The evaluation mode to apply to the test function ( CEED_EVAL_INTERP,
-          CEED_EVAL_GRAD, etc.)*/
-      EvalMode test_op;
-   };
-#endif
-};
-
-/** This class represent a matrix-free operator using libCEED. */
-class MFIntegrator : public ceed::Operator
-{
-#ifdef MFEM_USE_CEED
-protected:
-   CeedBasis trial_basis, test_basis, mesh_basis;
-   CeedElemRestriction trial_restr, test_restr, mesh_restr, restr_i;
-   CeedQFunction apply_qfunc;
-   CeedVector node_coords, qdata;
-   Coefficient *coeff;
-   CeedQFunctionContext build_ctx;
-
-public:
-   MFIntegrator()
-      : Operator(),
-        trial_basis(nullptr), test_basis(nullptr), mesh_basis(nullptr),
-        trial_restr(nullptr), test_restr(nullptr), mesh_restr(nullptr),
-        restr_i(nullptr),
-        apply_qfunc(nullptr), node_coords(nullptr),
-        qdata(nullptr), coeff(nullptr), build_ctx(nullptr) {}
-
-   /** @brief This method assembles the `MFIntegrator` with the given
-       `CeedOperatorInfo` @a info, an `mfem::FiniteElementSpace` @a fes, an
-       `mfem::IntegrationRule` @a ir, and `mfem::Coefficient`,
-       `mfem::VectorCoefficient`, or `mfem::MatrixCoefficient` @a Q.
-       The `CeedOperatorInfo` type is expected to inherit from `OperatorInfo`,
-       and contain a `Context` type relevant to the QFunctions.
-
-       @param[in] info is the structure describing the CeedOperator to assemble.
-       @param[in] fes is the finite element space.
-       @param[in] ir is the integration rule for the operator.
-       @param[in] Q is the coefficient from the `Integrator`. */
-   template <typename CeedOperatorInfo, typename CoeffType>
-   void Assemble(CeedOperatorInfo &info,
-                 const mfem::FiniteElementSpace &fes,
-                 const mfem::IntegrationRule &ir,
-                 CoeffType *Q)
-   {
-      Assemble(info, fes, ir, fes.GetNE(), nullptr, Q);
-   }
-
-   /** @brief This method assembles the `MFIntegrator` with the given
-       `CeedOperatorInfo` @a info, an `mfem::FiniteElementSpace` @a fes, an
-       `mfem::IntegrationRule` @a ir, and `mfem::Coefficient`,
-       `mfem::VectorCoefficient`, or `mfem::MatrixCoefficient` @a Q for the
-       elements given by the indices @a indices.
-       The `CeedOperatorInfo` type is expected to inherit from `OperatorInfo`,
-       and contain a `Context` type relevant to the QFunctions.
-
-       @param[in] info is the structure describing the CeedOperator to assemble.
-       @param[in] fes is the finite element space.
-       @param[in] ir is the integration rule for the operator.
-       @param[in] nelem The number of elements.
-       @param[in] indices The indices of the elements of same type in the
-                          `FiniteElementSpace`. If `indices == nullptr`, assumes
-                          that the `FiniteElementSpace` is not mixed.
-       @param[in] Q is the coefficient from the `Integrator`. */
-   template <typename CeedOperatorInfo, typename CoeffType>
-   void Assemble(CeedOperatorInfo &info,
-                 const mfem::FiniteElementSpace &fes,
-                 const mfem::IntegrationRule &ir,
-                 int nelem,
-                 const int *indices,
-                 CoeffType *Q)
-   {
-      Assemble(info, fes, fes, ir, nelem, indices, Q);
-   }
-
-   /** This method assembles the MFIntegrator for mixed forms.
-
-       @param[in] info the `CeedOperatorInfo` describing the `CeedOperator`,
-                       the `CeedOperatorInfo` type is expected to inherit from
-                       `OperatorInfo` and contain a `Context` type relevant to
-                       the QFunctions.
-       @param[in] trial_fes the trial `FiniteElementSpace` for the form,
-       @param[in] test_fes the test `FiniteElementSpace` for the form,
-       @param[in] ir the `IntegrationRule` for the numerical integration,
-       @param[in] Q `Coefficient`, `VectorCoefficient`, or
-                    `MatrixCoefficient`. */
-   template <typename CeedOperatorInfo, typename CoeffType>
-   void Assemble(CeedOperatorInfo &info,
-                 const mfem::FiniteElementSpace &trial_fes,
-                 const mfem::FiniteElementSpace &test_fes,
-                 const mfem::IntegrationRule &ir,
-                 CoeffType *Q)
-   {
-      Assemble(info, trial_fes, test_fes, ir, trial_fes.GetNE(), nullptr, Q);
-   }
-
-   /** This method assembles the MFIntegrator for mixed forms.
-
-       @param[in] info the `CeedOperatorInfo` describing the `CeedOperator`,
-                       the `CeedOperatorInfo` type is expected to inherit from
-                       `OperatorInfo` and contain a `Context` type relevant to
-                       the QFunctions.
-       @param[in] trial_fes the trial `FiniteElementSpace` for the form,
-       @param[in] test_fes the test `FiniteElementSpace` for the form,
-       @param[in] ir the `IntegrationRule` for the numerical integration,
-       @param[in] nelem The number of elements,
-       @param[in] indices The indices of the elements of same type in the
-                          `FiniteElementSpace`. If `indices == nullptr`, assumes
-                          that the `FiniteElementSpace` is not mixed,
-       @param[in] Q `Coefficient`, `VectorCoefficient`, or
-                     `MatrixCoefficient`. */
-   template <typename CeedOperatorInfo, typename CoeffType>
-   void Assemble(CeedOperatorInfo &info,
-                 const mfem::FiniteElementSpace &trial_fes,
-                 const mfem::FiniteElementSpace &test_fes,
-                 const mfem::IntegrationRule &ir,
-                 int nelem,
-                 const int *indices,
-                 CoeffType *Q)
-   {
-      Ceed ceed(internal::ceed);
-      mfem::Mesh &mesh = *trial_fes.GetMesh();
-      MFEM_VERIFY(!(!indices && mesh.GetNumGeometries(mesh.Dimension()) > 1),
-                  "Use ceed::MixedIntegrator on mixed meshes.");
-      InitCoefficient(Q, mesh, ir, nelem, indices, coeff);
-      std::string apply_func = (coeff == nullptr) ? info.apply_func_mf_const
-                               : info.apply_func_mf_quad;
-      CeedQFunctionUser apply_qf = (coeff == nullptr) ? info.apply_qf_mf_const
-                                   : info.apply_qf_mf_quad;
-      MFOperator op {info.header,
-                     apply_func, apply_qf,
-                     info.trial_op,
-                     info.test_op
-                    };
-      CeedInt dim = mesh.Dimension();
-      CeedInt space_dim = mesh.SpaceDimension();
-      CeedInt trial_vdim = trial_fes.GetVDim();
-      CeedInt test_vdim = test_fes.GetVDim();
-
-      mesh.EnsureNodes();
-      if (&trial_fes == &test_fes)
-      {
-         InitBasisAndRestriction(trial_fes, ir, nelem, indices, ceed,
-                                 &trial_basis, &trial_restr);
-         test_basis = trial_basis;
-         test_restr = trial_restr;
-      }
-      else
-      {
-         InitBasisAndRestriction(trial_fes, ir, nelem, indices, ceed,
-                                 &trial_basis, &trial_restr);
-         InitBasisAndRestriction(test_fes, ir, nelem, indices, ceed,
-                                 &test_basis, &test_restr);
-      }
-
-      const mfem::FiniteElementSpace *mesh_fes = mesh.GetNodalFESpace();
-      MFEM_VERIFY(mesh_fes, "the Mesh has no nodal FE space");
-      InitBasisAndRestriction(*mesh_fes, ir, nelem, indices, ceed, &mesh_basis,
-                              &mesh_restr);
-
-      CeedInt trial_nqpts, test_nqpts;
-      CeedBasisGetNumQuadraturePoints(trial_basis, &trial_nqpts);
-      CeedBasisGetNumQuadraturePoints(trial_basis, &test_nqpts);
-      MFEM_VERIFY(trial_nqpts == test_nqpts,
-                  "Trial and test basis must have the same number of quadrature"
-                  " points.");
-      CeedInt nqpts = trial_nqpts;
-
-      InitVector(*mesh.GetNodes(), node_coords);
-
-      std::string qf_file = GetCeedPath() + op.header;
-      std::string qf = qf_file + op.apply_func;
-      CeedQFunctionCreateInterior(ceed, 1, op.apply_qf, qf.c_str(),
-                                  &apply_qfunc);
-
-      // Create the Q-function that builds the operator (i.e. computes its
-      // quadrature data) and set its context data.
-      if (coeff)
-      {
+         // coefficient
          CeedQFunctionAddInput(apply_qfunc, "coeff", coeff->ncomp, coeff->emode);
       }
       // input
-      switch (op.trial_op)
+      switch (info.trial_op)
       {
          case EvalMode::None:
             CeedQFunctionAddInput(apply_qfunc, "u", trial_vdim, CEED_EVAL_NONE);
@@ -616,10 +358,18 @@ public:
             CeedQFunctionAddInput(apply_qfunc, "gu", trial_vdim * dim, CEED_EVAL_GRAD);
             break;
       }
-      CeedQFunctionAddInput(apply_qfunc, "dx", dim * space_dim, CEED_EVAL_GRAD);
-      CeedQFunctionAddInput(apply_qfunc, "weights", 1, CEED_EVAL_WEIGHT);
+      if (use_mf)
+      {
+         CeedQFunctionAddInput(apply_qfunc, "dx", dim * space_dim, CEED_EVAL_GRAD);
+         CeedQFunctionAddInput(apply_qfunc, "weights", 1, CEED_EVAL_WEIGHT);
+      }
+      else
+      {
+         // qdata
+         CeedQFunctionAddInput(apply_qfunc, "qdata", info.qdatasize, CEED_EVAL_NONE);
+      }
       // output
-      switch (op.test_op)
+      switch (info.test_op)
       {
          case EvalMode::None:
             CeedQFunctionAddOutput(apply_qfunc, "v", test_vdim, CEED_EVAL_NONE);
@@ -635,36 +385,34 @@ public:
             CeedQFunctionAddOutput(apply_qfunc, "gv", test_vdim * dim, CEED_EVAL_GRAD);
             break;
       }
-
-      CeedQFunctionContextCreate(ceed, &build_ctx);
-      CeedQFunctionContextSetData(build_ctx, CEED_MEM_HOST,
-                                  CEED_COPY_VALUES,
-                                  sizeof(info.ctx),
-                                  &info.ctx);
-      CeedQFunctionSetContext(apply_qfunc, build_ctx);
+      CeedQFunctionSetContext(apply_qfunc, apply_ctx);
 
       // Create the operator.
       CeedOperatorCreate(ceed, apply_qfunc, NULL, NULL, &oper);
-      // coefficient
-      if (GridCoefficient *gridCoeff = dynamic_cast<GridCoefficient *>(coeff))
+      if (use_mf)
       {
-         InitBasisAndRestriction(*gridCoeff->gf.FESpace(), ir, nelem, indices,
-                                 ceed, &gridCoeff->basis, &gridCoeff->restr);
-         CeedOperatorSetField(oper, "coeff", gridCoeff->restr,
-                              gridCoeff->basis, gridCoeff->coeffVector);
-      }
-      else if (QuadCoefficient *quadCoeff = dynamic_cast<QuadCoefficient *>(coeff))
-      {
-         const int ncomp = quadCoeff->ncomp;
-         CeedInt strides[3] = {ncomp, 1, ncomp * nqpts};
-         InitStridedRestriction(*mesh.GetNodalFESpace(),
-                                nelem, nqpts, ncomp, strides,
-                                &quadCoeff->restr);
-         CeedOperatorSetField(oper, "coeff", quadCoeff->restr,
-                              CEED_BASIS_COLLOCATED, quadCoeff->coeffVector);
+         // coefficient
+         if (GridCoefficient *gridCoeff = dynamic_cast<GridCoefficient *>(coeff))
+         {
+            InitBasisAndRestriction(*gridCoeff->gf.FESpace(), ir,
+                                    use_bdr, nelem, indices, ceed,
+                                    &gridCoeff->basis, &gridCoeff->restr);
+            CeedOperatorSetField(oper, "coeff", gridCoeff->restr,
+                                 gridCoeff->basis, gridCoeff->coeffVector);
+         }
+         else if (QuadCoefficient *quadCoeff = dynamic_cast<QuadCoefficient *>(coeff))
+         {
+            const int ncomp = quadCoeff->ncomp;
+            CeedInt strides[3] = {ncomp, 1, ncomp * nqpts};
+            InitStridedRestriction(*mesh.GetNodalFESpace(),
+                                   nelem, nqpts, ncomp, strides, ceed,
+                                   &quadCoeff->restr);
+            CeedOperatorSetField(oper, "coeff", quadCoeff->restr,
+                                 CEED_BASIS_COLLOCATED, quadCoeff->coeffVector);
+         }
       }
       // input
-      switch (op.trial_op)
+      switch (info.trial_op)
       {
          case EvalMode::None:
             CeedOperatorSetField(oper, "u", trial_restr,
@@ -681,11 +429,19 @@ public:
             CeedOperatorSetField(oper, "gu", trial_restr, trial_basis, CEED_VECTOR_ACTIVE);
             break;
       }
-      CeedOperatorSetField(oper, "dx", mesh_restr, mesh_basis, node_coords);
-      CeedOperatorSetField(oper, "weights", CEED_ELEMRESTRICTION_NONE,
-                           mesh_basis, CEED_VECTOR_NONE);
+      if (use_mf)
+      {
+         CeedOperatorSetField(oper, "dx", mesh_restr, mesh_basis, node_coords);
+         CeedOperatorSetField(oper, "weights", CEED_ELEMRESTRICTION_NONE,
+                              mesh_basis, CEED_VECTOR_NONE);
+      }
+      else
+      {
+         // qdata
+         CeedOperatorSetField(oper, "qdata", restr_i, CEED_BASIS_COLLOCATED, qdata);
+      }
       // output
-      switch (op.test_op)
+      switch (info.test_op)
       {
          case EvalMode::None:
             CeedOperatorSetField(oper, "v", test_restr,
@@ -707,33 +463,15 @@ public:
       CeedVectorCreate(ceed, test_vdim * test_fes.GetNDofs(), &v);
    }
 
-   virtual ~MFIntegrator()
+   virtual ~Integrator()
    {
+      // All basis and restriction objects are destroyed by fes destructor
       CeedQFunctionDestroy(&apply_qfunc);
-      CeedQFunctionContextDestroy(&build_ctx);
+      CeedQFunctionContextDestroy(&apply_ctx);
       CeedVectorDestroy(&node_coords);
       CeedVectorDestroy(&qdata);
       delete coeff;
    }
-
-private:
-   /** This structure contains the data to assemble a matrix-free operator with
-       libCEED. */
-   struct MFOperator
-   {
-      /** The path to the header containing the functions for libCEED. */
-      std::string header;
-      /** The name of the QFunction to apply the operator. */
-      std::string apply_func;
-      /** The QFunction to apply the operator. */
-      CeedQFunctionUser apply_qf;
-      /** The evaluation mode to apply to the trial function (CEED_EVAL_INTERP,
-          CEED_EVAL_GRAD, etc.) */
-      EvalMode trial_op;
-      /** The evaluation mode to apply to the test function (CEED_EVAL_INTERP,
-          CEED_EVAL_GRAD, etc.) */
-      EvalMode test_op;
-   };
 #endif
 };
 

--- a/fem/ceed/interface/integrator.hpp
+++ b/fem/ceed/interface/integrator.hpp
@@ -273,7 +273,7 @@ public:
          CeedQFunctionUser build_qf = coeff ? info.build_qf_quad
                                       : info.build_qf_const;
 
-         // Create the Q-function that builds the operator (i.e. computes its
+         // Create the QFunction that builds the operator (i.e. computes its
          // quadrature data) and set its context data.
          CeedQFunction build_qfunc;
          std::string qf_file = GetCeedPath() + info.header;
@@ -331,7 +331,7 @@ public:
                                    (coeff ? info.apply_qf_mf_quad
                                     : info.apply_qf_mf_const);
 
-      // Create the Q-function that defines the action of the operator.
+      // Create the QFunction that defines the action of the operator.
       std::string qf_file = GetCeedPath() + info.header;
       std::string qf = qf_file + apply_func;
       CeedQFunctionCreateInterior(ceed, 1, apply_qf, qf.c_str(),

--- a/fem/ceed/interface/integrator.hpp
+++ b/fem/ceed/interface/integrator.hpp
@@ -35,34 +35,34 @@ enum class EvalMode { None, Interp, Grad, InterpAndGrad };
     PAIntegrator and MFIntegrator. See ceed/mass.cpp for an example. */
 struct OperatorInfo
 {
-   /** The path to the qFunction header. */
+   /** The path to the QFunction header. */
    const char *header;
-   /** The name of the qFunction to build a partially assembled CeedOperator
+   /** The name of the QFunction to build a partially assembled CeedOperator
        with a constant Coefficient. */
    const char *build_func_const;
-   /** The qFunction to build a partially assembled CeedOperator with a constant
+   /** The QFunction to build a partially assembled CeedOperator with a constant
        Coefficient. */
    CeedQFunctionUser build_qf_const;
-   /** The name of the qFunction to build a partially assembled CeedOperator
+   /** The name of the QFunction to build a partially assembled CeedOperator
        with a variable Coefficient. */
    const char *build_func_quad;
-   /** The qFunction to build a partially assembled CeedOperator with a variable
+   /** The QFunction to build a partially assembled CeedOperator with a variable
        Coefficient. */
    CeedQFunctionUser build_qf_quad;
-   /** The name of the qFunction to apply a partially assembled CeedOperator. */
+   /** The name of the QFunction to apply a partially assembled CeedOperator. */
    const char *apply_func;
-   /** The qFunction to apply a partially assembled CeedOperator. */
+   /** The QFunction to apply a partially assembled CeedOperator. */
    CeedQFunctionUser apply_qf;
-   /** The name of the qFunction to apply a matrix-free CeedOperator with a
+   /** The name of the QFunction to apply a matrix-free CeedOperator with a
        constant Coefficient. */
    const char *apply_func_mf_const;
-   /** The qFunction to apply a matrix-free CeedOperator with a constant
+   /** The QFunction to apply a matrix-free CeedOperator with a constant
        Coefficient. */
    CeedQFunctionUser apply_qf_mf_const;
-   /** The name of the qFunction to apply a matrix-free CeedOperator with a
+   /** The name of the QFunction to apply a matrix-free CeedOperator with a
        variable Coefficient. */
    const char *apply_func_mf_quad;
-   /** The qFunction to apply a matrix-free CeedOperator with a variable
+   /** The QFunction to apply a matrix-free CeedOperator with a variable
        Coefficient. */
    CeedQFunctionUser apply_qf_mf_quad;
    /** The EvalMode on the trial basis functions. */
@@ -79,7 +79,7 @@ class PAIntegrator : public ceed::Operator
 {
 #ifdef MFEM_USE_CEED
 protected:
-   CeedBasis  trial_basis, test_basis, mesh_basis;
+   CeedBasis trial_basis, test_basis, mesh_basis;
    CeedElemRestriction trial_restr, test_restr, mesh_restr, restr_i;
    CeedQFunction build_qfunc, apply_qfunc;
    CeedVector node_coords, qdata;
@@ -94,15 +94,14 @@ public:
         trial_restr(nullptr), test_restr(nullptr), mesh_restr(nullptr),
         restr_i(nullptr),
         build_qfunc(nullptr), apply_qfunc(nullptr), node_coords(nullptr),
-        qdata(nullptr), coeff(nullptr), build_ctx(nullptr), build_oper(nullptr)
-   { }
+        qdata(nullptr), coeff(nullptr), build_ctx(nullptr), build_oper(nullptr) {}
 
    /** @brief This method assembles the `PAIntegrator` with the given
        `CeedOperatorInfo` @a info, an `mfem::FiniteElementSpace` @a fes, an
-       `mfem::IntegrationRule` @a ir, and `mfem::Coefficient` or
-       `mfem::VectorCoefficient` @a Q.
+       `mfem::IntegrationRule` @a ir, and `mfem::Coefficient`,
+       `mfem::VectorCoefficient`, or `mfem::MatrixCoefficient` @a Q.
        The `CeedOperatorInfo` type is expected to inherit from `OperatorInfo`,
-       and contain a `Context` type relevant to the qFunctions.
+       and contain a `Context` type relevant to the QFunctions.
 
        @param[in] info is the structure describing the CeedOperator to assemble.
        @param[in] fes is the finite element space.
@@ -119,11 +118,11 @@ public:
 
    /** @brief This method assembles the `PAIntegrator` with the given
        `CeedOperatorInfo` @a info, an `mfem::FiniteElementSpace` @a fes, an
-       `mfem::IntegrationRule` @a ir, and `mfem::Coefficient` or
-       `mfem::VectorCoefficient` @a Q for the elements given by the indices
-       @a indices.
+       `mfem::IntegrationRule` @a ir, and `mfem::Coefficient`,
+       `mfem::VectorCoefficient`, or `mfem::MatrixCoefficient` @a Q for the
+       elements given by the indices @a indices.
        The `CeedOperatorInfo` type is expected to inherit from `OperatorInfo`,
-       and contain a `Context` type relevant to the qFunctions.
+       and contain a `Context` type relevant to the QFunctions.
 
        @param[in] info is the structure describing the CeedOperator to assemble.
        @param[in] fes is the finite element space.
@@ -138,7 +137,7 @@ public:
                  const mfem::FiniteElementSpace &fes,
                  const mfem::IntegrationRule &ir,
                  int nelem,
-                 const int* indices,
+                 const int *indices,
                  CoeffType *Q)
    {
       Assemble(info, fes, fes, ir, nelem, indices, Q);
@@ -149,11 +148,12 @@ public:
        @param[in] info the `CeedOperatorInfo` describing the `CeedOperator`,
                        the `CeedOperatorInfo` type is expected to inherit from
                        `OperatorInfo` and contain a `Context` type relevant to
-                       the qFunctions.
+                       the QFunctions.
        @param[in] trial_fes the trial `FiniteElementSpace` for the form,
        @param[in] test_fes the test `FiniteElementSpace` for the form,
        @param[in] ir the `IntegrationRule` for the numerical integration,
-       @param[in] Q `Coefficient` or `VectorCoefficient`. */
+       @param[in] Q `Coefficient`, `VectorCoefficient`, or
+                    `MatrixCoefficient`. */
    template <typename CeedOperatorInfo, typename CoeffType>
    void Assemble(CeedOperatorInfo &info,
                  const mfem::FiniteElementSpace &trial_fes,
@@ -169,7 +169,7 @@ public:
        @param[in] info the `CeedOperatorInfo` describing the `CeedOperator`,
                        the `CeedOperatorInfo` type is expected to inherit from
                        `OperatorInfo` and contain a `Context` type relevant to
-                       the qFunctions.
+                       the QFunctions.
        @param[in] trial_fes the trial `FiniteElementSpace` for the form,
        @param[in] test_fes the test `FiniteElementSpace` for the form,
        @param[in] ir the `IntegrationRule` for the numerical integration,
@@ -177,25 +177,25 @@ public:
        @param[in] indices The indices of the elements of same type in the
                           `FiniteElementSpace`. If `indices == nullptr`, assumes
                           that the `FiniteElementSpace` is not mixed,
-       @param[in] Q `Coefficient` or `VectorCoefficient`. */
+       @param[in] Q `Coefficient`, `VectorCoefficient`, or
+                    `MatrixCoefficient`. */
    template <typename CeedOperatorInfo, typename CoeffType>
    void Assemble(CeedOperatorInfo &info,
                  const mfem::FiniteElementSpace &trial_fes,
                  const mfem::FiniteElementSpace &test_fes,
                  const mfem::IntegrationRule &ir,
                  int nelem,
-                 const int* indices,
+                 const int *indices,
                  CoeffType *Q)
    {
       Ceed ceed(internal::ceed);
       mfem::Mesh &mesh = *trial_fes.GetMesh();
       MFEM_VERIFY(!(!indices && mesh.GetNumGeometries(mesh.Dimension()) > 1),
                   "Use ceed::MixedIntegrator on mixed meshes.");
-      InitCoefficient(Q, mesh, ir, nelem, indices, coeff, info.ctx);
-      bool const_coeff = coeff->IsConstant();
-      std::string build_func = const_coeff ? info.build_func_const
+      InitCoefficient(Q, mesh, ir, nelem, indices, coeff);
+      std::string build_func = (coeff == nullptr) ? info.build_func_const
                                : info.build_func_quad;
-      CeedQFunctionUser build_qf = const_coeff ? info.build_qf_const
+      CeedQFunctionUser build_qf = (coeff == nullptr) ? info.build_qf_const
                                    : info.build_qf_quad;
       PAOperator op {info.qdatasize, info.header,
                      build_func, build_qf,
@@ -203,12 +203,13 @@ public:
                      info.trial_op,
                      info.test_op
                     };
-      CeedInt dim = mesh.SpaceDimension();
+      CeedInt dim = mesh.Dimension();
+      CeedInt space_dim = mesh.SpaceDimension();
       CeedInt trial_vdim = trial_fes.GetVDim();
       CeedInt test_vdim = test_fes.GetVDim();
 
       mesh.EnsureNodes();
-      if ( &trial_fes == &test_fes )
+      if (&trial_fes == &test_fes)
       {
          InitBasisAndRestriction(trial_fes, ir, nelem, indices,
                                  ceed, &trial_basis, &trial_restr);
@@ -245,11 +246,6 @@ public:
 
       CeedVectorCreate(ceed, nelem * nqpts * qdatasize, &qdata);
 
-      // Context data to be passed to the Q-function.
-      info.ctx.dim = mesh.Dimension();
-      info.ctx.space_dim = mesh.SpaceDimension();
-      info.ctx.vdim = trial_fes.GetVDim();
-
       std::string qf_file = GetCeedPath() + op.header;
       std::string qf = qf_file + op.build_func;
       CeedQFunctionCreateInterior(ceed, 1, op.build_qf, qf.c_str(),
@@ -257,13 +253,11 @@ public:
 
       // Create the Q-function that builds the operator (i.e. computes its
       // quadrature data) and set its context data.
-      if (VariableCoefficient *var_coeff =
-             dynamic_cast<VariableCoefficient*>(coeff))
+      if (coeff)
       {
-         CeedQFunctionAddInput(build_qfunc, "coeff", coeff->ncomp,
-                               var_coeff->emode);
+         CeedQFunctionAddInput(build_qfunc, "coeff", coeff->ncomp, coeff->emode);
       }
-      CeedQFunctionAddInput(build_qfunc, "dx", dim * dim, CEED_EVAL_GRAD);
+      CeedQFunctionAddInput(build_qfunc, "dx", dim * space_dim, CEED_EVAL_GRAD);
       CeedQFunctionAddInput(build_qfunc, "weights", 1, CEED_EVAL_WEIGHT);
       CeedQFunctionAddOutput(build_qfunc, "qdata", qdatasize, CEED_EVAL_NONE);
 
@@ -276,7 +270,7 @@ public:
 
       // Create the operator that builds the quadrature data for the operator.
       CeedOperatorCreate(ceed, build_qfunc, NULL, NULL, &build_oper);
-      if (GridCoefficient *gridCoeff = dynamic_cast<GridCoefficient*>(coeff))
+      if (GridCoefficient *gridCoeff = dynamic_cast<GridCoefficient *>(coeff))
       {
          InitBasisAndRestriction(*gridCoeff->gf.FESpace(), ir,
                                  nelem, indices, ceed,
@@ -285,11 +279,10 @@ public:
          CeedOperatorSetField(build_oper, "coeff", gridCoeff->restr,
                               gridCoeff->basis, gridCoeff->coeffVector);
       }
-      else if (QuadCoefficient *quadCoeff =
-                  dynamic_cast<QuadCoefficient*>(coeff))
+      else if (QuadCoefficient *quadCoeff = dynamic_cast<QuadCoefficient *>(coeff))
       {
          const int ncomp = quadCoeff->ncomp;
-         CeedInt strides[3] = {ncomp, 1, ncomp*nqpts};
+         CeedInt strides[3] = {ncomp, 1, ncomp * nqpts};
          InitStridedRestriction(*mesh.GetNodalFESpace(),
                                 nelem, nqpts, ncomp, strides,
                                 &quadCoeff->restr);
@@ -320,11 +313,11 @@ public:
             CeedQFunctionAddInput(apply_qfunc, "u", trial_vdim, CEED_EVAL_INTERP);
             break;
          case EvalMode::Grad:
-            CeedQFunctionAddInput(apply_qfunc, "gu", trial_vdim*dim, CEED_EVAL_GRAD);
+            CeedQFunctionAddInput(apply_qfunc, "gu", trial_vdim * dim, CEED_EVAL_GRAD);
             break;
          case EvalMode::InterpAndGrad:
             CeedQFunctionAddInput(apply_qfunc, "u", trial_vdim, CEED_EVAL_INTERP);
-            CeedQFunctionAddInput(apply_qfunc, "gu", trial_vdim*dim, CEED_EVAL_GRAD);
+            CeedQFunctionAddInput(apply_qfunc, "gu", trial_vdim * dim, CEED_EVAL_GRAD);
             break;
       }
       // qdata
@@ -339,11 +332,11 @@ public:
             CeedQFunctionAddOutput(apply_qfunc, "v", test_vdim, CEED_EVAL_INTERP);
             break;
          case EvalMode::Grad:
-            CeedQFunctionAddOutput(apply_qfunc, "gv", test_vdim*dim, CEED_EVAL_GRAD);
+            CeedQFunctionAddOutput(apply_qfunc, "gv", test_vdim * dim, CEED_EVAL_GRAD);
             break;
          case EvalMode::InterpAndGrad:
             CeedQFunctionAddOutput(apply_qfunc, "v", test_vdim, CEED_EVAL_INTERP);
-            CeedQFunctionAddOutput(apply_qfunc, "gv", test_vdim*dim, CEED_EVAL_GRAD);
+            CeedQFunctionAddOutput(apply_qfunc, "gv", test_vdim * dim, CEED_EVAL_GRAD);
             break;
       }
       CeedQFunctionSetContext(apply_qfunc, build_ctx);
@@ -390,8 +383,8 @@ public:
             break;
       }
 
-      CeedVectorCreate(ceed, trial_vdim*trial_fes.GetNDofs(), &u);
-      CeedVectorCreate(ceed, test_vdim*test_fes.GetNDofs(), &v);
+      CeedVectorCreate(ceed, trial_vdim * trial_fes.GetNDofs(), &u);
+      CeedVectorCreate(ceed, test_vdim * test_fes.GetNDofs(), &v);
    }
 
    virtual ~PAIntegrator()
@@ -414,13 +407,13 @@ private:
       int qdatasize;
       /** The path to the header containing the functions for libCEED. */
       std::string header;
-      /** The name of the Qfunction to build the quadrature data. */
+      /** The name of the QFunction to build the quadrature data. */
       std::string build_func;
-      /** The Qfunction to build the quadrature data. */
+      /** The QFunction to build the quadrature data. */
       CeedQFunctionUser build_qf;
-      /** The name of the Qfunction to apply the operator. */
+      /** The name of the QFunction to apply the operator. */
       std::string apply_func;
-      /** The Qfunction to apply the operator. */
+      /** The QFunction to apply the operator. */
       CeedQFunctionUser apply_qf;
       /** The evaluation mode to apply to the trial function (CEED_EVAL_INTERP,
           CEED_EVAL_GRAD, etc.) */
@@ -451,14 +444,14 @@ public:
         trial_restr(nullptr), test_restr(nullptr), mesh_restr(nullptr),
         restr_i(nullptr),
         apply_qfunc(nullptr), node_coords(nullptr),
-        qdata(nullptr), coeff(nullptr), build_ctx(nullptr) { }
+        qdata(nullptr), coeff(nullptr), build_ctx(nullptr) {}
 
    /** @brief This method assembles the `MFIntegrator` with the given
        `CeedOperatorInfo` @a info, an `mfem::FiniteElementSpace` @a fes, an
-       `mfem::IntegrationRule` @a ir, and `mfem::Coefficient` or
-       `mfem::VectorCoefficient` @a Q.
+       `mfem::IntegrationRule` @a ir, and `mfem::Coefficient`,
+       `mfem::VectorCoefficient`, or `mfem::MatrixCoefficient` @a Q.
        The `CeedOperatorInfo` type is expected to inherit from `OperatorInfo`,
-       and contain a `Context` type relevant to the qFunctions.
+       and contain a `Context` type relevant to the QFunctions.
 
        @param[in] info is the structure describing the CeedOperator to assemble.
        @param[in] fes is the finite element space.
@@ -475,11 +468,11 @@ public:
 
    /** @brief This method assembles the `MFIntegrator` with the given
        `CeedOperatorInfo` @a info, an `mfem::FiniteElementSpace` @a fes, an
-       `mfem::IntegrationRule` @a ir, and `mfem::Coefficient` or
-       `mfem::VectorCoefficient` @a Q for the elements given by the indices
-       @a indices.
+       `mfem::IntegrationRule` @a ir, and `mfem::Coefficient`,
+       `mfem::VectorCoefficient`, or `mfem::MatrixCoefficient` @a Q for the
+       elements given by the indices @a indices.
        The `CeedOperatorInfo` type is expected to inherit from `OperatorInfo`,
-       and contain a `Context` type relevant to the qFunctions.
+       and contain a `Context` type relevant to the QFunctions.
 
        @param[in] info is the structure describing the CeedOperator to assemble.
        @param[in] fes is the finite element space.
@@ -494,7 +487,7 @@ public:
                  const mfem::FiniteElementSpace &fes,
                  const mfem::IntegrationRule &ir,
                  int nelem,
-                 const int* indices,
+                 const int *indices,
                  CoeffType *Q)
    {
       Assemble(info, fes, fes, ir, nelem, indices, Q);
@@ -505,11 +498,12 @@ public:
        @param[in] info the `CeedOperatorInfo` describing the `CeedOperator`,
                        the `CeedOperatorInfo` type is expected to inherit from
                        `OperatorInfo` and contain a `Context` type relevant to
-                       the qFunctions.
+                       the QFunctions.
        @param[in] trial_fes the trial `FiniteElementSpace` for the form,
        @param[in] test_fes the test `FiniteElementSpace` for the form,
        @param[in] ir the `IntegrationRule` for the numerical integration,
-       @param[in] Q `Coefficient` or `VectorCoefficient`. */
+       @param[in] Q `Coefficient`, `VectorCoefficient`, or
+                    `MatrixCoefficient`. */
    template <typename CeedOperatorInfo, typename CoeffType>
    void Assemble(CeedOperatorInfo &info,
                  const mfem::FiniteElementSpace &trial_fes,
@@ -525,7 +519,7 @@ public:
        @param[in] info the `CeedOperatorInfo` describing the `CeedOperator`,
                        the `CeedOperatorInfo` type is expected to inherit from
                        `OperatorInfo` and contain a `Context` type relevant to
-                       the qFunctions.
+                       the QFunctions.
        @param[in] trial_fes the trial `FiniteElementSpace` for the form,
        @param[in] test_fes the test `FiniteElementSpace` for the form,
        @param[in] ir the `IntegrationRule` for the numerical integration,
@@ -533,38 +527,38 @@ public:
        @param[in] indices The indices of the elements of same type in the
                           `FiniteElementSpace`. If `indices == nullptr`, assumes
                           that the `FiniteElementSpace` is not mixed,
-       @param[in] Q `Coefficient` or `VectorCoefficient`. */
+       @param[in] Q `Coefficient`, `VectorCoefficient`, or
+                     `MatrixCoefficient`. */
    template <typename CeedOperatorInfo, typename CoeffType>
    void Assemble(CeedOperatorInfo &info,
                  const mfem::FiniteElementSpace &trial_fes,
                  const mfem::FiniteElementSpace &test_fes,
                  const mfem::IntegrationRule &ir,
                  int nelem,
-                 const int* indices,
+                 const int *indices,
                  CoeffType *Q)
    {
       Ceed ceed(internal::ceed);
-      Mesh &mesh = *trial_fes.GetMesh();
+      mfem::Mesh &mesh = *trial_fes.GetMesh();
       MFEM_VERIFY(!(!indices && mesh.GetNumGeometries(mesh.Dimension()) > 1),
                   "Use ceed::MixedIntegrator on mixed meshes.");
-      InitCoefficient(Q, mesh, ir, nelem, indices, coeff, info.ctx);
-      bool const_coeff = coeff->IsConstant();
-      std::string apply_func = const_coeff ? info.apply_func_mf_const
+      InitCoefficient(Q, mesh, ir, nelem, indices, coeff);
+      std::string apply_func = (coeff == nullptr) ? info.apply_func_mf_const
                                : info.apply_func_mf_quad;
-      CeedQFunctionUser apply_qf = const_coeff ? info.apply_qf_mf_const
+      CeedQFunctionUser apply_qf = (coeff == nullptr) ? info.apply_qf_mf_const
                                    : info.apply_qf_mf_quad;
       MFOperator op {info.header,
                      apply_func, apply_qf,
                      info.trial_op,
                      info.test_op
                     };
-
-      CeedInt dim = mesh.SpaceDimension();
+      CeedInt dim = mesh.Dimension();
+      CeedInt space_dim = mesh.SpaceDimension();
       CeedInt trial_vdim = trial_fes.GetVDim();
       CeedInt test_vdim = test_fes.GetVDim();
 
       mesh.EnsureNodes();
-      if ( &trial_fes == &test_fes )
+      if (&trial_fes == &test_fes)
       {
          InitBasisAndRestriction(trial_fes, ir, nelem, indices, ceed,
                                  &trial_basis, &trial_restr);
@@ -594,11 +588,6 @@ public:
 
       InitVector(*mesh.GetNodes(), node_coords);
 
-      // Context data to be passed to the Q-function.
-      info.ctx.dim = mesh.Dimension();
-      info.ctx.space_dim = mesh.SpaceDimension();
-      info.ctx.vdim = trial_fes.GetVDim();
-
       std::string qf_file = GetCeedPath() + op.header;
       std::string qf = qf_file + op.apply_func;
       CeedQFunctionCreateInterior(ceed, 1, op.apply_qf, qf.c_str(),
@@ -606,56 +595,44 @@ public:
 
       // Create the Q-function that builds the operator (i.e. computes its
       // quadrature data) and set its context data.
-      if (VariableCoefficient *var_coeff =
-             dynamic_cast<VariableCoefficient*>(coeff))
+      if (coeff)
       {
-         CeedQFunctionAddInput(apply_qfunc, "coeff", coeff->ncomp,
-                               var_coeff->emode);
+         CeedQFunctionAddInput(apply_qfunc, "coeff", coeff->ncomp, coeff->emode);
       }
       // input
       switch (op.trial_op)
       {
          case EvalMode::None:
-            CeedQFunctionAddInput(apply_qfunc, "u", trial_vdim,
-                                  CEED_EVAL_NONE);
+            CeedQFunctionAddInput(apply_qfunc, "u", trial_vdim, CEED_EVAL_NONE);
             break;
          case EvalMode::Interp:
-            CeedQFunctionAddInput(apply_qfunc, "u", trial_vdim,
-                                  CEED_EVAL_INTERP);
+            CeedQFunctionAddInput(apply_qfunc, "u", trial_vdim, CEED_EVAL_INTERP);
             break;
          case EvalMode::Grad:
-            CeedQFunctionAddInput(apply_qfunc, "gu", trial_vdim*dim,
-                                  CEED_EVAL_GRAD);
+            CeedQFunctionAddInput(apply_qfunc, "gu", trial_vdim * dim, CEED_EVAL_GRAD);
             break;
          case EvalMode::InterpAndGrad:
-            CeedQFunctionAddInput(apply_qfunc, "u", trial_vdim,
-                                  CEED_EVAL_INTERP);
-            CeedQFunctionAddInput(apply_qfunc, "gu", trial_vdim*dim,
-                                  CEED_EVAL_GRAD);
+            CeedQFunctionAddInput(apply_qfunc, "u", trial_vdim, CEED_EVAL_INTERP);
+            CeedQFunctionAddInput(apply_qfunc, "gu", trial_vdim * dim, CEED_EVAL_GRAD);
             break;
       }
-      CeedQFunctionAddInput(apply_qfunc, "dx", dim * dim, CEED_EVAL_GRAD);
+      CeedQFunctionAddInput(apply_qfunc, "dx", dim * space_dim, CEED_EVAL_GRAD);
       CeedQFunctionAddInput(apply_qfunc, "weights", 1, CEED_EVAL_WEIGHT);
       // output
       switch (op.test_op)
       {
          case EvalMode::None:
-            CeedQFunctionAddOutput(apply_qfunc, "v", test_vdim,
-                                   CEED_EVAL_NONE);
+            CeedQFunctionAddOutput(apply_qfunc, "v", test_vdim, CEED_EVAL_NONE);
             break;
          case EvalMode::Interp:
-            CeedQFunctionAddOutput(apply_qfunc, "v", test_vdim,
-                                   CEED_EVAL_INTERP);
+            CeedQFunctionAddOutput(apply_qfunc, "v", test_vdim, CEED_EVAL_INTERP);
             break;
          case EvalMode::Grad:
-            CeedQFunctionAddOutput(apply_qfunc, "gv", test_vdim*dim,
-                                   CEED_EVAL_GRAD);
+            CeedQFunctionAddOutput(apply_qfunc, "gv", test_vdim * dim, CEED_EVAL_GRAD);
             break;
          case EvalMode::InterpAndGrad:
-            CeedQFunctionAddOutput(apply_qfunc, "v", test_vdim,
-                                   CEED_EVAL_INTERP);
-            CeedQFunctionAddOutput(apply_qfunc, "gv", test_vdim*dim,
-                                   CEED_EVAL_GRAD);
+            CeedQFunctionAddOutput(apply_qfunc, "v", test_vdim, CEED_EVAL_INTERP);
+            CeedQFunctionAddOutput(apply_qfunc, "gv", test_vdim * dim, CEED_EVAL_GRAD);
             break;
       }
 
@@ -669,18 +646,17 @@ public:
       // Create the operator.
       CeedOperatorCreate(ceed, apply_qfunc, NULL, NULL, &oper);
       // coefficient
-      if (GridCoefficient *gridCoeff = dynamic_cast<GridCoefficient*>(coeff))
+      if (GridCoefficient *gridCoeff = dynamic_cast<GridCoefficient *>(coeff))
       {
          InitBasisAndRestriction(*gridCoeff->gf.FESpace(), ir, nelem, indices,
                                  ceed, &gridCoeff->basis, &gridCoeff->restr);
          CeedOperatorSetField(oper, "coeff", gridCoeff->restr,
                               gridCoeff->basis, gridCoeff->coeffVector);
       }
-      else if (QuadCoefficient *quadCoeff =
-                  dynamic_cast<QuadCoefficient*>(coeff))
+      else if (QuadCoefficient *quadCoeff = dynamic_cast<QuadCoefficient *>(coeff))
       {
          const int ncomp = quadCoeff->ncomp;
-         CeedInt strides[3] = {ncomp, 1, ncomp*nqpts};
+         CeedInt strides[3] = {ncomp, 1, ncomp * nqpts};
          InitStridedRestriction(*mesh.GetNodalFESpace(),
                                 nelem, nqpts, ncomp, strides,
                                 &quadCoeff->restr);
@@ -695,22 +671,17 @@ public:
                                  CEED_BASIS_COLLOCATED, CEED_VECTOR_ACTIVE);
             break;
          case EvalMode::Interp:
-            CeedOperatorSetField(oper, "u", trial_restr, trial_basis,
-                                 CEED_VECTOR_ACTIVE);
+            CeedOperatorSetField(oper, "u", trial_restr, trial_basis, CEED_VECTOR_ACTIVE);
             break;
          case EvalMode::Grad:
-            CeedOperatorSetField(oper, "gu", trial_restr, trial_basis,
-                                 CEED_VECTOR_ACTIVE);
+            CeedOperatorSetField(oper, "gu", trial_restr, trial_basis, CEED_VECTOR_ACTIVE);
             break;
          case EvalMode::InterpAndGrad:
-            CeedOperatorSetField(oper, "u", trial_restr, trial_basis,
-                                 CEED_VECTOR_ACTIVE);
-            CeedOperatorSetField(oper, "gu", trial_restr, trial_basis,
-                                 CEED_VECTOR_ACTIVE);
+            CeedOperatorSetField(oper, "u", trial_restr, trial_basis, CEED_VECTOR_ACTIVE);
+            CeedOperatorSetField(oper, "gu", trial_restr, trial_basis, CEED_VECTOR_ACTIVE);
             break;
       }
-      CeedOperatorSetField(oper, "dx", mesh_restr,
-                           mesh_basis, node_coords);
+      CeedOperatorSetField(oper, "dx", mesh_restr, mesh_basis, node_coords);
       CeedOperatorSetField(oper, "weights", CEED_ELEMRESTRICTION_NONE,
                            mesh_basis, CEED_VECTOR_NONE);
       // output
@@ -721,23 +692,19 @@ public:
                                  CEED_BASIS_COLLOCATED, CEED_VECTOR_ACTIVE);
             break;
          case EvalMode::Interp:
-            CeedOperatorSetField(oper, "v", test_restr, test_basis,
-                                 CEED_VECTOR_ACTIVE);
+            CeedOperatorSetField(oper, "v", test_restr, test_basis, CEED_VECTOR_ACTIVE);
             break;
          case EvalMode::Grad:
-            CeedOperatorSetField(oper, "gv", test_restr, test_basis,
-                                 CEED_VECTOR_ACTIVE);
+            CeedOperatorSetField(oper, "gv", test_restr, test_basis, CEED_VECTOR_ACTIVE);
             break;
          case EvalMode::InterpAndGrad:
-            CeedOperatorSetField(oper, "v", test_restr, test_basis,
-                                 CEED_VECTOR_ACTIVE);
-            CeedOperatorSetField(oper, "gv", test_restr, test_basis,
-                                 CEED_VECTOR_ACTIVE);
+            CeedOperatorSetField(oper, "v", test_restr, test_basis, CEED_VECTOR_ACTIVE);
+            CeedOperatorSetField(oper, "gv", test_restr, test_basis, CEED_VECTOR_ACTIVE);
             break;
       }
 
-      CeedVectorCreate(ceed, trial_vdim*trial_fes.GetNDofs(), &u);
-      CeedVectorCreate(ceed, test_vdim*test_fes.GetNDofs(), &v);
+      CeedVectorCreate(ceed, trial_vdim * trial_fes.GetNDofs(), &u);
+      CeedVectorCreate(ceed, test_vdim * test_fes.GetNDofs(), &v);
    }
 
    virtual ~MFIntegrator()
@@ -756,14 +723,14 @@ private:
    {
       /** The path to the header containing the functions for libCEED. */
       std::string header;
-      /** The name of the Qfunction to apply the operator. */
+      /** The name of the QFunction to apply the operator. */
       std::string apply_func;
-      /** The Qfunction to apply the operator. */
+      /** The QFunction to apply the operator. */
       CeedQFunctionUser apply_qf;
       /** The evaluation mode to apply to the trial function (CEED_EVAL_INTERP,
           CEED_EVAL_GRAD, etc.) */
       EvalMode trial_op;
-      /** The evaluation mode to apply to the test function ( CEED_EVAL_INTERP,
+      /** The evaluation mode to apply to the test function (CEED_EVAL_INTERP,
           CEED_EVAL_GRAD, etc.) */
       EvalMode test_op;
    };

--- a/fem/ceed/interface/mixed_integrator.hpp
+++ b/fem/ceed/interface/mixed_integrator.hpp
@@ -77,7 +77,7 @@ public:
       {
          ElementKey key(fes.GetElementType(i), fes.GetElementOrder(i));
          int &offset = *(offsets[key]);
-         int* indices_array = element_indices[key];
+         int *indices_array = element_indices[key];
          indices_array[offset] = i;
          offset++;
       }
@@ -89,7 +89,7 @@ public:
       sub_ops.reserve(element_indices.size());
       for (const auto& value : element_indices)
       {
-         const int* indices = value.second;
+         const int *indices = value.second;
          const int first_index = indices[0];
          const mfem::FiniteElement &el = *fes.GetFE(first_index);
          auto &T = *fes.GetMesh()->GetElementTransformation(first_index);

--- a/fem/ceed/interface/mixed_integrator.hpp
+++ b/fem/ceed/interface/mixed_integrator.hpp
@@ -82,7 +82,7 @@ public:
             integ.GetIntegrationRule() ? *integ.GetIntegrationRule() :
             integ.GetRule(trial_fe, test_fe, T);
          sub_ops.reserve(1);
-         auto sub_op = new Integrator();
+         auto *sub_op = new Integrator();
          sub_op->Assemble(info, trial_fes, test_fes, ir, Q, use_bdr, use_mf);
          sub_ops.push_back(sub_op);
 
@@ -156,11 +156,10 @@ public:
             use_bdr ? *test_fes.GetBE(first_index) : *test_fes.GetFE(first_index);
          auto &T = use_bdr ? *mesh.GetBdrElementTransformation(first_index) :
                    *mesh.GetElementTransformation(first_index);
-         MFEM_ASSERT(!integ.GetIntegrationRule(),
-                     "Mixed mesh integrators should not have an"
-                     " IntegrationRule.");
-         const IntegrationRule &ir = integ.GetRule(el, el, T);
-         auto sub_op = new Integrator();
+         MFEM_VERIFY(!integ.GetIntegrationRule(),
+                     "Mixed mesh integrators should not have an IntegrationRule.");
+         const IntegrationRule &ir = integ.GetRule(trial_fe, test_fe, T);
+         auto *sub_op = new Integrator();
          sub_op->Assemble(info, trial_fes, test_fes, ir, *count[value.first], indices, Q,
                           use_bdr, use_mf);
          sub_ops.push_back(sub_op);
@@ -174,7 +173,7 @@ public:
 
    virtual ~MixedIntegrator()
    {
-      for (auto sub_op : sub_ops)
+      for (auto *sub_op : sub_ops)
       {
          delete sub_op;
       }

--- a/fem/ceed/interface/mixed_integrator.hpp
+++ b/fem/ceed/interface/mixed_integrator.hpp
@@ -12,9 +12,11 @@
 #ifndef MFEM_LIBCEED_MIXED_INTEGRATOR
 #define MFEM_LIBCEED_MIXED_INTEGRATOR
 
-#include "ceed.hpp"
-#include "integrator.hpp"
+#include <array>
 #include <unordered_map>
+#include "integrator.hpp"
+#include "util.hpp"
+#include "ceed.hpp"
 
 namespace mfem
 {
@@ -22,38 +24,89 @@ namespace mfem
 namespace ceed
 {
 
-/** @brief This class wraps a `ceed::PAIntegrator` or `ceed::MFIntegrator` to
-    support mixed finite element spaces. */
-template <typename CeedInteg>
-class MixedIntegrator : public ceed::Operator
+/** @brief This class wraps one or more `ceed::Integrator` objects to support
+    finite element spaces on mixed meshes. */
+class MixedIntegrator : public Operator
 {
 #ifdef MFEM_USE_CEED
-   using ElementKey = std::pair<int, int>; //< Element::Type, Order >
-   struct key_hash
+   using ElementKey =
+      std::array<int, 3>; // <mfem::Element::Type, TrialOrder, TestOrder>
+   struct ElementHash
    {
-      std::size_t operator()(const ElementKey& k) const
+      std::size_t operator()(const ElementKey &k) const
       {
-         return k.first + 2 * k.second;
+         return CeedHashCombine(
+                   CeedHashCombine(CeedHash(k[0]), CeedHash(k[1])),
+                   CeedHash(k[2]));
       }
    };
-   using ElementsMap = std::unordered_map<const ElementKey, int*, key_hash>;
-   std::vector<CeedInteg*> sub_ops;
+   using ElementsMap = std::unordered_map<const ElementKey, int *, ElementHash>;
+   std::vector<Integrator *> sub_ops;
 
 public:
-   template <typename Integrator, typename CeedOperatorInfo, typename CoeffType>
-   void Assemble(const Integrator &integ,
+   template <typename IntegratorType, typename CeedOperatorInfo, typename CoeffType>
+   void Assemble(const IntegratorType &integ,
                  CeedOperatorInfo &info,
                  const mfem::FiniteElementSpace &fes,
-                 CoeffType *Q)
+                 CoeffType *Q,
+                 const bool use_bdr = false,
+                 const bool use_mf = false)
    {
+      Assemble(integ, info, fes, fes, Q, use_bdr, use_mf);
+   }
+
+   template <typename IntegratorType, typename CeedOperatorInfo, typename CoeffType>
+   void Assemble(const IntegratorType &integ,
+                 CeedOperatorInfo &info,
+                 const mfem::FiniteElementSpace &trial_fes,
+                 const mfem::FiniteElementSpace &test_fes,
+                 CoeffType *Q,
+                 const bool use_bdr = false,
+                 const bool use_mf = false)
+   {
+      MFEM_VERIFY(trial_fes.GetMesh() == test_fes.GetMesh(),
+                  "Trial and test basis must correspond to the same Mesh.");
+      mfem::Mesh &mesh = *trial_fes.GetMesh();
+      const bool mixed =
+         mesh.GetNumGeometries(mesh.Dimension() - (use_bdr * 1)) > 1 ||
+         trial_fes.IsVariableOrder() || test_fes.IsVariableOrder();
+      if (!mixed)
+      {
+         const mfem::FiniteElement &trial_fe = use_bdr ? *trial_fes.GetBE(0) :
+                                               *trial_fes.GetFE(0);
+         const mfem::FiniteElement &test_fe = use_bdr ? *test_fes.GetBE(0) :
+                                              *test_fes.GetFE(0);
+         auto &T = use_bdr ? *mesh.GetBdrElementTransformation(0) :
+                   *mesh.GetElementTransformation(0);
+         const mfem::IntegrationRule &ir =
+            integ.GetIntegrationRule() ? *integ.GetIntegrationRule() :
+            integ.GetRule(trial_fe, test_fe, T);
+         sub_ops.reserve(1);
+         auto sub_op = new Integrator();
+         sub_op->Assemble(info, trial_fes, test_fes, ir, Q, use_bdr, use_mf);
+         sub_ops.push_back(sub_op);
+
+         CeedOperatorReferenceCopy(sub_op->GetCeedOperator(), &oper);
+         CeedVectorReferenceCopy(sub_op->GetCeedVectorU(), &u);
+         CeedVectorReferenceCopy(sub_op->GetCeedVectorV(), &v);
+         return;
+      }
+
+      // Count the number of elements of each type
       ElementsMap count;
       ElementsMap element_indices;
       ElementsMap offsets;
 
-      // Count the number of elements of each type
-      for (int i = 0; i < fes.GetNE(); i++)
+      const int ne = use_bdr ? mesh.GetNBE() : mesh.GetNE();
+      for (int i = 0; i < ne; i++)
       {
-         ElementKey key(fes.GetElementType(i), fes.GetElementOrder(i));
+         const mfem::FiniteElement &trial_fe = use_bdr ? *trial_fes.GetBE(i) :
+                                               *trial_fes.GetFE(i);
+         const mfem::FiniteElement &test_fe = use_bdr ? *test_fes.GetBE(i) :
+                                              *test_fes.GetFE(i);
+         mfem::Element::Type type = use_bdr ? mesh.GetBdrElementType(i) :
+                                    mesh.GetElementType(i);
+         ElementKey key = {type, trial_fe.GetOrder(), test_fe.GetOrder()};
          auto value = count.find(key);
          if (value == count.end())
          {
@@ -66,16 +119,22 @@ public:
       }
 
       // Initialization of the arrays
-      for ( const auto& value : count )
+      for (const auto &value : count)
       {
          element_indices[value.first] = new int[*value.second];
          offsets[value.first] = new int(0);
       }
 
       // Populates the indices arrays for each element type
-      for (int i = 0; i < fes.GetNE(); i++)
+      for (int i = 0; i < ne; i++)
       {
-         ElementKey key(fes.GetElementType(i), fes.GetElementOrder(i));
+         const mfem::FiniteElement &trial_fe = use_bdr ? *trial_fes.GetBE(i) :
+                                               *trial_fes.GetFE(i);
+         const mfem::FiniteElement &test_fe = use_bdr ? *test_fes.GetBE(i) :
+                                              *test_fes.GetFE(i);
+         mfem::Element::Type type = use_bdr ? mesh.GetBdrElementType(i) :
+                                    mesh.GetElementType(i);
+         ElementKey key = {type, trial_fe.GetOrder(), test_fe.GetOrder()};
          int &offset = *(offsets[key]);
          int *indices_array = element_indices[key];
          indices_array[offset] = i;
@@ -87,26 +146,30 @@ public:
 
       // Create each sub-CeedOperator
       sub_ops.reserve(element_indices.size());
-      for (const auto& value : element_indices)
+      for (const auto &value : element_indices)
       {
          const int *indices = value.second;
          const int first_index = indices[0];
-         const mfem::FiniteElement &el = *fes.GetFE(first_index);
-         auto &T = *fes.GetMesh()->GetElementTransformation(first_index);
+         const mfem::FiniteElement &trial_fe =
+            use_bdr ? *trial_fes.GetBE(first_index) : *trial_fes.GetFE(first_index);
+         const mfem::FiniteElement &test_fe =
+            use_bdr ? *test_fes.GetBE(first_index) : *test_fes.GetFE(first_index);
+         auto &T = use_bdr ? *mesh.GetBdrElementTransformation(first_index) :
+                   *mesh.GetElementTransformation(first_index);
          MFEM_ASSERT(!integ.GetIntegrationRule(),
                      "Mixed mesh integrators should not have an"
                      " IntegrationRule.");
          const IntegrationRule &ir = integ.GetRule(el, el, T);
-         auto sub_op = new CeedInteg();
-         int nelem = *count[value.first];
-         sub_op->Assemble(info, fes, ir, nelem, indices, Q);
+         auto sub_op = new Integrator();
+         sub_op->Assemble(info, trial_fes, test_fes, ir, *count[value.first], indices, Q,
+                          use_bdr, use_mf);
          sub_ops.push_back(sub_op);
          CeedCompositeOperatorAddSub(oper, sub_op->GetCeedOperator());
       }
 
-      const int ndofs = fes.GetVDim() * fes.GetNDofs();
-      CeedVectorCreate(internal::ceed, ndofs, &u);
-      CeedVectorCreate(internal::ceed, ndofs, &v);
+      CeedVectorCreate(internal::ceed, trial_fes.GetVDim() * trial_fes.GetNDofs(),
+                       &u);
+      CeedVectorCreate(internal::ceed, test_fes.GetVDim() * test_fes.GetNDofs(), &v);
    }
 
    virtual ~MixedIntegrator()

--- a/fem/ceed/interface/mixed_integrator.hpp
+++ b/fem/ceed/interface/mixed_integrator.hpp
@@ -68,7 +68,7 @@ public:
                   "Trial and test basis must correspond to the same Mesh.");
       mfem::Mesh &mesh = *trial_fes.GetMesh();
       const bool mixed =
-         mesh.GetNumGeometries(mesh.Dimension() - (use_bdr * 1)) > 1 ||
+         mesh.GetNumGeometries(mesh.Dimension() - use_bdr) > 1 ||
          trial_fes.IsVariableOrder() || test_fes.IsVariableOrder();
       if (!mixed)
       {

--- a/fem/ceed/interface/operator.cpp
+++ b/fem/ceed/interface/operator.cpp
@@ -11,11 +11,9 @@
 
 #include "operator.hpp"
 
-#include "../../../config/config.hpp"
 #include "../../../linalg/vector.hpp"
 #include "../../fespace.hpp"
 #include "util.hpp"
-#include "ceed.hpp"
 
 namespace mfem
 {

--- a/fem/ceed/interface/operator.cpp
+++ b/fem/ceed/interface/operator.cpp
@@ -44,7 +44,7 @@ void Operator::Mult(const mfem::Vector &x, mfem::Vector &y) const
    CeedScalar *y_ptr;
    CeedMemType mem;
    CeedGetPreferredMemType(mfem::internal::ceed, &mem);
-   if ( Device::Allows(Backend::DEVICE_MASK) && mem==CEED_MEM_DEVICE )
+   if (Device::Allows(Backend::DEVICE_MASK) && mem == CEED_MEM_DEVICE)
    {
       x_ptr = x.Read();
       y_ptr = y.Write();
@@ -76,7 +76,7 @@ void Operator::AddMult(const mfem::Vector &x, mfem::Vector &y,
    CeedScalar *y_ptr;
    CeedMemType mem;
    CeedGetPreferredMemType(mfem::internal::ceed, &mem);
-   if ( Device::Allows(Backend::DEVICE_MASK) && mem==CEED_MEM_DEVICE )
+   if (Device::Allows(Backend::DEVICE_MASK) && mem == CEED_MEM_DEVICE)
    {
       x_ptr = x.Read();
       y_ptr = y.ReadWrite();
@@ -105,7 +105,7 @@ void Operator::GetDiagonal(mfem::Vector &diag) const
    CeedScalar *d_ptr;
    CeedMemType mem;
    CeedGetPreferredMemType(mfem::internal::ceed, &mem);
-   if ( Device::Allows(Backend::DEVICE_MASK) && mem==CEED_MEM_DEVICE )
+   if (Device::Allows(Backend::DEVICE_MASK) && mem == CEED_MEM_DEVICE)
    {
       d_ptr = diag.ReadWrite();
    }

--- a/fem/ceed/interface/operator.hpp
+++ b/fem/ceed/interface/operator.hpp
@@ -41,11 +41,12 @@ public:
    CeedVector &GetCeedVectorU() { return u; }
    CeedVector &GetCeedVectorV() { return v; }
 #endif
+
    void Mult(const mfem::Vector &x, mfem::Vector &y) const override;
    void AddMult(const mfem::Vector &x, mfem::Vector &y,
                 const double a = 1.0) const override;
    void GetDiagonal(mfem::Vector &diag) const;
-   using mfem::Operator::SetupRAP;
+
    virtual ~Operator()
    {
 #ifdef MFEM_USE_CEED

--- a/fem/ceed/interface/operator.hpp
+++ b/fem/ceed/interface/operator.hpp
@@ -29,13 +29,17 @@ protected:
    CeedOperator oper;
    CeedVector u, v;
 
-   Operator() : oper(nullptr), u(nullptr), v(nullptr) { }
+   Operator() : oper(nullptr), u(nullptr), v(nullptr) {}
 #endif
 
 public:
 #ifdef MFEM_USE_CEED
    /// This class takes ownership of op and will delete it
    Operator(CeedOperator op);
+
+   CeedOperator &GetCeedOperator() { return oper; }
+   CeedVector &GetCeedVectorU() { return u; }
+   CeedVector &GetCeedVectorV() { return v; }
 #endif
    void Mult(const mfem::Vector &x, mfem::Vector &y) const override;
    void AddMult(const mfem::Vector &x, mfem::Vector &y,
@@ -50,10 +54,6 @@ public:
       CeedVectorDestroy(&v);
 #endif
    }
-
-#ifdef MFEM_USE_CEED
-   CeedOperator& GetCeedOperator() { return oper; }
-#endif
 };
 
 } // namespace ceed

--- a/fem/ceed/interface/restriction.cpp
+++ b/fem/ceed/interface/restriction.cpp
@@ -9,8 +9,9 @@
 // terms of the BSD-3 license. We welcome feedback and contributions, see file
 // CONTRIBUTING.md for details.
 
-#include "../../../fem/gridfunc.hpp"
-#include "ceed.hpp"
+#include "restriction.hpp"
+
+#include "util.hpp"
 
 namespace mfem
 {
@@ -21,20 +22,27 @@ namespace ceed
 #ifdef MFEM_USE_CEED
 
 static void InitNativeRestr(const mfem::FiniteElementSpace &fes,
-                            Ceed ceed, CeedElemRestriction *restr)
+                            bool use_bdr,
+                            Ceed ceed,
+                            CeedElemRestriction *restr)
 {
-   const mfem::FiniteElement *fe = fes.GetFE(0);
+   const int nelem = use_bdr ? fes.GetNBE() : fes.GetNE();
+   const mfem::FiniteElement *fe = use_bdr ? fes.GetBE(0) :
+                                   fes.GetFE(0);
    const int P = fe->GetDof();
-   CeedInt compstride = fes.GetOrdering()==Ordering::byVDIM ? 1 : fes.GetNDofs();
-   const mfem::Table &el_dof = fes.GetElementToDofTable();
-   mfem::Array<int> tp_el_dof(el_dof.Size_of_connections());
-   const mfem::TensorBasisElement * tfe =
+   const mfem::TensorBasisElement *tfe =
       dynamic_cast<const mfem::TensorBasisElement *>(fe);
-   const int stride = compstride == 1 ? fes.GetVDim() : 1;
    const mfem::Array<int>& dof_map = tfe->GetDofMap();
+   CeedInt compstride =
+      (fes.GetOrdering() == Ordering::byVDIM) ? 1 : fes.GetNDofs();
+   const int stride = (compstride == 1) ? fes.GetVDim() : 1;
+   const mfem::Table &el_dof = use_bdr ? fes.GetBdrElementToDofTable() :
+                               fes.GetElementToDofTable();
+   mfem::Array<int> tp_el_dof(el_dof.Size_of_connections());
 
-   for (int i = 0; i < fes.GetNE(); i++)
+   for (int i = 0; i < nelem; i++)
    {
+      // TODO: Implement DofTransformation support
       const int el_offset = P * i;
       for (int j = 0; j < P; j++)
       {
@@ -42,72 +50,73 @@ static void InitNativeRestr(const mfem::FiniteElementSpace &fes,
       }
    }
 
-   CeedElemRestrictionCreate(ceed, fes.GetNE(), P, fes.GetVDim(),
-                             compstride, (fes.GetVDim())*(fes.GetNDofs()),
+   CeedElemRestrictionCreate(ceed, nelem, P, fes.GetVDim(),
+                             compstride, fes.GetVDim() * fes.GetNDofs(),
                              CEED_MEM_HOST, CEED_COPY_VALUES,
                              tp_el_dof.GetData(), restr);
 }
 
 static void InitLexicoRestr(const mfem::FiniteElementSpace &fes,
-                            Ceed ceed, CeedElemRestriction *restr)
+                            bool use_bdr,
+                            Ceed ceed,
+                            CeedElemRestriction *restr)
 {
-   const mfem::FiniteElement *fe = fes.GetFE(0);
+   const int nelem = use_bdr ? fes.GetNBE() : fes.GetNE();
+   const mfem::FiniteElement *fe = use_bdr ? fes.GetBE(0) :
+                                   fes.GetFE(0);
    const int P = fe->GetDof();
-   CeedInt compstride = fes.GetOrdering()==Ordering::byVDIM ? 1 : fes.GetNDofs();
-   const mfem::Table &el_dof = fes.GetElementToDofTable();
+   CeedInt compstride =
+      (fes.GetOrdering() == Ordering::byVDIM) ? 1 : fes.GetNDofs();
+   const int stride = (compstride == 1) ? fes.GetVDim() : 1;
+   const mfem::Table &el_dof = use_bdr ? fes.GetBdrElementToDofTable() :
+                               fes.GetElementToDofTable();
    mfem::Array<int> tp_el_dof(el_dof.Size_of_connections());
-   const int stride = compstride == 1 ? fes.GetVDim() : 1;
 
-   for (int e = 0; e < fes.GetNE(); e++)
+   for (int e = 0; e < nelem; e++)
    {
+      // TODO: Implement DofTransformation support
       for (int i = 0; i < P; i++)
       {
          tp_el_dof[i + e*P] = stride*el_dof.GetJ()[i + e*P];
       }
    }
 
-   CeedElemRestrictionCreate(ceed, fes.GetNE(), P, fes.GetVDim(),
-                             compstride, (fes.GetVDim())*(fes.GetNDofs()),
+   CeedElemRestrictionCreate(ceed, nelem, P, fes.GetVDim(),
+                             compstride, fes.GetVDim() * fes.GetNDofs(),
                              CEED_MEM_HOST, CEED_COPY_VALUES,
                              tp_el_dof.GetData(), restr);
 }
 
-static void InitRestrictionImpl(const mfem::FiniteElementSpace &fes,
-                                Ceed ceed, CeedElemRestriction *restr)
+static void InitNativeRestrWithIndices(const mfem::FiniteElementSpace &fes,
+                                       bool use_bdr,
+                                       int nelem,
+                                       const int *indices,
+                                       Ceed ceed,
+                                       CeedElemRestriction *restr)
 {
-   const mfem::FiniteElement *fe = fes.GetFE(0);
-   const mfem::TensorBasisElement * tfe =
-      dynamic_cast<const mfem::TensorBasisElement *>(fe);
-   if ( tfe && tfe->GetDofMap().Size()>0 ) // Native ordering using dof_map
-   {
-      InitNativeRestr(fes, ceed, restr);
-   }
-   else  // Lexicographic ordering
-   {
-      InitLexicoRestr(fes, ceed, restr);
-   }
-}
-
-static void InitNativeRestrWithIndices(
-   const mfem::FiniteElementSpace &fes,
-   int nelem,
-   const int* indices,
-   Ceed ceed, CeedElemRestriction *restr)
-{
-   const mfem::FiniteElement *fe = fes.GetFE(indices[0]);
+   const mfem::FiniteElement *fe = use_bdr ? fes.GetBE(indices[0]) :
+                                   fes.GetFE(indices[0]);
    const int P = fe->GetDof();
-   CeedInt compstride = fes.GetOrdering()==Ordering::byVDIM ? 1 : fes.GetNDofs();
-   mfem::Array<int> tp_el_dof(nelem*P);
-   const mfem::TensorBasisElement * tfe =
+   const mfem::TensorBasisElement *tfe =
       dynamic_cast<const mfem::TensorBasisElement *>(fe);
-   Array<int> dofs;
-   const int stride = compstride == 1 ? fes.GetVDim() : 1;
-   const mfem::Array<int>& dof_map = tfe->GetDofMap();
+   const mfem::Array<int> &dof_map = tfe->GetDofMap();
+   CeedInt compstride =
+      (fes.GetOrdering() == Ordering::byVDIM) ? 1 : fes.GetNDofs();
+   const int stride = (compstride == 1) ? fes.GetVDim() : 1;
+   mfem::Array<int> tp_el_dof(nelem * P), dofs;
 
    for (int i = 0; i < nelem; i++)
    {
+      // TODO: Implement DofTransformation support
       const int elem_index = indices[i];
-      fes.GetElementDofs(elem_index, dofs);
+      if (use_bdr)
+      {
+         fes.GetBdrElementDofs(elem_index, dofs);
+      }
+      else
+      {
+         fes.GetElementDofs(elem_index, dofs);
+      }
       const int el_offset = P * i;
       for (int j = 0; j < P; j++)
       {
@@ -116,28 +125,38 @@ static void InitNativeRestrWithIndices(
    }
 
    CeedElemRestrictionCreate(ceed, nelem, P, fes.GetVDim(),
-                             compstride, (fes.GetVDim())*(fes.GetNDofs()),
+                             compstride, fes.GetVDim() * fes.GetNDofs(),
                              CEED_MEM_HOST, CEED_COPY_VALUES,
                              tp_el_dof.GetData(), restr);
 }
 
-static void InitLexicoRestrWithIndices(
-   const mfem::FiniteElementSpace &fes,
-   int nelem,
-   const int* indices,
-   Ceed ceed, CeedElemRestriction *restr)
+static void InitLexicoRestrWithIndices(const mfem::FiniteElementSpace &fes,
+                                       bool use_bdr,
+                                       int nelem,
+                                       const int *indices,
+                                       Ceed ceed,
+                                       CeedElemRestriction *restr)
 {
-   const mfem::FiniteElement *fe = fes.GetFE(indices[0]);
+   const mfem::FiniteElement *fe = use_bdr ? fes.GetBE(indices[0]) :
+                                   fes.GetFE(indices[0]);
    const int P = fe->GetDof();
-   CeedInt compstride = fes.GetOrdering()==Ordering::byVDIM ? 1 : fes.GetNDofs();
-   mfem::Array<int> tp_el_dof(nelem*P);
-   Array<int> dofs;
-   const int stride = compstride == 1 ? fes.GetVDim() : 1;
+   CeedInt compstride =
+      (fes.GetOrdering() == Ordering::byVDIM) ? 1 : fes.GetNDofs();
+   const int stride = (compstride == 1) ? fes.GetVDim() : 1;
+   mfem::Array<int> tp_el_dof(nelem * P), dofs;
 
    for (int i = 0; i < nelem; i++)
    {
+      // TODO: Implement DofTransformation support
       const int elem_index = indices[i];
-      fes.GetElementDofs(elem_index, dofs);
+      if (use_bdr)
+      {
+         fes.GetBdrElementDofs(elem_index, dofs);
+      }
+      else
+      {
+         fes.GetElementDofs(elem_index, dofs);
+      }
       const int el_offset = P * i;
       for (int j = 0; j < P; j++)
       {
@@ -146,86 +165,57 @@ static void InitLexicoRestrWithIndices(
    }
 
    CeedElemRestrictionCreate(ceed, nelem, P, fes.GetVDim(),
-                             compstride, (fes.GetVDim())*(fes.GetNDofs()),
+                             compstride, fes.GetVDim() * fes.GetNDofs(),
                              CEED_MEM_HOST, CEED_COPY_VALUES,
                              tp_el_dof.GetData(), restr);
 }
 
-static void InitRestrictionWithIndicesImpl(
-   const mfem::FiniteElementSpace &fes,
-   int nelem,
-   const int* indices,
-   Ceed ceed, CeedElemRestriction *restr)
+static void InitRestrictionImpl(const mfem::FiniteElementSpace &fes,
+                                bool use_bdr,
+                                Ceed ceed,
+                                CeedElemRestriction *restr)
 {
-   const mfem::FiniteElement *fe = fes.GetFE(indices[0]);
-   const mfem::TensorBasisElement * tfe =
+   const mfem::FiniteElement *fe = use_bdr ? fes.GetBE(0): fes.GetFE(0);
+   const mfem::TensorBasisElement *tfe =
       dynamic_cast<const mfem::TensorBasisElement *>(fe);
-   if ( tfe && tfe->GetDofMap().Size()>0 ) // Native ordering using dof_map
+   if (tfe && tfe->GetDofMap().Size() > 0)  // Native ordering using dof_map
    {
-      InitNativeRestrWithIndices(fes, nelem, indices, ceed, restr);
+      InitNativeRestr(fes, use_bdr, ceed, restr);
    }
    else  // Lexicographic ordering
    {
-      InitLexicoRestrWithIndices(fes, nelem, indices, ceed, restr);
+      InitLexicoRestr(fes, use_bdr, ceed, restr);
    }
 }
 
-static void InitCoeffRestrictionWithIndicesImpl(
-   const mfem::FiniteElementSpace &fes,
-   int nelem,
-   const int* indices,
-   int nquads,
-   int ncomp,
-   Ceed ceed,
-   CeedElemRestriction *restr)
+static void InitRestrictionWithIndicesImpl(const mfem::FiniteElementSpace &fes,
+                                           bool use_bdr,
+                                           int nelem,
+                                           const int *indices,
+                                           Ceed ceed,
+                                           CeedElemRestriction *restr)
 {
-   mfem::Array<int> tp_el_dof(nelem*nquads);
-   const int stride_quad = ncomp;
-   const int stride_elem = ncomp*nquads;
-   // TODO generalize to support different #quads
-   for (int i = 0; i < nelem; i++)
+   const mfem::FiniteElement *fe = use_bdr ? fes.GetBE(indices[0]) :
+                                   fes.GetFE(indices[0]);
+   const mfem::TensorBasisElement *tfe =
+      dynamic_cast<const mfem::TensorBasisElement *>(fe);
+   if (tfe && tfe->GetDofMap().Size() > 0)  // Native ordering using dof_map
    {
-      const int elem_index = indices[i];
-      const int el_offset = elem_index * stride_elem;
-      for (int j = 0; j < nquads; j++)
-      {
-         tp_el_dof[j + nquads * i] = j * stride_quad + el_offset;
-      }
+      InitNativeRestrWithIndices(fes, use_bdr, nelem, indices, ceed, restr);
    }
-   CeedElemRestrictionCreate(ceed, nelem, nquads, ncomp, 1,
-                             ncomp*fes.GetNE()*nquads,
-                             CEED_MEM_HOST, CEED_COPY_VALUES,
-                             tp_el_dof.GetData(), restr);
-}
-
-void InitStridedRestriction(const mfem::FiniteElementSpace &fes,
-                            CeedInt nelem, CeedInt nqpts, CeedInt qdatasize,
-                            const CeedInt *strides,
-                            CeedElemRestriction *restr)
-{
-   RestrKey restr_key(&fes, nelem, nqpts, qdatasize, restr_type::Strided);
-   auto restr_itr = mfem::internal::ceed_restr_map.find(restr_key);
-   if (restr_itr == mfem::internal::ceed_restr_map.end())
+   else  // Lexicographic ordering
    {
-      CeedElemRestrictionCreateStrided(mfem::internal::ceed, nelem, nqpts, qdatasize,
-                                       nelem*nqpts*qdatasize,
-                                       strides,
-                                       restr);
-      // Will be automatically destroyed when @a fes gets destroyed.
-      mfem::internal::ceed_restr_map[restr_key] = *restr;
-   }
-   else
-   {
-      *restr = restr_itr->second;
+      InitLexicoRestrWithIndices(fes, use_bdr, nelem, indices, ceed, restr);
    }
 }
 
 void InitRestriction(const FiniteElementSpace &fes,
+                     bool use_bdr,
                      Ceed ceed,
                      CeedElemRestriction *restr)
 {
-   // Check for FES -> basis, restriction in hash tables
-   const mfem::FiniteElement *fe = fes.GetFE(0);
+   // Check for fes -> restriction in hash table
+   const mfem::FiniteElement *fe = use_bdr ? fes.GetBE(0) : fes.GetFE(0);
    const int P = fe->GetDof();
    const int nelem = fes.GetNE();
    const int ncomp = fes.GetVDim();
@@ -235,7 +225,7 @@ void InitRestriction(const FiniteElementSpace &fes,
    // Init or retrieve key values
    if (restr_itr == mfem::internal::ceed_restr_map.end())
    {
-      InitRestrictionImpl(fes, ceed, restr);
+      InitRestrictionImpl(fes, use_bdr, ceed, restr);
       mfem::internal::ceed_restr_map[restr_key] = *restr;
    }
    else
@@ -245,13 +235,15 @@ void InitRestriction(const FiniteElementSpace &fes,
 }
 
 void InitRestrictionWithIndices(const FiniteElementSpace &fes,
+                                bool use_bdr,
                                 int nelem,
-                                const int* indices,
+                                const int *indices,
                                 Ceed ceed,
                                 CeedElemRestriction *restr)
 {
-   // Check for FES -> basis, restriction in hash tables
-   const mfem::FiniteElement *fe = fes.GetFE(indices[0]);
+   // Check for fes -> restriction in hash table
+   const mfem::FiniteElement *fe = use_bdr ? fes.GetBE(indices[0]) :
+                                   fes.GetFE(indices[0]);
    const int P = fe->GetDof();
    const int ncomp = fes.GetVDim();
    RestrKey restr_key(&fes, nelem, P, ncomp, restr_type::Standard);
@@ -260,7 +252,7 @@ void InitRestrictionWithIndices(const FiniteElementSpace &fes,
    // Init or retrieve key values
    if (restr_itr == mfem::internal::ceed_restr_map.end())
    {
-      InitRestrictionWithIndicesImpl(fes, nelem, indices, ceed, restr);
+      InitRestrictionWithIndicesImpl(fes, use_bdr, nelem, indices, ceed, restr);
       mfem::internal::ceed_restr_map[restr_key] = *restr;
    }
    else
@@ -269,23 +261,24 @@ void InitRestrictionWithIndices(const FiniteElementSpace &fes,
    }
 }
 
-void InitCoeffRestrictionWithIndices(const FiniteElementSpace &fes,
-                                     int nelem,
-                                     const int* indices,
-                                     int nquads,
-                                     int ncomp,
-                                     Ceed ceed,
-                                     CeedElemRestriction *restr)
+void InitStridedRestriction(const mfem::FiniteElementSpace &fes,
+                            CeedInt nelem,
+                            CeedInt nqpts,
+                            CeedInt qdatasize,
+                            const CeedInt *strides,
+                            Ceed ceed,
+                            CeedElemRestriction *restr)
 {
-   // Check for FES -> basis, restriction in hash tables
-   RestrKey restr_key(&fes, nelem, nquads, ncomp, restr_type::Coeff);
+   // Check for fes -> restriction in hash table
+   RestrKey restr_key(&fes, nelem, nqpts, qdatasize, restr_type::Strided);
    auto restr_itr = mfem::internal::ceed_restr_map.find(restr_key);
 
    // Init or retrieve key values
    if (restr_itr == mfem::internal::ceed_restr_map.end())
    {
-      InitCoeffRestrictionWithIndicesImpl(fes, nelem, indices, nquads, ncomp,
-                                          ceed, restr);
+      CeedElemRestrictionCreateStrided(ceed, nelem, nqpts, qdatasize,
+                                       nelem * nqpts * qdatasize, strides,
+                                       restr);
       mfem::internal::ceed_restr_map[restr_key] = *restr;
    }
    else

--- a/fem/ceed/interface/restriction.cpp
+++ b/fem/ceed/interface/restriction.cpp
@@ -215,11 +215,12 @@ void InitRestriction(const FiniteElementSpace &fes,
                      CeedElemRestriction *restr)
 {
    // Check for fes -> restriction in hash table
+   // {-1, -1, -1} is unique from CEED_STRIDES_BACKEND for non-strided restrictions
+   const int nelem = use_bdr ? fes.GetNBE() : fes.GetNE();
    const mfem::FiniteElement *fe = use_bdr ? fes.GetBE(0) : fes.GetFE(0);
    const int P = fe->GetDof();
-   const int nelem = fes.GetNE();
    const int ncomp = fes.GetVDim();
-   RestrKey restr_key(&fes, nelem, P, ncomp, restr_type::Standard);
+   RestrKey restr_key(&fes, nelem, P, ncomp, -1, -1, -1);
    auto restr_itr = mfem::internal::ceed_restr_map.find(restr_key);
 
    // Init or retrieve key values
@@ -242,11 +243,12 @@ void InitRestrictionWithIndices(const FiniteElementSpace &fes,
                                 CeedElemRestriction *restr)
 {
    // Check for fes -> restriction in hash table
+   // {-1, -1, -1} is unique from CEED_STRIDES_BACKEND for non-strided restrictions
    const mfem::FiniteElement *fe = use_bdr ? fes.GetBE(indices[0]) :
                                    fes.GetFE(indices[0]);
    const int P = fe->GetDof();
    const int ncomp = fes.GetVDim();
-   RestrKey restr_key(&fes, nelem, P, ncomp, restr_type::Standard);
+   RestrKey restr_key(&fes, nelem, P, ncomp, -1, -1, -1);
    auto restr_itr = mfem::internal::ceed_restr_map.find(restr_key);
 
    // Init or retrieve key values
@@ -265,12 +267,13 @@ void InitStridedRestriction(const mfem::FiniteElementSpace &fes,
                             CeedInt nelem,
                             CeedInt nqpts,
                             CeedInt qdatasize,
-                            const CeedInt *strides,
+                            const CeedInt strides[3],
                             Ceed ceed,
                             CeedElemRestriction *restr)
 {
    // Check for fes -> restriction in hash table
-   RestrKey restr_key(&fes, nelem, nqpts, qdatasize, restr_type::Strided);
+   RestrKey restr_key(&fes, nelem, nqpts, qdatasize,
+                      strides[0], strides[1], strides[2]);
    auto restr_itr = mfem::internal::ceed_restr_map.find(restr_key);
 
    // Init or retrieve key values

--- a/fem/ceed/interface/restriction.hpp
+++ b/fem/ceed/interface/restriction.hpp
@@ -68,7 +68,7 @@ void InitStridedRestriction(const mfem::FiniteElementSpace &fes,
                             CeedInt nelem,
                             CeedInt nqpts,
                             CeedInt qdatasize,
-                            const CeedInt *strides,
+                            const CeedInt strides[3],
                             Ceed ceed,
                             CeedElemRestriction *restr);
 

--- a/fem/ceed/interface/restriction.hpp
+++ b/fem/ceed/interface/restriction.hpp
@@ -12,6 +12,7 @@
 #ifndef MFEM_LIBCEED_RESTR
 #define MFEM_LIBCEED_RESTR
 
+#include "../../fespace.hpp"
 #include "ceed.hpp"
 
 namespace mfem
@@ -21,64 +22,55 @@ namespace ceed
 {
 
 #ifdef MFEM_USE_CEED
+
 /** @brief Initialize a CeedElemRestriction for non-mixed meshes.
 
     @param[in] fes Input finite element space.
+    @param[in] use_bdr Create restriction for boundary elements.
     @param[in] ceed Input Ceed object.
     @param[out] restr The address of the initialized CeedElemRestriction object.
 */
 void InitRestriction(const FiniteElementSpace &fes,
+                     bool use_bdr,
                      Ceed ceed,
                      CeedElemRestriction *restr);
 
 /** @brief Initialize a CeedElemRestriction for mixed meshes.
 
     @param[in] fes The finite element space.
-    @param[in] ceed The Ceed object.
+    @param[in] use_bdr Create restriction for boundary elements.
     @param[in] nelem The number of elements.
     @param[in] indices The indices of the elements of same type in the
                        `FiniteElementSpace`.
+    @param[in] ceed The Ceed object.
     @param[out] restr The `CeedElemRestriction` to initialize. */
 void InitRestrictionWithIndices(const FiniteElementSpace &fes,
+                                bool use_bdr,
                                 int nelem,
-                                const int* indices,
+                                const int *indices,
                                 Ceed ceed,
                                 CeedElemRestriction *restr);
 
-/** @brief Initialize a strided CeedElemRestriction
+/** @brief Initialize a strided CeedElemRestriction.
 
     @param[in] fes Input finite element space.
     @param[in] nelem is the number of elements.
     @param[in] nqpts is the total number of quadrature points.
     @param[in] qdatasize is the number of data per quadrature point.
     @param[in] strides Array for strides between [nodes, components, elements].
-    Data for node i, component j, element k can be found in the L-vector at
-    index i*strides[0] + j*strides[1] + k*strides[2]. CEED_STRIDES_BACKEND may
-    be used with vectors created by a Ceed backend.
-    @param[out] restr The `CeedElemRestriction` to initialize. */
-void InitStridedRestriction(const mfem::FiniteElementSpace &fes,
-                            CeedInt nelem, CeedInt nqpts, CeedInt qdatasize,
-                            const CeedInt *strides,
-                            CeedElemRestriction *restr);
-
-/** @brief Initialize a CeedElemRestriction for a mfem::Coefficient on a mixed
-    mesh.
-
-    @param[in] fes The finite element space.
-    @param[in] nelem is the number of elements.
-    @param[in] indices The indices of the elements of same type in the
-                       `FiniteElementSpace`.
-    @param[in] nquads is the total number of quadrature points
-    @param[in] ncomp is the number of data per quadrature point
+                       Data for node i, component j, element k can be found in
+                       the L-vector at index i*strides[0] + j*strides[1] +
+                       k*strides[2]. CEED_STRIDES_BACKEND may be used with
+                       vectors created by a Ceed backend.
     @param[in] ceed The Ceed object.
     @param[out] restr The `CeedElemRestriction` to initialize. */
-void InitCoeffRestrictionWithIndices(const FiniteElementSpace &fes,
-                                     int nelem,
-                                     const int* indices,
-                                     int nquads,
-                                     int ncomp,
-                                     Ceed ceed,
-                                     CeedElemRestriction *restr);
+void InitStridedRestriction(const mfem::FiniteElementSpace &fes,
+                            CeedInt nelem,
+                            CeedInt nqpts,
+                            CeedInt qdatasize,
+                            const CeedInt *strides,
+                            Ceed ceed,
+                            CeedElemRestriction *restr);
 
 #endif
 

--- a/fem/ceed/interface/util.hpp
+++ b/fem/ceed/interface/util.hpp
@@ -80,7 +80,7 @@ void InitBasisAndRestriction(const FiniteElementSpace &fes,
 
 int CeedOperatorGetActiveField(CeedOperator oper, CeedOperatorField *field);
 
-/// Return the path to the libCEED q-function headers.
+/// Return the path to the libCEED QFunction headers.
 const std::string &GetCeedPath();
 
 /// Wrapper for std::hash.

--- a/fem/ceed/interface/util.hpp
+++ b/fem/ceed/interface/util.hpp
@@ -118,11 +118,9 @@ struct BasisHash
 };
 using BasisMap = std::unordered_map<const BasisKey, CeedBasis, BasisHash>;
 
-enum restr_type {Standard, Strided};
-
 // Hash table for CeedElemRestriction
 using RestrKey =
-   std::tuple<const mfem::FiniteElementSpace *, int, int, int, int>;
+   std::tuple<const mfem::FiniteElementSpace *, int, int, int, int, int, int>;
 struct RestrHash
 {
    std::size_t operator()(const RestrKey &k) const
@@ -134,7 +132,10 @@ struct RestrHash
                       CeedHash(std::get<1>(k))),
                    CeedHashCombine(CeedHash(std::get<2>(k)),
                                    CeedHash(std::get<3>(k)))),
-                CeedHash(std::get<4>(k)));
+                CeedHashCombine(
+                   CeedHashCombine(CeedHash(std::get<4>(k)),
+                                   CeedHash(std::get<5>(k))),
+                   CeedHash(std::get<6>(k))));
    }
 };
 using RestrMap =

--- a/fem/ceed/solvers/algebraic.cpp
+++ b/fem/ceed/solvers/algebraic.cpp
@@ -638,7 +638,7 @@ AlgebraicSpaceHierarchy::AlgebraicSpaceHierarchy(FiniteElementSpace &fes)
    current_order = order;
 
    Ceed ceed = internal::ceed;
-   InitRestriction(fes, ceed, &fine_er);
+   InitRestriction(fes, false, ceed, &fine_er);
    CeedElemRestriction er = fine_er;
 
    int dim = fes.GetMesh()->Dimension();

--- a/fem/ceed/solvers/algebraic.hpp
+++ b/fem/ceed/solvers/algebraic.hpp
@@ -12,9 +12,9 @@
 #ifndef MFEM_CEED_ALGEBRAIC_HPP
 #define MFEM_CEED_ALGEBRAIC_HPP
 
+#include "../../../linalg/sparsemat.hpp"
 #include "../../fespacehierarchy.hpp"
 #include "../../multigrid.hpp"
-#include "../interface/operator.hpp"
 #include "../interface/ceed.hpp"
 
 namespace mfem
@@ -191,7 +191,7 @@ private:
 #endif
 
 public:
-   /** @brief Constructs algebraic multigrid hierarchy and solver.
+   /** @brief Constructs algebraic multigrid hierarchy and solver
 
        This only works if the Ceed device backend is enabled.
 
@@ -203,6 +203,17 @@ public:
    void Mult(const Vector& x, Vector& y) const;
    void SetOperator(const mfem::Operator& op);
 };
+
+#ifdef MFEM_USE_CEED
+/** @brief Assemble the CeedOperators from a BilinearForm as an
+    mfem::SparseMatrix
+
+    In parallel, this assembles independently on each processor, that is, it
+    assembles at the L-vector level. The assembly procedure is always performed
+    on the host, but this works also for operators stored on device by copying
+    memory. */
+SparseMatrix *CeedOperatorFullAssemble(BilinearForm &form);
+#endif
 
 } // namespace ceed
 

--- a/fem/ceed/solvers/algebraic.hpp
+++ b/fem/ceed/solvers/algebraic.hpp
@@ -33,12 +33,13 @@ class AlgebraicCoarseSpace : public FiniteElementSpace
 public:
    AlgebraicCoarseSpace(FiniteElementSpace &fine_fes, CeedElemRestriction fine_er,
                         int order, int dim, int order_reduction_);
+   ~AlgebraicCoarseSpace();
+
    int GetOrderReduction() const { return order_reduction; }
    CeedElemRestriction GetCeedElemRestriction() const { return ceed_elem_restriction; }
    CeedBasis GetCeedCoarseToFine() const { return coarse_to_fine; }
    virtual const mfem::Operator *GetProlongationMatrix() const override { return NULL; }
    virtual const SparseMatrix *GetRestrictionMatrix() const override { return NULL; }
-   ~AlgebraicCoarseSpace();
 
 protected:
    int *dof_map;
@@ -64,11 +65,12 @@ public:
       int order_reduction_,
       GroupCommunicator *gc_fine
    );
+   ~ParAlgebraicCoarseSpace();
+
    virtual const mfem::Operator *GetProlongationMatrix() const override { return P; }
    virtual const SparseMatrix *GetRestrictionMatrix() const override { return R_mat; }
    GroupCommunicator *GetGroupCommunicator() const { return gc; }
    HypreParMatrix *GetProlongationHypreParMatrix();
-   ~ParAlgebraicCoarseSpace();
 
 private:
    SparseMatrix *R_mat;
@@ -92,14 +94,11 @@ public:
       Ceed ceed, CeedBasis basisctof,
       CeedElemRestriction erestrictu_coarse,
       CeedElemRestriction erestrictu_fine);
-
    ~AlgebraicInterpolation();
 
    virtual void Mult(const mfem::Vector& x, mfem::Vector& y) const;
-
    virtual void MultTranspose(const mfem::Vector& x, mfem::Vector& y) const;
 
-   using mfem::Operator::SetupRAP;
 private:
    int Initialize(Ceed ceed, CeedBasis basisctof,
                   CeedElemRestriction erestrictu_coarse,
@@ -127,11 +126,6 @@ public:
        The given space is a real (geometric) space, but the coarse spaces are
        constructed semi-algebraically with no mesh information. */
    AlgebraicSpaceHierarchy(FiniteElementSpace &fespace);
-   AlgebraicCoarseSpace& GetAlgebraicCoarseSpace(int level)
-   {
-      MFEM_ASSERT(level < GetNumLevels() - 1, "");
-      return static_cast<AlgebraicCoarseSpace&>(*fespaces[level]);
-   }
    ~AlgebraicSpaceHierarchy()
    {
       for (int i=0; i<R_tr.Size(); ++i)
@@ -142,6 +136,12 @@ public:
       {
          delete ceed_interpolations[i];
       }
+   }
+
+   AlgebraicCoarseSpace& GetAlgebraicCoarseSpace(int level)
+   {
+      MFEM_ASSERT(level < GetNumLevels() - 1, "");
+      return static_cast<AlgebraicCoarseSpace&>(*fespaces[level]);
    }
 
 private:
@@ -168,8 +168,9 @@ public:
       BilinearForm &form,
       const Array<int> &ess_tdofs
    );
-   virtual void SetOperator(const mfem::Operator &op) override { }
    ~AlgebraicMultigrid();
+
+   virtual void SetOperator(const mfem::Operator &op) override {}
 
 private:
    OperatorHandle fine_operator;
@@ -200,6 +201,7 @@ public:
     */
    AlgebraicSolver(BilinearForm &form, const Array<int>& ess_tdofs);
    ~AlgebraicSolver();
+
    void Mult(const Vector& x, Vector& y) const;
    void SetOperator(const mfem::Operator& op);
 };

--- a/fem/ceed/solvers/full-assembly.cpp
+++ b/fem/ceed/solvers/full-assembly.cpp
@@ -11,9 +11,9 @@
 
 #include "full-assembly.hpp"
 
-#include "../../../linalg/sparsemat.hpp"
-#include "../interface/util.hpp"
-#include "../interface/ceed.hpp"
+#ifdef MFEM_USE_CEED
+#include <ceed/backend.h>
+#endif
 
 #ifdef MFEM_USE_CEED
 
@@ -23,7 +23,7 @@ namespace mfem
 namespace ceed
 {
 
-int CeedHackReallocArray(size_t n, size_t unit, void *p)
+int CeedInternalReallocArray(size_t n, size_t unit, void *p)
 {
    *(void **)p = realloc(*(void **)p, n*unit);
    if (n && unit && !*(void **)p)
@@ -32,16 +32,16 @@ int CeedHackReallocArray(size_t n, size_t unit, void *p)
    return 0;
 }
 
-#define CeedHackRealloc(n, p) CeedHackReallocArray((n), sizeof(**(p)), p)
+#define CeedInternalRealloc(n, p) CeedInternalReallocArray((n), sizeof(**(p)), p)
 
-int CeedHackFree(void *p)
+int CeedInternalFree(void *p)
 {
    free(*(void **)p);
    *(void **)p = NULL;
    return 0;
 }
 
-int CeedSingleOperatorFullAssemble(CeedOperator op, SparseMatrix *out)
+int CeedSingleOperatorFullAssemble(CeedOperator op, SparseMatrix &out)
 {
    int ierr;
    Ceed ceed;
@@ -50,128 +50,99 @@ int CeedSingleOperatorFullAssemble(CeedOperator op, SparseMatrix *out)
    // Assemble QFunction
    CeedQFunction qf;
    ierr = CeedOperatorGetQFunction(op, &qf); CeedChk(ierr);
-   CeedInt numinputfields, numoutputfields;
-   CeedChk(ierr);
-   CeedVector assembledqf;
+   CeedInt num_input_fields, num_output_fields; CeedChk(ierr);
+   CeedVector assembled_qf;
    CeedElemRestriction rstr_q;
-   ierr = CeedOperatorLinearAssembleQFunction(
-             op, &assembledqf, &rstr_q, CEED_REQUEST_IMMEDIATE); CeedChk(ierr);
+   ierr = CeedOperatorLinearAssembleQFunction(op, &assembled_qf, &rstr_q,
+                                              CEED_REQUEST_IMMEDIATE); CeedChk(ierr);
 
-   CeedSize qflength;
-   ierr = CeedVectorGetLength(assembledqf, &qflength); CeedChk(ierr);
+   CeedSize qf_length;
+   ierr = CeedVectorGetLength(assembled_qf, &qf_length); CeedChk(ierr);
 
    CeedOperatorField *input_fields;
    CeedOperatorField *output_fields;
-   ierr = CeedOperatorGetFields(op, &numinputfields, &input_fields,
-                                &numoutputfields, &output_fields);
-   CeedChk(ierr);
+   ierr = CeedOperatorGetFields(op, &num_input_fields, &input_fields,
+                                &num_output_fields, &output_fields); CeedChk(ierr);
 
    // Determine active input basis
-   CeedQFunctionField *qffields;
-   ierr = CeedQFunctionGetFields(qf, &numinputfields, &qffields,
-                                 &numoutputfields, NULL);
-   CeedChk(ierr);
-   CeedInt numemodein = 0, ncomp, dim = 1;
-   CeedEvalMode *emodein = NULL;
-   CeedBasis basisin = NULL;
-   CeedElemRestriction rstrin = NULL;
-   for (CeedInt i=0; i<numinputfields; i++)
+   CeedQFunctionField *qf_fields;
+   ierr = CeedQFunctionGetFields(qf, &num_input_fields, &qf_fields,
+                                 &num_output_fields, NULL); CeedChk(ierr);
+   CeedInt num_emode_in = 0, dim, ncomp, qcomp;
+   CeedEvalMode *emode_in = NULL;
+   CeedBasis basis_in = NULL;
+   CeedElemRestriction rstr_in = NULL;
+   for (CeedInt i = 0; i < num_input_fields; i++)
    {
       CeedVector vec;
       ierr = CeedOperatorFieldGetVector(input_fields[i], &vec); CeedChk(ierr);
       if (vec == CEED_VECTOR_ACTIVE)
       {
-         ierr = CeedOperatorFieldGetBasis(input_fields[i], &basisin);
-         CeedChk(ierr);
-         ierr = CeedBasisGetNumComponents(basisin, &ncomp); CeedChk(ierr);
-         ierr = CeedBasisGetDimension(basisin, &dim); CeedChk(ierr);
-         ierr = CeedOperatorFieldGetElemRestriction(input_fields[i], &rstrin);
-         CeedChk(ierr);
          CeedEvalMode emode;
-         ierr = CeedQFunctionFieldGetEvalMode(qffields[i], &emode);
+         ierr = CeedQFunctionFieldGetEvalMode(qf_fields[i], &emode); CeedChk(ierr);
+         ierr = CeedOperatorFieldGetBasis(input_fields[i], &basis_in); CeedChk(ierr);
+         ierr = CeedOperatorFieldGetElemRestriction(input_fields[i], &rstr_in);
          CeedChk(ierr);
-         switch (emode)
+         ierr = CeedBasisGetDimension(basis_in, &dim); CeedChk(ierr);
+         ierr = CeedBasisGetNumComponents(basis_in, &ncomp); CeedChk(ierr);
+         ierr = CeedBasisGetNumQuadratureComponents(basis_in, emode, &qcomp);
+         CeedChk(ierr);
+         if (emode != CEED_EVAL_WEIGHT)
          {
-            case CEED_EVAL_NONE:
-            case CEED_EVAL_INTERP:
-               ierr = CeedHackRealloc(numemodein + 1, &emodein); CeedChk(ierr);
-               emodein[numemodein] = emode;
-               numemodein += 1;
-               break;
-            case CEED_EVAL_GRAD:
-               ierr = CeedHackRealloc(numemodein + dim, &emodein); CeedChk(ierr);
-               for (CeedInt d=0; d<dim; d++)
-               {
-                  emodein[numemodein+d] = emode;
-               }
-               numemodein += dim;
-               break;
-            case CEED_EVAL_WEIGHT:
-            case CEED_EVAL_DIV:
-            case CEED_EVAL_CURL:
-               break; // Caught by QF Assembly
+            ierr = CeedInternalRealloc(num_emode_in + qcomp, &emode_in); CeedChk(ierr);
+            for (CeedInt d = 0; d < qcomp; d++)
+            {
+               emode_in[num_emode_in + d] = emode;
+            }
+            num_emode_in += qcomp;
          }
       }
    }
 
    // Determine active output basis
-   ierr = CeedQFunctionGetFields(qf, &numinputfields, NULL, &numoutputfields,
-                                 &qffields); CeedChk(ierr);
-   CeedInt numemodeout = 0;
-   CeedEvalMode *emodeout = NULL;
-   CeedBasis basisout = NULL;
-   CeedElemRestriction rstrout = NULL;
-   for (CeedInt i=0; i<numoutputfields; i++)
+   ierr = CeedQFunctionGetFields(qf, &num_input_fields, NULL, &num_output_fields,
+                                 &qf_fields); CeedChk(ierr);
+   CeedInt num_emode_out = 0;
+   CeedEvalMode *emode_out = NULL;
+   CeedBasis basis_out = NULL;
+   CeedElemRestriction rstr_out = NULL;
+   for (CeedInt i = 0; i < num_output_fields; i++)
    {
       CeedVector vec;
       ierr = CeedOperatorFieldGetVector(output_fields[i], &vec); CeedChk(ierr);
       if (vec == CEED_VECTOR_ACTIVE)
       {
-         ierr = CeedOperatorFieldGetBasis(output_fields[i], &basisout);
-         CeedChk(ierr);
-         ierr = CeedOperatorFieldGetElemRestriction(output_fields[i], &rstrout);
-         CeedChk(ierr);
-         CeedChk(ierr);
          CeedEvalMode emode;
-         ierr = CeedQFunctionFieldGetEvalMode(qffields[i], &emode);
+         ierr = CeedQFunctionFieldGetEvalMode(qf_fields[i], &emode); CeedChk(ierr);
+         ierr = CeedOperatorFieldGetBasis(output_fields[i], &basis_out); CeedChk(ierr);
+         ierr = CeedOperatorFieldGetElemRestriction(output_fields[i], &rstr_out);
          CeedChk(ierr);
-         switch (emode)
+         ierr = CeedBasisGetNumQuadratureComponents(basis_out, emode, &qcomp);
+         CeedChk(ierr);
+         if (emode != CEED_EVAL_WEIGHT)
          {
-            case CEED_EVAL_NONE:
-            case CEED_EVAL_INTERP:
-               ierr = CeedHackRealloc(numemodeout + 1, &emodeout); CeedChk(ierr);
-               emodeout[numemodeout] = emode;
-               numemodeout += 1;
-               break;
-            case CEED_EVAL_GRAD:
-               ierr = CeedHackRealloc(numemodeout + dim, &emodeout); CeedChk(ierr);
-               for (CeedInt d=0; d<dim; d++)
-               {
-                  emodeout[numemodeout+d] = emode;
-               }
-               numemodeout += dim;
-               break;
-            case CEED_EVAL_WEIGHT:
-            case CEED_EVAL_DIV:
-            case CEED_EVAL_CURL:
-               break; // Caught by QF Assembly
+            ierr = CeedInternalRealloc(num_emode_out + qcomp, &emode_out); CeedChk(ierr);
+            for (CeedInt d = 0; d < qcomp; d++)
+            {
+               emode_out[num_emode_out + d] = emode;
+            }
+            num_emode_out += qcomp;
          }
       }
    }
 
    CeedInt nelem, elemsize, nqpts;
    CeedSize nnodes;
-   ierr = CeedElemRestrictionGetNumElements(rstrin, &nelem); CeedChk(ierr);
-   ierr = CeedElemRestrictionGetElementSize(rstrin, &elemsize); CeedChk(ierr);
-   ierr = CeedElemRestrictionGetLVectorSize(rstrin, &nnodes); CeedChk(ierr);
-   ierr = CeedBasisGetNumQuadraturePoints(basisin, &nqpts); CeedChk(ierr);
+   ierr = CeedElemRestrictionGetNumElements(rstr_in, &nelem); CeedChk(ierr);
+   ierr = CeedElemRestrictionGetElementSize(rstr_in, &elemsize); CeedChk(ierr);
+   ierr = CeedElemRestrictionGetLVectorSize(rstr_in, &nnodes); CeedChk(ierr);
+   ierr = CeedBasisGetNumQuadraturePoints(basis_in, &nqpts); CeedChk(ierr);
 
    // Determine elem_dof relation
    CeedVector index_vec;
    ierr = CeedVectorCreate(ceed, nnodes, &index_vec); CeedChk(ierr);
    CeedScalar *array;
-   ierr = CeedVectorGetArrayWrite(index_vec, CEED_MEM_HOST, &array);
-   CeedChk(ierr);
+   ierr = CeedVectorGetArrayWrite(index_vec, CEED_MEM_HOST, &array); CeedChk(ierr);
    for (CeedSize i = 0; i < nnodes; ++i)
    {
       array[i] = i;
@@ -180,113 +151,131 @@ int CeedSingleOperatorFullAssemble(CeedOperator op, SparseMatrix *out)
    CeedVector elem_dof;
    ierr = CeedVectorCreate(ceed, nelem * elemsize, &elem_dof); CeedChk(ierr);
    ierr = CeedVectorSetValue(elem_dof, 0.0); CeedChk(ierr);
-   CeedElemRestrictionApply(rstrin, CEED_NOTRANSPOSE, index_vec,
+   CeedElemRestrictionApply(rstr_in, CEED_NOTRANSPOSE, index_vec,
                             elem_dof, CEED_REQUEST_IMMEDIATE); CeedChk(ierr);
-   const CeedScalar * elem_dof_a;
+   const CeedScalar *elem_dof_a;
    ierr = CeedVectorGetArrayRead(elem_dof, CEED_MEM_HOST, &elem_dof_a);
    CeedChk(ierr);
    ierr = CeedVectorDestroy(&index_vec); CeedChk(ierr);
 
    // loop over elements and put in SparseMatrix
-   // SparseMatrix * out = new SparseMatrix(nnodes, nnodes);
-   MFEM_ASSERT(out->Height() == nnodes, "Sizes don't match!");
-   MFEM_ASSERT(out->Width() == nnodes, "Sizes don't match!");
-   const CeedScalar *interpin, *gradin;
-   ierr = CeedBasisGetInterp(basisin, &interpin); CeedChk(ierr);
-   ierr = CeedBasisGetGrad(basisin, &gradin); CeedChk(ierr);
+   MFEM_ASSERT(out.Height() == nnodes, "Sizes don't match!");
+   MFEM_ASSERT(out.Width() == nnodes, "Sizes don't match!");
 
-   const CeedScalar * assembledqfarray;
-   ierr = CeedVectorGetArrayRead(assembledqf, CEED_MEM_HOST, &assembledqfarray);
+   const CeedScalar *assembled_qf_array;
+   ierr = CeedVectorGetArrayRead(assembled_qf, CEED_MEM_HOST, &assembled_qf_array);
    CeedChk(ierr);
 
    CeedInt layout[3];
    ierr = CeedElemRestrictionGetELayout(rstr_q, &layout); CeedChk(ierr);
    ierr = CeedElemRestrictionDestroy(&rstr_q); CeedChk(ierr);
 
-   // enforce structurally symmetric for later elimination
+   // Enforce structurally symmetric for later elimination
    const int skip_zeros = 0;
-   MFEM_ASSERT(numemodein == numemodeout,
+   MFEM_ASSERT(num_emode_in == num_emode_out,
                "Ceed full assembly not implemented for this case.");
    for (int e = 0; e < nelem; ++e)
    {
-      // get Array<int> for use in SparseMatrix::AddSubMatrix()
+      // Get Array<int> for use in SparseMatrix::AddSubMatrix()
       Array<int> rows(elemsize);
       for (int i = 0; i < elemsize; ++i)
       {
          rows[i] = elem_dof_a[e * elemsize + i];
       }
 
-      // form element matrix itself
-      DenseMatrix Bmat(nqpts * numemodein, elemsize);
-      Bmat = 0.0;
-      // Store block-diagonal D matrix as collection of small dense blocks
-      DenseTensor Dmat(numemodeout, numemodein, nqpts);
+      // Form element matrix itself, storing block-diagonal D matrix as a
+      // collection of small dense blocks
+      DenseTensor Dmat(num_emode_out, num_emode_in, nqpts);
       Dmat = 0.0;
-      DenseMatrix elem_mat(elemsize, elemsize);
-      elem_mat = 0.0;
+      DenseMatrix Bmat(nqpts * num_emode_in, elemsize);
+      Bmat = 0.0;
       for (int q = 0; q < nqpts; ++q)
       {
          for (int n = 0; n < elemsize; ++n)
          {
-            CeedInt din = -1;
-            for (int ein = 0; ein < numemodein; ++ein)
+            CeedInt d_in = 0;
+            CeedEvalMode emode_prev = CEED_EVAL_NONE;
+            for (int e_in = 0; e_in < num_emode_in; ++e_in)
             {
-               if (emodein[ein] == CEED_EVAL_INTERP)
+               const CeedScalar *B;
+               switch (emode_in[e_in])
                {
-                  Bmat(numemodein * q + ein, n) += interpin[q * elemsize + n];
+                  case CEED_EVAL_INTERP:
+                     ierr = CeedBasisGetInterp(basis_in, &B); CeedChk(ierr);
+                     break;
+                  case CEED_EVAL_GRAD:
+                     ierr = CeedBasisGetGrad(basis_in, &B); CeedChk(ierr);
+                     break;
+                  case CEED_EVAL_DIV:
+                     ierr = CeedBasisGetDiv(basis_in, &B); CeedChk(ierr);
+                     break;
+                  case CEED_EVAL_CURL:
+                     ierr = CeedBasisGetCurl(basis_in, &B); CeedChk(ierr);
+                     break;
+                  case CEED_EVAL_NONE:
+                  default:
+                     MFEM_ABORT("CeedEvalMode is not implemented.");
                }
-               else if (emodein[ein] == CEED_EVAL_GRAD)
+               ierr = CeedBasisGetNumQuadratureComponents(basis_in, emode_in[e_in], &qcomp);
+               CeedChk(ierr);
+               if (qcomp > 1)
                {
-                  din += 1;
-                  Bmat(numemodein * q + ein, n) += gradin[(din*nqpts+q) * elemsize + n];
+                  if (e_in == 0 || emode_in[e_in] != emode_prev)
+                  {
+                     d_in = 0;
+                  }
+                  else
+                  {
+                     d_in++;
+                  }
                }
-               else
-               {
-                  MFEM_ASSERT(false, "Not implemented!");
-               }
+               Bmat(num_emode_in * q + e_in, n) += B[(d_in * nqpts + q) * elemsize + n];
+               emode_prev = emode_in[e_in];
             }
          }
-         for (int ei = 0; ei < numemodein; ++ei)
+         for (int ei = 0; ei < num_emode_in; ++ei)
          {
-            for (int ej = 0; ej < numemodein; ++ej)
+            for (int ej = 0; ej < num_emode_in; ++ej)
             {
-               const int comp = ei * numemodein + ej;
-               const int index = q*layout[0] + comp*layout[1] + e*layout[2];
-               Dmat(ei, ej, q) += assembledqfarray[index];
+               const int comp = ei * num_emode_in + ej;
+               const int index = q * layout[0] + comp * layout[1] + e * layout[2];
+               Dmat(ei, ej, q) += assembled_qf_array[index];
             }
          }
       }
-      DenseMatrix BTD(elemsize, nqpts*numemodein);
-      // Compute B^T*D
-      BTD = 0.0;
-      for (int j=0; j<elemsize; ++j)
+
+      // Compute B^T * D
+      DenseMatrix BtD(elemsize, nqpts * num_emode_in);
+      BtD = 0.0;
+      for (int j = 0; j < elemsize; ++j)
       {
-         for (int q=0; q<nqpts; ++q)
+         for (int q = 0; q < nqpts; ++q)
          {
-            int qq = numemodein*q;
-            for (int ei = 0; ei < numemodein; ++ei)
+            int qq = num_emode_in * q;
+            for (int ei = 0; ei < num_emode_in; ++ei)
             {
-               for (int ej = 0; ej < numemodein; ++ej)
+               for (int ej = 0; ej < num_emode_in; ++ej)
                {
-                  BTD(j,qq+ei) += Bmat(qq+ej,j)*Dmat(ej,ei,q);
+                  BtD(j, qq + ei) += Bmat(qq + ej, j) * Dmat(ej, ei, q);
                }
             }
          }
       }
 
-      Mult(BTD, Bmat, elem_mat);
-
-      // put element matrix in sparsemat
-      out->AddSubMatrix(rows, rows, elem_mat, skip_zeros);
+      // Put element matrix in sparsemat
+      DenseMatrix elem_mat(elemsize, elemsize);
+      elem_mat = 0.0;
+      Mult(BtD, Bmat, elem_mat);
+      out.AddSubMatrix(rows, rows, elem_mat, skip_zeros);
    }
 
    ierr = CeedVectorRestoreArrayRead(elem_dof, &elem_dof_a); CeedChk(ierr);
    ierr = CeedVectorDestroy(&elem_dof); CeedChk(ierr);
-   ierr = CeedVectorRestoreArrayRead(assembledqf, &assembledqfarray);
+   ierr = CeedVectorRestoreArrayRead(assembled_qf, &assembled_qf_array);
    CeedChk(ierr);
-   ierr = CeedVectorDestroy(&assembledqf); CeedChk(ierr);
-   ierr = CeedHackFree(&emodein); CeedChk(ierr);
-   ierr = CeedHackFree(&emodeout); CeedChk(ierr);
+   ierr = CeedVectorDestroy(&assembled_qf); CeedChk(ierr);
+   ierr = CeedInternalFree(&emode_in); CeedChk(ierr);
+   ierr = CeedInternalFree(&emode_out); CeedChk(ierr);
 
    return 0;
 }
@@ -296,10 +285,9 @@ int CeedOperatorFullAssemble(CeedOperator op, SparseMatrix **mat)
    int ierr;
 
    CeedSize in_len, out_len;
-   ierr = CeedOperatorGetActiveVectorLengths(op, &in_len, &out_len);
-   CeedChk(ierr);
+   ierr = CeedOperatorGetActiveVectorLengths(op, &in_len, &out_len); CeedChk(ierr);
    const int nnodes = in_len;
-   MFEM_VERIFY(in_len == out_len, "not a square CeedOperator");
+   MFEM_VERIFY(in_len == out_len, "Not a square CeedOperator.");
    MFEM_VERIFY(in_len == nnodes, "size overflow");
 
    SparseMatrix *out = new SparseMatrix(nnodes, nnodes);
@@ -319,14 +307,14 @@ int CeedOperatorFullAssemble(CeedOperator op, SparseMatrix **mat)
 #endif
       for (int i = 0; i < numsub; ++i)
       {
-         ierr = CeedSingleOperatorFullAssemble(subops[i], out); CeedChk(ierr);
+         ierr = CeedSingleOperatorFullAssemble(subops[i], *out); CeedChk(ierr);
       }
    }
    else
    {
-      ierr = CeedSingleOperatorFullAssemble(op, out); CeedChk(ierr);
+      ierr = CeedSingleOperatorFullAssemble(op, *out); CeedChk(ierr);
    }
-   // enforce structurally symmetric for later elimination
+   // Enforce structurally symmetric for later elimination
    const int skip_zeros = 0;
    out->Finalize(skip_zeros);
    *mat = out;

--- a/fem/ceed/solvers/full-assembly.hpp
+++ b/fem/ceed/solvers/full-assembly.hpp
@@ -12,6 +12,7 @@
 #ifndef MFEM_CEED_ASSEMBLE_HPP
 #define MFEM_CEED_ASSEMBLE_HPP
 
+#include "../../../linalg/sparsemat.hpp"
 #include "../interface/ceed.hpp"
 
 #ifdef MFEM_USE_CEED

--- a/fem/ceed/solvers/solvers-atpmg.cpp
+++ b/fem/ceed/solvers/solvers-atpmg.cpp
@@ -11,15 +11,13 @@
 
 #include "solvers-atpmg.hpp"
 
-#include "../interface/ceed.hpp"
+#include <math.h>
 #include "../interface/util.hpp"
-
 #ifdef MFEM_USE_CEED
 #include <ceed/backend.h>
+#endif
 
-#include <math.h>
-// todo: should probably use Ceed memory wrappers instead of calloc/free?
-#include <stdlib.h>
+#ifdef MFEM_USE_CEED
 
 namespace mfem
 {
@@ -96,7 +94,7 @@ int CeedATPMGElemRestriction(int order,
    ierr = CeedElemRestrictionGetNumComponents(er_in, &numcomp); CeedChk(ierr);
    if (numcomp != 1)
    {
-      // todo: multi-component will require more thought
+      // TODO: multi-component will require more thought
       return CeedError(ceed, 1, "Algebraic element restriction not "
                        "implemented for multiple components.");
    }
@@ -538,7 +536,7 @@ int CeedBasisATPMGCoarsen(CeedBasis basisin,
    CeedScalar * fine_nodal_points = new CeedScalar[P1d];
 
    // these things are in [-1, 1], not [0, 1], which matters
-   // (todo: how can we determine this or something related, algebraically?)
+   // (TODO: how can we determine this or something related, algebraically?)
    /* one way you might be able to tell is to just run this algorithm
       with coarse_P1d = 2 (i.e., linear) and look for symmetry in the coarse
       basis matrix? */

--- a/fem/ceed/solvers/solvers-atpmg.hpp
+++ b/fem/ceed/solvers/solvers-atpmg.hpp
@@ -25,7 +25,7 @@ namespace ceed
 /** @brief Take given (high-order) CeedElemRestriction and make a new
     CeedElemRestriction, which corresponds to a lower-order problem.
 
-    Assumes a Gauss-Lobatto basis and tensor product elements, and assumes that
+    Assumes a Gauss-Lobatto basis and tensor-product elements, and assumes that
     the nodes in er_in are ordered in a tensor-product way.
 
     This is a setup routine that operates on the host.

--- a/fem/integ/bilininteg_convection_mf.cpp
+++ b/fem/integ/bilininteg_convection_mf.cpp
@@ -18,28 +18,39 @@ namespace mfem
 
 void ConvectionIntegrator::AssembleMF(const FiniteElementSpace &fes)
 {
-   // Assuming the same element type
    Mesh *mesh = fes.GetMesh();
    if (mesh->GetNE() == 0) { return; }
-   const FiniteElement &el = *fes.GetFE(0);
-   ElementTransformation &Trans = *fes.GetElementTransformation(0);
-   const IntegrationRule *ir = IntRule ? IntRule : &GetRule(el, Trans);
    if (DeviceCanUseCeed())
    {
       delete ceedOp;
-      const bool mixed = mesh->GetNumGeometries(mesh->Dimension()) > 1 ||
-                         fes.IsVariableOrder();
-      if (mixed)
-      {
-         ceedOp = new ceed::MixedMFConvectionIntegrator(*this, fes, Q, alpha);
-      }
-      else
-      {
-         ceedOp = new ceed::MFConvectionIntegrator(fes, *ir, Q, alpha);
-      }
+      ceedOp = new ceed::MFConvectionIntegrator(*this, fes, Q, alpha);
       return;
    }
+
+   // Assuming the same element type
+   // const FiniteElement &el = *fes.GetFE(0);
+   // ElementTransformation &T = *fes.GetElementTransformation(0);
+   // const IntegrationRule *ir = IntRule ? IntRule : &GetRule(el, T);
    MFEM_ABORT("Error: ConvectionIntegrator::AssembleMF only implemented with"
+              " libCEED");
+}
+
+void ConvectionIntegrator::AssembleMFBoundary(const FiniteElementSpace &fes)
+{
+   Mesh *mesh = fes.GetMesh();
+   if (mesh->GetNBE() == 0) { return; }
+   if (DeviceCanUseCeed())
+   {
+      delete ceedOp;
+      ceedOp = new ceed::MFConvectionIntegrator(*this, fes, Q, alpha, true);
+      return;
+   }
+
+   // Assuming the same element type
+   // const FiniteElement &el = *fes.GetBE(0);
+   // ElementTransformation &T = *fes.GetBdrElementTransformation(0);
+   // const IntegrationRule *ir = IntRule ? IntRule : &GetRule(el, T);
+   MFEM_ABORT("Error: ConvectionIntegrator::AssembleMFBoundary only implemented with"
               " libCEED");
 }
 

--- a/fem/integ/bilininteg_convection_pa.cpp
+++ b/fem/integ/bilininteg_convection_pa.cpp
@@ -116,26 +116,19 @@ void ConvectionIntegrator::AssemblePA(const FiniteElementSpace &fes)
 {
    const MemoryType mt = (pa_mt == MemoryType::DEFAULT) ?
                          Device::GetDeviceMemoryType() : pa_mt;
-   // Assumes tensor-product elements
    Mesh *mesh = fes.GetMesh();
-   const FiniteElement &el = *fes.GetFE(0);
-   ElementTransformation &T = *fes.GetElementTransformation(0);
-   const IntegrationRule *ir = IntRule ? IntRule : &GetRule(el, T);
+   if (mesh->GetNE() == 0) { return; }
    if (DeviceCanUseCeed())
    {
       delete ceedOp;
-      const bool mixed = mesh->GetNumGeometries(mesh->Dimension()) > 1 ||
-                         fes.IsVariableOrder();
-      if (mixed)
-      {
-         ceedOp = new ceed::MixedPAConvectionIntegrator(*this, fes, Q, alpha);
-      }
-      else
-      {
-         ceedOp = new ceed::PAConvectionIntegrator(fes, *ir, Q, alpha);
-      }
+      ceedOp = new ceed::PAConvectionIntegrator(*this, fes, Q, alpha);
       return;
    }
+
+   // Assumes tensor-product elements
+   const FiniteElement &el = *fes.GetFE(0);
+   ElementTransformation &T = *fes.GetElementTransformation(0);
+   const IntegrationRule *ir = IntRule ? IntRule : &GetRule(el, T);
    const int dims = el.GetDim();
    const int symmDims = dims;
    nq = ir->GetNPoints();
@@ -164,6 +157,25 @@ void ConvectionIntegrator::AssemblePA(const FiniteElementSpace &fes)
       PAConvectionSetup3D(nq, ne, ir->GetWeights(), geom->J,
                           vel, alpha, pa_data);
    }
+}
+
+void ConvectionIntegrator::AssemblePABoundary(const FiniteElementSpace &fes)
+{
+   Mesh *mesh = fes.GetMesh();
+   if (mesh->GetNBE() == 0) { return; }
+   if (DeviceCanUseCeed())
+   {
+      delete ceedOp;
+      ceedOp = new ceed::PAConvectionIntegrator(*this, fes, Q, alpha, true);
+      return;
+   }
+
+   // Assuming the same element type
+   // const FiniteElement &el = *fes.GetBE(0);
+   // ElementTransformation &T = *fes.GetBdrElementTransformation(0);
+   // const IntegrationRule *ir = IntRule ? IntRule : &GetRule(el, T);
+   MFEM_ABORT("Error: ConvectionIntegrator::AssemblePABoundary only implemented with"
+              " libCEED");
 }
 
 void ConvectionIntegrator::AssembleDiagonalPA(Vector &diag)

--- a/fem/integ/bilininteg_diffusion_mf.cpp
+++ b/fem/integ/bilininteg_diffusion_mf.cpp
@@ -18,31 +18,43 @@ namespace mfem
 
 void DiffusionIntegrator::AssembleMF(const FiniteElementSpace &fes)
 {
-   // Assuming the same element type
    Mesh *mesh = fes.GetMesh();
    if (mesh->GetNE() == 0) { return; }
-   const FiniteElement &el = *fes.GetFE(0);
-   ElementTransformation &T = *mesh->GetElementTransformation(0);
-   const IntegrationRule *ir = IntRule ? IntRule : &GetRule(el, T);
    if (DeviceCanUseCeed())
    {
       delete ceedOp;
-      MFEM_VERIFY(!VQ && !MQ,
-                  "Only scalar coefficient supported for DiffusionIntegrator"
-                  " with libCEED");
-      const bool mixed = mesh->GetNumGeometries(mesh->Dimension()) > 1 ||
-                         fes.IsVariableOrder();
-      if (mixed)
-      {
-         ceedOp = new ceed::MixedMFDiffusionIntegrator(*this, fes, Q);
-      }
-      else
-      {
-         ceedOp = new ceed::MFDiffusionIntegrator(fes, *ir, Q);
-      }
+      if (MQ) { ceedOp = new ceed::MFDiffusionIntegrator(*this, fes, MQ); }
+      else if (VQ) { ceedOp = new ceed::MFDiffusionIntegrator(*this, fes, VQ); }
+      else { ceedOp = new ceed::MFDiffusionIntegrator(*this, fes, Q); }
       return;
    }
+
+   // Assuming the same element type
+   // const FiniteElement &el = *fes.GetFE(0);
+   // ElementTransformation &T = *mesh->GetElementTransformation(0);
+   // const IntegrationRule *ir = IntRule ? IntRule : &GetRule(el, T);
    MFEM_ABORT("Error: DiffusionIntegrator::AssembleMF only implemented with"
+              " libCEED");
+}
+
+void DiffusionIntegrator::AssembleMFBoundary(const FiniteElementSpace &fes)
+{
+   Mesh *mesh = fes.GetMesh();
+   if (mesh->GetNBE() == 0) { return; }
+   if (DeviceCanUseCeed())
+   {
+      delete ceedOp;
+      if (MQ) { ceedOp = new ceed::MFDiffusionIntegrator(*this, fes, MQ, true); }
+      else if (VQ) { ceedOp = new ceed::MFDiffusionIntegrator(*this, fes, VQ, true); }
+      else { ceedOp = new ceed::MFDiffusionIntegrator(*this, fes, Q, true); }
+      return;
+   }
+
+   // Assuming the same element type
+   // const FiniteElement &el = *fes.GetBE(0);
+   // ElementTransformation &T = *mesh->GetBdrElementTransformation(0);
+   // const IntegrationRule *ir = IntRule ? IntRule : &GetRule(el, T);
+   MFEM_ABORT("Error: DiffusionIntegrator::AssembleMFBoundary only implemented with"
               " libCEED");
 }
 

--- a/fem/integ/bilininteg_mass_mf.cpp
+++ b/fem/integ/bilininteg_mass_mf.cpp
@@ -18,42 +18,40 @@ namespace mfem
 
 void MassIntegrator::AssembleMF(const FiniteElementSpace &fes)
 {
-   // Assuming the same element type
    Mesh *mesh = fes.GetMesh();
    if (mesh->GetNE() == 0) { return; }
-   const FiniteElement &el = *fes.GetFE(0);
-   ElementTransformation &T = *mesh->GetElementTransformation(0);
-   const IntegrationRule *ir = IntRule ? IntRule : &GetRule(el, T);
    if (DeviceCanUseCeed())
    {
       delete ceedOp;
-      const bool mixed = mesh->GetNumGeometries(mesh->Dimension()) > 1 ||
-                         fes.IsVariableOrder();
-      if (mixed)
-      {
-         ceedOp = new ceed::MixedMFMassIntegrator(*this, fes, Q);
-      }
-      else
-      {
-         ceedOp = new ceed::MFMassIntegrator(fes, *ir, Q);
-      }
+      ceedOp = new ceed::MFMassIntegrator(*this, fes, Q);
       return;
    }
+
+   // Assuming the same element type
+   // const FiniteElement &el = *fes.GetFE(0);
+   // ElementTransformation &T = *mesh->GetElementTransformation(0);
+   // const IntegrationRule *ir = IntRule ? IntRule : &GetRule(el, T);
    MFEM_ABORT("Error: MassIntegrator::AssembleMF only implemented with"
               " libCEED");
 }
 
-void MassIntegrator::AddMultMF(const Vector &x, Vector &y) const
+void MassIntegrator::AssembleMFBoundary(const FiniteElementSpace &fes)
 {
+   Mesh *mesh = fes.GetMesh();
+   if (mesh->GetNBE() == 0) { return; }
    if (DeviceCanUseCeed())
    {
-      ceedOp->AddMult(x, y);
+      delete ceedOp;
+      ceedOp = new ceed::MFMassIntegrator(*this, fes, Q, true);
+      return;
    }
-   else
-   {
-      MFEM_ABORT("Error: MassIntegrator::AddMultMF only implemented with"
-                 " libCEED");
-   }
+
+   // Assuming the same element type
+   // const FiniteElement &el = *fes.GetBE(0);
+   // ElementTransformation &T = *mesh->GetBdrElementTransformation(0);
+   // const IntegrationRule *ir = IntRule ? IntRule : &GetRule(el, T);
+   MFEM_ABORT("Error: MassIntegrator::AssembleMFBoundary only implemented with"
+              " libCEED");
 }
 
 void MassIntegrator::AssembleDiagonalMF(Vector &diag)
@@ -66,6 +64,19 @@ void MassIntegrator::AssembleDiagonalMF(Vector &diag)
    {
       MFEM_ABORT("Error: MassIntegrator::AssembleDiagonalMF only implemented"
                  " with libCEED");
+   }
+}
+
+void MassIntegrator::AddMultMF(const Vector &x, Vector &y) const
+{
+   if (DeviceCanUseCeed())
+   {
+      ceedOp->AddMult(x, y);
+   }
+   else
+   {
+      MFEM_ABORT("Error: MassIntegrator::AddMultMF only implemented with"
+                 " libCEED");
    }
 }
 

--- a/fem/integ/bilininteg_mass_pa.cpp
+++ b/fem/integ/bilininteg_mass_pa.cpp
@@ -23,28 +23,19 @@ void MassIntegrator::AssemblePA(const FiniteElementSpace &fes)
 {
    const MemoryType mt = (pa_mt == MemoryType::DEFAULT) ?
                          Device::GetDeviceMemoryType() : pa_mt;
-
-   // Assuming the same element type
    Mesh *mesh = fes.GetMesh();
    if (mesh->GetNE() == 0) { return; }
-   const FiniteElement &el = *fes.GetFE(0);
-   ElementTransformation &T =* mesh->GetElementTransformation(0);
-   const IntegrationRule *ir = IntRule ? IntRule : &GetRule(el, T);
    if (DeviceCanUseCeed())
    {
       delete ceedOp;
-      const bool mixed = mesh->GetNumGeometries(mesh->Dimension()) > 1 ||
-                         fes.IsVariableOrder();
-      if (mixed)
-      {
-         ceedOp = new ceed::MixedPAMassIntegrator(*this, fes, Q);
-      }
-      else
-      {
-         ceedOp = new ceed::PAMassIntegrator(fes, *ir, Q);
-      }
+      ceedOp = new ceed::PAMassIntegrator(*this, fes, Q);
       return;
    }
+
+   // Assuming the same element type
+   const FiniteElement &el = *fes.GetFE(0);
+   ElementTransformation &T =* mesh->GetElementTransformation(0);
+   const IntegrationRule *ir = IntRule ? IntRule : &GetRule(el, T);
    int map_type = el.GetMapType();
    dim = mesh->Dimension();
    ne = fes.GetMesh()->GetNE();
@@ -116,10 +107,16 @@ void MassIntegrator::AssemblePABoundary(const FiniteElementSpace &fes)
 {
    const MemoryType mt = (pa_mt == MemoryType::DEFAULT) ?
                          Device::GetDeviceMemoryType() : pa_mt;
-
-   // Assuming the same element type
    Mesh *mesh = fes.GetMesh();
    if (mesh->GetNBE() == 0) { return; }
+   if (DeviceCanUseCeed())
+   {
+      delete ceedOp;
+      ceedOp = new ceed::PAMassIntegrator(*this, fes, Q, true);
+      return;
+   }
+
+   // Assuming the same element type
    const FiniteElement &el = *fes.GetBE(0);
    ElementTransformation *T0 = mesh->GetBdrElementTransformation(0);
    const IntegrationRule *ir = IntRule ? IntRule : &GetRule(el, *T0);

--- a/fem/integ/bilininteg_vecdiffusion_mf.cpp
+++ b/fem/integ/bilininteg_vecdiffusion_mf.cpp
@@ -22,10 +22,10 @@ void VectorDiffusionIntegrator::AssembleMF(const FiniteElementSpace &fes)
    if (mesh->GetNE() == 0) { return; }
    if (DeviceCanUseCeed())
    {
+      MFEM_VERIFY(!VQ && !MQ,
+                  "Only scalar coefficient is supported for matrix-free assembly for VectorDiffusionIntegrator");
       delete ceedOp;
-      if (MQ) { ceedOp = new ceed::MFDiffusionIntegrator(*this, fes, MQ); }
-      else if (VQ) { ceedOp = new ceed::MFDiffusionIntegrator(*this, fes, VQ); }
-      else { ceedOp = new ceed::MFDiffusionIntegrator(*this, fes, Q); }
+      ceedOp = new ceed::MFDiffusionIntegrator(*this, fes, Q);
       return;
    }
 
@@ -44,10 +44,10 @@ void VectorDiffusionIntegrator::AssembleMFBoundary(
    if (mesh->GetNBE() == 0) { return; }
    if (DeviceCanUseCeed())
    {
+      MFEM_VERIFY(!VQ && !MQ,
+                  "Only scalar coefficient is supported for matrix-free assembly for VectorDiffusionIntegrator");
       delete ceedOp;
-      if (MQ) { ceedOp = new ceed::MFDiffusionIntegrator(*this, fes, MQ, true); }
-      else if (VQ) { ceedOp = new ceed::MFDiffusionIntegrator(*this, fes, VQ, true); }
-      else { ceedOp = new ceed::MFDiffusionIntegrator(*this, fes, Q, true); }
+      ceedOp = new ceed::MFDiffusionIntegrator(*this, fes, Q, true);
       return;
    }
 

--- a/fem/integ/bilininteg_vecdiffusion_pa.cpp
+++ b/fem/integ/bilininteg_vecdiffusion_pa.cpp
@@ -118,10 +118,10 @@ void VectorDiffusionIntegrator::AssemblePA(const FiniteElementSpace &fes)
    if (mesh->GetNE() == 0) { return; }
    if (DeviceCanUseCeed())
    {
+      MFEM_VERIFY(!VQ && !MQ,
+                  "Only scalar coefficient is supported for partial assembly for VectorDiffusionIntegrator");
       delete ceedOp;
-      if (MQ) { ceedOp = new ceed::PADiffusionIntegrator(*this, fes, MQ); }
-      else if (VQ) { ceedOp = new ceed::PADiffusionIntegrator(*this, fes, VQ); }
-      else { ceedOp = new ceed::PADiffusionIntegrator(*this, fes, Q); }
+      ceedOp = new ceed::PADiffusionIntegrator(*this, fes, Q);
       return;
    }
 
@@ -211,10 +211,10 @@ void VectorDiffusionIntegrator::AssemblePABoundary(
    if (mesh->GetNBE() == 0) { return; }
    if (DeviceCanUseCeed())
    {
+      MFEM_VERIFY(!VQ && !MQ,
+                  "Only scalar coefficient is supported for partial assembly for VectorDiffusionIntegrator");
       delete ceedOp;
-      if (MQ) { ceedOp = new ceed::PADiffusionIntegrator(*this, fes, MQ, true); }
-      else if (VQ) { ceedOp = new ceed::PADiffusionIntegrator(*this, fes, VQ, true); }
-      else { ceedOp = new ceed::PADiffusionIntegrator(*this, fes, Q, true); }
+      ceedOp = new ceed::PADiffusionIntegrator(*this, fes, Q, true);
       return;
    }
 

--- a/fem/integ/bilininteg_vecmass_mf.cpp
+++ b/fem/integ/bilininteg_vecmass_mf.cpp
@@ -18,42 +18,40 @@ namespace mfem
 
 void VectorMassIntegrator::AssembleMF(const FiniteElementSpace &fes)
 {
-   // Assuming the same element type
    Mesh *mesh = fes.GetMesh();
    if (mesh->GetNE() == 0) { return; }
-   const FiniteElement &el = *fes.GetFE(0);
-   ElementTransformation &T = *mesh->GetElementTransformation(0);
-   const IntegrationRule *ir = IntRule ? IntRule : &GetRule(el, T);
    if (DeviceCanUseCeed())
    {
       delete ceedOp;
-      const bool mixed = mesh->GetNumGeometries(mesh->Dimension()) > 1 ||
-                         fes.IsVariableOrder();
-      if (mixed)
-      {
-         ceedOp = new ceed::MixedMFMassIntegrator(*this, fes, Q);
-      }
-      else
-      {
-         ceedOp = new ceed::MFMassIntegrator(fes, *ir, Q);
-      }
+      ceedOp = new ceed::MFMassIntegrator(*this, fes, Q);
       return;
    }
+
+   // Assuming the same element type
+   // const FiniteElement &el = *fes.GetFE(0);
+   // ElementTransformation &T = *mesh->GetElementTransformation(0);
+   // const IntegrationRule *ir = IntRule ? IntRule : &GetRule(el, T);
    MFEM_ABORT("Error: VectorMassIntegrator::AssembleMF only implemented with"
               " libCEED");
 }
 
-void VectorMassIntegrator::AddMultMF(const Vector &x, Vector &y) const
+void VectorMassIntegrator::AssembleMFBoundary(const FiniteElementSpace &fes)
 {
+   Mesh *mesh = fes.GetMesh();
+   if (mesh->GetNBE() == 0) { return; }
    if (DeviceCanUseCeed())
    {
-      ceedOp->AddMult(x, y);
+      delete ceedOp;
+      ceedOp = new ceed::MFMassIntegrator(*this, fes, Q, true);
+      return;
    }
-   else
-   {
-      MFEM_ABORT("Error: VectorMassIntegrator::AddMultMF only implemented with"
-                 " libCEED");
-   }
+
+   // Assuming the same element type
+   // const FiniteElement &el = *fes.GetBE(0);
+   // ElementTransformation &T = *mesh->GetBdrElementTransformation(0);
+   // const IntegrationRule *ir = IntRule ? IntRule : &GetRule(el, T);
+   MFEM_ABORT("Error: VectorMassIntegrator::AssembleMFBoundary only implemented with"
+              " libCEED");
 }
 
 void VectorMassIntegrator::AssembleDiagonalMF(Vector &diag)
@@ -66,6 +64,19 @@ void VectorMassIntegrator::AssembleDiagonalMF(Vector &diag)
    {
       MFEM_ABORT("Error: VectorMassIntegrator::AssembleDiagonalMF only"
                  " implemented with libCEED");
+   }
+}
+
+void VectorMassIntegrator::AddMultMF(const Vector &x, Vector &y) const
+{
+   if (DeviceCanUseCeed())
+   {
+      ceedOp->AddMult(x, y);
+   }
+   else
+   {
+      MFEM_ABORT("Error: VectorMassIntegrator::AddMultMF only implemented with"
+                 " libCEED");
    }
 }
 

--- a/fem/integ/nonlininteg_vecconvection_mf.cpp
+++ b/fem/integ/nonlininteg_vecconvection_mf.cpp
@@ -18,27 +18,22 @@ namespace mfem
 void VectorConvectionNLFIntegrator::AssembleMF(const FiniteElementSpace &fes)
 {
    MFEM_ASSERT(fes.GetOrdering() == Ordering::byNODES,
-               "PA Only supports Ordering::byNODES!");
+               "MF only supports Ordering::byNODES!");
    Mesh *mesh = fes.GetMesh();
-   const FiniteElement &el = *fes.GetFE(0);
-   ElementTransformation &T = *mesh->GetElementTransformation(0);
-   const IntegrationRule *ir = IntRule ? IntRule : &GetRule(el, T);
+   if (mesh->GetNE() == 0) { return; }
    if (DeviceCanUseCeed())
    {
       delete ceedOp;
-      const bool mixed = mesh->GetNumGeometries(mesh->Dimension()) > 1 ||
-                         fes.IsVariableOrder();
-      if (mixed)
-      {
-         ceedOp = new ceed::MixedMFVectorConvectionNLIntegrator(*this, fes, Q);
-      }
-      else
-      {
-         ceedOp = new ceed::MFVectorConvectionNLFIntegrator(fes, *ir, Q);
-      }
+      ceedOp = new ceed::MFVectorConvectionNLIntegrator(*this, fes, Q);
       return;
    }
-   MFEM_ABORT("Not yet implemented.");
+
+   // Assuming the same element type
+   // const FiniteElement &el = *fes.GetFE(0);
+   // ElementTransformation &T = *mesh->GetElementTransformation(0);
+   // const IntegrationRule *ir = IntRule ? IntRule : &GetRule(el, T);
+   MFEM_ABORT("Error: VectorConvectionNLFIntegrator::AssembleMF only"
+              " implemented with libCEED");
 }
 
 void VectorConvectionNLFIntegrator::AddMultMF(const Vector &x, Vector &y) const

--- a/general/array.cpp
+++ b/general/array.cpp
@@ -175,6 +175,7 @@ void Array2D<T>::Print(std::ostream &os, int width_)
    }
 }
 
+template class Array<bool>;
 template class Array<char>;
 template class Array<int>;
 template class Array<long long>;

--- a/general/device.cpp
+++ b/general/device.cpp
@@ -404,14 +404,14 @@ static void OccaDeviceSetup(const int dev)
 #endif
 }
 
-static void CeedDeviceSetup(const char* ceed_spec)
+static void CeedDeviceSetup(const char *ceed_spec)
 {
 #ifdef MFEM_USE_CEED
    CeedInit(ceed_spec, &internal::ceed);
    const char *ceed_backend;
    CeedGetResource(internal::ceed, &ceed_backend);
-   if (strcmp(ceed_spec, ceed_backend) && strcmp(ceed_spec, "/cpu/self") &&
-       strcmp(ceed_spec, "/gpu/hip"))
+   size_t ceed_spec_len = strlen(ceed_spec);
+   if (strncmp(ceed_spec, ceed_backend, ceed_spec_len))
    {
       mfem::out << std::endl << "WARNING!!!\n"
                 "libCEED is not using the requested backend!!!\n"

--- a/makefile
+++ b/makefile
@@ -730,17 +730,16 @@ status info:
 ASTYLE_BIN = astyle
 ASTYLE = $(ASTYLE_BIN) --options=$(SRC)config/mfem.astylerc
 ASTYLE_VER = "Artistic Style Version 3.1"
-FORMAT_FILES = $(foreach dir,$(DIRS) $(EM_DIRS) config,$(dir)/*.?pp)
-FORMAT_FILES += tests/unit/*.?pp
-UNIT_TESTS_SUBDIRS = general linalg mesh fem miniapps ceed
-MINIAPPS_SUBDIRS = dpg/util hooke/operators hooke/preconditioners hooke/materials hooke/kernels
-FORMAT_FILES += $(foreach dir,$(UNIT_TESTS_SUBDIRS),tests/unit/$(dir)/*.?pp)
-FORMAT_FILES += $(foreach dir,$(MINIAPPS_SUBDIRS),miniapps/$(dir)/*.?pp)
-FORMAT_EXCLUDE = general/tinyxml2.cpp tests/unit/catch.hpp
+FORMAT_FILES = $(foreach dir,$(DIRS) $(EM_DIRS) config,$(dir)/*.[ch]pp $(dir)/*.[ch])
+FORMAT_FILES += tests/unit/*.[ch]pp
+FORMAT_FILES += $(foreach dir,$(wildcard tests/unit/*),$(dir)/*.[ch]pp $(dir)/*.[ch])
+FORMAT_FILES += $(foreach dir,$(wildcard miniapps/*/*),$(dir)/*.[ch]pp $(dir)/*.[ch])
+FORMAT_EXCLUDE = general/tinyxml2.cpp tests/unit/catch.hpp fem/picojson.h general/tinyxml2.h
 FORMAT_LIST = $(filter-out $(FORMAT_EXCLUDE),$(wildcard $(FORMAT_FILES)))
 
-COUT_CERR_FILES = $(foreach dir,$(DIRS),$(dir)/*.[ch]pp)
-COUT_CERR_EXCLUDE = '^general/error\.cpp' '^general/globals\.[ch]pp'
+COUT_CERR_FILES = $(foreach dir,$(DIRS),$(dir)/*.[ch]pp $(dir)/*.[ch])
+COUT_CERR_EXCLUDE = general/error.cpp general/globals.cpp general/globals.hpp
+COUT_CERR_LIST = $(filter-out $(COUT_CERR_EXCLUDE),$(wildcard $(COUT_CERR_FILES)))
 
 DEPRECATION_WARNING := \
 "This feature is planned for removal in the next release."\
@@ -776,12 +775,12 @@ style:
 	    "Please make sure the changes are committed");\
 	echo "Checking for use of std::cout...";\
 	$(call mfem_check_command,\
-	   grep cout $(COUT_CERR_FILES) | grep -v $(COUT_CERR_EXCLUDE:%=-e %),\
+	   grep cout $(COUT_CERR_LIST),\
 	   "No use of std::cout found", "Use mfem::out instead of std::cout");\
 	echo "Checking for use of std::cerr...";\
 	$(call mfem_check_command,\
-	   grep cerr $(COUT_CERR_FILES) |\
-	      grep -v $(COUT_CERR_EXCLUDE:%=-e %) -e cerrno,\
+	   grep cerr $(COUT_CERR_LIST) |\
+	      grep -v -e cerrno,\
 	   "No use of std::cerr found", "Use mfem::err instead of std::cerr");\
 	exit $$err_code
 

--- a/makefile
+++ b/makefile
@@ -409,7 +409,8 @@ endif
 DIRS = general linalg linalg/simd mesh mesh/submesh fem fem/ceed/interface \
        fem/ceed/integrators/mass fem/ceed/integrators/convection \
        fem/ceed/integrators/diffusion fem/ceed/integrators/nlconvection \
-       fem/ceed/solvers fem/fe fem/lor fem/qinterp fem/integ fem/tmop
+       fem/ceed/integrators/util fem/ceed/solvers \
+       fem/fe fem/lor fem/qinterp fem/integ fem/tmop
 
 ifeq ($(MFEM_USE_MOONOLITH),YES)
    MFEM_CXXFLAGS += $(MOONOLITH_CXX_FLAGS)
@@ -603,6 +604,8 @@ install: $(if $(static),$(BLD)libmfem.a) $(if $(shared),$(BLD)libmfem.$(SO_EXT))
 	$(INSTALL) -m 640 $(SRC)fem/ceed/integrators/diffusion/*.h $(PREFIX_INC)/mfem/fem/ceed/integrators/diffusion
 	mkdir -p $(PREFIX_INC)/mfem/fem/ceed/integrators/nlconvection
 	$(INSTALL) -m 640 $(SRC)fem/ceed/integrators/nlconvection/*.h $(PREFIX_INC)/mfem/fem/ceed/integrators/nlconvection
+	mkdir -p $(PREFIX_INC)/mfem/fem/ceed/integrators/util
+	$(INSTALL) -m 640 $(SRC)fem/ceed/integrators/util/*.h $(PREFIX_INC)/mfem/fem/ceed/integrators/util
 # install config.mk in $(PREFIX_SHARE)
 	mkdir -p $(PREFIX_SHARE)
 	$(MAKE) -C $(BLD)config config-mk CONFIG_MK=config-install.mk

--- a/tests/unit/enzyme/compatibility.cpp
+++ b/tests/unit/enzyme/compatibility.cpp
@@ -8,38 +8,40 @@
 template<typename VectorT>
 void square(const VectorT& v, double& y)
 {
-  for (int i = 0; i < 4; i++) {
-    y += v[i]*v[i];
-  }
+   for (int i = 0; i < 4; i++)
+   {
+      y += v[i]*v[i];
+   }
 }
 
 template<typename VectorT>
 void dsquare(const VectorT& v, double& y, VectorT& dydv)
 {
-  double seed = 1.0;
-  __enzyme_autodiff<void>(square<VectorT>, &v, &dydv, &y, &seed);
+   double seed = 1.0;
+   __enzyme_autodiff<void>(square<VectorT>, &v, &dydv, &y, &seed);
 }
 
 template<typename VectorT>
-void run_test() {
-  VectorT v(4);
-  v[0] = 2.0;
-  v[1] = 3.0;
-  v[2] = 1.0;
-  v[3] = 7.0;
+void run_test()
+{
+   VectorT v(4);
+   v[0] = 2.0;
+   v[1] = 3.0;
+   v[2] = 1.0;
+   v[3] = 7.0;
 
-  double yy = 0;
-  VectorT dydv(4);
-  dydv[0] = 0;
-  dydv[1] = 0;
-  dydv[2] = 0;
-  dydv[3] = 0;
-  dsquare(v, yy, dydv);
+   double yy = 0;
+   VectorT dydv(4);
+   dydv[0] = 0;
+   dydv[1] = 0;
+   dydv[2] = 0;
+   dydv[3] = 0;
+   dsquare(v, yy, dydv);
 
-  REQUIRE(dydv[0] == MFEM_Approx(4.0));
-  REQUIRE(dydv[1] == MFEM_Approx(6.0));
-  REQUIRE(dydv[2] == MFEM_Approx(2.0));
-  REQUIRE(dydv[3] == MFEM_Approx(14.0));
+   REQUIRE(dydv[0] == MFEM_Approx(4.0));
+   REQUIRE(dydv[1] == MFEM_Approx(6.0));
+   REQUIRE(dydv[2] == MFEM_Approx(2.0));
+   REQUIRE(dydv[3] == MFEM_Approx(14.0));
 }
 
 TEST_CASE("AD Vector implementation", "[Enzyme]")


### PR DESCRIPTION
NOTE: Based on https://github.com/mfem/mfem/pull/3618

This PR makes some upgrades to MFEM's libCEED integration in order to add two new features:
- Vector- and matrix-valued coefficient support for relevant integrators like `DiffusionIntegrator`
- PA and MF and support for `BilinearForm::AddBoundaryIntegrator` for libCEED integrators

Unit tests covering this new functionality have been added to `tests/unit/ceed/test_ceed.cpp`.