### PR TITLE
`ParMesh` constructor improvement

### DIFF
--- a/mesh/mesh.cpp
+++ b/mesh/mesh.cpp
@@ -2450,7 +2450,7 @@ void Mesh::MarkTriMeshForRefinement()
    }
 }
 
-void Mesh::GetEdgeOrdering(DSTable &v_to_v, Array<int> &order)
+void Mesh::GetEdgeOrdering(const DSTable &v_to_v, Array<int> &order)
 {
    NumOfEdges = v_to_v.NumberOfEntries();
    order.SetSize(NumOfEdges);
@@ -2475,7 +2475,7 @@ void Mesh::GetEdgeOrdering(DSTable &v_to_v, Array<int> &order)
    }
 }
 
-void Mesh::MarkTetMeshForRefinement(DSTable &v_to_v)
+void Mesh::MarkTetMeshForRefinement(const DSTable &v_to_v)
 {
    // Mark the longest tetrahedral edge by rotating the indices so that
    // vertex 0 - vertex 1 is the longest edge in the element.

--- a/mesh/mesh.hpp
+++ b/mesh/mesh.hpp
@@ -31,8 +31,6 @@
 namespace mfem
 {
 
-// Data type mesh
-
 class GeometricFactors;
 class FaceGeometricFactors;
 class KnotVector;
@@ -49,15 +47,15 @@ class ParMesh;
 class ParNCMesh;
 #endif
 
+/// Mesh data type
 class Mesh
 {
+   friend class NCMesh;
+   friend class NURBSExtension;
 #ifdef MFEM_USE_MPI
    friend class ParMesh;
    friend class ParNCMesh;
 #endif
-   friend class NCMesh;
-   friend class NURBSExtension;
-
 #ifdef MFEM_USE_ADIOS2
    friend class adios2stream;
 #endif
@@ -336,8 +334,8 @@ protected:
 
    void MarkForRefinement();
    void MarkTriMeshForRefinement();
-   void GetEdgeOrdering(DSTable &v_to_v, Array<int> &order);
-   virtual void MarkTetMeshForRefinement(DSTable &v_to_v);
+   void GetEdgeOrdering(const DSTable &v_to_v, Array<int> &order);
+   virtual void MarkTetMeshForRefinement(const DSTable &v_to_v);
 
    // Methods used to prepare and apply permutation of the mesh nodes assuming
    // that the mesh elements may be rotated (e.g. to mark triangle or tet edges

--- a/mesh/pmesh.cpp
+++ b/mesh/pmesh.cpp
@@ -1730,7 +1730,7 @@ void ParMesh::GetSharedTriCommunicator(int ordering,
    stria_comm.Finalize();
 }
 
-void ParMesh::MarkTetMeshForRefinement(DSTable &v_to_v)
+void ParMesh::MarkTetMeshForRefinement(const DSTable &v_to_v)
 {
    Array<int> order;
    GetEdgeOrdering(v_to_v, order); // local edge ordering

--- a/mesh/pmesh.hpp
+++ b/mesh/pmesh.hpp
@@ -317,7 +317,8 @@ public:
 
    /// Read a parallel mesh, each MPI rank from its own file/stream.
    /** The @a refine parameter is passed to the method Mesh::Finalize(). */
-   ParMesh(MPI_Comm comm, std::istream &input, bool refine = true);
+   ParMesh(MPI_Comm comm, std::istream &input, int generate_edges = 0,
+           int refine = 1, bool fix_orientation = true);
 
    /// Deprecated: see @a ParMesh::MakeRefined
    MFEM_DEPRECATED

--- a/mesh/pmesh.hpp
+++ b/mesh/pmesh.hpp
@@ -24,6 +24,7 @@
 
 namespace mfem
 {
+
 #ifdef MFEM_USE_PUMI
 class ParPumiMesh;
 #endif
@@ -31,9 +32,16 @@ class ParPumiMesh;
 /// Class for parallel meshes
 class ParMesh : public Mesh
 {
-protected:
+   friend class ParNCMesh;
    friend class ParSubMesh;
+#ifdef MFEM_USE_PUMI
+   friend class ParPumiMesh;
+#endif
+#ifdef MFEM_USE_ADIOS2
+   friend class adios2stream;
+#endif
 
+protected:
    MPI_Comm MyComm;
    int NRanks, MyRank;
 
@@ -102,7 +110,7 @@ protected:
 
    // Mark all tets to ensure consistency across MPI tasks; also mark the
    // shared and boundary triangle faces using the consistently marked tets.
-   void MarkTetMeshForRefinement(DSTable &v_to_v) override;
+   void MarkTetMeshForRefinement(const DSTable &v_to_v) override;
 
    /// Return a number(0-1) identifying how the given edge has been split
    int GetEdgeSplittings(Element *edge, const DSTable &v_to_v, int *middle);
@@ -665,14 +673,6 @@ public:
    void PrintSharedEntities(const std::string &fname_prefix) const;
 
    virtual ~ParMesh();
-
-   friend class ParNCMesh;
-#ifdef MFEM_USE_PUMI
-   friend class ParPumiMesh;
-#endif
-#ifdef MFEM_USE_ADIOS2
-   friend class adios2stream;
-#endif
 };
 
 }


### PR DESCRIPTION
Expose the `generate_edges` and `fix_orientations` parameters passed to `Loader` and `Finalize` methods in addition to `refine` for the `ParMesh(MPI_Comm comm, std::istream &input, int generate_edges = 0, int refine = 1, bool fix_orientation = true)` constructor. This now mirrors the same constructor for `Mesh` without hardcoding the values inside the definition.

Also includes some organizational improvement in `friend` class declarations for consistency between `Mesh` and `ParMesh`, as well as a minor change for `const` correctness.