### PR TITLE
Proposed changes to #3557

### DIFF
--- a/fem/transfer.cpp
+++ b/fem/transfer.cpp
@@ -670,7 +670,7 @@ void L2ProjectionGridTransfer::L2ProjectionH1Space::Mult(
       Y.SetSubVector(vdofs_list, Y_dim);
    }
 
-   SetTDofs(fes_lor, std::move(Y), y);
+   SetTDofs(fes_lor, Y, y);
 }
 
 void L2ProjectionGridTransfer::L2ProjectionH1Space::MultTranspose(
@@ -695,7 +695,7 @@ void L2ProjectionGridTransfer::L2ProjectionH1Space::MultTranspose(
       Y.SetSubVector(vdofs_list, Y_dim);
    }
 
-   SetTDofs(fes_ho, std::move(Y), y);
+   SetTDofs(fes_ho, Y, y);
 }
 
 void L2ProjectionGridTransfer::L2ProjectionH1Space::Prolongate(
@@ -724,7 +724,7 @@ void L2ProjectionGridTransfer::L2ProjectionH1Space::Prolongate(
       Y.SetSubVector(vdofs_list, Y_dim);
    }
 
-   SetTDofs(fes_ho, std::move(Y), y);
+   SetTDofs(fes_ho, Y, y);
 }
 
 void L2ProjectionGridTransfer::L2ProjectionH1Space::ProlongateTranspose(
@@ -753,7 +753,7 @@ void L2ProjectionGridTransfer::L2ProjectionH1Space::ProlongateTranspose(
       Y.SetSubVector(vdofs_list, Y_dim);
    }
 
-   SetTDofs(fes_lor, std::move(Y), y);
+   SetTDofs(fes_lor, Y, y);
 }
 
 void L2ProjectionGridTransfer::L2ProjectionH1Space::SetRelTol(double p_rtol_)
@@ -921,12 +921,12 @@ void L2ProjectionGridTransfer::L2ProjectionH1Space::GetTDofs(
    }
    else
    {
-      X.NewDataAndSize(x.GetData(), x.Size());
+      X = x;
    }
 }
 
 void L2ProjectionGridTransfer::L2ProjectionH1Space::SetTDofs(
-   const FiniteElementSpace& fes, Vector&& X, Vector& x) const
+   const FiniteElementSpace& fes, const Vector &X, Vector& x) const
 {
    const Operator* P = fes.GetProlongationMatrix();
    if (P)
@@ -935,7 +935,7 @@ void L2ProjectionGridTransfer::L2ProjectionH1Space::SetTDofs(
    }
    else
    {
-      x = std::move(X);
+      x = X;
    }
 }
 

--- a/fem/transfer.hpp
+++ b/fem/transfer.hpp
@@ -306,7 +306,7 @@ protected:
       std::pair<std::unique_ptr<SparseMatrix>,
           std::unique_ptr<SparseMatrix>> ComputeSparseRAndM_LH();
       void GetTDofs(const FiniteElementSpace& fes, const Vector& x, Vector& X) const;
-      void SetTDofs(const FiniteElementSpace& fes, Vector&& X, Vector& x) const;
+      void SetTDofs(const FiniteElementSpace& fes, const Vector& X, Vector& x) const;
       void TDofsListByVDim(const FiniteElementSpace& fes,
                            int vdim, Array<int>& vdofs_list) const;
       /// Returns the inverse of an on-rank lumped mass matrix

--- a/fem/transfer.hpp
+++ b/fem/transfer.hpp
@@ -298,16 +298,14 @@ protected:
       virtual void SetAbsTol(double p_atol_);
    protected:
       /// Computes on-rank R and M_LH matrices
-      std::pair<std::unique_ptr<SparseMatrix>, std::unique_ptr<SparseMatrix>>
-                                                                           ComputeSparseRAndM_LH();
-      virtual void GetTDofs(const FiniteElementSpace& fes,
-                            const Vector& x, Vector& X) const;
-      virtual void SetTDofs(const FiniteElementSpace& fes,
-                            Vector&& X, Vector& x) const;
-      virtual void TDofsListByVDim(const FiniteElementSpace& fes,
-                                   int vdim, Array<int>& vdofs_list) const;
+      std::pair<std::unique_ptr<SparseMatrix>,
+          std::unique_ptr<SparseMatrix>> ComputeSparseRAndM_LH();
+      void GetTDofs(const FiniteElementSpace& fes, const Vector& x, Vector& X) const;
+      void SetTDofs(const FiniteElementSpace& fes, Vector&& X, Vector& x) const;
+      void TDofsListByVDim(const FiniteElementSpace& fes,
+                           int vdim, Array<int>& vdofs_list) const;
       /// Returns the inverse of an on-rank lumped mass matrix
-      virtual void LumpedMassInverse(Vector& ML_inv) const;
+      void LumpedMassInverse(Vector& ML_inv) const;
 
       CGSolver pcg;
       std::unique_ptr<Solver> precon;
@@ -334,17 +332,8 @@ protected:
    class ParL2ProjectionH1Space : public L2ProjectionH1Space
    {
    public:
-      ParL2ProjectionH1Space(const ParFiniteElementSpace& pfes_ho_,
-                             const ParFiniteElementSpace& pfes_lor_);
-      virtual ~ParL2ProjectionH1Space() = default;
-   private:
-      void TDofsListByVDim(const FiniteElementSpace& fes,
-                           int vdim, Array<int>& vdofs_list) const override;
-      /// Computes inverse of a lumped mass matrix (stored as a vector)
-      void LumpedMassInverse(Vector& ML_inv) const override;
-
-      const ParFiniteElementSpace& pfes_ho;
-      const ParFiniteElementSpace& pfes_lor;
+      ParL2ProjectionH1Space(const ParFiniteElementSpace& pfes_ho,
+                             const ParFiniteElementSpace& pfes_lor);
    };
 
 #endif

