### PR TITLE
Improve GPU algorithm in FormDiscreteDivergenceMatrix

### DIFF
--- a/miniapps/hdiv-linear-solver/discrete_divergence.cpp
+++ b/miniapps/hdiv-linear-solver/discrete_divergence.cpp
@@ -213,24 +213,25 @@ HypreParMatrix *FormDiscreteDivergenceMatrix(ParFiniteElementSpace &fes_rt,
    auto J = D_local.WriteJ();
    auto V = D_local.WriteData();
 
+   const int two_dim = 2*dim;
+
    // Loop over L2 DOFs
-   MFEM_FORALL(i, n_l2,
+   MFEM_FORALL(ii, n_l2*2*dim,
    {
+      const int k = ii % (two_dim);
+      const int i = ii / (two_dim);
       const int i_loc = i%nvol_per_el;
       const int i_el = i/nvol_per_el;
 
-      for (int k = 0; k < 2*dim; ++k)
-      {
-         const int sjv_loc = e2f(k, i_loc);
-         const int jv_loc = (sjv_loc >= 0) ? sjv_loc : -1 - sjv_loc;
-         const int sgn1 = (sjv_loc >= 0) ? 1 : -1;
-         const int sj = gather_rt(jv_loc, i_el);
-         const int j = (sj >= 0) ? sj : -1 - sj;
-         const int sgn2 = (sj >= 0) ? 1 : -1;
+      const int sjv_loc = e2f(k, i_loc);
+      const int jv_loc = (sjv_loc >= 0) ? sjv_loc : -1 - sjv_loc;
+      const int sgn1 = (sjv_loc >= 0) ? 1 : -1;
+      const int sj = gather_rt(jv_loc, i_el);
+      const int j = (sj >= 0) ? sj : -1 - sj;
+      const int sgn2 = (sj >= 0) ? 1 : -1;
 
-         J[k + 2*dim*i] = j;
-         V[k + 2*dim*i] = sgn1*sgn2;
-      }
+      J[k + 2*dim*i] = j;
+      V[k + 2*dim*i] = sgn1*sgn2;
    });
 
    // Create a block diagonal parallel matrix

--- a/miniapps/hdiv-linear-solver/hdiv_linear_solver.cpp
+++ b/miniapps/hdiv-linear-solver/hdiv_linear_solver.cpp
@@ -51,7 +51,7 @@ HypreParMatrix *MakeDiagonalMatrix(Vector &diag,
 
    HYPRE_BigInt global_size = fes.GlobalTrueVSize();
    HYPRE_BigInt *row_starts = fes.GetTrueDofOffsets();
-   HypreParMatrix D(MPI_COMM_WORLD, global_size, row_starts, &diag_spmat);
+   HypreParMatrix D(fes.GetComm(), global_size, row_starts, &diag_spmat);
    return new HypreParMatrix(D); // make a deep copy
 }
 


### PR DESCRIPTION
This small PR improves the algorithm used to form the discrete divergence matrix in the H(div) saddle-point solver miniapp. It allows for more parallelism by threading over every matrix entry rather than just over every row.

A performance comparison is below. The dashed line represents a performance model for theoretical peak performance based on memory bandwidth and kernel launch latency.

| Before | After |
|--------|--------|
| ![div_prev](https://github.com/mfem/mfem/assets/11493037/29411c97-f627-4937-9225-be21126e86c7) | ![div](https://github.com/mfem/mfem/assets/11493037/b7ef0be5-e5b5-4cb8-8d20-dcf2ef694bce) |

