### PR TITLE
libCEED interface: Solver updates + shared-memory parallelism with OpenMP

### DIFF
--- a/fem/ceed/interface/basis.hpp
+++ b/fem/ceed/interface/basis.hpp
@@ -43,7 +43,7 @@ void InitBasis(const FiniteElementSpace &fes,
 
     @param[in] fes The finite element space.
     @param[in] ir The integration rule.
-    @param[in] use_bdr Create the basis and restriction for boundary elements.
+    @param[in] use_bdr Create the basis for boundary elements.
     @param[in] indices The indices of the elements of same type in the
                        `FiniteElementSpace`. If `indices == nullptr`, assumes
                        that the `FiniteElementSpace` is not mixed.
@@ -56,16 +56,10 @@ inline void InitBasis(const FiniteElementSpace &fes,
                       Ceed ceed,
                       CeedBasis *basis)
 {
-   const mfem::FiniteElement *fe;
-   if (indices)
-   {
-      fe = use_bdr ? fes.GetBE(indices[0]) : fes.GetFE(indices[0]);
-   }
-   else
-   {
-      fe = use_bdr ? fes.GetBE(0) : fes.GetFE(0);
-   }
-   InitBasis(fes, *fe, ir, ceed, basis);
+   const int first_index = indices ? indices[0] : 0;
+   const mfem::FiniteElement &fe =
+      use_bdr ? *fes.GetBE(first_index) : *fes.GetFE(first_index);
+   InitBasis(fes, fe, ir, ceed, basis);
 }
 
 inline void InitBasis(const FiniteElementSpace &fes,

--- a/fem/ceed/interface/ceed.hpp
+++ b/fem/ceed/interface/ceed.hpp
@@ -27,6 +27,9 @@ namespace internal
 
 // Definition in general/device.cpp.
 extern Ceed ceed;
+#ifdef MFEM_USE_OPENMP
+#pragma omp threadprivate(ceed)
+#endif
 
 } // namespace internal
 

--- a/fem/ceed/interface/mixed_operator.hpp
+++ b/fem/ceed/interface/mixed_operator.hpp
@@ -242,9 +242,11 @@ public:
                {
                   mesh.GetElementTransformation(first_index, &T);
                }
-               MFEM_VERIFY(!integ.GetIntegrationRule(),
+               MFEM_VERIFY(!integ.GetIntegrationRule() || element_indices.size() == 1,
                            "Mixed mesh integrators should not have an IntegrationRule.");
-               const IntegrationRule &ir = integ.GetRule(trial_fe, test_fe, T);
+               const mfem::IntegrationRule &ir =
+                  integ.GetIntegrationRule() ? *integ.GetIntegrationRule() :
+                  integ.GetRule(trial_fe, test_fe, T);
                loc_sub_ops.push_back(new OpType);
                auto &sub_op = *loc_sub_ops.back();
                sub_op.Assemble(internal::ceed, info, trial_fes, test_fes, ir,

--- a/fem/ceed/interface/mixed_operator.hpp
+++ b/fem/ceed/interface/mixed_operator.hpp
@@ -12,12 +12,16 @@
 #ifndef MFEM_LIBCEED_MIXED_OPERATOR
 #define MFEM_LIBCEED_MIXED_OPERATOR
 
-#include <array>
-#include <unordered_map>
 #include "../../fespace.hpp"
 #include "operator.hpp"
 #include "util.hpp"
 #include "ceed.hpp"
+#include <array>
+#include <unordered_map>
+#include <vector>
+#ifdef MFEM_USE_OPENMP
+#include <omp.h>
+#endif
 
 namespace mfem
 {
@@ -25,8 +29,8 @@ namespace mfem
 namespace ceed
 {
 
-/** @brief This class wraps one or more `OpType` objects to support
-    finite element spaces on mixed meshes. */
+/** @brief This class wraps one or more `OpType` objects to support finite
+    element spaces on mixed meshes. */
 template <typename OpType>
 class MixedOperator : public Operator
 {
@@ -42,8 +46,11 @@ class MixedOperator : public Operator
                    CeedHash(k[2]));
       }
    };
-   using ElementsMap = std::unordered_map<const ElementKey, int *, ElementHash>;
+#ifndef MFEM_USE_OPENMP
    std::vector<OpType *> sub_ops;
+#else
+   std::vector<std::vector<OpType *>> sub_ops;
+#endif
 
 public:
    template <typename IntegratorType, typename CeedOperatorInfo, typename CoeffType>
@@ -58,7 +65,8 @@ public:
                use_mf);
    }
 
-   template <typename IntegratorType, typename CeedOperatorInfo, typename CoeffType1, typename CoeffType2>
+   template <typename IntegratorType, typename CeedOperatorInfo,
+             typename CoeffType1, typename CoeffType2>
    void Assemble(const IntegratorType &integ,
                  CeedOperatorInfo &info,
                  const mfem::FiniteElementSpace &fes,
@@ -83,7 +91,8 @@ public:
                use_bdr, use_mf);
    }
 
