### PR TITLE
Update the GitLab CI config for Lassen

### DIFF
--- a/.gitlab/lassen-build-and-test.yml
+++ b/.gitlab/lassen-build-and-test.yml
@@ -14,14 +14,14 @@ stages:
   - build_and_test
   - report
 
-opt_mpi_cuda_xl_16_1_1_8:
+opt_mpi_cuda_xl_16_1_1_12:
   variables:
-    SPEC: "%xl@16.1.1.8 +mpi +cuda cuda_arch=70"
+    SPEC: "%xl@16.1.1.12 +mpi +cuda cuda_arch=70"
   extends: .build_and_test_on_lassen
 
 opt_mpi_cuda_hypre_cuda_xl:
   variables:
-    SPEC: "%xl@16.1.1.8 +mpi +cuda cuda_arch=70 ^hypre+cuda~shared cuda_arch=70"
+    SPEC: "%xl@16.1.1.12 +mpi +cuda cuda_arch=70 ^hypre+cuda~shared cuda_arch=70"
   extends: .build_and_test_on_lassen
 
 # Jobs report

--- a/tests/gitlab/get_mfem_uberenv
+++ b/tests/gitlab/get_mfem_uberenv
@@ -18,7 +18,7 @@ set -o errexit
 set -o nounset
 
 uberenv_url="https://github.com/mfem/mfem-uberenv.git"
-uberenv_ref="8208bf86c14a35c0b5c80dff64101bf190dee67b"
+uberenv_ref="6f01b138427c34e109d9b7dc34d932ef13087c4e"
 
 [[ ! -d tests/uberenv ]] && git clone ${uberenv_url} tests/uberenv
 cd tests/uberenv


### PR DESCRIPTION
The old compilers are no longer available.

This update uses the branch https://github.com/mfem/mfem-uberenv/tree/blueos-update-2023-04-29 (hash https://github.com/mfem/mfem-uberenv/commit/6f01b138427c34e109d9b7dc34d932ef13087c4e).
