### PR TITLE
Vector::Sum on device

### DIFF
--- a/linalg/vector.cpp
+++ b/linalg/vector.cpp
@@ -981,7 +981,7 @@ static __global__ void cuKernelDot(const int N, double *gdsr,
    const int tid = threadIdx.x;
    const int bbd = bid*blockDim.x;
    const int rid = bbd+tid;
-   s_dot[tid] = x[n] * (y ? y[n] : 1.0);
+   s_dot[tid] = y ? (x[n] * y[n]) : x[n];
    for (int workers=blockDim.x>>1; workers>0; workers>>=1)
    {
       __syncthreads();
@@ -1070,7 +1070,7 @@ static __global__ void hipKernelDot(const int N, double *gdsr,
    const int tid = hipThreadIdx_x;
    const int bbd = bid*hipBlockDim_x;
    const int rid = bbd+tid;
-   s_dot[tid] = x[n] * (y ? y[n] : 1.0);
+   s_dot[tid] = y ? (x[n] * y[n]) : x[n];
    for (int workers=hipBlockDim_x>>1; workers>0; workers>>=1)
    {
       __syncthreads();

--- a/tests/unit/linalg/test_vector.cpp
+++ b/tests/unit/linalg/test_vector.cpp
@@ -11,6 +11,7 @@
 
 #include "mfem.hpp"
 #include "unit_tests.hpp"
+#include <numeric>
 
 using namespace mfem;
 
@@ -224,4 +225,17 @@ TEST_CASE("Vector Tests", "[Vector]")
       subtract(tmp, apb, diff);
       REQUIRE(diff.Norml2() < tol);
    }
+}
+
+TEST_CASE("Vector Sum", "[Vector],[CUDA]")
+{
+   Vector x(1024);
+   x.Randomize(1);
+   x.UseDevice(true);
+
+   x.HostRead();
+   const double sum_1 = std::accumulate(x.begin(), x.end(), 0.0);
+   const double sum_2 = x.Sum();
+
+   REQUIRE(sum_1 == MFEM_Approx(sum_2));
 }


### PR DESCRIPTION
Implements `Vector::Sum` on GPU when `UseDevice` is true. I tested with CUDA, but not with HIP.

For the implementation, I added a ternary operator to the dot product kernels so we can reuse them for sum when the second vector is NULL. I didn't see any difference in runtimes with nvprof (but maybe someone who is more versed in GPU benchmarking could double-check).<!--GHEX{"author":"pazner","assignment":"2023-05-23T17:39:20","editor":"v-dobrev","id":3662,"reviewers":["artv3","v-dobrev"],"merge":"2023-09-26T19:08:30","approval":"2023-09-25T18:26:57"}XEHG-->
<!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge|
 | --- | --- | --- | --- | --- | --- | --- |
| [#3662](https://github.com/mfem/mfem/pull/3662) | @pazner | @v-dobrev | @artv3 + @v-dobrev | 5/23/23 | 9/25/23 | 9/26/23 | |
<!--ELBATXEHG-->
<details>
<summary>PR Checklist</summary>
    
- [ ] Code builds.
- [ ] Code passes `make style`.
- [ ] Update `CHANGELOG`:
    - [ ] Is this a new feature users need to be aware of? New or updated example or miniapp?
    - [ ] Does it make sense to create a new section in the `CHANGELOG` to group with other related features?
- [ ] Update `INSTALL`:
    - [ ] Had a new optional library been added? If so, what range of versions of this library are required? (*Make sure the external library is compatible with our BSD license, e.g. it is not licensed under GPL!*)
    - [ ] Have the version ranges for any required or optional libraries changed?
    - [ ] Does `make` or `cmake` have a new target?
    - [ ] Did the requirements or the installation process change? *(rare)*
- [ ] Update continuous integration server configurations if necessary (e.g. with new version requirements for each of MFEM's dependencies)
    - [ ] `.github`
    - [ ] `.appveyor.yml`
- [ ] Update `.gitignore`:
    - [ ] Check if `make distclean; git status` shows any files that were generated from the source by the project (not an IDE) but we don't want to track in the repository.
    - [ ] Add new patterns (just for the new files above) and re-run the above test.
- [ ] New examples:
    - [ ] All sample runs at the top of the example source file work.
    - [ ] Update `examples/makefile`:
      - [ ] Add the example code to the appropriate `SEQ_EXAMPLES` and `PAR_EXAMPLES` variables.
      - [ ] Add any files generated by it to the `clean` target.
      - [ ] Add the example binary and any files generated by it to the top-level `.gitignore` file.
    - [ ] Update `examples/CMakeLists.txt`:
      - [ ] Add the example code to the `ALL_EXE_SRCS` variable.
      - [ ] Make sure `THIS_TEST_OPTIONS` is set correctly for the new example.
   - [ ] List the new example in `doc/CodeDocumentation.dox`.
   - [ ] If new examples directory (e.g.`examples/pumi`), list it in `doc/CodeDocumentation.conf.in`
   - [ ] Companion pull request for documentation in [mfem/web](https://github.com/mfem/web) repo:
      - [ ] Update or add example-specific documentation, see e.g. the `src/examples.md`.
      - [ ] Add the description, labels and screenshots in `src/examples.md` and `src/img`.
      - [ ] In `examples.md`, list the example under the appropriate categories, add new categories if necessary.
      - [ ] Add a short description of the example in the "Extensive Examples" section of `features.md`.
- [ ] New miniapps:
   - [ ] All sample runs at the top of the miniapp source file work.
   - [ ] Update top-level `makefile` and `makefile` in corresponding miniapp directory.
   - [ ] Add the miniapp binary and any files generated by it to the top-level `.gitignore` file.
   - [ ] Update CMake build system:
      - [ ] Update the `CMakeLists.txt` file in the `miniapps` directory, if the new miniapp is in a new directory.
      - [ ] Add/update the `CMakeLists.txt` file in the new miniapp directory.
      - [ ] Consider adding a new test for the new miniapp.
   - [ ] List the new miniapp in `doc/CodeDocumentation.dox`
   - [ ] If new miniapps directory (e.g.`miniapps/nurbs`), add it to `MINIAPP_SUBDIRS` in the `makefile`.
   - [ ] If new miniapps directory (e.g.`miniapps/nurbs`), list it in `doc/CodeDocumentation.conf.in`
   - [ ] Companion pull request for documentation in [mfem/web](https://github.com/mfem/web) repo:
     - [ ] Update or add miniapp-specific documentation, see e.g. the `src/meshing.md` and `src/electromagnetics.md` files.
     - [ ] Add the description, labels and screenshots in `src/examples.md` and `src/img`.
     - [ ] The miniapps go at the end of the page, and are usually listed only under a specific "Application (PDE)" category.
     - [ ] Add a short description of the miniapp in the "Extensive Examples" section of `features.md`.
- [ ] New capability:
   - [ ] All new public, protected, and private classes, methods, data members, and functions have full Doxygen-style documentation in source comments. Documentation should include descriptions of member data, function arguments and return values, template parameters, and prerequisites for calling new functions.
   - [ ] Pointer arguments and return values must specify whether ownership is being transferred or lent with the call.
   - [ ] Any new functions should include descriptions of their intended use e.g. for internal use only, user-facing, etc., along with references to example code whenever possible/appropriate.
   - [ ] Consider adding new sample runs in existing examples to highlight the new capability.
   - [ ] Consider saving cool simulation pictures with the new capability in the Confluence gallery (LLNL only) or submitting them, via pull request, to the gallery section of the `mfem/web` repo.
   - [ ] If this is a major new feature, consider mentioning it in the short summary inside `README` *(rare)*.
   - [ ] List major new classes in `doc/CodeDocumentation.dox` *(rare)*.
- [ ] Update this checklist, if the new pull request affects it.
- [ ] Run `make unittest` to make sure all unit tests pass.
- [ ] Run the tests in `tests/scripts`.
- [ ] (LLNL only) After merging:
   - [ ] Update internal tests to include the new features.
</details>