-   template <typename IntegratorType, typename CeedOperatorInfo, typename CoeffType1, typename CoeffType2>
+   template <typename IntegratorType, typename CeedOperatorInfo,
+             typename CoeffType1, typename CoeffType2>
    void Assemble(const IntegratorType &integ,
                  CeedOperatorInfo &info,
                  const mfem::FiniteElementSpace &trial_fes,
@@ -96,6 +105,7 @@ public:
       MFEM_VERIFY(trial_fes.GetMesh() == test_fes.GetMesh(),
                   "Trial and test basis must correspond to the same Mesh.");
       mfem::Mesh &mesh = *trial_fes.GetMesh();
+#ifndef MFEM_USE_OPENMP
       const bool mixed =
          mesh.GetNumGeometries(mesh.Dimension() - use_bdr) > 1 ||
          trial_fes.IsVariableOrder() || test_fes.IsVariableOrder();
@@ -110,115 +120,170 @@ public:
          const mfem::IntegrationRule &ir =
             integ.GetIntegrationRule() ? *integ.GetIntegrationRule() :
             integ.GetRule(trial_fe, test_fe, T);
-         sub_ops.reserve(1);
-         auto *sub_op = new OpType();
-         sub_op->Assemble(info, trial_fes, test_fes, ir,
-                          Q1, Q2, use_bdr, use_mf);
-         sub_ops.push_back(sub_op);
-
-         CeedOperatorReferenceCopy(sub_op->GetCeedOperator(), &oper);
-         if (sub_op->GetCeedOperatorTranspose())
+         sub_ops.push_back(new OpType);
+         auto &sub_op = *sub_ops.back();
+         sub_op.Assemble(internal::ceed, info, trial_fes, test_fes, ir,
+                         Q1, Q2, use_bdr, use_mf);
+         CeedOperatorReferenceCopy(sub_op.GetOperator(), &oper);
+         if (sub_op.GetTransposeOperator())
          {
-            CeedOperatorReferenceCopy(sub_op->GetCeedOperatorTranspose(), &oper_t);
+            CeedOperatorReferenceCopy(sub_op.GetTransposeOperator(), &oper_t);
          }
-         CeedVectorReferenceCopy(sub_op->GetCeedVectorU(), &u);
-         CeedVectorReferenceCopy(sub_op->GetCeedVectorV(), &v);
+         CeedVectorCreate(internal::ceed,
+                          trial_fes.GetVDim() * trial_fes.GetNDofs(), &u);
+         CeedVectorCreate(internal::ceed,
+                          test_fes.GetVDim() * test_fes.GetNDofs(), &v);
          return;
       }
+#endif
 
