### PR TITLE
Fix NC tet edge-face constraint bug

### DIFF
--- a/fem/pfespace.cpp
+++ b/fem/pfespace.cpp
@@ -2058,7 +2058,7 @@ void NeighborRowMessage::Encode(int rank)
    for (unsigned i = 0; i < rows.size(); i++)
    {
       const RowInfo &ri = rows[i];
-      const MeshId &id = pncmesh->GetNCList(ri.entity).LookUp(ri.index);
+      const MeshId &id = *pncmesh->GetNCList(ri.entity).GetMeshIdAndType(ri.index).id;
       ent_ids[ri.entity].Append(id);
       row_idx[ri.entity].Append(i);
       group_ids[ri.entity].Append(ri.group);

--- a/mesh/ncmesh.cpp
+++ b/mesh/ncmesh.cpp
@@ -3021,13 +3021,13 @@ void NCMesh::TraverseTetEdge(int vn0, int vn1, const Point &p0, const Point &p1,
    if (nd.HasEdge())
    {
       // check if the edge is already a master in 'edge_list'
-      int type;
-      const MeshId &eid = edge_list.LookUp(nd.edge_index, &type);
-      if (type == 1)
+      const auto eid_and_type = edge_list.GetMeshIdAndType(nd.edge_index);
+      if (eid_and_type.type == NCList::MeshIdType::MASTER
+          || eid_and_type.type == NCList::MeshIdType::CONFORMING)
       {
          // in this case we need to add an edge-face constraint, because the
-         // master edge is really a (face-)slave itself
-
+         // non-slave edge is really a (face-)slave itself.
+         const MeshId &eid = *eid_and_type.id;
          face_list.slaves.Append(
             Slave(-1 - eid.index, eid.element, eid.local, Geometry::TRIANGLE));
 
@@ -3048,9 +3048,10 @@ void NCMesh::TraverseTetEdge(int vn0, int vn1, const Point &p0, const Point &p1,
    TraverseTetEdge(mid, vn1, pmid, p1, matrix_map);
 }
 
-bool NCMesh::TraverseTriFace(int vn0, int vn1, int vn2,
-                             const PointMatrix& pm, int level,
-                             MatrixMap &matrix_map)
+NCMesh::TriFaceTraverseResults NCMesh::TraverseTriFace(int vn0, int vn1,
+                                                       int vn2,
+                                                       const PointMatrix& pm, int level,
+                                                       MatrixMap &matrix_map)
 {
    if (level > 0)
    {
@@ -3069,7 +3070,7 @@ bool NCMesh::TraverseTriFace(int vn0, int vn1, int vn2,
          sl.local = ReorderFacePointMat(vn0, vn1, vn2, -1, elem, pm, pm_r);
          sl.matrix = matrix_map.GetIndex(pm_r);
 
-         return true;
+         return {true, elements[elem].rank != MyRank};
       }
    }
 
@@ -3077,7 +3078,7 @@ bool NCMesh::TraverseTriFace(int vn0, int vn1, int vn2,
    if (TriFaceSplit(vn0, vn1, vn2, mid))
    {
       Point pmid0(pm(0), pm(1)), pmid1(pm(1), pm(2)), pmid2(pm(2), pm(0));
-      bool b[4];
+      TriFaceTraverseResults b[4];
 
       b[0] = TraverseTriFace(vn0, mid[0], mid[2],
                              PointMatrix(pm(0), pmid0, pmid2),
@@ -3095,16 +3096,21 @@ bool NCMesh::TraverseTriFace(int vn0, int vn1, int vn2,
                              PointMatrix(pmid1, pmid2, pmid0),
                              level+1, matrix_map);
 
-      // traverse possible tet edges constrained by the master face
-      if (HaveTets() && !b[3])
+      // Traverse possible tet edges constrained by the master face. This needs to occur if
+      // none of these first NC level faces are split further, OR if they are on different
+      // processors. The different processor constraint is needed in the case of local
+      // elements constrained by this face via the edge alone. Cannot know this a priori, so
+      // just constrain any edge attached to two neighbors.
+      if (HaveTets() && (!b[3].unsplit || b[3].ghost_neighbor))
       {
-         if (!b[1]) { TraverseTetEdge(mid[0],mid[1], pmid0,pmid1, matrix_map); }
-         if (!b[2]) { TraverseTetEdge(mid[1],mid[2], pmid1,pmid2, matrix_map); }
-         if (!b[0]) { TraverseTetEdge(mid[2],mid[0], pmid2,pmid0, matrix_map); }
+         // If the faces have no further splits, so would not be captured by normal face
+         // relations, add possible edge constraints.
+         if (!b[1].unsplit || b[1].ghost_neighbor) { TraverseTetEdge(mid[0],mid[1], pmid0,pmid1, matrix_map); }
+         if (!b[2].unsplit || b[2].ghost_neighbor) { TraverseTetEdge(mid[1],mid[2], pmid1,pmid2, matrix_map); }
+         if (!b[0].unsplit || b[0].ghost_neighbor) { TraverseTetEdge(mid[2],mid[0], pmid2,pmid0, matrix_map); }
       }
    }
-
-   return false;
+   return {false, false};
 }
 
 void NCMesh::BuildFaceList()
@@ -3402,76 +3408,80 @@ void NCMesh::NCList::Clear()
       point_matrices[i].DeleteAll();
    }
 
-   inv_index.DeleteAll();
+   inv_index.clear();
 }
 
-long NCMesh::NCList::TotalSize() const
+NCMesh::NCList::MeshIdAndType
+NCMesh::NCList::GetMeshIdAndType(int index) const
 {
-   return conforming.Size() + masters.Size() + slaves.Size();
-}
-
-const NCMesh::MeshId& NCMesh::NCList::LookUp(int index, int *type) const
-{
-   if (!inv_index.Size())
+   BuildIndex();
+   if (inv_index.size() == 0)
    {
-      int max_index = -1;
+      MFEM_ABORT("Inverse index not built.");
+   }
+   const auto it = inv_index.find(index);
+   auto ft = it != inv_index.end() ? it->second.first : MeshIdType::UNRECOGNIZED;
+   switch (ft)
+   {
+      case MeshIdType::CONFORMING:
+         return {&conforming[it->second.second], it->second.first};
+      case MeshIdType::MASTER:
+         return {&masters[it->second.second], it->second.first};
+      case MeshIdType::SLAVE:
+         return {&slaves[it->second.second], it->second.first};
+      case MeshIdType::UNRECOGNIZED:
+      default:
+         return {nullptr, MeshIdType::UNRECOGNIZED};
+   }
+}
+
+NCMesh::NCList::MeshIdType
+NCMesh::NCList::GetMeshIdType(int index) const
+{
+   BuildIndex();
+   auto it = inv_index.find(index);
+   return (it != inv_index.end()) ? it->second.first : MeshIdType::UNRECOGNIZED;
+}
+
+bool
+NCMesh::NCList::CheckMeshIdType(int index, MeshIdType ft) const
+{
+   return GetMeshIdType(index) == ft;
+}
+
+void
+NCMesh::NCList::BuildIndex() const
+{
+   if (inv_index.size() == 0)
+   {
+      auto index_compare = [](const MeshId &a, const MeshId &b) { return a.index < b.index; };
+      auto max_conforming = std::max_element(conforming.begin(), conforming.end(),
+                                             index_compare);
+      auto max_master = std::max_element(masters.begin(), masters.end(),
+                                         index_compare);
+      auto max_slave = std::max_element(slaves.begin(), slaves.end(), index_compare);
+
+      int max_conforming_index = max_conforming != nullptr ? max_conforming->index :
+                                 -1;
+      int max_master_index = max_master != nullptr ? max_master->index : -1;
+      int max_slave_index = max_slave != nullptr ? max_slave->index : -1;
+
+      inv_index.reserve(std::max({max_conforming_index, max_master_index, max_slave_index}));
       for (int i = 0; i < conforming.Size(); i++)
       {
-         max_index = std::max(conforming[i].index, max_index);
+         inv_index.emplace(conforming[i].index, std::make_pair(MeshIdType::CONFORMING,
+                                                               i));
       }
       for (int i = 0; i < masters.Size(); i++)
       {
-         max_index = std::max(masters[i].index, max_index);
+         inv_index.emplace(masters[i].index, std::make_pair(MeshIdType::MASTER, i));
       }
       for (int i = 0; i < slaves.Size(); i++)
       {
-         if (slaves[i].index < 0) { continue; }
-         max_index = std::max(slaves[i].index, max_index);
+         inv_index.emplace(slaves[i].index, std::make_pair(MeshIdType::SLAVE, i));
       }
-
-      inv_index.SetSize(max_index + 1);
-      inv_index = -1;
-
-      for (int i = 0; i < conforming.Size(); i++)
-      {
-         inv_index[conforming[i].index] = (i << 2);
-      }
-      for (int i = 0; i < masters.Size(); i++)
-      {
-         inv_index[masters[i].index] = (i << 2) + 1;
-      }
-      for (int i = 0; i < slaves.Size(); i++)
-      {
-         if (slaves[i].index < 0) { continue; }
-         inv_index[slaves[i].index] = (i << 2) + 2;
-      }
-   }
-
-   MFEM_ASSERT(index >= 0 && index < inv_index.Size(), "");
-   int key = inv_index[index];
-
-   if (!type)
-   {
-      MFEM_VERIFY(key >= 0, "index " << index << " not found.");
-   }
-   else // return entity type if requested, don't abort when not found
-   {
-      *type = (key >= 0) ? (key & 0x3) : -1;
-
-      static MeshId invalid;
-      if (*type < 0) { return invalid; } // not found
-   }
-
-   // return found entity MeshId
-   switch (key & 0x3)
-   {
-      case 0: return conforming[key >> 2];
-      case 1: return masters[key >> 2];
-      case 2: return slaves[key >> 2];
-      default: MFEM_ABORT("internal error"); return conforming[0];
    }
 }
-
 
 //// Neighbors /////////////////////////////////////////////////////////////////
 

--- a/mesh/ncmesh.cpp
+++ b/mesh/ncmesh.cpp
@@ -3415,10 +3415,6 @@ NCMesh::NCList::MeshIdAndType
 NCMesh::NCList::GetMeshIdAndType(int index) const
 {
    BuildIndex();
-   if (inv_index.size() == 0)
-   {
-      MFEM_ABORT("Inverse index not built.");
-   }
    const auto it = inv_index.find(index);
    auto ft = it != inv_index.end() ? it->second.first : MeshIdType::UNRECOGNIZED;
    switch (ft)
@@ -3481,6 +3477,9 @@ NCMesh::NCList::BuildIndex() const
          inv_index.emplace(slaves[i].index, std::make_pair(MeshIdType::SLAVE, i));
       }
    }
+
+   MFEM_ASSERT(inv_index.size() > 0,
+               "Empty inverse index, member lists must be populated before BuildIndex is called!");
 }
 
 //// Neighbors /////////////////////////////////////////////////////////////////

--- a/mesh/ncmesh.hpp
+++ b/mesh/ncmesh.hpp
@@ -238,14 +238,16 @@ public:
       void OrientedPointMatrix(const Slave &slave,
                                DenseMatrix &oriented_matrix) const;
 
-      /// Particular MeshId type, used for allowing static casting to the appropriate
-      /// child type after searching the NCList. UNRECOGNIZED denotes that an instance is not
-      /// known within the NCList, meaning that it does not play a part in NC mechanics.
-      /// This can be because the index did not exist in the original Mesh, or because the
-      /// entry is a boundary face, whose NC status is always conforming.
+      /// Particular MeshId type, used for allowing static casting to the
+      /// appropriate child type after searching the NCList. UNRECOGNIZED
+      /// denotes that an instance is not known within the NCList, meaning that
+      /// it does not play a part in NC mechanics. This can be because the index
+      /// did not exist in the original Mesh, or because the entry is a boundary
+      /// face, whose NC status is always conforming.
       enum class MeshIdType : char {CONFORMING, MASTER, SLAVE, UNRECOGNIZED};
 
-      /// Helper storing a reference to a MeshId type, and the face type it can be cast to
+      /// Helper storing a reference to a MeshId type, and the face type it can
+      /// be cast to
       struct MeshIdAndType
       {
          const MeshId * const id; ///< Pointer to a possible MeshId, nullptr if not found
@@ -275,17 +277,19 @@ public:
       {
          return conforming.Size() + masters.Size() + slaves.Size();
       }
-      /// The memory usage of the three public arrays. Does not account for the inverse index.
+      /// The memory usage of the three public arrays. Does not account for the
+      /// inverse index.
       long MemoryUsage() const;
       ~NCList() { Clear(); }
    private:
-      // Check for existence or construct the inv_index list map if necessary. const because only
-      // modifies the mutable member inv_index.
+      // Check for existence or construct the inv_index list map if necessary.
+      // const because only modifies the mutable member inv_index.
       void BuildIndex() const;
 
-      /// A lazily constructed map from index to MeshId. Built whenever GetMeshIdAndType, GetMeshIdType or
-      /// CheckMeshIdType is called for the first time. The MeshIdType is stored with, to enable
-      /// casting to Slave or Master elements appropriately.
+      /// A lazily constructed map from index to MeshId. Built whenever
+      /// GetMeshIdAndType, GetMeshIdType or CheckMeshIdType is called for the
+      /// first time. The MeshIdType is stored with, to enable casting to Slave
+      /// or Master elements appropriately.
       mutable std::unordered_map<int, std::pair<MeshIdType, int>> inv_index;
    };
 

--- a/mesh/ncmesh.hpp
+++ b/mesh/ncmesh.hpp
@@ -24,6 +24,7 @@
 #include <vector>
 #include <map>
 #include <iostream>
+#include <unordered_map>
 
 namespace mfem
 {
@@ -223,30 +224,69 @@ public:
          , master(-1), matrix(0), edge_flags(0) {}
    };
 
+
    /// Lists all edges/faces in the nonconforming mesh.
    struct NCList
    {
-      Array<MeshId> conforming;
-      Array<Master> masters;
-      Array<Slave> slaves;
+      Array<MeshId> conforming; ///< All MeshIds corresponding to conformal faces
+      Array<Master> masters; ///< All MeshIds corresponding to master faces
+      Array<Slave> slaves; ///< All MeshIds corresponding to slave faces
 
       /// List of unique point matrices for each slave geometry.
       Array<DenseMatrix*> point_matrices[Geometry::NumGeom];
 
-      /// Return the point matrix oriented according to the master and slave edges
       void OrientedPointMatrix(const Slave &slave,
                                DenseMatrix &oriented_matrix) const;
 
+      /// Particular MeshId type, used for allowing static casting to the appropriate
+      /// child type after searching the NCList. UNRECOGNIZED denotes that an instance is not
+      /// known within the NCList, meaning that it does not play a part in NC mechanics.
+      /// This can be because the index did not exist in the original Mesh, or because the
+      /// entry is a boundary face, whose NC status is always conforming.
+      enum class MeshIdType : char {CONFORMING, MASTER, SLAVE, UNRECOGNIZED};
+
+      /// Helper storing a reference to a MeshId type, and the face type it can be cast to
+      struct MeshIdAndType
+      {
+         const MeshId * const id; ///< Pointer to a possible MeshId, nullptr if not found
+         /// MeshIdType corresponding to the MeshId. UNRECOGNIZED if unfound.
+         const MeshIdType type;
+      };
+      /// Return a mesh id and type for a given nc index.
+      MeshIdAndType GetMeshIdAndType(int index) const;
+
+      /// Return a face type for a given nc index.
+      MeshIdType GetMeshIdType(int index) const;
+
+      /// Given an index, check if this is a certain face type.
+      bool CheckMeshIdType(int index, MeshIdType type) const;
+
+      /// Erase the contents of the conforming, master and slave arrays.
       void Clear();
-      bool Empty() const { return !conforming.Size() && !masters.Size(); }
-      long TotalSize() const;
+      /// Whether the NCList is empty.
+      bool Empty() const
+      {
+         return conforming.Size() == 0
+                && masters.Size() == 0
+                && slaves.Size() == 0;
+      }
+      /// The total size of the component arrays in the NCList.
+      long TotalSize() const
+      {
+         return conforming.Size() + masters.Size() + slaves.Size();
+      }
+      /// The memory usage of the three public arrays. Does not account for the inverse index.
       long MemoryUsage() const;
-
-      const MeshId& LookUp(int index, int *type = NULL) const;
-
       ~NCList() { Clear(); }
    private:
-      mutable Array<int> inv_index;
+      // Check for existence or construct the inv_index list map if necessary. const because only
+      // modifies the mutable member inv_index.
+      void BuildIndex() const;
+
+      /// A lazily constructed map from index to MeshId. Built whenever GetMeshIdAndType, GetMeshIdType or
+      /// CheckMeshIdType is called for the first time. The MeshIdType is stored with, to enable
+      /// casting to Slave or Master elements appropriately.
+      mutable std::unordered_map<int, std::pair<MeshIdType, int>> inv_index;
    };
 
    /// Return the current list of conforming and nonconforming faces.
@@ -727,9 +767,14 @@ protected: // implementation
    void TraverseQuadFace(int vn0, int vn1, int vn2, int vn3,
                          const PointMatrix& pm, int level, Face* eface[4],
                          MatrixMap &matrix_map);
-   bool TraverseTriFace(int vn0, int vn1, int vn2,
-                        const PointMatrix& pm, int level,
-                        MatrixMap &matrix_map);
+   struct TriFaceTraverseResults
+   {
+      bool unsplit; ///< Whether this face has no further splits.
+      bool ghost_neighbor; ///< Whether the face neighbor is a ghost.
+   };
+   TriFaceTraverseResults TraverseTriFace(int vn0, int vn1, int vn2,
+                                          const PointMatrix& pm, int level,
+                                          MatrixMap &matrix_map);
    void TraverseTetEdge(int vn0, int vn1, const Point &p0, const Point &p1,
                         MatrixMap &matrix_map);
    void TraverseEdge(int vn0, int vn1, double t0, double t1, int flags,

--- a/tests/unit/mesh/test_ncmesh.cpp
+++ b/tests/unit/mesh/test_ncmesh.cpp
@@ -518,23 +518,19 @@ TEST_CASE("EdgeFaceConstraint",  "[Parallel], [NCMesh]")
          {
             auto error = CheckL2Projection(ttmp, sttmp, 4, exact_soln);
             double constexpr tol = 1e-9;
-            // std::cout << "R" << Mpi::WorldRank() << ": " << error[0] << " " << error[1] << std::endl;
             CHECK(std::abs(error[1] - error[0]) < tol);
          }
          ttmp.ExchangeFaceNbrData();
          ttmp.Rebalance();
-         MPI_Barrier(MPI_COMM_WORLD);
-
          {
             auto error = CheckL2Projection(ttmp, sttmp, 4, exact_soln);
             double constexpr tol = 1e-9;
-            // std::cout << "R" << Mpi::WorldRank() << ": " << error[0] << " " << error[1] << std::endl;
             CHECK(std::abs(error[1] - error[0]) < tol);
          }
       }
    }
 
-   auto CheckSerialParalelH1Equivalence = [](Mesh &smesh)
+   auto CheckSerialParallelH1Equivalence = [](Mesh &smesh)
    {
       constexpr int dim = 3;
       constexpr int order = 2;
@@ -552,7 +548,7 @@ TEST_CASE("EdgeFaceConstraint",  "[Parallel], [NCMesh]")
       CHECK(serial_ntdof == parallel_ntdof);
    };
 
-   auto CheckSerialParalelNDEquivalence = [](Mesh &smesh)
+   auto CheckSerialParallelNDEquivalence = [](Mesh &smesh)
    {
       constexpr int dim = 3;
       constexpr int order = 1;
@@ -592,8 +588,8 @@ TEST_CASE("EdgeFaceConstraint",  "[Parallel], [NCMesh]")
             el_to_refine[0] = m;
             smesh3.GeneralRefinement(el_to_refine);
             CAPTURE(n,m);
-            CheckSerialParalelNDEquivalence(smesh3);
-            CheckSerialParalelH1Equivalence(smesh3);
+            CheckSerialParallelNDEquivalence(smesh3);
+            CheckSerialParallelH1Equivalence(smesh3);
          }
       }
    }