--- a/fem/transfer.hpp
+++ b/fem/transfer.hpp
@@ -259,9 +259,12 @@ protected:
    class L2ProjectionH1Space : public L2Projection
    {
    public:
-      L2ProjectionH1Space(const FiniteElementSpace& fes_ho_,
-                          const FiniteElementSpace& fes_lor_,
-                          bool build_operators = true);
+      L2ProjectionH1Space(const FiniteElementSpace &fes_ho_,
+                          const FiniteElementSpace &fes_lor_);
+#ifdef MFEM_USE_MPI
+      L2ProjectionH1Space(const ParFiniteElementSpace &pfes_ho_,
+                          const ParFiniteElementSpace &pfes_lor_);
+#endif
       virtual ~L2ProjectionH1Space() = default;
       /// Maps <tt>x</tt>, primal field coefficients defined on a coarse mesh
       /// with a higher order H1 finite element space, to <tt>y</tt>, primal
@@ -297,6 +300,8 @@ protected:
       virtual void SetRelTol(double p_rtol_);
       virtual void SetAbsTol(double p_atol_);
    protected:
+      /// Sets up the PCG solver (sets parameters, operator, and preconditioner)
+      void SetupPCG();
       /// Computes on-rank R and M_LH matrices
       std::pair<std::unique_ptr<SparseMatrix>,
           std::unique_ptr<SparseMatrix>> ComputeSparseRAndM_LH();
@@ -322,21 +327,6 @@ protected:
       /// refined LOR elements.
       std::unique_ptr<SparseMatrix> AllocR();
    };
-
-
-#ifdef MFEM_USE_MPI
-
-   /** Implements class for projection operator between a H1 high-order finite
-       element space on a coarse mesh, and a H1 low-order finite element space
-       on a refined mesh (LOR) in parallel. */
-   class ParL2ProjectionH1Space : public L2ProjectionH1Space
-   {
-   public:
-      ParL2ProjectionH1Space(const ParFiniteElementSpace& pfes_ho,
-                             const ParFiniteElementSpace& pfes_lor);
-   };
-
-#endif
 
    /** Mass-conservative prolongation operator going in the opposite direction
        as L2Projection. This operator is a left inverse to the L2Projection. */

--- a/miniapps/tools/lor-transfer.cpp
+++ b/miniapps/tools/lor-transfer.cpp
@@ -282,14 +282,11 @@ double compute_mass(FiniteElementSpace *L2, double massL2,
                     VisItDataCollection &dc, string prefix)
 {
    ConstantCoefficient one(1.0);
-   BilinearForm ML2(L2);
-   ML2.AddDomainIntegrator(new MassIntegrator(one));
-   ML2.Assemble();
+   LinearForm lf(L2);
+   lf.AddDomainIntegrator(new DomainLFIntegrator(one));
+   lf.Assemble();
 
-   GridFunction rhoone(L2);
-   rhoone = 1.0;
-
-   double newmass = ML2.InnerProduct(*dc.GetField("density"),rhoone);
+   double newmass = lf(*dc.GetField("density"));
    cout.precision(18);
    cout << space << " " << prefix << " mass   = " << newmass;
    if (massL2 >= 0)

--- a/miniapps/tools/plor-transfer.cpp
+++ b/miniapps/tools/plor-transfer.cpp
@@ -210,9 +210,6 @@ int main(int argc, char *argv[])
    }
 
    // HO* to LOR* dual fields
-   ParGridFunction ones(&fespace), ones_lor(&fespace_lor);
-   ones = 1.0;
-   ones_lor = 1.0;
    ParLinearForm M_rho(&fespace), M_rho_lor(&fespace_lor);
    auto global_sum = [](const Vector& v)
    {

--- a/miniapps/tools/plor-transfer.cpp
+++ b/miniapps/tools/plor-transfer.cpp
@@ -345,21 +345,11 @@ double compute_mass(ParFiniteElementSpace *L2, double massL2,
                     VisItDataCollection &dc, string prefix)
 {
    ConstantCoefficient one(1.0);
-   ParBilinearForm ML2(L2);
-   ML2.AddDomainIntegrator(new MassIntegrator(one));
-   ML2.Assemble();
-   ML2.Finalize();
-   HypreParMatrix* pML2 = ML2.ParallelAssemble();
+   ParLinearForm lf(L2);
+   lf.AddDomainIntegrator(new DomainLFIntegrator(one));
+   lf.Assemble();
 
-   Vector rhoone(L2->GetTrueVSize());
-   rhoone = 1.0;
-
-   Vector Mdiag(L2->GetTrueVSize());
-   pML2->Mult(rhoone, Mdiag);
-   delete pML2;
-   HypreParVector* rho = dc.GetParField("density")->GetTrueDofs();
-   double newmass = InnerProduct(MPI_COMM_WORLD, *rho, Mdiag);
-   delete rho;
+   double newmass = lf(*dc.GetParField("density"));
    if (Mpi::Root())
    {
       cout.precision(18);


### PR DESCRIPTION
Some proposed changes to PR #3557:

* Remove the class `ParL2ProjectionH1Space`. Instead the serial and parallel versions are in a single class, `L2ProjectionH1Space`. Only the constructor is different.
* Make sure to do RAP in serial when the prolongation matrices are not identity (e.g. AMR meshes)
* Simplify mass computation in the miniapp code
* Remove the optimization where the DOF and true-DOF vectors would alias each other in certain cases. This way is clearer and safer, but a bit less efficient. With a parallel build this optimization isn't going to matter.