### PR TITLE
Allow `Submesh::From::Boundary` for nonconforming mesh

### DIFF
--- a/mesh/submesh/psubmesh.cpp
+++ b/mesh/submesh/psubmesh.cpp
@@ -348,7 +348,7 @@ void ParSubMesh::FindSharedEdgesRanks(Array<int> &rhe)
    sedge_comm.Bcast<int>(rhe, 0);
 }
 
-void ParSubMesh::FindSharedFacesRanks(Array<int>& rht, Array<int> &rhq)
+void ParSubMesh::FindSharedFacesRanks(Array<int> &rht, Array<int> &rhq)
 {
    GroupCommunicator squad_comm(parent_.gtopo);
    parent_.GetSharedQuadCommunicator(squad_comm);
@@ -522,7 +522,7 @@ void ParSubMesh::AppendSharedEdgesGroups(ListOfIntegerSets &groups,
 }
 
 void ParSubMesh::AppendSharedFacesGroups(ListOfIntegerSets &groups,
-                                         Array<int>& rht, Array<int> &rhq)
+                                         Array<int> &rht, Array<int> &rhq)
 {
    IntegerSet quad_group;
 
@@ -607,8 +607,8 @@ void ParSubMesh::AppendSharedFacesGroups(ListOfIntegerSets &groups,
    }
 }
 