-      // Count the number of elements of each type
-      ElementsMap count;
-      ElementsMap element_indices;
-      ElementsMap offsets;
-
-      const int ne = use_bdr ? mesh.GetNBE() : mesh.GetNE();
-      for (int i = 0; i < ne; i++)
+#ifdef MFEM_USE_OPENMP
+      #pragma omp parallel
+#endif
       {
-         const mfem::FiniteElement &trial_fe = use_bdr ? *trial_fes.GetBE(i) :
-                                               *trial_fes.GetFE(i);
-         const mfem::FiniteElement &test_fe = use_bdr ? *test_fes.GetBE(i) :
-                                              *test_fes.GetFE(i);
-         mfem::Element::Type type = use_bdr ? mesh.GetBdrElementType(i) :
-                                    mesh.GetElementType(i);
-         ElementKey key = {type, trial_fe.GetOrder(), test_fe.GetOrder()};
-         auto value = count.find(key);
-         if (value == count.end())
+         const int ne = use_bdr ? mesh.GetNBE() : mesh.GetNE();
+#ifdef MFEM_USE_OPENMP
+         const int nt = omp_get_num_threads();
+         #pragma omp master
          {
-            count[key] = new int(1);
+            thread_ops.resize(nt, nullptr);
+            thread_ops_t.resize(nt, nullptr);
+            thread_u.resize(nt, nullptr);
+            thread_v.resize(nt, nullptr);
+            sub_ops.resize(nt);
          }
-         else
+         const int tid = omp_get_thread_num();
+         const int stride = (ne + nt - 1) / nt;
+         const int start = tid * stride;
+         const int stop = std::min(start + stride, ne);
+#else
+         const int start = 0;
+         const int stop = ne;
+#endif
+
+         // Count the number of elements of each type
+         std::unordered_map<ElementKey, int, ElementHash> counts, offsets;
+         std::unordered_map<ElementKey, std::vector<int>, ElementHash> element_indices;
+         for (int i = start; i < stop; i++)
          {
-            (*value->second)++;
+            const mfem::FiniteElement &trial_fe = use_bdr ? *trial_fes.GetBE(i) :
+                                                  *trial_fes.GetFE(i);
+            const mfem::FiniteElement &test_fe = use_bdr ? *test_fes.GetBE(i) :
+                                                 *test_fes.GetFE(i);
+            mfem::Element::Type type = use_bdr ? mesh.GetBdrElementType(i) :
+                                       mesh.GetElementType(i);
+            ElementKey key = {type, trial_fe.GetOrder(), test_fe.GetOrder()};
+            auto value = counts.find(key);
+            if (value == counts.end())
+            {
+               counts[key] = 1;
+            }
+            else
+            {
+               value->second++;
+            }
          }
-      }
 
