### PR TITLE
Allow `HypreParMatrixFromBlocks` with empty local `HypreParMatrix` blocks

### DIFF
--- a/linalg/hypre.cpp
+++ b/linalg/hypre.cpp
@@ -2996,10 +2996,7 @@ void GatherBlockOffsetData(MPI_Comm comm, const int rank, const int nprocs,
    for (int i = 0; i < nprocs; ++i)
    {
       globalNum += all_num_loc[i];
-      if (rank == 0)
-      {
-         MFEM_VERIFY(globalNum >= 0, "overflow in global size");
-      }
+      MFEM_VERIFY(globalNum >= 0, "overflow in global size");
       if (i < rank)
       {
          firstLocal += all_num_loc[i];
@@ -3064,9 +3061,6 @@ HypreParMatrix * HypreParMatrixFromBlocks(Array2D<HypreParMatrix*> &blocks,
             const int nrows = blocks(i,j)->NumRows();
             const int ncols = blocks(i,j)->NumCols();
 
-            MFEM_VERIFY(nrows > 0 &&
-                        ncols > 0, "Invalid block in HypreParMatrixFromBlocks");
-
             if (rowOffsets[i+1] == 0)
             {
                rowOffsets[i+1] = nrows;
@@ -3088,14 +3082,11 @@ HypreParMatrix * HypreParMatrixFromBlocks(Array2D<HypreParMatrix*> &blocks,
             }
          }
       }
-
-      MFEM_VERIFY(rowOffsets[i+1] > 0, "Invalid input blocks");
       rowOffsets[i+1] += rowOffsets[i];
    }
 
    for (int j=0; j<numBlockCols; ++j)
    {
-      MFEM_VERIFY(colOffsets[j+1] > 0, "Invalid input blocks");
       colOffsets[j+1] += colOffsets[j];
    }
 


### PR DESCRIPTION
Sometimes a processor may have no local rows or columns in a `HypreParMatrix`, yet we can still construct a block `HypreParMatrix` using `HypreParMatrixFromBlocks`.<!--GHEX{"author":"sebastiangrimberg","assignment":"2023-06-06T22:25:25","editor":"mlstowell","id":3699,"reviewers":["dylan-copeland","psocratis"],"merge":"2023-06-13T23:20:26","approval":"2023-06-08T17:25:58"}XEHG-->
<!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge|
 | --- | --- | --- | --- | --- | --- | --- |
| [#3699](https://github.com/mfem/mfem/pull/3699) | @sebastiangrimberg | @mlstowell | @dylan-copeland + @psocratis | 6/6/23 | 6/8/23 | 6/13/23 | |
<!--ELBATXEHG-->