### PR TITLE
Fix warnings about extra semicolons from GCC

### DIFF
--- a/miniapps/hdiv-linear-solver/grad_div.cpp
+++ b/miniapps/hdiv-linear-solver/grad_div.cpp
@@ -278,4 +278,4 @@ void SolveCG(Operator &A, Solver &P, const Vector &B, Vector &X)
       cout << "Done.\nIterations: " << cg.GetNumIterations()
            << "\nElapsed: " << tic_toc.RealTime() << endl;
    }
-};
+}

--- a/miniapps/nurbs/nurbs_ex1.cpp
+++ b/miniapps/nurbs/nurbs_ex1.cpp
@@ -49,8 +49,8 @@ public:
    Data(double x_, double val_) {x=x_; val=val_;};
 };
 
-inline bool operator==(const Data& d1,const Data& d2) { return (d1.x == d2.x); };
-inline bool operator <(const Data& d1,const Data& d2) { return (d1.x  < d2.x); };
+inline bool operator==(const Data& d1,const Data& d2) { return (d1.x == d2.x); }
+inline bool operator <(const Data& d1,const Data& d2) { return (d1.x  < d2.x); }
 
 /** Class for integrating the bilinear form a(u,v) := (Q Laplace u, v) where Q
     can be a scalar coefficient. */

--- a/miniapps/spde/spde_solver.cpp
+++ b/miniapps/spde/spde_solver.cpp
@@ -237,7 +237,7 @@ void Boundary::AddInhomogeneousDirichletBoundaryCondition(int boundary,
 void Boundary::SetRobinCoefficient(double coefficient)
 {
    robin_coefficient = coefficient;
-};
+}
 
 double IntegrateBC(const ParGridFunction &x, const Array<int> &bdr,
                    double alpha, double beta, double gamma, double &glb_err)
@@ -549,7 +549,7 @@ void SPDESolver::SetupRandomFieldGenerator(int seed)
       new WhiteGaussianNoiseDomainLFIntegrator(fespace_ptr_->GetComm(), seed);
    b_wn = new ParLinearForm(fespace_ptr_);
    b_wn->AddDomainIntegrator(integ);
-};
+}
 
 void SPDESolver::GenerateRandomField(ParGridFunction &x)
 {
@@ -565,7 +565,7 @@ void SPDESolver::GenerateRandomField(ParGridFunction &x)
 
    // Call back to solve to generate the random field
    Solve(*b_wn, x);
-};
+}
 
 double SPDESolver::ConstructNormalizationCoefficient(double nu, double l1,
                                                      double l2, double l3,

--- a/tests/unit/mesh/test_ncmesh.cpp
+++ b/tests/unit/mesh/test_ncmesh.cpp
@@ -395,7 +395,7 @@ std::array<double, 2> CheckL2Projection(ParMesh& pmesh, Mesh& smesh, int order,
    }();
 
    return {serror, perror};
-};
+}
 
 
 TEST_CASE("EdgeFaceConstraint",  "[Parallel], [NCMesh]")


### PR DESCRIPTION
These are generated by GCC (at least by v6.3.1) with `-pedantic` flag.