--- a/tests/unit/mesh/test_ncmesh.cpp
+++ b/tests/unit/mesh/test_ncmesh.cpp
@@ -301,7 +301,7 @@ TEST_CASE("pNCMesh PA diagonal",  "[Parallel], [NCMesh]")
 // Given a parallel and a serial mesh, perform an L2 projection and check the
 // solutions match exactly.
 std::array<double, 2> CheckL2Projection(ParMesh& pmesh, Mesh& smesh, int order,
-                       std::function<double(Vector const&)> exact_soln)
+                                        std::function<double(Vector const&)> exact_soln)
 {
    REQUIRE(pmesh.GetGlobalNE() == smesh.GetNE());
    REQUIRE(pmesh.Dimension() == smesh.Dimension());
@@ -625,15 +625,17 @@ TEST_CASE("EdgeFaceConstraint",  "[Parallel], [NCMesh]")
       }
       ParMesh pmesh(MPI_COMM_WORLD, smesh, partition.get());
 
-      constexpr int dim = 3;
-      constexpr int order = 1;
-      ND_FECollection nd_fec(order, dim);
-      FiniteElementSpace fes(&smesh, &nd_fec);
-      const auto serial_ntdof = fes.GetTrueVSize();
-      ParFiniteElementSpace pfes(&pmesh, &nd_fec);
-      pfes.ExchangeFaceNbrData();
-      const auto parallel_ntdof = pfes.GlobalTrueVSize();
-      CHECK(serial_ntdof == parallel_ntdof);
+      {
+         constexpr int dim = 3;
+         constexpr int order = 1;
+         ND_FECollection nd_fec(order, dim);
+         FiniteElementSpace fes(&smesh, &nd_fec);
+         const auto serial_ntdof = fes.GetTrueVSize();
+         ParFiniteElementSpace pfes(&pmesh, &nd_fec);
+         pfes.ExchangeFaceNbrData();
+         const auto parallel_ntdof = pfes.GlobalTrueVSize();
+         CHECK(serial_ntdof == parallel_ntdof);
+      }
 
       for (int order = 1; order <= 4; order++)
       {

--- a/tests/unit/mesh/test_ncmesh.cpp
+++ b/tests/unit/mesh/test_ncmesh.cpp
@@ -12,6 +12,7 @@
 #include "mfem.hpp"
 #include "unit_tests.hpp"
 
+#include <array>
 namespace mfem
 {
 
@@ -299,7 +300,7 @@ TEST_CASE("pNCMesh PA diagonal",  "[Parallel], [NCMesh]")
 
 // Given a parallel and a serial mesh, perform an L2 projection and check the
 // solutions match exactly.
-void CheckL2Projection(ParMesh& pmesh, Mesh& smesh, int order,
+std::array<double, 2> CheckL2Projection(ParMesh& pmesh, Mesh& smesh, int order,
                        std::function<double(Vector const&)> exact_soln)
 {
    REQUIRE(pmesh.GetGlobalNE() == smesh.GetNE());
@@ -393,26 +394,12 @@ void CheckL2Projection(ParMesh& pmesh, Mesh& smesh, int order,
       return x.ComputeL2Error(rhs_coef) / pnorm;
    }();
 
-   constexpr double test_tol = 1e-9;
-   CHECK(std::abs(serror - perror) < test_tol);
+   return {serror, perror};
 };
 
 
-TEST_CASE("FaceEdgeConstraint",  "[Parallel], [NCMesh]")
+TEST_CASE("EdgeFaceConstraint",  "[Parallel], [NCMesh]")
 {
-   constexpr int refining_rank = 0;
-   auto smesh = Mesh("../../data/ref-tetrahedron.mesh");
-
-   REQUIRE(smesh.GetNE() == 1);
-   {
-      // Start the test with two tetrahedra attached by triangle.
-      auto single_edge_refine = Array<Refinement>(1);
-      single_edge_refine[0].index = 0;
-      single_edge_refine[0].ref_type = Refinement::X;
-
-      smesh.GeneralRefinement(single_edge_refine, 0); // conformal
-   }
-
    auto exact_soln = [](const Vector& x)
    {
       // sin(|| x - d ||^2) -> non polynomial but very smooth.
@@ -422,103 +409,241 @@ TEST_CASE("FaceEdgeConstraint",  "[Parallel], [NCMesh]")
       return std::sin(d * d);
    };
 
-   REQUIRE(smesh.GetNE() == 2);
-   smesh.EnsureNCMesh(true);
-   smesh.Finalize();
-
-   auto partition = std::unique_ptr<int[]>(new int[smesh.GetNE()]);
-   partition[0] = 0;
-   partition[1] = Mpi::WorldSize() > 1 ? 1 : 0;
-
-   auto pmesh = ParMesh(MPI_COMM_WORLD, smesh, partition.get());
-
-   // Construct the NC refined mesh in parallel and serial. Once constructed a
-   // global L2 projected solution should match exactly on each.
-   Array<int> refines, serial_refines(1);
-   if (Mpi::WorldRank() == refining_rank)
+   SECTION("ReferenceTet")
    {
-      refines.Append(0);
-   }
+      constexpr int refining_rank = 0;
+      auto smesh = Mesh("../../data/ref-tetrahedron.mesh");
 
-   // Must be called on all ranks as it uses MPI calls internally.
-   // All ranks will use the global element number dictated by rank 0 though.
-   serial_refines[0] = pmesh.GetGlobalElementNum(0);
-   MPI_Bcast(&serial_refines[0], 1, MPI_INT, refining_rank, MPI_COMM_WORLD);
+      REQUIRE(smesh.GetNE() == 1);
+      {
+         // Start the test with two tetrahedra attached by triangle.
+         auto single_edge_refine = Array<Refinement>(1);
+         single_edge_refine[0].index = 0;
+         single_edge_refine[0].ref_type = Refinement::X;
 
-   // Rank 0 refines the parallel mesh, all ranks refine the serial mesh
-   smesh.GeneralRefinement(serial_refines, 1); // nonconformal
-   pmesh.GeneralRefinement(refines, 1); // nonconformal
+         smesh.GeneralRefinement(single_edge_refine, 0); // conformal
+      }
 
-   REQUIRE(pmesh.GetGlobalNE() == 8 + 1);
-   REQUIRE(smesh.GetNE() == 8 + 1);
 
-   // Each pair of indices here represents sequential element indices to refine.
-   // First the i element is refined, then in the resulting mesh the j element is
-   // refined. These pairs were arrived at by looping over all possible i,j pairs and
-   // checking for the addition of a face-edge constraint.
-   std::vector<std::pair<int,int>> indices{{2,13}, {3,13}, {6,2}, {6,3}};
+      REQUIRE(smesh.GetNE() == 2);
+      smesh.EnsureNCMesh(true);
+      smesh.Finalize();
 
-   // Rank 0 has all but one element in the parallel mesh. The remaining element
-   // is owned by another processor if the number of ranks is greater than one.
-   for (const auto &ij : indices)
-   {
-      int i = ij.first;
-      int j = ij.second;
+      auto partition = std::unique_ptr<int[]>(new int[smesh.GetNE()]);
+      partition[0] = 0;
+      partition[1] = Mpi::WorldSize() > 1 ? 1 : 0;
+
+      auto pmesh = ParMesh(MPI_COMM_WORLD, smesh, partition.get());
+
+      // Construct the NC refined mesh in parallel and serial. Once constructed a
+      // global L2 projected solution should match exactly on each.
+      Array<int> refines, serial_refines(1);
       if (Mpi::WorldRank() == refining_rank)
       {
-         refines[0] = i;
+         refines.Append(0);
       }
-      // Inform all ranks of the serial mesh
-      serial_refines[0] = pmesh.GetGlobalElementNum(i);
-      MPI_Bcast(&serial_refines[0], 1, MPI_INT, 0, MPI_COMM_WORLD);
 
-      ParMesh tmp(pmesh);
-      tmp.GeneralRefinement(refines);
+      // Must be called on all ranks as it uses MPI calls internally.
+      // All ranks will use the global element number dictated by rank 0 though.
+      serial_refines[0] = pmesh.GetGlobalElementNum(0);
+      MPI_Bcast(&serial_refines[0], 1, MPI_INT, refining_rank, MPI_COMM_WORLD);
 
-      REQUIRE(tmp.GetGlobalNE() == 1 + 8 - 1 + 8); // 16 elements
+      // Rank 0 refines the parallel mesh, all ranks refine the serial mesh
+      smesh.GeneralRefinement(serial_refines, 1); // nonconformal
+      pmesh.GeneralRefinement(refines, 1); // nonconformal
 
-      Mesh stmp(smesh);
-      stmp.GeneralRefinement(serial_refines);
-      REQUIRE(stmp.GetNE() == 1 + 8 - 1 + 8); // 16 elements
+      REQUIRE(pmesh.GetGlobalNE() == 8 + 1);
+      REQUIRE(smesh.GetNE() == 8 + 1);
 
-      if (Mpi::WorldRank() == refining_rank)
+      // Each pair of indices here represents sequential element indices to refine.
+      // First the i element is refined, then in the resulting mesh the j element is
+      // refined. These pairs were arrived at by looping over all possible i,j pairs and
+      // checking for the addition of a face-edge constraint.
+      std::vector<std::pair<int,int>> indices{{2,13}, {3,13}, {6,2}, {6,3}};
+
+      // Rank 0 has all but one element in the parallel mesh. The remaining element
+      // is owned by another processor if the number of ranks is greater than one.
+      for (const auto &ij : indices)
       {
-         refines[0] = j;
+         int i = ij.first;
+         int j = ij.second;
+         if (Mpi::WorldRank() == refining_rank)
+         {
+            refines[0] = i;
+         }
+         // Inform all ranks of the serial mesh
+         serial_refines[0] = pmesh.GetGlobalElementNum(i);
+         MPI_Bcast(&serial_refines[0], 1, MPI_INT, 0, MPI_COMM_WORLD);
+
+         ParMesh tmp(pmesh);
+         tmp.GeneralRefinement(refines);
+
+         REQUIRE(tmp.GetGlobalNE() == 1 + 8 - 1 + 8); // 16 elements
+
+         Mesh stmp(smesh);
+         stmp.GeneralRefinement(serial_refines);
+         REQUIRE(stmp.GetNE() == 1 + 8 - 1 + 8); // 16 elements
+
+         if (Mpi::WorldRank() == refining_rank)
+         {
+            refines[0] = j;
+         }
+         // Inform all ranks of the serial mesh
+         serial_refines[0] = tmp.GetGlobalElementNum(j);
+         MPI_Bcast(&serial_refines[0], 1, MPI_INT, 0, MPI_COMM_WORLD);
+
+         ParMesh ttmp(tmp);
+         ttmp.GeneralRefinement(refines);
+
+         REQUIRE(ttmp.GetGlobalNE() == 1 + 8 - 1 + 8 - 1 + 8); // 23 elements
+
+         Mesh sttmp(stmp);
+         sttmp.GeneralRefinement(serial_refines);
+         REQUIRE(sttmp.GetNE() == 1 + 8 - 1 + 8 - 1 + 8); // 23 elements
+
+         // Loop over interior faces, fill and check face transform on the serial.
+         for (int iface = 0; iface < sttmp.GetNumFaces(); ++iface)
+         {
+            const auto face_transform = sttmp.GetFaceElementTransformations(iface);
+            CHECK(face_transform->CheckConsistency(0) < 1e-12);
+         }
+
+         for (int iface = 0; iface < ttmp.GetNumFacesWithGhost(); ++iface)
+         {
+            const auto face_transform = ttmp.GetFaceElementTransformations(iface);
+            CHECK(face_transform->CheckConsistency(0) < 1e-12);
+         }
+
+         // Use P4 to ensure there's a few fully interior DOF.
+         {
+            auto error = CheckL2Projection(ttmp, sttmp, 4, exact_soln);
+            double constexpr tol = 1e-9;
+            // std::cout << "R" << Mpi::WorldRank() << ": " << error[0] << " " << error[1] << std::endl;
+            CHECK(std::abs(error[1] - error[0]) < tol);
+         }
+         ttmp.ExchangeFaceNbrData();
+         ttmp.Rebalance();
+         MPI_Barrier(MPI_COMM_WORLD);
+
+         {
+            auto error = CheckL2Projection(ttmp, sttmp, 4, exact_soln);
+            double constexpr tol = 1e-9;
+            // std::cout << "R" << Mpi::WorldRank() << ": " << error[0] << " " << error[1] << std::endl;
+            CHECK(std::abs(error[1] - error[0]) < tol);
+         }
       }
-      // Inform all ranks of the serial mesh
-      serial_refines[0] = tmp.GetGlobalElementNum(j);
-      MPI_Bcast(&serial_refines[0], 1, MPI_INT, 0, MPI_COMM_WORLD);
-
-      ParMesh ttmp(tmp);
-      ttmp.GeneralRefinement(refines);
-
-      REQUIRE(ttmp.GetGlobalNE() == 1 + 8 - 1 + 8 - 1 + 8); // 23 elements
-
-      Mesh sttmp(stmp);
-      sttmp.GeneralRefinement(serial_refines);
-      REQUIRE(sttmp.GetNE() == 1 + 8 - 1 + 8 - 1 + 8); // 23 elements
-
-      // Loop over interior faces, fill and check face transform on the serial.
-      for (int iface = 0; iface < sttmp.GetNumFaces(); ++iface)
-      {
-         const auto face_transform = sttmp.GetFaceElementTransformations(iface);
-         CHECK(face_transform->CheckConsistency(0) < 1e-12);
-      }
-
-      for (int iface = 0; iface < ttmp.GetNumFacesWithGhost(); ++iface)
-      {
-         const auto face_transform = ttmp.GetFaceElementTransformations(iface);
-         CHECK(face_transform->CheckConsistency(0) < 1e-12);
-      }
-
-      // Use P4 to ensure there's a few fully interior DOF.
-      CheckL2Projection(ttmp, sttmp, 4, exact_soln);
-
-      ttmp.ExchangeFaceNbrData();
-      ttmp.Rebalance();
-
-      CheckL2Projection(ttmp, sttmp, 4, exact_soln);
    }
+
+   auto CheckSerialParalelH1Equivalence = [](Mesh &smesh)
+   {
+      constexpr int dim = 3;
+      constexpr int order = 2;
+      H1_FECollection nd_fec(order, dim);
+      FiniteElementSpace fes(&smesh, &nd_fec);
+      const auto serial_ntdof = fes.GetTrueVSize();
+
+      ParMesh mesh(MPI_COMM_WORLD, smesh);
+      ParFiniteElementSpace pfes(&mesh, &nd_fec);
+      const auto parallel_ntdof = pfes.GlobalTrueVSize();
+
+      // If nc constraints have been observed correctly, the number of true dof in
+      // parallel should match the number of true dof in serial. If the number of
+      // parallel dofs is greater, then a slave constraint has not been fully labeled.
+      CHECK(serial_ntdof == parallel_ntdof);
+   };
+
+   auto CheckSerialParalelNDEquivalence = [](Mesh &smesh)
+   {
+      constexpr int dim = 3;
+      constexpr int order = 1;
+      ND_FECollection nd_fec(order, dim);
+      FiniteElementSpace fes(&smesh, &nd_fec);
+      const auto serial_ntdof = fes.GetTrueVSize();
+
+      ParMesh mesh(MPI_COMM_WORLD, smesh);
+      ParFiniteElementSpace pfes(&mesh, &nd_fec);
+      const auto parallel_ntdof = pfes.GlobalTrueVSize();
+
+      // If nc constraints have been observed correctly, the number of true dof in
+      // parallel should match the number of true dof in serial. If the number of
+      // parallel dofs is greater, then a slave constraint has not been fully labeled.
+      CHECK(serial_ntdof == parallel_ntdof);
+   };
+
+   SECTION("LevelTwoRefinement")
+   {
+      Mesh smesh("../../data/ref-tetrahedron.mesh");
+      Array<Refinement> aniso_ref(1);
+      aniso_ref[0].index = 0;
+      aniso_ref[0].ref_type = Refinement::X;
+      smesh.GeneralRefinement(aniso_ref);
+      smesh.UniformRefinement();
+      smesh.EnsureNCMesh(true);
+      Array<int> el_to_refine(1);
+
+      for (int n = 0; n < smesh.GetNE(); n++)
+      {
+         Mesh smesh2(smesh);
+         el_to_refine[0] = n;
+         smesh2.GeneralRefinement(el_to_refine);
+         for (int m = 0; m < smesh2.GetNE(); m++)
+         {
+            Mesh smesh3(smesh2);
+            el_to_refine[0] = m;
+            smesh3.GeneralRefinement(el_to_refine);
+            CAPTURE(n,m);
+            CheckSerialParalelNDEquivalence(smesh3);
+            CheckSerialParalelH1Equivalence(smesh3);
+         }
+      }
+   }
+
+   SECTION("EdgeCasePartition")
+   {
+      Mesh smesh("../../data/ref-tetrahedron.mesh");
+      smesh.UniformRefinement();
+      smesh.EnsureNCMesh(true);
+      Array<int> el_to_refine(1);
+
+      el_to_refine[0] = 0;
+      smesh.GeneralRefinement(el_to_refine);
+
+      // This particular partition was found by brute force search. The default rebalancing
+      // can in rare cases produce similar local patterns, particularly for highly adapted meshes.
+      auto partition = std::unique_ptr<int[]>(new int[smesh.GetNE()]);
+      if (Mpi::WorldSize() > 1)
+      {
+         auto bad_partition = std::vector<int> {0, 0, 1, 1, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0};
+         std::copy(bad_partition.begin(), bad_partition.end(), partition.get());
+      }
+      else
+      {
+         for (int i = 0; i < smesh.GetNE(); i++)
+         {
+            partition[i] = 0;
+         }
+      }
+      ParMesh pmesh(MPI_COMM_WORLD, smesh, partition.get());
+
+      constexpr int dim = 3;
+      constexpr int order = 1;
+      ND_FECollection nd_fec(order, dim);
+      FiniteElementSpace fes(&smesh, &nd_fec);
+      const auto serial_ntdof = fes.GetTrueVSize();
+      ParFiniteElementSpace pfes(&pmesh, &nd_fec);
+      pfes.ExchangeFaceNbrData();
+      const auto parallel_ntdof = pfes.GlobalTrueVSize();
+      CHECK(serial_ntdof == parallel_ntdof);
+
+      for (int order = 1; order <= 4; order++)
+      {
+         CAPTURE(order);
+         auto error = CheckL2Projection(pmesh, smesh, order, exact_soln);
+         double constexpr tol = 1e-9;
+         CHECK(std::abs(error[1] - error[0]) < tol);
+      }
+   }
+
 } // test case
 
 Mesh CylinderMesh(Geometry::Type el_type, bool quadratic, int variant = 0)
@@ -716,7 +841,8 @@ TEST_CASE("P2Q1PureTetHexPri",  "[Parallel], [NCMesh]")
       auto pmesh = ParMesh(MPI_COMM_WORLD, smesh);
 
       // P2 ensures there are triangles without dofs
-      CheckL2Projection(pmesh, smesh, 2, exact_soln);
+      auto error = CheckL2Projection(pmesh, smesh, 2, exact_soln);
+      CHECK(std::abs(error[1] - error[0]) < 1e-9);
    }
 } // test case
 
@@ -759,7 +885,8 @@ TEST_CASE("PNQ2PureTetHexPri",  "[Parallel], [NCMesh]")
 
       for (int p = 1; p < 3; ++p)
       {
-         CheckL2Projection(pmesh, smesh, p, exact_soln);
+         auto error = CheckL2Projection(pmesh, smesh, p, exact_soln);
+         CHECK(std::abs(error[1] - error[0]) < 1e-9);
       }
    }
 } // test case


