### PR TITLE
libCEED interface: Partial and matrix-free assembly support for H(div) and H(curl) vector FE spaces

### DIFF
--- a/fem/CMakeLists.txt
+++ b/fem/CMakeLists.txt
@@ -17,12 +17,14 @@ set(SRCS
   integ/bilininteg_convection_mf.cpp
   integ/bilininteg_convection_pa.cpp
   integ/bilininteg_convection_ea.cpp
+  integ/bilininteg_curlcurl_mf.cpp
   integ/bilininteg_curlcurl_pa.cpp
   integ/bilininteg_dgtrace_pa.cpp
   integ/bilininteg_dgtrace_ea.cpp
   integ/bilininteg_diffusion_mf.cpp
   integ/bilininteg_diffusion_pa.cpp
   integ/bilininteg_diffusion_ea.cpp
+  integ/bilininteg_divdiv_mf.cpp
   integ/bilininteg_divdiv_pa.cpp
   integ/bilininteg_gradient_pa.cpp
   integ/bilininteg_interp_pa.cpp
@@ -38,6 +40,7 @@ set(SRCS
   integ/bilininteg_vecmass_mf.cpp
   integ/bilininteg_vecmass_pa.cpp
   integ/bilininteg_vectorfediv_pa.cpp
+  integ/bilininteg_vectorfemass_mf.cpp
   integ/bilininteg_vectorfemass_pa.cpp
   integ/bilininteg_diffusion_kernels.cpp
   integ/bilininteg_hcurl_kernels.cpp
@@ -84,6 +87,9 @@ set(SRCS
   ceed/integrators/convection/convection.cpp
   ceed/integrators/diffusion/diffusion.cpp
   ceed/integrators/nlconvection/nlconvection.cpp
+  ceed/integrators/vecfemass/vecfemass.cpp
+  ceed/integrators/divdiv/divdiv.cpp
+  ceed/integrators/curlcurl/curlcurl.cpp
   ceed/solvers/algebraic.cpp
   ceed/solvers/full-assembly.cpp
   ceed/solvers/solvers-atpmg.cpp
@@ -201,6 +207,12 @@ set(HDRS
   ceed/integrators/diffusion/diffusion_qf.h
   ceed/integrators/nlconvection/nlconvection.hpp
   ceed/integrators/nlconvection/nlconvection_qf.h
+  ceed/integrators/vecfemass/vecfemass.hpp
+  ceed/integrators/vecfemass/vecfemass_qf.h
+  ceed/integrators/divdiv/divdiv.hpp
+  ceed/integrators/divdiv/divdiv_qf.h
+  ceed/integrators/curlcurl/curlcurl.hpp
+  ceed/integrators/curlcurl/curlcurl_qf.h
   ceed/integrators/util/util_qf.h
   ceed/solvers/algebraic.hpp
   ceed/solvers/full-assembly.hpp

--- a/fem/CMakeLists.txt
+++ b/fem/CMakeLists.txt
@@ -31,7 +31,9 @@ set(SRCS
   integ/bilininteg_mass_mf.cpp
   integ/bilininteg_mass_pa.cpp
   integ/bilininteg_mass_ea.cpp
+  integ/bilininteg_mixedcurl_mf.cpp
   integ/bilininteg_mixedcurl_pa.cpp
+  integ/bilininteg_mixedvecgrad_mf.cpp
   integ/bilininteg_mixedvecgrad_pa.cpp
   integ/bilininteg_transpose_ea.cpp
   integ/bilininteg_vecdiffusion_mf.cpp
@@ -90,6 +92,8 @@ set(SRCS
   ceed/integrators/vecfemass/vecfemass.cpp
   ceed/integrators/divdiv/divdiv.cpp
   ceed/integrators/curlcurl/curlcurl.cpp
+  ceed/integrators/mixedvecgrad/mixedvecgrad.cpp
+  ceed/integrators/mixedveccurl/mixedveccurl.cpp
   ceed/solvers/algebraic.cpp
   ceed/solvers/full-assembly.cpp
   ceed/solvers/solvers-atpmg.cpp
@@ -213,6 +217,8 @@ set(HDRS
   ceed/integrators/divdiv/divdiv_qf.h
   ceed/integrators/curlcurl/curlcurl.hpp
   ceed/integrators/curlcurl/curlcurl_qf.h
+  ceed/integrators/mixedvecgrad/mixedvecgrad.hpp
+  ceed/integrators/mixedveccurl/mixedveccurl.hpp
   ceed/integrators/util/util_qf.h
   ceed/solvers/algebraic.hpp
   ceed/solvers/full-assembly.hpp

--- a/fem/bilininteg.cpp
+++ b/fem/bilininteg.cpp
@@ -2694,11 +2694,11 @@ void VectorFEMassIntegrator::AssembleElementMatrix2(
 #endif
 
       elmat.SetSize(vdim*test_dof, trial_dof);
+      elmat = 0.0;
 
       const IntegrationRule *ir = IntRule ? IntRule : &GetRule(trial_fe, test_fe,
                                                                Trans);
 
-      elmat = 0.0;
       for (int i = 0; i < ir->GetNPoints(); i++)
       {
          const IntegrationPoint &ip = ir->IntPoint(i);
@@ -2791,12 +2791,8 @@ void VectorFEMassIntegrator::AssembleElementMatrix2(
 
       elmat.SetSize(test_dof, trial_dof);
 
-      const IntegrationRule *ir = IntRule;
-      if (ir == NULL)
-      {
-         int order = (Trans.OrderW() + test_fe.GetOrder() + trial_fe.GetOrder());
-         ir = &IntRules.Get(test_fe.GetGeomType(), order);
-      }
+      const IntegrationRule *ir = IntRule ? IntRule : &GetRule(trial_fe, test_fe,
+                                                               Trans);
 
       elmat = 0.0;
       for (int i = 0; i < ir->GetNPoints(); i++)

--- a/fem/bilininteg.hpp
+++ b/fem/bilininteg.hpp
@@ -1928,10 +1928,6 @@ public:
    virtual void AssemblePA(const FiniteElementSpace &trial_fes,
                            const FiniteElementSpace &test_fes);
 
-   using BilinearFormIntegrator::AssemblePABoundary;
-   virtual void AssemblePABoundary(const FiniteElementSpace &trial_fes,
-                                   const FiniteElementSpace &test_fes);
-
    virtual void AddMultPA(const Vector &x, Vector &y) const;
 
    virtual void AddMultTransposePA(const Vector &x, Vector &y) const;
@@ -1939,10 +1935,6 @@ public:
    using BilinearFormIntegrator::AssembleMF;
    virtual void AssembleMF(const FiniteElementSpace &trial_fes,
                            const FiniteElementSpace &test_fes);
-
-   using BilinearFormIntegrator::AssembleMFBoundary;
-   virtual void AssembleMFBoundary(const FiniteElementSpace &trial_fes,
-                                   const FiniteElementSpace &test_fes);
 
    virtual void AddMultMF(const Vector &x, Vector &y) const;
 
@@ -2004,10 +1996,6 @@ public:
    virtual void AssemblePA(const FiniteElementSpace &trial_fes,
                            const FiniteElementSpace &test_fes);
 
-   using BilinearFormIntegrator::AssemblePABoundary;
-   virtual void AssemblePABoundary(const FiniteElementSpace &trial_fes,
-                                   const FiniteElementSpace &test_fes);
-
    virtual void AddMultPA(const Vector &x, Vector &y) const;
 
    virtual void AddMultTransposePA(const Vector &x, Vector &y) const;
@@ -2015,10 +2003,6 @@ public:
    using BilinearFormIntegrator::AssembleMF;
    virtual void AssembleMF(const FiniteElementSpace &trial_fes,
                            const FiniteElementSpace &test_fes);
-
-   using BilinearFormIntegrator::AssembleMFBoundary;
-   virtual void AssembleMFBoundary(const FiniteElementSpace &trial_fes,
-                                   const FiniteElementSpace &test_fes);
 
    virtual void AddMultMF(const Vector &x, Vector &y) const;
 

--- a/fem/bilininteg.hpp
+++ b/fem/bilininteg.hpp
@@ -2196,6 +2196,7 @@ public:
    using BilinearFormIntegrator::AssemblePA;
    virtual void AssemblePA(const FiniteElementSpace &fes);
 
+   using BilinearFormIntegrator::AssemblePABoundary;
    virtual void AssemblePABoundary(const FiniteElementSpace &fes);
 
    virtual void AssembleDiagonalPA(Vector &diag);
@@ -2207,6 +2208,7 @@ public:
    using BilinearFormIntegrator::AssembleMF;
    virtual void AssembleMF(const FiniteElementSpace &fes);
 
+   using BilinearFormIntegrator::AssembleMFBoundary;
    virtual void AssembleMFBoundary(const FiniteElementSpace &fes);
 
    virtual void AssembleDiagonalMF(Vector &diag);
@@ -2285,6 +2287,7 @@ public:
    using BilinearFormIntegrator::AssembleMF;
    virtual void AssembleMF(const FiniteElementSpace &fes);
 
+   using BilinearFormIntegrator::AssembleMFBoundary;
    virtual void AssembleMFBoundary(const FiniteElementSpace &fes);
 
    virtual void AssembleDiagonalMF(Vector &diag);
@@ -2351,6 +2354,7 @@ public:
    using BilinearFormIntegrator::AssemblePA;
    virtual void AssemblePA(const FiniteElementSpace &fes);
 
+   using BilinearFormIntegrator::AssemblePABoundary;
    virtual void AssemblePABoundary(const FiniteElementSpace &fes);
 
    virtual void AssembleDiagonalPA(Vector &diag);
@@ -2362,6 +2366,7 @@ public:
    using BilinearFormIntegrator::AssembleMF;
    virtual void AssembleMF(const FiniteElementSpace &fes);
 
+   using BilinearFormIntegrator::AssembleMFBoundary;
    virtual void AssembleMFBoundary(const FiniteElementSpace &fes);
 
    virtual void AssembleDiagonalMF(Vector &diag);
@@ -2506,6 +2511,7 @@ public:
    using BilinearFormIntegrator::AssemblePA;
    virtual void AssemblePA(const FiniteElementSpace &fes);
 
+   using BilinearFormIntegrator::AssemblePABoundary;
    virtual void AssemblePABoundary(const FiniteElementSpace &fes);
 
    virtual void AssembleDiagonalPA(Vector &diag);
@@ -2515,6 +2521,7 @@ public:
    using BilinearFormIntegrator::AssembleMF;
    virtual void AssembleMF(const FiniteElementSpace &fes);
 
+   using BilinearFormIntegrator::AssembleMFBoundary;
    virtual void AssembleMFBoundary(const FiniteElementSpace &fes);
 
    virtual void AssembleDiagonalMF(Vector &diag);
@@ -2587,6 +2594,7 @@ public:
    using BilinearFormIntegrator::AssemblePA;
    virtual void AssemblePA(const FiniteElementSpace &fes);
 
+   using BilinearFormIntegrator::AssemblePABoundary;
    virtual void AssemblePABoundary(const FiniteElementSpace &fes);
 
    virtual void AssembleDiagonalPA(Vector &diag);
@@ -2596,6 +2604,7 @@ public:
    using BilinearFormIntegrator::AssembleMF;
    virtual void AssembleMF(const FiniteElementSpace &fes);
 
+   using BilinearFormIntegrator::AssembleMFBoundary;
    virtual void AssembleMFBoundary(const FiniteElementSpace &fes);
 
    virtual void AssembleDiagonalMF(Vector &diag);
@@ -2778,6 +2787,8 @@ public:
    CurlCurlIntegrator(MatrixCoefficient &mq, const IntegrationRule *ir = NULL) :
       BilinearFormIntegrator(ir), Q(NULL), DQ(NULL), MQ(&mq) {}
 
+   virtual bool SupportsCeed() const { return DeviceCanUseCeed(); }
+
    using NonlinearFormIntegrator::GetRule;
    virtual const IntegrationRule &GetRule(const FiniteElement &trial_fe,
                                           const FiniteElement &test_fe,
@@ -2807,9 +2818,22 @@ public:
    using BilinearFormIntegrator::AssemblePA;
    virtual void AssemblePA(const FiniteElementSpace &fes);
 
+   using BilinearFormIntegrator::AssemblePABoundary;
+   virtual void AssemblePABoundary(const FiniteElementSpace &fes);
+
    virtual void AssembleDiagonalPA(Vector &diag);
 
    virtual void AddMultPA(const Vector &x, Vector &y) const;
+
+   using BilinearFormIntegrator::AssembleMF;
+   virtual void AssembleMF(const FiniteElementSpace &fes);
+
+   using BilinearFormIntegrator::AssembleMFBoundary;
+   virtual void AssembleMFBoundary(const FiniteElementSpace &fes);
+
+   virtual void AssembleDiagonalMF(Vector &diag);
+
+   virtual void AddMultMF(const Vector &x, Vector &y) const;
 
    const Coefficient *GetCoefficient() const { return Q; }
 };
@@ -2924,6 +2948,8 @@ public:
    VectorFEMassIntegrator(MatrixCoefficient *mq_) { Init(NULL, NULL, mq_); }
    VectorFEMassIntegrator(MatrixCoefficient &mq) { Init(NULL, NULL, &mq); }
 
+   virtual bool SupportsCeed() const { return DeviceCanUseCeed(); }
+
    using NonlinearFormIntegrator::GetRule;
    virtual const IntegrationRule &GetRule(const FiniteElement &trial_fe,
                                           const FiniteElement &test_fe,
@@ -2942,11 +2968,24 @@ public:
    virtual void AssemblePA(const FiniteElementSpace &trial_fes,
                            const FiniteElementSpace &test_fes);
 
+   using BilinearFormIntegrator::AssemblePABoundary;
+   virtual void AssemblePABoundary(const FiniteElementSpace &fes);
+
    virtual void AssembleDiagonalPA(Vector &diag);
 
    virtual void AddMultPA(const Vector &x, Vector &y) const;
 
    virtual void AddMultTransposePA(const Vector &x, Vector &y) const;
+
+   using BilinearFormIntegrator::AssembleMF;
+   virtual void AssembleMF(const FiniteElementSpace &fes);
+
+   using BilinearFormIntegrator::AssembleMFBoundary;
+   virtual void AssembleMFBoundary(const FiniteElementSpace &fes);
+
+   virtual void AssembleDiagonalMF(Vector &diag);
+
+   virtual void AddMultMF(const Vector &x, Vector &y) const;
 
    const Coefficient *GetCoefficient() const { return Q; }
 };
@@ -3022,6 +3061,8 @@ public:
    DivDivIntegrator(Coefficient &q, const IntegrationRule *ir = NULL) :
       BilinearFormIntegrator(ir), Q(&q) {}
 
+   virtual bool SupportsCeed() const { return DeviceCanUseCeed(); }
+
    using NonlinearFormIntegrator::GetRule;
    virtual const IntegrationRule &GetRule(const FiniteElement &trial_fe,
                                           const FiniteElement &test_fe,
@@ -3039,9 +3080,22 @@ public:
    using BilinearFormIntegrator::AssemblePA;
    virtual void AssemblePA(const FiniteElementSpace &fes);
 
+   using BilinearFormIntegrator::AssemblePABoundary;
+   virtual void AssemblePABoundary(const FiniteElementSpace &fes);
+
    virtual void AssembleDiagonalPA(Vector &diag);
 
    virtual void AddMultPA(const Vector &x, Vector &y) const;
+
+   using BilinearFormIntegrator::AssembleMF;
+   virtual void AssembleMF(const FiniteElementSpace &fes);
+
+   using BilinearFormIntegrator::AssembleMFBoundary;
+   virtual void AssembleMFBoundary(const FiniteElementSpace &fes);
+
+   virtual void AssembleDiagonalMF(Vector &diag);
+
+   virtual void AddMultMF(const Vector &x, Vector &y) const;
 
    const Coefficient *GetCoefficient() const { return Q; }
 };

--- a/fem/bilininteg.hpp
+++ b/fem/bilininteg.hpp
@@ -1847,13 +1847,29 @@ public:
    MixedVectorGradientIntegrator(MatrixCoefficient &mq)
       : MixedVectorIntegrator(mq) {}
 
+   virtual bool SupportsCeed() const { return DeviceCanUseCeed(); }
+
    using BilinearFormIntegrator::AssemblePA;
    virtual void AssemblePA(const FiniteElementSpace &trial_fes,
                            const FiniteElementSpace &test_fes);
 
+   using BilinearFormIntegrator::AssemblePABoundary;
+   virtual void AssemblePABoundary(const FiniteElementSpace &trial_fes,
+                                   const FiniteElementSpace &test_fes);
+
    virtual void AddMultPA(const Vector &x, Vector &y) const;
 
    virtual void AddMultTransposePA(const Vector &x, Vector &y) const;
+
+   using BilinearFormIntegrator::AssembleMF;
+   virtual void AssembleMF(const FiniteElementSpace &trial_fes,
+                           const FiniteElementSpace &test_fes);
+
+   using BilinearFormIntegrator::AssembleMFBoundary;
+   virtual void AssembleMFBoundary(const FiniteElementSpace &trial_fes,
+                                   const FiniteElementSpace &test_fes);
+
+   virtual void AddMultMF(const Vector &x, Vector &y) const;
 
 protected:
    virtual bool VerifyFiniteElementTypes(
@@ -1906,13 +1922,29 @@ public:
    MixedVectorCurlIntegrator(MatrixCoefficient &mq)
       : MixedVectorIntegrator(mq) {}
 
+   virtual bool SupportsCeed() const { return DeviceCanUseCeed(); }
+
    using BilinearFormIntegrator::AssemblePA;
    virtual void AssemblePA(const FiniteElementSpace &trial_fes,
                            const FiniteElementSpace &test_fes);
 
+   using BilinearFormIntegrator::AssemblePABoundary;
+   virtual void AssemblePABoundary(const FiniteElementSpace &trial_fes,
+                                   const FiniteElementSpace &test_fes);
+
    virtual void AddMultPA(const Vector &x, Vector &y) const;
 
    virtual void AddMultTransposePA(const Vector &x, Vector &y) const;
+
+   using BilinearFormIntegrator::AssembleMF;
+   virtual void AssembleMF(const FiniteElementSpace &trial_fes,
+                           const FiniteElementSpace &test_fes);
+
+   using BilinearFormIntegrator::AssembleMFBoundary;
+   virtual void AssembleMFBoundary(const FiniteElementSpace &trial_fes,
+                                   const FiniteElementSpace &test_fes);
+
+   virtual void AddMultMF(const Vector &x, Vector &y) const;
 
 protected:
    virtual bool VerifyFiniteElementTypes(
@@ -1966,13 +1998,29 @@ public:
    MixedVectorWeakCurlIntegrator(MatrixCoefficient &mq)
       : MixedVectorIntegrator(mq) {}
 
+   virtual bool SupportsCeed() const { return DeviceCanUseCeed(); }
+
    using BilinearFormIntegrator::AssemblePA;
    virtual void AssemblePA(const FiniteElementSpace &trial_fes,
                            const FiniteElementSpace &test_fes);
 
+   using BilinearFormIntegrator::AssemblePABoundary;
+   virtual void AssemblePABoundary(const FiniteElementSpace &trial_fes,
+                                   const FiniteElementSpace &test_fes);
+
    virtual void AddMultPA(const Vector &x, Vector &y) const;
 
    virtual void AddMultTransposePA(const Vector &x, Vector &y) const;
+
+   using BilinearFormIntegrator::AssembleMF;
+   virtual void AssembleMF(const FiniteElementSpace &trial_fes,
+                           const FiniteElementSpace &test_fes);
+
+   using BilinearFormIntegrator::AssembleMFBoundary;
+   virtual void AssembleMFBoundary(const FiniteElementSpace &trial_fes,
+                                   const FiniteElementSpace &test_fes);
+
+   virtual void AddMultMF(const Vector &x, Vector &y) const;
 
 protected:
    virtual bool VerifyFiniteElementTypes(
@@ -2023,6 +2071,28 @@ public:
       : MixedVectorIntegrator(dq, true) {}
    MixedVectorWeakDivergenceIntegrator(MatrixCoefficient &mq)
       : MixedVectorIntegrator(mq) {}
+
+   virtual bool SupportsCeed() const { return DeviceCanUseCeed(); }
+
+   using BilinearFormIntegrator::AssemblePA;
+   virtual void AssemblePA(const FiniteElementSpace &trial_fes,
+                           const FiniteElementSpace &test_fes);
+
+   using BilinearFormIntegrator::AssemblePABoundary;
+   virtual void AssemblePABoundary(const FiniteElementSpace &trial_fes,
+                                   const FiniteElementSpace &test_fes);
+
+   virtual void AddMultPA(const Vector &x, Vector &y) const;
+
+   using BilinearFormIntegrator::AssembleMF;
+   virtual void AssembleMF(const FiniteElementSpace &trial_fes,
+                           const FiniteElementSpace &test_fes);
+
+   using BilinearFormIntegrator::AssembleMFBoundary;
+   virtual void AssembleMFBoundary(const FiniteElementSpace &trial_fes,
+                                   const FiniteElementSpace &test_fes);
+
+   virtual void AddMultMF(const Vector &x, Vector &y) const;
 
 protected:
    virtual bool VerifyFiniteElementTypes(

--- a/fem/ceed/integrators/convection/convection_qf.h
+++ b/fem/ceed/integrators/convection/convection_qf.h
@@ -16,12 +16,11 @@
 
 #define LIBCEED_CONV_COEFF_COMP_MAX 3
 
-/// A structure used to pass additional data to f_build_conv and f_apply_conv
 struct ConvectionContext
 {
    CeedInt dim, space_dim;
-   CeedScalar coeff[LIBCEED_CONV_COEFF_COMP_MAX];
    CeedScalar alpha;
+   CeedScalar coeff[LIBCEED_CONV_COEFF_COMP_MAX];
 };
 
 /// libCEED QFunction for building quadrature data for a convection operator
@@ -34,7 +33,7 @@ CEED_QFUNCTION(f_build_conv_const)(void *ctx, CeedInt Q,
    // in[0] is Jacobians with shape [dim, ncomp=space_dim, Q]
    // in[1] is quadrature weights, size (Q)
    //
-   // At every quadrature point, compute and store qw * α * c^T adj(J)^T.
+   // At every quadrature point, compute and store qw * α * c^T adj(J)^T
    const CeedScalar alpha  = bc->alpha;
    const CeedScalar *coeff = bc->coeff;
    const CeedScalar *J = in[0], *qw = in[1];
@@ -77,7 +76,7 @@ CEED_QFUNCTION(f_build_conv_const)(void *ctx, CeedInt Q,
 }
 
 /// libCEED QFunction for building quadrature data for a convection operator
-/// with a coefficient evaluated at quadrature points.
+/// with a coefficient evaluated at quadrature points
 CEED_QFUNCTION(f_build_conv_quad)(void *ctx, CeedInt Q,
                                   const CeedScalar *const *in,
                                   CeedScalar *const *out)
@@ -87,7 +86,7 @@ CEED_QFUNCTION(f_build_conv_quad)(void *ctx, CeedInt Q,
    // in[1] is Jacobians with shape [dim, ncomp=space_dim, Q]
    // in[2] is quadrature weights, size (Q)
    //
-   // At every quadrature point, compute and store qw * α * c^T adj(J)^T.
+   // At every quadrature point, compute and store qw * α * c^T adj(J)^T
    const CeedScalar alpha  = bc->alpha;
    const CeedScalar *c = in[0], *J = in[1], *qw = in[2];
    CeedScalar *qd = out[0];
@@ -127,7 +126,7 @@ CEED_QFUNCTION(f_build_conv_quad)(void *ctx, CeedInt Q,
    return 0;
 }
 
-/// libCEED QFunction for applying a conv operator
+/// libCEED QFunction for applying a convection operator
 CEED_QFUNCTION(f_apply_conv)(void *ctx, CeedInt Q,
                              const CeedScalar *const *in,
                              CeedScalar *const *out)
@@ -166,7 +165,8 @@ CEED_QFUNCTION(f_apply_conv)(void *ctx, CeedInt Q,
    return 0;
 }
 
-/// libCEED QFunction for applying a conv operator
+/// libCEED QFunction for applying a convection operator with a constant
+/// coefficient
 CEED_QFUNCTION(f_apply_conv_mf_const)(void *ctx, CeedInt Q,
                                       const CeedScalar *const *in,
                                       CeedScalar *const *out)
@@ -177,7 +177,7 @@ CEED_QFUNCTION(f_apply_conv_mf_const)(void *ctx, CeedInt Q,
    // in[2] is quadrature weights, size (Q)
    // out[0] has shape [ncomp=1, Q]
    //
-   // At every quadrature point, compute qw * α * c^T adj(J)^T.
+   // At every quadrature point, compute qw * α * c^T adj(J)^T
    const CeedScalar alpha  = bc->alpha;
    const CeedScalar *coeff = bc->coeff;
    const CeedScalar *ug = in[0], *J = in[1], *qw = in[2];
@@ -235,7 +235,8 @@ CEED_QFUNCTION(f_apply_conv_mf_const)(void *ctx, CeedInt Q,
    return 0;
 }
 
-/// libCEED QFunction for applying a conv operator
+/// libCEED QFunction for applying a convection operator with a coefficient
+/// evaluated at quadrature points
 CEED_QFUNCTION(f_apply_conv_mf_quad)(void *ctx, CeedInt Q,
                                      const CeedScalar *const *in,
                                      CeedScalar *const *out)
@@ -247,7 +248,7 @@ CEED_QFUNCTION(f_apply_conv_mf_quad)(void *ctx, CeedInt Q,
    // in[3] is quadrature weights, size (Q)
    // out[0] has shape [ncomp=1, Q]
    //
-   // At every quadrature point, compute qw * α * c^T adj(J)^T.
+   // At every quadrature point, compute qw * α * c^T adj(J)^T
    const CeedScalar alpha  = bc->alpha;
    const CeedScalar *ug = in[0], *c = in[1], *J = in[2], *qw = in[3];
    CeedScalar *vg = out[0];

--- a/fem/ceed/integrators/curlcurl/curlcurl.cpp
+++ b/fem/ceed/integrators/curlcurl/curlcurl.cpp
@@ -1,0 +1,174 @@
+// Copyright (c) 2010-2023, Lawrence Livermore National Security, LLC. Produced
+// at the Lawrence Livermore National Laboratory. All Rights reserved. See files
+// LICENSE and NOTICE for details. LLNL-CODE-806117.
+//
+// This file is part of the MFEM library. For more information and source code
+// availability visit https://mfem.org.
+//
+// MFEM is free software; you can redistribute it and/or modify it under the
+// terms of the BSD-3 license. We welcome feedback and contributions, see file
+// CONTRIBUTING.md for details.
+
+#include "curlcurl.hpp"
+
+#include "../../../../config/config.hpp"
+#ifdef MFEM_USE_CEED
+#include "curlcurl_qf.h"
+#endif
+
+namespace mfem
+{
+
+namespace ceed
+{
+
+#ifdef MFEM_USE_CEED
+struct CurlCurlOperatorInfo : public OperatorInfo
+{
+   CurlCurlContext ctx;
+   template <typename CoeffType>
+   CurlCurlOperatorInfo(const mfem::FiniteElementSpace &fes, CoeffType *Q,
+                        bool use_bdr)
+   {
+      MFEM_VERIFY(fes.GetVDim() == 1,
+                  "libCEED interface for vector FE does not support VDim > 1!");
+      ctx.dim = fes.GetMesh()->Dimension() - use_bdr;
+      MFEM_VERIFY(ctx.dim == 2 || ctx.dim == 3,
+                  "CurlCurlIntegrator requires dim == 2 or dim == 3!");
+      ctx.space_dim = fes.GetMesh()->SpaceDimension();
+      ctx.curl_dim = (ctx.dim < 3) ? 1 : ctx.dim;
+      InitCoefficient(Q);
+
+      header = "/integrators/curlcurl/curlcurl_qf.h";
+      build_func_const = ":f_build_curlcurl_const";
+      build_qf_const = &f_build_curlcurl_const;
+      build_func_quad = ":f_build_curlcurl_quad";
+      build_qf_quad = &f_build_curlcurl_quad;
+      apply_func = ":f_apply_curlcurl";
+      apply_qf = &f_apply_curlcurl;
+      apply_func_mf_const = ":f_apply_curlcurl_mf_const";
+      apply_qf_mf_const = &f_apply_curlcurl_mf_const;
+      apply_func_mf_quad = ":f_apply_curlcurl_mf_quad";
+      apply_qf_mf_quad = &f_apply_curlcurl_mf_quad;
+      trial_op = EvalMode::Curl;
+      test_op = EvalMode::Curl;
+      qdatasize = (ctx.curl_dim * (ctx.curl_dim + 1)) / 2;
+   }
+   void InitCoefficient(mfem::Coefficient *Q)
+   {
+      ctx.coeff_comp = 1;
+      if (Q == nullptr)
+      {
+         ctx.coeff[0] = 1.0;
+      }
+      else if (ConstantCoefficient *const_coeff =
+                  dynamic_cast<ConstantCoefficient *>(Q))
+      {
+         ctx.coeff[0] = const_coeff->constant;
+      }
+   }
+   void InitCoefficient(mfem::VectorCoefficient *VQ)
+   {
+      if (VQ == nullptr)
+      {
+         ctx.coeff_comp = 1;
+         ctx.coeff[0] = 1.0;
+         return;
+      }
+      const int vdim = VQ->GetVDim();
+      ctx.coeff_comp = vdim;
+      if (VectorConstantCoefficient *const_coeff =
+             dynamic_cast<VectorConstantCoefficient *>(VQ))
+      {
+         MFEM_VERIFY(ctx.coeff_comp <= LIBCEED_CURLCURL_COEFF_COMP_MAX,
+                     "VectorCoefficient dimension exceeds context storage!");
+         const mfem::Vector &val = const_coeff->GetVec();
+         for (int i = 0; i < vdim; i++)
+         {
+            ctx.coeff[i] = val[i];
+         }
+      }
+   }
+   void InitCoefficient(mfem::MatrixCoefficient *MQ)
+   {
+      if (MQ == nullptr)
+      {
+         ctx.coeff_comp = 1;
+         ctx.coeff[0] = 1.0;
+         return;
+      }
+      // Assumes matrix coefficient is symmetric
+      const int vdim = MQ->GetVDim();
+      ctx.coeff_comp = (vdim * (vdim + 1)) / 2;
+      if (MatrixConstantCoefficient *const_coeff =
+             dynamic_cast<MatrixConstantCoefficient *>(MQ))
+      {
+         MFEM_VERIFY(ctx.coeff_comp <= LIBCEED_CURLCURL_COEFF_COMP_MAX,
+                     "MatrixCoefficient dimensions exceed context storage!");
+         const mfem::DenseMatrix &val = const_coeff->GetMatrix();
+         for (int j = 0; j < vdim; j++)
+         {
+            for (int i = j; i < vdim; i++)
+            {
+               const int idx = (j * vdim) - (((j - 1) * j) / 2) + i - j;
+               ctx.coeff[idx] = val(i, j);
+            }
+         }
+      }
+   }
+};
+#endif
+
+template <typename CoeffType>
+PACurlCurlIntegrator::PACurlCurlIntegrator(
+   const mfem::CurlCurlIntegrator &integ,
+   const mfem::FiniteElementSpace &fes,
+   CoeffType *Q,
+   const bool use_bdr)
+{
+#ifdef MFEM_USE_CEED
+   CurlCurlOperatorInfo info(fes, Q, use_bdr);
+   Assemble(integ, info, fes, Q, use_bdr);
+#else
+   MFEM_ABORT("MFEM must be built with MFEM_USE_CEED=YES to use libCEED.");
+#endif
+}
+
+template <typename CoeffType>
+MFCurlCurlIntegrator::MFCurlCurlIntegrator(
+   const mfem::CurlCurlIntegrator &integ,
+   const mfem::FiniteElementSpace &fes,
+   CoeffType *Q,
+   const bool use_bdr)
+{
+#ifdef MFEM_USE_CEED
+   CurlCurlOperatorInfo info(fes, Q, use_bdr);
+   Assemble(integ, info, fes, Q, use_bdr, true);
+#else
+   MFEM_ABORT("MFEM must be built with MFEM_USE_CEED=YES to use libCEED.");
+#endif
+}
+
+template PACurlCurlIntegrator::PACurlCurlIntegrator(
+   const mfem::CurlCurlIntegrator &, const mfem::FiniteElementSpace &,
+   mfem::Coefficient *, const bool);
+template PACurlCurlIntegrator::PACurlCurlIntegrator(
+   const mfem::CurlCurlIntegrator &, const mfem::FiniteElementSpace &,
+   mfem::VectorCoefficient *, const bool);
+template PACurlCurlIntegrator::PACurlCurlIntegrator(
+   const mfem::CurlCurlIntegrator &, const mfem::FiniteElementSpace &,
+   mfem::MatrixCoefficient *, const bool);
+
+template MFCurlCurlIntegrator::MFCurlCurlIntegrator(
+   const mfem::CurlCurlIntegrator &, const mfem::FiniteElementSpace &,
+   mfem::Coefficient *, const bool);
+template MFCurlCurlIntegrator::MFCurlCurlIntegrator(
+   const mfem::CurlCurlIntegrator &, const mfem::FiniteElementSpace &,
+   mfem::VectorCoefficient *, const bool);
+template MFCurlCurlIntegrator::MFCurlCurlIntegrator(
+   const mfem::CurlCurlIntegrator &, const mfem::FiniteElementSpace &,
+   mfem::MatrixCoefficient *, const bool);
+
+} // namespace ceed
+
+} // namespace mfem

--- a/fem/ceed/integrators/curlcurl/curlcurl.cpp
+++ b/fem/ceed/integrators/curlcurl/curlcurl.cpp
@@ -25,10 +25,10 @@ namespace ceed
 #ifdef MFEM_USE_CEED
 struct CurlCurlOperatorInfo : public OperatorInfo
 {
-   CurlCurlContext ctx;
+   CurlCurlContext ctx = {0};
    template <typename CoeffType>
    CurlCurlOperatorInfo(const mfem::FiniteElementSpace &fes, CoeffType *Q,
-                        bool use_bdr)
+                        bool use_bdr = false, bool use_mf = false)
    {
       MFEM_VERIFY(fes.GetVDim() == 1,
                   "libCEED interface for vector FE does not support VDim > 1!");
@@ -37,65 +37,116 @@ struct CurlCurlOperatorInfo : public OperatorInfo
                   "CurlCurlIntegrator requires dim == 2 or dim == 3!");
       ctx.space_dim = fes.GetMesh()->SpaceDimension();
       ctx.curl_dim = (ctx.dim < 3) ? 1 : ctx.dim;
-      if (Q == nullptr)
+      if (!use_mf)
       {
-         ctx.coeff_comp = 1;
-         ctx.coeff[0] = 1.0;
+         apply_func = ":f_apply_curlcurl";
+         apply_qf = &f_apply_curlcurl;
       }
       else
       {
-         InitCoefficient(*Q);
+         build_func = "";
+         build_qf = nullptr;
       }
-
+      if (Q == nullptr)
+      {
+         ctx.coeff[0] = 1.0;
+         if (!use_mf)
+         {
+            build_func = ":f_build_curlcurl_const_scalar";
+            build_qf = &f_build_curlcurl_const_scalar;
+         }
+         else
+         {
+            apply_func = ":f_apply_curlcurl_mf_const_scalar";
+            apply_qf = &f_apply_curlcurl_mf_const_scalar;
+         }
+      }
+      else
+      {
+         InitCoefficient(*Q, use_mf);
+      }
       header = "/integrators/curlcurl/curlcurl_qf.h";
-      build_func_const = ":f_build_curlcurl_const";
-      build_qf_const = &f_build_curlcurl_const;
-      build_func_quad = ":f_build_curlcurl_quad";
-      build_qf_quad = &f_build_curlcurl_quad;
-      apply_func = ":f_apply_curlcurl";
-      apply_qf = &f_apply_curlcurl;
-      apply_func_mf_const = ":f_apply_curlcurl_mf_const";
-      apply_qf_mf_const = &f_apply_curlcurl_mf_const;
-      apply_func_mf_quad = ":f_apply_curlcurl_mf_quad";
-      apply_qf_mf_quad = &f_apply_curlcurl_mf_quad;
       trial_op = EvalMode::Curl;
       test_op = EvalMode::Curl;
       qdatasize = (ctx.curl_dim * (ctx.curl_dim + 1)) / 2;
    }
-   void InitCoefficient(mfem::Coefficient &Q)
+   void InitCoefficient(mfem::Coefficient &Q, bool use_mf)
    {
-      ctx.coeff_comp = 1;
-      if (ConstantCoefficient *const_coeff =
-             dynamic_cast<ConstantCoefficient *>(&Q))
+      if (mfem::ConstantCoefficient *const_coeff =
+             dynamic_cast<mfem::ConstantCoefficient *>(&Q))
       {
          ctx.coeff[0] = const_coeff->constant;
+         if (!use_mf)
+         {
+            build_func = ":f_build_curlcurl_const_scalar";
+            build_qf = &f_build_curlcurl_const_scalar;
+         }
+         else
+         {
+            apply_func = ":f_apply_curlcurl_mf_const_scalar";
+            apply_qf = &f_apply_curlcurl_mf_const_scalar;
+         }
+      }
+      else
+      {
+         if (!use_mf)
+         {
+            build_func = ":f_build_curlcurl_quad_scalar";
+            build_qf = &f_build_curlcurl_quad_scalar;
+         }
+         else
+         {
+            apply_func = ":f_apply_curlcurl_mf_quad_scalar";
+            apply_qf = &f_apply_curlcurl_mf_quad_scalar;
+         }
       }
    }
-   void InitCoefficient(mfem::VectorCoefficient &VQ)
+   void InitCoefficient(mfem::VectorCoefficient &VQ, bool use_mf)
    {
-      const int vdim = VQ.GetVDim();
-      ctx.coeff_comp = vdim;
-      if (VectorConstantCoefficient *const_coeff =
-             dynamic_cast<VectorConstantCoefficient *>(&VQ))
+      if (mfem::VectorConstantCoefficient *const_coeff =
+             dynamic_cast<mfem::VectorConstantCoefficient *>(&VQ))
       {
-         MFEM_VERIFY(ctx.coeff_comp <= LIBCEED_CURLCURL_COEFF_COMP_MAX,
+         const int vdim = VQ.GetVDim();
+         MFEM_VERIFY(vdim <= LIBCEED_CURLCURL_COEFF_COMP_MAX,
                      "VectorCoefficient dimension exceeds context storage!");
          const mfem::Vector &val = const_coeff->GetVec();
          for (int i = 0; i < vdim; i++)
          {
             ctx.coeff[i] = val[i];
          }
+         if (!use_mf)
+         {
+            build_func = ":f_build_curlcurl_const_vector";
+            build_qf = &f_build_curlcurl_const_vector;
+         }
+         else
+         {
+            apply_func = ":f_apply_curlcurl_mf_const_vector";
+            apply_qf = &f_apply_curlcurl_mf_const_vector;
+         }
+      }
+      else
+      {
+         if (!use_mf)
+         {
+            build_func = ":f_build_curlcurl_quad_vector";
+            build_qf = &f_build_curlcurl_quad_vector;
+         }
+         else
+         {
+            apply_func = ":f_apply_curlcurl_mf_quad_vector";
+            apply_qf = &f_apply_curlcurl_mf_quad_vector;
+         }
       }
    }
-   void InitCoefficient(mfem::MatrixCoefficient &MQ)
+   void InitCoefficient(mfem::MatrixCoefficient &MQ, bool use_mf)
    {
       // Assumes matrix coefficient is symmetric
-      const int vdim = MQ.GetVDim();
-      ctx.coeff_comp = (vdim * (vdim + 1)) / 2;
-      if (MatrixConstantCoefficient *const_coeff =
-             dynamic_cast<MatrixConstantCoefficient *>(&MQ))
+      if (mfem::MatrixConstantCoefficient *const_coeff =
+             dynamic_cast<mfem::MatrixConstantCoefficient *>(&MQ))
       {
-         MFEM_VERIFY(ctx.coeff_comp <= LIBCEED_CURLCURL_COEFF_COMP_MAX,
+         const int vdim = MQ.GetVDim();
+         MFEM_VERIFY((vdim * (vdim + 1)) / 2 <= LIBCEED_CURLCURL_COEFF_COMP_MAX,
                      "MatrixCoefficient dimensions exceed context storage!");
          const mfem::DenseMatrix &val = const_coeff->GetMatrix();
          for (int j = 0; j < vdim; j++)
@@ -105,6 +156,29 @@ struct CurlCurlOperatorInfo : public OperatorInfo
                const int idx = (j * vdim) - (((j - 1) * j) / 2) + i - j;
                ctx.coeff[idx] = val(i, j);
             }
+         }
+         if (!use_mf)
+         {
+            build_func = ":f_build_curlcurl_const_matrix";
+            build_qf = &f_build_curlcurl_const_matrix;
+         }
+         else
+         {
+            apply_func = ":f_apply_curlcurl_mf_const_matrix";
+            apply_qf = &f_apply_curlcurl_mf_const_matrix;
+         }
+      }
+      else
+      {
+         if (!use_mf)
+         {
+            build_func = ":f_build_curlcurl_quad_matrix";
+            build_qf = &f_build_curlcurl_quad_matrix;
+         }
+         else
+         {
+            apply_func = ":f_apply_curlcurl_mf_quad_matrix";
+            apply_qf = &f_apply_curlcurl_mf_quad_matrix;
          }
       }
    }
@@ -134,7 +208,7 @@ MFCurlCurlIntegrator::MFCurlCurlIntegrator(
    const bool use_bdr)
 {
 #ifdef MFEM_USE_CEED
-   CurlCurlOperatorInfo info(fes, Q, use_bdr);
+   CurlCurlOperatorInfo info(fes, Q, use_bdr, true);
    Assemble(integ, info, fes, Q, use_bdr, true);
 #else
    MFEM_ABORT("MFEM must be built with MFEM_USE_CEED=YES to use libCEED.");

--- a/fem/ceed/integrators/curlcurl/curlcurl.cpp
+++ b/fem/ceed/integrators/curlcurl/curlcurl.cpp
@@ -141,6 +141,8 @@ MFCurlCurlIntegrator::MFCurlCurlIntegrator(
 #endif
 }
 
+// @cond DOXYGEN_SKIP
+
 template PACurlCurlIntegrator::PACurlCurlIntegrator(
    const mfem::CurlCurlIntegrator &, const mfem::FiniteElementSpace &,
    mfem::Coefficient *, const bool);
@@ -160,6 +162,8 @@ template MFCurlCurlIntegrator::MFCurlCurlIntegrator(
 template MFCurlCurlIntegrator::MFCurlCurlIntegrator(
    const mfem::CurlCurlIntegrator &, const mfem::FiniteElementSpace &,
    mfem::MatrixCoefficient *, const bool);
+
+// @endcond
 
 } // namespace ceed
 

--- a/fem/ceed/integrators/curlcurl/curlcurl.hpp
+++ b/fem/ceed/integrators/curlcurl/curlcurl.hpp
@@ -1,0 +1,50 @@
+// Copyright (c) 2010-2023, Lawrence Livermore National Security, LLC. Produced
+// at the Lawrence Livermore National Laboratory. All Rights reserved. See files
+// LICENSE and NOTICE for details. LLNL-CODE-806117.
+//
+// This file is part of the MFEM library. For more information and source code
+// availability visit https://mfem.org.
+//
+// MFEM is free software; you can redistribute it and/or modify it under the
+// terms of the BSD-3 license. We welcome feedback and contributions, see file
+// CONTRIBUTING.md for details.
+
+#ifndef MFEM_LIBCEED_CURLCURL_HPP
+#define MFEM_LIBCEED_CURLCURL_HPP
+
+#include "../../interface/mixed_integrator.hpp"
+#include "../../../fespace.hpp"
+
+namespace mfem
+{
+
+namespace ceed
+{
+
+/// Represent a CurlCurlIntegrator with AssemblyLevel::Partial using libCEED.
+class PACurlCurlIntegrator : public MixedIntegrator
+{
+public:
+   template <typename CoeffType>
+   PACurlCurlIntegrator(const mfem::CurlCurlIntegrator &integ,
+                        const mfem::FiniteElementSpace &fes,
+                        CoeffType *Q,
+                        const bool use_bdr = false);
+};
+
+/// Represent a CurlCurlIntegrator with AssemblyLevel::None using libCEED.
+class MFCurlCurlIntegrator : public MixedIntegrator
+{
+public:
+   template <typename CoeffType>
+   MFCurlCurlIntegrator(const mfem::CurlCurlIntegrator &integ,
+                        const mfem::FiniteElementSpace &fes,
+                        CoeffType *Q,
+                        const bool use_bdr = false);
+};
+
+}
+
+}
+
+#endif // MFEM_LIBCEED_CURLCURL_HPP

--- a/fem/ceed/integrators/curlcurl/curlcurl_qf.h
+++ b/fem/ceed/integrators/curlcurl/curlcurl_qf.h
@@ -1,0 +1,239 @@
+// Copyright (c) 2010-2023, Lawrence Livermore National Security, LLC. Produced
+// at the Lawrence Livermore National Laboratory. All Rights reserved. See files
+// LICENSE and NOTICE for details. LLNL-CODE-806117.
+//
+// This file is part of the MFEM library. For more information and source code
+// availability visit https://mfem.org.
+//
+// MFEM is free software; you can redistribute it and/or modify it under the
+// terms of the BSD-3 license. We welcome feedback and contributions, see file
+// CONTRIBUTING.md for details.
+
+#ifndef MFEM_LIBCEED_CURLCURL_QF_H
+#define MFEM_LIBCEED_CURLCURL_QF_H
+
+#include "../util/util_qf.h"
+
+#define LIBCEED_CURLCURL_COEFF_COMP_MAX 6
+
+/// A structure used to pass additional data to f_build_curlcurl and
+/// f_apply_curlcurl
+struct CurlCurlContext
+{
+   CeedInt dim, space_dim, curl_dim, coeff_comp;
+   CeedScalar coeff[LIBCEED_CURLCURL_COEFF_COMP_MAX];
+};
+
+/// libCEED QFunction for building quadrature data for a curl-curl
+/// operator with a constant coefficient
+CEED_QFUNCTION(f_build_curlcurl_const)(void *ctx, CeedInt Q,
+                                       const CeedScalar *const *in,
+                                       CeedScalar *const *out)
+{
+   CurlCurlContext *bc = (CurlCurlContext *)ctx;
+   // in[0] is Jacobians with shape [dim, ncomp=space_dim, Q]
+   // in[1] is quadrature weights, size (Q)
+   //
+   // At every quadrature point, compute qw/det(J) J^T C J and store the
+   // symmetric part of the result. In 2D, compute and store qw * c / det(J).
+   const CeedInt coeff_comp = bc->coeff_comp;
+   const CeedScalar *coeff = bc->coeff;
+   const CeedScalar *J = in[0], *qw = in[1];
+   CeedScalar *qd = out[0];
+   switch (100 * bc->space_dim + 10 * bc->dim + bc->curl_dim)
+   {
+      case 221:
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+         {
+            const CeedScalar coeff0 = coeff[0];
+            qd[i] = qw[i] * coeff0 / DetJ22(J + i, Q);
+         }
+         break;
+      case 321:
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+         {
+            const CeedScalar coeff0 = coeff[0];
+            qd[i] = qw[i] * coeff0 / DetJ32(J + i, Q);
+         }
+         break;
+      case 333:
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+         {
+            MultJtCJ33(J + i, Q, coeff, 1, coeff_comp, qw[i], Q, qd + i);
+         }
+         break;
+   }
+   return 0;
+}
+
+/// libCEED QFunction for building quadrature data for a curl-curl
+/// operator with a coefficient evaluated at quadrature points.
+CEED_QFUNCTION(f_build_curlcurl_quad)(void *ctx, CeedInt Q,
+                                      const CeedScalar *const *in,
+                                      CeedScalar *const *out)
+{
+   CurlCurlContext *bc = (CurlCurlContext *)ctx;
+   // in[0] is coefficients with shape [ncomp=coeff_comp, Q]
+   // in[1] is Jacobians with shape [dim, ncomp=space_dim, Q]
+   // in[2] is quadrature weights, size (Q)
+   //
+   // At every quadrature point, compute qw/det(J) J^T C J and store the
+   // symmetric part of the result. In 2D, compute and store qw * c / det(J).
+   const CeedInt coeff_comp = bc->coeff_comp;
+   const CeedScalar *c = in[0], *J = in[1], *qw = in[2];
+   CeedScalar *qd = out[0];
+   switch (100 * bc->space_dim + 10 * bc->dim + bc->curl_dim)
+   {
+      case 221:
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+         {
+            qd[i] = qw[i] * c[i] / DetJ22(J + i, Q);
+         }
+         break;
+      case 321:
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+         {
+            qd[i] = qw[i] * c[i] / DetJ32(J + i, Q);
+         }
+         break;
+      case 333:
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+         {
+            MultJtCJ33(J + i, Q, c + i, Q, coeff_comp, qw[i], Q, qd + i);
+         }
+         break;
+   }
+   return 0;
+}
+
+/// libCEED QFunction for applying a curl-curl operator
+CEED_QFUNCTION(f_apply_curlcurl)(void *ctx, CeedInt Q,
+                                 const CeedScalar *const *in,
+                                 CeedScalar *const *out)
+{
+   CurlCurlContext *bc = (CurlCurlContext *)ctx;
+   // in[0], out[0] have shape [curl_dim, ncomp=1, Q]
+   const CeedScalar *uc = in[0], *qd = in[1];
+   CeedScalar *vc = out[0];
+   switch (10 * bc->dim + bc->curl_dim)
+   {
+      case 21:
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+         {
+            vc[i] = qd[i] * uc[i];
+         }
+         break;
+      case 33:
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+         {
+            const CeedScalar uc0 = uc[i + Q * 0];
+            const CeedScalar uc1 = uc[i + Q * 1];
+            const CeedScalar uc2 = uc[i + Q * 2];
+            vc[i + Q * 0] = qd[i + Q * 0] * uc0 + qd[i + Q * 1] * uc1 + qd[i + Q * 2] * uc2;
+            vc[i + Q * 1] = qd[i + Q * 1] * uc0 + qd[i + Q * 3] * uc1 + qd[i + Q * 4] * uc2;
+            vc[i + Q * 2] = qd[i + Q * 2] * uc0 + qd[i + Q * 4] * uc1 + qd[i + Q * 5] * uc2;
+         }
+         break;
+   }
+   return 0;
+}
+
+/// libCEED QFunction for applying a curl-curl operator
+CEED_QFUNCTION(f_apply_curlcurl_mf_const)(void *ctx, CeedInt Q,
+                                          const CeedScalar *const *in,
+                                          CeedScalar *const *out)
+{
+   CurlCurlContext *bc = (CurlCurlContext *)ctx;
+   // in[0], out[0] have shape [curl_dim, ncomp=1, Q]
+   // in[1] is Jacobians with shape [dim, ncomp=space_dim, Q]
+   // in[2] is quadrature weights, size (Q)
+   //
+   // At every quadrature point, compute qw/det(J) J^T C J.
+   const CeedInt coeff_comp = bc->coeff_comp;
+   const CeedScalar *coeff = bc->coeff;
+   const CeedScalar *uc = in[0], *J = in[1], *qw = in[2];
+   CeedScalar *vc = out[0];
+   switch (100 * bc->space_dim + 10 * bc->dim + bc->curl_dim)
+   {
+      case 221:
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+         {
+            const CeedScalar coeff0 = coeff[0];
+            const CeedScalar qd = qw[i] * coeff0 / DetJ22(J + i, Q);
+            vc[i] = qd * uc[i];
+         }
+         break;
+      case 321:
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+         {
+            const CeedScalar coeff0 = coeff[0];
+            const CeedScalar qd = qw[i] * coeff0 / DetJ32(J + i, Q);
+            vc[i] = qd * uc[i];
+         }
+         break;
+      case 333:
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+         {
+            CeedScalar qd[6];
+            MultJtCJ33(J + i, Q, coeff, 1, coeff_comp, qw[i], 1, qd);
+            const CeedScalar uc0 = uc[i + Q * 0];
+            const CeedScalar uc1 = uc[i + Q * 1];
+            const CeedScalar uc2 = uc[i + Q * 2];
+            vc[i + Q * 0] = qd[0] * uc0 + qd[1] * uc1 + qd[2] * uc2;
+            vc[i + Q * 1] = qd[1] * uc0 + qd[3] * uc1 + qd[4] * uc2;
+            vc[i + Q * 2] = qd[2] * uc0 + qd[4] * uc1 + qd[5] * uc2;
+         }
+         break;
+   }
+   return 0;
+}
+
+/// libCEED QFunction for applying a curl-curl operator
+CEED_QFUNCTION(f_apply_curlcurl_mf_quad)(void *ctx, CeedInt Q,
+                                         const CeedScalar *const *in,
+                                         CeedScalar *const *out)
+{
+   CurlCurlContext *bc = (CurlCurlContext *)ctx;
+   // in[0], out[0] have shape [curl_dim, ncomp=1, Q]
+   // in[1] is coefficients with shape [ncomp=coeff_comp, Q]
+   // in[2] is Jacobians with shape [dim, ncomp=space_dim, Q]
+   // in[3] is quadrature weights, size (Q)
+   //
+   // At every quadrature point, compute qw/det(J) J^T C J.
+   const CeedInt coeff_comp = bc->coeff_comp;
+   const CeedScalar *uc = in[0], *c = in[1], *J = in[2], *qw = in[3];
+   CeedScalar *vc = out[0];
+   switch (100 * bc->space_dim + 10 * bc->dim + bc->curl_dim)
+   {
+      case 221:
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+         {
+            const CeedScalar qd = qw[i] * c[i] / DetJ22(J + i, Q);
+            vc[i] = qd * uc[i];
+         }
+         break;
+      case 321:
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+         {
+            const CeedScalar qd = qw[i] * c[i] / DetJ32(J + i, Q);
+            vc[i] = qd * uc[i];
+         }
+         break;
+      case 333:
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+         {
+            CeedScalar qd[6];
+            MultJtCJ33(J + i, Q, c + i, Q, coeff_comp, qw[i], 1, qd);
+            const CeedScalar uc0 = uc[i + Q * 0];
+            const CeedScalar uc1 = uc[i + Q * 1];
+            const CeedScalar uc2 = uc[i + Q * 2];
+            vc[i + Q * 0] = qd[0] * uc0 + qd[1] * uc1 + qd[2] * uc2;
+            vc[i + Q * 1] = qd[1] * uc0 + qd[3] * uc1 + qd[4] * uc2;
+            vc[i + Q * 2] = qd[2] * uc0 + qd[4] * uc1 + qd[5] * uc2;
+         }
+         break;
+   }
+   return 0;
+}
+
+#endif // MFEM_LIBCEED_CURLCURL_QF_H

--- a/fem/ceed/integrators/curlcurl/curlcurl_qf.h
+++ b/fem/ceed/integrators/curlcurl/curlcurl_qf.h
@@ -36,30 +36,42 @@ CEED_QFUNCTION(f_build_curlcurl_const)(void *ctx, CeedInt Q,
    //
    // At every quadrature point, compute qw/det(J) J^T C J and store the
    // symmetric part of the result. In 2D, compute and store qw * c / det(J).
-   const CeedInt coeff_comp = bc->coeff_comp;
    const CeedScalar *coeff = bc->coeff;
    const CeedScalar *J = in[0], *qw = in[1];
    CeedScalar *qd = out[0];
-   switch (100 * bc->space_dim + 10 * bc->dim + bc->curl_dim)
+   switch (1000 * bc->space_dim + 100 * bc->dim + 10 * bc->curl_dim +
+           bc->coeff_comp)
    {
-      case 221:
+      case 2211:
          CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
             const CeedScalar coeff0 = coeff[0];
             qd[i] = qw[i] * coeff0 / DetJ22(J + i, Q);
          }
          break;
-      case 321:
+      case 3211:
          CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
             const CeedScalar coeff0 = coeff[0];
             qd[i] = qw[i] * coeff0 / DetJ32(J + i, Q);
          }
          break;
-      case 333:
+      case 3336:
          CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
-            MultJtCJ33(J + i, Q, coeff, 1, coeff_comp, qw[i], Q, qd + i);
+            MultJtCJ33(J + i, Q, coeff, 1, 6, qw[i], Q, qd + i);
+         }
+         break;
+      case 3333:
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+         {
+            MultJtCJ33(J + i, Q, coeff, 1, 3, qw[i], Q, qd + i);
+         }
+         break;
+      case 3331:
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+         {
+            MultJtCJ33(J + i, Q, coeff, 1, 1, qw[i], Q, qd + i);
          }
          break;
    }
@@ -79,27 +91,39 @@ CEED_QFUNCTION(f_build_curlcurl_quad)(void *ctx, CeedInt Q,
    //
    // At every quadrature point, compute qw/det(J) J^T C J and store the
    // symmetric part of the result. In 2D, compute and store qw * c / det(J).
-   const CeedInt coeff_comp = bc->coeff_comp;
    const CeedScalar *c = in[0], *J = in[1], *qw = in[2];
    CeedScalar *qd = out[0];
-   switch (100 * bc->space_dim + 10 * bc->dim + bc->curl_dim)
+   switch (1000 * bc->space_dim + 100 * bc->dim + 10 * bc->curl_dim +
+           bc->coeff_comp)
    {
-      case 221:
+      case 2211:
          CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
             qd[i] = qw[i] * c[i] / DetJ22(J + i, Q);
          }
          break;
-      case 321:
+      case 3211:
          CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
             qd[i] = qw[i] * c[i] / DetJ32(J + i, Q);
          }
          break;
-      case 333:
+      case 3336:
          CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
-            MultJtCJ33(J + i, Q, c + i, Q, coeff_comp, qw[i], Q, qd + i);
+            MultJtCJ33(J + i, Q, c + i, Q, 6, qw[i], Q, qd + i);
+         }
+         break;
+      case 3333:
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+         {
+            MultJtCJ33(J + i, Q, c + i, Q, 3, qw[i], Q, qd + i);
+         }
+         break;
+      case 3331:
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+         {
+            MultJtCJ33(J + i, Q, c + i, Q, 1, qw[i], Q, qd + i);
          }
          break;
    }
@@ -149,13 +173,13 @@ CEED_QFUNCTION(f_apply_curlcurl_mf_const)(void *ctx, CeedInt Q,
    // in[2] is quadrature weights, size (Q)
    //
    // At every quadrature point, compute qw/det(J) J^T C J.
-   const CeedInt coeff_comp = bc->coeff_comp;
    const CeedScalar *coeff = bc->coeff;
    const CeedScalar *uc = in[0], *J = in[1], *qw = in[2];
    CeedScalar *vc = out[0];
-   switch (100 * bc->space_dim + 10 * bc->dim + bc->curl_dim)
+   switch (1000 * bc->space_dim + 100 * bc->dim + 10 * bc->curl_dim +
+           bc->coeff_comp)
    {
-      case 221:
+      case 2211:
          CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
             const CeedScalar coeff0 = coeff[0];
@@ -163,7 +187,7 @@ CEED_QFUNCTION(f_apply_curlcurl_mf_const)(void *ctx, CeedInt Q,
             vc[i] = qd * uc[i];
          }
          break;
-      case 321:
+      case 3211:
          CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
             const CeedScalar coeff0 = coeff[0];
@@ -171,11 +195,37 @@ CEED_QFUNCTION(f_apply_curlcurl_mf_const)(void *ctx, CeedInt Q,
             vc[i] = qd * uc[i];
          }
          break;
-      case 333:
+      case 3336:
          CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
             CeedScalar qd[6];
-            MultJtCJ33(J + i, Q, coeff, 1, coeff_comp, qw[i], 1, qd);
+            MultJtCJ33(J + i, Q, coeff, 1, 6, qw[i], 1, qd);
+            const CeedScalar uc0 = uc[i + Q * 0];
+            const CeedScalar uc1 = uc[i + Q * 1];
+            const CeedScalar uc2 = uc[i + Q * 2];
+            vc[i + Q * 0] = qd[0] * uc0 + qd[1] * uc1 + qd[2] * uc2;
+            vc[i + Q * 1] = qd[1] * uc0 + qd[3] * uc1 + qd[4] * uc2;
+            vc[i + Q * 2] = qd[2] * uc0 + qd[4] * uc1 + qd[5] * uc2;
+         }
+         break;
+      case 3333:
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+         {
+            CeedScalar qd[6];
+            MultJtCJ33(J + i, Q, coeff, 1, 3, qw[i], 1, qd);
+            const CeedScalar uc0 = uc[i + Q * 0];
+            const CeedScalar uc1 = uc[i + Q * 1];
+            const CeedScalar uc2 = uc[i + Q * 2];
+            vc[i + Q * 0] = qd[0] * uc0 + qd[1] * uc1 + qd[2] * uc2;
+            vc[i + Q * 1] = qd[1] * uc0 + qd[3] * uc1 + qd[4] * uc2;
+            vc[i + Q * 2] = qd[2] * uc0 + qd[4] * uc1 + qd[5] * uc2;
+         }
+         break;
+      case 3331:
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+         {
+            CeedScalar qd[6];
+            MultJtCJ33(J + i, Q, coeff, 1, 1, qw[i], 1, qd);
             const CeedScalar uc0 = uc[i + Q * 0];
             const CeedScalar uc1 = uc[i + Q * 1];
             const CeedScalar uc2 = uc[i + Q * 2];
@@ -200,30 +250,56 @@ CEED_QFUNCTION(f_apply_curlcurl_mf_quad)(void *ctx, CeedInt Q,
    // in[3] is quadrature weights, size (Q)
    //
    // At every quadrature point, compute qw/det(J) J^T C J.
-   const CeedInt coeff_comp = bc->coeff_comp;
    const CeedScalar *uc = in[0], *c = in[1], *J = in[2], *qw = in[3];
    CeedScalar *vc = out[0];
-   switch (100 * bc->space_dim + 10 * bc->dim + bc->curl_dim)
+   switch (1000 * bc->space_dim + 100 * bc->dim + 10 * bc->curl_dim +
+           bc->coeff_comp)
    {
-      case 221:
+      case 2211:
          CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
             const CeedScalar qd = qw[i] * c[i] / DetJ22(J + i, Q);
             vc[i] = qd * uc[i];
          }
          break;
-      case 321:
+      case 3211:
          CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
             const CeedScalar qd = qw[i] * c[i] / DetJ32(J + i, Q);
             vc[i] = qd * uc[i];
          }
          break;
-      case 333:
+      case 3336:
          CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
             CeedScalar qd[6];
-            MultJtCJ33(J + i, Q, c + i, Q, coeff_comp, qw[i], 1, qd);
+            MultJtCJ33(J + i, Q, c + i, Q, 6, qw[i], 1, qd);
+            const CeedScalar uc0 = uc[i + Q * 0];
+            const CeedScalar uc1 = uc[i + Q * 1];
+            const CeedScalar uc2 = uc[i + Q * 2];
+            vc[i + Q * 0] = qd[0] * uc0 + qd[1] * uc1 + qd[2] * uc2;
+            vc[i + Q * 1] = qd[1] * uc0 + qd[3] * uc1 + qd[4] * uc2;
+            vc[i + Q * 2] = qd[2] * uc0 + qd[4] * uc1 + qd[5] * uc2;
+         }
+         break;
+      case 3333:
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+         {
+            CeedScalar qd[6];
+            MultJtCJ33(J + i, Q, c + i, Q, 3, qw[i], 1, qd);
+            const CeedScalar uc0 = uc[i + Q * 0];
+            const CeedScalar uc1 = uc[i + Q * 1];
+            const CeedScalar uc2 = uc[i + Q * 2];
+            vc[i + Q * 0] = qd[0] * uc0 + qd[1] * uc1 + qd[2] * uc2;
+            vc[i + Q * 1] = qd[1] * uc0 + qd[3] * uc1 + qd[4] * uc2;
+            vc[i + Q * 2] = qd[2] * uc0 + qd[4] * uc1 + qd[5] * uc2;
+         }
+         break;
+      case 3331:
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+         {
+            CeedScalar qd[6];
+            MultJtCJ33(J + i, Q, c + i, Q, 1, qw[i], 1, qd);
             const CeedScalar uc0 = uc[i + Q * 0];
             const CeedScalar uc1 = uc[i + Q * 1];
             const CeedScalar uc2 = uc[i + Q * 2];

--- a/fem/ceed/integrators/diffusion/diffusion.cpp
+++ b/fem/ceed/integrators/diffusion/diffusion.cpp
@@ -25,73 +25,124 @@ namespace ceed
 #ifdef MFEM_USE_CEED
 struct DiffusionOperatorInfo : public OperatorInfo
 {
-   DiffusionContext ctx;
+   DiffusionContext ctx = {0};
    template <typename CoeffType>
    DiffusionOperatorInfo(const mfem::FiniteElementSpace &fes, CoeffType *Q,
-                         bool use_bdr)
+                         bool use_bdr = false, bool use_mf = false)
    {
       ctx.dim = fes.GetMesh()->Dimension() - use_bdr;
       ctx.space_dim = fes.GetMesh()->SpaceDimension();
       ctx.vdim = fes.GetVDim();
-      if (Q == nullptr)
+      if (!use_mf)
       {
-         ctx.coeff_comp = 1;
-         ctx.coeff[0] = 1.0;
+         apply_func = ":f_apply_diff";
+         apply_qf = &f_apply_diff;
       }
       else
       {
-         InitCoefficient(*Q);
+         build_func = "";
+         build_qf = nullptr;
       }
-
+      if (Q == nullptr)
+      {
+         ctx.coeff[0] = 1.0;
+         if (!use_mf)
+         {
+            build_func = ":f_build_diff_const_scalar";
+            build_qf = &f_build_diff_const_scalar;
+         }
+         else
+         {
+            apply_func = ":f_apply_diff_mf_const_scalar";
+            apply_qf = &f_apply_diff_mf_const_scalar;
+         }
+      }
+      else
+      {
+         InitCoefficient(*Q, use_mf);
+      }
       header = "/integrators/diffusion/diffusion_qf.h";
-      build_func_const = ":f_build_diff_const";
-      build_qf_const = &f_build_diff_const;
-      build_func_quad = ":f_build_diff_quad";
-      build_qf_quad = &f_build_diff_quad;
-      apply_func = ":f_apply_diff";
-      apply_qf = &f_apply_diff;
-      apply_func_mf_const = ":f_apply_diff_mf_const";
-      apply_qf_mf_const = &f_apply_diff_mf_const;
-      apply_func_mf_quad = ":f_apply_diff_mf_quad";
-      apply_qf_mf_quad = &f_apply_diff_mf_quad;
       trial_op = EvalMode::Grad;
       test_op = EvalMode::Grad;
       qdatasize = (ctx.dim * (ctx.dim + 1)) / 2;
    }
-   void InitCoefficient(mfem::Coefficient &Q)
+   void InitCoefficient(mfem::Coefficient &Q, bool use_mf)
    {
-      ctx.coeff_comp = 1;
-      if (ConstantCoefficient *const_coeff =
-             dynamic_cast<ConstantCoefficient *>(&Q))
+      if (mfem::ConstantCoefficient *const_coeff =
+             dynamic_cast<mfem::ConstantCoefficient *>(&Q))
       {
          ctx.coeff[0] = const_coeff->constant;
+         if (!use_mf)
+         {
+            build_func = ":f_build_diff_const_scalar";
+            build_qf = &f_build_diff_const_scalar;
+         }
+         else
+         {
+            apply_func = ":f_apply_diff_mf_const_scalar";
+            apply_qf = &f_apply_diff_mf_const_scalar;
+         }
+      }
+      else
+      {
+         if (!use_mf)
+         {
+            build_func = ":f_build_diff_quad_scalar";
+            build_qf = &f_build_diff_quad_scalar;
+         }
+         else
+         {
+            apply_func = ":f_apply_diff_mf_quad_scalar";
+            apply_qf = &f_apply_diff_mf_quad_scalar;
+         }
       }
    }
-   void InitCoefficient(mfem::VectorCoefficient &VQ)
+   void InitCoefficient(mfem::VectorCoefficient &VQ, bool use_mf)
    {
-      const int vdim = VQ.GetVDim();
-      ctx.coeff_comp = vdim;
-      if (VectorConstantCoefficient *const_coeff =
-             dynamic_cast<VectorConstantCoefficient *>(&VQ))
+      if (mfem::VectorConstantCoefficient *const_coeff =
+             dynamic_cast<mfem::VectorConstantCoefficient *>(&VQ))
       {
-         MFEM_VERIFY(ctx.coeff_comp <= LIBCEED_DIFF_COEFF_COMP_MAX,
+         const int vdim = VQ.GetVDim();
+         MFEM_VERIFY(vdim <= LIBCEED_DIFF_COEFF_COMP_MAX,
                      "VectorCoefficient dimension exceeds context storage!");
          const mfem::Vector &val = const_coeff->GetVec();
          for (int i = 0; i < vdim; i++)
          {
             ctx.coeff[i] = val[i];
          }
+         if (!use_mf)
+         {
+            build_func = ":f_build_diff_const_vector";
+            build_qf = &f_build_diff_const_vector;
+         }
+         else
+         {
+            apply_func = ":f_apply_diff_mf_const_vector";
+            apply_qf = &f_apply_diff_mf_const_vector;
+         }
+      }
+      else
+      {
+         if (!use_mf)
+         {
+            build_func = ":f_build_diff_quad_vector";
+            build_qf = &f_build_diff_quad_vector;
+         }
+         else
+         {
+            apply_func = ":f_apply_diff_mf_quad_vector";
+            apply_qf = &f_apply_diff_mf_quad_vector;
+         }
       }
    }
-   void InitCoefficient(mfem::MatrixCoefficient &MQ)
+   void InitCoefficient(mfem::MatrixCoefficient &MQ, bool use_mf)
    {
       // Assumes matrix coefficient is symmetric
-      const int vdim = MQ.GetVDim();
-      ctx.coeff_comp = (vdim * (vdim + 1)) / 2;
-      if (MatrixConstantCoefficient *const_coeff =
-             dynamic_cast<MatrixConstantCoefficient *>(&MQ))
+      if (mfem::MatrixConstantCoefficient *const_coeff =
+             dynamic_cast<mfem::MatrixConstantCoefficient *>(&MQ))
       {
-         MFEM_VERIFY(ctx.coeff_comp <= LIBCEED_DIFF_COEFF_COMP_MAX,
+         const int vdim = MQ.GetVDim();
+         MFEM_VERIFY((vdim * (vdim + 1)) / 2 <= LIBCEED_DIFF_COEFF_COMP_MAX,
                      "MatrixCoefficient dimensions exceed context storage!");
          const mfem::DenseMatrix &val = const_coeff->GetMatrix();
          for (int j = 0; j < vdim; j++)
@@ -101,6 +152,29 @@ struct DiffusionOperatorInfo : public OperatorInfo
                const int idx = (j * vdim) - (((j - 1) * j) / 2) + i - j;
                ctx.coeff[idx] = val(i, j);
             }
+         }
+         if (!use_mf)
+         {
+            build_func = ":f_build_diff_const_matrix";
+            build_qf = &f_build_diff_const_matrix;
+         }
+         else
+         {
+            apply_func = ":f_apply_diff_mf_const_matrix";
+            apply_qf = &f_apply_diff_mf_const_matrix;
+         }
+      }
+      else
+      {
+         if (!use_mf)
+         {
+            build_func = ":f_build_diff_quad_matrix";
+            build_qf = &f_build_diff_quad_matrix;
+         }
+         else
+         {
+            apply_func = ":f_apply_diff_mf_quad_matrix";
+            apply_qf = &f_apply_diff_mf_quad_matrix;
          }
       }
    }
@@ -145,7 +219,7 @@ MFDiffusionIntegrator::MFDiffusionIntegrator(
    const bool use_bdr)
 {
 #ifdef MFEM_USE_CEED
-   DiffusionOperatorInfo info(fes, Q, use_bdr);
+   DiffusionOperatorInfo info(fes, Q, use_bdr, true);
    Assemble(integ, info, fes, Q, use_bdr, true);
 #else
    MFEM_ABORT("MFEM must be built with MFEM_USE_CEED=YES to use libCEED.");
@@ -160,7 +234,7 @@ MFDiffusionIntegrator::MFDiffusionIntegrator(
    const bool use_bdr)
 {
 #ifdef MFEM_USE_CEED
-   DiffusionOperatorInfo info(fes, Q, use_bdr);
+   DiffusionOperatorInfo info(fes, Q, use_bdr, true);
    Assemble(integ, info, fes, Q, use_bdr, true);
 #else
    MFEM_ABORT("MFEM must be built with MFEM_USE_CEED=YES to use libCEED.");

--- a/fem/ceed/integrators/diffusion/diffusion_qf.h
+++ b/fem/ceed/integrators/diffusion/diffusion_qf.h
@@ -35,41 +35,88 @@ CEED_QFUNCTION(f_build_diff_const)(void *ctx, CeedInt Q,
    //
    // At every quadrature point, compute qw/det(J) adj(J) C adj(J)^T and store
    // the symmetric part of the result.
-   const CeedInt coeff_comp = bc->coeff_comp;
    const CeedScalar *coeff = bc->coeff;
    const CeedScalar *J = in[0], *qw = in[1];
    CeedScalar *qd = out[0];
-   switch (10 * bc->space_dim + bc->dim)
+   switch (100 * bc->space_dim + 10 * bc->dim + bc->coeff_comp)
    {
-      case 11:
+      case 111:
          CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
             const CeedScalar coeff0 = coeff[0];
             qd[i] = qw[i] * coeff0 / J[i];
          }
          break;
-      case 21:
+      case 213:
          CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
-            MultAdjJCAdjJt21(J + i, Q, coeff, 1, coeff_comp, qw[i], Q, qd + i);
+            MultAdjJCAdjJt21(J + i, Q, coeff, 1, 3, qw[i], Q, qd + i);
          }
          break;
-      case 22:
+      case 212:
          CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
-            MultAdjJCAdjJt22(J + i, Q, coeff, 1, coeff_comp, qw[i], Q, qd + i);
+            MultAdjJCAdjJt21(J + i, Q, coeff, 1, 2, qw[i], Q, qd + i);
          }
          break;
-      case 32:
+      case 211:
          CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
-            MultAdjJCAdjJt32(J + i, Q, coeff, 1, coeff_comp, qw[i], Q, qd + i);
+            MultAdjJCAdjJt21(J + i, Q, coeff, 1, 1, qw[i], Q, qd + i);
          }
          break;
-      case 33:
+      case 223:
          CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
-            MultAdjJCAdjJt33(J + i, Q, coeff, 1, coeff_comp, qw[i], Q, qd + i);
+            MultAdjJCAdjJt22(J + i, Q, coeff, 1, 3, qw[i], Q, qd + i);
+         }
+         break;
+      case 222:
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+         {
+            MultAdjJCAdjJt22(J + i, Q, coeff, 1, 2, qw[i], Q, qd + i);
+         }
+         break;
+      case 221:
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+         {
+            MultAdjJCAdjJt22(J + i, Q, coeff, 1, 1, qw[i], Q, qd + i);
+         }
+         break;
+      case 326:
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+         {
+            MultAdjJCAdjJt32(J + i, Q, coeff, 1, 6, qw[i], Q, qd + i);
+         }
+         break;
+      case 323:
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+         {
+            MultAdjJCAdjJt32(J + i, Q, coeff, 1, 3, qw[i], Q, qd + i);
+         }
+         break;
+      case 321:
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+         {
+            MultAdjJCAdjJt32(J + i, Q, coeff, 1, 1, qw[i], Q, qd + i);
+         }
+         break;
+      case 336:
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+         {
+            MultAdjJCAdjJt33(J + i, Q, coeff, 1, 6, qw[i], Q, qd + i);
+         }
+         break;
+      case 333:
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+         {
+            MultAdjJCAdjJt33(J + i, Q, coeff, 1, 3, qw[i], Q, qd + i);
+         }
+         break;
+      case 331:
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+         {
+            MultAdjJCAdjJt33(J + i, Q, coeff, 1, 1, qw[i], Q, qd + i);
          }
          break;
    }
@@ -89,39 +136,86 @@ CEED_QFUNCTION(f_build_diff_quad)(void *ctx, CeedInt Q,
    //
    // At every quadrature point, compute qw/det(J) adj(J) C adj(J)^T and store
    // the symmetric part of the result.
-   const CeedInt coeff_comp = bc->coeff_comp;
    const CeedScalar *c = in[0], *J = in[1], *qw = in[2];
    CeedScalar *qd = out[0];
-   switch (10 * bc->space_dim + bc->dim)
+   switch (100 * bc->space_dim + 10 * bc->dim + bc->coeff_comp)
    {
-      case 11:
+      case 111:
          CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
             qd[i] = qw[i] * c[i] / J[i];
          }
          break;
-      case 21:
+      case 213:
          CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
-            MultAdjJCAdjJt21(J + i, Q, c + i, Q, coeff_comp, qw[i], Q, qd + i);
+            MultAdjJCAdjJt21(J + i, Q, c + i, Q, 3, qw[i], Q, qd + i);
          }
          break;
-      case 22:
+      case 212:
          CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
-            MultAdjJCAdjJt22(J + i, Q, c + i, Q, coeff_comp, qw[i], Q, qd + i);
+            MultAdjJCAdjJt21(J + i, Q, c + i, Q, 2, qw[i], Q, qd + i);
          }
          break;
-      case 32:
+      case 211:
          CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
-            MultAdjJCAdjJt32(J + i, Q, c + i, Q, coeff_comp, qw[i], Q, qd + i);
+            MultAdjJCAdjJt21(J + i, Q, c + i, Q, 1, qw[i], Q, qd + i);
          }
          break;
-      case 33:
+      case 223:
          CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
-            MultAdjJCAdjJt33(J + i, Q, c + i, Q, coeff_comp, qw[i], Q, qd + i);
+            MultAdjJCAdjJt22(J + i, Q, c + i, Q, 3, qw[i], Q, qd + i);
+         }
+         break;
+      case 222:
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+         {
+            MultAdjJCAdjJt22(J + i, Q, c + i, Q, 2, qw[i], Q, qd + i);
+         }
+         break;
+      case 221:
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+         {
+            MultAdjJCAdjJt22(J + i, Q, c + i, Q, 1, qw[i], Q, qd + i);
+         }
+         break;
+      case 326:
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+         {
+            MultAdjJCAdjJt32(J + i, Q, c + i, Q, 6, qw[i], Q, qd + i);
+         }
+         break;
+      case 323:
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+         {
+            MultAdjJCAdjJt32(J + i, Q, c + i, Q, 3, qw[i], Q, qd + i);
+         }
+         break;
+      case 321:
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+         {
+            MultAdjJCAdjJt32(J + i, Q, c + i, Q, 1, qw[i], Q, qd + i);
+         }
+         break;
+      case 336:
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+         {
+            MultAdjJCAdjJt33(J + i, Q, c + i, Q, 6, qw[i], Q, qd + i);
+         }
+         break;
+      case 333:
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+         {
+            MultAdjJCAdjJt33(J + i, Q, c + i, Q, 3, qw[i], Q, qd + i);
+         }
+         break;
+      case 331:
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+         {
+            MultAdjJCAdjJt33(J + i, Q, c + i, Q, 1, qw[i], Q, qd + i);
          }
          break;
    }
@@ -245,13 +339,12 @@ CEED_QFUNCTION(f_apply_diff_mf_const)(void *ctx, CeedInt Q,
    // in[2] is quadrature weights, size (Q)
    //
    // At every quadrature point, compute qw/det(J) adj(J) C adj(J)^T.
-   const CeedInt coeff_comp = bc->coeff_comp;
    const CeedScalar *coeff = bc->coeff;
    const CeedScalar *ug = in[0], *J = in[1], *qw = in[2];
    CeedScalar *vg = out[0];
-   switch (100 * bc->space_dim + 10 * bc->dim + bc->vdim)
+   switch (1000 * bc->space_dim + 100 * bc->dim + 10 * bc->coeff_comp + bc->vdim)
    {
-      case 111:
+      case 1111:
          CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
             const CeedScalar coeff0 = coeff[0];
@@ -259,41 +352,79 @@ CEED_QFUNCTION(f_apply_diff_mf_const)(void *ctx, CeedInt Q,
             vg[i] = qd * ug[i];
          }
          break;
-      case 211:
+      case 2131:
          CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
             CeedScalar qd;
-            MultAdjJCAdjJt21(J + i, Q, coeff, 1, coeff_comp, qw[i], 1, &qd);
+            MultAdjJCAdjJt21(J + i, Q, coeff, 1, 3, qw[i], 1, &qd);
             vg[i] = qd * ug[i];
          }
          break;
-      case 212:
+      case 2132:
          CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
             CeedScalar qd;
-            MultAdjJCAdjJt21(J + i, Q, coeff, 1, coeff_comp, qw[i], 1, &qd);
+            MultAdjJCAdjJt21(J + i, Q, coeff, 1, 3, qw[i], 1, &qd);
             CeedPragmaSIMD for (CeedInt d = 0; d < 2; d++)
             {
                vg[i + Q * d] = qd * ug[i + Q * d];
             }
          }
          break;
-      case 221:
+      case 2121:
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+         {
+            CeedScalar qd;
+            MultAdjJCAdjJt21(J + i, Q, coeff, 1, 2, qw[i], 1, &qd);
+            vg[i] = qd * ug[i];
+         }
+         break;
+      case 2122:
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+         {
+            CeedScalar qd;
+            MultAdjJCAdjJt21(J + i, Q, coeff, 1, 2, qw[i], 1, &qd);
+            CeedPragmaSIMD for (CeedInt d = 0; d < 2; d++)
+            {
+               vg[i + Q * d] = qd * ug[i + Q * d];
+            }
+         }
+         break;
+      case 2111:
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+         {
+            CeedScalar qd;
+            MultAdjJCAdjJt21(J + i, Q, coeff, 1, 1, qw[i], 1, &qd);
+            vg[i] = qd * ug[i];
+         }
+         break;
+      case 2112:
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+         {
+            CeedScalar qd;
+            MultAdjJCAdjJt21(J + i, Q, coeff, 1, 1, qw[i], 1, &qd);
+            CeedPragmaSIMD for (CeedInt d = 0; d < 2; d++)
+            {
+               vg[i + Q * d] = qd * ug[i + Q * d];
+            }
+         }
+         break;
+      case 2231:
          CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
             CeedScalar qd[3];
-            MultAdjJCAdjJt22(J + i, Q, coeff, 1, coeff_comp, qw[i], 1, qd);
+            MultAdjJCAdjJt22(J + i, Q, coeff, 1, 3, qw[i], 1, qd);
             const CeedScalar ug0 = ug[i + Q * 0];
             const CeedScalar ug1 = ug[i + Q * 1];
             vg[i + Q * 0] = qd[0] * ug0 + qd[1] * ug1;
             vg[i + Q * 1] = qd[1] * ug0 + qd[2] * ug1;
          }
          break;
-      case 222:
+      case 2232:
          CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
             CeedScalar qd[3];
-            MultAdjJCAdjJt22(J + i, Q, coeff, 1, coeff_comp, qw[i], 1, qd);
+            MultAdjJCAdjJt22(J + i, Q, coeff, 1, 3, qw[i], 1, qd);
             CeedPragmaSIMD for (CeedInt d = 0; d < 2; d++)
             {
                const CeedScalar ug0 = ug[i + Q * (d + 2 * 0)];
@@ -303,22 +434,72 @@ CEED_QFUNCTION(f_apply_diff_mf_const)(void *ctx, CeedInt Q,
             }
          }
          break;
-      case 321:
+      case 2221:
          CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
             CeedScalar qd[3];
-            MultAdjJCAdjJt32(J + i, Q, coeff, 1, coeff_comp, qw[i], 1, qd);
+            MultAdjJCAdjJt22(J + i, Q, coeff, 1, 2, qw[i], 1, qd);
             const CeedScalar ug0 = ug[i + Q * 0];
             const CeedScalar ug1 = ug[i + Q * 1];
             vg[i + Q * 0] = qd[0] * ug0 + qd[1] * ug1;
             vg[i + Q * 1] = qd[1] * ug0 + qd[2] * ug1;
          }
          break;
-      case 323:
+      case 2222:
          CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
             CeedScalar qd[3];
-            MultAdjJCAdjJt32(J + i, Q, coeff, 1, coeff_comp, qw[i], 1, qd);
+            MultAdjJCAdjJt22(J + i, Q, coeff, 1, 2, qw[i], 1, qd);
+            CeedPragmaSIMD for (CeedInt d = 0; d < 2; d++)
+            {
+               const CeedScalar ug0 = ug[i + Q * (d + 2 * 0)];
+               const CeedScalar ug1 = ug[i + Q * (d + 2 * 1)];
+               vg[i + Q * (d + 2 * 0)] = qd[0] * ug0 + qd[1] * ug1;
+               vg[i + Q * (d + 2 * 1)] = qd[1] * ug0 + qd[2] * ug1;
+            }
+         }
+         break;
+      case 2211:
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+         {
+            CeedScalar qd[3];
+            MultAdjJCAdjJt22(J + i, Q, coeff, 1, 1, qw[i], 1, qd);
+            const CeedScalar ug0 = ug[i + Q * 0];
+            const CeedScalar ug1 = ug[i + Q * 1];
+            vg[i + Q * 0] = qd[0] * ug0 + qd[1] * ug1;
+            vg[i + Q * 1] = qd[1] * ug0 + qd[2] * ug1;
+         }
+         break;
+      case 2212:
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+         {
+            CeedScalar qd[3];
+            MultAdjJCAdjJt22(J + i, Q, coeff, 1, 1, qw[i], 1, qd);
+            CeedPragmaSIMD for (CeedInt d = 0; d < 2; d++)
+            {
+               const CeedScalar ug0 = ug[i + Q * (d + 2 * 0)];
+               const CeedScalar ug1 = ug[i + Q * (d + 2 * 1)];
+               vg[i + Q * (d + 2 * 0)] = qd[0] * ug0 + qd[1] * ug1;
+               vg[i + Q * (d + 2 * 1)] = qd[1] * ug0 + qd[2] * ug1;
+            }
+         }
+         break;
+      case 3261:
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+         {
+            CeedScalar qd[3];
+            MultAdjJCAdjJt32(J + i, Q, coeff, 1, 6, qw[i], 1, qd);
+            const CeedScalar ug0 = ug[i + Q * 0];
+            const CeedScalar ug1 = ug[i + Q * 1];
+            vg[i + Q * 0] = qd[0] * ug0 + qd[1] * ug1;
+            vg[i + Q * 1] = qd[1] * ug0 + qd[2] * ug1;
+         }
+         break;
+      case 3263:
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+         {
+            CeedScalar qd[3];
+            MultAdjJCAdjJt32(J + i, Q, coeff, 1, 6, qw[i], 1, qd);
             CeedPragmaSIMD for (CeedInt d = 0; d < 3; d++)
             {
                const CeedScalar ug0 = ug[i + Q * (d + 3 * 0)];
@@ -328,11 +509,61 @@ CEED_QFUNCTION(f_apply_diff_mf_const)(void *ctx, CeedInt Q,
             }
          }
          break;
-      case 331:
+      case 3231:
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+         {
+            CeedScalar qd[3];
+            MultAdjJCAdjJt32(J + i, Q, coeff, 1, 3, qw[i], 1, qd);
+            const CeedScalar ug0 = ug[i + Q * 0];
+            const CeedScalar ug1 = ug[i + Q * 1];
+            vg[i + Q * 0] = qd[0] * ug0 + qd[1] * ug1;
+            vg[i + Q * 1] = qd[1] * ug0 + qd[2] * ug1;
+         }
+         break;
+      case 3233:
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+         {
+            CeedScalar qd[3];
+            MultAdjJCAdjJt32(J + i, Q, coeff, 1, 3, qw[i], 1, qd);
+            CeedPragmaSIMD for (CeedInt d = 0; d < 3; d++)
+            {
+               const CeedScalar ug0 = ug[i + Q * (d + 3 * 0)];
+               const CeedScalar ug1 = ug[i + Q * (d + 3 * 1)];
+               vg[i + Q * (d + 3 * 0)] = qd[0] * ug0 + qd[1] * ug1;
+               vg[i + Q * (d + 3 * 1)] = qd[1] * ug0 + qd[2] * ug1;
+            }
+         }
+         break;
+      case 3211:
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+         {
+            CeedScalar qd[3];
+            MultAdjJCAdjJt32(J + i, Q, coeff, 1, 1, qw[i], 1, qd);
+            const CeedScalar ug0 = ug[i + Q * 0];
+            const CeedScalar ug1 = ug[i + Q * 1];
+            vg[i + Q * 0] = qd[0] * ug0 + qd[1] * ug1;
+            vg[i + Q * 1] = qd[1] * ug0 + qd[2] * ug1;
+         }
+         break;
+      case 3213:
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+         {
+            CeedScalar qd[3];
+            MultAdjJCAdjJt32(J + i, Q, coeff, 1, 1, qw[i], 1, qd);
+            CeedPragmaSIMD for (CeedInt d = 0; d < 3; d++)
+            {
+               const CeedScalar ug0 = ug[i + Q * (d + 3 * 0)];
+               const CeedScalar ug1 = ug[i + Q * (d + 3 * 1)];
+               vg[i + Q * (d + 3 * 0)] = qd[0] * ug0 + qd[1] * ug1;
+               vg[i + Q * (d + 3 * 1)] = qd[1] * ug0 + qd[2] * ug1;
+            }
+         }
+         break;
+      case 3361:
          CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
             CeedScalar qd[6];
-            MultAdjJCAdjJt33(J + i, Q, coeff, 1, coeff_comp, qw[i], 1, qd);
+            MultAdjJCAdjJt33(J + i, Q, coeff, 1, 6, qw[i], 1, qd);
             const CeedScalar ug0 = ug[i + Q * 0];
             const CeedScalar ug1 = ug[i + Q * 1];
             const CeedScalar ug2 = ug[i + Q * 2];
@@ -341,11 +572,69 @@ CEED_QFUNCTION(f_apply_diff_mf_const)(void *ctx, CeedInt Q,
             vg[i + Q * 2] = qd[2] * ug0 + qd[4] * ug1 + qd[5] * ug2;
          }
          break;
-      case 333:
+      case 3363:
          CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
             CeedScalar qd[6];
-            MultAdjJCAdjJt33(J + i, Q, coeff, 1, coeff_comp, qw[i], 1, qd);
+            MultAdjJCAdjJt33(J + i, Q, coeff, 1, 6, qw[i], 1, qd);
+            CeedPragmaSIMD for (CeedInt d = 0; d < 3; d++)
+            {
+               const CeedScalar ug0 = ug[i + Q * (d + 3 * 0)];
+               const CeedScalar ug1 = ug[i + Q * (d + 3 * 1)];
+               const CeedScalar ug2 = ug[i + Q * (d + 3 * 2)];
+               vg[i + Q * (d + 3 * 0)] = qd[0] * ug0 + qd[1] * ug1 + qd[2] * ug2;
+               vg[i + Q * (d + 3 * 1)] = qd[1] * ug0 + qd[3] * ug1 + qd[4] * ug2;
+               vg[i + Q * (d + 3 * 2)] = qd[2] * ug0 + qd[4] * ug1 + qd[5] * ug2;
+            }
+         }
+         break;
+      case 3331:
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+         {
+            CeedScalar qd[6];
+            MultAdjJCAdjJt33(J + i, Q, coeff, 1, 3, qw[i], 1, qd);
+            const CeedScalar ug0 = ug[i + Q * 0];
+            const CeedScalar ug1 = ug[i + Q * 1];
+            const CeedScalar ug2 = ug[i + Q * 2];
+            vg[i + Q * 0] = qd[0] * ug0 + qd[1] * ug1 + qd[2] * ug2;
+            vg[i + Q * 1] = qd[1] * ug0 + qd[3] * ug1 + qd[4] * ug2;
+            vg[i + Q * 2] = qd[2] * ug0 + qd[4] * ug1 + qd[5] * ug2;
+         }
+         break;
+      case 3333:
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+         {
+            CeedScalar qd[6];
+            MultAdjJCAdjJt33(J + i, Q, coeff, 1, 3, qw[i], 1, qd);
+            CeedPragmaSIMD for (CeedInt d = 0; d < 3; d++)
+            {
+               const CeedScalar ug0 = ug[i + Q * (d + 3 * 0)];
+               const CeedScalar ug1 = ug[i + Q * (d + 3 * 1)];
+               const CeedScalar ug2 = ug[i + Q * (d + 3 * 2)];
+               vg[i + Q * (d + 3 * 0)] = qd[0] * ug0 + qd[1] * ug1 + qd[2] * ug2;
+               vg[i + Q * (d + 3 * 1)] = qd[1] * ug0 + qd[3] * ug1 + qd[4] * ug2;
+               vg[i + Q * (d + 3 * 2)] = qd[2] * ug0 + qd[4] * ug1 + qd[5] * ug2;
+            }
+         }
+         break;
+      case 3311:
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+         {
+            CeedScalar qd[6];
+            MultAdjJCAdjJt33(J + i, Q, coeff, 1, 1, qw[i], 1, qd);
+            const CeedScalar ug0 = ug[i + Q * 0];
+            const CeedScalar ug1 = ug[i + Q * 1];
+            const CeedScalar ug2 = ug[i + Q * 2];
+            vg[i + Q * 0] = qd[0] * ug0 + qd[1] * ug1 + qd[2] * ug2;
+            vg[i + Q * 1] = qd[1] * ug0 + qd[3] * ug1 + qd[4] * ug2;
+            vg[i + Q * 2] = qd[2] * ug0 + qd[4] * ug1 + qd[5] * ug2;
+         }
+         break;
+      case 3313:
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+         {
+            CeedScalar qd[6];
+            MultAdjJCAdjJt33(J + i, Q, coeff, 1, 1, qw[i], 1, qd);
             CeedPragmaSIMD for (CeedInt d = 0; d < 3; d++)
             {
                const CeedScalar ug0 = ug[i + Q * (d + 3 * 0)];
@@ -373,53 +662,90 @@ CEED_QFUNCTION(f_apply_diff_mf_quad)(void *ctx, CeedInt Q,
    // in[3] is quadrature weights, size (Q)
    //
    // At every quadrature point, compute qw/det(J) adj(J) C adj(J)^T.
-   const CeedInt coeff_comp = bc->coeff_comp;
    const CeedScalar *ug = in[0], *c = in[1], *J = in[2], *qw = in[3];
    CeedScalar *vg = out[0];
-   switch (100 * bc->space_dim + 10 * bc->dim + bc->vdim)
+   switch (1000 * bc->space_dim + 100 * bc->dim + 10 * bc->coeff_comp + bc->vdim)
    {
-      case 111:
+      case 1111:
          CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
             const CeedScalar qd = qw[i] * c[i] / J[i];
             vg[i] = qd * ug[i];
          }
          break;
-      case 211:
+      case 2131:
          CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
             CeedScalar qd;
-            MultAdjJCAdjJt21(J + i, Q, c + i, Q, coeff_comp, qw[i], 1, &qd);
+            MultAdjJCAdjJt21(J + i, Q, c + i, Q, 3, qw[i], 1, &qd);
             vg[i] = qd * ug[i];
          }
          break;
-      case 212:
+      case 2132:
          CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
             CeedScalar qd;
-            MultAdjJCAdjJt21(J + i, Q, c + i, Q, coeff_comp, qw[i], 1, &qd);
+            MultAdjJCAdjJt21(J + i, Q, c + i, Q, 3, qw[i], 1, &qd);
             CeedPragmaSIMD for (CeedInt d = 0; d < 2; d++)
             {
                vg[i + Q * d] = qd * ug[i + Q * d];
             }
          }
          break;
-      case 221:
+      case 2121:
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+         {
+            CeedScalar qd;
+            MultAdjJCAdjJt21(J + i, Q, c + i, Q, 2, qw[i], 1, &qd);
+            vg[i] = qd * ug[i];
+         }
+         break;
+      case 2122:
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+         {
+            CeedScalar qd;
+            MultAdjJCAdjJt21(J + i, Q, c + i, Q, 2, qw[i], 1, &qd);
+            CeedPragmaSIMD for (CeedInt d = 0; d < 2; d++)
+            {
+               vg[i + Q * d] = qd * ug[i + Q * d];
+            }
+         }
+         break;
+      case 2111:
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+         {
+            CeedScalar qd;
+            MultAdjJCAdjJt21(J + i, Q, c + i, Q, 1, qw[i], 1, &qd);
+            vg[i] = qd * ug[i];
+         }
+         break;
+      case 2112:
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+         {
+            CeedScalar qd;
+            MultAdjJCAdjJt21(J + i, Q, c + i, Q, 1, qw[i], 1, &qd);
+            CeedPragmaSIMD for (CeedInt d = 0; d < 2; d++)
+            {
+               vg[i + Q * d] = qd * ug[i + Q * d];
+            }
+         }
+         break;
+      case 2231:
          CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
             CeedScalar qd[3];
-            MultAdjJCAdjJt22(J + i, Q, c + i, Q, coeff_comp, qw[i], 1, qd);
+            MultAdjJCAdjJt22(J + i, Q, c + i, Q, 3, qw[i], 1, qd);
             const CeedScalar ug0 = ug[i + Q * 0];
             const CeedScalar ug1 = ug[i + Q * 1];
             vg[i + Q * 0] = qd[0] * ug0 + qd[1] * ug1;
             vg[i + Q * 1] = qd[1] * ug0 + qd[2] * ug1;
          }
          break;
-      case 222:
+      case 2232:
          CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
             CeedScalar qd[3];
-            MultAdjJCAdjJt22(J + i, Q, c + i, Q, coeff_comp, qw[i], 1, qd);
+            MultAdjJCAdjJt22(J + i, Q, c + i, Q, 3, qw[i], 1, qd);
             CeedPragmaSIMD for (CeedInt d = 0; d < 2; d++)
             {
                const CeedScalar ug0 = ug[i + Q * (d + 2 * 0)];
@@ -429,22 +755,72 @@ CEED_QFUNCTION(f_apply_diff_mf_quad)(void *ctx, CeedInt Q,
             }
          }
          break;
-      case 321:
+      case 2221:
          CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
             CeedScalar qd[3];
-            MultAdjJCAdjJt32(J + i, Q, c + i, Q, coeff_comp, qw[i], 1, qd);
+            MultAdjJCAdjJt22(J + i, Q, c + i, Q, 2, qw[i], 1, qd);
             const CeedScalar ug0 = ug[i + Q * 0];
             const CeedScalar ug1 = ug[i + Q * 1];
             vg[i + Q * 0] = qd[0] * ug0 + qd[1] * ug1;
             vg[i + Q * 1] = qd[1] * ug0 + qd[2] * ug1;
          }
          break;
-      case 323:
+      case 2222:
          CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
             CeedScalar qd[3];
-            MultAdjJCAdjJt32(J + i, Q, c + i, Q, coeff_comp, qw[i], 1, qd);
+            MultAdjJCAdjJt22(J + i, Q, c + i, Q, 2, qw[i], 1, qd);
+            CeedPragmaSIMD for (CeedInt d = 0; d < 2; d++)
+            {
+               const CeedScalar ug0 = ug[i + Q * (d + 2 * 0)];
+               const CeedScalar ug1 = ug[i + Q * (d + 2 * 1)];
+               vg[i + Q * (d + 2 * 0)] = qd[0] * ug0 + qd[1] * ug1;
+               vg[i + Q * (d + 2 * 1)] = qd[1] * ug0 + qd[2] * ug1;
+            }
+         }
+         break;
+      case 2211:
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+         {
+            CeedScalar qd[3];
+            MultAdjJCAdjJt22(J + i, Q, c + i, Q, 1, qw[i], 1, qd);
+            const CeedScalar ug0 = ug[i + Q * 0];
+            const CeedScalar ug1 = ug[i + Q * 1];
+            vg[i + Q * 0] = qd[0] * ug0 + qd[1] * ug1;
+            vg[i + Q * 1] = qd[1] * ug0 + qd[2] * ug1;
+         }
+         break;
+      case 2212:
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+         {
+            CeedScalar qd[3];
+            MultAdjJCAdjJt22(J + i, Q, c + i, Q, 1, qw[i], 1, qd);
+            CeedPragmaSIMD for (CeedInt d = 0; d < 2; d++)
+            {
+               const CeedScalar ug0 = ug[i + Q * (d + 2 * 0)];
+               const CeedScalar ug1 = ug[i + Q * (d + 2 * 1)];
+               vg[i + Q * (d + 2 * 0)] = qd[0] * ug0 + qd[1] * ug1;
+               vg[i + Q * (d + 2 * 1)] = qd[1] * ug0 + qd[2] * ug1;
+            }
+         }
+         break;
+      case 3261:
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+         {
+            CeedScalar qd[3];
+            MultAdjJCAdjJt32(J + i, Q, c + i, Q, 6, qw[i], 1, qd);
+            const CeedScalar ug0 = ug[i + Q * 0];
+            const CeedScalar ug1 = ug[i + Q * 1];
+            vg[i + Q * 0] = qd[0] * ug0 + qd[1] * ug1;
+            vg[i + Q * 1] = qd[1] * ug0 + qd[2] * ug1;
+         }
+         break;
+      case 3263:
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+         {
+            CeedScalar qd[3];
+            MultAdjJCAdjJt32(J + i, Q, c + i, Q, 6, qw[i], 1, qd);
             CeedPragmaSIMD for (CeedInt d = 0; d < 3; d++)
             {
                const CeedScalar ug0 = ug[i + Q * (d + 3 * 0)];
@@ -454,11 +830,61 @@ CEED_QFUNCTION(f_apply_diff_mf_quad)(void *ctx, CeedInt Q,
             }
          }
          break;
-      case 331:
+      case 3231:
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+         {
+            CeedScalar qd[3];
+            MultAdjJCAdjJt32(J + i, Q, c + i, Q, 3, qw[i], 1, qd);
+            const CeedScalar ug0 = ug[i + Q * 0];
+            const CeedScalar ug1 = ug[i + Q * 1];
+            vg[i + Q * 0] = qd[0] * ug0 + qd[1] * ug1;
+            vg[i + Q * 1] = qd[1] * ug0 + qd[2] * ug1;
+         }
+         break;
+      case 3233:
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+         {
+            CeedScalar qd[3];
+            MultAdjJCAdjJt32(J + i, Q, c + i, Q, 3, qw[i], 1, qd);
+            CeedPragmaSIMD for (CeedInt d = 0; d < 3; d++)
+            {
+               const CeedScalar ug0 = ug[i + Q * (d + 3 * 0)];
+               const CeedScalar ug1 = ug[i + Q * (d + 3 * 1)];
+               vg[i + Q * (d + 3 * 0)] = qd[0] * ug0 + qd[1] * ug1;
+               vg[i + Q * (d + 3 * 1)] = qd[1] * ug0 + qd[2] * ug1;
+            }
+         }
+         break;
+      case 3211:
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+         {
+            CeedScalar qd[3];
+            MultAdjJCAdjJt32(J + i, Q, c + i, Q, 1, qw[i], 1, qd);
+            const CeedScalar ug0 = ug[i + Q * 0];
+            const CeedScalar ug1 = ug[i + Q * 1];
+            vg[i + Q * 0] = qd[0] * ug0 + qd[1] * ug1;
+            vg[i + Q * 1] = qd[1] * ug0 + qd[2] * ug1;
+         }
+         break;
+      case 3213:
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+         {
+            CeedScalar qd[3];
+            MultAdjJCAdjJt32(J + i, Q, c + i, Q, 1, qw[i], 1, qd);
+            CeedPragmaSIMD for (CeedInt d = 0; d < 3; d++)
+            {
+               const CeedScalar ug0 = ug[i + Q * (d + 3 * 0)];
+               const CeedScalar ug1 = ug[i + Q * (d + 3 * 1)];
+               vg[i + Q * (d + 3 * 0)] = qd[0] * ug0 + qd[1] * ug1;
+               vg[i + Q * (d + 3 * 1)] = qd[1] * ug0 + qd[2] * ug1;
+            }
+         }
+         break;
+      case 3361:
          CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
             CeedScalar qd[6];
-            MultAdjJCAdjJt33(J + i, Q, c + i, Q, coeff_comp, qw[i], 1, qd);
+            MultAdjJCAdjJt33(J + i, Q, c + i, Q, 6, qw[i], 1, qd);
             const CeedScalar ug0 = ug[i + Q * 0];
             const CeedScalar ug1 = ug[i + Q * 1];
             const CeedScalar ug2 = ug[i + Q * 2];
@@ -467,11 +893,69 @@ CEED_QFUNCTION(f_apply_diff_mf_quad)(void *ctx, CeedInt Q,
             vg[i + Q * 2] = qd[2] * ug0 + qd[4] * ug1 + qd[5] * ug2;
          }
          break;
-      case 333:
+      case 3363:
          CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
             CeedScalar qd[6];
-            MultAdjJCAdjJt33(J + i, Q, c + i, Q, coeff_comp, qw[i], 1, qd);
+            MultAdjJCAdjJt33(J + i, Q, c + i, Q, 6, qw[i], 1, qd);
+            CeedPragmaSIMD for (CeedInt d = 0; d < 3; d++)
+            {
+               const CeedScalar ug0 = ug[i + Q * (d + 3 * 0)];
+               const CeedScalar ug1 = ug[i + Q * (d + 3 * 1)];
+               const CeedScalar ug2 = ug[i + Q * (d + 3 * 2)];
+               vg[i + Q * (d + 3 * 0)] = qd[0] * ug0 + qd[1] * ug1 + qd[2] * ug2;
+               vg[i + Q * (d + 3 * 1)] = qd[1] * ug0 + qd[3] * ug1 + qd[4] * ug2;
+               vg[i + Q * (d + 3 * 2)] = qd[2] * ug0 + qd[4] * ug1 + qd[5] * ug2;
+            }
+         }
+         break;
+      case 3331:
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+         {
+            CeedScalar qd[6];
+            MultAdjJCAdjJt33(J + i, Q, c + i, Q, 3, qw[i], 1, qd);
+            const CeedScalar ug0 = ug[i + Q * 0];
+            const CeedScalar ug1 = ug[i + Q * 1];
+            const CeedScalar ug2 = ug[i + Q * 2];
+            vg[i + Q * 0] = qd[0] * ug0 + qd[1] * ug1 + qd[2] * ug2;
+            vg[i + Q * 1] = qd[1] * ug0 + qd[3] * ug1 + qd[4] * ug2;
+            vg[i + Q * 2] = qd[2] * ug0 + qd[4] * ug1 + qd[5] * ug2;
+         }
+         break;
+      case 3333:
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+         {
+            CeedScalar qd[6];
+            MultAdjJCAdjJt33(J + i, Q, c + i, Q, 3, qw[i], 1, qd);
+            CeedPragmaSIMD for (CeedInt d = 0; d < 3; d++)
+            {
+               const CeedScalar ug0 = ug[i + Q * (d + 3 * 0)];
+               const CeedScalar ug1 = ug[i + Q * (d + 3 * 1)];
+               const CeedScalar ug2 = ug[i + Q * (d + 3 * 2)];
+               vg[i + Q * (d + 3 * 0)] = qd[0] * ug0 + qd[1] * ug1 + qd[2] * ug2;
+               vg[i + Q * (d + 3 * 1)] = qd[1] * ug0 + qd[3] * ug1 + qd[4] * ug2;
+               vg[i + Q * (d + 3 * 2)] = qd[2] * ug0 + qd[4] * ug1 + qd[5] * ug2;
+            }
+         }
+         break;
+      case 3311:
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+         {
+            CeedScalar qd[6];
+            MultAdjJCAdjJt33(J + i, Q, c + i, Q, 1, qw[i], 1, qd);
+            const CeedScalar ug0 = ug[i + Q * 0];
+            const CeedScalar ug1 = ug[i + Q * 1];
+            const CeedScalar ug2 = ug[i + Q * 2];
+            vg[i + Q * 0] = qd[0] * ug0 + qd[1] * ug1 + qd[2] * ug2;
+            vg[i + Q * 1] = qd[1] * ug0 + qd[3] * ug1 + qd[4] * ug2;
+            vg[i + Q * 2] = qd[2] * ug0 + qd[4] * ug1 + qd[5] * ug2;
+         }
+         break;
+      case 3313:
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+         {
+            CeedScalar qd[6];
+            MultAdjJCAdjJt33(J + i, Q, c + i, Q, 1, qw[i], 1, qd);
             CeedPragmaSIMD for (CeedInt d = 0; d < 3; d++)
             {
                const CeedScalar ug0 = ug[i + Q * (d + 3 * 0)];

--- a/fem/ceed/integrators/divdiv/divdiv.cpp
+++ b/fem/ceed/integrators/divdiv/divdiv.cpp
@@ -1,0 +1,92 @@
+// Copyright (c) 2010-2023, Lawrence Livermore National Security, LLC. Produced
+// at the Lawrence Livermore National Laboratory. All Rights reserved. See files
+// LICENSE and NOTICE for details. LLNL-CODE-806117.
+//
+// This file is part of the MFEM library. For more information and source code
+// availability visit https://mfem.org.
+//
+// MFEM is free software; you can redistribute it and/or modify it under the
+// terms of the BSD-3 license. We welcome feedback and contributions, see file
+// CONTRIBUTING.md for details.
+
+#include "divdiv.hpp"
+
+#include "../../../../config/config.hpp"
+#ifdef MFEM_USE_CEED
+#include "divdiv_qf.h"
+#endif
+
+namespace mfem
+{
+
+namespace ceed
+{
+
+#ifdef MFEM_USE_CEED
+struct DivDivOperatorInfo : public OperatorInfo
+{
+   DivDivContext ctx;
+   DivDivOperatorInfo(const mfem::FiniteElementSpace &fes, mfem::Coefficient *Q,
+                      bool use_bdr)
+   {
+      MFEM_VERIFY(fes.GetVDim() == 1,
+                  "libCEED interface for vector FE does not support VDim > 1!");
+      ctx.dim = fes.GetMesh()->Dimension() - use_bdr;
+      ctx.space_dim = fes.GetMesh()->SpaceDimension();
+      if (Q == nullptr)
+      {
+         ctx.coeff = 1.0;
+      }
+      else if (ConstantCoefficient *const_coeff =
+                  dynamic_cast<ConstantCoefficient *>(Q))
+      {
+         ctx.coeff = const_coeff->constant;
+      }
+
+      header = "/integrators/divdiv/divdiv_qf.h";
+      build_func_const = ":f_build_divdiv_const";
+      build_qf_const = &f_build_divdiv_const;
+      build_func_quad = ":f_build_divdiv_quad";
+      build_qf_quad = &f_build_divdiv_quad;
+      apply_func = ":f_apply_divdiv";
+      apply_qf = &f_apply_divdiv;
+      apply_func_mf_const = ":f_apply_divdiv_mf_const";
+      apply_qf_mf_const = &f_apply_divdiv_mf_const;
+      apply_func_mf_quad = ":f_apply_divdiv_mf_quad";
+      apply_qf_mf_quad = &f_apply_divdiv_mf_quad;
+      trial_op = EvalMode::Div;
+      test_op = EvalMode::Div;
+      qdatasize = 1;
+   }
+};
+#endif
+
+PADivDivIntegrator::PADivDivIntegrator(const mfem::DivDivIntegrator &integ,
+                                       const mfem::FiniteElementSpace &fes,
+                                       mfem::Coefficient *Q,
+                                       const bool use_bdr)
+{
+#ifdef MFEM_USE_CEED
+   DivDivOperatorInfo info(fes, Q, use_bdr);
+   Assemble(integ, info, fes, Q, use_bdr);
+#else
+   MFEM_ABORT("MFEM must be built with MFEM_USE_CEED=YES to use libCEED.");
+#endif
+}
+
+MFDivDivIntegrator::MFDivDivIntegrator(const mfem::DivDivIntegrator &integ,
+                                       const mfem::FiniteElementSpace &fes,
+                                       mfem::Coefficient *Q,
+                                       const bool use_bdr)
+{
+#ifdef MFEM_USE_CEED
+   DivDivOperatorInfo info(fes, Q, use_bdr);
+   Assemble(integ, info, fes, Q, use_bdr, true);
+#else
+   MFEM_ABORT("MFEM must be built with MFEM_USE_CEED=YES to use libCEED.");
+#endif
+}
+
+} // namespace ceed
+
+} // namespace mfem

--- a/fem/ceed/integrators/divdiv/divdiv.hpp
+++ b/fem/ceed/integrators/divdiv/divdiv.hpp
@@ -1,0 +1,48 @@
+// Copyright (c) 2010-2023, Lawrence Livermore National Security, LLC. Produced
+// at the Lawrence Livermore National Laboratory. All Rights reserved. See files
+// LICENSE and NOTICE for details. LLNL-CODE-806117.
+//
+// This file is part of the MFEM library. For more information and source code
+// availability visit https://mfem.org.
+//
+// MFEM is free software; you can redistribute it and/or modify it under the
+// terms of the BSD-3 license. We welcome feedback and contributions, see file
+// CONTRIBUTING.md for details.
+
+#ifndef MFEM_LIBCEED_DIVDIV_HPP
+#define MFEM_LIBCEED_DIVDIV_HPP
+
+#include "../../interface/mixed_integrator.hpp"
+#include "../../../fespace.hpp"
+
+namespace mfem
+{
+
+namespace ceed
+{
+
+/// Represent a DivDivIntegrator with AssemblyLevel::Partial using libCEED.
+class PADivDivIntegrator : public MixedIntegrator
+{
+public:
+   PADivDivIntegrator(const mfem::DivDivIntegrator &integ,
+                      const mfem::FiniteElementSpace &fes,
+                      mfem::Coefficient *Q,
+                      const bool use_bdr = false);
+};
+
+/// Represent a DivDivIntegrator with AssemblyLevel::None using libCEED.
+class MFDivDivIntegrator : public MixedIntegrator
+{
+public:
+   MFDivDivIntegrator(const mfem::DivDivIntegrator &integ,
+                      const mfem::FiniteElementSpace &fes,
+                      mfem::Coefficient *Q,
+                      const bool use_bdr = false);
+};
+
+}
+
+}
+
+#endif // MFEM_LIBCEED_DIVDIV_HPP

--- a/fem/ceed/integrators/divdiv/divdiv_qf.h
+++ b/fem/ceed/integrators/divdiv/divdiv_qf.h
@@ -1,0 +1,248 @@
+// Copyright (c) 2010-2023, Lawrence Livermore National Security, LLC. Produced
+// at the Lawrence Livermore National Laboratory. All Rights reserved. See files
+// LICENSE and NOTICE for details. LLNL-CODE-806117.
+//
+// This file is part of the MFEM library. For more information and source code
+// availability visit https://mfem.org.
+//
+// MFEM is free software; you can redistribute it and/or modify it under the
+// terms of the BSD-3 license. We welcome feedback and contributions, see file
+// CONTRIBUTING.md for details.
+
+#ifndef MFEM_LIBCEED_DIVDIV_QF_H
+#define MFEM_LIBCEED_DIVDIV_QF_H
+
+#include "../util/util_qf.h"
+
+/// A structure used to pass additional data to f_build_divdiv and
+/// f_apply_divdiv
+struct DivDivContext
+{
+   CeedInt dim, space_dim;
+   CeedScalar coeff;
+};
+
+/// libCEED QFunction for building quadrature data for a div-div operator with
+/// a constant coefficient
+CEED_QFUNCTION(f_build_divdiv_const)(void *ctx, CeedInt Q,
+                                     const CeedScalar *const *in,
+                                     CeedScalar *const *out)
+{
+   DivDivContext *bc = (DivDivContext *)ctx;
+   // in[0] is Jacobians with shape [dim, ncomp=space_dim, Q]
+   // in[1] is quadrature weights, size (Q)
+   //
+   // At every quadrature point, compute and store qw * c / det(J).
+   const CeedScalar coeff = bc->coeff;
+   const CeedScalar *J = in[0], *qw = in[1];
+   CeedScalar *qd = out[0];
+   switch (10 * bc->space_dim + bc->dim)
+   {
+      case 11:
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+         {
+            qd[i] = qw[i] * coeff / J[i];
+         }
+         break;
+      case 21:
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+         {
+            qd[i] = qw[i] * coeff / DetJ21(J + i, Q);
+         }
+         break;
+      case 22:
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+         {
+            qd[i] = qw[i] * coeff / DetJ22(J + i, Q);
+         }
+         break;
+      case 32:
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+         {
+            qd[i] = qw[i] * coeff / DetJ32(J + i, Q);
+         }
+         break;
+      case 33:
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+         {
+            qd[i] = qw[i] * coeff / DetJ33(J + i, Q);
+         }
+         break;
+   }
+   return 0;
+}
+
+/// libCEED QFunction for building quadrature data for a div-div operator with
+/// a coefficient evaluated at quadrature points.
+CEED_QFUNCTION(f_build_divdiv_quad)(void *ctx, CeedInt Q,
+                                    const CeedScalar *const *in,
+                                    CeedScalar *const *out)
+{
+   DivDivContext *bc = (DivDivContext *)ctx;
+   // in[0] is coefficients, size (Q)
+   // in[1] is Jacobians with shape [dim, ncomp=space_dim, Q]
+   // in[2] is quadrature weights, size (Q)
+   //
+   // At every quadrature point, compute and store qw * c / det(J).
+   const CeedScalar *c = in[0], *J = in[1], *qw = in[2];
+   CeedScalar *qd = out[0];
+   switch (10 * bc->space_dim + bc->dim)
+   {
+      case 11:
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+         {
+            qd[i] = qw[i] * c[i] / J[i];
+         }
+         break;
+      case 21:
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+         {
+            qd[i] = qw[i] * c[i] / DetJ21(J + i, Q);
+         }
+         break;
+      case 22:
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+         {
+            qd[i] = qw[i] * c[i] / DetJ22(J + i, Q);
+         }
+         break;
+      case 32:
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+         {
+            qd[i] = qw[i] * c[i] / DetJ32(J + i, Q);
+         }
+         break;
+      case 33:
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+         {
+            qd[i] = qw[i] * c[i] / DetJ33(J + i, Q);
+         }
+         break;
+   }
+   return 0;
+}
+
+/// libCEED QFunction for applying a div-div operator
+CEED_QFUNCTION(f_apply_divdiv)(void *ctx, CeedInt Q,
+                               const CeedScalar *const *in,
+                               CeedScalar *const *out)
+{
+   // in[0], out[0] have shape [ncomp=1, Q]
+   const CeedScalar *ud = in[0], *qd = in[1];
+   CeedScalar *vd = out[0];
+   CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+   {
+      vd[i] = qd[i] * ud[i];
+   }
+   return 0;
+}
+
+/// libCEED QFunction for applying a div-div operator
+CEED_QFUNCTION(f_apply_divdiv_mf_const)(void *ctx, CeedInt Q,
+                                        const CeedScalar *const *in, CeedScalar *const *out)
+{
+   DivDivContext *bc = (DivDivContext *)ctx;
+   // in[0], out[0] have shape [ncomp=1, Q]
+   // in[1] is Jacobians with shape [dim, ncomp=space_dim, Q]
+   // in[2] is quadrature weights, size (Q)
+   //
+   // At every quadrature point, compute qw * c / det(J).
+   const CeedScalar coeff = bc->coeff;
+   const CeedScalar *ud = in[0], *J = in[1], *qw = in[2];
+   CeedScalar *vd = out[0];
+   switch (10 * bc->space_dim + bc->dim)
+   {
+      case 11:
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+         {
+            const CeedScalar qd = qw[i] * coeff / J[i];
+            vd[i] = qd * ud[i];
+         }
+         break;
+      case 21:
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+         {
+            const CeedScalar qd = qw[i] * coeff / DetJ21(J + i, Q);
+            vd[i] = qd * ud[i];
+         }
+         break;
+      case 22:
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+         {
+            const CeedScalar qd = qw[i] * coeff / DetJ22(J + i, Q);
+            vd[i] = qd * ud[i];
+         }
+         break;
+      case 32:
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+         {
+            const CeedScalar qd = qw[i] * coeff / DetJ32(J + i, Q);
+            vd[i] = qd * ud[i];
+         }
+         break;
+      case 33:
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+         {
+            const CeedScalar qd = qw[i] * coeff / DetJ33(J + i, Q);
+            vd[i] = qd * ud[i];
+         }
+         break;
+   }
+   return 0;
+}
+
+/// libCEED QFunction for applying a div-div operator
+CEED_QFUNCTION(f_apply_divdiv_mf_quad)(void *ctx, CeedInt Q,
+                                       const CeedScalar *const *in, CeedScalar *const *out)
+{
+   DivDivContext *bc = (DivDivContext *)ctx;
+   // in[0], out[0] have shape [ncomp=1, Q]
+   // in[0] is coefficients, size (Q)
+   // in[2] is Jacobians with shape [dim, ncomp=space_dim, Q]
+   // in[3] is quadrature weights, size (Q)
+   //
+   // At every quadrature point, compute qw * c / det(J).
+   const CeedScalar *ud = in[0], *c = in[1], *J = in[2], *qw = in[3];
+   CeedScalar *vd = out[0];
+   switch (10 * bc->space_dim + bc->dim)
+   {
+      case 11:
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+         {
+            const CeedScalar qd = qw[i] * c[i] / J[i];
+            vd[i] = qd * ud[i];
+         }
+         break;
+      case 21:
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+         {
+            const CeedScalar qd = qw[i] * c[i] / DetJ21(J + i, Q);
+            vd[i] = qd * ud[i];
+         }
+         break;
+      case 22:
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+         {
+            const CeedScalar qd = qw[i] * c[i] / DetJ22(J + i, Q);
+            vd[i] = qd * ud[i];
+         }
+         break;
+      case 32:
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+         {
+            const CeedScalar qd = qw[i] * c[i] / DetJ32(J + i, Q);
+            vd[i] = qd * ud[i];
+         }
+         break;
+      case 33:
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+         {
+            const CeedScalar qd = qw[i] * c[i] / DetJ33(J + i, Q);
+            vd[i] = qd * ud[i];
+         }
+         break;
+   }
+   return 0;
+}
+
+#endif // MFEM_LIBCEED_DIVDIV_QF_H

--- a/fem/ceed/integrators/divdiv/divdiv_qf.h
+++ b/fem/ceed/integrators/divdiv/divdiv_qf.h
@@ -14,16 +14,14 @@
 
 #include "../util/util_qf.h"
 
-/// A structure used to pass additional data to f_build_divdiv and
-/// f_apply_divdiv
 struct DivDivContext
 {
    CeedInt dim, space_dim;
    CeedScalar coeff;
 };
 
-/// libCEED QFunction for building quadrature data for a div-div operator with
-/// a constant coefficient
+/// libCEED QFunction for building quadrature data for a div-div operator
+/// with a constant coefficient
 CEED_QFUNCTION(f_build_divdiv_const)(void *ctx, CeedInt Q,
                                      const CeedScalar *const *in,
                                      CeedScalar *const *out)
@@ -32,7 +30,7 @@ CEED_QFUNCTION(f_build_divdiv_const)(void *ctx, CeedInt Q,
    // in[0] is Jacobians with shape [dim, ncomp=space_dim, Q]
    // in[1] is quadrature weights, size (Q)
    //
-   // At every quadrature point, compute and store qw * c / det(J).
+   // At every quadrature point, compute and store qw * c / det(J)
    const CeedScalar coeff = bc->coeff;
    const CeedScalar *J = in[0], *qw = in[1];
    CeedScalar *qd = out[0];
@@ -72,8 +70,8 @@ CEED_QFUNCTION(f_build_divdiv_const)(void *ctx, CeedInt Q,
    return 0;
 }
 
-/// libCEED QFunction for building quadrature data for a div-div operator with
-/// a coefficient evaluated at quadrature points.
+/// libCEED QFunction for building quadrature data for a div-div operator
+/// with a coefficient evaluated at quadrature points
 CEED_QFUNCTION(f_build_divdiv_quad)(void *ctx, CeedInt Q,
                                     const CeedScalar *const *in,
                                     CeedScalar *const *out)
@@ -83,7 +81,7 @@ CEED_QFUNCTION(f_build_divdiv_quad)(void *ctx, CeedInt Q,
    // in[1] is Jacobians with shape [dim, ncomp=space_dim, Q]
    // in[2] is quadrature weights, size (Q)
    //
-   // At every quadrature point, compute and store qw * c / det(J).
+   // At every quadrature point, compute and store qw * c / det(J)
    const CeedScalar *c = in[0], *J = in[1], *qw = in[2];
    CeedScalar *qd = out[0];
    switch (10 * bc->space_dim + bc->dim)
@@ -137,16 +135,18 @@ CEED_QFUNCTION(f_apply_divdiv)(void *ctx, CeedInt Q,
    return 0;
 }
 
-/// libCEED QFunction for applying a div-div operator
+/// libCEED QFunction for applying a div-div operator with a constant
+/// coefficient
 CEED_QFUNCTION(f_apply_divdiv_mf_const)(void *ctx, CeedInt Q,
-                                        const CeedScalar *const *in, CeedScalar *const *out)
+                                        const CeedScalar *const *in,
+                                        CeedScalar *const *out)
 {
    DivDivContext *bc = (DivDivContext *)ctx;
    // in[0], out[0] have shape [ncomp=1, Q]
    // in[1] is Jacobians with shape [dim, ncomp=space_dim, Q]
    // in[2] is quadrature weights, size (Q)
    //
-   // At every quadrature point, compute qw * c / det(J).
+   // At every quadrature point, compute qw * c / det(J)
    const CeedScalar coeff = bc->coeff;
    const CeedScalar *ud = in[0], *J = in[1], *qw = in[2];
    CeedScalar *vd = out[0];
@@ -191,9 +191,11 @@ CEED_QFUNCTION(f_apply_divdiv_mf_const)(void *ctx, CeedInt Q,
    return 0;
 }
 
-/// libCEED QFunction for applying a div-div operator
+/// libCEED QFunction for applying a div-div operator with a coefficient
+/// evaluated at quadrature points
 CEED_QFUNCTION(f_apply_divdiv_mf_quad)(void *ctx, CeedInt Q,
-                                       const CeedScalar *const *in, CeedScalar *const *out)
+                                       const CeedScalar *const *in,
+                                       CeedScalar *const *out)
 {
    DivDivContext *bc = (DivDivContext *)ctx;
    // in[0], out[0] have shape [ncomp=1, Q]
@@ -201,7 +203,7 @@ CEED_QFUNCTION(f_apply_divdiv_mf_quad)(void *ctx, CeedInt Q,
    // in[2] is Jacobians with shape [dim, ncomp=space_dim, Q]
    // in[3] is quadrature weights, size (Q)
    //
-   // At every quadrature point, compute qw * c / det(J).
+   // At every quadrature point, compute qw * c / det(J)
    const CeedScalar *ud = in[0], *c = in[1], *J = in[2], *qw = in[3];
    CeedScalar *vd = out[0];
    switch (10 * bc->space_dim + bc->dim)

--- a/fem/ceed/integrators/mass/mass_qf.h
+++ b/fem/ceed/integrators/mass/mass_qf.h
@@ -14,15 +14,14 @@
 
 #include "../util/util_qf.h"
 
-/// A structure used to pass additional data to f_build_mass and f_apply_mass
 struct MassContext
 {
    CeedInt dim, space_dim, vdim;
    CeedScalar coeff;
 };
 
-/// libCEED QFunction for building quadrature data for a mass operator with a
-/// constant coefficient
+/// libCEED QFunction for building quadrature data for a mass operator
+/// with a constant coefficient
 CEED_QFUNCTION(f_build_mass_const)(void *ctx, CeedInt Q,
                                    const CeedScalar *const *in,
                                    CeedScalar *const *out)
@@ -30,7 +29,7 @@ CEED_QFUNCTION(f_build_mass_const)(void *ctx, CeedInt Q,
    // in[0] is Jacobians with shape [dim, ncomp=space_dim, Q]
    // in[1] is quadrature weights, size (Q)
    //
-   // At every quadrature point, compute and store qw * c * det(J).
+   // At every quadrature point, compute and store qw * c * det(J)
    MassContext *bc = (MassContext *)ctx;
    const CeedScalar coeff = bc->coeff;
    const CeedScalar *J = in[0], *qw = in[1];
@@ -71,8 +70,8 @@ CEED_QFUNCTION(f_build_mass_const)(void *ctx, CeedInt Q,
    return 0;
 }
 
-/// libCEED QFunction for building quadrature data for a mass operator with a
-/// coefficient evaluated at quadrature points.
+/// libCEED QFunction for building quadrature data for a mass operator
+/// with a coefficient evaluated at quadrature points
 CEED_QFUNCTION(f_build_mass_quad)(void *ctx, CeedInt Q,
                                   const CeedScalar *const *in,
                                   CeedScalar *const *out)
@@ -81,7 +80,7 @@ CEED_QFUNCTION(f_build_mass_quad)(void *ctx, CeedInt Q,
    // in[1] is Jacobians with shape [dim, ncomp=space_dim, Q]
    // in[2] is quadrature weights, size (Q)
    //
-   // At every quadrature point, compute and store qw * c * det(J).
+   // At every quadrature point, compute and store qw * c * det(J)
    MassContext *bc = (MassContext *)ctx;
    const CeedScalar *c = in[0], *J = in[1], *qw = in[2];
    CeedScalar *qd = out[0];
@@ -162,16 +161,18 @@ CEED_QFUNCTION(f_apply_mass)(void *ctx, CeedInt Q,
    return 0;
 }
 
-/// libCEED QFunction for applying a mass operator
+/// libCEED QFunction for applying a mass operator with a constant
+/// coefficient
 CEED_QFUNCTION(f_apply_mass_mf_const)(void *ctx, CeedInt Q,
-                                      const CeedScalar *const *in, CeedScalar *const *out)
+                                      const CeedScalar *const *in,
+                                      CeedScalar *const *out)
 {
    MassContext *bc = (MassContext *)ctx;
    // in[0], out[0] have shape [ncomp=vdim, Q]
    // in[1] is Jacobians with shape [dim, ncomp=space_dim, Q]
    // in[2] is quadrature weights, size (Q)
    //
-   // At every quadrature point, compute qw * c * det(J).
+   // At every quadrature point, compute qw * c * det(J)
    const CeedScalar coeff = bc->coeff;
    const CeedScalar *u = in[0], *J = in[1], *qw = in[2];
    CeedScalar *v = out[0];
@@ -256,16 +257,18 @@ CEED_QFUNCTION(f_apply_mass_mf_const)(void *ctx, CeedInt Q,
    return 0;
 }
 
-/// libCEED QFunction for applying a mass operator
+/// libCEED QFunction for applying a mass operator with a coefficient
+/// evaluated at quadrature points
 CEED_QFUNCTION(f_apply_mass_mf_quad)(void *ctx, CeedInt Q,
-                                     const CeedScalar *const *in, CeedScalar *const *out)
+                                     const CeedScalar *const *in,
+                                     CeedScalar *const *out)
 {
    MassContext *bc = (MassContext *)ctx;
    // in[0], out[0] have shape [ncomp=vdim, Q]
    // in[1] is Jacobians with shape [dim, ncomp=space_dim, Q]
    // in[2] is quadrature weights, size (Q)
    //
-   // At every quadrature point, compute qw * c * det(J).
+   // At every quadrature point, compute qw * c * det(J)
    const CeedScalar *u = in[0], *c = in[1], *J = in[2], *qw = in[3];
    CeedScalar *v = out[0];
    switch (100 * bc->space_dim + 10 * bc->dim + bc->vdim)

--- a/fem/ceed/integrators/mixedveccurl/mixedveccurl.cpp
+++ b/fem/ceed/integrators/mixedveccurl/mixedveccurl.cpp
@@ -190,6 +190,8 @@ MFMixedVectorWeakCurlIntegrator::MFMixedVectorWeakCurlIntegrator(
 #endif
 }
 
+// @cond DOXYGEN_SKIP
+
 template PAMixedVectorCurlIntegrator::PAMixedVectorCurlIntegrator(
    const mfem::MixedVectorCurlIntegrator &, const mfem::FiniteElementSpace &,
    const mfem::FiniteElementSpace &, mfem::Coefficient *, const bool);
@@ -229,6 +231,8 @@ template MFMixedVectorWeakCurlIntegrator::MFMixedVectorWeakCurlIntegrator(
 template MFMixedVectorWeakCurlIntegrator::MFMixedVectorWeakCurlIntegrator(
    const mfem::MixedVectorWeakCurlIntegrator &, const mfem::FiniteElementSpace &,
    const mfem::FiniteElementSpace &, mfem::MatrixCoefficient *, const bool);
+
+// @endcond
 
 } // namespace ceed
 

--- a/fem/ceed/integrators/mixedveccurl/mixedveccurl.cpp
+++ b/fem/ceed/integrators/mixedveccurl/mixedveccurl.cpp
@@ -1,0 +1,239 @@
+// Copyright (c) 2010-2023, Lawrence Livermore National Security, LLC. Produced
+// at the Lawrence Livermore National Laboratory. All Rights reserved. See files
+// LICENSE and NOTICE for details. LLNL-CODE-806117.
+//
+// This file is part of the MFEM library. For more information and source code
+// availability visit https://mfem.org.
+//
+// MFEM is free software; you can redistribute it and/or modify it under the
+// terms of the BSD-3 license. We welcome feedback and contributions, see file
+// CONTRIBUTING.md for details.
+
+#include "mixedveccurl.hpp"
+
+#include "../../../../config/config.hpp"
+#ifdef MFEM_USE_CEED
+#include "../curlcurl/curlcurl_qf.h"
+#endif
+
+namespace mfem
+{
+
+namespace ceed
+{
+
+#ifdef MFEM_USE_CEED
+struct MixedVectorCurlOperatorInfo : public OperatorInfo
+{
+   CurlCurlContext ctx;
+   template <typename CoeffType>
+   MixedVectorCurlOperatorInfo(const mfem::FiniteElementSpace &trial_fes,
+                               const mfem::FiniteElementSpace &test_fes,
+                               CoeffType *Q, bool use_bdr, bool weak_curl)
+   {
+      MFEM_VERIFY(trial_fes.GetVDim() == 1 && test_fes.GetVDim() == 1,
+                  "libCEED interface for vector FE does not support VDim > 1!");
+      ctx.dim = trial_fes.GetMesh()->Dimension() - use_bdr;
+      MFEM_VERIFY(ctx.dim == 3,
+                  "MixedVectorCurlIntegrator and MixedVectorWeakCurlIntegrator "
+                  "require dim == 3!");
+      MFEM_VERIFY(
+         (trial_fes.FEColl()->GetDerivMapType(ctx.dim) == mfem::FiniteElement::H_DIV &&
+          test_fes.FEColl()->GetMapType(ctx.dim) == mfem::FiniteElement::H_DIV) ||
+         (trial_fes.FEColl()->GetMapType(ctx.dim) == mfem::FiniteElement::H_DIV &&
+          test_fes.FEColl()->GetDerivMapType(ctx.dim) == mfem::FiniteElement::H_DIV),
+         "libCEED interface for MixedVectorCurlIntegrator and "
+         "MixedVectorWeakCurlIntegrator requires H(curl) domain and H(div) "
+         "range FE spaces or vice versa!");
+      ctx.space_dim = trial_fes.GetMesh()->SpaceDimension();
+      ctx.curl_dim = 3;
+      InitCoefficient(Q);
+
+      // Reuse H(div) quadrature functions for CurlCurlIntegrator
+      header = "/integrators/curlcurl/curlcurl_qf.h";
+      build_func_const = ":f_build_curlcurl_const";
+      build_qf_const = &f_build_curlcurl_const;
+      build_func_quad = ":f_build_curlcurl_quad";
+      build_qf_quad = &f_build_curlcurl_quad;
+      apply_func = ":f_apply_curlcurl";
+      apply_qf = &f_apply_curlcurl;
+      apply_func_mf_const = ":f_apply_curlcurl_mf_const";
+      apply_qf_mf_const = &f_apply_curlcurl_mf_const;
+      apply_func_mf_quad = ":f_apply_curlcurl_mf_quad";
+      apply_qf_mf_quad = &f_apply_curlcurl_mf_quad;
+      trial_op = weak_curl ? EvalMode::Interp : EvalMode::Curl;
+      test_op = weak_curl ? EvalMode::Curl : EvalMode::Interp;
+      qdatasize = (ctx.curl_dim * (ctx.curl_dim + 1)) / 2;
+   }
+   void InitCoefficient(mfem::Coefficient *Q)
+   {
+      ctx.coeff_comp = 1;
+      if (Q == nullptr)
+      {
+         ctx.coeff[0] = 1.0;
+      }
+      else if (ConstantCoefficient *const_coeff =
+                  dynamic_cast<ConstantCoefficient *>(Q))
+      {
+         ctx.coeff[0] = const_coeff->constant;
+      }
+   }
+   void InitCoefficient(mfem::VectorCoefficient *VQ)
+   {
+      if (VQ == nullptr)
+      {
+         ctx.coeff_comp = 1;
+         ctx.coeff[0] = 1.0;
+         return;
+      }
+      const int vdim = VQ->GetVDim();
+      ctx.coeff_comp = vdim;
+      if (VectorConstantCoefficient *const_coeff =
+             dynamic_cast<VectorConstantCoefficient *>(VQ))
+      {
+         MFEM_VERIFY(ctx.coeff_comp <= LIBCEED_CURLCURL_COEFF_COMP_MAX,
+                     "VectorCoefficient dimension exceeds context storage!");
+         const mfem::Vector &val = const_coeff->GetVec();
+         for (int i = 0; i < vdim; i++)
+         {
+            ctx.coeff[i] = val[i];
+         }
+      }
+   }
+   void InitCoefficient(mfem::MatrixCoefficient *MQ)
+   {
+      if (MQ == nullptr)
+      {
+         ctx.coeff_comp = 1;
+         ctx.coeff[0] = 1.0;
+         return;
+      }
+      // Assumes matrix coefficient is symmetric
+      const int vdim = MQ->GetVDim();
+      ctx.coeff_comp = (vdim * (vdim + 1)) / 2;
+      if (MatrixConstantCoefficient *const_coeff =
+             dynamic_cast<MatrixConstantCoefficient *>(MQ))
+      {
+         MFEM_VERIFY(ctx.coeff_comp <= LIBCEED_CURLCURL_COEFF_COMP_MAX,
+                     "MatrixCoefficient dimensions exceed context storage!");
+         const mfem::DenseMatrix &val = const_coeff->GetMatrix();
+         for (int j = 0; j < vdim; j++)
+         {
+            for (int i = j; i < vdim; i++)
+            {
+               const int idx = (j * vdim) - (((j - 1) * j) / 2) + i - j;
+               ctx.coeff[idx] = val(i, j);
+            }
+         }
+      }
+   }
+};
+#endif
+
+template <typename CoeffType>
+PAMixedVectorCurlIntegrator::PAMixedVectorCurlIntegrator(
+   const mfem::MixedVectorCurlIntegrator &integ,
+   const mfem::FiniteElementSpace &trial_fes,
+   const mfem::FiniteElementSpace &test_fes,
+   CoeffType *Q,
+   const bool use_bdr)
+{
+#ifdef MFEM_USE_CEED
+   MixedVectorCurlOperatorInfo info(trial_fes, test_fes, Q, use_bdr, true);
+   Assemble(integ, info, trial_fes, test_fes, Q, use_bdr);
+#else
+   MFEM_ABORT("MFEM must be built with MFEM_USE_CEED=YES to use libCEED.");
+#endif
+}
+
+template <typename CoeffType>
+MFMixedVectorCurlIntegrator::MFMixedVectorCurlIntegrator(
+   const mfem::MixedVectorCurlIntegrator &integ,
+   const mfem::FiniteElementSpace &trial_fes,
+   const mfem::FiniteElementSpace &test_fes,
+   CoeffType *Q,
+   const bool use_bdr)
+{
+#ifdef MFEM_USE_CEED
+   MixedVectorCurlOperatorInfo info(trial_fes, test_fes, Q, use_bdr, true);
+   Assemble(integ, info, trial_fes, test_fes, Q, use_bdr, true);
+#else
+   MFEM_ABORT("MFEM must be built with MFEM_USE_CEED=YES to use libCEED.");
+#endif
+}
+
+template <typename CoeffType>
+PAMixedVectorWeakCurlIntegrator::PAMixedVectorWeakCurlIntegrator(
+   const mfem::MixedVectorWeakCurlIntegrator &integ,
+   const mfem::FiniteElementSpace &trial_fes,
+   const mfem::FiniteElementSpace &test_fes,
+   CoeffType *Q,
+   const bool use_bdr)
+{
+#ifdef MFEM_USE_CEED
+   MixedVectorCurlOperatorInfo info(trial_fes, test_fes, Q, use_bdr, true);
+   Assemble(integ, info, trial_fes, test_fes, Q, use_bdr);
+#else
+   MFEM_ABORT("MFEM must be built with MFEM_USE_CEED=YES to use libCEED.");
+#endif
+}
+
+template <typename CoeffType>
+MFMixedVectorWeakCurlIntegrator::MFMixedVectorWeakCurlIntegrator(
+   const mfem::MixedVectorWeakCurlIntegrator &integ,
+   const mfem::FiniteElementSpace &trial_fes,
+   const mfem::FiniteElementSpace &test_fes,
+   CoeffType *Q,
+   const bool use_bdr)
+{
+#ifdef MFEM_USE_CEED
+   MixedVectorCurlOperatorInfo info(trial_fes, test_fes, Q, use_bdr, true);
+   Assemble(integ, info, trial_fes, test_fes, Q, use_bdr, true);
+#else
+   MFEM_ABORT("MFEM must be built with MFEM_USE_CEED=YES to use libCEED.");
+#endif
+}
+
+template PAMixedVectorCurlIntegrator::PAMixedVectorCurlIntegrator(
+   const mfem::MixedVectorCurlIntegrator &, const mfem::FiniteElementSpace &,
+   const mfem::FiniteElementSpace &, mfem::Coefficient *, const bool);
+template PAMixedVectorCurlIntegrator::PAMixedVectorCurlIntegrator(
+   const mfem::MixedVectorCurlIntegrator &, const mfem::FiniteElementSpace &,
+   const mfem::FiniteElementSpace &, mfem::VectorCoefficient *, const bool);
+template PAMixedVectorCurlIntegrator::PAMixedVectorCurlIntegrator(
+   const mfem::MixedVectorCurlIntegrator &, const mfem::FiniteElementSpace &,
+   const mfem::FiniteElementSpace &, mfem::MatrixCoefficient *, const bool);
+
+template MFMixedVectorCurlIntegrator::MFMixedVectorCurlIntegrator(
+   const mfem::MixedVectorCurlIntegrator &, const mfem::FiniteElementSpace &,
+   const mfem::FiniteElementSpace &, mfem::Coefficient *, const bool);
+template MFMixedVectorCurlIntegrator::MFMixedVectorCurlIntegrator(
+   const mfem::MixedVectorCurlIntegrator &, const mfem::FiniteElementSpace &,
+   const mfem::FiniteElementSpace &, mfem::VectorCoefficient *, const bool);
+template MFMixedVectorCurlIntegrator::MFMixedVectorCurlIntegrator(
+   const mfem::MixedVectorCurlIntegrator &, const mfem::FiniteElementSpace &,
+   const mfem::FiniteElementSpace &, mfem::MatrixCoefficient *, const bool);
+
+template PAMixedVectorWeakCurlIntegrator::PAMixedVectorWeakCurlIntegrator(
+   const mfem::MixedVectorWeakCurlIntegrator &, const mfem::FiniteElementSpace &,
+   const mfem::FiniteElementSpace &, mfem::Coefficient *, const bool);
+template PAMixedVectorWeakCurlIntegrator::PAMixedVectorWeakCurlIntegrator(
+   const mfem::MixedVectorWeakCurlIntegrator &, const mfem::FiniteElementSpace &,
+   const mfem::FiniteElementSpace &, mfem::VectorCoefficient *, const bool);
+template PAMixedVectorWeakCurlIntegrator::PAMixedVectorWeakCurlIntegrator(
+   const mfem::MixedVectorWeakCurlIntegrator &, const mfem::FiniteElementSpace &,
+   const mfem::FiniteElementSpace &, mfem::MatrixCoefficient *, const bool);
+
+template MFMixedVectorWeakCurlIntegrator::MFMixedVectorWeakCurlIntegrator(
+   const mfem::MixedVectorWeakCurlIntegrator &, const mfem::FiniteElementSpace &,
+   const mfem::FiniteElementSpace &, mfem::Coefficient *, const bool);
+template MFMixedVectorWeakCurlIntegrator::MFMixedVectorWeakCurlIntegrator(
+   const mfem::MixedVectorWeakCurlIntegrator &, const mfem::FiniteElementSpace &,
+   const mfem::FiniteElementSpace &, mfem::VectorCoefficient *, const bool);
+template MFMixedVectorWeakCurlIntegrator::MFMixedVectorWeakCurlIntegrator(
+   const mfem::MixedVectorWeakCurlIntegrator &, const mfem::FiniteElementSpace &,
+   const mfem::FiniteElementSpace &, mfem::MatrixCoefficient *, const bool);
+
+} // namespace ceed
+
+} // namespace mfem

--- a/fem/ceed/integrators/mixedveccurl/mixedveccurl.hpp
+++ b/fem/ceed/integrators/mixedveccurl/mixedveccurl.hpp
@@ -1,0 +1,84 @@
+// Copyright (c) 2010-2023, Lawrence Livermore National Security, LLC. Produced
+// at the Lawrence Livermore National Laboratory. All Rights reserved. See files
+// LICENSE and NOTICE for details. LLNL-CODE-806117.
+//
+// This file is part of the MFEM library. For more information and source code
+// availability visit https://mfem.org.
+//
+// MFEM is free software; you can redistribute it and/or modify it under the
+// terms of the BSD-3 license. We welcome feedback and contributions, see file
+// CONTRIBUTING.md for details.
+
+#ifndef MFEM_LIBCEED_MIXEDVECCURL_HPP
+#define MFEM_LIBCEED_MIXEDVECCURL_HPP
+
+#include "../../interface/mixed_integrator.hpp"
+#include "../../../fespace.hpp"
+
+namespace mfem
+{
+
+namespace ceed
+{
+
+/** Represent a MixedVectorCurlIntegrator with AssemblyLevel::Partial
+    using libCEED. */
+class PAMixedVectorCurlIntegrator : public MixedIntegrator
+{
+public:
+   template <typename CoeffType>
+   PAMixedVectorCurlIntegrator(
+      const mfem::MixedVectorCurlIntegrator &integ,
+      const mfem::FiniteElementSpace &trial_fes,
+      const mfem::FiniteElementSpace &test_fes,
+      CoeffType *Q,
+      const bool use_bdr = false);
+};
+
+/** Represent a MixedVectorCurlIntegrator with AssemblyLevel::None
+    using libCEED. */
+class MFMixedVectorCurlIntegrator : public MixedIntegrator
+{
+public:
+   template <typename CoeffType>
+   MFMixedVectorCurlIntegrator(
+      const mfem::MixedVectorCurlIntegrator &integ,
+      const mfem::FiniteElementSpace &trial_fes,
+      const mfem::FiniteElementSpace &test_fes,
+      CoeffType *Q,
+      const bool use_bdr = false);
+};
+
+/** Represent a MixedVectorWeakCurlIntegrator with AssemblyLevel::Partial
+    using libCEED. */
+class PAMixedVectorWeakCurlIntegrator : public MixedIntegrator
+{
+public:
+   template <typename CoeffType>
+   PAMixedVectorWeakCurlIntegrator(
+      const mfem::MixedVectorWeakCurlIntegrator &integ,
+      const mfem::FiniteElementSpace &trial_fes,
+      const mfem::FiniteElementSpace &test_fes,
+      CoeffType *Q,
+      const bool use_bdr = false);
+};
+
+/** Represent a MixedVectorWeakCurlIntegrator with AssemblyLevel::None
+    using libCEED. */
+class MFMixedVectorWeakCurlIntegrator : public MixedIntegrator
+{
+public:
+   template <typename CoeffType>
+   MFMixedVectorWeakCurlIntegrator(
+      const mfem::MixedVectorWeakCurlIntegrator &integ,
+      const mfem::FiniteElementSpace &trial_fes,
+      const mfem::FiniteElementSpace &test_fes,
+      CoeffType *Q,
+      const bool use_bdr = false);
+};
+
+}
+
+}
+
+#endif // MFEM_LIBCEED_MIXEDVECCURL_HPP

--- a/fem/ceed/integrators/mixedvecgrad/mixedvecgrad.cpp
+++ b/fem/ceed/integrators/mixedvecgrad/mixedvecgrad.cpp
@@ -23,94 +23,132 @@ namespace ceed
 {
 
 #ifdef MFEM_USE_CEED
-struct MixedVectorGradientOperatorInfo : public OperatorInfo
+struct MixedVectorGradientOperatorInfoBase : public OperatorInfo
 {
-   DiffusionContext ctx;
+   DiffusionContext ctx = {0};
    template <typename CoeffType>
-   MixedVectorGradientOperatorInfo(const mfem::FiniteElementSpace &trial_fes,
-                                   const mfem::FiniteElementSpace &test_fes,
-                                   CoeffType *Q, bool use_bdr, bool mixed_vector_grad)
+   MixedVectorGradientOperatorInfoBase(const mfem::FiniteElementSpace &trial_fes,
+                                       const mfem::FiniteElementSpace &test_fes,
+                                       CoeffType *Q, bool use_bdr = false,
+                                       bool use_mf = false)
    {
+      // Reuse H(curl) quadrature functions for DiffusionIntegrator
       MFEM_VERIFY(trial_fes.GetVDim() == 1 && test_fes.GetVDim() == 1,
                   "libCEED interface for vector FE does not support VDim > 1!");
       ctx.dim = trial_fes.GetMesh()->Dimension() - use_bdr;
       MFEM_VERIFY(ctx.dim == 2 || ctx.dim == 3,
                   "MixedVectorGradientIntegrator and MixedVectorWeakDivergenceIntegrator "
                   "require dim == 2 or dim == 3!");
-      MFEM_VERIFY(
-         !mixed_vector_grad ||
-         (trial_fes.FEColl()->GetDerivMapType(ctx.dim) == mfem::FiniteElement::H_CURL &&
-          test_fes.FEColl()->GetMapType(ctx.dim) == mfem::FiniteElement::H_CURL),
-         "libCEED interface for MixedVectorGradientIntegrator requires "
-         "H^1 domain and H(curl) range FE spaces!");
-      MFEM_VERIFY(
-         mixed_vector_grad ||
-         (trial_fes.FEColl()->GetMapType(ctx.dim) == mfem::FiniteElement::H_CURL &&
-          test_fes.FEColl()->GetDerivMapType(ctx.dim) == mfem::FiniteElement::H_CURL),
-         "libCEED interface for MixedVectorWeakDivergenceIntegrator requires "
-         "H(curl) domain and H^1 range FE spaces!");
       ctx.space_dim = trial_fes.GetMesh()->SpaceDimension();
       ctx.vdim = 1;
-      if (Q == nullptr)
+      if (!use_mf)
       {
-         ctx.coeff_comp = 1;
-         ctx.coeff[0] = mixed_vector_grad ? 1.0 : -1.0;
+         apply_func = ":f_apply_diff";
+         apply_qf = &f_apply_diff;
       }
       else
       {
-         InitCoefficient(*Q, mixed_vector_grad ? 1.0 : -1.0);
+         build_func = "";
+         build_qf = nullptr;
       }
-
-      // Reuse H(curl) quadrature functions for DiffusionIntegrator
+      if (Q == nullptr)
+      {
+         ctx.coeff[0] = 1.0;
+         if (!use_mf)
+         {
+            build_func = ":f_build_diff_const_scalar";
+            build_qf = &f_build_diff_const_scalar;
+         }
+         else
+         {
+            apply_func = ":f_apply_diff_mf_const_scalar";
+            apply_qf = &f_apply_diff_mf_const_scalar;
+         }
+      }
+      else
+      {
+         InitCoefficient(*Q, use_mf);
+      }
       header = "/integrators/diffusion/diffusion_qf.h";
-      build_func_const = ":f_build_diff_const";
-      build_qf_const = &f_build_diff_const;
-      build_func_quad = ":f_build_diff_quad";
-      build_qf_quad = &f_build_diff_quad;
-      apply_func = ":f_apply_diff";
-      apply_qf = &f_apply_diff;
-      apply_func_mf_const = ":f_apply_diff_mf_const";
-      apply_qf_mf_const = &f_apply_diff_mf_const;
-      apply_func_mf_quad = ":f_apply_diff_mf_quad";
-      apply_qf_mf_quad = &f_apply_diff_mf_quad;
-      trial_op = mixed_vector_grad ? EvalMode::Grad : EvalMode::Interp;
-      test_op = mixed_vector_grad ? EvalMode::Interp : EvalMode::Grad;
       qdatasize = (ctx.dim * (ctx.dim + 1)) / 2;
    }
-   void InitCoefficient(mfem::Coefficient &Q, double sign)
+   void InitCoefficient(mfem::Coefficient &Q, bool use_mf)
    {
-      ctx.coeff_comp = 1;
-      if (ConstantCoefficient *const_coeff =
-             dynamic_cast<ConstantCoefficient *>(&Q))
+      if (mfem::ConstantCoefficient *const_coeff =
+             dynamic_cast<mfem::ConstantCoefficient *>(&Q))
       {
-         ctx.coeff[0] = sign * const_coeff->constant;
+         ctx.coeff[0] = const_coeff->constant;
+         if (!use_mf)
+         {
+            build_func = ":f_build_diff_const_scalar";
+            build_qf = &f_build_diff_const_scalar;
+         }
+         else
+         {
+            apply_func = ":f_apply_diff_mf_const_scalar";
+            apply_qf = &f_apply_diff_mf_const_scalar;
+         }
+      }
+      else
+      {
+         if (!use_mf)
+         {
+            build_func = ":f_build_diff_quad_scalar";
+            build_qf = &f_build_diff_quad_scalar;
+         }
+         else
+         {
+            apply_func = ":f_apply_diff_mf_quad_scalar";
+            apply_qf = &f_apply_diff_mf_quad_scalar;
+         }
       }
    }
-   void InitCoefficient(mfem::VectorCoefficient &VQ, double sign)
+   void InitCoefficient(mfem::VectorCoefficient &VQ, bool use_mf)
    {
-      const int vdim = VQ.GetVDim();
-      ctx.coeff_comp = vdim;
-      if (VectorConstantCoefficient *const_coeff =
-             dynamic_cast<VectorConstantCoefficient *>(&VQ))
+      if (mfem::VectorConstantCoefficient *const_coeff =
+             dynamic_cast<mfem::VectorConstantCoefficient *>(&VQ))
       {
-         MFEM_VERIFY(ctx.coeff_comp <= LIBCEED_DIFF_COEFF_COMP_MAX,
+         const int vdim = VQ.GetVDim();
+         MFEM_VERIFY(vdim <= LIBCEED_DIFF_COEFF_COMP_MAX,
                      "VectorCoefficient dimension exceeds context storage!");
          const mfem::Vector &val = const_coeff->GetVec();
          for (int i = 0; i < vdim; i++)
          {
-            ctx.coeff[i] = sign * val[i];
+            ctx.coeff[i] = val[i];
+         }
+         if (!use_mf)
+         {
+            build_func = ":f_build_diff_const_vector";
+            build_qf = &f_build_diff_const_vector;
+         }
+         else
+         {
+            apply_func = ":f_apply_diff_mf_const_vector";
+            apply_qf = &f_apply_diff_mf_const_vector;
+         }
+      }
+      else
+      {
+         if (!use_mf)
+         {
+            build_func = ":f_build_diff_quad_vector";
+            build_qf = &f_build_diff_quad_vector;
+         }
+         else
+         {
+            apply_func = ":f_apply_diff_mf_quad_vector";
+            apply_qf = &f_apply_diff_mf_quad_vector;
          }
       }
    }
-   void InitCoefficient(mfem::MatrixCoefficient &MQ, double sign)
+   void InitCoefficient(mfem::MatrixCoefficient &MQ, bool use_mf)
    {
       // Assumes matrix coefficient is symmetric
-      const int vdim = MQ.GetVDim();
-      ctx.coeff_comp = (vdim * (vdim + 1)) / 2;
-      if (MatrixConstantCoefficient *const_coeff =
-             dynamic_cast<MatrixConstantCoefficient *>(&MQ))
+      if (mfem::MatrixConstantCoefficient *const_coeff =
+             dynamic_cast<mfem::MatrixConstantCoefficient *>(&MQ))
       {
-         MFEM_VERIFY(ctx.coeff_comp <= LIBCEED_DIFF_COEFF_COMP_MAX,
+         const int vdim = MQ.GetVDim();
+         MFEM_VERIFY((vdim * (vdim + 1)) / 2 <= LIBCEED_DIFF_COEFF_COMP_MAX,
                      "MatrixCoefficient dimensions exceed context storage!");
          const mfem::DenseMatrix &val = const_coeff->GetMatrix();
          for (int j = 0; j < vdim; j++)
@@ -118,9 +156,76 @@ struct MixedVectorGradientOperatorInfo : public OperatorInfo
             for (int i = j; i < vdim; i++)
             {
                const int idx = (j * vdim) - (((j - 1) * j) / 2) + i - j;
-               ctx.coeff[idx] = sign * val(i, j);
+               ctx.coeff[idx] = val(i, j);
             }
          }
+         if (!use_mf)
+         {
+            build_func = ":f_build_diff_const_matrix";
+            build_qf = &f_build_diff_const_matrix;
+         }
+         else
+         {
+            apply_func = ":f_apply_diff_mf_const_matrix";
+            apply_qf = &f_apply_diff_mf_const_matrix;
+         }
+      }
+      else
+      {
+         if (!use_mf)
+         {
+            build_func = ":f_build_diff_quad_matrix";
+            build_qf = &f_build_diff_quad_matrix;
+         }
+         else
+         {
+            apply_func = ":f_apply_diff_mf_quad_matrix";
+            apply_qf = &f_apply_diff_mf_quad_matrix;
+         }
+      }
+   }
+};
+
+struct MixedVectorGradientOperatorInfo :
+   public MixedVectorGradientOperatorInfoBase
+{
+   template <typename CoeffType>
+   MixedVectorGradientOperatorInfo(const mfem::FiniteElementSpace &trial_fes,
+                                   const mfem::FiniteElementSpace &test_fes,
+                                   CoeffType *Q, bool use_bdr = false,
+                                   bool use_mf = false)
+      : MixedVectorGradientOperatorInfoBase(trial_fes, test_fes, Q, use_bdr, use_mf)
+   {
+      MFEM_VERIFY(
+         (trial_fes.FEColl()->GetDerivMapType(ctx.dim) == mfem::FiniteElement::H_CURL &&
+          test_fes.FEColl()->GetMapType(ctx.dim) == mfem::FiniteElement::H_CURL),
+         "libCEED interface for MixedVectorGradientIntegrator requires "
+         "H^1 domain and H(curl) range FE spaces!");
+      trial_op = EvalMode::Grad;
+      test_op = EvalMode::Interp;
+   }
+};
+
+struct MixedVectorWeakDivergenceOperatorInfo :
+   public MixedVectorGradientOperatorInfoBase
+{
+   template <typename CoeffType>
+   MixedVectorWeakDivergenceOperatorInfo(const mfem::FiniteElementSpace &trial_fes,
+                                         const mfem::FiniteElementSpace &test_fes,
+                                         CoeffType *Q, bool use_bdr = false,
+                                         bool use_mf = false)
+      : MixedVectorGradientOperatorInfoBase(trial_fes, test_fes, Q, use_bdr, use_mf)
+   {
+      MFEM_VERIFY(
+         (trial_fes.FEColl()->GetMapType(ctx.dim) == mfem::FiniteElement::H_CURL &&
+          test_fes.FEColl()->GetDerivMapType(ctx.dim) == mfem::FiniteElement::H_CURL),
+         "libCEED interface for MixedVectorWeakDivergenceIntegrator requires "
+         "H(curl) domain and H^1 range FE spaces!");
+      trial_op = EvalMode::Interp;
+      test_op = EvalMode::Grad;
+      for (int i = 0; i < LIBCEED_DIFF_COEFF_COMP_MAX; i++)
+      {
+         ctx.coeff[i] *= -1.0;
       }
    }
 };
@@ -135,7 +240,7 @@ PAMixedVectorGradientIntegrator::PAMixedVectorGradientIntegrator(
    const bool use_bdr)
 {
 #ifdef MFEM_USE_CEED
-   MixedVectorGradientOperatorInfo info(trial_fes, test_fes, Q, use_bdr, true);
+   MixedVectorGradientOperatorInfo info(trial_fes, test_fes, Q, use_bdr);
    Assemble(integ, info, trial_fes, test_fes, Q, use_bdr);
 #else
    MFEM_ABORT("MFEM must be built with MFEM_USE_CEED=YES to use libCEED.");
@@ -158,133 +263,79 @@ MFMixedVectorGradientIntegrator::MFMixedVectorGradientIntegrator(
 #endif
 }
 
-template <>
+namespace
+{
+
+#ifdef MFEM_USE_CEED
+mfem::Coefficient *NegativeCoeff(mfem::Coefficient &Q)
+{
+   return (dynamic_cast<mfem::ConstantCoefficient *>(&Q) != nullptr) ?
+          nullptr : new mfem::ProductCoefficient(-1.0, Q);
+}
+
+mfem::VectorCoefficient *NegativeCoeff(mfem::VectorCoefficient &Q)
+{
+   return (dynamic_cast<mfem::VectorConstantCoefficient *>(&Q) != nullptr) ?
+          nullptr : new mfem::ScalarVectorProductCoefficient(-1.0, Q);
+}
+
+mfem::MatrixCoefficient *NegativeCoeff(mfem::MatrixCoefficient &Q)
+{
+   return (dynamic_cast<mfem::MatrixConstantCoefficient *>(&Q) != nullptr) ?
+          nullptr : new mfem::ScalarMatrixProductCoefficient(-1.0, Q);
+}
+#endif
+
+} // namespace
+
+template <typename CoeffType>
 PAMixedVectorWeakDivergenceIntegrator::PAMixedVectorWeakDivergenceIntegrator(
    const mfem::MixedVectorWeakDivergenceIntegrator &integ,
    const mfem::FiniteElementSpace &trial_fes,
    const mfem::FiniteElementSpace &test_fes,
-   mfem::Coefficient *Q,
+   CoeffType *Q,
    const bool use_bdr)
 {
 #ifdef MFEM_USE_CEED
-   MixedVectorGradientOperatorInfo info(trial_fes, test_fes, Q, use_bdr, false);
+   MixedVectorWeakDivergenceOperatorInfo info(trial_fes, test_fes, Q, use_bdr);
    if (Q)
    {
       // Does not inherit ownership of old Q
-      Q = new ProductCoefficient(-1.0, *Q);
+      auto *nQ = NegativeCoeff(*Q);
+      Assemble(integ, info, trial_fes, test_fes, nQ, use_bdr);
+      delete nQ;
    }
-   Assemble(integ, info, trial_fes, test_fes, Q, use_bdr);
-   delete Q;
+   else
+   {
+      Assemble(integ, info, trial_fes, test_fes, Q, use_bdr);
+   }
 #else
    MFEM_ABORT("MFEM must be built with MFEM_USE_CEED=YES to use libCEED.");
 #endif
 }
 
-template <>
-PAMixedVectorWeakDivergenceIntegrator::PAMixedVectorWeakDivergenceIntegrator(
-   const mfem::MixedVectorWeakDivergenceIntegrator &integ,
-   const mfem::FiniteElementSpace &trial_fes,
-   const mfem::FiniteElementSpace &test_fes,
-   mfem::VectorCoefficient *Q,
-   const bool use_bdr)
-{
-#ifdef MFEM_USE_CEED
-   MixedVectorGradientOperatorInfo info(trial_fes, test_fes, Q, use_bdr, false);
-   if (Q)
-   {
-      // Does not inherit ownership of old Q
-      Q = new ScalarVectorProductCoefficient(-1.0, *Q);
-   }
-   Assemble(integ, info, trial_fes, test_fes, Q, use_bdr);
-   delete Q;
-#else
-   MFEM_ABORT("MFEM must be built with MFEM_USE_CEED=YES to use libCEED.");
-#endif
-}
-
-template <>
-PAMixedVectorWeakDivergenceIntegrator::PAMixedVectorWeakDivergenceIntegrator(
-   const mfem::MixedVectorWeakDivergenceIntegrator &integ,
-   const mfem::FiniteElementSpace &trial_fes,
-   const mfem::FiniteElementSpace &test_fes,
-   mfem::MatrixCoefficient *Q,
-   const bool use_bdr)
-{
-#ifdef MFEM_USE_CEED
-   MixedVectorGradientOperatorInfo info(trial_fes, test_fes, Q, use_bdr, false);
-   if (Q)
-   {
-      // Does not inherit ownership of old Q
-      Q = new ScalarMatrixProductCoefficient(-1.0, *Q);
-   }
-   Assemble(integ, info, trial_fes, test_fes, Q, use_bdr);
-   delete Q;
-#else
-   MFEM_ABORT("MFEM must be built with MFEM_USE_CEED=YES to use libCEED.");
-#endif
-}
-
-template <>
+template <typename CoeffType>
 MFMixedVectorWeakDivergenceIntegrator::MFMixedVectorWeakDivergenceIntegrator(
    const mfem::MixedVectorWeakDivergenceIntegrator &integ,
    const mfem::FiniteElementSpace &trial_fes,
    const mfem::FiniteElementSpace &test_fes,
-   mfem::Coefficient *Q,
+   CoeffType *Q,
    const bool use_bdr)
 {
 #ifdef MFEM_USE_CEED
-   MixedVectorGradientOperatorInfo info(trial_fes, test_fes, Q, use_bdr, false);
+   MixedVectorWeakDivergenceOperatorInfo info(trial_fes, test_fes, Q, use_bdr,
+                                              true);
    if (Q)
    {
       // Does not inherit ownership of old Q
-      Q = new ProductCoefficient(-1.0, *Q);
+      auto *nQ = NegativeCoeff(*Q);
+      Assemble(integ, info, trial_fes, test_fes, nQ, use_bdr, true);
+      delete nQ;
    }
-   Assemble(integ, info, trial_fes, test_fes, Q, use_bdr, true);
-   delete Q;
-#else
-   MFEM_ABORT("MFEM must be built with MFEM_USE_CEED=YES to use libCEED.");
-#endif
-}
-
-template <>
-MFMixedVectorWeakDivergenceIntegrator::MFMixedVectorWeakDivergenceIntegrator(
-   const mfem::MixedVectorWeakDivergenceIntegrator &integ,
-   const mfem::FiniteElementSpace &trial_fes,
-   const mfem::FiniteElementSpace &test_fes,
-   mfem::VectorCoefficient *Q,
-   const bool use_bdr)
-{
-#ifdef MFEM_USE_CEED
-   MixedVectorGradientOperatorInfo info(trial_fes, test_fes, Q, use_bdr, false);
-   if (Q)
+   else
    {
-      // Does not inherit ownership of old Q
-      Q = new ScalarVectorProductCoefficient(-1.0, *Q);
+      Assemble(integ, info, trial_fes, test_fes, Q, use_bdr, true);
    }
-   Assemble(integ, info, trial_fes, test_fes, Q, use_bdr, true);
-   delete Q;
-#else
-   MFEM_ABORT("MFEM must be built with MFEM_USE_CEED=YES to use libCEED.");
-#endif
-}
-
-template <>
-MFMixedVectorWeakDivergenceIntegrator::MFMixedVectorWeakDivergenceIntegrator(
-   const mfem::MixedVectorWeakDivergenceIntegrator &integ,
-   const mfem::FiniteElementSpace &trial_fes,
-   const mfem::FiniteElementSpace &test_fes,
-   mfem::MatrixCoefficient *Q,
-   const bool use_bdr)
-{
-#ifdef MFEM_USE_CEED
-   MixedVectorGradientOperatorInfo info(trial_fes, test_fes, Q, use_bdr, false);
-   if (Q)
-   {
-      // Does not inherit ownership of old Q
-      Q = new ScalarMatrixProductCoefficient(-1.0, *Q);
-   }
-   Assemble(integ, info, trial_fes, test_fes, Q, use_bdr, true);
-   delete Q;
 #else
    MFEM_ABORT("MFEM must be built with MFEM_USE_CEED=YES to use libCEED.");
 #endif
@@ -302,6 +353,19 @@ template PAMixedVectorGradientIntegrator::PAMixedVectorGradientIntegrator(
    const mfem::MixedVectorGradientIntegrator &, const mfem::FiniteElementSpace &,
    const mfem::FiniteElementSpace &, mfem::MatrixCoefficient *, const bool);
 
+template PAMixedVectorWeakDivergenceIntegrator::PAMixedVectorWeakDivergenceIntegrator(
+   const mfem::MixedVectorWeakDivergenceIntegrator &,
+   const mfem::FiniteElementSpace &, const mfem::FiniteElementSpace &,
+   mfem::Coefficient *, const bool);
+template PAMixedVectorWeakDivergenceIntegrator::PAMixedVectorWeakDivergenceIntegrator(
+   const mfem::MixedVectorWeakDivergenceIntegrator &,
+   const mfem::FiniteElementSpace &, const mfem::FiniteElementSpace &,
+   mfem::VectorCoefficient *, const bool);
+template PAMixedVectorWeakDivergenceIntegrator::PAMixedVectorWeakDivergenceIntegrator(
+   const mfem::MixedVectorWeakDivergenceIntegrator &,
+   const mfem::FiniteElementSpace &, const mfem::FiniteElementSpace &,
+   mfem::MatrixCoefficient *, const bool);
+
 template MFMixedVectorGradientIntegrator::MFMixedVectorGradientIntegrator(
    const mfem::MixedVectorGradientIntegrator &, const mfem::FiniteElementSpace &,
    const mfem::FiniteElementSpace &, mfem::Coefficient *, const bool);
@@ -311,6 +375,19 @@ template MFMixedVectorGradientIntegrator::MFMixedVectorGradientIntegrator(
 template MFMixedVectorGradientIntegrator::MFMixedVectorGradientIntegrator(
    const mfem::MixedVectorGradientIntegrator &, const mfem::FiniteElementSpace &,
    const mfem::FiniteElementSpace &, mfem::MatrixCoefficient *, const bool);
+
+template MFMixedVectorWeakDivergenceIntegrator::MFMixedVectorWeakDivergenceIntegrator(
+   const mfem::MixedVectorWeakDivergenceIntegrator &,
+   const mfem::FiniteElementSpace &, const mfem::FiniteElementSpace &,
+   mfem::Coefficient *, const bool);
+template MFMixedVectorWeakDivergenceIntegrator::MFMixedVectorWeakDivergenceIntegrator(
+   const mfem::MixedVectorWeakDivergenceIntegrator &,
+   const mfem::FiniteElementSpace &, const mfem::FiniteElementSpace &,
+   mfem::VectorCoefficient *, const bool);
+template MFMixedVectorWeakDivergenceIntegrator::MFMixedVectorWeakDivergenceIntegrator(
+   const mfem::MixedVectorWeakDivergenceIntegrator &,
+   const mfem::FiniteElementSpace &, const mfem::FiniteElementSpace &,
+   mfem::MatrixCoefficient *, const bool);
 
 // @endcond
 

--- a/fem/ceed/integrators/mixedvecgrad/mixedvecgrad.cpp
+++ b/fem/ceed/integrators/mixedvecgrad/mixedvecgrad.cpp
@@ -290,6 +290,8 @@ MFMixedVectorWeakDivergenceIntegrator::MFMixedVectorWeakDivergenceIntegrator(
 #endif
 }
 
+// @cond DOXYGEN_SKIP
+
 template PAMixedVectorGradientIntegrator::PAMixedVectorGradientIntegrator(
    const mfem::MixedVectorGradientIntegrator &, const mfem::FiniteElementSpace &,
    const mfem::FiniteElementSpace &, mfem::Coefficient *, const bool);
@@ -309,6 +311,8 @@ template MFMixedVectorGradientIntegrator::MFMixedVectorGradientIntegrator(
 template MFMixedVectorGradientIntegrator::MFMixedVectorGradientIntegrator(
    const mfem::MixedVectorGradientIntegrator &, const mfem::FiniteElementSpace &,
    const mfem::FiniteElementSpace &, mfem::MatrixCoefficient *, const bool);
+
+// @endcond
 
 } // namespace ceed
 

--- a/fem/ceed/integrators/mixedvecgrad/mixedvecgrad.cpp
+++ b/fem/ceed/integrators/mixedvecgrad/mixedvecgrad.cpp
@@ -1,0 +1,349 @@
+// Copyright (c) 2010-2023, Lawrence Livermore National Security, LLC. Produced
+// at the Lawrence Livermore National Laboratory. All Rights reserved. See files
+// LICENSE and NOTICE for details. LLNL-CODE-806117.
+//
+// This file is part of the MFEM library. For more information and source code
+// availability visit https://mfem.org.
+//
+// MFEM is free software; you can redistribute it and/or modify it under the
+// terms of the BSD-3 license. We welcome feedback and contributions, see file
+// CONTRIBUTING.md for details.
+
+#include "mixedvecgrad.hpp"
+
+#include "../../../../config/config.hpp"
+#ifdef MFEM_USE_CEED
+#include "../diffusion/diffusion_qf.h"
+#endif
+
+namespace mfem
+{
+
+namespace ceed
+{
+
+#ifdef MFEM_USE_CEED
+struct MixedVectorGradientOperatorInfo : public OperatorInfo
+{
+   DiffusionContext ctx;
+   template <typename CoeffType>
+   MixedVectorGradientOperatorInfo(const mfem::FiniteElementSpace &trial_fes,
+                                   const mfem::FiniteElementSpace &test_fes,
+                                   CoeffType *Q, bool use_bdr, bool mixed_vector_grad)
+   {
+      MFEM_VERIFY(trial_fes.GetVDim() == 1 && test_fes.GetVDim() == 1,
+                  "libCEED interface for vector FE does not support VDim > 1!");
+      ctx.dim = trial_fes.GetMesh()->Dimension() - use_bdr;
+      MFEM_VERIFY(ctx.dim == 2 || ctx.dim == 3,
+                  "MixedVectorGradientIntegrator and MixedVectorWeakDivergenceIntegrator "
+                  "require dim == 2 or dim == 3!");
+      MFEM_VERIFY(
+         !mixed_vector_grad ||
+         (trial_fes.FEColl()->GetDerivMapType(ctx.dim) == mfem::FiniteElement::H_CURL &&
+          test_fes.FEColl()->GetMapType(ctx.dim) == mfem::FiniteElement::H_CURL),
+         "libCEED interface for MixedVectorGradientIntegrator requires "
+         "H^1 domain and H(curl) range FE spaces!");
+      MFEM_VERIFY(
+         mixed_vector_grad ||
+         (trial_fes.FEColl()->GetMapType(ctx.dim) == mfem::FiniteElement::H_CURL &&
+          test_fes.FEColl()->GetDerivMapType(ctx.dim) == mfem::FiniteElement::H_CURL),
+         "libCEED interface for MixedVectorWeakDivergenceIntegrator requires "
+         "H(curl) domain and H^1 range FE spaces!");
+      ctx.space_dim = trial_fes.GetMesh()->SpaceDimension();
+      ctx.vdim = 1;
+      InitCoefficient(Q, mixed_vector_grad ? 1 : -1);
+
+      // Reuse H(curl) quadrature functions for DiffusionIntegrator
+      header = "/integrators/diffusion/diffusion_qf.h";
+      build_func_const = ":f_build_diff_const";
+      build_qf_const = &f_build_diff_const;
+      build_func_quad = ":f_build_diff_quad";
+      build_qf_quad = &f_build_diff_quad;
+      apply_func = ":f_apply_diff";
+      apply_qf = &f_apply_diff;
+      apply_func_mf_const = ":f_apply_diff_mf_const";
+      apply_qf_mf_const = &f_apply_diff_mf_const;
+      apply_func_mf_quad = ":f_apply_diff_mf_quad";
+      apply_qf_mf_quad = &f_apply_diff_mf_quad;
+      trial_op = mixed_vector_grad ? EvalMode::Grad : EvalMode::Interp;
+      test_op = mixed_vector_grad ? EvalMode::Interp : EvalMode::Grad;
+      qdatasize = (ctx.dim * (ctx.dim + 1)) / 2;
+   }
+   void InitCoefficient(mfem::Coefficient *Q, int sign)
+   {
+      ctx.coeff_comp = 1;
+      if (Q == nullptr)
+      {
+         ctx.coeff[0] = sign * 1.0;
+      }
+      else if (ConstantCoefficient *const_coeff =
+                  dynamic_cast<ConstantCoefficient *>(Q))
+      {
+         ctx.coeff[0] = const_coeff->constant;
+      }
+   }
+   void InitCoefficient(mfem::VectorCoefficient *VQ, int sign)
+   {
+      if (VQ == nullptr)
+      {
+         ctx.coeff_comp = 1;
+         ctx.coeff[0] = sign * 1.0;
+         return;
+      }
+      const int vdim = VQ->GetVDim();
+      ctx.coeff_comp = vdim;
+      if (VectorConstantCoefficient *const_coeff =
+             dynamic_cast<VectorConstantCoefficient *>(VQ))
+      {
+         MFEM_VERIFY(ctx.coeff_comp <= LIBCEED_DIFF_COEFF_COMP_MAX,
+                     "VectorCoefficient dimension exceeds context storage!");
+         const mfem::Vector &val = const_coeff->GetVec();
+         for (int i = 0; i < vdim; i++)
+         {
+            ctx.coeff[i] = val[i];
+         }
+      }
+   }
+   void InitCoefficient(mfem::MatrixCoefficient *MQ, int sign)
+   {
+      if (MQ == nullptr)
+      {
+         ctx.coeff_comp = 1;
+         ctx.coeff[0] = sign * 1.0;
+         return;
+      }
+      // Assumes matrix coefficient is symmetric
+      const int vdim = MQ->GetVDim();
+      ctx.coeff_comp = (vdim * (vdim + 1)) / 2;
+      if (MatrixConstantCoefficient *const_coeff =
+             dynamic_cast<MatrixConstantCoefficient *>(MQ))
+      {
+         MFEM_VERIFY(ctx.coeff_comp <= LIBCEED_DIFF_COEFF_COMP_MAX,
+                     "MatrixCoefficient dimensions exceed context storage!");
+         const mfem::DenseMatrix &val = const_coeff->GetMatrix();
+         for (int j = 0; j < vdim; j++)
+         {
+            for (int i = j; i < vdim; i++)
+            {
+               const int idx = (j * vdim) - (((j - 1) * j) / 2) + i - j;
+               ctx.coeff[idx] = val(i, j);
+            }
+         }
+      }
+   }
+};
+#endif
+
+template <typename CoeffType>
+PAMixedVectorGradientIntegrator::PAMixedVectorGradientIntegrator(
+   const mfem::MixedVectorGradientIntegrator &integ,
+   const mfem::FiniteElementSpace &trial_fes,
+   const mfem::FiniteElementSpace &test_fes,
+   CoeffType *Q,
+   const bool use_bdr)
+{
+#ifdef MFEM_USE_CEED
+   MixedVectorGradientOperatorInfo info(trial_fes, test_fes, Q, use_bdr, true);
+   Assemble(integ, info, trial_fes, test_fes, Q, use_bdr);
+#else
+   MFEM_ABORT("MFEM must be built with MFEM_USE_CEED=YES to use libCEED.");
+#endif
+}
+
+template <typename CoeffType>
+MFMixedVectorGradientIntegrator::MFMixedVectorGradientIntegrator(
+   const mfem::MixedVectorGradientIntegrator &integ,
+   const mfem::FiniteElementSpace &trial_fes,
+   const mfem::FiniteElementSpace &test_fes,
+   CoeffType *Q,
+   const bool use_bdr)
+{
+#ifdef MFEM_USE_CEED
+   MixedVectorGradientOperatorInfo info(trial_fes, test_fes, Q, use_bdr, true);
+   Assemble(integ, info, trial_fes, test_fes, Q, use_bdr, true);
+#else
+   MFEM_ABORT("MFEM must be built with MFEM_USE_CEED=YES to use libCEED.");
+#endif
+}
+
+template <>
+PAMixedVectorWeakDivergenceIntegrator::PAMixedVectorWeakDivergenceIntegrator(
+   const mfem::MixedVectorWeakDivergenceIntegrator &integ,
+   const mfem::FiniteElementSpace &trial_fes,
+   const mfem::FiniteElementSpace &test_fes,
+   mfem::Coefficient *Q,
+   const bool use_bdr)
+{
+#ifdef MFEM_USE_CEED
+   if (Q)
+   {
+      // Does not inherit ownership of old Q
+      Q = new ProductCoefficient(-1.0, *Q);
+   }
+   MixedVectorGradientOperatorInfo info(trial_fes, test_fes, Q, use_bdr, false);
+   Assemble(integ, info, trial_fes, test_fes, Q, use_bdr);
+   delete Q;
+#else
+   MFEM_ABORT("MFEM must be built with MFEM_USE_CEED=YES to use libCEED.");
+#endif
+}
+
+template <>
+PAMixedVectorWeakDivergenceIntegrator::PAMixedVectorWeakDivergenceIntegrator(
+   const mfem::MixedVectorWeakDivergenceIntegrator &integ,
+   const mfem::FiniteElementSpace &trial_fes,
+   const mfem::FiniteElementSpace &test_fes,
+   mfem::VectorCoefficient *Q,
+   const bool use_bdr)
+{
+#ifdef MFEM_USE_CEED
+   if (Q)
+   {
+      // Does not inherit ownership of old Q
+      Q = new ScalarVectorProductCoefficient(-1.0, *Q);
+   }
+   MixedVectorGradientOperatorInfo info(trial_fes, test_fes, Q, use_bdr, false);
+   Assemble(integ, info, trial_fes, test_fes, Q, use_bdr);
+   delete Q;
+#else
+   MFEM_ABORT("MFEM must be built with MFEM_USE_CEED=YES to use libCEED.");
+#endif
+}
+
+template <>
+PAMixedVectorWeakDivergenceIntegrator::PAMixedVectorWeakDivergenceIntegrator(
+   const mfem::MixedVectorWeakDivergenceIntegrator &integ,
+   const mfem::FiniteElementSpace &trial_fes,
+   const mfem::FiniteElementSpace &test_fes,
+   mfem::MatrixCoefficient *Q,
+   const bool use_bdr)
+{
+#ifdef MFEM_USE_CEED
+   if (Q)
+   {
+      // Does not inherit ownership of old Q
+      Q = new ScalarMatrixProductCoefficient(-1.0, *Q);
+   }
+   MixedVectorGradientOperatorInfo info(trial_fes, test_fes, Q, use_bdr, false);
+   Assemble(integ, info, trial_fes, test_fes, Q, use_bdr);
+   delete Q;
+#else
+   MFEM_ABORT("MFEM must be built with MFEM_USE_CEED=YES to use libCEED.");
+#endif
+}
+
+template <>
+MFMixedVectorWeakDivergenceIntegrator::MFMixedVectorWeakDivergenceIntegrator(
+   const mfem::MixedVectorWeakDivergenceIntegrator &integ,
+   const mfem::FiniteElementSpace &trial_fes,
+   const mfem::FiniteElementSpace &test_fes,
+   mfem::Coefficient *Q,
+   const bool use_bdr)
+{
+#ifdef MFEM_USE_CEED
+   if (Q)
+   {
+      // Does not inherit ownership of old Q
+      Q = new ProductCoefficient(-1.0, *Q);
+   }
+   MixedVectorGradientOperatorInfo info(trial_fes, test_fes, Q, use_bdr, false);
+   Assemble(integ, info, trial_fes, test_fes, Q, use_bdr, true);
+   delete Q;
+#else
+   MFEM_ABORT("MFEM must be built with MFEM_USE_CEED=YES to use libCEED.");
+#endif
+}
+
+template <>
+MFMixedVectorWeakDivergenceIntegrator::MFMixedVectorWeakDivergenceIntegrator(
+   const mfem::MixedVectorWeakDivergenceIntegrator &integ,
+   const mfem::FiniteElementSpace &trial_fes,
+   const mfem::FiniteElementSpace &test_fes,
+   mfem::VectorCoefficient *Q,
+   const bool use_bdr)
+{
+#ifdef MFEM_USE_CEED
+   if (Q)
+   {
+      // Does not inherit ownership of old Q
+      Q = new ScalarVectorProductCoefficient(-1.0, *Q);
+   }
+   MixedVectorGradientOperatorInfo info(trial_fes, test_fes, Q, use_bdr, false);
+   Assemble(integ, info, trial_fes, test_fes, Q, use_bdr, true);
+   delete Q;
+#else
+   MFEM_ABORT("MFEM must be built with MFEM_USE_CEED=YES to use libCEED.");
+#endif
+}
+
+template <>
+MFMixedVectorWeakDivergenceIntegrator::MFMixedVectorWeakDivergenceIntegrator(
+   const mfem::MixedVectorWeakDivergenceIntegrator &integ,
+   const mfem::FiniteElementSpace &trial_fes,
+   const mfem::FiniteElementSpace &test_fes,
+   mfem::MatrixCoefficient *Q,
+   const bool use_bdr)
+{
+#ifdef MFEM_USE_CEED
+   if (Q)
+   {
+      // Does not inherit ownership of old Q
+      Q = new ScalarMatrixProductCoefficient(-1.0, *Q);
+   }
+   MixedVectorGradientOperatorInfo info(trial_fes, test_fes, Q, use_bdr, false);
+   Assemble(integ, info, trial_fes, test_fes, Q, use_bdr, true);
+   delete Q;
+#else
+   MFEM_ABORT("MFEM must be built with MFEM_USE_CEED=YES to use libCEED.");
+#endif
+}
+
+template PAMixedVectorGradientIntegrator::PAMixedVectorGradientIntegrator(
+   const mfem::MixedVectorGradientIntegrator &, const mfem::FiniteElementSpace &,
+   const mfem::FiniteElementSpace &, mfem::Coefficient *, const bool);
+template PAMixedVectorGradientIntegrator::PAMixedVectorGradientIntegrator(
+   const mfem::MixedVectorGradientIntegrator &, const mfem::FiniteElementSpace &,
+   const mfem::FiniteElementSpace &, mfem::VectorCoefficient *, const bool);
+template PAMixedVectorGradientIntegrator::PAMixedVectorGradientIntegrator(
+   const mfem::MixedVectorGradientIntegrator &, const mfem::FiniteElementSpace &,
+   const mfem::FiniteElementSpace &, mfem::MatrixCoefficient *, const bool);
+
+template MFMixedVectorGradientIntegrator::MFMixedVectorGradientIntegrator(
+   const mfem::MixedVectorGradientIntegrator &, const mfem::FiniteElementSpace &,
+   const mfem::FiniteElementSpace &, mfem::Coefficient *, const bool);
+template MFMixedVectorGradientIntegrator::MFMixedVectorGradientIntegrator(
+   const mfem::MixedVectorGradientIntegrator &, const mfem::FiniteElementSpace &,
+   const mfem::FiniteElementSpace &, mfem::VectorCoefficient *, const bool);
+template MFMixedVectorGradientIntegrator::MFMixedVectorGradientIntegrator(
+   const mfem::MixedVectorGradientIntegrator &, const mfem::FiniteElementSpace &,
+   const mfem::FiniteElementSpace &, mfem::MatrixCoefficient *, const bool);
+
+template PAMixedVectorWeakDivergenceIntegrator::PAMixedVectorWeakDivergenceIntegrator(
+   const mfem::MixedVectorWeakDivergenceIntegrator &,
+   const mfem::FiniteElementSpace &, const mfem::FiniteElementSpace &,
+   mfem::Coefficient *, const bool);
+template PAMixedVectorWeakDivergenceIntegrator::PAMixedVectorWeakDivergenceIntegrator(
+   const mfem::MixedVectorWeakDivergenceIntegrator &,
+   const mfem::FiniteElementSpace &, const mfem::FiniteElementSpace &,
+   mfem::VectorCoefficient *, const bool);
+template PAMixedVectorWeakDivergenceIntegrator::PAMixedVectorWeakDivergenceIntegrator(
+   const mfem::MixedVectorWeakDivergenceIntegrator &,
+   const mfem::FiniteElementSpace &, const mfem::FiniteElementSpace &,
+   mfem::MatrixCoefficient *, const bool);
+
+template MFMixedVectorWeakDivergenceIntegrator::MFMixedVectorWeakDivergenceIntegrator(
+   const mfem::MixedVectorWeakDivergenceIntegrator &,
+   const mfem::FiniteElementSpace &, const mfem::FiniteElementSpace &,
+   mfem::Coefficient *, const bool);
+template MFMixedVectorWeakDivergenceIntegrator::MFMixedVectorWeakDivergenceIntegrator(
+   const mfem::MixedVectorWeakDivergenceIntegrator &,
+   const mfem::FiniteElementSpace &, const mfem::FiniteElementSpace &,
+   mfem::VectorCoefficient *, const bool);
+template MFMixedVectorWeakDivergenceIntegrator::MFMixedVectorWeakDivergenceIntegrator(
+   const mfem::MixedVectorWeakDivergenceIntegrator &,
+   const mfem::FiniteElementSpace &, const mfem::FiniteElementSpace &,
+   mfem::MatrixCoefficient *, const bool);
+
+} // namespace ceed
+
+} // namespace mfem

--- a/fem/ceed/integrators/mixedvecgrad/mixedvecgrad.hpp
+++ b/fem/ceed/integrators/mixedvecgrad/mixedvecgrad.hpp
@@ -1,0 +1,84 @@
+// Copyright (c) 2010-2023, Lawrence Livermore National Security, LLC. Produced
+// at the Lawrence Livermore National Laboratory. All Rights reserved. See files
+// LICENSE and NOTICE for details. LLNL-CODE-806117.
+//
+// This file is part of the MFEM library. For more information and source code
+// availability visit https://mfem.org.
+//
+// MFEM is free software; you can redistribute it and/or modify it under the
+// terms of the BSD-3 license. We welcome feedback and contributions, see file
+// CONTRIBUTING.md for details.
+
+#ifndef MFEM_LIBCEED_MIXEDVECGRAD_HPP
+#define MFEM_LIBCEED_MIXEDVECGRAD_HPP
+
+#include "../../interface/mixed_integrator.hpp"
+#include "../../../fespace.hpp"
+
+namespace mfem
+{
+
+namespace ceed
+{
+
+/** Represent a MixedVectorGradientIntegrator with AssemblyLevel::Partial
+    using libCEED. */
+class PAMixedVectorGradientIntegrator : public MixedIntegrator
+{
+public:
+   template <typename CoeffType>
+   PAMixedVectorGradientIntegrator(
+      const mfem::MixedVectorGradientIntegrator &integ,
+      const mfem::FiniteElementSpace &trial_fes,
+      const mfem::FiniteElementSpace &test_fes,
+      CoeffType *Q,
+      const bool use_bdr = false);
+};
+
+/** Represent a MixedVectorGradientIntegrator with AssemblyLevel::None
+    using libCEED. */
+class MFMixedVectorGradientIntegrator : public MixedIntegrator
+{
+public:
+   template <typename CoeffType>
+   MFMixedVectorGradientIntegrator(
+      const mfem::MixedVectorGradientIntegrator &integ,
+      const mfem::FiniteElementSpace &trial_fes,
+      const mfem::FiniteElementSpace &test_fes,
+      CoeffType *Q,
+      const bool use_bdr = false);
+};
+
+/** Represent a MixedVectorWeakDivergenceIntegrator with AssemblyLevel::Partial
+    using libCEED. */
+class PAMixedVectorWeakDivergenceIntegrator : public MixedIntegrator
+{
+public:
+   template <typename CoeffType>
+   PAMixedVectorWeakDivergenceIntegrator(
+      const mfem::MixedVectorWeakDivergenceIntegrator &integ,
+      const mfem::FiniteElementSpace &trial_fes,
+      const mfem::FiniteElementSpace &test_fes,
+      CoeffType *Q,
+      const bool use_bdr = false);
+};
+
+/** Represent a MixedVectorWeakDivergenceIntegrator with AssemblyLevel::None
+    using libCEED. */
+class MFMixedVectorWeakDivergenceIntegrator : public MixedIntegrator
+{
+public:
+   template <typename CoeffType>
+   MFMixedVectorWeakDivergenceIntegrator(
+      const mfem::MixedVectorWeakDivergenceIntegrator &integ,
+      const mfem::FiniteElementSpace &trial_fes,
+      const mfem::FiniteElementSpace &test_fes,
+      CoeffType *Q,
+      const bool use_bdr = false);
+};
+
+}
+
+}
+
+#endif // MFEM_LIBCEED_MIXEDVECGRAD_HPP

--- a/fem/ceed/integrators/nlconvection/nlconvection_qf.h
+++ b/fem/ceed/integrators/nlconvection/nlconvection_qf.h
@@ -14,15 +14,14 @@
 
 #include "../util/util_qf.h"
 
-/// A structure used to pass additional data to f_build_conv and f_apply_conv
 struct NLConvectionContext
 {
    CeedInt dim, space_dim;
    CeedScalar coeff;
 };
 
-/// libCEED QFunction for building quadrature data for a convection operator
-/// with a constant coefficient
+/// libCEED QFunction for building quadrature data for a convection
+/// operator with a constant coefficient
 CEED_QFUNCTION(f_build_conv_const)(void *ctx, CeedInt Q,
                                    const CeedScalar *const *in,
                                    CeedScalar *const *out)
@@ -31,7 +30,7 @@ CEED_QFUNCTION(f_build_conv_const)(void *ctx, CeedInt Q,
    // in[0] is Jacobians with shape [dim, ncomp=space_dim, Q]
    // in[1] is quadrature weights, size (Q)
    //
-   // At every quadrature point, compute and store qw * c * adj(J)^T.
+   // At every quadrature point, compute and store qw * c * adj(J)^T
    const CeedScalar coeff = bc->coeff;
    const CeedScalar *J = in[0], *qw = in[1];
    CeedScalar *qd = out[0];
@@ -71,8 +70,8 @@ CEED_QFUNCTION(f_build_conv_const)(void *ctx, CeedInt Q,
    return 0;
 }
 
-/// libCEED QFunction for building quadrature data for a convection operator
-/// with a coefficient evaluated at quadrature points.
+/// libCEED QFunction for building quadrature data for a convection
+/// operator with a coefficient evaluated at quadrature points
 CEED_QFUNCTION(f_build_conv_quad)(void *ctx, CeedInt Q,
                                   const CeedScalar *const *in,
                                   CeedScalar *const *out)
@@ -82,7 +81,7 @@ CEED_QFUNCTION(f_build_conv_quad)(void *ctx, CeedInt Q,
    // in[1] is Jacobians with shape [dim, ncomp=space_dim, Q]
    // in[2] is quadrature weights, size (Q)
    //
-   // At every quadrature point, compute and store qw * c * adj(J)^T.
+   // At every quadrature point, compute and store qw * c * adj(J)^T
    const CeedScalar *c = in[0], *J = in[1], *qw = in[2];
    CeedScalar *qd = out[0];
    switch (10 * bc->space_dim + bc->dim)
@@ -121,7 +120,7 @@ CEED_QFUNCTION(f_build_conv_quad)(void *ctx, CeedInt Q,
    return 0;
 }
 
-/// libCEED QFunction for applying a conv operator
+/// libCEED QFunction for applying a convection operator
 CEED_QFUNCTION(f_apply_conv)(void *ctx, CeedInt Q,
                              const CeedScalar *const *in,
                              CeedScalar *const *out)
@@ -251,7 +250,8 @@ CEED_QFUNCTION(f_apply_conv)(void *ctx, CeedInt Q,
    return 0;
 }
 
-/// libCEED QFunction for applying a conv operator
+/// libCEED QFunction for applying a convection operator with a constant
+/// coefficient
 CEED_QFUNCTION(f_apply_conv_mf_const)(void *ctx, CeedInt Q,
                                       const CeedScalar *const *in,
                                       CeedScalar *const *out)
@@ -263,7 +263,7 @@ CEED_QFUNCTION(f_apply_conv_mf_const)(void *ctx, CeedInt Q,
    // in[3] is quadrature weights, size (Q)
    // out[0] has shape [ncomp=space_dim, Q]
    //
-   // At every quadrature point, compute qw * c * adj(J)^T.
+   // At every quadrature point, compute qw * c * adj(J)^T
    const CeedScalar coeff = bc->coeff;
    const CeedScalar *u = in[0], *ug = in[1], *J = in[2], *qw = in[3];
    CeedScalar *vg = out[0];
@@ -375,7 +375,8 @@ CEED_QFUNCTION(f_apply_conv_mf_const)(void *ctx, CeedInt Q,
    return 0;
 }
 
-/// libCEED QFunction for applying a conv operator
+/// libCEED QFunction for applying a convection operator with a coefficient
+/// evaluated at quadrature points
 CEED_QFUNCTION(f_apply_conv_mf_quad)(void *ctx, CeedInt Q,
                                      const CeedScalar *const *in,
                                      CeedScalar *const *out)
@@ -388,7 +389,7 @@ CEED_QFUNCTION(f_apply_conv_mf_quad)(void *ctx, CeedInt Q,
    // in[4] is quadrature weights, size (Q)
    // out[0] has shape [ncomp=space_dim, Q]
    //
-   // At every quadrature point, compute qw * c * adj(J)^T.
+   // At every quadrature point, compute qw * c * adj(J)^T
    const CeedScalar *u = in[0], *ug = in[1], *c = in[2], *J = in[3], *qw = in[4];
    CeedScalar *vg = out[0];
    switch (10 * bc->space_dim + bc->dim)

--- a/fem/ceed/integrators/util/util_qf.h
+++ b/fem/ceed/integrators/util/util_qf.h
@@ -73,7 +73,7 @@ CEED_QFUNCTION_HELPER void MultAdjJCAdjJt22(const CeedScalar *J,
                                             const CeedInt qd_stride,
                                             CeedScalar *qd)
 {
-   // compute qw/det(J) adj(J) C adj(J)^T and store the symmetric part of the result.
+   // compute qw/det(J) adj(J) C adj(J)^T and store the symmetric part of the result
    // J: 0 2   adj(J):  J22 -J12   qd: 0 1
    //    1 3           -J21  J11       1 2
    const CeedScalar J11 = J[J_stride * 0];
@@ -122,7 +122,7 @@ CEED_QFUNCTION_HELPER void MultAdjJCAdjJt21(const CeedScalar *J,
                                             const CeedInt qd_stride,
                                             CeedScalar *qd)
 {
-   // compute qw/det(J) adj(J) C adj(J)^T and store the symmetric part of the result.
+   // compute qw/det(J) adj(J) C adj(J)^T and store the symmetric part of the result
    // J: 0   adj(J): 1/sqrt(J^T J) J^T   qd: 0
    //    1
    const CeedScalar J11 = J[J_stride * 0];
@@ -160,7 +160,7 @@ CEED_QFUNCTION_HELPER void MultAdjJCAdjJt33(const CeedScalar *J,
                                             const CeedInt qd_stride,
                                             CeedScalar *qd)
 {
-   // compute qw/det(J) adj(J) C adj(J)^T and store the symmetric part of the result.
+   // compute qw/det(J) adj(J) C adj(J)^T and store the symmetric part of the result
    // J: 0 3 6   qd: 0 1 2
    //    1 4 7       1 3 4
    //    2 5 8       2 4 5
@@ -273,7 +273,7 @@ CEED_QFUNCTION_HELPER void MultAdjJCAdjJt32(const CeedScalar *J,
                                             const CeedInt qd_stride,
                                             CeedScalar *qd)
 {
-   // compute qw/det(J) adj(J) C adj(J)^T and store the symmetric part of the result.
+   // compute qw/det(J) adj(J) C adj(J)^T and store the symmetric part of the result
    // J: 0 3   qd: 0 1
    //    1 4       1 2
    //    2 5
@@ -373,7 +373,7 @@ CEED_QFUNCTION_HELPER void MultJtCJ22(const CeedScalar *J,
                                       const CeedInt qd_stride,
                                       CeedScalar *qd)
 {
-   // compute qw/det(J) J^T C J and store the symmetric part of the result.
+   // compute qw/det(J) J^T C J and store the symmetric part of the result
    // J: 0 2   qd: 0 1
    //    1 3       1 2
    const CeedScalar J11 = J[J_stride * 0];
@@ -422,7 +422,7 @@ CEED_QFUNCTION_HELPER void MultJtCJ21(const CeedScalar *J,
                                       const CeedInt qd_stride,
                                       CeedScalar *qd)
 {
-   // compute qw/det(J) J^T C J and store the symmetric part of the result.
+   // compute qw/det(J) J^T C J and store the symmetric part of the result
    // J: 0   qd: 0
    //    1
    const CeedScalar J11 = J[J_stride * 0];
@@ -460,7 +460,7 @@ CEED_QFUNCTION_HELPER void MultJtCJ33(const CeedScalar *J,
                                       const CeedInt qd_stride,
                                       CeedScalar *qd)
 {
-   // compute qw/det(J) J^T C J and store the symmetric part of the result.
+   // compute qw/det(J) J^T C J and store the symmetric part of the result
    // J: 0 3 6   qd: 0 1 2
    //    1 4 7       1 3 4
    //    2 5 8       2 4 5
@@ -566,7 +566,7 @@ CEED_QFUNCTION_HELPER void MultJtCJ32(const CeedScalar *J,
                                       const CeedInt qd_stride,
                                       CeedScalar *qd)
 {
-   // compute qw/det(J) J^T C J and store the symmetric part of the result.
+   // compute qw/det(J) J^T C J and store the symmetric part of the result
    // J: 0 3   qd: 0 1
    //    1 4       1 2
    //    2 5
@@ -639,7 +639,7 @@ CEED_QFUNCTION_HELPER void MultCtAdjJt22(const CeedScalar *J,
                                          const CeedInt qd_stride,
                                          CeedScalar *qd)
 {
-   // compute qw c^T adj(J)^T and store the result vector.
+   // compute qw c^T adj(J)^T and store the result vector
    // J: 0 2   adj(J):  J22 -J12
    //    1 3           -J21  J11
    const CeedScalar J11 = J[J_stride * 0];
@@ -660,7 +660,7 @@ CEED_QFUNCTION_HELPER void MultCtAdjJt21(const CeedScalar *J,
                                          const CeedInt qd_stride,
                                          CeedScalar *qd)
 {
-   // compute qw c^T adj(J)^T and store the result vector.
+   // compute qw c^T adj(J)^T and store the result vector
    // J: 0   adj(J): 1/sqrt(J^T J) J^T
    //    1
    const CeedScalar J11 = J[J_stride * 0];
@@ -679,7 +679,7 @@ CEED_QFUNCTION_HELPER void MultCtAdjJt33(const CeedScalar *J,
                                          const CeedInt qd_stride,
                                          CeedScalar *qd)
 {
-   // compute qw c^T adj(J)^T and store the result vector.
+   // compute qw c^T adj(J)^T and store the result vector
    // J: 0 3 6
    //    1 4 7
    //    2 5 8
@@ -717,7 +717,7 @@ CEED_QFUNCTION_HELPER void MultCtAdjJt32(const CeedScalar *J,
                                          const CeedInt qd_stride,
                                          CeedScalar *qd)
 {
-   // compute qw c^T adj(J)^T and store the result vector.
+   // compute qw c^T adj(J)^T and store the result vector
    // J: 0 3
    //    1 4
    //    2 5
@@ -750,7 +750,7 @@ CEED_QFUNCTION_HELPER void MultAdjJt22(const CeedScalar *J,
                                        const CeedInt qd_stride,
                                        CeedScalar *qd)
 {
-   // compute qw adj(J)^T and store the result matrix.
+   // compute qw adj(J)^T and store the result matrix
    // J: 0 2   adj(J):  J22 -J12   qd: 0 2
    //    1 3           -J21  J11       1 3
    const CeedScalar J11 = J[J_stride * 0];
@@ -769,7 +769,7 @@ CEED_QFUNCTION_HELPER void MultAdjJt21(const CeedScalar *J,
                                        const CeedInt qd_stride,
                                        CeedScalar *qd)
 {
-   // compute qw adj(J)^T and store the result matrix.
+   // compute qw adj(J)^T and store the result matrix
    // J: 0   adj(J):  1/sqrt(J^T J) J^T   qd: 0
    //    1                                    1
    const CeedScalar J11 = J[J_stride * 0];
@@ -785,7 +785,7 @@ CEED_QFUNCTION_HELPER void MultAdjJt33(const CeedScalar *J,
                                        const CeedInt qd_stride,
                                        CeedScalar *qd)
 {
-   // compute qw adj(J)^T and store the result matrix.
+   // compute qw adj(J)^T and store the result matrix
    // J: 0 3 6   qd: 0 3 6
    //    1 4 7       1 4 7
    //    2 5 8       2 5 8
@@ -824,7 +824,7 @@ CEED_QFUNCTION_HELPER void MultAdjJt32(const CeedScalar *J,
                                        const CeedInt qd_stride,
                                        CeedScalar *qd)
 {
-   // compute qw adj(J)^T and store the result matrix.
+   // compute qw adj(J)^T and store the result matrix
    // J: 0 3   qd: 0 3
    //    1 4       1 4
    //    2 5       2 5

--- a/fem/ceed/integrators/util/util_qf.h
+++ b/fem/ceed/integrators/util/util_qf.h
@@ -386,10 +386,10 @@ CEED_QFUNCTION_HELPER void MultJtCJ22(const CeedScalar *J,
       // First compute entries of R = C J
       // c: 0 1
       //    1 2
-      const CeedScalar R11 = c[c_stride * 0] * J11 + c[c_stride * 1] * J12;
-      const CeedScalar R21 = c[c_stride * 1] * J11 + c[c_stride * 2] * J12;
-      const CeedScalar R12 = c[c_stride * 0] * J21 + c[c_stride * 1] * J22;
-      const CeedScalar R22 = c[c_stride * 1] * J21 + c[c_stride * 2] * J22;
+      const CeedScalar R11 = c[c_stride * 0] * J11 + c[c_stride * 1] * J21;
+      const CeedScalar R21 = c[c_stride * 1] * J11 + c[c_stride * 2] * J21;
+      const CeedScalar R12 = c[c_stride * 0] * J12 + c[c_stride * 1] * J22;
+      const CeedScalar R22 = c[c_stride * 1] * J12 + c[c_stride * 2] * J22;
       qd[qd_stride * 0] = w * (J11 * R11 + J21 * R21);
       qd[qd_stride * 1] = w * (J11 * R12 + J21 * R22);
       qd[qd_stride * 2] = w * (J12 * R12 + J22 * R22);

--- a/fem/ceed/integrators/util/util_qf.h
+++ b/fem/ceed/integrators/util/util_qf.h
@@ -496,7 +496,7 @@ CEED_QFUNCTION_HELPER void MultJtCJ33(const CeedScalar *J,
                              c[c_stride * 4] * J31;
       const CeedScalar R22 = c[c_stride * 1] * J12 +
                              c[c_stride * 3] * J22 +
-                             c[c_stride * 4] * J31;
+                             c[c_stride * 4] * J32;
       const CeedScalar R23 = c[c_stride * 1] * J13 +
                              c[c_stride * 3] * J23 +
                              c[c_stride * 4] * J33;

--- a/fem/ceed/integrators/vecfemass/vecfemass.cpp
+++ b/fem/ceed/integrators/vecfemass/vecfemass.cpp
@@ -1,0 +1,175 @@
+// Copyright (c) 2010-2023, Lawrence Livermore National Security, LLC. Produced
+// at the Lawrence Livermore National Laboratory. All Rights reserved. See files
+// LICENSE and NOTICE for details. LLNL-CODE-806117.
+//
+// This file is part of the MFEM library. For more information and source code
+// availability visit https://mfem.org.
+//
+// MFEM is free software; you can redistribute it and/or modify it under the
+// terms of the BSD-3 license. We welcome feedback and contributions, see file
+// CONTRIBUTING.md for details.
+
+#include "vecfemass.hpp"
+
+#include "../../../../config/config.hpp"
+#ifdef MFEM_USE_CEED
+#include "vecfemass_qf.h"
+#endif
+
+namespace mfem
+{
+
+namespace ceed
+{
+
+#ifdef MFEM_USE_CEED
+struct VectorFEMassOperatorInfo : public OperatorInfo
+{
+   VectorFEMassContext ctx;
+   template <typename CoeffType>
+   VectorFEMassOperatorInfo(const mfem::FiniteElementSpace &fes, CoeffType *Q,
+                            bool use_bdr)
+   {
+      MFEM_VERIFY(fes.GetVDim() == 1,
+                  "libCEED interface for vector FE does not support VDim > 1!");
+      ctx.dim = fes.GetMesh()->Dimension() - use_bdr;
+      ctx.space_dim = fes.GetMesh()->SpaceDimension();
+      ctx.is_hdiv = (fes.FEColl()->GetDerivType(ctx.dim) == mfem::FiniteElement::DIV);
+      MFEM_VERIFY(ctx.is_hdiv ||
+                  fes.FEColl()->GetDerivType(ctx.dim) == mfem::FiniteElement::CURL,
+                  "VectorFEMassIntegrator requires H(div) or H(curl) FE space!");
+      InitCoefficient(Q);
+
+      header = "/integrators/vecfemass/vecfemass_qf.h";
+      build_func_const = ":f_build_vecfemass_const";
+      build_qf_const = &f_build_vecfemass_const;
+      build_func_quad = ":f_build_vecfemass_quad";
+      build_qf_quad = &f_build_vecfemass_quad;
+      apply_func = ":f_apply_vecfemass";
+      apply_qf = &f_apply_vecfemass;
+      apply_func_mf_const = ":f_apply_vecfemass_mf_const";
+      apply_qf_mf_const = &f_apply_vecfemass_mf_const;
+      apply_func_mf_quad = ":f_apply_vecfemass_mf_quad";
+      apply_qf_mf_quad = &f_apply_vecfemass_mf_quad;
+      trial_op = EvalMode::Interp;
+      test_op = EvalMode::Interp;
+      qdatasize = (ctx.dim * (ctx.dim + 1)) / 2;
+   }
+   void InitCoefficient(mfem::Coefficient *Q)
+   {
+      ctx.coeff_comp = 1;
+      if (Q == nullptr)
+      {
+         ctx.coeff[0] = 1.0;
+      }
+      else if (ConstantCoefficient *const_coeff =
+                  dynamic_cast<ConstantCoefficient *>(Q))
+      {
+         ctx.coeff[0] = const_coeff->constant;
+      }
+   }
+   void InitCoefficient(mfem::VectorCoefficient *VQ)
+   {
+      if (VQ == nullptr)
+      {
+         ctx.coeff_comp = 1;
+         ctx.coeff[0] = 1.0;
+         return;
+      }
+      const int vdim = VQ->GetVDim();
+      ctx.coeff_comp = vdim;
+      if (VectorConstantCoefficient *const_coeff =
+             dynamic_cast<VectorConstantCoefficient *>(VQ))
+      {
+         MFEM_VERIFY(ctx.coeff_comp <= LIBCEED_VECFEMASS_COEFF_COMP_MAX,
+                     "VectorCoefficient dimension exceeds context storage!");
+         const mfem::Vector &val = const_coeff->GetVec();
+         for (int i = 0; i < vdim; i++)
+         {
+            ctx.coeff[i] = val[i];
+         }
+      }
+   }
+   void InitCoefficient(mfem::MatrixCoefficient *MQ)
+   {
+      if (MQ == nullptr)
+      {
+         ctx.coeff_comp = 1;
+         ctx.coeff[0] = 1.0;
+         return;
+      }
+      // Assumes matrix coefficient is symmetric
+      const int vdim = MQ->GetVDim();
+      ctx.coeff_comp = (vdim * (vdim + 1)) / 2;
+      if (MatrixConstantCoefficient *const_coeff =
+             dynamic_cast<MatrixConstantCoefficient *>(MQ))
+      {
+         MFEM_VERIFY(ctx.coeff_comp <= LIBCEED_VECFEMASS_COEFF_COMP_MAX,
+                     "MatrixCoefficient dimensions exceed context storage!");
+         const mfem::DenseMatrix &val = const_coeff->GetMatrix();
+         for (int j = 0; j < vdim; j++)
+         {
+            for (int i = j; i < vdim; i++)
+            {
+               const int idx = (j * vdim) - (((j - 1) * j) / 2) + i - j;
+               ctx.coeff[idx] = val(i, j);
+            }
+         }
+      }
+   }
+};
+#endif
+
+template <typename CoeffType>
+PAVectorFEMassIntegrator::PAVectorFEMassIntegrator(
+   const mfem::VectorFEMassIntegrator &integ,
+   const mfem::FiniteElementSpace &fes,
+   CoeffType *Q,
+   const bool use_bdr)
+{
+#ifdef MFEM_USE_CEED
+   VectorFEMassOperatorInfo info(fes, Q, use_bdr);
+   Assemble(integ, info, fes, Q, use_bdr);
+#else
+   MFEM_ABORT("MFEM must be built with MFEM_USE_CEED=YES to use libCEED.");
+#endif
+}
+
+template <typename CoeffType>
+MFVectorFEMassIntegrator::MFVectorFEMassIntegrator(
+   const mfem::VectorFEMassIntegrator &integ,
+   const mfem::FiniteElementSpace &fes,
+   CoeffType *Q,
+   const bool use_bdr)
+{
+#ifdef MFEM_USE_CEED
+   VectorFEMassOperatorInfo info(fes, Q, use_bdr);
+   Assemble(integ, info, fes, Q, use_bdr, true);
+#else
+   MFEM_ABORT("MFEM must be built with MFEM_USE_CEED=YES to use libCEED.");
+#endif
+}
+
+template PAVectorFEMassIntegrator::PAVectorFEMassIntegrator(
+   const mfem::VectorFEMassIntegrator &, const mfem::FiniteElementSpace &,
+   mfem::Coefficient *, const bool);
+template PAVectorFEMassIntegrator::PAVectorFEMassIntegrator(
+   const mfem::VectorFEMassIntegrator &, const mfem::FiniteElementSpace &,
+   mfem::VectorCoefficient *, const bool);
+template PAVectorFEMassIntegrator::PAVectorFEMassIntegrator(
+   const mfem::VectorFEMassIntegrator &, const mfem::FiniteElementSpace &,
+   mfem::MatrixCoefficient *, const bool);
+
+template MFVectorFEMassIntegrator::MFVectorFEMassIntegrator(
+   const mfem::VectorFEMassIntegrator &, const mfem::FiniteElementSpace &,
+   mfem::Coefficient *, const bool);
+template MFVectorFEMassIntegrator::MFVectorFEMassIntegrator(
+   const mfem::VectorFEMassIntegrator &, const mfem::FiniteElementSpace &,
+   mfem::VectorCoefficient *, const bool);
+template MFVectorFEMassIntegrator::MFVectorFEMassIntegrator(
+   const mfem::VectorFEMassIntegrator &, const mfem::FiniteElementSpace &,
+   mfem::MatrixCoefficient *, const bool);
+
+} // namespace ceed
+
+} // namespace mfem

--- a/fem/ceed/integrators/vecfemass/vecfemass.cpp
+++ b/fem/ceed/integrators/vecfemass/vecfemass.cpp
@@ -142,6 +142,8 @@ MFVectorFEMassIntegrator::MFVectorFEMassIntegrator(
 #endif
 }
 
+// @cond DOXYGEN_SKIP
+
 template PAVectorFEMassIntegrator::PAVectorFEMassIntegrator(
    const mfem::VectorFEMassIntegrator &, const mfem::FiniteElementSpace &,
    mfem::Coefficient *, const bool);
@@ -161,6 +163,8 @@ template MFVectorFEMassIntegrator::MFVectorFEMassIntegrator(
 template MFVectorFEMassIntegrator::MFVectorFEMassIntegrator(
    const mfem::VectorFEMassIntegrator &, const mfem::FiniteElementSpace &,
    mfem::MatrixCoefficient *, const bool);
+
+// @endcond
 
 } // namespace ceed
 

--- a/fem/ceed/integrators/vecfemass/vecfemass.cpp
+++ b/fem/ceed/integrators/vecfemass/vecfemass.cpp
@@ -34,9 +34,9 @@ struct VectorFEMassOperatorInfo : public OperatorInfo
                   "libCEED interface for vector FE does not support VDim > 1!");
       ctx.dim = fes.GetMesh()->Dimension() - use_bdr;
       ctx.space_dim = fes.GetMesh()->SpaceDimension();
-      ctx.is_hdiv = (fes.FEColl()->GetDerivType(ctx.dim) == mfem::FiniteElement::DIV);
-      MFEM_VERIFY(ctx.is_hdiv ||
-                  fes.FEColl()->GetDerivType(ctx.dim) == mfem::FiniteElement::CURL,
+      ctx.hdiv = (fes.FEColl()->GetMapType(ctx.dim) == mfem::FiniteElement::H_DIV);
+      MFEM_VERIFY(ctx.hdiv ||
+                  fes.FEColl()->GetMapType(ctx.dim) == mfem::FiniteElement::H_CURL,
                   "VectorFEMassIntegrator requires H(div) or H(curl) FE space!");
       InitCoefficient(Q);
 

--- a/fem/ceed/integrators/vecfemass/vecfemass.cpp
+++ b/fem/ceed/integrators/vecfemass/vecfemass.cpp
@@ -33,10 +33,6 @@ struct VectorFEMassOperatorInfo : public OperatorInfo
       MFEM_VERIFY(fes.GetVDim() == 1,
                   "libCEED interface for vector FE does not support VDim > 1!");
       ctx.dim = fes.GetMesh()->Dimension() - use_bdr;
-      ctx.hdiv = (fes.FEColl()->GetMapType(ctx.dim) == mfem::FiniteElement::H_DIV);
-      MFEM_VERIFY(ctx.hdiv ||
-                  fes.FEColl()->GetMapType(ctx.dim) == mfem::FiniteElement::H_CURL,
-                  "VectorFEMassIntegrator requires H(div) or H(curl) FE space!");
       ctx.space_dim = fes.GetMesh()->SpaceDimension();
       if (Q == nullptr)
       {
@@ -49,16 +45,34 @@ struct VectorFEMassOperatorInfo : public OperatorInfo
       }
 
       header = "/integrators/vecfemass/vecfemass_qf.h";
-      build_func_const = ":f_build_vecfemass_const";
-      build_qf_const = &f_build_vecfemass_const;
-      build_func_quad = ":f_build_vecfemass_quad";
-      build_qf_quad = &f_build_vecfemass_quad;
-      apply_func = ":f_apply_vecfemass";
-      apply_qf = &f_apply_vecfemass;
-      apply_func_mf_const = ":f_apply_vecfemass_mf_const";
-      apply_qf_mf_const = &f_apply_vecfemass_mf_const;
-      apply_func_mf_quad = ":f_apply_vecfemass_mf_quad";
-      apply_qf_mf_quad = &f_apply_vecfemass_mf_quad;
+      if (fes.FEColl()->GetMapType(ctx.dim) == mfem::FiniteElement::H_DIV)
+      {
+         build_func_const = ":f_build_hdivmass_const";
+         build_qf_const = &f_build_hdivmass_const;
+         build_func_quad = ":f_build_hdivmass_quad";
+         build_qf_quad = &f_build_hdivmass_quad;
+         apply_func = ":f_apply_vecfemass";
+         apply_qf = &f_apply_vecfemass;
+         apply_func_mf_const = ":f_apply_hdivmass_mf_const";
+         apply_qf_mf_const = &f_apply_hdivmass_mf_const;
+         apply_func_mf_quad = ":f_apply_hdivmass_mf_quad";
+         apply_qf_mf_quad = &f_apply_hdivmass_mf_quad;
+      }
+      else
+      {
+         MFEM_VERIFY(fes.FEColl()->GetMapType(ctx.dim) == mfem::FiniteElement::H_CURL,
+                     "VectorFEMassIntegrator requires H(div) or H(curl) FE space!");
+         build_func_const = ":f_build_hcurlmass_const";
+         build_qf_const = &f_build_hcurlmass_const;
+         build_func_quad = ":f_build_hcurlmass_quad";
+         build_qf_quad = &f_build_hcurlmass_quad;
+         apply_func = ":f_apply_vecfemass";
+         apply_qf = &f_apply_vecfemass;
+         apply_func_mf_const = ":f_apply_hcurlmass_mf_const";
+         apply_qf_mf_const = &f_apply_hcurlmass_mf_const;
+         apply_func_mf_quad = ":f_apply_hcurlmass_mf_quad";
+         apply_qf_mf_quad = &f_apply_hcurlmass_mf_quad;
+      }
       trial_op = EvalMode::Interp;
       test_op = EvalMode::Interp;
       qdatasize = (ctx.dim * (ctx.dim + 1)) / 2;

--- a/fem/ceed/integrators/vecfemass/vecfemass.cpp
+++ b/fem/ceed/integrators/vecfemass/vecfemass.cpp
@@ -25,92 +25,150 @@ namespace ceed
 #ifdef MFEM_USE_CEED
 struct VectorFEMassOperatorInfo : public OperatorInfo
 {
-   VectorFEMassContext ctx;
+   VectorFEMassContext ctx = {0};
    template <typename CoeffType>
    VectorFEMassOperatorInfo(const mfem::FiniteElementSpace &fes, CoeffType *Q,
-                            bool use_bdr)
+                            bool use_bdr = false, bool use_mf = false)
    {
       MFEM_VERIFY(fes.GetVDim() == 1,
                   "libCEED interface for vector FE does not support VDim > 1!");
       ctx.dim = fes.GetMesh()->Dimension() - use_bdr;
       ctx.space_dim = fes.GetMesh()->SpaceDimension();
+      bool is_hdiv = (fes.FEColl()->GetMapType(ctx.dim) ==
+                      mfem::FiniteElement::H_DIV);
+      MFEM_VERIFY(is_hdiv ||
+                  fes.FEColl()->GetMapType(ctx.dim) == mfem::FiniteElement::H_CURL,
+                  "VectorFEMassIntegrator requires H(div) or H(curl) FE space!");
+      if (!use_mf)
+      {
+         apply_func = ":f_apply_vecfemass";
+         apply_qf = &f_apply_vecfemass;
+      }
+      else
+      {
+         build_func = "";
+         build_qf = nullptr;
+      }
       if (Q == nullptr)
       {
-         ctx.coeff_comp = 1;
          ctx.coeff[0] = 1.0;
+         if (!use_mf)
+         {
+            build_func = is_hdiv ? ":f_build_hdivmass_const_scalar" :
+                         ":f_build_hcurlmass_const_scalar";
+            build_qf = is_hdiv ? &f_build_hdivmass_const_scalar :
+                       &f_build_hcurlmass_const_scalar;
+         }
+         else
+         {
+            apply_func = is_hdiv ? ":f_apply_hdivmass_mf_const_scalar" :
+                         ":f_apply_hcurlmass_mf_const_scalar";
+            apply_qf = is_hdiv ? &f_apply_hdivmass_mf_const_scalar :
+                       &f_apply_hcurlmass_mf_const_scalar;
+         }
       }
       else
       {
-         InitCoefficient(*Q);
+         InitCoefficient(*Q, is_hdiv, use_mf);
       }
-
       header = "/integrators/vecfemass/vecfemass_qf.h";
-      if (fes.FEColl()->GetMapType(ctx.dim) == mfem::FiniteElement::H_DIV)
-      {
-         build_func_const = ":f_build_hdivmass_const";
-         build_qf_const = &f_build_hdivmass_const;
-         build_func_quad = ":f_build_hdivmass_quad";
-         build_qf_quad = &f_build_hdivmass_quad;
-         apply_func = ":f_apply_vecfemass";
-         apply_qf = &f_apply_vecfemass;
-         apply_func_mf_const = ":f_apply_hdivmass_mf_const";
-         apply_qf_mf_const = &f_apply_hdivmass_mf_const;
-         apply_func_mf_quad = ":f_apply_hdivmass_mf_quad";
-         apply_qf_mf_quad = &f_apply_hdivmass_mf_quad;
-      }
-      else
-      {
-         MFEM_VERIFY(fes.FEColl()->GetMapType(ctx.dim) == mfem::FiniteElement::H_CURL,
-                     "VectorFEMassIntegrator requires H(div) or H(curl) FE space!");
-         build_func_const = ":f_build_hcurlmass_const";
-         build_qf_const = &f_build_hcurlmass_const;
-         build_func_quad = ":f_build_hcurlmass_quad";
-         build_qf_quad = &f_build_hcurlmass_quad;
-         apply_func = ":f_apply_vecfemass";
-         apply_qf = &f_apply_vecfemass;
-         apply_func_mf_const = ":f_apply_hcurlmass_mf_const";
-         apply_qf_mf_const = &f_apply_hcurlmass_mf_const;
-         apply_func_mf_quad = ":f_apply_hcurlmass_mf_quad";
-         apply_qf_mf_quad = &f_apply_hcurlmass_mf_quad;
-      }
       trial_op = EvalMode::Interp;
       test_op = EvalMode::Interp;
       qdatasize = (ctx.dim * (ctx.dim + 1)) / 2;
    }
-   void InitCoefficient(mfem::Coefficient &Q)
+   void InitCoefficient(mfem::Coefficient &Q, bool is_hdiv, bool use_mf)
    {
-      ctx.coeff_comp = 1;
-      if (ConstantCoefficient *const_coeff =
-             dynamic_cast<ConstantCoefficient *>(&Q))
+      if (mfem::ConstantCoefficient *const_coeff =
+             dynamic_cast<mfem::ConstantCoefficient *>(&Q))
       {
          ctx.coeff[0] = const_coeff->constant;
+         if (!use_mf)
+         {
+            build_func = is_hdiv ? ":f_build_hdivmass_const_scalar" :
+                         ":f_build_hcurlmass_const_scalar";
+            build_qf = is_hdiv ? &f_build_hdivmass_const_scalar :
+                       &f_build_hcurlmass_const_scalar;
+         }
+         else
+         {
+            apply_func = is_hdiv ? ":f_apply_hdivmass_mf_const_scalar" :
+                         ":f_apply_hcurlmass_mf_const_scalar";
+            apply_qf = is_hdiv ? &f_apply_hdivmass_mf_const_scalar :
+                       &f_apply_hcurlmass_mf_const_scalar;
+         }
+      }
+      else
+      {
+         if (!use_mf)
+         {
+            build_func = is_hdiv ? ":f_build_hdivmass_quad_scalar" :
+                         ":f_build_hcurlmass_quad_scalar";
+            build_qf = is_hdiv ? &f_build_hdivmass_quad_scalar :
+                       &f_build_hcurlmass_quad_scalar;
+         }
+         else
+         {
+            apply_func = is_hdiv ? ":f_apply_hdivmass_mf_quad_scalar" :
+                         ":f_apply_hcurlmass_mf_quad_scalar";
+            apply_qf = is_hdiv ? &f_apply_hdivmass_mf_quad_scalar :
+                       &f_apply_hcurlmass_mf_quad_scalar;
+         }
       }
    }
-   void InitCoefficient(mfem::VectorCoefficient &VQ)
+   void InitCoefficient(mfem::VectorCoefficient &VQ, bool is_hdiv, bool use_mf)
    {
-      const int vdim = VQ.GetVDim();
-      ctx.coeff_comp = vdim;
-      if (VectorConstantCoefficient *const_coeff =
-             dynamic_cast<VectorConstantCoefficient *>(&VQ))
+      if (mfem::VectorConstantCoefficient *const_coeff =
+             dynamic_cast<mfem::VectorConstantCoefficient *>(&VQ))
       {
-         MFEM_VERIFY(ctx.coeff_comp <= LIBCEED_VECFEMASS_COEFF_COMP_MAX,
+         const int vdim = VQ.GetVDim();
+         MFEM_VERIFY(vdim <= LIBCEED_VECFEMASS_COEFF_COMP_MAX,
                      "VectorCoefficient dimension exceeds context storage!");
          const mfem::Vector &val = const_coeff->GetVec();
          for (int i = 0; i < vdim; i++)
          {
             ctx.coeff[i] = val[i];
          }
+         if (!use_mf)
+         {
+            build_func = is_hdiv ? ":f_build_hdivmass_const_vector" :
+                         ":f_build_hcurlmass_const_vector";
+            build_qf = is_hdiv ? &f_build_hdivmass_const_vector :
+                       &f_build_hcurlmass_const_vector;
+         }
+         else
+         {
+            apply_func = is_hdiv ? ":f_apply_hdivmass_mf_const_vector" :
+                         ":f_apply_hcurlmass_mf_const_vector";
+            apply_qf = is_hdiv ? &f_apply_hdivmass_mf_const_vector :
+                       &f_apply_hcurlmass_mf_const_vector;
+         }
+      }
+      else
+      {
+         if (!use_mf)
+         {
+            build_func = is_hdiv ? ":f_build_hdivmass_quad_vector" :
+                         ":f_build_hcurlmass_quad_vector";
+            build_qf = is_hdiv ? &f_build_hdivmass_quad_vector :
+                       &f_build_hcurlmass_quad_vector;
+         }
+         else
+         {
+            apply_func = is_hdiv ? ":f_apply_hdivmass_mf_quad_vector" :
+                         ":f_apply_hcurlmass_mf_quad_vector";
+            apply_qf = is_hdiv ? &f_apply_hdivmass_mf_quad_vector :
+                       &f_apply_hcurlmass_mf_quad_vector;
+         }
       }
    }
-   void InitCoefficient(mfem::MatrixCoefficient &MQ)
+   void InitCoefficient(mfem::MatrixCoefficient &MQ, bool is_hdiv, bool use_mf)
    {
       // Assumes matrix coefficient is symmetric
-      const int vdim = MQ.GetVDim();
-      ctx.coeff_comp = (vdim * (vdim + 1)) / 2;
-      if (MatrixConstantCoefficient *const_coeff =
-             dynamic_cast<MatrixConstantCoefficient *>(&MQ))
+      if (mfem::MatrixConstantCoefficient *const_coeff =
+             dynamic_cast<mfem::MatrixConstantCoefficient *>(&MQ))
       {
-         MFEM_VERIFY(ctx.coeff_comp <= LIBCEED_VECFEMASS_COEFF_COMP_MAX,
+         const int vdim = MQ.GetVDim();
+         MFEM_VERIFY((vdim * (vdim + 1)) / 2 <= LIBCEED_VECFEMASS_COEFF_COMP_MAX,
                      "MatrixCoefficient dimensions exceed context storage!");
          const mfem::DenseMatrix &val = const_coeff->GetMatrix();
          for (int j = 0; j < vdim; j++)
@@ -120,6 +178,37 @@ struct VectorFEMassOperatorInfo : public OperatorInfo
                const int idx = (j * vdim) - (((j - 1) * j) / 2) + i - j;
                ctx.coeff[idx] = val(i, j);
             }
+         }
+         if (!use_mf)
+         {
+            build_func = is_hdiv ? ":f_build_hdivmass_const_matrix" :
+                         ":f_build_hcurlmass_const_matrix";
+            build_qf = is_hdiv ? &f_build_hdivmass_const_matrix :
+                       &f_build_hcurlmass_const_matrix;
+         }
+         else
+         {
+            apply_func = is_hdiv ? ":f_apply_hdivmass_mf_const_matrix" :
+                         ":f_apply_hcurlmass_mf_const_matrix";
+            apply_qf = is_hdiv ? &f_apply_hdivmass_mf_const_matrix :
+                       &f_apply_hcurlmass_mf_const_matrix;
+         }
+      }
+      else
+      {
+         if (!use_mf)
+         {
+            build_func = is_hdiv ? ":f_build_hdivmass_quad_matrix" :
+                         ":f_build_hcurlmass_quad_matrix";
+            build_qf = is_hdiv ? &f_build_hdivmass_quad_matrix :
+                       &f_build_hcurlmass_quad_matrix;
+         }
+         else
+         {
+            apply_func = is_hdiv ? ":f_apply_hdivmass_mf_quad_matrix" :
+                         ":f_apply_hcurlmass_mf_quad_matrix";
+            apply_qf = is_hdiv ? &f_apply_hdivmass_mf_quad_matrix :
+                       &f_apply_hcurlmass_mf_quad_matrix;
          }
       }
    }
@@ -149,7 +238,7 @@ MFVectorFEMassIntegrator::MFVectorFEMassIntegrator(
    const bool use_bdr)
 {
 #ifdef MFEM_USE_CEED
-   VectorFEMassOperatorInfo info(fes, Q, use_bdr);
+   VectorFEMassOperatorInfo info(fes, Q, use_bdr, true);
    Assemble(integ, info, fes, Q, use_bdr, true);
 #else
    MFEM_ABORT("MFEM must be built with MFEM_USE_CEED=YES to use libCEED.");

--- a/fem/ceed/integrators/vecfemass/vecfemass.hpp
+++ b/fem/ceed/integrators/vecfemass/vecfemass.hpp
@@ -1,0 +1,50 @@
+// Copyright (c) 2010-2023, Lawrence Livermore National Security, LLC. Produced
+// at the Lawrence Livermore National Laboratory. All Rights reserved. See files
+// LICENSE and NOTICE for details. LLNL-CODE-806117.
+//
+// This file is part of the MFEM library. For more information and source code
+// availability visit https://mfem.org.
+//
+// MFEM is free software; you can redistribute it and/or modify it under the
+// terms of the BSD-3 license. We welcome feedback and contributions, see file
+// CONTRIBUTING.md for details.
+
+#ifndef MFEM_LIBCEED_VECFEMASS_HPP
+#define MFEM_LIBCEED_VECFEMASS_HPP
+
+#include "../../interface/mixed_integrator.hpp"
+#include "../../../fespace.hpp"
+
+namespace mfem
+{
+
+namespace ceed
+{
+
+/// Represent a VectorFEMassIntegrator with AssemblyLevel::Partial using libCEED.
+class PAVectorFEMassIntegrator : public MixedIntegrator
+{
+public:
+   template <typename CoeffType>
+   PAVectorFEMassIntegrator(const mfem::VectorFEMassIntegrator &integ,
+                            const mfem::FiniteElementSpace &fes,
+                            CoeffType *Q,
+                            const bool use_bdr = false);
+};
+
+/// Represent a VectorFEMassIntegrator with AssemblyLevel::None using libCEED.
+class MFVectorFEMassIntegrator : public MixedIntegrator
+{
+public:
+   template <typename CoeffType>
+   MFVectorFEMassIntegrator(const mfem::VectorFEMassIntegrator &integ,
+                            const mfem::FiniteElementSpace &fes,
+                            CoeffType *Q,
+                            const bool use_bdr = false);
+};
+
+}
+
+}
+
+#endif // MFEM_LIBCEED_VECFEMASS_HPP

--- a/fem/ceed/integrators/vecfemass/vecfemass_qf.h
+++ b/fem/ceed/integrators/vecfemass/vecfemass_qf.h
@@ -1,0 +1,341 @@
+// Copyright (c) 2010-2023, Lawrence Livermore National Security, LLC. Produced
+// at the Lawrence Livermore National Laboratory. All Rights reserved. See files
+// LICENSE and NOTICE for details. LLNL-CODE-806117.
+//
+// This file is part of the MFEM library. For more information and source code
+// availability visit https://mfem.org.
+//
+// MFEM is free software; you can redistribute it and/or modify it under the
+// terms of the BSD-3 license. We welcome feedback and contributions, see file
+// CONTRIBUTING.md for details.
+
+#ifndef MFEM_LIBCEED_VECFEMASS_QF_H
+#define MFEM_LIBCEED_VECFEMASS_QF_H
+
+#include "../util/util_qf.h"
+
+#define LIBCEED_VECFEMASS_COEFF_COMP_MAX 6
+
+/// A structure used to pass additional data to f_build_vecfemass and
+/// f_apply_vecfemass
+struct VectorFEMassContext
+{
+   CeedInt dim, space_dim, coeff_comp;
+   bool is_hdiv;
+   CeedScalar coeff[LIBCEED_VECFEMASS_COEFF_COMP_MAX];
+};
+
+/// libCEED QFunction for building quadrature data for a vector FE mass
+/// operator with a constant coefficient
+CEED_QFUNCTION(f_build_vecfemass_const)(void *ctx, CeedInt Q,
+                                        const CeedScalar *const *in,
+                                        CeedScalar *const *out)
+{
+   VectorFEMassContext *bc = (VectorFEMassContext *)ctx;
+   // in[0] is Jacobians with shape [dim, ncomp=space_dim, Q]
+   // in[1] is quadrature weights, size (Q)
+   //
+   // At every quadrature point, compute qw/det(J) adj(J) C adj(J)^T (for
+   // H(curl)) or qw/det(J) J^T C J (for H(div)) and store the symmetric part
+   // of the result.
+   const bool is_hdiv = bc->is_hdiv;
+   const CeedInt coeff_comp = bc->coeff_comp;
+   const CeedScalar *coeff = bc->coeff;
+   const CeedScalar *J = in[0], *qw = in[1];
+   CeedScalar *qd = out[0];
+   switch (10 * bc->space_dim + bc->dim)
+   {
+      case 11:
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+         {
+            const CeedScalar coeff0 = coeff[0];
+            qd[i] = qw[i] * coeff0 * (is_hdiv ? J[i] : 1.0 / J[i]);
+         }
+         break;
+      case 21:
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+         {
+            (is_hdiv ? MultJtCJ21 : MultAdjJCAdjJt21)(J + i, Q, coeff, 1, coeff_comp,
+                                                      qw[i], Q, qd + i);
+         }
+         break;
+      case 22:
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+         {
+            (is_hdiv ? MultJtCJ22 : MultAdjJCAdjJt22)(J + i, Q, coeff, 1, coeff_comp,
+                                                      qw[i], Q, qd + i);
+         }
+         break;
+      case 32:
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+         {
+            (is_hdiv ? MultJtCJ32 : MultAdjJCAdjJt32)(J + i, Q, coeff, 1, coeff_comp,
+                                                      qw[i], Q, qd + i);
+         }
+         break;
+      case 33:
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+         {
+            (is_hdiv ? MultJtCJ33 : MultAdjJCAdjJt33)(J + i, Q, coeff, 1, coeff_comp,
+                                                      qw[i], Q, qd + i);
+         }
+         break;
+   }
+   return 0;
+}
+
+/// libCEED QFunction for building quadrature data for a vector FE mass
+/// operator with a coefficient evaluated at quadrature points.
+CEED_QFUNCTION(f_build_vecfemass_quad)(void *ctx, CeedInt Q,
+                                       const CeedScalar *const *in,
+                                       CeedScalar *const *out)
+{
+   VectorFEMassContext *bc = (VectorFEMassContext *)ctx;
+   // in[0] is coefficients with shape [ncomp=coeff_comp, Q]
+   // in[1] is Jacobians with shape [dim, ncomp=space_dim, Q]
+   // in[2] is quadrature weights, size (Q)
+   //
+   // At every quadrature point, compute qw/det(J) adj(J) C adj(J)^T (for
+   // H(curl)) or qw/det(J) J^T C J (for H(div)) and store the symmetric part
+   // of the result.
+   const bool is_hdiv = bc->is_hdiv;
+   const CeedInt coeff_comp = bc->coeff_comp;
+   const CeedScalar *c = in[0], *J = in[1], *qw = in[2];
+   CeedScalar *qd = out[0];
+   switch (10 * bc->space_dim + bc->dim)
+   {
+      case 11:
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+         {
+            qd[i] = qw[i] * c[i] * (is_hdiv ? J[i] : 1.0 / J[i]);
+         }
+         break;
+      case 21:
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+         {
+            (is_hdiv ? MultJtCJ21 : MultAdjJCAdjJt21)(J + i, Q, c + i, Q, coeff_comp,
+                                                      qw[i], Q, qd + i);
+         }
+         break;
+      case 22:
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+         {
+            (is_hdiv ? MultJtCJ22 : MultAdjJCAdjJt22)(J + i, Q, c + i, Q, coeff_comp,
+                                                      qw[i], Q, qd + i);
+         }
+         break;
+      case 32:
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+         {
+            (is_hdiv ? MultJtCJ32 : MultAdjJCAdjJt32)(J + i, Q, c + i, Q, coeff_comp,
+                                                      qw[i], Q, qd + i);
+         }
+         break;
+      case 33:
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+         {
+            (is_hdiv ? MultJtCJ33 : MultAdjJCAdjJt33)(J + i, Q, c + i, Q, coeff_comp,
+                                                      qw[i], Q, qd + i);
+         }
+         break;
+   }
+   return 0;
+}
+
+/// libCEED QFunction for applying a vector FE mass operator
+CEED_QFUNCTION(f_apply_vecfemass)(void *ctx, CeedInt Q,
+                                  const CeedScalar *const *in,
+                                  CeedScalar *const *out)
+{
+   VectorFEMassContext *bc = (VectorFEMassContext *)ctx;
+   // in[0], out[0] have shape [dim, ncomp=1, Q]
+   const CeedScalar *ug = in[0], *qd = in[1];
+   CeedScalar *vg = out[0];
+   switch (bc->dim)
+   {
+      case 1:
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+         {
+            vg[i] = qd[i] * ug[i];
+         }
+         break;
+      case 2:
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+         {
+            const CeedScalar ug0 = ug[i + Q * 0];
+            const CeedScalar ug1 = ug[i + Q * 1];
+            vg[i + Q * 0] = qd[i + Q * 0] * ug0 + qd[i + Q * 1] * ug1;
+            vg[i + Q * 1] = qd[i + Q * 1] * ug0 + qd[i + Q * 2] * ug1;
+         }
+         break;
+      case 3:
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+         {
+            const CeedScalar ug0 = ug[i + Q * 0];
+            const CeedScalar ug1 = ug[i + Q * 1];
+            const CeedScalar ug2 = ug[i + Q * 2];
+            vg[i + Q * 0] = qd[i + Q * 0] * ug0 + qd[i + Q * 1] * ug1 + qd[i + Q * 2] * ug2;
+            vg[i + Q * 1] = qd[i + Q * 1] * ug0 + qd[i + Q * 3] * ug1 + qd[i + Q * 4] * ug2;
+            vg[i + Q * 2] = qd[i + Q * 2] * ug0 + qd[i + Q * 4] * ug1 + qd[i + Q * 5] * ug2;
+         }
+         break;
+   }
+   return 0;
+}
+
+/// libCEED QFunction for applying a vector FE mass operator
+CEED_QFUNCTION(f_apply_vecfemass_mf_const)(void *ctx, CeedInt Q,
+                                           const CeedScalar *const *in,
+                                           CeedScalar *const *out)
+{
+   VectorFEMassContext *bc = (VectorFEMassContext *)ctx;
+   // in[0], out[0] have shape [dim, ncomp=1, Q]
+   // in[1] is Jacobians with shape [dim, ncomp=space_dim, Q]
+   // in[2] is quadrature weights, size (Q)
+   //
+   // At every quadrature point, compute qw/det(J) adj(J) C adj(J)^T (for
+   // H(curl)) or qw/det(J) J^T C J (for H(div)).
+   const bool is_hdiv = bc->is_hdiv;
+   const CeedInt coeff_comp = bc->coeff_comp;
+   const CeedScalar *coeff = bc->coeff;
+   const CeedScalar *ug = in[0], *J = in[1], *qw = in[2];
+   CeedScalar *vg = out[0];
+   switch (10 * bc->space_dim + bc->dim)
+   {
+      case 11:
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+         {
+            const CeedScalar coeff0 = coeff[0];
+            const CeedScalar qd = qw[i] * coeff0 * (is_hdiv ? J[i] : 1.0 / J[i]);
+            vg[i] = qd * ug[i];
+         }
+         break;
+      case 21:
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+         {
+            CeedScalar qd;
+            (is_hdiv ? MultJtCJ21 : MultAdjJCAdjJt21)(J + i, Q, coeff, 1, coeff_comp,
+                                                      qw[i], 1, &qd);
+            vg[i] = qd * ug[i];
+         }
+         break;
+      case 22:
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+         {
+            CeedScalar qd[3];
+            (is_hdiv ? MultJtCJ22 : MultAdjJCAdjJt22)(J + i, Q, coeff, 1, coeff_comp,
+                                                      qw[i], 1, qd);
+            const CeedScalar ug0 = ug[i + Q * 0];
+            const CeedScalar ug1 = ug[i + Q * 1];
+            vg[i + Q * 0] = qd[0] * ug0 + qd[1] * ug1;
+            vg[i + Q * 1] = qd[1] * ug0 + qd[2] * ug1;
+         }
+         break;
+      case 32:
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+         {
+            CeedScalar qd[3];
+            (is_hdiv ? MultJtCJ32 : MultAdjJCAdjJt32)(J + i, Q, coeff, 1, coeff_comp,
+                                                      qw[i], 1, qd);
+            const CeedScalar ug0 = ug[i + Q * 0];
+            const CeedScalar ug1 = ug[i + Q * 1];
+            vg[i + Q * 0] = qd[0] * ug0 + qd[1] * ug1;
+            vg[i + Q * 1] = qd[1] * ug0 + qd[2] * ug1;
+         }
+         break;
+      case 33:
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+         {
+            CeedScalar qd[6];
+            (is_hdiv ? MultJtCJ33 : MultAdjJCAdjJt33)(J + i, Q, coeff, 1, coeff_comp,
+                                                      qw[i], 1, qd);
+            const CeedScalar ug0 = ug[i + Q * 0];
+            const CeedScalar ug1 = ug[i + Q * 1];
+            const CeedScalar ug2 = ug[i + Q * 2];
+            vg[i + Q * 0] = qd[0] * ug0 + qd[1] * ug1 + qd[2] * ug2;
+            vg[i + Q * 1] = qd[1] * ug0 + qd[3] * ug1 + qd[4] * ug2;
+            vg[i + Q * 2] = qd[2] * ug0 + qd[4] * ug1 + qd[5] * ug2;
+         }
+         break;
+   }
+   return 0;
+}
+
+/// libCEED QFunction for applying a vector FE mass operator
+CEED_QFUNCTION(f_apply_vecfemass_mf_quad)(void *ctx, CeedInt Q,
+                                          const CeedScalar *const *in,
+                                          CeedScalar *const *out)
+{
+   VectorFEMassContext *bc = (VectorFEMassContext *)ctx;
+   // in[0], out[0] have shape [dim, ncomp=1, Q]
+   // in[1] is coefficients with shape [ncomp=coeff_comp, Q]
+   // in[2] is Jacobians with shape [dim, ncomp=space_dim, Q]
+   // in[3] is quadrature weights, size (Q)
+   //
+   // At every quadrature point, compute qw/det(J) adj(J) C adj(J)^T (for
+   // H(curl)) or qw/det(J) J^T C J (for H(div)).
+   const bool is_hdiv = bc->is_hdiv;
+   const CeedInt coeff_comp = bc->coeff_comp;
+   const CeedScalar *ug = in[0], *c = in[1], *J = in[2], *qw = in[3];
+   CeedScalar *vg = out[0];
+   switch (10 * bc->space_dim + bc->dim)
+   {
+      case 11:
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+         {
+            const CeedScalar qd = qw[i] * c[i] * (is_hdiv ? J[i] : 1.0 / J[i]);
+            vg[i] = qd * ug[i];
+         }
+         break;
+      case 21:
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+         {
+            CeedScalar qd;
+            (is_hdiv ? MultJtCJ21 : MultAdjJCAdjJt21)(J + i, Q, c + i, Q, coeff_comp,
+                                                      qw[i], 1, &qd);
+            vg[i] = qd * ug[i];
+         }
+         break;
+      case 22:
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+         {
+            CeedScalar qd[3];
+            (is_hdiv ? MultJtCJ22 : MultAdjJCAdjJt22)(J + i, Q, c + i, Q, coeff_comp,
+                                                      qw[i], 1, qd);
+            const CeedScalar ug0 = ug[i + Q * 0];
+            const CeedScalar ug1 = ug[i + Q * 1];
+            vg[i + Q * 0] = qd[0] * ug0 + qd[1] * ug1;
+            vg[i + Q * 1] = qd[1] * ug0 + qd[2] * ug1;
+         }
+         break;
+      case 32:
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+         {
+            CeedScalar qd[3];
+            (is_hdiv ? MultJtCJ32 : MultAdjJCAdjJt32)(J + i, Q, c + i, Q, coeff_comp,
+                                                      qw[i], 1, qd);
+            const CeedScalar ug0 = ug[i + Q * 0];
+            const CeedScalar ug1 = ug[i + Q * 1];
+            vg[i + Q * 0] = qd[0] * ug0 + qd[1] * ug1;
+            vg[i + Q * 1] = qd[1] * ug0 + qd[2] * ug1;
+         }
+         break;
+      case 33:
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+         {
+            CeedScalar qd[6];
+            (is_hdiv ? MultJtCJ33 : MultAdjJCAdjJt33)(J + i, Q, c + i, Q, coeff_comp,
+                                                      qw[i], 1, qd);
+            const CeedScalar ug0 = ug[i + Q * 0];
+            const CeedScalar ug1 = ug[i + Q * 1];
+            const CeedScalar ug2 = ug[i + Q * 2];
+            vg[i + Q * 0] = qd[0] * ug0 + qd[1] * ug1 + qd[2] * ug2;
+            vg[i + Q * 1] = qd[1] * ug0 + qd[3] * ug1 + qd[4] * ug2;
+            vg[i + Q * 2] = qd[2] * ug0 + qd[4] * ug1 + qd[5] * ug2;
+         }
+         break;
+   }
+   return 0;
+}
+
+#endif // MFEM_LIBCEED_VECFEMASS_QF_H

--- a/fem/ceed/integrators/vecfemass/vecfemass_qf.h
+++ b/fem/ceed/integrators/vecfemass/vecfemass_qf.h
@@ -20,8 +20,8 @@
 /// f_apply_vecfemass
 struct VectorFEMassContext
 {
+   bool hdiv;
    CeedInt dim, space_dim, coeff_comp;
-   bool is_hdiv;
    CeedScalar coeff[LIBCEED_VECFEMASS_COEFF_COMP_MAX];
 };
 
@@ -38,7 +38,7 @@ CEED_QFUNCTION(f_build_vecfemass_const)(void *ctx, CeedInt Q,
    // At every quadrature point, compute qw/det(J) adj(J) C adj(J)^T (for
    // H(curl)) or qw/det(J) J^T C J (for H(div)) and store the symmetric part
    // of the result.
-   const bool is_hdiv = bc->is_hdiv;
+   const bool hdiv = bc->hdiv;
    const CeedInt coeff_comp = bc->coeff_comp;
    const CeedScalar *coeff = bc->coeff;
    const CeedScalar *J = in[0], *qw = in[1];
@@ -49,35 +49,35 @@ CEED_QFUNCTION(f_build_vecfemass_const)(void *ctx, CeedInt Q,
          CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
             const CeedScalar coeff0 = coeff[0];
-            qd[i] = qw[i] * coeff0 * (is_hdiv ? J[i] : 1.0 / J[i]);
+            qd[i] = qw[i] * coeff0 * (hdiv ? J[i] : 1.0 / J[i]);
          }
          break;
       case 21:
          CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
-            (is_hdiv ? MultJtCJ21 : MultAdjJCAdjJt21)(J + i, Q, coeff, 1, coeff_comp,
-                                                      qw[i], Q, qd + i);
+            (hdiv ? MultJtCJ21 : MultAdjJCAdjJt21)(J + i, Q, coeff, 1, coeff_comp,
+                                                   qw[i], Q, qd + i);
          }
          break;
       case 22:
          CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
-            (is_hdiv ? MultJtCJ22 : MultAdjJCAdjJt22)(J + i, Q, coeff, 1, coeff_comp,
-                                                      qw[i], Q, qd + i);
+            (hdiv ? MultJtCJ22 : MultAdjJCAdjJt22)(J + i, Q, coeff, 1, coeff_comp,
+                                                   qw[i], Q, qd + i);
          }
          break;
       case 32:
          CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
-            (is_hdiv ? MultJtCJ32 : MultAdjJCAdjJt32)(J + i, Q, coeff, 1, coeff_comp,
-                                                      qw[i], Q, qd + i);
+            (hdiv ? MultJtCJ32 : MultAdjJCAdjJt32)(J + i, Q, coeff, 1, coeff_comp,
+                                                   qw[i], Q, qd + i);
          }
          break;
       case 33:
          CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
-            (is_hdiv ? MultJtCJ33 : MultAdjJCAdjJt33)(J + i, Q, coeff, 1, coeff_comp,
-                                                      qw[i], Q, qd + i);
+            (hdiv ? MultJtCJ33 : MultAdjJCAdjJt33)(J + i, Q, coeff, 1, coeff_comp,
+                                                   qw[i], Q, qd + i);
          }
          break;
    }
@@ -98,7 +98,7 @@ CEED_QFUNCTION(f_build_vecfemass_quad)(void *ctx, CeedInt Q,
    // At every quadrature point, compute qw/det(J) adj(J) C adj(J)^T (for
    // H(curl)) or qw/det(J) J^T C J (for H(div)) and store the symmetric part
    // of the result.
-   const bool is_hdiv = bc->is_hdiv;
+   const bool hdiv = bc->hdiv;
    const CeedInt coeff_comp = bc->coeff_comp;
    const CeedScalar *c = in[0], *J = in[1], *qw = in[2];
    CeedScalar *qd = out[0];
@@ -107,35 +107,35 @@ CEED_QFUNCTION(f_build_vecfemass_quad)(void *ctx, CeedInt Q,
       case 11:
          CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
-            qd[i] = qw[i] * c[i] * (is_hdiv ? J[i] : 1.0 / J[i]);
+            qd[i] = qw[i] * c[i] * (hdiv ? J[i] : 1.0 / J[i]);
          }
          break;
       case 21:
          CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
-            (is_hdiv ? MultJtCJ21 : MultAdjJCAdjJt21)(J + i, Q, c + i, Q, coeff_comp,
-                                                      qw[i], Q, qd + i);
+            (hdiv ? MultJtCJ21 : MultAdjJCAdjJt21)(J + i, Q, c + i, Q, coeff_comp,
+                                                   qw[i], Q, qd + i);
          }
          break;
       case 22:
          CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
-            (is_hdiv ? MultJtCJ22 : MultAdjJCAdjJt22)(J + i, Q, c + i, Q, coeff_comp,
-                                                      qw[i], Q, qd + i);
+            (hdiv ? MultJtCJ22 : MultAdjJCAdjJt22)(J + i, Q, c + i, Q, coeff_comp,
+                                                   qw[i], Q, qd + i);
          }
          break;
       case 32:
          CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
-            (is_hdiv ? MultJtCJ32 : MultAdjJCAdjJt32)(J + i, Q, c + i, Q, coeff_comp,
-                                                      qw[i], Q, qd + i);
+            (hdiv ? MultJtCJ32 : MultAdjJCAdjJt32)(J + i, Q, c + i, Q, coeff_comp,
+                                                   qw[i], Q, qd + i);
          }
          break;
       case 33:
          CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
-            (is_hdiv ? MultJtCJ33 : MultAdjJCAdjJt33)(J + i, Q, c + i, Q, coeff_comp,
-                                                      qw[i], Q, qd + i);
+            (hdiv ? MultJtCJ33 : MultAdjJCAdjJt33)(J + i, Q, c + i, Q, coeff_comp,
+                                                   qw[i], Q, qd + i);
          }
          break;
    }
@@ -149,34 +149,34 @@ CEED_QFUNCTION(f_apply_vecfemass)(void *ctx, CeedInt Q,
 {
    VectorFEMassContext *bc = (VectorFEMassContext *)ctx;
    // in[0], out[0] have shape [dim, ncomp=1, Q]
-   const CeedScalar *ug = in[0], *qd = in[1];
-   CeedScalar *vg = out[0];
+   const CeedScalar *u = in[0], *qd = in[1];
+   CeedScalar *v = out[0];
    switch (bc->dim)
    {
       case 1:
          CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
-            vg[i] = qd[i] * ug[i];
+            v[i] = qd[i] * u[i];
          }
          break;
       case 2:
          CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
-            const CeedScalar ug0 = ug[i + Q * 0];
-            const CeedScalar ug1 = ug[i + Q * 1];
-            vg[i + Q * 0] = qd[i + Q * 0] * ug0 + qd[i + Q * 1] * ug1;
-            vg[i + Q * 1] = qd[i + Q * 1] * ug0 + qd[i + Q * 2] * ug1;
+            const CeedScalar u0 = u[i + Q * 0];
+            const CeedScalar u1 = u[i + Q * 1];
+            v[i + Q * 0] = qd[i + Q * 0] * u0 + qd[i + Q * 1] * u1;
+            v[i + Q * 1] = qd[i + Q * 1] * u0 + qd[i + Q * 2] * u1;
          }
          break;
       case 3:
          CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
-            const CeedScalar ug0 = ug[i + Q * 0];
-            const CeedScalar ug1 = ug[i + Q * 1];
-            const CeedScalar ug2 = ug[i + Q * 2];
-            vg[i + Q * 0] = qd[i + Q * 0] * ug0 + qd[i + Q * 1] * ug1 + qd[i + Q * 2] * ug2;
-            vg[i + Q * 1] = qd[i + Q * 1] * ug0 + qd[i + Q * 3] * ug1 + qd[i + Q * 4] * ug2;
-            vg[i + Q * 2] = qd[i + Q * 2] * ug0 + qd[i + Q * 4] * ug1 + qd[i + Q * 5] * ug2;
+            const CeedScalar u0 = u[i + Q * 0];
+            const CeedScalar u1 = u[i + Q * 1];
+            const CeedScalar u2 = u[i + Q * 2];
+            v[i + Q * 0] = qd[i + Q * 0] * u0 + qd[i + Q * 1] * u1 + qd[i + Q * 2] * u2;
+            v[i + Q * 1] = qd[i + Q * 1] * u0 + qd[i + Q * 3] * u1 + qd[i + Q * 4] * u2;
+            v[i + Q * 2] = qd[i + Q * 2] * u0 + qd[i + Q * 4] * u1 + qd[i + Q * 5] * u2;
          }
          break;
    }
@@ -195,66 +195,66 @@ CEED_QFUNCTION(f_apply_vecfemass_mf_const)(void *ctx, CeedInt Q,
    //
    // At every quadrature point, compute qw/det(J) adj(J) C adj(J)^T (for
    // H(curl)) or qw/det(J) J^T C J (for H(div)).
-   const bool is_hdiv = bc->is_hdiv;
+   const bool hdiv = bc->hdiv;
    const CeedInt coeff_comp = bc->coeff_comp;
    const CeedScalar *coeff = bc->coeff;
-   const CeedScalar *ug = in[0], *J = in[1], *qw = in[2];
-   CeedScalar *vg = out[0];
+   const CeedScalar *u = in[0], *J = in[1], *qw = in[2];
+   CeedScalar *v = out[0];
    switch (10 * bc->space_dim + bc->dim)
    {
       case 11:
          CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
             const CeedScalar coeff0 = coeff[0];
-            const CeedScalar qd = qw[i] * coeff0 * (is_hdiv ? J[i] : 1.0 / J[i]);
-            vg[i] = qd * ug[i];
+            const CeedScalar qd = qw[i] * coeff0 * (hdiv ? J[i] : 1.0 / J[i]);
+            v[i] = qd * u[i];
          }
          break;
       case 21:
          CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
             CeedScalar qd;
-            (is_hdiv ? MultJtCJ21 : MultAdjJCAdjJt21)(J + i, Q, coeff, 1, coeff_comp,
-                                                      qw[i], 1, &qd);
-            vg[i] = qd * ug[i];
+            (hdiv ? MultJtCJ21 : MultAdjJCAdjJt21)(J + i, Q, coeff, 1, coeff_comp,
+                                                   qw[i], 1, &qd);
+            v[i] = qd * u[i];
          }
          break;
       case 22:
          CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
             CeedScalar qd[3];
-            (is_hdiv ? MultJtCJ22 : MultAdjJCAdjJt22)(J + i, Q, coeff, 1, coeff_comp,
-                                                      qw[i], 1, qd);
-            const CeedScalar ug0 = ug[i + Q * 0];
-            const CeedScalar ug1 = ug[i + Q * 1];
-            vg[i + Q * 0] = qd[0] * ug0 + qd[1] * ug1;
-            vg[i + Q * 1] = qd[1] * ug0 + qd[2] * ug1;
+            (hdiv ? MultJtCJ22 : MultAdjJCAdjJt22)(J + i, Q, coeff, 1, coeff_comp,
+                                                   qw[i], 1, qd);
+            const CeedScalar u0 = u[i + Q * 0];
+            const CeedScalar u1 = u[i + Q * 1];
+            v[i + Q * 0] = qd[0] * u0 + qd[1] * u1;
+            v[i + Q * 1] = qd[1] * u0 + qd[2] * u1;
          }
          break;
       case 32:
          CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
             CeedScalar qd[3];
-            (is_hdiv ? MultJtCJ32 : MultAdjJCAdjJt32)(J + i, Q, coeff, 1, coeff_comp,
-                                                      qw[i], 1, qd);
-            const CeedScalar ug0 = ug[i + Q * 0];
-            const CeedScalar ug1 = ug[i + Q * 1];
-            vg[i + Q * 0] = qd[0] * ug0 + qd[1] * ug1;
-            vg[i + Q * 1] = qd[1] * ug0 + qd[2] * ug1;
+            (hdiv ? MultJtCJ32 : MultAdjJCAdjJt32)(J + i, Q, coeff, 1, coeff_comp,
+                                                   qw[i], 1, qd);
+            const CeedScalar u0 = u[i + Q * 0];
+            const CeedScalar u1 = u[i + Q * 1];
+            v[i + Q * 0] = qd[0] * u0 + qd[1] * u1;
+            v[i + Q * 1] = qd[1] * u0 + qd[2] * u1;
          }
          break;
       case 33:
          CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
             CeedScalar qd[6];
-            (is_hdiv ? MultJtCJ33 : MultAdjJCAdjJt33)(J + i, Q, coeff, 1, coeff_comp,
-                                                      qw[i], 1, qd);
-            const CeedScalar ug0 = ug[i + Q * 0];
-            const CeedScalar ug1 = ug[i + Q * 1];
-            const CeedScalar ug2 = ug[i + Q * 2];
-            vg[i + Q * 0] = qd[0] * ug0 + qd[1] * ug1 + qd[2] * ug2;
-            vg[i + Q * 1] = qd[1] * ug0 + qd[3] * ug1 + qd[4] * ug2;
-            vg[i + Q * 2] = qd[2] * ug0 + qd[4] * ug1 + qd[5] * ug2;
+            (hdiv ? MultJtCJ33 : MultAdjJCAdjJt33)(J + i, Q, coeff, 1, coeff_comp,
+                                                   qw[i], 1, qd);
+            const CeedScalar u0 = u[i + Q * 0];
+            const CeedScalar u1 = u[i + Q * 1];
+            const CeedScalar u2 = u[i + Q * 2];
+            v[i + Q * 0] = qd[0] * u0 + qd[1] * u1 + qd[2] * u2;
+            v[i + Q * 1] = qd[1] * u0 + qd[3] * u1 + qd[4] * u2;
+            v[i + Q * 2] = qd[2] * u0 + qd[4] * u1 + qd[5] * u2;
          }
          break;
    }
@@ -274,64 +274,64 @@ CEED_QFUNCTION(f_apply_vecfemass_mf_quad)(void *ctx, CeedInt Q,
    //
    // At every quadrature point, compute qw/det(J) adj(J) C adj(J)^T (for
    // H(curl)) or qw/det(J) J^T C J (for H(div)).
-   const bool is_hdiv = bc->is_hdiv;
+   const bool hdiv = bc->hdiv;
    const CeedInt coeff_comp = bc->coeff_comp;
-   const CeedScalar *ug = in[0], *c = in[1], *J = in[2], *qw = in[3];
-   CeedScalar *vg = out[0];
+   const CeedScalar *u = in[0], *c = in[1], *J = in[2], *qw = in[3];
+   CeedScalar *v = out[0];
    switch (10 * bc->space_dim + bc->dim)
    {
       case 11:
          CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
-            const CeedScalar qd = qw[i] * c[i] * (is_hdiv ? J[i] : 1.0 / J[i]);
-            vg[i] = qd * ug[i];
+            const CeedScalar qd = qw[i] * c[i] * (hdiv ? J[i] : 1.0 / J[i]);
+            v[i] = qd * u[i];
          }
          break;
       case 21:
          CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
             CeedScalar qd;
-            (is_hdiv ? MultJtCJ21 : MultAdjJCAdjJt21)(J + i, Q, c + i, Q, coeff_comp,
-                                                      qw[i], 1, &qd);
-            vg[i] = qd * ug[i];
+            (hdiv ? MultJtCJ21 : MultAdjJCAdjJt21)(J + i, Q, c + i, Q, coeff_comp,
+                                                   qw[i], 1, &qd);
+            v[i] = qd * u[i];
          }
          break;
       case 22:
          CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
             CeedScalar qd[3];
-            (is_hdiv ? MultJtCJ22 : MultAdjJCAdjJt22)(J + i, Q, c + i, Q, coeff_comp,
-                                                      qw[i], 1, qd);
-            const CeedScalar ug0 = ug[i + Q * 0];
-            const CeedScalar ug1 = ug[i + Q * 1];
-            vg[i + Q * 0] = qd[0] * ug0 + qd[1] * ug1;
-            vg[i + Q * 1] = qd[1] * ug0 + qd[2] * ug1;
+            (hdiv ? MultJtCJ22 : MultAdjJCAdjJt22)(J + i, Q, c + i, Q, coeff_comp,
+                                                   qw[i], 1, qd);
+            const CeedScalar u0 = u[i + Q * 0];
+            const CeedScalar u1 = u[i + Q * 1];
+            v[i + Q * 0] = qd[0] * u0 + qd[1] * u1;
+            v[i + Q * 1] = qd[1] * u0 + qd[2] * u1;
          }
          break;
       case 32:
          CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
             CeedScalar qd[3];
-            (is_hdiv ? MultJtCJ32 : MultAdjJCAdjJt32)(J + i, Q, c + i, Q, coeff_comp,
-                                                      qw[i], 1, qd);
-            const CeedScalar ug0 = ug[i + Q * 0];
-            const CeedScalar ug1 = ug[i + Q * 1];
-            vg[i + Q * 0] = qd[0] * ug0 + qd[1] * ug1;
-            vg[i + Q * 1] = qd[1] * ug0 + qd[2] * ug1;
+            (hdiv ? MultJtCJ32 : MultAdjJCAdjJt32)(J + i, Q, c + i, Q, coeff_comp,
+                                                   qw[i], 1, qd);
+            const CeedScalar u0 = u[i + Q * 0];
+            const CeedScalar u1 = u[i + Q * 1];
+            v[i + Q * 0] = qd[0] * u0 + qd[1] * u1;
+            v[i + Q * 1] = qd[1] * u0 + qd[2] * u1;
          }
          break;
       case 33:
          CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
             CeedScalar qd[6];
-            (is_hdiv ? MultJtCJ33 : MultAdjJCAdjJt33)(J + i, Q, c + i, Q, coeff_comp,
-                                                      qw[i], 1, qd);
-            const CeedScalar ug0 = ug[i + Q * 0];
-            const CeedScalar ug1 = ug[i + Q * 1];
-            const CeedScalar ug2 = ug[i + Q * 2];
-            vg[i + Q * 0] = qd[0] * ug0 + qd[1] * ug1 + qd[2] * ug2;
-            vg[i + Q * 1] = qd[1] * ug0 + qd[3] * ug1 + qd[4] * ug2;
-            vg[i + Q * 2] = qd[2] * ug0 + qd[4] * ug1 + qd[5] * ug2;
+            (hdiv ? MultJtCJ33 : MultAdjJCAdjJt33)(J + i, Q, c + i, Q, coeff_comp,
+                                                   qw[i], 1, qd);
+            const CeedScalar u0 = u[i + Q * 0];
+            const CeedScalar u1 = u[i + Q * 1];
+            const CeedScalar u2 = u[i + Q * 2];
+            v[i + Q * 0] = qd[0] * u0 + qd[1] * u1 + qd[2] * u2;
+            v[i + Q * 1] = qd[1] * u0 + qd[3] * u1 + qd[4] * u2;
+            v[i + Q * 2] = qd[2] * u0 + qd[4] * u1 + qd[5] * u2;
          }
          break;
    }

--- a/fem/ceed/integrators/vecfemass/vecfemass_qf.h
+++ b/fem/ceed/integrators/vecfemass/vecfemass_qf.h
@@ -20,14 +20,112 @@
 /// f_apply_vecfemass
 struct VectorFEMassContext
 {
-   bool hdiv;
    CeedInt dim, space_dim, coeff_comp;
    CeedScalar coeff[LIBCEED_VECFEMASS_COEFF_COMP_MAX];
 };
 
 /// libCEED QFunction for building quadrature data for a vector FE mass
 /// operator with a constant coefficient
-CEED_QFUNCTION(f_build_vecfemass_const)(void *ctx, CeedInt Q,
+CEED_QFUNCTION(f_build_hdivmass_const)(void *ctx, CeedInt Q,
+                                       const CeedScalar *const *in,
+                                       CeedScalar *const *out)
+{
+   VectorFEMassContext *bc = (VectorFEMassContext *)ctx;
+   // in[0] is Jacobians with shape [dim, ncomp=space_dim, Q]
+   // in[1] is quadrature weights, size (Q)
+   //
+   // At every quadrature point, compute qw/det(J) adj(J) C adj(J)^T (for
+   // H(curl)) or qw/det(J) J^T C J (for H(div)) and store the symmetric part
+   // of the result.
+   const CeedScalar *coeff = bc->coeff;
+   const CeedScalar *J = in[0], *qw = in[1];
+   CeedScalar *qd = out[0];
+   switch (100 * bc->space_dim + 10 * bc->dim + bc->coeff_comp)
+   {
+      case 111:
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+         {
+            const CeedScalar coeff0 = coeff[0];
+            qd[i] = qw[i] * coeff0 * J[i];
+         }
+         break;
+      case 213:
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+         {
+            MultJtCJ21(J + i, Q, coeff, 1, 3, qw[i], Q, qd + i);
+         }
+         break;
+      case 212:
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+         {
+            MultJtCJ21(J + i, Q, coeff, 1, 2, qw[i], Q, qd + i);
+         }
+         break;
+      case 211:
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+         {
+            MultJtCJ21(J + i, Q, coeff, 1, 1, qw[i], Q, qd + i);
+         }
+         break;
+      case 223:
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+         {
+            MultJtCJ22(J + i, Q, coeff, 1, 3, qw[i], Q, qd + i);
+         }
+         break;
+      case 222:
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+         {
+            MultJtCJ22(J + i, Q, coeff, 1, 2, qw[i], Q, qd + i);
+         }
+         break;
+      case 221:
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+         {
+            MultJtCJ22(J + i, Q, coeff, 1, 1, qw[i], Q, qd + i);
+         }
+         break;
+      case 326:
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+         {
+            MultJtCJ32(J + i, Q, coeff, 1, 6, qw[i], Q, qd + i);
+         }
+         break;
+      case 323:
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+         {
+            MultJtCJ32(J + i, Q, coeff, 1, 3, qw[i], Q, qd + i);
+         }
+         break;
+      case 321:
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+         {
+            MultJtCJ32(J + i, Q, coeff, 1, 1, qw[i], Q, qd + i);
+         }
+         break;
+      case 336:
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+         {
+            MultJtCJ33(J + i, Q, coeff, 1, 6, qw[i], Q, qd + i);
+         }
+         break;
+      case 333:
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+         {
+            MultJtCJ33(J + i, Q, coeff, 1, 3, qw[i], Q, qd + i);
+         }
+         break;
+      case 331:
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+         {
+            MultJtCJ33(J + i, Q, coeff, 1, 1, qw[i], Q, qd + i);
+         }
+         break;
+   }
+   return 0;
+}
+
+CEED_QFUNCTION(f_build_hcurlmass_const)(void *ctx, CeedInt Q,
                                         const CeedScalar *const *in,
                                         CeedScalar *const *out)
 {
@@ -38,46 +136,88 @@ CEED_QFUNCTION(f_build_vecfemass_const)(void *ctx, CeedInt Q,
    // At every quadrature point, compute qw/det(J) adj(J) C adj(J)^T (for
    // H(curl)) or qw/det(J) J^T C J (for H(div)) and store the symmetric part
    // of the result.
-   const bool hdiv = bc->hdiv;
-   const CeedInt coeff_comp = bc->coeff_comp;
    const CeedScalar *coeff = bc->coeff;
    const CeedScalar *J = in[0], *qw = in[1];
    CeedScalar *qd = out[0];
-   switch (10 * bc->space_dim + bc->dim)
+   switch (100 * bc->space_dim + 10 * bc->dim + bc->coeff_comp)
    {
-      case 11:
+      case 111:
          CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
             const CeedScalar coeff0 = coeff[0];
-            qd[i] = qw[i] * coeff0 * (hdiv ? J[i] : 1.0 / J[i]);
+            qd[i] = qw[i] * coeff0 / J[i];
          }
          break;
-      case 21:
+      case 213:
          CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
-            (hdiv ? MultJtCJ21 : MultAdjJCAdjJt21)(J + i, Q, coeff, 1, coeff_comp,
-                                                   qw[i], Q, qd + i);
+            MultAdjJCAdjJt21(J + i, Q, coeff, 1, 3, qw[i], Q, qd + i);
          }
          break;
-      case 22:
+      case 212:
          CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
-            (hdiv ? MultJtCJ22 : MultAdjJCAdjJt22)(J + i, Q, coeff, 1, coeff_comp,
-                                                   qw[i], Q, qd + i);
+            MultAdjJCAdjJt21(J + i, Q, coeff, 1, 2, qw[i], Q, qd + i);
          }
          break;
-      case 32:
+      case 211:
          CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
-            (hdiv ? MultJtCJ32 : MultAdjJCAdjJt32)(J + i, Q, coeff, 1, coeff_comp,
-                                                   qw[i], Q, qd + i);
+            MultAdjJCAdjJt21(J + i, Q, coeff, 1, 1, qw[i], Q, qd + i);
          }
          break;
-      case 33:
+      case 223:
          CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
-            (hdiv ? MultJtCJ33 : MultAdjJCAdjJt33)(J + i, Q, coeff, 1, coeff_comp,
-                                                   qw[i], Q, qd + i);
+            MultAdjJCAdjJt22(J + i, Q, coeff, 1, 3, qw[i], Q, qd + i);
+         }
+         break;
+      case 222:
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+         {
+            MultAdjJCAdjJt22(J + i, Q, coeff, 1, 2, qw[i], Q, qd + i);
+         }
+         break;
+      case 221:
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+         {
+            MultAdjJCAdjJt22(J + i, Q, coeff, 1, 1, qw[i], Q, qd + i);
+         }
+         break;
+      case 326:
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+         {
+            MultAdjJCAdjJt32(J + i, Q, coeff, 1, 6, qw[i], Q, qd + i);
+         }
+         break;
+      case 323:
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+         {
+            MultAdjJCAdjJt32(J + i, Q, coeff, 1, 3, qw[i], Q, qd + i);
+         }
+         break;
+      case 321:
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+         {
+            MultAdjJCAdjJt32(J + i, Q, coeff, 1, 1, qw[i], Q, qd + i);
+         }
+         break;
+      case 336:
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+         {
+            MultAdjJCAdjJt33(J + i, Q, coeff, 1, 6, qw[i], Q, qd + i);
+         }
+         break;
+      case 333:
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+         {
+            MultAdjJCAdjJt33(J + i, Q, coeff, 1, 3, qw[i], Q, qd + i);
+         }
+         break;
+      case 331:
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+         {
+            MultAdjJCAdjJt33(J + i, Q, coeff, 1, 1, qw[i], Q, qd + i);
          }
          break;
    }
@@ -86,7 +226,105 @@ CEED_QFUNCTION(f_build_vecfemass_const)(void *ctx, CeedInt Q,
 
 /// libCEED QFunction for building quadrature data for a vector FE mass
 /// operator with a coefficient evaluated at quadrature points.
-CEED_QFUNCTION(f_build_vecfemass_quad)(void *ctx, CeedInt Q,
+CEED_QFUNCTION(f_build_hdivmass_quad)(void *ctx, CeedInt Q,
+                                      const CeedScalar *const *in,
+                                      CeedScalar *const *out)
+{
+   VectorFEMassContext *bc = (VectorFEMassContext *)ctx;
+   // in[0] is coefficients with shape [ncomp=coeff_comp, Q]
+   // in[1] is Jacobians with shape [dim, ncomp=space_dim, Q]
+   // in[2] is quadrature weights, size (Q)
+   //
+   // At every quadrature point, compute qw/det(J) adj(J) C adj(J)^T (for
+   // H(curl)) or qw/det(J) J^T C J (for H(div)) and store the symmetric part
+   // of the result.
+   const CeedScalar *c = in[0], *J = in[1], *qw = in[2];
+   CeedScalar *qd = out[0];
+   switch (100 * bc->space_dim + 10 * bc->dim + bc->coeff_comp)
+   {
+      case 111:
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+         {
+            qd[i] = qw[i] * c[i] * J[i];
+         }
+         break;
+      case 213:
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+         {
+            MultJtCJ21(J + i, Q, c + i, Q, 3, qw[i], Q, qd + i);
+         }
+         break;
+      case 212:
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+         {
+            MultJtCJ21(J + i, Q, c + i, Q, 2, qw[i], Q, qd + i);
+         }
+         break;
+      case 211:
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+         {
+            MultJtCJ21(J + i, Q, c + i, Q, 1, qw[i], Q, qd + i);
+         }
+         break;
+      case 223:
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+         {
+            MultJtCJ22(J + i, Q, c + i, Q, 3, qw[i], Q, qd + i);
+         }
+         break;
+      case 222:
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+         {
+            MultJtCJ22(J + i, Q, c + i, Q, 2, qw[i], Q, qd + i);
+         }
+         break;
+      case 221:
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+         {
+            MultJtCJ22(J + i, Q, c + i, Q, 1, qw[i], Q, qd + i);
+         }
+         break;
+      case 326:
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+         {
+            MultJtCJ32(J + i, Q, c + i, Q, 6, qw[i], Q, qd + i);
+         }
+         break;
+      case 323:
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+         {
+            MultJtCJ32(J + i, Q, c + i, Q, 3, qw[i], Q, qd + i);
+         }
+         break;
+      case 321:
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+         {
+            MultJtCJ32(J + i, Q, c + i, Q, 1, qw[i], Q, qd + i);
+         }
+         break;
+      case 336:
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+         {
+            MultJtCJ33(J + i, Q, c + i, Q, 6, qw[i], Q, qd + i);
+         }
+         break;
+      case 333:
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+         {
+            MultJtCJ33(J + i, Q, c + i, Q, 3, qw[i], Q, qd + i);
+         }
+         break;
+      case 331:
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+         {
+            MultJtCJ33(J + i, Q, c + i, Q, 1, qw[i], Q, qd + i);
+         }
+         break;
+   }
+   return 0;
+}
+
+CEED_QFUNCTION(f_build_hcurlmass_quad)(void *ctx, CeedInt Q,
                                        const CeedScalar *const *in,
                                        CeedScalar *const *out)
 {
@@ -98,44 +336,86 @@ CEED_QFUNCTION(f_build_vecfemass_quad)(void *ctx, CeedInt Q,
    // At every quadrature point, compute qw/det(J) adj(J) C adj(J)^T (for
    // H(curl)) or qw/det(J) J^T C J (for H(div)) and store the symmetric part
    // of the result.
-   const bool hdiv = bc->hdiv;
-   const CeedInt coeff_comp = bc->coeff_comp;
    const CeedScalar *c = in[0], *J = in[1], *qw = in[2];
    CeedScalar *qd = out[0];
-   switch (10 * bc->space_dim + bc->dim)
+   switch (100 * bc->space_dim + 10 * bc->dim + bc->coeff_comp)
    {
-      case 11:
+      case 111:
          CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
-            qd[i] = qw[i] * c[i] * (hdiv ? J[i] : 1.0 / J[i]);
+            qd[i] = qw[i] * c[i] / J[i];
          }
          break;
-      case 21:
+      case 213:
          CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
-            (hdiv ? MultJtCJ21 : MultAdjJCAdjJt21)(J + i, Q, c + i, Q, coeff_comp,
-                                                   qw[i], Q, qd + i);
+            MultAdjJCAdjJt21(J + i, Q, c + i, Q, 3, qw[i], Q, qd + i);
          }
          break;
-      case 22:
+      case 212:
          CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
-            (hdiv ? MultJtCJ22 : MultAdjJCAdjJt22)(J + i, Q, c + i, Q, coeff_comp,
-                                                   qw[i], Q, qd + i);
+            MultAdjJCAdjJt21(J + i, Q, c + i, Q, 2, qw[i], Q, qd + i);
          }
          break;
-      case 32:
+      case 211:
          CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
-            (hdiv ? MultJtCJ32 : MultAdjJCAdjJt32)(J + i, Q, c + i, Q, coeff_comp,
-                                                   qw[i], Q, qd + i);
+            MultAdjJCAdjJt21(J + i, Q, c + i, Q, 1, qw[i], Q, qd + i);
          }
          break;
-      case 33:
+      case 223:
          CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
-            (hdiv ? MultJtCJ33 : MultAdjJCAdjJt33)(J + i, Q, c + i, Q, coeff_comp,
-                                                   qw[i], Q, qd + i);
+            MultAdjJCAdjJt22(J + i, Q, c + i, Q, 3, qw[i], Q, qd + i);
+         }
+         break;
+      case 222:
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+         {
+            MultAdjJCAdjJt22(J + i, Q, c + i, Q, 2, qw[i], Q, qd + i);
+         }
+         break;
+      case 221:
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+         {
+            MultAdjJCAdjJt22(J + i, Q, c + i, Q, 1, qw[i], Q, qd + i);
+         }
+         break;
+      case 326:
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+         {
+            MultAdjJCAdjJt32(J + i, Q, c + i, Q, 6, qw[i], Q, qd + i);
+         }
+         break;
+      case 323:
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+         {
+            MultAdjJCAdjJt32(J + i, Q, c + i, Q, 3, qw[i], Q, qd + i);
+         }
+         break;
+      case 321:
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+         {
+            MultAdjJCAdjJt32(J + i, Q, c + i, Q, 1, qw[i], Q, qd + i);
+         }
+         break;
+      case 336:
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+         {
+            MultAdjJCAdjJt33(J + i, Q, c + i, Q, 6, qw[i], Q, qd + i);
+         }
+         break;
+      case 333:
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+         {
+            MultAdjJCAdjJt33(J + i, Q, c + i, Q, 3, qw[i], Q, qd + i);
+         }
+         break;
+      case 331:
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+         {
+            MultAdjJCAdjJt33(J + i, Q, c + i, Q, 1, qw[i], Q, qd + i);
          }
          break;
    }
@@ -184,7 +464,164 @@ CEED_QFUNCTION(f_apply_vecfemass)(void *ctx, CeedInt Q,
 }
 
 /// libCEED QFunction for applying a vector FE mass operator
-CEED_QFUNCTION(f_apply_vecfemass_mf_const)(void *ctx, CeedInt Q,
+CEED_QFUNCTION(f_apply_hdivmass_mf_const)(void *ctx, CeedInt Q,
+                                          const CeedScalar *const *in,
+                                          CeedScalar *const *out)
+{
+   VectorFEMassContext *bc = (VectorFEMassContext *)ctx;
+   // in[0], out[0] have shape [dim, ncomp=1, Q]
+   // in[1] is Jacobians with shape [dim, ncomp=space_dim, Q]
+   // in[2] is quadrature weights, size (Q)
+   //
+   // At every quadrature point, compute qw/det(J) adj(J) C adj(J)^T (for
+   // H(curl)) or qw/det(J) J^T C J (for H(div)).
+   const CeedScalar *coeff = bc->coeff;
+   const CeedScalar *u = in[0], *J = in[1], *qw = in[2];
+   CeedScalar *v = out[0];
+   switch (100 * bc->space_dim + 10 * bc->dim + bc->coeff_comp)
+   {
+      case 111:
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+         {
+            const CeedScalar coeff0 = coeff[0];
+            const CeedScalar qd = qw[i] * coeff0 * J[i];
+            v[i] = qd * u[i];
+         }
+         break;
+      case 213:
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+         {
+            CeedScalar qd;
+            MultJtCJ21(J + i, Q, coeff, 1, 3, qw[i], 1, &qd);
+            v[i] = qd * u[i];
+         }
+         break;
+      case 212:
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+         {
+            CeedScalar qd;
+            MultJtCJ21(J + i, Q, coeff, 1, 2, qw[i], 1, &qd);
+            v[i] = qd * u[i];
+         }
+         break;
+      case 211:
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+         {
+            CeedScalar qd;
+            MultJtCJ21(J + i, Q, coeff, 1, 1, qw[i], 1, &qd);
+            v[i] = qd * u[i];
+         }
+         break;
+      case 223:
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+         {
+            CeedScalar qd[3];
+            MultJtCJ22(J + i, Q, coeff, 1, 3, qw[i], 1, qd);
+            const CeedScalar u0 = u[i + Q * 0];
+            const CeedScalar u1 = u[i + Q * 1];
+            v[i + Q * 0] = qd[0] * u0 + qd[1] * u1;
+            v[i + Q * 1] = qd[1] * u0 + qd[2] * u1;
+         }
+         break;
+      case 222:
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+         {
+            CeedScalar qd[3];
+            MultJtCJ22(J + i, Q, coeff, 1, 2, qw[i], 1, qd);
+            const CeedScalar u0 = u[i + Q * 0];
+            const CeedScalar u1 = u[i + Q * 1];
+            v[i + Q * 0] = qd[0] * u0 + qd[1] * u1;
+            v[i + Q * 1] = qd[1] * u0 + qd[2] * u1;
+         }
+         break;
+      case 221:
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+         {
+            CeedScalar qd[3];
+            MultJtCJ22(J + i, Q, coeff, 1, 1, qw[i], 1, qd);
+            const CeedScalar u0 = u[i + Q * 0];
+            const CeedScalar u1 = u[i + Q * 1];
+            v[i + Q * 0] = qd[0] * u0 + qd[1] * u1;
+            v[i + Q * 1] = qd[1] * u0 + qd[2] * u1;
+         }
+         break;
+      case 326:
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+         {
+            CeedScalar qd[3];
+            MultJtCJ32(J + i, Q, coeff, 1, 6, qw[i], 1, qd);
+            const CeedScalar u0 = u[i + Q * 0];
+            const CeedScalar u1 = u[i + Q * 1];
+            v[i + Q * 0] = qd[0] * u0 + qd[1] * u1;
+            v[i + Q * 1] = qd[1] * u0 + qd[2] * u1;
+         }
+         break;
+      case 323:
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+         {
+            CeedScalar qd[3];
+            MultJtCJ32(J + i, Q, coeff, 1, 3, qw[i], 1, qd);
+            const CeedScalar u0 = u[i + Q * 0];
+            const CeedScalar u1 = u[i + Q * 1];
+            v[i + Q * 0] = qd[0] * u0 + qd[1] * u1;
+            v[i + Q * 1] = qd[1] * u0 + qd[2] * u1;
+         }
+         break;
+      case 321:
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+         {
+            CeedScalar qd[3];
+            MultJtCJ32(J + i, Q, coeff, 1, 1, qw[i], 1, qd);
+            const CeedScalar u0 = u[i + Q * 0];
+            const CeedScalar u1 = u[i + Q * 1];
+            v[i + Q * 0] = qd[0] * u0 + qd[1] * u1;
+            v[i + Q * 1] = qd[1] * u0 + qd[2] * u1;
+         }
+         break;
+      case 336:
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+         {
+            CeedScalar qd[6];
+            MultJtCJ33(J + i, Q, coeff, 1, 6, qw[i], 1, qd);
+            const CeedScalar u0 = u[i + Q * 0];
+            const CeedScalar u1 = u[i + Q * 1];
+            const CeedScalar u2 = u[i + Q * 2];
+            v[i + Q * 0] = qd[0] * u0 + qd[1] * u1 + qd[2] * u2;
+            v[i + Q * 1] = qd[1] * u0 + qd[3] * u1 + qd[4] * u2;
+            v[i + Q * 2] = qd[2] * u0 + qd[4] * u1 + qd[5] * u2;
+         }
+         break;
+      case 333:
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+         {
+            CeedScalar qd[6];
+            MultJtCJ33(J + i, Q, coeff, 1, 3, qw[i], 1, qd);
+            const CeedScalar u0 = u[i + Q * 0];
+            const CeedScalar u1 = u[i + Q * 1];
+            const CeedScalar u2 = u[i + Q * 2];
+            v[i + Q * 0] = qd[0] * u0 + qd[1] * u1 + qd[2] * u2;
+            v[i + Q * 1] = qd[1] * u0 + qd[3] * u1 + qd[4] * u2;
+            v[i + Q * 2] = qd[2] * u0 + qd[4] * u1 + qd[5] * u2;
+         }
+         break;
+      case 331:
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+         {
+            CeedScalar qd[6];
+            MultJtCJ33(J + i, Q, coeff, 1, 1, qw[i], 1, qd);
+            const CeedScalar u0 = u[i + Q * 0];
+            const CeedScalar u1 = u[i + Q * 1];
+            const CeedScalar u2 = u[i + Q * 2];
+            v[i + Q * 0] = qd[0] * u0 + qd[1] * u1 + qd[2] * u2;
+            v[i + Q * 1] = qd[1] * u0 + qd[3] * u1 + qd[4] * u2;
+            v[i + Q * 2] = qd[2] * u0 + qd[4] * u1 + qd[5] * u2;
+         }
+         break;
+   }
+   return 0;
+}
+
+CEED_QFUNCTION(f_apply_hcurlmass_mf_const)(void *ctx, CeedInt Q,
                                            const CeedScalar *const *in,
                                            CeedScalar *const *out)
 {
@@ -195,60 +632,140 @@ CEED_QFUNCTION(f_apply_vecfemass_mf_const)(void *ctx, CeedInt Q,
    //
    // At every quadrature point, compute qw/det(J) adj(J) C adj(J)^T (for
    // H(curl)) or qw/det(J) J^T C J (for H(div)).
-   const bool hdiv = bc->hdiv;
-   const CeedInt coeff_comp = bc->coeff_comp;
    const CeedScalar *coeff = bc->coeff;
    const CeedScalar *u = in[0], *J = in[1], *qw = in[2];
    CeedScalar *v = out[0];
-   switch (10 * bc->space_dim + bc->dim)
+   switch (100 * bc->space_dim + 10 * bc->dim + bc->coeff_comp)
    {
-      case 11:
+      case 111:
          CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
             const CeedScalar coeff0 = coeff[0];
-            const CeedScalar qd = qw[i] * coeff0 * (hdiv ? J[i] : 1.0 / J[i]);
+            const CeedScalar qd = qw[i] * coeff0 / J[i];
             v[i] = qd * u[i];
          }
          break;
-      case 21:
+      case 213:
          CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
             CeedScalar qd;
-            (hdiv ? MultJtCJ21 : MultAdjJCAdjJt21)(J + i, Q, coeff, 1, coeff_comp,
-                                                   qw[i], 1, &qd);
+            MultAdjJCAdjJt21(J + i, Q, coeff, 1, 3, qw[i], 1, &qd);
             v[i] = qd * u[i];
          }
          break;
-      case 22:
+      case 212:
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+         {
+            CeedScalar qd;
+            MultAdjJCAdjJt21(J + i, Q, coeff, 1, 2, qw[i], 1, &qd);
+            v[i] = qd * u[i];
+         }
+         break;
+      case 211:
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+         {
+            CeedScalar qd;
+            MultAdjJCAdjJt21(J + i, Q, coeff, 1, 1, qw[i], 1, &qd);
+            v[i] = qd * u[i];
+         }
+         break;
+      case 223:
          CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
             CeedScalar qd[3];
-            (hdiv ? MultJtCJ22 : MultAdjJCAdjJt22)(J + i, Q, coeff, 1, coeff_comp,
-                                                   qw[i], 1, qd);
+            MultAdjJCAdjJt22(J + i, Q, coeff, 1, 3, qw[i], 1, qd);
             const CeedScalar u0 = u[i + Q * 0];
             const CeedScalar u1 = u[i + Q * 1];
             v[i + Q * 0] = qd[0] * u0 + qd[1] * u1;
             v[i + Q * 1] = qd[1] * u0 + qd[2] * u1;
          }
          break;
-      case 32:
+      case 222:
          CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
             CeedScalar qd[3];
-            (hdiv ? MultJtCJ32 : MultAdjJCAdjJt32)(J + i, Q, coeff, 1, coeff_comp,
-                                                   qw[i], 1, qd);
+            MultAdjJCAdjJt22(J + i, Q, coeff, 1, 2, qw[i], 1, qd);
             const CeedScalar u0 = u[i + Q * 0];
             const CeedScalar u1 = u[i + Q * 1];
             v[i + Q * 0] = qd[0] * u0 + qd[1] * u1;
             v[i + Q * 1] = qd[1] * u0 + qd[2] * u1;
          }
          break;
-      case 33:
+      case 221:
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+         {
+            CeedScalar qd[3];
+            MultAdjJCAdjJt22(J + i, Q, coeff, 1, 1, qw[i], 1, qd);
+            const CeedScalar u0 = u[i + Q * 0];
+            const CeedScalar u1 = u[i + Q * 1];
+            v[i + Q * 0] = qd[0] * u0 + qd[1] * u1;
+            v[i + Q * 1] = qd[1] * u0 + qd[2] * u1;
+         }
+         break;
+      case 326:
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+         {
+            CeedScalar qd[3];
+            MultAdjJCAdjJt32(J + i, Q, coeff, 1, 6, qw[i], 1, qd);
+            const CeedScalar u0 = u[i + Q * 0];
+            const CeedScalar u1 = u[i + Q * 1];
+            v[i + Q * 0] = qd[0] * u0 + qd[1] * u1;
+            v[i + Q * 1] = qd[1] * u0 + qd[2] * u1;
+         }
+         break;
+      case 323:
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+         {
+            CeedScalar qd[3];
+            MultAdjJCAdjJt32(J + i, Q, coeff, 1, 3, qw[i], 1, qd);
+            const CeedScalar u0 = u[i + Q * 0];
+            const CeedScalar u1 = u[i + Q * 1];
+            v[i + Q * 0] = qd[0] * u0 + qd[1] * u1;
+            v[i + Q * 1] = qd[1] * u0 + qd[2] * u1;
+         }
+         break;
+      case 321:
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+         {
+            CeedScalar qd[3];
+            MultAdjJCAdjJt32(J + i, Q, coeff, 1, 1, qw[i], 1, qd);
+            const CeedScalar u0 = u[i + Q * 0];
+            const CeedScalar u1 = u[i + Q * 1];
+            v[i + Q * 0] = qd[0] * u0 + qd[1] * u1;
+            v[i + Q * 1] = qd[1] * u0 + qd[2] * u1;
+         }
+         break;
+      case 336:
          CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
             CeedScalar qd[6];
-            (hdiv ? MultJtCJ33 : MultAdjJCAdjJt33)(J + i, Q, coeff, 1, coeff_comp,
-                                                   qw[i], 1, qd);
+            MultAdjJCAdjJt33(J + i, Q, coeff, 1, 6, qw[i], 1, qd);
+            const CeedScalar u0 = u[i + Q * 0];
+            const CeedScalar u1 = u[i + Q * 1];
+            const CeedScalar u2 = u[i + Q * 2];
+            v[i + Q * 0] = qd[0] * u0 + qd[1] * u1 + qd[2] * u2;
+            v[i + Q * 1] = qd[1] * u0 + qd[3] * u1 + qd[4] * u2;
+            v[i + Q * 2] = qd[2] * u0 + qd[4] * u1 + qd[5] * u2;
+         }
+         break;
+      case 333:
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+         {
+            CeedScalar qd[6];
+            MultAdjJCAdjJt33(J + i, Q, coeff, 1, 3, qw[i], 1, qd);
+            const CeedScalar u0 = u[i + Q * 0];
+            const CeedScalar u1 = u[i + Q * 1];
+            const CeedScalar u2 = u[i + Q * 2];
+            v[i + Q * 0] = qd[0] * u0 + qd[1] * u1 + qd[2] * u2;
+            v[i + Q * 1] = qd[1] * u0 + qd[3] * u1 + qd[4] * u2;
+            v[i + Q * 2] = qd[2] * u0 + qd[4] * u1 + qd[5] * u2;
+         }
+         break;
+      case 331:
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+         {
+            CeedScalar qd[6];
+            MultAdjJCAdjJt33(J + i, Q, coeff, 1, 1, qw[i], 1, qd);
             const CeedScalar u0 = u[i + Q * 0];
             const CeedScalar u1 = u[i + Q * 1];
             const CeedScalar u2 = u[i + Q * 2];
@@ -262,7 +779,163 @@ CEED_QFUNCTION(f_apply_vecfemass_mf_const)(void *ctx, CeedInt Q,
 }
 
 /// libCEED QFunction for applying a vector FE mass operator
-CEED_QFUNCTION(f_apply_vecfemass_mf_quad)(void *ctx, CeedInt Q,
+CEED_QFUNCTION(f_apply_hdivmass_mf_quad)(void *ctx, CeedInt Q,
+                                         const CeedScalar *const *in,
+                                         CeedScalar *const *out)
+{
+   VectorFEMassContext *bc = (VectorFEMassContext *)ctx;
+   // in[0], out[0] have shape [dim, ncomp=1, Q]
+   // in[1] is coefficients with shape [ncomp=coeff_comp, Q]
+   // in[2] is Jacobians with shape [dim, ncomp=space_dim, Q]
+   // in[3] is quadrature weights, size (Q)
+   //
+   // At every quadrature point, compute qw/det(J) adj(J) C adj(J)^T (for
+   // H(curl)) or qw/det(J) J^T C J (for H(div)).
+   const CeedScalar *u = in[0], *c = in[1], *J = in[2], *qw = in[3];
+   CeedScalar *v = out[0];
+   switch (100 * bc->space_dim + 10 * bc->dim + bc->coeff_comp)
+   {
+      case 111:
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+         {
+            const CeedScalar qd = qw[i] * c[i] * J[i];
+            v[i] = qd * u[i];
+         }
+         break;
+      case 213:
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+         {
+            CeedScalar qd;
+            MultJtCJ21(J + i, Q, c + i, Q, 3, qw[i], 1, &qd);
+            v[i] = qd * u[i];
+         }
+         break;
+      case 212:
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+         {
+            CeedScalar qd;
+            MultJtCJ21(J + i, Q, c + i, Q, 2, qw[i], 1, &qd);
+            v[i] = qd * u[i];
+         }
+         break;
+      case 211:
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+         {
+            CeedScalar qd;
+            MultJtCJ21(J + i, Q, c + i, Q, 1, qw[i], 1, &qd);
+            v[i] = qd * u[i];
+         }
+         break;
+      case 223:
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+         {
+            CeedScalar qd[3];
+            MultJtCJ22(J + i, Q, c + i, Q, 3, qw[i], 1, qd);
+            const CeedScalar u0 = u[i + Q * 0];
+            const CeedScalar u1 = u[i + Q * 1];
+            v[i + Q * 0] = qd[0] * u0 + qd[1] * u1;
+            v[i + Q * 1] = qd[1] * u0 + qd[2] * u1;
+         }
+         break;
+      case 222:
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+         {
+            CeedScalar qd[3];
+            MultJtCJ22(J + i, Q, c + i, Q, 2, qw[i], 1, qd);
+            const CeedScalar u0 = u[i + Q * 0];
+            const CeedScalar u1 = u[i + Q * 1];
+            v[i + Q * 0] = qd[0] * u0 + qd[1] * u1;
+            v[i + Q * 1] = qd[1] * u0 + qd[2] * u1;
+         }
+         break;
+      case 221:
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+         {
+            CeedScalar qd[3];
+            MultJtCJ22(J + i, Q, c + i, Q, 1, qw[i], 1, qd);
+            const CeedScalar u0 = u[i + Q * 0];
+            const CeedScalar u1 = u[i + Q * 1];
+            v[i + Q * 0] = qd[0] * u0 + qd[1] * u1;
+            v[i + Q * 1] = qd[1] * u0 + qd[2] * u1;
+         }
+         break;
+      case 326:
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+         {
+            CeedScalar qd[3];
+            MultJtCJ32(J + i, Q, c + i, Q, 6, qw[i], 1, qd);
+            const CeedScalar u0 = u[i + Q * 0];
+            const CeedScalar u1 = u[i + Q * 1];
+            v[i + Q * 0] = qd[0] * u0 + qd[1] * u1;
+            v[i + Q * 1] = qd[1] * u0 + qd[2] * u1;
+         }
+         break;
+      case 323:
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+         {
+            CeedScalar qd[3];
+            MultJtCJ32(J + i, Q, c + i, Q, 3, qw[i], 1, qd);
+            const CeedScalar u0 = u[i + Q * 0];
+            const CeedScalar u1 = u[i + Q * 1];
+            v[i + Q * 0] = qd[0] * u0 + qd[1] * u1;
+            v[i + Q * 1] = qd[1] * u0 + qd[2] * u1;
+         }
+         break;
+      case 321:
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+         {
+            CeedScalar qd[3];
+            MultJtCJ32(J + i, Q, c + i, Q, 1, qw[i], 1, qd);
+            const CeedScalar u0 = u[i + Q * 0];
+            const CeedScalar u1 = u[i + Q * 1];
+            v[i + Q * 0] = qd[0] * u0 + qd[1] * u1;
+            v[i + Q * 1] = qd[1] * u0 + qd[2] * u1;
+         }
+         break;
+      case 336:
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+         {
+            CeedScalar qd[6];
+            MultJtCJ33(J + i, Q, c + i, Q, 6, qw[i], 1, qd);
+            const CeedScalar u0 = u[i + Q * 0];
+            const CeedScalar u1 = u[i + Q * 1];
+            const CeedScalar u2 = u[i + Q * 2];
+            v[i + Q * 0] = qd[0] * u0 + qd[1] * u1 + qd[2] * u2;
+            v[i + Q * 1] = qd[1] * u0 + qd[3] * u1 + qd[4] * u2;
+            v[i + Q * 2] = qd[2] * u0 + qd[4] * u1 + qd[5] * u2;
+         }
+         break;
+      case 333:
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+         {
+            CeedScalar qd[6];
+            MultJtCJ33(J + i, Q, c + i, Q, 3, qw[i], 1, qd);
+            const CeedScalar u0 = u[i + Q * 0];
+            const CeedScalar u1 = u[i + Q * 1];
+            const CeedScalar u2 = u[i + Q * 2];
+            v[i + Q * 0] = qd[0] * u0 + qd[1] * u1 + qd[2] * u2;
+            v[i + Q * 1] = qd[1] * u0 + qd[3] * u1 + qd[4] * u2;
+            v[i + Q * 2] = qd[2] * u0 + qd[4] * u1 + qd[5] * u2;
+         }
+         break;
+      case 331:
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+         {
+            CeedScalar qd[6];
+            MultJtCJ33(J + i, Q, c + i, Q, 1, qw[i], 1, qd);
+            const CeedScalar u0 = u[i + Q * 0];
+            const CeedScalar u1 = u[i + Q * 1];
+            const CeedScalar u2 = u[i + Q * 2];
+            v[i + Q * 0] = qd[0] * u0 + qd[1] * u1 + qd[2] * u2;
+            v[i + Q * 1] = qd[1] * u0 + qd[3] * u1 + qd[4] * u2;
+            v[i + Q * 2] = qd[2] * u0 + qd[4] * u1 + qd[5] * u2;
+         }
+         break;
+   }
+   return 0;
+}
+
+CEED_QFUNCTION(f_apply_hcurlmass_mf_quad)(void *ctx, CeedInt Q,
                                           const CeedScalar *const *in,
                                           CeedScalar *const *out)
 {
@@ -274,58 +947,138 @@ CEED_QFUNCTION(f_apply_vecfemass_mf_quad)(void *ctx, CeedInt Q,
    //
    // At every quadrature point, compute qw/det(J) adj(J) C adj(J)^T (for
    // H(curl)) or qw/det(J) J^T C J (for H(div)).
-   const bool hdiv = bc->hdiv;
-   const CeedInt coeff_comp = bc->coeff_comp;
    const CeedScalar *u = in[0], *c = in[1], *J = in[2], *qw = in[3];
    CeedScalar *v = out[0];
-   switch (10 * bc->space_dim + bc->dim)
+   switch (100 * bc->space_dim + 10 * bc->dim + bc->coeff_comp)
    {
-      case 11:
+      case 111:
          CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
-            const CeedScalar qd = qw[i] * c[i] * (hdiv ? J[i] : 1.0 / J[i]);
+            const CeedScalar qd = qw[i] * c[i] / J[i];
             v[i] = qd * u[i];
          }
          break;
-      case 21:
+      case 213:
          CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
             CeedScalar qd;
-            (hdiv ? MultJtCJ21 : MultAdjJCAdjJt21)(J + i, Q, c + i, Q, coeff_comp,
-                                                   qw[i], 1, &qd);
+            MultAdjJCAdjJt21(J + i, Q, c + i, Q, 3, qw[i], 1, &qd);
             v[i] = qd * u[i];
          }
          break;
-      case 22:
+      case 212:
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+         {
+            CeedScalar qd;
+            MultAdjJCAdjJt21(J + i, Q, c + i, Q, 2, qw[i], 1, &qd);
+            v[i] = qd * u[i];
+         }
+         break;
+      case 211:
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+         {
+            CeedScalar qd;
+            MultAdjJCAdjJt21(J + i, Q, c + i, Q, 1, qw[i], 1, &qd);
+            v[i] = qd * u[i];
+         }
+         break;
+      case 223:
          CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
             CeedScalar qd[3];
-            (hdiv ? MultJtCJ22 : MultAdjJCAdjJt22)(J + i, Q, c + i, Q, coeff_comp,
-                                                   qw[i], 1, qd);
+            MultAdjJCAdjJt22(J + i, Q, c + i, Q, 3, qw[i], 1, qd);
             const CeedScalar u0 = u[i + Q * 0];
             const CeedScalar u1 = u[i + Q * 1];
             v[i + Q * 0] = qd[0] * u0 + qd[1] * u1;
             v[i + Q * 1] = qd[1] * u0 + qd[2] * u1;
          }
          break;
-      case 32:
+      case 222:
          CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
             CeedScalar qd[3];
-            (hdiv ? MultJtCJ32 : MultAdjJCAdjJt32)(J + i, Q, c + i, Q, coeff_comp,
-                                                   qw[i], 1, qd);
+            MultAdjJCAdjJt22(J + i, Q, c + i, Q, 2, qw[i], 1, qd);
             const CeedScalar u0 = u[i + Q * 0];
             const CeedScalar u1 = u[i + Q * 1];
             v[i + Q * 0] = qd[0] * u0 + qd[1] * u1;
             v[i + Q * 1] = qd[1] * u0 + qd[2] * u1;
          }
          break;
-      case 33:
+      case 221:
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+         {
+            CeedScalar qd[3];
+            MultAdjJCAdjJt22(J + i, Q, c + i, Q, 1, qw[i], 1, qd);
+            const CeedScalar u0 = u[i + Q * 0];
+            const CeedScalar u1 = u[i + Q * 1];
+            v[i + Q * 0] = qd[0] * u0 + qd[1] * u1;
+            v[i + Q * 1] = qd[1] * u0 + qd[2] * u1;
+         }
+         break;
+      case 326:
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+         {
+            CeedScalar qd[3];
+            MultAdjJCAdjJt32(J + i, Q, c + i, Q, 6, qw[i], 1, qd);
+            const CeedScalar u0 = u[i + Q * 0];
+            const CeedScalar u1 = u[i + Q * 1];
+            v[i + Q * 0] = qd[0] * u0 + qd[1] * u1;
+            v[i + Q * 1] = qd[1] * u0 + qd[2] * u1;
+         }
+         break;
+      case 323:
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+         {
+            CeedScalar qd[3];
+            MultAdjJCAdjJt32(J + i, Q, c + i, Q, 3, qw[i], 1, qd);
+            const CeedScalar u0 = u[i + Q * 0];
+            const CeedScalar u1 = u[i + Q * 1];
+            v[i + Q * 0] = qd[0] * u0 + qd[1] * u1;
+            v[i + Q * 1] = qd[1] * u0 + qd[2] * u1;
+         }
+         break;
+      case 321:
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+         {
+            CeedScalar qd[3];
+            MultAdjJCAdjJt32(J + i, Q, c + i, Q, 1, qw[i], 1, qd);
+            const CeedScalar u0 = u[i + Q * 0];
+            const CeedScalar u1 = u[i + Q * 1];
+            v[i + Q * 0] = qd[0] * u0 + qd[1] * u1;
+            v[i + Q * 1] = qd[1] * u0 + qd[2] * u1;
+         }
+         break;
+      case 336:
          CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
          {
             CeedScalar qd[6];
-            (hdiv ? MultJtCJ33 : MultAdjJCAdjJt33)(J + i, Q, c + i, Q, coeff_comp,
-                                                   qw[i], 1, qd);
+            MultAdjJCAdjJt33(J + i, Q, c + i, Q, 6, qw[i], 1, qd);
+            const CeedScalar u0 = u[i + Q * 0];
+            const CeedScalar u1 = u[i + Q * 1];
+            const CeedScalar u2 = u[i + Q * 2];
+            v[i + Q * 0] = qd[0] * u0 + qd[1] * u1 + qd[2] * u2;
+            v[i + Q * 1] = qd[1] * u0 + qd[3] * u1 + qd[4] * u2;
+            v[i + Q * 2] = qd[2] * u0 + qd[4] * u1 + qd[5] * u2;
+         }
+         break;
+      case 333:
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+         {
+            CeedScalar qd[6];
+            MultAdjJCAdjJt33(J + i, Q, c + i, Q, 3, qw[i], 1, qd);
+            const CeedScalar u0 = u[i + Q * 0];
+            const CeedScalar u1 = u[i + Q * 1];
+            const CeedScalar u2 = u[i + Q * 2];
+            v[i + Q * 0] = qd[0] * u0 + qd[1] * u1 + qd[2] * u2;
+            v[i + Q * 1] = qd[1] * u0 + qd[3] * u1 + qd[4] * u2;
+            v[i + Q * 2] = qd[2] * u0 + qd[4] * u1 + qd[5] * u2;
+         }
+         break;
+      case 331:
+         CeedPragmaSIMD for (CeedInt i = 0; i < Q; i++)
+         {
+            CeedScalar qd[6];
+            MultAdjJCAdjJt33(J + i, Q, c + i, Q, 1, qw[i], 1, qd);
             const CeedScalar u0 = u[i + Q * 0];
             const CeedScalar u1 = u[i + Q * 1];
             const CeedScalar u2 = u[i + Q * 2];

--- a/fem/ceed/interface/coefficient.hpp
+++ b/fem/ceed/interface/coefficient.hpp
@@ -74,7 +74,7 @@ inline void InitCoefficient(mfem::Coefficient *Q, mfem::Mesh &mesh,
                             const mfem::IntegrationRule &ir, bool use_bdr,
                             Coefficient *&coeff_ptr)
 {
-   if (Q == nullptr || dynamic_cast<ConstantCoefficient *>(Q))
+   if (Q == nullptr || dynamic_cast<mfem::ConstantCoefficient *>(Q))
    {
       // The constant coefficient case is handled by the QFunction context
       coeff_ptr = nullptr;
@@ -277,15 +277,15 @@ inline void InitCoefficientWithIndices(mfem::Coefficient *Q,
       // The constant coefficient case is handled by the QFunction context
       coeff_ptr = nullptr;
    }
-   else if (GridFunctionCoefficient *gf_coeff =
-               dynamic_cast<GridFunctionCoefficient *>(Q))
+   else if (mfem::GridFunctionCoefficient *gf_coeff =
+               dynamic_cast<mfem::GridFunctionCoefficient *>(Q))
    {
       GridCoefficient *ceed_coeff =
          new GridCoefficient(*gf_coeff->GetGridFunction());
       coeff_ptr = ceed_coeff;
    }
-   else if (QuadratureFunctionCoefficient *qf_coeff =
-               dynamic_cast<QuadratureFunctionCoefficient *>(Q))
+   else if (mfem::QuadratureFunctionCoefficient *qf_coeff =
+               dynamic_cast<mfem::QuadratureFunctionCoefficient *>(Q))
    {
       const int ne = use_bdr ? mesh.GetNBE() : mesh.GetNE();
       const int nq = ir.GetNPoints();
@@ -360,15 +360,15 @@ inline void InitCoefficientWithIndices(mfem::VectorCoefficient *VQ,
       // The constant coefficient case is handled by the QFunction context
       coeff_ptr = nullptr;
    }
-   else if (VectorGridFunctionCoefficient *vgf_coeff =
-               dynamic_cast<VectorGridFunctionCoefficient *>(VQ))
+   else if (mfem::VectorGridFunctionCoefficient *vgf_coeff =
+               dynamic_cast<mfem::VectorGridFunctionCoefficient *>(VQ))
    {
       GridCoefficient *ceed_coeff =
          new GridCoefficient(*vgf_coeff->GetGridFunction());
       coeff_ptr = ceed_coeff;
    }
-   else if (VectorQuadratureFunctionCoefficient *vqf_coeff =
-               dynamic_cast<VectorQuadratureFunctionCoefficient *>(VQ))
+   else if (mfem::VectorQuadratureFunctionCoefficient *vqf_coeff =
+               dynamic_cast<mfem::VectorQuadratureFunctionCoefficient *>(VQ))
    {
       const int vdim = vqf_coeff->GetVDim();
       const int ne = use_bdr ? mesh.GetNBE() : mesh.GetNE();

--- a/fem/ceed/interface/integrator.hpp
+++ b/fem/ceed/interface/integrator.hpp
@@ -36,34 +36,18 @@ struct OperatorInfo
 {
    /** The path to the QFunction header. */
    const char *header;
-   /** The name of the QFunction to build a partially assembled CeedOperator
-       with a constant Coefficient. */
-   const char *build_func_const;
-   /** The QFunction to build a partially assembled CeedOperator with a constant
-       Coefficient. */
-   CeedQFunctionUser build_qf_const;
-   /** The name of the QFunction to build a partially assembled CeedOperator
-       with a variable Coefficient. */
-   const char *build_func_quad;
-   /** The QFunction to build a partially assembled CeedOperator with a variable
-       Coefficient. */
-   CeedQFunctionUser build_qf_quad;
+   /** The name of the QFunction to build a partially assembled CeedOperator. */
+   const char *build_func;
+   /** The QFunction to build a partially assembled CeedOperator. */
+   CeedQFunctionUser build_qf;
    /** The name of the QFunction to apply a partially assembled CeedOperator. */
    const char *apply_func;
    /** The QFunction to apply a partially assembled CeedOperator. */
    CeedQFunctionUser apply_qf;
-   /** The name of the QFunction to apply a matrix-free CeedOperator with a
-       constant Coefficient. */
-   const char *apply_func_mf_const;
-   /** The QFunction to apply a matrix-free CeedOperator with a constant
-       Coefficient. */
-   CeedQFunctionUser apply_qf_mf_const;
-   /** The name of the QFunction to apply a matrix-free CeedOperator with a
-       variable Coefficient. */
-   const char *apply_func_mf_quad;
-   /** The QFunction to apply a matrix-free CeedOperator with a variable
-       Coefficient. */
-   CeedQFunctionUser apply_qf_mf_quad;
+   /** The name of the QFunction to apply a matrix-free CeedOperator. */
+   const char *apply_func_mf;
+   /** The QFunction to apply a matrix-free CeedOperator. */
+   CeedQFunctionUser apply_qf_mf;
    /** The EvalMode on the trial basis functions. */
    EvalMode trial_op;
    /** The EvalMode on the test basis functions. */
@@ -274,17 +258,11 @@ public:
                                 &qdata_restr);
          CeedVectorCreate(ceed, nelem * nqpts * qdatasize, &qdata);
 
-         std::string build_func = coeff ? info.build_func_quad
-                                  : info.build_func_const;
-         CeedQFunctionUser build_qf = coeff ? info.build_qf_quad
-                                      : info.build_qf_const;
-
          // Create the QFunction that builds the operator (i.e. computes its
          // quadrature data) and set its context data.
          CeedQFunction build_qfunc;
-         std::string qf_file = GetCeedPath() + info.header;
-         std::string qf = qf_file + build_func;
-         CeedQFunctionCreateInterior(ceed, 1, build_qf, qf.c_str(),
+         std::string qf = GetCeedPath() + info.header + info.build_func;
+         CeedQFunctionCreateInterior(ceed, 1, info.build_qf, qf.c_str(),
                                      &build_qfunc);
          if (coeff)
          {
@@ -335,17 +313,9 @@ public:
          coeff = nullptr;
       }
 
-      std::string apply_func = !use_mf ? info.apply_func :
-                               (coeff ? info.apply_func_mf_quad
-                                : info.apply_func_mf_const);
-      CeedQFunctionUser apply_qf = !use_mf ? info.apply_qf :
-                                   (coeff ? info.apply_qf_mf_quad
-                                    : info.apply_qf_mf_const);
-
       // Create the QFunction that defines the action of the operator.
-      std::string qf_file = GetCeedPath() + info.header;
-      std::string qf = qf_file + apply_func;
-      CeedQFunctionCreateInterior(ceed, 1, apply_qf, qf.c_str(),
+      std::string qf = GetCeedPath() + info.header + info.apply_func;
+      CeedQFunctionCreateInterior(ceed, 1, info.apply_qf, qf.c_str(),
                                   &apply_qfunc);
       // input
       switch (info.trial_op)

--- a/fem/ceed/interface/integrator.hpp
+++ b/fem/ceed/interface/integrator.hpp
@@ -328,6 +328,11 @@ public:
 
          CeedOperatorDestroy(&build_oper);
          CeedQFunctionDestroy(&build_qfunc);
+
+         CeedVectorDestroy(&node_coords);
+         node_coords = nullptr;
+         delete coeff;
+         coeff = nullptr;
       }
 
       std::string apply_func = !use_mf ? info.apply_func :

--- a/fem/ceed/interface/integrator.hpp
+++ b/fem/ceed/interface/integrator.hpp
@@ -118,7 +118,8 @@ public:
                  const bool use_bdr = false,
                  const bool use_mf = false)
    {
-      Assemble(info, fes, ir, use_bdr ? fes.GetNBE() : fes.GetNE(),
+      Assemble(info, fes, fes, ir,
+               use_bdr ? fes.GetNBE() : fes.GetNE(),
                nullptr, Q, use_bdr, use_mf);
    }
 

--- a/fem/integ/bilininteg_curlcurl_mf.cpp
+++ b/fem/integ/bilininteg_curlcurl_mf.cpp
@@ -1,0 +1,89 @@
+// Copyright (c) 2010-2023, Lawrence Livermore National Security, LLC. Produced
+// at the Lawrence Livermore National Laboratory. All Rights reserved. See files
+// LICENSE and NOTICE for details. LLNL-CODE-806117.
+//
+// This file is part of the MFEM library. For more information and source code
+// availability visit https://mfem.org.
+//
+// MFEM is free software; you can redistribute it and/or modify it under the
+// terms of the BSD-3 license. We welcome feedback and contributions, see file
+// CONTRIBUTING.md for details.
+
+#include "../bilininteg.hpp"
+#include "../gridfunc.hpp"
+#include "../ceed/integrators/curlcurl/curlcurl.hpp"
+
+using namespace std;
+
+namespace mfem
+{
+
+void CurlCurlIntegrator::AssembleMF(const FiniteElementSpace &fes)
+{
+   Mesh *mesh = fes.GetMesh();
+   if (mesh->GetNE() == 0) { return; }
+   if (DeviceCanUseCeed())
+   {
+      delete ceedOp;
+      if (MQ) { ceedOp = new ceed::MFCurlCurlIntegrator(*this, fes, MQ); }
+      else if (DQ) { ceedOp = new ceed::MFCurlCurlIntegrator(*this, fes, DQ); }
+      else { ceedOp = new ceed::MFCurlCurlIntegrator(*this, fes, Q); }
+      return;
+   }
+
+   // Assumes tensor-product elements
+   // const FiniteElement &el = *fes.GetFE(0);
+   // ElementTransformation &T = *mesh->GetElementTransformation(0);
+   // const IntegrationRule *ir = IntRule ? IntRule : &GetRule(*el, T);
+   MFEM_ABORT("Error: CurlCurlIntegrator::AssembleMF only implemented with"
+              " libCEED");
+}
+
+void CurlCurlIntegrator::AssembleMFBoundary(const FiniteElementSpace &fes)
+{
+   Mesh *mesh = fes.GetMesh();
+   if (mesh->GetNBE() == 0) { return; }
+   if (DeviceCanUseCeed())
+   {
+      delete ceedOp;
+      if (MQ) { ceedOp = new ceed::MFCurlCurlIntegrator(*this, fes, MQ, true); }
+      else if (DQ) { ceedOp = new ceed::MFCurlCurlIntegrator(*this, fes, DQ, true); }
+      else { ceedOp = new ceed::MFCurlCurlIntegrator(*this, fes, Q, true); }
+      return;
+   }
+
+   // Assumes tensor-product elements
+   // const FiniteElement &el = *fes.GetBE(0);
+   // ElementTransformation &T = *mesh->GetBdrElementTransformation(0);
+   // const IntegrationRule *ir = IntRule ? IntRule : &GetRule(*el, T);
+   MFEM_ABORT("Error: CurlCurlIntegrator::AssembleMFBoundary only implemented with"
+              " libCEED");
+}
+
+void CurlCurlIntegrator::AssembleDiagonalMF(Vector &diag)
+{
+   if (DeviceCanUseCeed())
+   {
+      ceedOp->GetDiagonal(diag);
+   }
+   else
+   {
+      MFEM_ABORT("Error: CurlCurlIntegrator::AssembleDiagonalMF only"
+                 " implemented with libCEED");
+   }
+}
+
+void CurlCurlIntegrator::AddMultMF(const Vector &x, Vector &y) const
+{
+   if (DeviceCanUseCeed())
+   {
+      ceedOp->AddMult(x, y);
+   }
+   else
+   {
+      MFEM_ABORT("Error: CurlCurlIntegrator::AddMultMF only implemented with"
+                 " libCEED");
+   }
+}
+
+}

--- a/fem/integ/bilininteg_curlcurl_pa.cpp
+++ b/fem/integ/bilininteg_curlcurl_pa.cpp
@@ -10,6 +10,7 @@
 // CONTRIBUTING.md for details.
 
 #include "../qfunction.hpp"
+#include "../ceed/integrators/curlcurl/curlcurl.hpp"
 #include "bilininteg_hcurl_kernels.hpp"
 
 namespace mfem
@@ -17,10 +18,19 @@ namespace mfem
 
 void CurlCurlIntegrator::AssemblePA(const FiniteElementSpace &fes)
 {
-   // Assumes tensor-product elements
    Mesh *mesh = fes.GetMesh();
-   const FiniteElement *fel = fes.GetFE(0);
+   if (mesh->GetNE() == 0) { return; }
+   if (DeviceCanUseCeed())
+   {
+      delete ceedOp;
+      if (MQ) { ceedOp = new ceed::PACurlCurlIntegrator(*this, fes, MQ); }
+      else if (DQ) { ceedOp = new ceed::PACurlCurlIntegrator(*this, fes, DQ); }
+      else { ceedOp = new ceed::PACurlCurlIntegrator(*this, fes, Q); }
+      return;
+   }
 
+   // Assumes tensor-product elements
+   const FiniteElement *fel = fes.GetFE(0);
    const VectorTensorFiniteElement *el =
       dynamic_cast<const VectorTensorFiniteElement*>(fel);
    MFEM_VERIFY(el != NULL, "Only VectorTensorFiniteElement is supported!");
@@ -28,18 +38,15 @@ void CurlCurlIntegrator::AssemblePA(const FiniteElementSpace &fes)
    const IntegrationRule *ir = IntRule ? IntRule : &GetRule(*el, T);
    const int dims = el->GetDim();
    MFEM_VERIFY(dims == 2 || dims == 3, "");
-
    nq = ir->GetNPoints();
    dim = mesh->Dimension();
    MFEM_VERIFY(dim == 2 || dim == 3, "");
-
    ne = fes.GetNE();
    geom = mesh->GetGeometricFactors(*ir, GeometricFactors::JACOBIANS);
    mapsC = &el->GetDofToQuad(*ir, DofToQuad::TENSOR);
    mapsO = &el->GetDofToQuadOpen(*ir, DofToQuad::TENSOR);
    dofs1D = mapsC->ndof;
    quad1D = mapsC->nqpt;
-
    MFEM_VERIFY(dofs1D == mapsO->ndof + 1 && quad1D == mapsO->nqpt, "");
 
    QuadratureSpace qs(*mesh, *ir);
@@ -72,130 +79,152 @@ void CurlCurlIntegrator::AssemblePA(const FiniteElementSpace &fes)
    }
 }
 
-void CurlCurlIntegrator::AssembleDiagonalPA(Vector& diag)
+void CurlCurlIntegrator::AssemblePABoundary(const FiniteElementSpace &fes)
 {
-   if (dim == 3)
+   Mesh *mesh = fes.GetMesh();
+   if (mesh->GetNBE() == 0) { return; }
+   if (DeviceCanUseCeed())
    {
-      if (Device::Allows(Backend::DEVICE_MASK))
-      {
-         const int ID = (dofs1D << 4) | quad1D;
-         switch (ID)
-         {
-            case 0x23:
-               return internal::SmemPACurlCurlAssembleDiagonal3D<2,3>(
-                         dofs1D,
-                         quad1D,
-                         symmetric, ne,
-                         mapsO->B, mapsC->B,
-                         mapsO->G, mapsC->G,
-                         pa_data, diag);
-            case 0x34:
-               return internal::SmemPACurlCurlAssembleDiagonal3D<3,4>(
-                         dofs1D,
-                         quad1D,
-                         symmetric, ne,
-                         mapsO->B, mapsC->B,
-                         mapsO->G, mapsC->G,
-                         pa_data, diag);
-            case 0x45:
-               return internal::SmemPACurlCurlAssembleDiagonal3D<4,5>(
-                         dofs1D,
-                         quad1D,
-                         symmetric, ne,
-                         mapsO->B, mapsC->B,
-                         mapsO->G, mapsC->G,
-                         pa_data, diag);
-            case 0x56:
-               return internal::SmemPACurlCurlAssembleDiagonal3D<5,6>(
-                         dofs1D,
-                         quad1D,
-                         symmetric, ne,
-                         mapsO->B, mapsC->B,
-                         mapsO->G, mapsC->G,
-                         pa_data, diag);
-            default:
-               return internal::SmemPACurlCurlAssembleDiagonal3D(
-                         dofs1D, quad1D,
-                         symmetric, ne,
-                         mapsO->B, mapsC->B,
-                         mapsO->G, mapsC->G,
-                         pa_data, diag);
-         }
-      }
-      else
-      {
-         internal::PACurlCurlAssembleDiagonal3D(dofs1D, quad1D, symmetric, ne,
-                                                mapsO->B, mapsC->B,
-                                                mapsO->G, mapsC->G,
-                                                pa_data, diag);
-      }
+      delete ceedOp;
+      if (MQ) { ceedOp = new ceed::PACurlCurlIntegrator(*this, fes, MQ, true); }
+      else if (DQ) { ceedOp = new ceed::PACurlCurlIntegrator(*this, fes, DQ, true); }
+      else { ceedOp = new ceed::PACurlCurlIntegrator(*this, fes, Q, true); }
+      return;
    }
-   else if (dim == 2)
+
+   // Assumes tensor-product elements
+   // const FiniteElement &el = *fes.GetBE(0);
+   // ElementTransformation &T = *mesh->GetBdrElementTransformation(0);
+   // const IntegrationRule *ir = IntRule ? IntRule : &GetRule(*el, T);
+   MFEM_ABORT("Error: CurlCurlIntegrator::AssemblePABoundary only implemented with"
+              " libCEED");
+}
+
+void CurlCurlIntegrator::AssembleDiagonalPA(Vector &diag)
+{
+   if (DeviceCanUseCeed())
    {
-      internal::PACurlCurlAssembleDiagonal2D(dofs1D, quad1D, ne,
-                                             mapsO->B, mapsC->G, pa_data, diag);
+      ceedOp->GetDiagonal(diag);
    }
    else
    {
-      MFEM_ABORT("Unsupported dimension!");
+      if (dim == 3)
+      {
+         if (Device::Allows(Backend::DEVICE_MASK))
+         {
+            const int ID = (dofs1D << 4) | quad1D;
+            switch (ID)
+            {
+               case 0x23:
+                  return internal::SmemPACurlCurlAssembleDiagonal3D<2,3>(
+                            dofs1D, quad1D, symmetric, ne,
+                            mapsO->B, mapsC->B,
+                            mapsO->G, mapsC->G,
+                            pa_data, diag);
+               case 0x34:
+                  return internal::SmemPACurlCurlAssembleDiagonal3D<3,4>(
+                            dofs1D, quad1D, symmetric, ne,
+                            mapsO->B, mapsC->B,
+                            mapsO->G, mapsC->G,
+                            pa_data, diag);
+               case 0x45:
+                  return internal::SmemPACurlCurlAssembleDiagonal3D<4,5>(
+                            dofs1D, quad1D, symmetric, ne,
+                            mapsO->B, mapsC->B,
+                            mapsO->G, mapsC->G,
+                            pa_data, diag);
+               case 0x56:
+                  return internal::SmemPACurlCurlAssembleDiagonal3D<5,6>(
+                            dofs1D, quad1D, symmetric, ne,
+                            mapsO->B, mapsC->B,
+                            mapsO->G, mapsC->G,
+                            pa_data, diag);
+               default:
+                  return internal::SmemPACurlCurlAssembleDiagonal3D(
+                            dofs1D, quad1D, symmetric, ne,
+                            mapsO->B, mapsC->B,
+                            mapsO->G, mapsC->G,
+                            pa_data, diag);
+            }
+         }
+         else
+         {
+            internal::PACurlCurlAssembleDiagonal3D(dofs1D, quad1D, symmetric, ne,
+                                                   mapsO->B, mapsC->B,
+                                                   mapsO->G, mapsC->G,
+                                                   pa_data, diag);
+         }
+      }
+      else if (dim == 2)
+      {
+         internal::PACurlCurlAssembleDiagonal2D(dofs1D, quad1D, ne,
+                                                mapsO->B, mapsC->G, pa_data, diag);
+      }
+      else
+      {
+         MFEM_ABORT("Unsupported dimension!");
+      }
    }
 }
 
 void CurlCurlIntegrator::AddMultPA(const Vector &x, Vector &y) const
 {
-   if (dim == 3)
+   if (DeviceCanUseCeed())
    {
-      if (Device::Allows(Backend::DEVICE_MASK))
-      {
-         const int ID = (dofs1D << 4) | quad1D;
-         switch (ID)
-         {
-            case 0x23:
-               return internal::SmemPACurlCurlApply3D<2,3>(
-                         dofs1D, quad1D,
-                         symmetric, ne,
-                         mapsO->B, mapsC->B, mapsO->Bt, mapsC->Bt,
-                         mapsC->G, mapsC->Gt, pa_data, x, y);
-            case 0x34:
-               return internal::SmemPACurlCurlApply3D<3,4>(
-                         dofs1D, quad1D,
-                         symmetric, ne,
-                         mapsO->B, mapsC->B, mapsO->Bt, mapsC->Bt,
-                         mapsC->G, mapsC->Gt, pa_data, x, y);
-            case 0x45:
-               return internal::SmemPACurlCurlApply3D<4,5>(
-                         dofs1D, quad1D,
-                         symmetric, ne,
-                         mapsO->B, mapsC->B, mapsO->Bt, mapsC->Bt,
-                         mapsC->G, mapsC->Gt, pa_data, x, y);
-            case 0x56:
-               return internal::SmemPACurlCurlApply3D<5,6>(
-                         dofs1D, quad1D,
-                         symmetric, ne,
-                         mapsO->B, mapsC->B, mapsO->Bt, mapsC->Bt,
-                         mapsC->G, mapsC->Gt, pa_data, x, y);
-            default:
-               return internal::SmemPACurlCurlApply3D(
-                         dofs1D, quad1D, symmetric, ne,
-                         mapsO->B, mapsC->B, mapsO->Bt, mapsC->Bt,
-                         mapsC->G, mapsC->Gt, pa_data, x, y);
-         }
-      }
-      else
-      {
-         internal::PACurlCurlApply3D(dofs1D, quad1D, symmetric, ne, mapsO->B, mapsC->B,
-                                     mapsO->Bt, mapsC->Bt, mapsC->G, mapsC->Gt,
-                                     pa_data, x, y);
-      }
-   }
-   else if (dim == 2)
-   {
-      internal::PACurlCurlApply2D(dofs1D, quad1D, ne, mapsO->B, mapsO->Bt,
-                                  mapsC->G, mapsC->Gt, pa_data, x, y);
+      ceedOp->AddMult(x, y);
    }
    else
    {
-      MFEM_ABORT("Unsupported dimension!");
+      if (dim == 3)
+      {
+         if (Device::Allows(Backend::DEVICE_MASK))
+         {
+            const int ID = (dofs1D << 4) | quad1D;
+            switch (ID)
+            {
+               case 0x23:
+                  return internal::SmemPACurlCurlApply3D<2,3>(
+                            dofs1D, quad1D, symmetric, ne,
+                            mapsO->B, mapsC->B, mapsO->Bt, mapsC->Bt,
+                            mapsC->G, mapsC->Gt, pa_data, x, y);
+               case 0x34:
+                  return internal::SmemPACurlCurlApply3D<3,4>(
+                            dofs1D, quad1D, symmetric, ne,
+                            mapsO->B, mapsC->B, mapsO->Bt, mapsC->Bt,
+                            mapsC->G, mapsC->Gt, pa_data, x, y);
+               case 0x45:
+                  return internal::SmemPACurlCurlApply3D<4,5>(
+                            dofs1D, quad1D, symmetric, ne,
+                            mapsO->B, mapsC->B, mapsO->Bt, mapsC->Bt,
+                            mapsC->G, mapsC->Gt, pa_data, x, y);
+               case 0x56:
+                  return internal::SmemPACurlCurlApply3D<5,6>(
+                            dofs1D, quad1D, symmetric, ne,
+                            mapsO->B, mapsC->B, mapsO->Bt, mapsC->Bt,
+                            mapsC->G, mapsC->Gt, pa_data, x, y);
+               default:
+                  return internal::SmemPACurlCurlApply3D(
+                            dofs1D, quad1D, symmetric, ne,
+                            mapsO->B, mapsC->B, mapsO->Bt, mapsC->Bt,
+                            mapsC->G, mapsC->Gt, pa_data, x, y);
+            }
+         }
+         else
+         {
+            internal::PACurlCurlApply3D(dofs1D, quad1D, symmetric, ne, mapsO->B, mapsC->B,
+                                        mapsO->Bt, mapsC->Bt, mapsC->G, mapsC->Gt,
+                                        pa_data, x, y);
+         }
+      }
+      else if (dim == 2)
+      {
+         internal::PACurlCurlApply2D(dofs1D, quad1D, ne, mapsO->B, mapsO->Bt,
+                                     mapsC->G, mapsC->Gt, pa_data, x, y);
+      }
+      else
+      {
+         MFEM_ABORT("Unsupported dimension!");
+      }
    }
 }
 

--- a/fem/integ/bilininteg_divdiv_mf.cpp
+++ b/fem/integ/bilininteg_divdiv_mf.cpp
@@ -1,0 +1,85 @@
+// Copyright (c) 2010-2023, Lawrence Livermore National Security, LLC. Produced
+// at the Lawrence Livermore National Laboratory. All Rights reserved. See files
+// LICENSE and NOTICE for details. LLNL-CODE-806117.
+//
+// This file is part of the MFEM library. For more information and source code
+// availability visit https://mfem.org.
+//
+// MFEM is free software; you can redistribute it and/or modify it under the
+// terms of the BSD-3 license. We welcome feedback and contributions, see file
+// CONTRIBUTING.md for details.
+
+#include "../bilininteg.hpp"
+#include "../gridfunc.hpp"
+#include "../ceed/integrators/divdiv/divdiv.hpp"
+
+using namespace std;
+
+namespace mfem
+{
+
+void DivDivIntegrator::AssembleMF(const FiniteElementSpace &fes)
+{
+   Mesh *mesh = fes.GetMesh();
+   if (mesh->GetNE() == 0) { return; }
+   if (DeviceCanUseCeed())
+   {
+      delete ceedOp;
+      ceedOp = new ceed::MFDivDivIntegrator(*this, fes, Q);
+      return;
+   }
+
+   // Assumes tensor-product elements
+   // const FiniteElement &el = *fes.GetFE(0);
+   // ElementTransformation &T = *mesh->GetElementTransformation(0);
+   // const IntegrationRule *ir = IntRule ? IntRule : &GetRule(*el, T);
+   MFEM_ABORT("Error: DivDivIntegrator::AssembleMF only implemented with"
+              " libCEED");
+}
+
+void DivDivIntegrator::AssembleMFBoundary(const FiniteElementSpace &fes)
+{
+   Mesh *mesh = fes.GetMesh();
+   if (mesh->GetNBE() == 0) { return; }
+   if (DeviceCanUseCeed())
+   {
+      delete ceedOp;
+      ceedOp = new ceed::MFDivDivIntegrator(*this, fes, Q, true);
+      return;
+   }
+
+   // Assumes tensor-product elements
+   // const FiniteElement &el = *fes.GetBE(0);
+   // ElementTransformation &T = *mesh->GetBdrElementTransformation(0);
+   // const IntegrationRule *ir = IntRule ? IntRule : &GetRule(*el, T);
+   MFEM_ABORT("Error: DivDivIntegrator::AssembleMFBoundary only implemented with"
+              " libCEED");
+}
+
+void DivDivIntegrator::AssembleDiagonalMF(Vector &diag)
+{
+   if (DeviceCanUseCeed())
+   {
+      ceedOp->GetDiagonal(diag);
+   }
+   else
+   {
+      MFEM_ABORT("Error: DivDivIntegrator::AssembleDiagonalMF only"
+                 " implemented with libCEED");
+   }
+}
+
+void DivDivIntegrator::AddMultMF(const Vector &x, Vector &y) const
+{
+   if (DeviceCanUseCeed())
+   {
+      ceedOp->AddMult(x, y);
+   }
+   else
+   {
+      MFEM_ABORT("Error: DivDivIntegrator::AddMultMF only implemented with"
+                 " libCEED");
+   }
+}
+
+}

--- a/fem/integ/bilininteg_divdiv_pa.cpp
+++ b/fem/integ/bilininteg_divdiv_pa.cpp
@@ -12,6 +12,7 @@
 #include "../bilininteg.hpp"
 #include "../gridfunc.hpp"
 #include "../qfunction.hpp"
+#include "../ceed/integrators/divdiv/divdiv.hpp"
 #include "bilininteg_hdiv_kernels.hpp"
 
 namespace mfem
@@ -19,10 +20,17 @@ namespace mfem
 
 void DivDivIntegrator::AssemblePA(const FiniteElementSpace &fes)
 {
-   // Assumes tensor-product elements
    Mesh *mesh = fes.GetMesh();
-   const FiniteElement *fel = fes.GetFE(0);
+   if (mesh->GetNE() == 0) { return; }
+   if (DeviceCanUseCeed())
+   {
+      delete ceedOp;
+      ceedOp = new ceed::PADivDivIntegrator(*this, fes, Q);
+      return;
+   }
 
+   // Assumes tensor-product elements
+   const FiniteElement *fel = fes.GetFE(0);
    const VectorTensorFiniteElement *el =
       dynamic_cast<const VectorTensorFiniteElement*>(fel);
    MFEM_VERIFY(el != NULL, "Only VectorTensorFiniteElement is supported!");
@@ -30,20 +38,16 @@ void DivDivIntegrator::AssemblePA(const FiniteElementSpace &fes)
    const IntegrationRule *ir = IntRule ? IntRule : &GetRule(*el, T);
    const int dims = el->GetDim();
    MFEM_VERIFY(dims == 2 || dims == 3, "");
-
    const int nq = ir->GetNPoints();
    dim = mesh->Dimension();
    MFEM_VERIFY(dim == 2 || dim == 3, "");
-
    ne = fes.GetNE();
    geom = mesh->GetGeometricFactors(*ir, GeometricFactors::JACOBIANS);
    mapsC = &el->GetDofToQuad(*ir, DofToQuad::TENSOR);
    mapsO = &el->GetDofToQuadOpen(*ir, DofToQuad::TENSOR);
    dofs1D = mapsC->ndof;
    quad1D = mapsC->nqpt;
-
    MFEM_VERIFY(dofs1D == mapsO->ndof + 1 && quad1D == mapsO->nqpt, "");
-
    pa_data.SetSize(nq * ne, Device::GetMemoryType());
 
    QuadratureSpace qs(*mesh, *ir);
@@ -65,31 +69,72 @@ void DivDivIntegrator::AssemblePA(const FiniteElementSpace &fes)
    }
 }
 
-void DivDivIntegrator::AssembleDiagonalPA(Vector& diag)
+void DivDivIntegrator::AssemblePABoundary(const FiniteElementSpace &fes)
 {
-   if (dim == 3)
+   Mesh *mesh = fes.GetMesh();
+   if (mesh->GetNBE() == 0) { return; }
+   if (DeviceCanUseCeed())
    {
-      internal::PADivDivAssembleDiagonal3D(dofs1D, quad1D, ne,
-                                           mapsO->B, mapsC->G, pa_data, diag);
+      delete ceedOp;
+      ceedOp = new ceed::PADivDivIntegrator(*this, fes, Q, true);
+      return;
+   }
+
+   // Assumes tensor-product elements
+   // const FiniteElement &el = *fes.GetBE(0);
+   // ElementTransformation &T = *mesh->GetBdrElementTransformation(0);
+   // const IntegrationRule *ir = IntRule ? IntRule : &GetRule(*el, T);
+   MFEM_ABORT("Error: DivDivIntegrator::AssemblePABoundary only implemented with"
+              " libCEED");
+}
+
+void DivDivIntegrator::AssembleDiagonalPA(Vector &diag)
+{
+   if (DeviceCanUseCeed())
+   {
+      ceedOp->GetDiagonal(diag);
    }
    else
    {
-      internal::PADivDivAssembleDiagonal2D(dofs1D, quad1D, ne,
-                                           mapsO->B, mapsC->G, pa_data, diag);
+      if (dim == 3)
+      {
+         internal::PADivDivAssembleDiagonal3D(dofs1D, quad1D, ne,
+                                              mapsO->B, mapsC->G, pa_data, diag);
+      }
+      else if (dim == 2)
+      {
+         internal::PADivDivAssembleDiagonal2D(dofs1D, quad1D, ne,
+                                              mapsO->B, mapsC->G, pa_data, diag);
+      }
+      else
+      {
+         MFEM_ABORT("Unsupported dimension!");
+      }
    }
 }
 
 void DivDivIntegrator::AddMultPA(const Vector &x, Vector &y) const
 {
-   if (dim == 3)
-      internal::PADivDivApply3D(dofs1D, quad1D, ne, mapsO->B, mapsC->G,
-                                mapsO->Bt, mapsC->Gt, pa_data, x, y);
-   else if (dim == 2)
-      internal::PADivDivApply2D(dofs1D, quad1D, ne, mapsO->B, mapsC->G,
-                                mapsO->Bt, mapsC->Gt, pa_data, x, y);
+   if (DeviceCanUseCeed())
+   {
+      ceedOp->AddMult(x, y);
+   }
    else
    {
-      MFEM_ABORT("Unsupported dimension!");
+      if (dim == 3)
+      {
+         internal::PADivDivApply3D(dofs1D, quad1D, ne, mapsO->B, mapsC->G,
+                                   mapsO->Bt, mapsC->Gt, pa_data, x, y);
+      }
+      else if (dim == 2)
+      {
+         internal::PADivDivApply2D(dofs1D, quad1D, ne, mapsO->B, mapsC->G,
+                                   mapsO->Bt, mapsC->Gt, pa_data, x, y);
+      }
+      else
+      {
+         MFEM_ABORT("Unsupported dimension!");
+      }
    }
 }
 

--- a/fem/integ/bilininteg_mixedcurl_mf.cpp
+++ b/fem/integ/bilininteg_mixedcurl_mf.cpp
@@ -1,0 +1,172 @@
+// Copyright (c) 2010-2023, Lawrence Livermore National Security, LLC. Produced
+// at the Lawrence Livermore National Laboratory. All Rights reserved. See files
+// LICENSE and NOTICE for details. LLNL-CODE-806117.
+//
+// This file is part of the MFEM library. For more information and source code
+// availability visit https://mfem.org.
+//
+// MFEM is free software; you can redistribute it and/or modify it under the
+// terms of the BSD-3 license. We welcome feedback and contributions, see file
+// CONTRIBUTING.md for details.
+
+#include "../bilininteg.hpp"
+#include "../gridfunc.hpp"
+#include "../ceed/integrators/mixedveccurl/mixedveccurl.hpp"
+
+namespace mfem
+{
+
+void MixedVectorCurlIntegrator::AssembleMF(const FiniteElementSpace &trial_fes,
+                                           const FiniteElementSpace &test_fes)
+{
+   Mesh *mesh = trial_fes.GetMesh();
+   if (mesh->GetNE() == 0) { return; }
+   if (DeviceCanUseCeed())
+   {
+      delete ceedOp;
+      if (MQ)
+      {
+         ceedOp = new ceed::MFMixedVectorCurlIntegrator(*this, trial_fes,
+                                                        test_fes, MQ);
+      }
+      else if (VQ)
+      {
+         ceedOp = new ceed::MFMixedVectorCurlIntegrator(*this, trial_fes,
+                                                        test_fes, VQ);
+      }
+      else
+      {
+         ceedOp = new ceed::MFMixedVectorCurlIntegrator(*this, trial_fes,
+                                                        test_fes, Q);
+      }
+      return;
+   }
+
+   // Assuming the same element type
+   MFEM_ABORT("Error: MixedVectorCurlIntegrator::AssembleMF only implemented with"
+              " libCEED");
+}
+
+void MixedVectorCurlIntegrator::AssembleMFBoundary(
+   const FiniteElementSpace &trial_fes,
+   const FiniteElementSpace &test_fes)
+{
+   Mesh *mesh = trial_fes.GetMesh();
+   if (mesh->GetNBE() == 0) { return; }
+   if (DeviceCanUseCeed())
+   {
+      delete ceedOp;
+      if (MQ)
+      {
+         ceedOp = new ceed::MFMixedVectorCurlIntegrator(*this, trial_fes,
+                                                        test_fes, MQ, true);
+      }
+      else if (VQ)
+      {
+         ceedOp = new ceed::MFMixedVectorCurlIntegrator(*this, trial_fes,
+                                                        test_fes, VQ, true);
+      }
+      else
+      {
+         ceedOp = new ceed::MFMixedVectorCurlIntegrator(*this, trial_fes,
+                                                        test_fes, Q, true);
+      }
+      return;
+   }
+
+   // Assuming the same element type
+   MFEM_ABORT("Error: MixedVectorCurlIntegrator::AssembleMFBoundary only implemented with"
+              " libCEED");
+}
+
+void MixedVectorCurlIntegrator::AddMultMF(const Vector &x, Vector &y) const
+{
+   if (DeviceCanUseCeed())
+   {
+      ceedOp->AddMult(x, y);
+   }
+   else
+   {
+      MFEM_ABORT("Error: MixedVectorCurlIntegrator::AddMultMF only"
+                 " implemented with libCEED");
+   }
+}
+
+void MixedVectorWeakCurlIntegrator::AssembleMF(
+   const FiniteElementSpace &trial_fes,
+   const FiniteElementSpace &test_fes)
+{
+   Mesh *mesh = trial_fes.GetMesh();
+   if (mesh->GetNE() == 0) { return; }
+   if (DeviceCanUseCeed())
+   {
+      delete ceedOp;
+      if (MQ)
+      {
+         ceedOp = new ceed::MFMixedVectorWeakCurlIntegrator(*this, trial_fes,
+                                                            test_fes, MQ);
+      }
+      else if (VQ)
+      {
+         ceedOp = new ceed::MFMixedVectorWeakCurlIntegrator(*this, trial_fes,
+                                                            test_fes, VQ);
+      }
+      else
+      {
+         ceedOp = new ceed::MFMixedVectorWeakCurlIntegrator(*this, trial_fes,
+                                                            test_fes, Q);
+      }
+      return;
+   }
+
+   // Assuming the same element type
+   MFEM_ABORT("Error: MixedVectorWeakCurlIntegrator::AssembleMF only"
+              " implemented with libCEED");
+}
+
+void MixedVectorWeakCurlIntegrator::AssembleMFBoundary(
+   const FiniteElementSpace &trial_fes,
+   const FiniteElementSpace &test_fes)
+{
+   Mesh *mesh = trial_fes.GetMesh();
+   if (mesh->GetNBE() == 0) { return; }
+   if (DeviceCanUseCeed())
+   {
+      delete ceedOp;
+      if (MQ)
+      {
+         ceedOp = new ceed::MFMixedVectorWeakCurlIntegrator(*this, trial_fes,
+                                                            test_fes, MQ, true);
+      }
+      else if (VQ)
+      {
+         ceedOp = new ceed::MFMixedVectorWeakCurlIntegrator(*this, trial_fes,
+                                                            test_fes, VQ, true);
+      }
+      else
+      {
+         ceedOp = new ceed::MFMixedVectorWeakCurlIntegrator(*this, trial_fes,
+                                                            test_fes, Q, true);
+      }
+      return;
+   }
+
+   // Assuming the same element type
+   MFEM_ABORT("Error: MixedVectorWeakCurlIntegrator::AssembleMFBoundary only"
+              " implemented with libCEED");
+}
+
+void MixedVectorWeakCurlIntegrator::AddMultMF(const Vector &x, Vector &y) const
+{
+   if (DeviceCanUseCeed())
+   {
+      ceedOp->AddMult(x, y);
+   }
+   else
+   {
+      MFEM_ABORT("Error: MixedVectorWeakCurlIntegrator::AddMultMF only"
+                 " implemented with libCEED");
+   }
+}
+
+} // namespace mfem

--- a/fem/integ/bilininteg_mixedcurl_mf.cpp
+++ b/fem/integ/bilininteg_mixedcurl_mf.cpp
@@ -29,10 +29,10 @@ void MixedVectorCurlIntegrator::AssembleMF(const FiniteElementSpace &trial_fes,
          ceedOp = new ceed::MFMixedVectorCurlIntegrator(*this, trial_fes,
                                                         test_fes, MQ);
       }
-      else if (VQ)
+      else if (DQ)
       {
          ceedOp = new ceed::MFMixedVectorCurlIntegrator(*this, trial_fes,
-                                                        test_fes, VQ);
+                                                        test_fes, DQ);
       }
       else
       {
@@ -44,38 +44,6 @@ void MixedVectorCurlIntegrator::AssembleMF(const FiniteElementSpace &trial_fes,
 
    // Assuming the same element type
    MFEM_ABORT("Error: MixedVectorCurlIntegrator::AssembleMF only implemented with"
-              " libCEED");
-}
-
-void MixedVectorCurlIntegrator::AssembleMFBoundary(
-   const FiniteElementSpace &trial_fes,
-   const FiniteElementSpace &test_fes)
-{
-   Mesh *mesh = trial_fes.GetMesh();
-   if (mesh->GetNBE() == 0) { return; }
-   if (DeviceCanUseCeed())
-   {
-      delete ceedOp;
-      if (MQ)
-      {
-         ceedOp = new ceed::MFMixedVectorCurlIntegrator(*this, trial_fes,
-                                                        test_fes, MQ, true);
-      }
-      else if (VQ)
-      {
-         ceedOp = new ceed::MFMixedVectorCurlIntegrator(*this, trial_fes,
-                                                        test_fes, VQ, true);
-      }
-      else
-      {
-         ceedOp = new ceed::MFMixedVectorCurlIntegrator(*this, trial_fes,
-                                                        test_fes, Q, true);
-      }
-      return;
-   }
-
-   // Assuming the same element type
-   MFEM_ABORT("Error: MixedVectorCurlIntegrator::AssembleMFBoundary only implemented with"
               " libCEED");
 }
 
@@ -106,10 +74,10 @@ void MixedVectorWeakCurlIntegrator::AssembleMF(
          ceedOp = new ceed::MFMixedVectorWeakCurlIntegrator(*this, trial_fes,
                                                             test_fes, MQ);
       }
-      else if (VQ)
+      else if (DQ)
       {
          ceedOp = new ceed::MFMixedVectorWeakCurlIntegrator(*this, trial_fes,
-                                                            test_fes, VQ);
+                                                            test_fes, DQ);
       }
       else
       {
@@ -121,38 +89,6 @@ void MixedVectorWeakCurlIntegrator::AssembleMF(
 
    // Assuming the same element type
    MFEM_ABORT("Error: MixedVectorWeakCurlIntegrator::AssembleMF only"
-              " implemented with libCEED");
-}
-
-void MixedVectorWeakCurlIntegrator::AssembleMFBoundary(
-   const FiniteElementSpace &trial_fes,
-   const FiniteElementSpace &test_fes)
-{
-   Mesh *mesh = trial_fes.GetMesh();
-   if (mesh->GetNBE() == 0) { return; }
-   if (DeviceCanUseCeed())
-   {
-      delete ceedOp;
-      if (MQ)
-      {
-         ceedOp = new ceed::MFMixedVectorWeakCurlIntegrator(*this, trial_fes,
-                                                            test_fes, MQ, true);
-      }
-      else if (VQ)
-      {
-         ceedOp = new ceed::MFMixedVectorWeakCurlIntegrator(*this, trial_fes,
-                                                            test_fes, VQ, true);
-      }
-      else
-      {
-         ceedOp = new ceed::MFMixedVectorWeakCurlIntegrator(*this, trial_fes,
-                                                            test_fes, Q, true);
-      }
-      return;
-   }
-
-   // Assuming the same element type
-   MFEM_ABORT("Error: MixedVectorWeakCurlIntegrator::AssembleMFBoundary only"
               " implemented with libCEED");
 }
 

--- a/fem/integ/bilininteg_mixedcurl_pa.cpp
+++ b/fem/integ/bilininteg_mixedcurl_pa.cpp
@@ -120,10 +120,10 @@ void MixedVectorCurlIntegrator::AssemblePA(const FiniteElementSpace &trial_fes,
          ceedOp = new ceed::PAMixedVectorCurlIntegrator(*this, trial_fes,
                                                         test_fes, MQ);
       }
-      else if (VQ)
+      else if (DQ)
       {
          ceedOp = new ceed::PAMixedVectorCurlIntegrator(*this, trial_fes,
-                                                        test_fes, VQ);
+                                                        test_fes, DQ);
       }
       else
       {
@@ -212,38 +212,6 @@ void MixedVectorCurlIntegrator::AssemblePA(const FiniteElementSpace &trial_fes,
    {
       MFEM_ABORT("Unknown kernel.");
    }
-}
-
-void MixedVectorCurlIntegrator::AssemblePABoundary(
-   const FiniteElementSpace &trial_fes,
-   const FiniteElementSpace &test_fes)
-{
-   Mesh *mesh = trial_fes.GetMesh();
-   if (mesh->GetNBE() == 0) { return; }
-   if (DeviceCanUseCeed())
-   {
-      delete ceedOp;
-      if (MQ)
-      {
-         ceedOp = new ceed::PAMixedVectorCurlIntegrator(*this, trial_fes,
-                                                        test_fes, MQ, true);
-      }
-      else if (VQ)
-      {
-         ceedOp = new ceed::PAMixedVectorCurlIntegrator(*this, trial_fes,
-                                                        test_fes, VQ, true);
-      }
-      else
-      {
-         ceedOp = new ceed::PAMixedVectorCurlIntegrator(*this, trial_fes,
-                                                        test_fes, Q, true);
-      }
-      return;
-   }
-
-   // Assuming the same element type
-   MFEM_ABORT("Error: MixedVectorCurlIntegrator::AssemblePABoundary only"
-              " implemented with libCEED");
 }
 
 void MixedVectorCurlIntegrator::AddMultPA(const Vector &x, Vector &y) const
@@ -349,10 +317,10 @@ void MixedVectorWeakCurlIntegrator::AssemblePA(const FiniteElementSpace
          ceedOp = new ceed::PAMixedVectorWeakCurlIntegrator(*this, trial_fes,
                                                             test_fes, MQ);
       }
-      else if (VQ)
+      else if (DQ)
       {
          ceedOp = new ceed::PAMixedVectorWeakCurlIntegrator(*this, trial_fes,
-                                                            test_fes, VQ);
+                                                            test_fes, DQ);
       }
       else
       {
@@ -437,38 +405,6 @@ void MixedVectorWeakCurlIntegrator::AssemblePA(const FiniteElementSpace
    {
       MFEM_ABORT("Unknown kernel.");
    }
-}
-
-void MixedVectorWeakCurlIntegrator::AssemblePABoundary(
-   const FiniteElementSpace &trial_fes,
-   const FiniteElementSpace &test_fes)
-{
-   Mesh *mesh = trial_fes.GetMesh();
-   if (mesh->GetNBE() == 0) { return; }
-   if (DeviceCanUseCeed())
-   {
-      delete ceedOp;
-      if (MQ)
-      {
-         ceedOp = new ceed::PAMixedVectorWeakCurlIntegrator(*this, trial_fes,
-                                                            test_fes, MQ, true);
-      }
-      else if (VQ)
-      {
-         ceedOp = new ceed::PAMixedVectorWeakCurlIntegrator(*this, trial_fes,
-                                                            test_fes, VQ, true);
-      }
-      else
-      {
-         ceedOp = new ceed::PAMixedVectorWeakCurlIntegrator(*this, trial_fes,
-                                                            test_fes, Q, true);
-      }
-      return;
-   }
-
-   // Assuming the same element type
-   MFEM_ABORT("Error: MixedVectorWeakCurlIntegrator::AssemblePABoundary only"
-              " implemented with libCEED");
 }
 
 void MixedVectorWeakCurlIntegrator::AddMultPA(const Vector &x, Vector &y) const

--- a/fem/integ/bilininteg_mixedvecgrad_mf.cpp
+++ b/fem/integ/bilininteg_mixedvecgrad_mf.cpp
@@ -1,0 +1,174 @@
+// Copyright (c) 2010-2023, Lawrence Livermore National Security, LLC. Produced
+// at the Lawrence Livermore National Laboratory. All Rights reserved. See files
+// LICENSE and NOTICE for details. LLNL-CODE-806117.
+//
+// This file is part of the MFEM library. For more information and source code
+// availability visit https://mfem.org.
+//
+// MFEM is free software; you can redistribute it and/or modify it under the
+// terms of the BSD-3 license. We welcome feedback and contributions, see file
+// CONTRIBUTING.md for details.
+
+#include "../bilininteg.hpp"
+#include "../gridfunc.hpp"
+#include "../ceed/integrators/mixedvecgrad/mixedvecgrad.hpp"
+
+namespace mfem
+{
+
+void MixedVectorGradientIntegrator::AssembleMF(
+   const FiniteElementSpace &trial_fes,
+   const FiniteElementSpace &test_fes)
+{
+   Mesh *mesh = trial_fes.GetMesh();
+   if (mesh->GetNE() == 0) { return; }
+   if (DeviceCanUseCeed())
+   {
+      delete ceedOp;
+      if (MQ)
+      {
+         ceedOp = new ceed::MFMixedVectorGradientIntegrator(*this, trial_fes,
+                                                            test_fes, MQ);
+      }
+      else if (VQ)
+      {
+         ceedOp = new ceed::MFMixedVectorGradientIntegrator(*this, trial_fes,
+                                                            test_fes, VQ);
+      }
+      else
+      {
+         ceedOp = new ceed::MFMixedVectorGradientIntegrator(*this, trial_fes,
+                                                            test_fes, Q);
+      }
+      return;
+   }
+
+   // Assuming the same element type
+   MFEM_ABORT("Error: MixedVectorGradientIntegrator::AssembleMF only"
+              " implemented with libCEED");
+}
+
+void MixedVectorGradientIntegrator::AssembleMFBoundary(
+   const FiniteElementSpace &trial_fes,
+   const FiniteElementSpace &test_fes)
+{
+   Mesh *mesh = trial_fes.GetMesh();
+   if (mesh->GetNBE() == 0) { return; }
+   if (DeviceCanUseCeed())
+   {
+      delete ceedOp;
+      if (MQ)
+      {
+         ceedOp = new ceed::MFMixedVectorGradientIntegrator(*this, trial_fes,
+                                                            test_fes, MQ, true);
+      }
+      else if (VQ)
+      {
+         ceedOp = new ceed::MFMixedVectorGradientIntegrator(*this, trial_fes,
+                                                            test_fes, VQ, true);
+      }
+      else
+      {
+         ceedOp = new ceed::MFMixedVectorGradientIntegrator(*this, trial_fes,
+                                                            test_fes, Q, true);
+      }
+      return;
+   }
+
+   // Assuming the same element type
+   MFEM_ABORT("Error: MixedVectorGradientIntegrator::AssembleMFBoundary only"
+              " implemented with libCEED");
+}
+
+void MixedVectorGradientIntegrator::AddMultMF(const Vector &x, Vector &y) const
+{
+   if (DeviceCanUseCeed())
+   {
+      ceedOp->AddMult(x, y);
+   }
+   else
+   {
+      MFEM_ABORT("Error: MixedVectorGradientIntegrator::AddMultMF only"
+                 " implemented with libCEED");
+   }
+}
+
+void MixedVectorWeakDivergenceIntegrator::AssembleMF(
+   const FiniteElementSpace &trial_fes,
+   const FiniteElementSpace &test_fes)
+{
+   Mesh *mesh = trial_fes.GetMesh();
+   if (mesh->GetNE() == 0) { return; }
+   if (DeviceCanUseCeed())
+   {
+      delete ceedOp;
+      if (MQ)
+      {
+         ceedOp = new ceed::MFMixedVectorWeakDivergenceIntegrator(*this, trial_fes,
+                                                                  test_fes, MQ);
+      }
+      else if (VQ)
+      {
+         ceedOp = new ceed::MFMixedVectorWeakDivergenceIntegrator(*this, trial_fes,
+                                                                  test_fes, VQ);
+      }
+      else
+      {
+         ceedOp = new ceed::MFMixedVectorWeakDivergenceIntegrator(*this, trial_fes,
+                                                                  test_fes, Q);
+      }
+      return;
+   }
+
+   // Assuming the same element type
+   MFEM_ABORT("Error: MixedVectorWeakDivergenceIntegrator::AssembleMF only"
+              " implemented with libCEED");
+}
+
+void MixedVectorWeakDivergenceIntegrator::AssembleMFBoundary(
+   const FiniteElementSpace &trial_fes,
+   const FiniteElementSpace &test_fes)
+{
+   Mesh *mesh = trial_fes.GetMesh();
+   if (mesh->GetNBE() == 0) { return; }
+   if (DeviceCanUseCeed())
+   {
+      delete ceedOp;
+      if (MQ)
+      {
+         ceedOp = new ceed::MFMixedVectorWeakDivergenceIntegrator(*this, trial_fes,
+                                                                  test_fes, MQ, true);
+      }
+      else if (VQ)
+      {
+         ceedOp = new ceed::MFMixedVectorWeakDivergenceIntegrator(*this, trial_fes,
+                                                                  test_fes, VQ, true);
+      }
+      else
+      {
+         ceedOp = new ceed::MFMixedVectorWeakDivergenceIntegrator(*this, trial_fes,
+                                                                  test_fes, Q, true);
+      }
+      return;
+   }
+
+   // Assuming the same element type
+   MFEM_ABORT("Error: MixedVectorWeakDivergenceIntegrator::AssembleMFBoundary only"
+              " implemented with libCEED");
+}
+
+void MixedVectorWeakDivergenceIntegrator::AddMultMF(const Vector &x,
+                                                    Vector &y) const
+{
+   if (DeviceCanUseCeed())
+   {
+      ceedOp->AddMult(x, y);
+   }
+   else
+   {
+      MFEM_ABORT("Error: MixedVectorWeakDivergenceIntegrator::AddMultMF only"
+                 " implemented with libCEED");
+   }
+}
+
+} // namespace mfem

--- a/fem/integ/bilininteg_mixedvecgrad_mf.cpp
+++ b/fem/integ/bilininteg_mixedvecgrad_mf.cpp
@@ -30,10 +30,10 @@ void MixedVectorGradientIntegrator::AssembleMF(
          ceedOp = new ceed::MFMixedVectorGradientIntegrator(*this, trial_fes,
                                                             test_fes, MQ);
       }
-      else if (VQ)
+      else if (DQ)
       {
          ceedOp = new ceed::MFMixedVectorGradientIntegrator(*this, trial_fes,
-                                                            test_fes, VQ);
+                                                            test_fes, DQ);
       }
       else
       {
@@ -62,10 +62,10 @@ void MixedVectorGradientIntegrator::AssembleMFBoundary(
          ceedOp = new ceed::MFMixedVectorGradientIntegrator(*this, trial_fes,
                                                             test_fes, MQ, true);
       }
-      else if (VQ)
+      else if (DQ)
       {
          ceedOp = new ceed::MFMixedVectorGradientIntegrator(*this, trial_fes,
-                                                            test_fes, VQ, true);
+                                                            test_fes, DQ, true);
       }
       else
       {
@@ -107,10 +107,10 @@ void MixedVectorWeakDivergenceIntegrator::AssembleMF(
          ceedOp = new ceed::MFMixedVectorWeakDivergenceIntegrator(*this, trial_fes,
                                                                   test_fes, MQ);
       }
-      else if (VQ)
+      else if (DQ)
       {
          ceedOp = new ceed::MFMixedVectorWeakDivergenceIntegrator(*this, trial_fes,
-                                                                  test_fes, VQ);
+                                                                  test_fes, DQ);
       }
       else
       {
@@ -139,10 +139,10 @@ void MixedVectorWeakDivergenceIntegrator::AssembleMFBoundary(
          ceedOp = new ceed::MFMixedVectorWeakDivergenceIntegrator(*this, trial_fes,
                                                                   test_fes, MQ, true);
       }
-      else if (VQ)
+      else if (DQ)
       {
          ceedOp = new ceed::MFMixedVectorWeakDivergenceIntegrator(*this, trial_fes,
-                                                                  test_fes, VQ, true);
+                                                                  test_fes, DQ, true);
       }
       else
       {

--- a/fem/integ/bilininteg_mixedvecgrad_pa.cpp
+++ b/fem/integ/bilininteg_mixedvecgrad_pa.cpp
@@ -33,10 +33,10 @@ void MixedVectorGradientIntegrator::AssemblePA(
          ceedOp = new ceed::PAMixedVectorGradientIntegrator(*this, trial_fes,
                                                             test_fes, MQ);
       }
-      else if (VQ)
+      else if (DQ)
       {
          ceedOp = new ceed::PAMixedVectorGradientIntegrator(*this, trial_fes,
-                                                            test_fes, VQ);
+                                                            test_fes, DQ);
       }
       else
       {
@@ -117,10 +117,10 @@ void MixedVectorGradientIntegrator::AssemblePABoundary(
          ceedOp = new ceed::PAMixedVectorGradientIntegrator(*this, trial_fes,
                                                             test_fes, MQ, true);
       }
-      else if (VQ)
+      else if (DQ)
       {
          ceedOp = new ceed::PAMixedVectorGradientIntegrator(*this, trial_fes,
-                                                            test_fes, VQ, true);
+                                                            test_fes, DQ, true);
       }
       else
       {
@@ -839,10 +839,10 @@ void MixedVectorWeakDivergenceIntegrator::AssemblePA(
          ceedOp = new ceed::PAMixedVectorWeakDivergenceIntegrator(*this, trial_fes,
                                                                   test_fes, MQ);
       }
-      else if (VQ)
+      else if (DQ)
       {
          ceedOp = new ceed::PAMixedVectorWeakDivergenceIntegrator(*this, trial_fes,
-                                                                  test_fes, VQ);
+                                                                  test_fes, DQ);
       }
       else
       {
@@ -871,10 +871,10 @@ void MixedVectorWeakDivergenceIntegrator::AssemblePABoundary(
          ceedOp = new ceed::PAMixedVectorWeakDivergenceIntegrator(*this, trial_fes,
                                                                   test_fes, MQ, true);
       }
-      else if (VQ)
+      else if (DQ)
       {
          ceedOp = new ceed::PAMixedVectorWeakDivergenceIntegrator(*this, trial_fes,
-                                                                  test_fes, VQ, true);
+                                                                  test_fes, DQ, true);
       }
       else
       {

--- a/fem/integ/bilininteg_vectorfemass_mf.cpp
+++ b/fem/integ/bilininteg_vectorfemass_mf.cpp
@@ -1,0 +1,89 @@
+// Copyright (c) 2010-2023, Lawrence Livermore National Security, LLC. Produced
+// at the Lawrence Livermore National Laboratory. All Rights reserved. See files
+// LICENSE and NOTICE for details. LLNL-CODE-806117.
+//
+// This file is part of the MFEM library. For more information and source code
+// availability visit https://mfem.org.
+//
+// MFEM is free software; you can redistribute it and/or modify it under the
+// terms of the BSD-3 license. We welcome feedback and contributions, see file
+// CONTRIBUTING.md for details.
+
+#include "../bilininteg.hpp"
+#include "../gridfunc.hpp"
+#include "../ceed/integrators/vecfemass/vecfemass.hpp"
+
+using namespace std;
+
+namespace mfem
+{
+
+void VectorFEMassIntegrator::AssembleMF(const FiniteElementSpace &fes)
+{
+   Mesh *mesh = fes.GetMesh();
+   if (mesh->GetNE() == 0) { return; }
+   if (DeviceCanUseCeed())
+   {
+      delete ceedOp;
+      if (MQ) { ceedOp = new ceed::MFVectorFEMassIntegrator(*this, fes, MQ); }
+      else if (DQ) { ceedOp = new ceed::MFVectorFEMassIntegrator(*this, fes, DQ); }
+      else { ceedOp = new ceed::MFVectorFEMassIntegrator(*this, fes, Q); }
+      return;
+   }
+
+   // Assumes tensor-product elements
+   // const FiniteElement &el = *fes.GetFE(0);
+   // ElementTransformation &T = *mesh->GetElementTransformation(0);
+   // const IntegrationRule *ir = IntRule ? IntRule : &GetRule(el, T);
+   MFEM_ABORT("Error: VectorFEMassIntegrator::AssembleMF only implemented with"
+              " libCEED");
+}
+
+void VectorFEMassIntegrator::AssembleMFBoundary(const FiniteElementSpace &fes)
+{
+   Mesh *mesh = fes.GetMesh();
+   if (mesh->GetNBE() == 0) { return; }
+   if (DeviceCanUseCeed())
+   {
+      delete ceedOp;
+      if (MQ) { ceedOp = new ceed::MFVectorFEMassIntegrator(*this, fes, MQ, true); }
+      else if (DQ) { ceedOp = new ceed::MFVectorFEMassIntegrator(*this, fes, DQ, true); }
+      else { ceedOp = new ceed::MFVectorFEMassIntegrator(*this, fes, Q, true); }
+      return;
+   }
+
+   // Assumes tensor-product elements
+   // const FiniteElement &el = *fes.GetBE(0);
+   // ElementTransformation &T = *mesh->GetBdrElementTransformation(0);
+   // const IntegrationRule *ir = IntRule ? IntRule : &GetRule(el, T);
+   MFEM_ABORT("Error: VectorFEMassIntegrator::AssembleMFBoundary only implemented with"
+              " libCEED");
+}
+
+void VectorFEMassIntegrator::AssembleDiagonalMF(Vector &diag)
+{
+   if (DeviceCanUseCeed())
+   {
+      ceedOp->GetDiagonal(diag);
+   }
+   else
+   {
+      MFEM_ABORT("Error: VectorFEMassIntegrator::AssembleDiagonalMF only"
+                 " implemented with libCEED");
+   }
+}
+
+void VectorFEMassIntegrator::AddMultMF(const Vector &x, Vector &y) const
+{
+   if (DeviceCanUseCeed())
+   {
+      ceedOp->AddMult(x, y);
+   }
+   else
+   {
+      MFEM_ABORT("Error: VectorFEMassIntegrator::AddMultMF only implemented with"
+                 " libCEED");
+   }
+}
+
+}

--- a/fem/integ/bilininteg_vectorfemass_pa.cpp
+++ b/fem/integ/bilininteg_vectorfemass_pa.cpp
@@ -12,6 +12,7 @@
 #include "../bilininteg.hpp"
 #include "../gridfunc.hpp"
 #include "../qfunction.hpp"
+#include "../ceed/integrators/vecfemass/vecfemass.hpp"
 #include "bilininteg_diffusion_kernels.hpp"
 #include "bilininteg_hcurl_kernels.hpp"
 #include "bilininteg_hdiv_kernels.hpp"
@@ -23,29 +24,37 @@ namespace mfem
 void VectorFEMassIntegrator::AssemblePA(const FiniteElementSpace &trial_fes,
                                         const FiniteElementSpace &test_fes)
 {
-   // Assumes tensor-product elements
    Mesh *mesh = trial_fes.GetMesh();
+   if (mesh->GetNE() == 0) { return; }
+   if (DeviceCanUseCeed())
+   {
+      MFEM_VERIFY(&trial_fes == &test_fes,
+                  "VectorFEMassIntegrator with mixed FE spaces is not supported by libCEED!");
+      delete ceedOp;
+      if (MQ) { ceedOp = new ceed::PAVectorFEMassIntegrator(*this, trial_fes, MQ); }
+      else if (DQ) { ceedOp = new ceed::PAVectorFEMassIntegrator(*this, trial_fes, DQ); }
+      else { ceedOp = new ceed::PAVectorFEMassIntegrator(*this, trial_fes, Q); }
+      return;
+   }
 
+   // Assumes tensor-product elements
    const FiniteElement *trial_fel = trial_fes.GetFE(0);
    const VectorTensorFiniteElement *trial_el =
       dynamic_cast<const VectorTensorFiniteElement*>(trial_fel);
    MFEM_VERIFY(trial_el != NULL, "Only VectorTensorFiniteElement is supported!");
-
    const FiniteElement *test_fel = test_fes.GetFE(0);
    const VectorTensorFiniteElement *test_el =
       dynamic_cast<const VectorTensorFiniteElement*>(test_fel);
    MFEM_VERIFY(test_el != NULL, "Only VectorTensorFiniteElement is supported!");
    ElementTransformation &T = *mesh->GetElementTransformation(0);
-   const IntegrationRule *ir = IntRule ? IntRule : &GetRule(*trial_el, *trial_el,
+   const IntegrationRule *ir = IntRule ? IntRule : &GetRule(*trial_el, *test_el,
                                                             T);
    const int dims = trial_el->GetDim();
    MFEM_VERIFY(dims == 2 || dims == 3, "");
-
    const int symmDims = (dims * (dims + 1)) / 2; // 1x1: 1, 2x2: 3, 3x3: 6
    nq = ir->GetNPoints();
    dim = mesh->Dimension();
    MFEM_VERIFY(dim == 2 || dim == 3, "");
-
    ne = trial_fes.GetNE();
    MFEM_VERIFY(ne == test_fes.GetNE(),
                "Different meshes for test and trial spaces");
@@ -54,13 +63,10 @@ void VectorFEMassIntegrator::AssemblePA(const FiniteElementSpace &trial_fes,
    mapsO = &trial_el->GetDofToQuadOpen(*ir, DofToQuad::TENSOR);
    dofs1D = mapsC->ndof;
    quad1D = mapsC->nqpt;
-
    mapsCtest = &test_el->GetDofToQuad(*ir, DofToQuad::TENSOR);
    mapsOtest = &test_el->GetDofToQuadOpen(*ir, DofToQuad::TENSOR);
    dofs1Dtest = mapsCtest->ndof;
-
    MFEM_VERIFY(dofs1D == mapsO->ndof + 1 && quad1D == mapsO->nqpt, "");
-
    trial_fetype = trial_el->GetDerivType();
    test_fetype = test_el->GetDerivType();
 
@@ -71,6 +77,7 @@ void VectorFEMassIntegrator::AssemblePA(const FiniteElementSpace &trial_fes,
 
    QuadratureSpace qs(*mesh, *ir);
    CoefficientVector coeff(qs, CoefficientStorage::SYMMETRIC);
+
    if (Q) { coeff.Project(*Q); }
    else if (MQ) { coeff.ProjectTranspose(*MQ); }
    else if (DQ) { coeff.Project(*DQ); }
@@ -137,172 +144,206 @@ void VectorFEMassIntegrator::AssemblePA(const FiniteElementSpace &trial_fes,
    }
 }
 
-void VectorFEMassIntegrator::AssembleDiagonalPA(Vector& diag)
+void VectorFEMassIntegrator::AssemblePABoundary(const FiniteElementSpace &fes)
 {
-   if (dim == 3)
+   Mesh *mesh = fes.GetMesh();
+   if (mesh->GetNBE() == 0) { return; }
+   if (DeviceCanUseCeed())
    {
-      if (trial_fetype == mfem::FiniteElement::CURL && test_fetype == trial_fetype)
+      delete ceedOp;
+      if (MQ) { ceedOp = new ceed::PAVectorFEMassIntegrator(*this, fes, MQ, true); }
+      else if (DQ) { ceedOp = new ceed::PAVectorFEMassIntegrator(*this, fes, DQ, true); }
+      else { ceedOp = new ceed::PAVectorFEMassIntegrator(*this, fes, Q, true); }
+      return;
+   }
+
+   // Assuming the same element type
+   // const FiniteElement &el = *fes.GetBE(0);
+   // ElementTransformation &T = *mesh->GetBdrElementTransformation(0);
+   // const IntegrationRule *ir = IntRule ? IntRule : &GetRule(el, T);
+   MFEM_ABORT("Error: VectorFEMassIntegrator::AssemblePABoundary only implemented with"
+              " libCEED");
+}
+
+void VectorFEMassIntegrator::AssembleDiagonalPA(Vector &diag)
+{
+   if (DeviceCanUseCeed())
+   {
+      ceedOp->GetDiagonal(diag);
+   }
+   else
+   {
+      if (dim == 3)
       {
-         if (Device::Allows(Backend::DEVICE_MASK))
+         if (trial_fetype == mfem::FiniteElement::CURL && test_fetype == trial_fetype)
          {
-            const int ID = (dofs1D << 4) | quad1D;
-            switch (ID)
+            if (Device::Allows(Backend::DEVICE_MASK))
             {
-               case 0x23:
-                  return internal::SmemPAHcurlMassAssembleDiagonal3D<2,3>(
-                            dofs1D, quad1D, ne, symmetric,
-                            mapsO->B, mapsC->B, pa_data, diag);
-               case 0x34:
-                  return internal::SmemPAHcurlMassAssembleDiagonal3D<3,4>(
-                            dofs1D, quad1D, ne, symmetric,
-                            mapsO->B, mapsC->B, pa_data, diag);
-               case 0x45:
-                  return internal::SmemPAHcurlMassAssembleDiagonal3D<4,5>(
-                            dofs1D, quad1D, ne, symmetric,
-                            mapsO->B, mapsC->B, pa_data, diag);
-               case 0x56:
-                  return internal::SmemPAHcurlMassAssembleDiagonal3D<5,6>(
-                            dofs1D, quad1D, ne, symmetric,
-                            mapsO->B, mapsC->B, pa_data, diag);
-               default:
-                  return internal::SmemPAHcurlMassAssembleDiagonal3D(
-                            dofs1D, quad1D, ne, symmetric,
-                            mapsO->B, mapsC->B, pa_data, diag);
+               const int ID = (dofs1D << 4) | quad1D;
+               switch (ID)
+               {
+                  case 0x23:
+                     return internal::SmemPAHcurlMassAssembleDiagonal3D<2,3>(
+                               dofs1D, quad1D, ne, symmetric,
+                               mapsO->B, mapsC->B, pa_data, diag);
+                  case 0x34:
+                     return internal::SmemPAHcurlMassAssembleDiagonal3D<3,4>(
+                               dofs1D, quad1D, ne, symmetric,
+                               mapsO->B, mapsC->B, pa_data, diag);
+                  case 0x45:
+                     return internal::SmemPAHcurlMassAssembleDiagonal3D<4,5>(
+                               dofs1D, quad1D, ne, symmetric,
+                               mapsO->B, mapsC->B, pa_data, diag);
+                  case 0x56:
+                     return internal::SmemPAHcurlMassAssembleDiagonal3D<5,6>(
+                               dofs1D, quad1D, ne, symmetric,
+                               mapsO->B, mapsC->B, pa_data, diag);
+                  default:
+                     return internal::SmemPAHcurlMassAssembleDiagonal3D(
+                               dofs1D, quad1D, ne, symmetric,
+                               mapsO->B, mapsC->B, pa_data, diag);
+               }
             }
+            else
+            {
+               internal::PAHcurlMassAssembleDiagonal3D(dofs1D, quad1D, ne, symmetric,
+                                                       mapsO->B, mapsC->B, pa_data, diag);
+            }
+         }
+         else if (trial_fetype == mfem::FiniteElement::DIV &&
+                  test_fetype == trial_fetype)
+         {
+            internal::PAHdivMassAssembleDiagonal3D(dofs1D, quad1D, ne, symmetric,
+                                                   mapsO->B, mapsC->B, pa_data, diag);
          }
          else
          {
-            internal::PAHcurlMassAssembleDiagonal3D(dofs1D, quad1D, ne, symmetric,
-                                                    mapsO->B, mapsC->B, pa_data, diag);
+            MFEM_ABORT("Unknown kernel.");
          }
       }
-      else if (trial_fetype == mfem::FiniteElement::DIV &&
-               test_fetype == trial_fetype)
+      else // 2D
       {
-         internal::PAHdivMassAssembleDiagonal3D(dofs1D, quad1D, ne, symmetric,
-                                                mapsO->B, mapsC->B, pa_data, diag);
-      }
-      else
-      {
-         MFEM_ABORT("Unknown kernel.");
-      }
-   }
-   else // 2D
-   {
-      if (trial_fetype == mfem::FiniteElement::CURL && test_fetype == trial_fetype)
-      {
-         internal::PAHcurlMassAssembleDiagonal2D(dofs1D, quad1D, ne, symmetric,
-                                                 mapsO->B, mapsC->B, pa_data, diag);
-      }
-      else if (trial_fetype == mfem::FiniteElement::DIV &&
-               test_fetype == trial_fetype)
-      {
-         internal::PAHdivMassAssembleDiagonal2D(dofs1D, quad1D, ne, symmetric,
-                                                mapsO->B, mapsC->B, pa_data, diag);
-      }
-      else
-      {
-         MFEM_ABORT("Unknown kernel.");
+         if (trial_fetype == mfem::FiniteElement::CURL && test_fetype == trial_fetype)
+         {
+            internal::PAHcurlMassAssembleDiagonal2D(dofs1D, quad1D, ne, symmetric,
+                                                    mapsO->B, mapsC->B, pa_data, diag);
+         }
+         else if (trial_fetype == mfem::FiniteElement::DIV &&
+                  test_fetype == trial_fetype)
+         {
+            internal::PAHdivMassAssembleDiagonal2D(dofs1D, quad1D, ne, symmetric,
+                                                   mapsO->B, mapsC->B, pa_data, diag);
+         }
+         else
+         {
+            MFEM_ABORT("Unknown kernel.");
+         }
       }
    }
 }
 
 void VectorFEMassIntegrator::AddMultPA(const Vector &x, Vector &y) const
 {
-   const bool trial_curl = (trial_fetype == mfem::FiniteElement::CURL);
-   const bool trial_div = (trial_fetype == mfem::FiniteElement::DIV);
-   const bool test_curl = (test_fetype == mfem::FiniteElement::CURL);
-   const bool test_div = (test_fetype == mfem::FiniteElement::DIV);
-
-   if (dim == 3)
+   if (DeviceCanUseCeed())
    {
-      if (trial_curl && test_curl)
+      ceedOp->AddMult(x, y);
+   }
+   else
+   {
+      const bool trial_curl = (trial_fetype == mfem::FiniteElement::CURL);
+      const bool trial_div = (trial_fetype == mfem::FiniteElement::DIV);
+      const bool test_curl = (test_fetype == mfem::FiniteElement::CURL);
+      const bool test_div = (test_fetype == mfem::FiniteElement::DIV);
+
+      if (dim == 3)
       {
-         if (Device::Allows(Backend::DEVICE_MASK))
+         if (trial_curl && test_curl)
          {
-            const int ID = (dofs1D << 4) | quad1D;
-            switch (ID)
+            if (Device::Allows(Backend::DEVICE_MASK))
             {
-               case 0x23:
-                  return internal::SmemPAHcurlMassApply3D<2,3>(
-                            dofs1D, quad1D, ne, symmetric,
-                            mapsO->B, mapsC->B, mapsO->Bt,
-                            mapsC->Bt, pa_data, x, y);
-               case 0x34:
-                  return internal::SmemPAHcurlMassApply3D<3,4>(
-                            dofs1D, quad1D, ne, symmetric,
-                            mapsO->B, mapsC->B, mapsO->Bt,
-                            mapsC->Bt, pa_data, x, y);
-               case 0x45:
-                  return internal::SmemPAHcurlMassApply3D<4,5>(
-                            dofs1D, quad1D, ne, symmetric,
-                            mapsO->B, mapsC->B, mapsO->Bt,
-                            mapsC->Bt, pa_data, x, y);
-               case 0x56:
-                  return internal::SmemPAHcurlMassApply3D<5,6>(
-                            dofs1D, quad1D, ne, symmetric,
-                            mapsO->B, mapsC->B, mapsO->Bt,
-                            mapsC->Bt, pa_data, x, y);
-               default:
-                  return internal::SmemPAHcurlMassApply3D(
-                            dofs1D, quad1D, ne, symmetric,
-                            mapsO->B, mapsC->B, mapsO->Bt,
-                            mapsC->Bt, pa_data, x, y);
+               const int ID = (dofs1D << 4) | quad1D;
+               switch (ID)
+               {
+                  case 0x23:
+                     return internal::SmemPAHcurlMassApply3D<2,3>(
+                               dofs1D, quad1D, ne, symmetric,
+                               mapsO->B, mapsC->B, mapsO->Bt,
+                               mapsC->Bt, pa_data, x, y);
+                  case 0x34:
+                     return internal::SmemPAHcurlMassApply3D<3,4>(
+                               dofs1D, quad1D, ne, symmetric,
+                               mapsO->B, mapsC->B, mapsO->Bt,
+                               mapsC->Bt, pa_data, x, y);
+                  case 0x45:
+                     return internal::SmemPAHcurlMassApply3D<4,5>(
+                               dofs1D, quad1D, ne, symmetric,
+                               mapsO->B, mapsC->B, mapsO->Bt,
+                               mapsC->Bt, pa_data, x, y);
+                  case 0x56:
+                     return internal::SmemPAHcurlMassApply3D<5,6>(
+                               dofs1D, quad1D, ne, symmetric,
+                               mapsO->B, mapsC->B, mapsO->Bt,
+                               mapsC->Bt, pa_data, x, y);
+                  default:
+                     return internal::SmemPAHcurlMassApply3D(
+                               dofs1D, quad1D, ne, symmetric,
+                               mapsO->B, mapsC->B, mapsO->Bt,
+                               mapsC->Bt, pa_data, x, y);
+               }
             }
+            else
+            {
+               internal::PAHcurlMassApply3D(dofs1D, quad1D, ne, symmetric, mapsO->B, mapsC->B,
+                                            mapsO->Bt, mapsC->Bt, pa_data, x, y);
+            }
+         }
+         else if (trial_div && test_div)
+         {
+            internal::PAHdivMassApply(3, dofs1D, quad1D, ne, symmetric, mapsO->B, mapsC->B,
+                                      mapsO->Bt, mapsC->Bt, pa_data, x, y);
+         }
+         else if (trial_curl && test_div)
+         {
+            const bool scalarCoeff = !(DQ || MQ);
+            internal::PAHcurlHdivMassApply3D(dofs1D, dofs1Dtest, quad1D, ne, scalarCoeff,
+                                             true, false, mapsO->B, mapsC->B, mapsOtest->Bt,
+                                             mapsCtest->Bt, pa_data, x, y);
+         }
+         else if (trial_div && test_curl)
+         {
+            const bool scalarCoeff = !(DQ || MQ);
+            internal::PAHcurlHdivMassApply3D(dofs1D, dofs1Dtest, quad1D, ne, scalarCoeff,
+                                             false, false, mapsO->B, mapsC->B, mapsOtest->Bt,
+                                             mapsCtest->Bt, pa_data, x, y);
          }
          else
          {
-            internal::PAHcurlMassApply3D(dofs1D, quad1D, ne, symmetric, mapsO->B, mapsC->B,
-                                         mapsO->Bt, mapsC->Bt, pa_data, x, y);
+            MFEM_ABORT("Unknown kernel.");
          }
       }
-      else if (trial_div && test_div)
+      else // 2D
       {
-         internal::PAHdivMassApply(3, dofs1D, quad1D, ne, symmetric, mapsO->B, mapsC->B,
-                                   mapsO->Bt, mapsC->Bt, pa_data, x, y);
-      }
-      else if (trial_curl && test_div)
-      {
-         const bool scalarCoeff = !(DQ || MQ);
-         internal::PAHcurlHdivMassApply3D(dofs1D, dofs1Dtest, quad1D, ne, scalarCoeff,
-                                          true, false, mapsO->B, mapsC->B, mapsOtest->Bt,
-                                          mapsCtest->Bt, pa_data, x, y);
-      }
-      else if (trial_div && test_curl)
-      {
-         const bool scalarCoeff = !(DQ || MQ);
-         internal::PAHcurlHdivMassApply3D(dofs1D, dofs1Dtest, quad1D, ne, scalarCoeff,
-                                          false, false, mapsO->B, mapsC->B, mapsOtest->Bt,
-                                          mapsCtest->Bt, pa_data, x, y);
-      }
-      else
-      {
-         MFEM_ABORT("Unknown kernel.");
-      }
-   }
-   else // 2D
-   {
-      if (trial_curl && test_curl)
-      {
-         internal::PAHcurlMassApply2D(dofs1D, quad1D, ne, symmetric, mapsO->B, mapsC->B,
+         if (trial_curl && test_curl)
+         {
+            internal::PAHcurlMassApply2D(dofs1D, quad1D, ne, symmetric, mapsO->B, mapsC->B,
+                                         mapsO->Bt, mapsC->Bt, pa_data, x, y);
+         }
+         else if (trial_div && test_div)
+         {
+            internal::PAHdivMassApply(2, dofs1D, quad1D, ne, symmetric, mapsO->B, mapsC->B,
                                       mapsO->Bt, mapsC->Bt, pa_data, x, y);
-      }
-      else if (trial_div && test_div)
-      {
-         internal::PAHdivMassApply(2, dofs1D, quad1D, ne, symmetric, mapsO->B, mapsC->B,
-                                   mapsO->Bt,
-                                   mapsC->Bt, pa_data, x, y);
-      }
-      else if ((trial_curl && test_div) || (trial_div && test_curl))
-      {
-         const bool scalarCoeff = !(DQ || MQ);
-         internal::PAHcurlHdivMassApply2D(dofs1D, dofs1Dtest, quad1D, ne, scalarCoeff,
-                                          trial_curl, false, mapsO->B, mapsC->B,
-                                          mapsOtest->Bt, mapsCtest->Bt, pa_data, x, y);
-      }
-      else
-      {
-         MFEM_ABORT("Unknown kernel.");
+         }
+         else if ((trial_curl && test_div) || (trial_div && test_curl))
+         {
+            const bool scalarCoeff = !(DQ || MQ);
+            internal::PAHcurlHdivMassApply2D(dofs1D, dofs1Dtest, quad1D, ne, scalarCoeff,
+                                             trial_curl, false, mapsO->B, mapsC->B,
+                                             mapsOtest->Bt, mapsCtest->Bt, pa_data, x, y);
+         }
+         else
+         {
+            MFEM_ABORT("Unknown kernel.");
+         }
       }
    }
 }
@@ -310,35 +351,43 @@ void VectorFEMassIntegrator::AddMultPA(const Vector &x, Vector &y) const
 void VectorFEMassIntegrator::AddMultTransposePA(const Vector &x,
                                                 Vector &y) const
 {
-   const bool trial_curl = (trial_fetype == mfem::FiniteElement::CURL);
-   const bool trial_div = (trial_fetype == mfem::FiniteElement::DIV);
-   const bool test_curl = (test_fetype == mfem::FiniteElement::CURL);
-   const bool test_div = (test_fetype == mfem::FiniteElement::DIV);
+   if (DeviceCanUseCeed())
+   {
+      MFEM_ABORT("AddMultTransposePA not yet implemented with libCEED for"
+                 " VectorFEMassIntegrator.");
+   }
+   else
+   {
+      const bool trial_curl = (trial_fetype == mfem::FiniteElement::CURL);
+      const bool trial_div = (trial_fetype == mfem::FiniteElement::DIV);
+      const bool test_curl = (test_fetype == mfem::FiniteElement::CURL);
+      const bool test_div = (test_fetype == mfem::FiniteElement::DIV);
 
-   bool symmetricSpaces = true;
-   if (dim == 3 && ((trial_div && test_curl) || (trial_curl && test_div)))
-   {
-      const bool scalarCoeff = !(DQ || MQ);
-      internal::PAHcurlHdivMassApply3D(dofs1D, dofs1Dtest, quad1D, ne, scalarCoeff,
-                                       trial_div, true, mapsO->B, mapsC->B,
-                                       mapsOtest->Bt, mapsCtest->Bt, pa_data, x, y);
-      symmetricSpaces = false;
-   }
-   else if (dim == 2 && ((trial_curl && test_div) || (trial_div && test_curl)))
-   {
-      const bool scalarCoeff = !(DQ || MQ);
-      internal::PAHcurlHdivMassApply2D(dofs1D, dofs1Dtest, quad1D, ne, scalarCoeff,
-                                       !trial_curl, true, mapsO->B, mapsC->B,
-                                       mapsOtest->Bt, mapsCtest->Bt, pa_data, x, y);
-      symmetricSpaces = false;
-   }
-   if (symmetricSpaces)
-   {
-      if (MQ && dynamic_cast<SymmetricMatrixCoefficient*>(MQ) == NULL)
+      bool symmetricSpaces = true;
+      if (dim == 3 && ((trial_div && test_curl) || (trial_curl && test_div)))
       {
-         MFEM_ABORT("VectorFEMassIntegrator transpose not implemented for asymmetric MatrixCoefficient");
+         const bool scalarCoeff = !(DQ || MQ);
+         internal::PAHcurlHdivMassApply3D(dofs1D, dofs1Dtest, quad1D, ne, scalarCoeff,
+                                          trial_div, true, mapsO->B, mapsC->B,
+                                          mapsOtest->Bt, mapsCtest->Bt, pa_data, x, y);
+         symmetricSpaces = false;
       }
-      AddMultPA(x, y);
+      else if (dim == 2 && ((trial_curl && test_div) || (trial_div && test_curl)))
+      {
+         const bool scalarCoeff = !(DQ || MQ);
+         internal::PAHcurlHdivMassApply2D(dofs1D, dofs1Dtest, quad1D, ne, scalarCoeff,
+                                          !trial_curl, true, mapsO->B, mapsC->B,
+                                          mapsOtest->Bt, mapsCtest->Bt, pa_data, x, y);
+         symmetricSpaces = false;
+      }
+      if (symmetricSpaces)
+      {
+         if (MQ && dynamic_cast<SymmetricMatrixCoefficient*>(MQ) == NULL)
+         {
+            MFEM_ABORT("VectorFEMassIntegrator transpose not implemented for asymmetric MatrixCoefficient");
+         }
+         AddMultPA(x, y);
+      }
    }
 }
 

--- a/makefile
+++ b/makefile
@@ -271,7 +271,6 @@ MFEM_REQ_LIB_DEPS = ENZYME SUPERLU MUMPS METIS FMS CONDUIT SIDRE LAPACK SUNDIALS
  GSLIB OCCA CEED RAJA UMPIRE MKL_CPARDISO MKL_PARDISO AMGX CALIPER PARELAG BENCHMARK\
  MOONOLITH ALGOIM
 
-
 PETSC_ERROR_MSG = $(if $(PETSC_FOUND),,. PETSC config not found: $(PETSC_VARS))
 SLEPC_ERROR_MSG = $(if $(SLEPC_FOUND),,. SLEPC config not found: $(SLEPC_VARS))
 
@@ -409,7 +408,8 @@ endif
 DIRS = general linalg linalg/simd mesh mesh/submesh fem fem/ceed/interface \
        fem/ceed/integrators/mass fem/ceed/integrators/convection \
        fem/ceed/integrators/diffusion fem/ceed/integrators/nlconvection \
-       fem/ceed/integrators/util fem/ceed/solvers \
+       fem/ceed/integrators/vecfemass fem/ceed/integrators/divdiv \
+       fem/ceed/integrators/curlcurl fem/ceed/integrators/util fem/ceed/solvers \
        fem/fe fem/lor fem/qinterp fem/integ fem/tmop
 
 ifeq ($(MFEM_USE_MOONOLITH),YES)
@@ -424,7 +424,7 @@ RELSRC_FILES = $(patsubst $(SRC)%,%,$(SOURCE_FILES))
 OBJECT_FILES = $(patsubst $(SRC)%,$(BLD)%,$(SOURCE_FILES:.cpp=.o))
 OKL_DIRS = fem
 
-.PHONY: lib all clean distclean install config status info deps serial parallel	\
+.PHONY: lib all clean distclean install config status info deps serial parallel \
 	debug pdebug cuda hip pcuda cudebug pcudebug hpc style check test unittest \
 	deprecation-warnings
 
@@ -604,6 +604,12 @@ install: $(if $(static),$(BLD)libmfem.a) $(if $(shared),$(BLD)libmfem.$(SO_EXT))
 	$(INSTALL) -m 640 $(SRC)fem/ceed/integrators/diffusion/*.h $(PREFIX_INC)/mfem/fem/ceed/integrators/diffusion
 	mkdir -p $(PREFIX_INC)/mfem/fem/ceed/integrators/nlconvection
 	$(INSTALL) -m 640 $(SRC)fem/ceed/integrators/nlconvection/*.h $(PREFIX_INC)/mfem/fem/ceed/integrators/nlconvection
+	mkdir -p $(PREFIX_INC)/mfem/fem/ceed/integrators/vecfemass
+	$(INSTALL) -m 640 $(SRC)fem/ceed/integrators/vecfemass/*.h $(PREFIX_INC)/mfem/fem/ceed/integrators/vecfemass
+	mkdir -p $(PREFIX_INC)/mfem/fem/ceed/integrators/divdiv
+	$(INSTALL) -m 640 $(SRC)fem/ceed/integrators/divdiv/*.h $(PREFIX_INC)/mfem/fem/ceed/integrators/divdiv
+	mkdir -p $(PREFIX_INC)/mfem/fem/ceed/integrators/curlcurl
+	$(INSTALL) -m 640 $(SRC)fem/ceed/integrators/curlcurl/*.h $(PREFIX_INC)/mfem/fem/ceed/integrators/curlcurl
 	mkdir -p $(PREFIX_INC)/mfem/fem/ceed/integrators/util
 	$(INSTALL) -m 640 $(SRC)fem/ceed/integrators/util/*.h $(PREFIX_INC)/mfem/fem/ceed/integrators/util
 # install config.mk in $(PREFIX_SHARE)

--- a/makefile
+++ b/makefile
@@ -409,8 +409,9 @@ DIRS = general linalg linalg/simd mesh mesh/submesh fem fem/ceed/interface \
        fem/ceed/integrators/mass fem/ceed/integrators/convection \
        fem/ceed/integrators/diffusion fem/ceed/integrators/nlconvection \
        fem/ceed/integrators/vecfemass fem/ceed/integrators/divdiv \
-       fem/ceed/integrators/curlcurl fem/ceed/integrators/util fem/ceed/solvers \
-       fem/fe fem/lor fem/qinterp fem/integ fem/tmop
+       fem/ceed/integrators/curlcurl fem/ceed/integrators/mixedvecgrad \
+       fem/ceed/integrators/mixedveccurl fem/ceed/integrators/util \
+       fem/ceed/solvers fem/fe fem/lor fem/qinterp fem/integ fem/tmop
 
 ifeq ($(MFEM_USE_MOONOLITH),YES)
    MFEM_CXXFLAGS += $(MOONOLITH_CXX_FLAGS)
@@ -610,6 +611,10 @@ install: $(if $(static),$(BLD)libmfem.a) $(if $(shared),$(BLD)libmfem.$(SO_EXT))
 	$(INSTALL) -m 640 $(SRC)fem/ceed/integrators/divdiv/*.h $(PREFIX_INC)/mfem/fem/ceed/integrators/divdiv
 	mkdir -p $(PREFIX_INC)/mfem/fem/ceed/integrators/curlcurl
 	$(INSTALL) -m 640 $(SRC)fem/ceed/integrators/curlcurl/*.h $(PREFIX_INC)/mfem/fem/ceed/integrators/curlcurl
+	mkdir -p $(PREFIX_INC)/mfem/fem/ceed/integrators/mixedvecgrad
+	$(INSTALL) -m 640 $(SRC)fem/ceed/integrators/mixedvecgrad/*.h $(PREFIX_INC)/mfem/fem/ceed/integrators/mixedvecgrad
+	mkdir -p $(PREFIX_INC)/mfem/fem/ceed/integrators/mixedveccurl
+	$(INSTALL) -m 640 $(SRC)fem/ceed/integrators/mixedveccurl/*.h $(PREFIX_INC)/mfem/fem/ceed/integrators/mixedveccurl
 	mkdir -p $(PREFIX_INC)/mfem/fem/ceed/integrators/util
 	$(INSTALL) -m 640 $(SRC)fem/ceed/integrators/util/*.h $(PREFIX_INC)/mfem/fem/ceed/integrators/util
 # install config.mk in $(PREFIX_SHARE)

--- a/tests/unit/ceed/test_ceed.cpp
+++ b/tests/unit/ceed/test_ceed.cpp
@@ -981,14 +981,13 @@ TEST_CASE("CEED p-adaptivity", "[CEED]")
 TEST_CASE("CEED vector and matrix coefficients and vector FE operators",
           "[CEED], [VectorFE]")
 {
-
    auto assembly = GENERATE(AssemblyLevel::PARTIAL,AssemblyLevel::NONE);
    auto coeff_type = GENERATE(CeedCoeffType::Const,CeedCoeffType::Quad,
                               CeedCoeffType::VecConst,CeedCoeffType::VecQuad,
                               CeedCoeffType::MatConst,CeedCoeffType::MatQuad);
    auto pb = GENERATE(Problem::MassDiffusion,Problem::VectorFEMassDivDiv,
                       Problem::VectorFEMassCurlCurl);
-   auto order = GENERATE(1);  // TODO p=2 curl-curl on tet mesh is not supported
+   auto order = GENERATE(1,3);
    auto bdr_integ = GENERATE(false,true);
    auto mesh = GENERATE("../../data/inline-quad.mesh",
                         "../../data/inline-hex.mesh",
@@ -1011,7 +1010,7 @@ TEST_CASE("CEED mixed integrators",
                               CeedCoeffType::VecConst,CeedCoeffType::VecQuad,
                               CeedCoeffType::MatConst,CeedCoeffType::MatQuad);
    auto pb = GENERATE(Problem::MixedVectorGradient,Problem::MixedVectorCurl);
-   auto order = GENERATE(1);  // TODO p=2 curl-curl on tet mesh is not supported
+   auto order = GENERATE(2);
    auto bdr_integ = GENERATE(false,true);
    auto mesh = GENERATE("../../data/inline-quad.mesh",
                         "../../data/inline-hex.mesh",


### PR DESCRIPTION
NOTE: Based on https://github.com/mfem/mfem/pull/3625

NOTE: Waiting on https://github.com/CEED/libCEED/pull/1156 (merged), https://github.com/CEED/libCEED/pull/1196 (merged), and https://github.com/CEED/libCEED/pull/1168 in libCEED to fully support diagonal assembly and high-order H(curl) spaces.

This PR adds PA and MF assembly support for: `VectorFEMassIntegrator`, `DivDivIntegrator`, and `CurlCurlIntegrator`for square `BilinearForm` objects, and `MixedVectorGradientIntegrator`, and `PAMixedVectorCurlIntegrator` for `MixedBilinearForm` objects. Arbitrary order H(div) and H(curl) finite element spaces on tensor-product element meshes or simplex or mixed meshes are supported. In all cases, the basis operation does not make use of tensor-product structure for these vector finite elements, which is a limitation of libCEED and leads to different performance (though surprisingly not that much different in my testing on CPU at least) versus the native MFEM PA backends for tensor-element meshes. Unit tests covering this new functionality have been added to `tests/unit/ceed/test_ceed.cpp`.

GPU libCEED backends do not yet support the special element restriction and (non-tensor) basis operations for vector FE spaces, but these will hopefully come soon. For now, all `cpu/self/*/serial` and `cpu/self/*/blocked` backends have been successfully tested.