-      // Initialization of the arrays
-      for (const auto &value : count)
-      {
-         element_indices[value.first] = new int[*value.second];
-         offsets[value.first] = new int(0);
-      }
-
-      // Populates the indices arrays for each element type
-      for (int i = 0; i < ne; i++)
-      {
-         const mfem::FiniteElement &trial_fe = use_bdr ? *trial_fes.GetBE(i) :
-                                               *trial_fes.GetFE(i);
-         const mfem::FiniteElement &test_fe = use_bdr ? *test_fes.GetBE(i) :
-                                              *test_fes.GetFE(i);
-         mfem::Element::Type type = use_bdr ? mesh.GetBdrElementType(i) :
-                                    mesh.GetElementType(i);
-         ElementKey key = {type, trial_fe.GetOrder(), test_fe.GetOrder()};
-         int &offset = *(offsets[key]);
-         int *indices_array = element_indices[key];
-         indices_array[offset] = i;
-         offset++;
-      }
-
-      // Create composite CeedOperator
-      CeedCompositeOperatorCreate(internal::ceed, &oper);
-
-      // Create each sub-CeedOperator
-      sub_ops.reserve(element_indices.size());
-      for (const auto &value : element_indices)
-      {
-         const int *indices = value.second;
-         const int first_index = indices[0];
-         const mfem::FiniteElement &trial_fe =
-            use_bdr ? *trial_fes.GetBE(first_index) : *trial_fes.GetFE(first_index);
-         const mfem::FiniteElement &test_fe =
-            use_bdr ? *test_fes.GetBE(first_index) : *test_fes.GetFE(first_index);
-         auto &T = use_bdr ? *mesh.GetBdrElementTransformation(first_index) :
-                   *mesh.GetElementTransformation(first_index);
-         MFEM_VERIFY(!integ.GetIntegrationRule(),
-                     "Mixed mesh integrators should not have an IntegrationRule.");
-         const IntegrationRule &ir = integ.GetRule(trial_fe, test_fe, T);
-         auto *sub_op = new OpType();
-         sub_op->Assemble(info, trial_fes, test_fes, ir,
-                          *count[value.first], indices,
-                          Q1, Q2, use_bdr, use_mf);
-         sub_ops.push_back(sub_op);
-         CeedCompositeOperatorAddSub(oper, sub_op->GetCeedOperator());
-         if (sub_op->GetCeedOperatorTranspose())
+         // Initialization of the arrays
+         for (const auto &value : counts)
          {
-            if (!oper_t) { CeedCompositeOperatorCreate(internal::ceed, &oper_t); }
-            CeedCompositeOperatorAddSub(oper_t, sub_op->GetCeedOperatorTranspose());
+            offsets[value.first] = 0;
+            element_indices[value.first] = std::vector<int>(value.second);
+         }
+
+         // Populates the indices arrays for each element type
+         for (int i = start; i < stop; i++)
+         {
+            const mfem::FiniteElement &trial_fe = use_bdr ? *trial_fes.GetBE(i) :
+                                                  *trial_fes.GetFE(i);
+            const mfem::FiniteElement &test_fe = use_bdr ? *test_fes.GetBE(i) :
+                                                 *test_fes.GetFE(i);
+            mfem::Element::Type type = use_bdr ? mesh.GetBdrElementType(i) :
+                                       mesh.GetElementType(i);
+            ElementKey key = {type, trial_fe.GetOrder(), test_fe.GetOrder()};
+            int &offset = offsets[key];
+            std::vector<int> &indices = element_indices[key];
+            indices[offset++] = i;
+         }
+
+         // Create each sub-CeedOperator, some threads may be empty
+#ifdef MFEM_USE_OPENMP
+         #pragma omp barrier
+         CeedOperator &loc_oper = thread_ops[tid];
+         CeedOperator &loc_oper_t = thread_ops_t[tid];
+         CeedVector &loc_u = thread_u[tid];
+         CeedVector &loc_v = thread_v[tid];
+         std::vector<OpType *> &loc_sub_ops = sub_ops[tid];
+#else
+         CeedOperator &loc_oper = oper;
+         CeedOperator &loc_oper_t = oper_t;
+         CeedVector &loc_u = u;
+         CeedVector &loc_v = v;
+         std::vector<OpType *> &loc_sub_ops = sub_ops;
+#endif
+         if (element_indices.size() > 0)
+         {
+            loc_sub_ops.reserve(element_indices.size());
+            CeedCompositeOperatorCreate(internal::ceed, &loc_oper);
+            IsoparametricTransformation T;  // Thread-safe
+            for (const auto &value : element_indices)
+            {
+               const std::vector<int> &indices = value.second;
+               const int first_index = indices[0];
+               const mfem::FiniteElement &trial_fe =
+                  use_bdr ? *trial_fes.GetBE(first_index) : *trial_fes.GetFE(first_index);
+               const mfem::FiniteElement &test_fe =
+                  use_bdr ? *test_fes.GetBE(first_index) : *test_fes.GetFE(first_index);
+               if (use_bdr)
+               {
+                  mesh.GetBdrElementTransformation(first_index, &T);
+               }
+               else
+               {
+                  mesh.GetElementTransformation(first_index, &T);
+               }
+               MFEM_VERIFY(!integ.GetIntegrationRule(),
+                           "Mixed mesh integrators should not have an IntegrationRule.");
+               const IntegrationRule &ir = integ.GetRule(trial_fe, test_fe, T);
+               loc_sub_ops.push_back(new OpType);
+               auto &sub_op = *loc_sub_ops.back();
+               sub_op.Assemble(internal::ceed, info, trial_fes, test_fes, ir,
+                               static_cast<int>(indices.size()), indices.data(),
+                               Q1, Q2, use_bdr, use_mf);
+               CeedCompositeOperatorAddSub(loc_oper, sub_op.GetOperator());
+               if (sub_op.GetTransposeOperator())
+               {
+                  if (!loc_oper_t) { CeedCompositeOperatorCreate(internal::ceed, &loc_oper_t); }
+                  CeedCompositeOperatorAddSub(loc_oper_t, sub_op.GetTransposeOperator());
+               }
+            }
+            CeedOperatorCheckReady(loc_oper);
+            if (loc_oper_t) { CeedOperatorCheckReady(loc_oper_t); }
+            CeedVectorCreate(internal::ceed,
+                             trial_fes.GetVDim() * trial_fes.GetNDofs(), &loc_u);
+            CeedVectorCreate(internal::ceed,
+                             test_fes.GetVDim() * test_fes.GetNDofs(), &loc_v);
          }
       }
-      CeedOperatorCheckReady(oper);
-      if (oper_t) { CeedOperatorCheckReady(oper_t); }
-
-      CeedVectorCreate(internal::ceed, trial_fes.GetVDim() * trial_fes.GetNDofs(),
-                       &u);
-      CeedVectorCreate(internal::ceed, test_fes.GetVDim() * test_fes.GetNDofs(), &v);
    }
 
    virtual ~MixedOperator()
    {
+#ifndef MFEM_USE_OPENMP
       for (auto *sub_op : sub_ops)
       {
          delete sub_op;
       }
+#else
+      #pragma omp parallel
+      {
+         const int tid = omp_get_thread_num();
+         for (auto *sub_op : sub_ops[tid])
+         {
+            delete sub_op;
+         }
+      }
+#endif
    }
 #endif
 };