### PR DESCRIPTION
This is a reproducing example and fix for https://github.com/mfem/mfem/issues/3925. This expands edge-face constraints on edges to all non-slave edges, and refactors the `NCList` to use an `unordered_map` to allow for simpler use, and do away with the bit hacking within the integer register.<!--GHEX{"author":"hughcars","assignment":"2023-10-18T01:25:58","editor":"tzanio","id":3926,"reviewers":["dylan-copeland","jakubcerveny"],"merge":"2023-10-28T19:21:43","approval":"2023-10-25T16:12:26"}XEHG-->
<!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge|
 | --- | --- | --- | --- | --- | --- | --- |
| [#3926](https://github.com/mfem/mfem/pull/3926) | @hughcars | @tzanio | @dylan-copeland + @jakubcerveny | 10/17/23 | 10/25/23 | 10/28/23 | |
<!--ELBATXEHG-->
<details>
<summary>PR Checklist</summary>
    
- [ ] Code builds.
- [ ] Code passes `make style`.
- [ ] Update `CHANGELOG`:
    - [ ] Is this a new feature users need to be aware of? New or updated example or miniapp?
    - [ ] Does it make sense to create a new section in the `CHANGELOG` to group with other related features?
- [ ] Update `INSTALL`:
    - [ ] Had a new optional library been added? If so, what range of versions of this library are required? (*Make sure the external library is compatible with our BSD license, e.g. it is not licensed under GPL!*)
    - [ ] Have the version ranges for any required or optional libraries changed?
    - [ ] Does `make` or `cmake` have a new target?
    - [ ] Did the requirements or the installation process change? *(rare)*
- [ ] Update continuous integration server configurations if necessary (e.g. with new version requirements for each of MFEM's dependencies)
    - [ ] `.github`
    - [ ] `.appveyor.yml`
- [ ] Update `.gitignore`:
    - [ ] Check if `make distclean; git status` shows any files that were generated from the source by the project (not an IDE) but we don't want to track in the repository.
    - [ ] Add new patterns (just for the new files above) and re-run the above test.
- [ ] New examples:
    - [ ] All sample runs at the top of the example source file work.
    - [ ] Update `examples/makefile`:
      - [ ] Add the example code to the appropriate `SEQ_EXAMPLES` and `PAR_EXAMPLES` variables.
      - [ ] Add any files generated by it to the `clean` target.
      - [ ] Add the example binary and any files generated by it to the top-level `.gitignore` file.
    - [ ] Update `examples/CMakeLists.txt`:
      - [ ] Add the example code to the `ALL_EXE_SRCS` variable.
      - [ ] Make sure `THIS_TEST_OPTIONS` is set correctly for the new example.
   - [ ] List the new example in `doc/CodeDocumentation.dox`.
   - [ ] If new examples directory (e.g.`examples/pumi`), list it in `doc/CodeDocumentation.conf.in`
   - [ ] Companion pull request for documentation in [mfem/web](https://github.com/mfem/web) repo:
      - [ ] Update or add example-specific documentation, see e.g. the `src/examples.md`.
      - [ ] Add the description, labels and screenshots in `src/examples.md` and `src/img`.
      - [ ] In `examples.md`, list the example under the appropriate categories, add new categories if necessary.
      - [ ] Add a short description of the example in the "Extensive Examples" section of `features.md`.
- [ ] New miniapps:
   - [ ] All sample runs at the top of the miniapp source file work.
   - [ ] Update top-level `makefile` and `makefile` in corresponding miniapp directory.
   - [ ] Add the miniapp binary and any files generated by it to the top-level `.gitignore` file.
   - [ ] Update CMake build system:
      - [ ] Update the `CMakeLists.txt` file in the `miniapps` directory, if the new miniapp is in a new directory.
      - [ ] Add/update the `CMakeLists.txt` file in the new miniapp directory.
      - [ ] Consider adding a new test for the new miniapp.
   - [ ] List the new miniapp in `doc/CodeDocumentation.dox`
   - [ ] If new miniapps directory (e.g.`miniapps/nurbs`), add it to `MINIAPP_SUBDIRS` in the `makefile`.
   - [ ] If new miniapps directory (e.g.`miniapps/nurbs`), list it in `doc/CodeDocumentation.conf.in`
   - [ ] Companion pull request for documentation in [mfem/web](https://github.com/mfem/web) repo:
     - [ ] Update or add miniapp-specific documentation, see e.g. the `src/meshing.md` and `src/electromagnetics.md` files.
     - [ ] Add the description, labels and screenshots in `src/examples.md` and `src/img`.
     - [ ] The miniapps go at the end of the page, and are usually listed only under a specific "Application (PDE)" category.
     - [ ] Add a short description of the miniapp in the "Extensive Examples" section of `features.md`.
- [ ] New capability:
   - [ ] All new public, protected, and private classes, methods, data members, and functions have full Doxygen-style documentation in source comments. Documentation should include descriptions of member data, function arguments and return values, template parameters, and prerequisites for calling new functions.
   - [ ] Pointer arguments and return values must specify whether ownership is being transferred or lent with the call.
   - [ ] Any new functions should include descriptions of their intended use e.g. for internal use only, user-facing, etc., along with references to example code whenever possible/appropriate.
   - [ ] Consider adding new sample runs in existing examples to highlight the new capability.
   - [ ] Consider saving cool simulation pictures with the new capability in the Confluence gallery (LLNL only) or submitting them, via pull request, to the gallery section of the `mfem/web` repo.
   - [ ] If this is a major new feature, consider mentioning it in the short summary inside `README` *(rare)*.
   - [ ] List major new classes in `doc/CodeDocumentation.dox` *(rare)*.
- [ ] Update this checklist, if the new pull request affects it.
- [ ] Run `make unittest` to make sure all unit tests pass.
- [ ] Run the tests in `tests/scripts`.
- [ ] (LLNL only) After merging:
   - [ ] Update internal tests to include the new features.
</details>