-void ParSubMesh::BuildVertexGroup(int ngroups, const Array<int>& rhvtx,
-                                  int& nsverts)
+void ParSubMesh::BuildVertexGroup(int ngroups, const Array<int> &rhvtx,
+                                  int &nsverts)
 {
    group_svert.MakeI(ngroups);
    for (int i = 0; i < rhvtx.Size(); i++)
@@ -631,8 +631,8 @@ void ParSubMesh::BuildVertexGroup(int ngroups, const Array<int>& rhvtx,
    group_svert.ShiftUpI();
 }
 
-void ParSubMesh::BuildEdgeGroup(int ngroups, const Array<int>& rhe,
-                                int& nsedges)
+void ParSubMesh::BuildEdgeGroup(int ngroups, const Array<int> &rhe,
+                                int &nsedges)
 {
    group_sedge.MakeI(ngroups);
    for (int i = 0; i < rhe.Size(); i++)
@@ -655,8 +655,8 @@ void ParSubMesh::BuildEdgeGroup(int ngroups, const Array<int>& rhe,
    group_sedge.ShiftUpI();
 }
 
-void ParSubMesh::BuildFaceGroup(int ngroups, const Array<int>& rht,
-                                int& nstrias, const Array<int>& rhq, int& nsquads)
+void ParSubMesh::BuildFaceGroup(int ngroups, const Array<int> &rht,
+                                int &nstrias, const Array<int> &rhq, int &nsquads)
 {
    group_squad.MakeI(ngroups);
    for (int i = 0; i < rhq.Size(); i++)
@@ -700,7 +700,7 @@ void ParSubMesh::BuildFaceGroup(int ngroups, const Array<int>& rht,
 }
 
 void ParSubMesh::BuildSharedVerticesMapping(const int nsverts,
-                                            const Array<int>& rhvtx)
+                                            const Array<int> &rhvtx)
 {
    svert_lvert.Reserve(nsverts);
 
@@ -724,7 +724,7 @@ void ParSubMesh::BuildSharedVerticesMapping(const int nsverts,
 }
 
 void ParSubMesh::BuildSharedEdgesMapping(const int sedges_ct,
-                                         const Array<int>& rhe)
+                                         const Array<int> &rhe)
 {
    shared_edges.Reserve(sedges_ct);
    sedge_ledge.Reserve(sedges_ct);
@@ -753,8 +753,8 @@ void ParSubMesh::BuildSharedEdgesMapping(const int sedges_ct,
 }
 
 void ParSubMesh::BuildSharedFacesMapping(const int nstrias,
-                                         const Array<int>& rht,
-                                         const int nsquads, const Array<int>& rhq)
+                                         const Array<int> &rht,
+                                         const int nsquads, const Array<int> &rhq)
 {
    shared_trias.Reserve(nstrias);
    shared_quads.Reserve(nsquads);

--- a/mesh/submesh/psubmesh.cpp
+++ b/mesh/submesh/psubmesh.cpp
@@ -36,12 +36,11 @@ ParSubMesh ParSubMesh::CreateFromBoundary(const ParMesh &parent,
 }
 
 ParSubMesh::ParSubMesh(const ParMesh &parent, SubMesh::From from,
-                       Array<int> &attributes) : parent_(parent), from_(from), attributes_(attributes)
+                       Array<int> &attributes)
+   : parent_(parent), from_(from), attributes_(attributes)
 {
-   if (Nonconforming())
-   {
-      MFEM_ABORT("SubMesh does not support non-conforming meshes");
-   }
+   MFEM_VERIFY(!Nonconforming() || from == SubMesh::From::Boundary,
+               "ParSubMesh does not support nonconforming meshes with From::Domain");
 
    MyComm = parent.GetComm();
    NRanks = parent.GetNRanks();

--- a/mesh/submesh/psubmesh.hpp
+++ b/mesh/submesh/psubmesh.hpp
@@ -238,7 +238,7 @@ private:
     *
     * @param[out] rhq Encoding of which rank contains which face quadrilateral.
     */
-   void FindSharedFacesRanks(Array<int>& rht, Array<int> &rhq);
+   void FindSharedFacesRanks(Array<int> &rht, Array<int> &rhq);
 
    /**
     * @brief Append shared vertices encoded in @a rhvtx to @a groups.
@@ -270,7 +270,7 @@ private:
     * quadrilateral. The output is reused s.t. the array index i (the face
     * quadrilateral id) is the associated group.
     */
-   void AppendSharedFacesGroups(ListOfIntegerSets &groups, Array<int>& rht,
+   void AppendSharedFacesGroups(ListOfIntegerSets &groups, Array<int> &rht,
                                 Array<int> &rhq);
 
    /**
@@ -280,7 +280,7 @@ private:
     * @param[in] rhvtx Encoding of which rank contains which vertex.
     * @param[in] nsverts Number of shared vertices.
     */
-   void BuildVertexGroup(int ngroups, const Array<int>& rhvtx, int& nsverts);
+   void BuildVertexGroup(int ngroups, const Array<int> &rhvtx, int &nsverts);
 
    /**
     * @brief Build edge group.
@@ -289,7 +289,7 @@ private:
     * @param[in] rhe Encoding of which rank contains which edge.
     * @param[in] nsedges Number of shared edges.
     */
-   void BuildEdgeGroup(int ngroups, const Array<int>& rhe, int& nsedges);
+   void BuildEdgeGroup(int ngroups, const Array<int> &rhe, int &nsedges);
 
    /**
     * @brief Build face group.
@@ -300,8 +300,8 @@ private:
     * @param[in] rhq Encoding of which rank contains which face quadrilateral.
     * @param[in] nsquads Number of shared face quadrilaterals.
     */
-   void BuildFaceGroup(int ngroups, const Array<int>& rht, int& nstrias,
-                       const Array<int>& rhq, int& nsquads);
+   void BuildFaceGroup(int ngroups, const Array<int> &rht, int &nstrias,
+                       const Array<int> &rhq, int &nsquads);
 
    /**
     * @brief Build the shared vertex to local vertex mapping.
@@ -309,7 +309,7 @@ private:
     * @param nsverts Number of shared vertices.
     * @param rhvtx Encoding of which rank contains which vertex.
     */
-   void BuildSharedVerticesMapping(const int nsverts, const Array<int>& rhvtx);
+   void BuildSharedVerticesMapping(const int nsverts, const Array<int> &rhvtx);
 
    /**
    * @brief Build the shared edge to local edge mapping.
@@ -317,7 +317,7 @@ private:
    * @param[in] nsedges Number of shared edges.
    * @param[in] rhe Encoding of which rank contains which edge.
    */
-   void BuildSharedEdgesMapping(const int nsedges, const Array<int>& rhe);
+   void BuildSharedEdgesMapping(const int nsedges, const Array<int> &rhe);
 
    /**
     * @brief Build the shared faces to local faces mapping.
@@ -329,8 +329,8 @@ private:
     * @param[in] nsquads Number of shared face quadrilaterals.
     * @param[in] rhq Encoding of which rank contains which face quadrilateral.
     */
-   void BuildSharedFacesMapping(const int nstrias, const Array<int>& rht,
-                                const int nsquads, const Array<int>& rhq);
+   void BuildSharedFacesMapping(const int nstrias, const Array<int> &rht,
+                                const int nsquads, const Array<int> &rhq);
 
    /// The parent Mesh
    const ParMesh &parent_;

--- a/mesh/submesh/submesh.cpp
+++ b/mesh/submesh/submesh.cpp
@@ -29,12 +29,11 @@ SubMesh SubMesh::CreateFromBoundary(const Mesh &parent,
 }
 
 SubMesh::SubMesh(const Mesh &parent, From from,
-                 Array<int> attributes) : parent_(parent), from_(from), attributes_(attributes)
+                 Array<int> attributes)
+   : parent_(parent), from_(from), attributes_(attributes)
 {
-   if (Nonconforming())
-   {
-      MFEM_ABORT("SubMesh does not support non-conforming meshes");
-   }
+   MFEM_VERIFY(!Nonconforming() || from == SubMesh::From::Boundary,
+               "SubMesh does not support nonconforming meshes with From::Domain");
 
    if (from == From::Domain)
    {

--- a/mesh/submesh/submesh.hpp
+++ b/mesh/submesh/submesh.hpp
@@ -105,7 +105,7 @@ public:
     *
     * SubMesh element id (array index) to parent Mesh element id.
     */
-   const Array<int>& GetParentElementIDMap() const
+   const Array<int> &GetParentElementIDMap() const
    {
       return parent_element_ids_;
    }
@@ -115,7 +115,7 @@ public:
     *
     * SubMesh element id (array index) to parent Mesh face id.
     */
-   const Array<int>& GetParentFaceIDMap() const
+   const Array<int> &GetParentFaceIDMap() const
    {
       return parent_face_ids_;
    }
@@ -125,7 +125,7 @@ public:
     *
     * SubMesh vertex id (array index) to parent Mesh vertex id.
     */
-   const Array<int>& GetParentVertexIDMap() const
+   const Array<int> &GetParentVertexIDMap() const
    {
       return parent_vertex_ids_;
    }

--- a/mesh/submesh/submesh_utils.cpp
+++ b/mesh/submesh/submesh_utils.cpp
@@ -44,8 +44,8 @@ bool ElementHasAttribute(const Element &el, const Array<int> &attributes)
 }
 
 std::tuple< Array<int>, Array<int> >
-AddElementsToMesh(const Mesh& parent,
-                  Mesh& mesh,
+AddElementsToMesh(const Mesh &parent,
+                  Mesh &mesh,
                   const Array<int> &attributes,
                   bool from_boundary)
 {
@@ -86,11 +86,11 @@ AddElementsToMesh(const Mesh& parent,
                                              parent_element_ids);
 }
 
-void BuildVdofToVdofMap(const FiniteElementSpace& subfes,
-                        const FiniteElementSpace& parentfes,
-                        const SubMesh::From& from,
-                        const Array<int>& parent_element_ids,
-                        Array<int>& vdof_to_vdof_map)
+void BuildVdofToVdofMap(const FiniteElementSpace &subfes,
+                        const FiniteElementSpace &parentfes,
+                        const SubMesh::From &from,
+                        const Array<int> &parent_element_ids,
+                        Array<int> &vdof_to_vdof_map)
 {
    auto *m = subfes.GetMesh();
    vdof_to_vdof_map.SetSize(subfes.GetVSize());
@@ -177,7 +177,7 @@ void BuildVdofToVdofMap(const FiniteElementSpace& subfes,
    }
 }
 
-Array<int> BuildFaceMap(const Mesh& pm, const Mesh& sm,
+Array<int> BuildFaceMap(const Mesh &pm, const Mesh &sm,
                         const Array<int> &parent_element_ids)
 {
    // TODO: Check if parent is really a parent of mesh

--- a/mesh/submesh/submesh_utils.cpp
+++ b/mesh/submesh/submesh_utils.cpp
@@ -54,8 +54,25 @@ AddElementsToMesh(const Mesh &parent,
    const int ne = from_boundary ? parent.GetNBE() : parent.GetNE();
    for (int i = 0; i < ne; i++)
    {
-      const Element *pel = from_boundary ?
-                           parent.GetBdrElement(i) : parent.GetElement(i);
+      const Element *pel;
+      if (from_boundary)
+      {
+         pel = parent.GetBdrElement(i);
+         if (parent.Nonconforming())
+         {
+            // Works in 2D or 3D
+            int f, info1, info2, nc;
+            f = parent.GetBdrElementEdgeIndex(i);
+            parent.GetFaceInfos(f, &info1, &info2, &nc);
+            MFEM_VERIFY(nc == -1 && info2 < 0,
+                        "SubMesh::From::Boundary should only be used for "
+                        "nonconforming meshes on true external boundaries");
+         }
+      }
+      else
+      {
+         pel = parent.GetElement(i);
+      }
       if (!ElementHasAttribute(*pel, attributes)) { continue; }
 
       Array<int> v;

--- a/mesh/submesh/submesh_utils.hpp
+++ b/mesh/submesh/submesh_utils.hpp
@@ -68,8 +68,8 @@ bool ElementHasAttribute(const Element &el, const Array<int> &attributes);
  * boundary of the parent.
  */
 std::tuple< Array<int>, Array<int> >
-AddElementsToMesh(const Mesh& parent,
-                  Mesh& mesh, const Array<int> &attributes,
+AddElementsToMesh(const Mesh &parent,
+                  Mesh &mesh, const Array<int> &attributes,
                   bool from_boundary = false);
 
 /**
@@ -80,7 +80,7 @@ AddElementsToMesh(const Mesh& parent,
  * @param mesh The Mesh to match its parents faces.
  * @param parent_element_ids The Mesh element to parent element id map.
  */
-Array<int> BuildFaceMap(const Mesh& parent, const Mesh& mesh,
+Array<int> BuildFaceMap(const Mesh &parent, const Mesh &mesh,
                         const Array<int> &parent_element_ids);
 
 /**
@@ -99,11 +99,11 @@ Array<int> BuildFaceMap(const Mesh& parent, const Mesh& mesh,
  * @param[in] parent_element_ids
  * @param[out] vdof_to_vdof_map
  */
-void BuildVdofToVdofMap(const FiniteElementSpace& subfes,
-                        const FiniteElementSpace& parentfes,
-                        const SubMesh::From& from,
-                        const Array<int>& parent_element_ids,
-                        Array<int>& vdof_to_vdof_map);
+void BuildVdofToVdofMap(const FiniteElementSpace &subfes,
+                        const FiniteElementSpace &parentfes,
+                        const SubMesh::From &from,
+                        const Array<int> &parent_element_ids,
+                        Array<int> &vdof_to_vdof_map);
 
 /**
  * @brief Identify the root parent of a given SubMesh.

--- a/tests/unit/mesh/test_submesh.cpp
+++ b/tests/unit/mesh/test_submesh.cpp
@@ -57,11 +57,17 @@ void test_2d(Element::Type element_type,
 {
    constexpr int dim = 2;
    const int vdim = (field_type == FieldType::SCALAR) ? 1 : dim;
+   const bool nonconforming = false;
    double Hy = 1.0;
    Mesh mesh = Mesh::MakeCartesian2D(5, 5, element_type, true, 1.0, Hy, false);
 
    if (from == SubMesh::From::Boundary)
    {
+      if (nonconforming)
+      {
+         mesh.EnsureNCMesh();
+         mesh.RandomRefinement(0.5);
+      }
       for (int i = 0; i < mesh.GetNBE(); i++)
       {
          Element *el = mesh.GetBdrElement(i);
@@ -228,11 +234,17 @@ void test_3d(Element::Type element_type,
 {
    constexpr int dim = 3;
    const int vdim = (field_type == FieldType::SCALAR) ? 1 : dim;
+   const bool nonconforming = false;
    double Hy = 1.0;
    Mesh mesh = Mesh::MakeCartesian3D(5, 5, 5, element_type, 1.0, Hy, 1.0, false);
 
    if (from == SubMesh::From::Boundary)
    {
+      if (nonconforming)
+      {
+         mesh.EnsureNCMesh();
+         mesh.RandomRefinement(0.5);
+      }
       for (int i = 0; i < mesh.GetNBE(); i++)
       {
          Element *el = mesh.GetBdrElement(i);


### PR DESCRIPTION
If a mesh is nonconforming, we should still be able to construct a `SubMesh` using `SubMesh::From::Boundary` when the boundary is a true external boundary and thus all the faces in the submesh are actually conforming. This PR aims to enable this. There is a check during `SubMesh` construction that the criteria for correctness are actually met. In addition, it was tested in `tests/unit/mesh/test_submesh.cpp` by manually setting the new parameter `nonconforming` to `true`. This should work both serially and in parallel, but the parallel unit test doesn't have any true exterior boundaries so we only test on the serial case.

Resolves https://github.com/mfem/mfem/issues/3727.