--- a/fem/ceed/interface/operator.cpp
+++ b/fem/ceed/interface/operator.cpp
@@ -14,6 +14,9 @@
 #include "../../../linalg/vector.hpp"
 #include "../../fespace.hpp"
 #include "util.hpp"
+#ifdef MFEM_USE_OPENMP
+#include <omp.h>
+#endif
 
 namespace mfem
 {
@@ -24,48 +27,78 @@ namespace ceed
 #ifdef MFEM_USE_CEED
 Operator::Operator(CeedOperator op)
 {
+   CeedSize in_len, out_len;
+   int ierr = CeedOperatorGetActiveVectorLengths(op, &in_len, &out_len);
+   PCeedChk(ierr);
+   width = in_len;
+   height = out_len;
+   MFEM_VERIFY(width == in_len, "width overflow");
+   MFEM_VERIFY(height == out_len, "height overflow");
+#ifndef MFEM_USE_OPENMP
    oper = op;
    oper_t = nullptr;
-   CeedSize in_len, out_len;
-   int ierr = CeedOperatorGetActiveVectorLengths(oper, &in_len, &out_len);
-   PCeedChk(ierr);
-   height = out_len;
-   width = in_len;
-   MFEM_VERIFY(height == out_len, "height overflow");
-   MFEM_VERIFY(width == in_len, "width overflow");
-   CeedVectorCreate(internal::ceed, height, &v);
    CeedVectorCreate(internal::ceed, width, &u);
+   CeedVectorCreate(internal::ceed, height, &v);
+#else
+   thread_ops = {op};
+   thread_ops_t = {nullptr};
+   thread_u.resize(1);
+   thread_v.resize(1);
+   CeedVectorCreate(internal::ceed, width, &thread_u[0]);
+   CeedVectorCreate(internal::ceed, height, &thread_v[0]);
+#endif
 }
 #endif
+
+Operator::~Operator()
+{
+#ifdef MFEM_USE_CEED
+#ifndef MFEM_USE_OPENMP
+   CeedOperatorDestroy(&oper);
+   CeedOperatorDestroy(&oper_t);
+   CeedVectorDestroy(&u);
+   CeedVectorDestroy(&v);
+#else
+   #pragma omp parallel
+   {
+      const int tid = omp_get_thread_num();
+      CeedOperatorDestroy(&thread_ops[tid]);
+      CeedOperatorDestroy(&thread_ops_t[tid]);
+      CeedVectorDestroy(&thread_u[tid]);
+      CeedVectorDestroy(&thread_v[tid]);
+   }
+#endif
+#endif
+}
 
 namespace
 {
 
 #ifdef MFEM_USE_CEED
-void CeedAddMult(CeedOperator oper, CeedVector u, CeedVector v,
-                 const mfem::Vector &x, mfem::Vector &y, double a)
+template <bool ADD>
+inline void CeedAddMult(CeedOperator oper, CeedVector u,
+                        CeedVector v, const mfem::Vector &x, mfem::Vector &y)
 {
-   MFEM_VERIFY(a == 0.0 || a == 1.0,
-               "General coefficient case is not yet supported!");
+   if (!oper) { return; }  // No-op for an empty operator
    const CeedScalar *x_ptr;
    CeedScalar *y_ptr;
    CeedMemType mem;
-   CeedGetPreferredMemType(mfem::internal::ceed, &mem);
+   CeedGetPreferredMemType(internal::ceed, &mem);
    if (Device::Allows(Backend::DEVICE_MASK) && mem == CEED_MEM_DEVICE)
    {
       x_ptr = x.Read();
-      y_ptr = (a == 0.0) ? y.Write() : y.ReadWrite();
+      y_ptr = (!ADD) ? y.Write() : y.ReadWrite();
    }
    else
    {
       x_ptr = x.HostRead();
-      y_ptr = (a == 0.0) ? y.HostWrite() : y.HostReadWrite();
+      y_ptr = (!ADD) ? y.HostWrite() : y.HostReadWrite();
       mem = CEED_MEM_HOST;
    }
+
    CeedVectorSetArray(u, mem, CEED_USE_POINTER, const_cast<CeedScalar*>(x_ptr));
    CeedVectorSetArray(v, mem, CEED_USE_POINTER, y_ptr);
-
-   if (a == 0.0)
+   if (!ADD)
    {
       CeedOperatorApply(oper, u, v, CEED_REQUEST_IMMEDIATE);
    }
@@ -73,10 +106,48 @@ void CeedAddMult(CeedOperator oper, CeedVector u, CeedVector v,
    {
       CeedOperatorApplyAdd(oper, u, v, CEED_REQUEST_IMMEDIATE);
    }
-
    CeedVectorTakeArray(u, mem, const_cast<CeedScalar**>(&x_ptr));
    CeedVectorTakeArray(v, mem, &y_ptr);
 }
+
+#ifdef MFEM_USE_OPENMP
+inline void CeedAddMult(const std::vector<CeedOperator> &ops,
+                        const std::vector<CeedVector> &u,
+                        const std::vector<CeedVector> &v,
+                        const mfem::Vector &x, mfem::Vector &y)
+{
+   const CeedScalar *x_ptr;
+   CeedScalar *y_ptr;
+   CeedMemType mem;
+   CeedGetPreferredMemType(internal::ceed, &mem);
+   if (Device::Allows(Backend::DEVICE_MASK) && mem == CEED_MEM_DEVICE)
+   {
+      x_ptr = x.Read();
+      y_ptr = y.ReadWrite();
+   }
+   else
+   {
+      x_ptr = x.HostRead();
+      y_ptr = y.HostReadWrite();
+      mem = CEED_MEM_HOST;
+   }
+
+   #pragma omp parallel
+   {
+      const int tid = omp_get_thread_num();
+      if (ops[tid])  // No-op for an empty operator
+      {
+         CeedScalar *u_ptr = const_cast<CeedScalar *>(x_ptr);
+         CeedScalar *v_ptr = y_ptr;
+         CeedVectorSetArray(u[tid], mem, CEED_USE_POINTER, u_ptr);
+         CeedVectorSetArray(v[tid], mem, CEED_USE_POINTER, v_ptr);
+         CeedOperatorApplyAdd(ops[tid], u[tid], v[tid], CEED_REQUEST_IMMEDIATE);
+         CeedVectorTakeArray(u[tid], mem, &u_ptr);
+         CeedVectorTakeArray(v[tid], mem, &v_ptr);
+      }
+   }
+}
+#endif
 #endif
 
 } // namespace
@@ -84,7 +155,12 @@ void CeedAddMult(CeedOperator oper, CeedVector u, CeedVector v,
 void Operator::Mult(const mfem::Vector &x, mfem::Vector &y) const
 {
 #ifdef MFEM_USE_CEED
-   CeedAddMult(oper, u, v, x, y, 0.0);
+#ifndef MFEM_USE_OPENMP
+   CeedAddMult<false>(oper, u, v, x, y);
+#else
+   y = 0.0;
+   CeedAddMult(thread_ops, thread_u, thread_v, x, y);
+#endif
 #else
    MFEM_ABORT("MFEM must be built with MFEM_USE_CEED=YES to use libCEED.");
 #endif
@@ -94,7 +170,12 @@ void Operator::AddMult(const mfem::Vector &x, mfem::Vector &y,
                        const double a) const
 {
 #ifdef MFEM_USE_CEED
-   CeedAddMult(oper, u, v, x, y, 1.0);
+   MFEM_ASSERT(a == 1.0, "General coefficient case is not yet supported");
+#ifndef MFEM_USE_OPENMP
+   CeedAddMult<true>(oper, u, v, x, y);
+#else
+   CeedAddMult(thread_ops, thread_u, thread_v, x, y);
+#endif
 #else
    MFEM_ABORT("MFEM must be built with MFEM_USE_CEED=YES to use libCEED.");
 #endif
@@ -103,9 +184,12 @@ void Operator::AddMult(const mfem::Vector &x, mfem::Vector &y,
 void Operator::MultTranspose(const mfem::Vector &x, mfem::Vector &y) const
 {
 #ifdef MFEM_USE_CEED
-   MFEM_ASSERT(oper_t,
-               "No transpose operator defined for ceed::Operator::MultTranspose.");
-   CeedAddMult(oper_t, v, u, x, y, 0.0);
+#ifndef MFEM_USE_OPENMP
+   CeedAddMult<false>(oper_t, v, u, x, y);
+#else
+   y = 0.0;
+   CeedAddMult(thread_ops_t, thread_v, thread_u, x, y);
+#endif
 #else
    MFEM_ABORT("MFEM must be built with MFEM_USE_CEED=YES to use libCEED.");
 #endif
@@ -115,9 +199,12 @@ void Operator::AddMultTranspose(const mfem::Vector &x, mfem::Vector &y,
                                 const double a) const
 {
 #ifdef MFEM_USE_CEED
-   MFEM_ASSERT(oper_t,
-               "No transpose operator defined for ceed::Operator::AddMultTranspose.");
-   CeedAddMult(oper_t, v, u, x, y, 1.0);
+   MFEM_ASSERT(a == 1.0, "General coefficient case is not yet supported");
+#ifndef MFEM_USE_OPENMP
+   CeedAddMult<true>(oper_t, v, u, x, y);
+#else
+   CeedAddMult(thread_ops_t, thread_v, thread_u, x, y);
+#endif
 #else
    MFEM_ABORT("MFEM must be built with MFEM_USE_CEED=YES to use libCEED.");
 #endif
@@ -128,7 +215,7 @@ void Operator::GetDiagonal(mfem::Vector &diag) const
 #ifdef MFEM_USE_CEED
    CeedScalar *d_ptr;
    CeedMemType mem;
-   CeedGetPreferredMemType(mfem::internal::ceed, &mem);
+   CeedGetPreferredMemType(internal::ceed, &mem);
    if (Device::Allows(Backend::DEVICE_MASK) && mem == CEED_MEM_DEVICE)
    {
       d_ptr = diag.ReadWrite();
@@ -138,11 +225,25 @@ void Operator::GetDiagonal(mfem::Vector &diag) const
       d_ptr = diag.HostReadWrite();
       mem = CEED_MEM_HOST;
    }
+
+#ifndef MFEM_USE_OPENMP
    CeedVectorSetArray(v, mem, CEED_USE_POINTER, d_ptr);
-
    CeedOperatorLinearAssembleAddDiagonal(oper, v, CEED_REQUEST_IMMEDIATE);
-
    CeedVectorTakeArray(v, mem, &d_ptr);
+#else
+   #pragma omp parallel
+   {
+      const int tid = omp_get_thread_num();
+      if (thread_ops[tid])  // No-op for an empty operator
+      {
+         CeedScalar *v_ptr = d_ptr;
+         CeedVectorSetArray(thread_v[tid], mem, CEED_USE_POINTER, v_ptr);
+         CeedOperatorLinearAssembleAddDiagonal(thread_ops[tid], thread_v[tid],
+                                               CEED_REQUEST_IMMEDIATE);
+         CeedVectorTakeArray(thread_v[tid], mem, &v_ptr);
+      }
+   }
+#endif
 #else
    MFEM_ABORT("MFEM must be built with MFEM_USE_CEED=YES to use libCEED.");
 #endif

--- a/fem/ceed/interface/restriction.cpp
+++ b/fem/ceed/interface/restriction.cpp
@@ -214,7 +214,7 @@ static void InitNativeRestrWithIndices(const mfem::FiniteElementSpace &fes,
    mfem::Vector el_trans_j;
    mfem::DofTransformation *dof_trans = use_bdr ? fes.GetBdrElementDofs(i0, dofs) :
                                         fes.GetElementDofs(i0, dofs);
-   if (!dof_trans)
+   if (!dof_trans || dof_trans->IsEmpty())
    {
       tp_el_orients.SetSize(nelem * P);
    }
@@ -235,7 +235,7 @@ static void InitNativeRestrWithIndices(const mfem::FiniteElementSpace &fes,
       {
          dof_trans = fes.GetElementDofs(elem_index, dofs);
       }
-      if (!dof_trans)
+      if (!dof_trans || dof_trans->IsEmpty())
       {
          for (int j = 0; j < P; j++)
          {
@@ -375,16 +375,16 @@ void InitRestriction(const FiniteElementSpace &fes,
                         "restriction.");
             InitLexicoRestr(fes, use_bdr, nelem, ceed, restr);
          }
-         else if (dof_trans)
+         else if (!dof_trans || dof_trans->IsEmpty())
+         {
+            // Native ordering without dof_trans
+            InitNativeRestr(fes, use_bdr, nelem, ceed, restr);
+         }
+         else
          {
             // Native ordering with dof_trans
             InitNativeRestrWithIndices(fes, use_bdr, false, nelem, nullptr,
                                        ceed, restr);
-         }
-         else
-         {
-            // Native ordering without dof_trans
-            InitNativeRestr(fes, use_bdr, nelem, ceed, restr);
          }
       }
       mfem::internal::ceed_restr_map[restr_key] = *restr;
@@ -465,16 +465,16 @@ void InitInterpolatorRestrictions(const FiniteElementSpace &trial_fes,
                            "restriction.");
                InitLexicoRestr(fes, false, nelem, ceed, restr);
             }
-            else if (dof_trans)
+            else if (!dof_trans || dof_trans->IsEmpty())
+            {
+               // Native ordering without dof_trans
+               InitNativeRestr(fes, false, nelem, ceed, restr);
+            }
+            else
             {
                // Native ordering with dof_trans
                InitNativeRestrWithIndices(fes, false, (s > 0), nelem, nullptr,
                                           ceed, restr);
-            }
-            else
-            {
-               // Native ordering without dof_trans
-               InitNativeRestr(fes, false, nelem, ceed, restr);
             }
          }
          mfem::internal::ceed_restr_map[restr_key] = *restr;

--- a/fem/ceed/interface/restriction.hpp
+++ b/fem/ceed/interface/restriction.hpp
@@ -28,7 +28,11 @@ namespace ceed
     of indices @a indices.
 
     @param[in] fes The finite element space.
-    @param[in] use_bdr Create the basis and restriction for boundary elements.
+    @param[in] use_bdr Create the restriction for boundary elements.
+    @param[in] is_interp Create the restriction for an interpolation operator
+                         (sometimes requires special treatment).
+    @param[in] is_range Create the restriction for the range space of an
+                        operator (sometimes requires special treatment).
     @param[in] nelem The number of elements.
     @param[in] indices The indices of the elements of same type in the
                        `FiniteElementSpace`. If `indices == nullptr`, assumes
@@ -37,6 +41,8 @@ namespace ceed
     @param[out] restr The `CeedElemRestriction` to initialize. */
 void InitRestriction(const FiniteElementSpace &fes,
                      bool use_bdr,
+                     bool is_interp,
+                     bool is_range,
                      int nelem,
                      const int *indices,
                      Ceed ceed,
@@ -44,44 +50,19 @@ void InitRestriction(const FiniteElementSpace &fes,
 
 inline void InitRestriction(const FiniteElementSpace &fes,
                             bool use_bdr,
+                            int nelem,
+                            const int *indices,
                             Ceed ceed,
                             CeedElemRestriction *restr)
 {
-   InitRestriction(fes, use_bdr, use_bdr ? fes.GetNBE() : fes.GetNE(),
-                   nullptr, ceed, restr);
+   InitRestriction(fes, use_bdr, false, false, nelem, indices, ceed, restr);
 }
 
-/** @brief Initialize a pair of CeedElemRestriction objects based on a
-    mfem::FiniteElementSpace @a trial_fes and @a test_fes, and an optional list
-    of @a nelem elements of indices @a indices.
-
-    @param[in] trial_fes The trial finite element space.
-    @param[in] test_fes The test finite element space.
-    @param[in] nelem The number of elements.
-    @param[in] indices The indices of the elements of same type in the
-                       `FiniteElementSpace`. If `indices == nullptr`, assumes
-                       that the `FiniteElementSpace` is not mixed.
-    @param[in] ceed The Ceed object.
-    @param[out] trial_restr The `CeedElemRestriction` to initialize for the
-                            trial space.
-    @param[out] test_restr The `CeedElemRestriction` to initialize for the
-                           test space. */
-void InitInterpolatorRestrictions(const FiniteElementSpace &trial_fes,
-                                  const FiniteElementSpace &test_fes,
-                                  int nelem,
-                                  const int *indices,
-                                  Ceed ceed,
-                                  CeedElemRestriction *trial_restr,
-                                  CeedElemRestriction *test_restr);
-
-inline void InitInterpolatorRestrictions(const FiniteElementSpace &trial_fes,
-                                         const FiniteElementSpace &test_fes,
-                                         Ceed ceed,
-                                         CeedElemRestriction *trial_restr,
-                                         CeedElemRestriction *test_restr)
+inline void InitRestriction(const FiniteElementSpace &fes,
+                            Ceed ceed,
+                            CeedElemRestriction *restr)
 {
-   InitInterpolatorRestrictions(trial_fes, test_fes, trial_fes.GetNE(),
-                                nullptr, ceed, trial_restr, test_restr);
+   InitRestriction(fes, false, false, false, fes.GetNE(), nullptr, ceed, restr);
 }
 
 /** @brief Initialize a strided CeedElemRestriction.


### PR DESCRIPTION
NOTE: Based on https://github.com/mfem/mfem/pull/3819

Adds thread-safety to a lot of base MFEM classes and global objects and adds OpenMP parallelism support for libCEED operators.