### PR TITLE
TMOP: PA support for the Coefficient of the metric integral

### DIFF
--- a/fem/tmop.cpp
+++ b/fem/tmop.cpp
@@ -4378,6 +4378,8 @@ UpdateAfterMeshPositionChange(const Vector &x_new,
 {
    if (discr_tc) { PA.Jtr_needs_update = true; }
 
+   if (PA.enabled) { UpdateCoefficientsPA(x_new); }
+
    Ordering::Type ordering = x_fes.GetOrdering();
 
    // Update the finite difference delta if FD are used.

--- a/fem/tmop.hpp
+++ b/fem/tmop.hpp
@@ -1821,13 +1821,19 @@ protected:
 
    // PA extension
    // ------------
+   // Jtr: all ref->target Jacobians, (dim x dim) Q-Vector as DenseTensor.
+   //      updated when needed, based on Jtr_needs_update.
+   //
    //  E: Q-vector for TMOP-energy
    //  O: Q-Vector of 1.0, used to compute sums using the dot product kernel.
    // X0: E-vector for initial nodal coordinates used for limiting.
    //  H: Q-Vector for Hessian associated with the metric term.
+   //     updated by every call to PANonlinearFormExtension::GetGradient().
    // C0: Q-Vector for spatial weight used for the limiting term.
    // LD: E-Vector constructed using limiting distance grid function (delta).
    // H0: Q-Vector for Hessian associated with the limiting term.
+   //     updated by every call to PANonlinearFormExtension::GetGradient().
+   // MC: Q-Vector for the metric Coefficient.
    //
    // maps:     Dof2Quad map for fes associated with the nodal coordinates.
    // maps_lim: Dof2Quad map for fes associated with the limiting dist GridFunc.
@@ -1849,8 +1855,7 @@ protected:
       mutable DenseTensor Jtr;
       mutable bool Jtr_needs_update;
       mutable bool Jtr_debug_grad;
-      mutable Vector E, O, X0, H, C0, LD, H0;
-      double metric_coeff_val;
+      mutable Vector E, O, X0, H, C0, LD, H0, MC;
       const DofToQuad *maps;
       const DofToQuad *maps_lim = nullptr;
       const GeometricFactors *geom;
@@ -1964,6 +1969,7 @@ protected:
 
    void AssemblePA_Limiting();
    void ComputeAllElementTargets(const Vector &xe = Vector()) const;
+   void UpdateCoefficientsPA() const;
 
    // Compute Min(Det(Jpt)) in the mesh, does not reduce over MPI.
    double ComputeMinDetT(const Vector &x, const FiniteElementSpace &fes);

--- a/fem/tmop.hpp
+++ b/fem/tmop.hpp
@@ -1829,9 +1829,8 @@ protected:
    // LD: E-Vector constructed using limiting distance grid function (delta).
    // H0: Q-Vector for Hessian associated with the limiting term.
    //
-   // maps:     Dof2Quad map for fespace associate with nodal coordinates.
-   // maps_lim: Dof2Quad map for fespace associated with the limiting distance
-   //            grid function.
+   // maps:     Dof2Quad map for fes associated with the nodal coordinates.
+   // maps_lim: Dof2Quad map for fes associated with the limiting dist GridFunc.
    //
    // Jtr_debug_grad
    //     We keep track if Jtr was set by AssembleGradPA() in Jtr_debug_grad: it
@@ -1851,6 +1850,7 @@ protected:
       mutable bool Jtr_needs_update;
       mutable bool Jtr_debug_grad;
       mutable Vector E, O, X0, H, C0, LD, H0;
+      double metric_coeff_val;
       const DofToQuad *maps;
       const DofToQuad *maps_lim = nullptr;
       const GeometricFactors *geom;

--- a/fem/tmop.hpp
+++ b/fem/tmop.hpp
@@ -1825,15 +1825,20 @@ protected:
    //      updated when needed, based on Jtr_needs_update.
    //
    //  E: Q-vector for TMOP-energy
+   //     Used as temporary storage when the total energy is computed.
    //  O: Q-Vector of 1.0, used to compute sums using the dot product kernel.
    // X0: E-vector for initial nodal coordinates used for limiting.
+   //     Does not change during the TMOP iteration.
    //  H: Q-Vector for Hessian associated with the metric term.
-   //     updated by every call to PANonlinearFormExtension::GetGradient().
+   //     Updated by every call to PANonlinearFormExtension::GetGradient().
    // C0: Q-Vector for spatial weight used for the limiting term.
+   //     Updated when the mesh nodes change.
    // LD: E-Vector constructed using limiting distance grid function (delta).
+   //     Does not change during the TMOP iteration.
    // H0: Q-Vector for Hessian associated with the limiting term.
-   //     updated by every call to PANonlinearFormExtension::GetGradient().
+   //     Updated by every call to PANonlinearFormExtension::GetGradient().
    // MC: Q-Vector for the metric Coefficient.
+   //     Updated when the mesh nodes change.
    //
    // maps:     Dof2Quad map for fes associated with the nodal coordinates.
    // maps_lim: Dof2Quad map for fes associated with the limiting dist GridFunc.
@@ -1969,7 +1974,9 @@ protected:
 
    void AssemblePA_Limiting();
    void ComputeAllElementTargets(const Vector &xe = Vector()) const;
-   void UpdateCoefficientsPA() const;
+   // Updates the Q-vectors for the metric_coeff and lim_coeff, based on the
+   // new physical positions of the quadrature points.
+   void UpdateCoefficientsPA(const Vector &x_loc);
 
    // Compute Min(Det(Jpt)) in the mesh, does not reduce over MPI.
    double ComputeMinDetT(const Vector &x, const FiniteElementSpace &fes);

--- a/fem/tmop/tmop_pa.cpp
+++ b/fem/tmop/tmop_pa.cpp
@@ -213,6 +213,14 @@ void TMOP_Integrator::AssemblePA(const FiniteElementSpace &fes)
    PA.O.SetSize(ne*nq, Device::GetDeviceMemoryType());
    PA.O = 1.0;
 
+   if (metric_coeff)
+   {
+      auto cc = dynamic_cast<ConstantCoefficient *>(metric_coeff);
+      MFEM_VERIFY(cc, "TMOP+PA is not supported for non-ConstantCoefficients");
+      PA.metric_coeff_val = cc->constant;
+   }
+   else { PA.metric_coeff_val = 1.0; }
+
    // Setup ref->target Jacobians, PA.Jtr, (dim x dim) Q-vector, DenseTensor
    PA.Jtr.SetSize(dim, dim, PA.ne*PA.nq, mt);
    PA.Jtr_needs_update = true;

--- a/fem/tmop/tmop_pa.cpp
+++ b/fem/tmop/tmop_pa.cpp
@@ -216,7 +216,7 @@ void TMOP_Integrator::AssemblePA(const FiniteElementSpace &fes)
    if (metric_coeff)
    {
       auto cc = dynamic_cast<ConstantCoefficient *>(metric_coeff);
-      MFEM_VERIFY(cc, "TMOP+PA is not supported for non-ConstantCoefficients");
+      MFEM_VERIFY(cc, "TMOP+PA supports only ConstantCoefficients.");
       PA.metric_coeff_val = cc->constant;
    }
    else { PA.metric_coeff_val = 1.0; }

--- a/fem/tmop/tmop_pa_h2s.cpp
+++ b/fem/tmop/tmop_pa_h2s.cpp
@@ -258,7 +258,7 @@ void EvalH_094(const int e, const int qx, const int qy,
 MFEM_REGISTER_TMOP_KERNELS(void, SetupGradPA_2D,
                            const Vector &x_,
                            const double metric_normal,
-                           const double metric_coeff,
+                           const Vector &m0_,
                            const Array<double> &metric_param,
                            const int mid,
                            const int NE,
@@ -274,11 +274,16 @@ MFEM_REGISTER_TMOP_KERNELS(void, SetupGradPA_2D,
                || mid == 80 || mid == 94,
                "2D metric not yet implemented!");
 
+   const bool const_m0 = m0_.Size() == 1;
+
    constexpr int DIM = 2;
    constexpr int NBZ = 1;
    const int D1D = T_D1D ? T_D1D : d1d;
    const int Q1D = T_Q1D ? T_Q1D : q1d;
 
+   const auto M0 = const_m0 ?
+                   Reshape(m0_.Read(), 1, 1, 1) :
+                   Reshape(m0_.Read(), Q1D, Q1D, NE);
    const auto W = Reshape(w_.Read(), Q1D, Q1D);
    const auto b = Reshape(b_.Read(), Q1D, D1D);
    const auto g = Reshape(g_.Read(), Q1D, D1D);
@@ -313,8 +318,8 @@ MFEM_REGISTER_TMOP_KERNELS(void, SetupGradPA_2D,
          {
             const double *Jtr = &J(0,0,qx,qy,e);
             const double detJtr = kernels::Det<2>(Jtr);
-            const double weight = metric_normal * metric_coeff *
-                                  W(qx,qy) * detJtr;
+            const double m_coef = const_m0 ? M0(0,0,0) : M0(qx,qy,e);
+            const double weight = metric_normal * m_coef * W(qx,qy) * detJtr;
 
             // Jrt = Jtr^{-1}
             double Jrt[4];
@@ -349,7 +354,7 @@ void TMOP_Integrator::AssembleGradPA_2D(const Vector &X) const
    const int Q1D = PA.maps->nqpt;
    const int id = (D1D << 4 ) | Q1D;
    const double mn = metric_normal;
-   const double mc = PA.metric_coeff_val;
+   const Vector &M0 = PA.MC;
    const DenseTensor &J = PA.Jtr;
    const Array<double> &W = PA.ir->GetWeights();
    const Array<double> &B = PA.maps->B;
@@ -362,7 +367,7 @@ void TMOP_Integrator::AssembleGradPA_2D(const Vector &X) const
       m->GetWeights(mp);
    }
 
-   MFEM_LAUNCH_TMOP_KERNEL(SetupGradPA_2D,id,X,mn,mc,mp,M,N,W,B,G,J,H);
+   MFEM_LAUNCH_TMOP_KERNEL(SetupGradPA_2D,id,X,mn,M0,mp,M,N,W,B,G,J,H);
 }
 
 } // namespace mfem

--- a/fem/tmop/tmop_pa_h2s.cpp
+++ b/fem/tmop/tmop_pa_h2s.cpp
@@ -258,6 +258,7 @@ void EvalH_094(const int e, const int qx, const int qy,
 MFEM_REGISTER_TMOP_KERNELS(void, SetupGradPA_2D,
                            const Vector &x_,
                            const double metric_normal,
+                           const double metric_coeff,
                            const Array<double> &metric_param,
                            const int mid,
                            const int NE,
@@ -312,7 +313,8 @@ MFEM_REGISTER_TMOP_KERNELS(void, SetupGradPA_2D,
          {
             const double *Jtr = &J(0,0,qx,qy,e);
             const double detJtr = kernels::Det<2>(Jtr);
-            const double weight = metric_normal * W(qx,qy) * detJtr;
+            const double weight = metric_normal * metric_coeff *
+                                  W(qx,qy) * detJtr;
 
             // Jrt = Jtr^{-1}
             double Jrt[4];
@@ -347,6 +349,7 @@ void TMOP_Integrator::AssembleGradPA_2D(const Vector &X) const
    const int Q1D = PA.maps->nqpt;
    const int id = (D1D << 4 ) | Q1D;
    const double mn = metric_normal;
+   const double mc = PA.metric_coeff_val;
    const DenseTensor &J = PA.Jtr;
    const Array<double> &W = PA.ir->GetWeights();
    const Array<double> &B = PA.maps->B;
@@ -359,7 +362,7 @@ void TMOP_Integrator::AssembleGradPA_2D(const Vector &X) const
       m->GetWeights(mp);
    }
 
-   MFEM_LAUNCH_TMOP_KERNEL(SetupGradPA_2D,id,X,mn,mp,M,N,W,B,G,J,H);
+   MFEM_LAUNCH_TMOP_KERNEL(SetupGradPA_2D,id,X,mn,mc,mp,M,N,W,B,G,J,H);
 }
 
 } // namespace mfem

--- a/fem/tmop/tmop_pa_h3s.cpp
+++ b/fem/tmop/tmop_pa_h3s.cpp
@@ -312,6 +312,7 @@ void EvalH_338(const int e, const int qx, const int qy, const int qz,
 
 MFEM_REGISTER_TMOP_KERNELS(void, SetupGradPA_3D,
                            const double metric_normal,
+                           const double metric_coeff,
                            const Array<double> &metric_param,
                            const int mid,
                            const Vector &x_,
@@ -369,7 +370,8 @@ MFEM_REGISTER_TMOP_KERNELS(void, SetupGradPA_3D,
             {
                const double *Jtr = &J(0,0,qx,qy,qz,e);
                const double detJtr = kernels::Det<3>(Jtr);
-               const double weight = metric_normal * W(qx,qy,qz) * detJtr;
+               const double weight = metric_normal * metric_coeff *
+                                     W(qx,qy,qz) * detJtr;
 
                // Jrt = Jtr^{-1}
                double Jrt[9];
@@ -438,6 +440,7 @@ void TMOP_Integrator::AssembleGradPA_3D(const Vector &X) const
    const int M = metric->Id();
    const int id = (D1D << 4 ) | Q1D;
    const double mn = metric_normal;
+   const double mc = PA.metric_coeff_val;
    const DenseTensor &J = PA.Jtr;
    const Array<double> &W = PA.ir->GetWeights();
    const Array<double> &B = PA.maps->B;
@@ -450,7 +453,7 @@ void TMOP_Integrator::AssembleGradPA_3D(const Vector &X) const
       m->GetWeights(mp);
    }
 
-   MFEM_LAUNCH_TMOP_KERNEL(SetupGradPA_3D,id,mn,mp,M,X,N,W,B,G,J,H);
+   MFEM_LAUNCH_TMOP_KERNEL(SetupGradPA_3D,id,mn,mc,mp,M,X,N,W,B,G,J,H);
 }
 
 } // namespace mfem

--- a/fem/tmop/tmop_pa_h3s.cpp
+++ b/fem/tmop/tmop_pa_h3s.cpp
@@ -312,7 +312,7 @@ void EvalH_338(const int e, const int qx, const int qy, const int qz,
 
 MFEM_REGISTER_TMOP_KERNELS(void, SetupGradPA_3D,
                            const double metric_normal,
-                           const double metric_coeff,
+                           const Vector &m0_,
                            const Array<double> &metric_param,
                            const int mid,
                            const Vector &x_,
@@ -329,10 +329,15 @@ MFEM_REGISTER_TMOP_KERNELS(void, SetupGradPA_3D,
                mid == 321 || mid == 332 || mid == 338,
                "3D metric not yet implemented!");
 
+   const bool const_m0 = m0_.Size() == 1;
+
    constexpr int DIM = 3;
    const int D1D = T_D1D ? T_D1D : d1d;
    const int Q1D = T_Q1D ? T_Q1D : q1d;
 
+   const auto M0 = const_m0 ?
+                   Reshape(m0_.Read(), 1, 1, 1, 1) :
+                   Reshape(m0_.Read(), Q1D, Q1D, Q1D, NE);
    const auto b = Reshape(b_.Read(), Q1D, D1D);
    const auto g = Reshape(g_.Read(), Q1D, D1D);
    const auto W = Reshape(w_.Read(), Q1D, Q1D, Q1D);
@@ -370,7 +375,8 @@ MFEM_REGISTER_TMOP_KERNELS(void, SetupGradPA_3D,
             {
                const double *Jtr = &J(0,0,qx,qy,qz,e);
                const double detJtr = kernels::Det<3>(Jtr);
-               const double weight = metric_normal * metric_coeff *
+               const double m_coef = const_m0 ? M0(0,0,0,0) : M0(qx,qy,qz,e);
+               const double weight = metric_normal * m_coef *
                                      W(qx,qy,qz) * detJtr;
 
                // Jrt = Jtr^{-1}
@@ -440,7 +446,7 @@ void TMOP_Integrator::AssembleGradPA_3D(const Vector &X) const
    const int M = metric->Id();
    const int id = (D1D << 4 ) | Q1D;
    const double mn = metric_normal;
-   const double mc = PA.metric_coeff_val;
+   const Vector &M0 = PA.MC;
    const DenseTensor &J = PA.Jtr;
    const Array<double> &W = PA.ir->GetWeights();
    const Array<double> &B = PA.maps->B;
@@ -453,7 +459,7 @@ void TMOP_Integrator::AssembleGradPA_3D(const Vector &X) const
       m->GetWeights(mp);
    }
 
-   MFEM_LAUNCH_TMOP_KERNEL(SetupGradPA_3D,id,mn,mc,mp,M,X,N,W,B,G,J,H);
+   MFEM_LAUNCH_TMOP_KERNEL(SetupGradPA_3D,id,mn,M0,mp,M,X,N,W,B,G,J,H);
 }
 
 } // namespace mfem

--- a/fem/tmop/tmop_pa_h3s.cpp
+++ b/fem/tmop/tmop_pa_h3s.cpp
@@ -312,7 +312,7 @@ void EvalH_338(const int e, const int qx, const int qy, const int qz,
 
 MFEM_REGISTER_TMOP_KERNELS(void, SetupGradPA_3D,
                            const double metric_normal,
-                           const Vector &m0_,
+                           const Vector &mc_,
                            const Array<double> &metric_param,
                            const int mid,
                            const Vector &x_,
@@ -329,15 +329,15 @@ MFEM_REGISTER_TMOP_KERNELS(void, SetupGradPA_3D,
                mid == 321 || mid == 332 || mid == 338,
                "3D metric not yet implemented!");
 
-   const bool const_m0 = m0_.Size() == 1;
+   const bool const_m0 = mc_.Size() == 1;
 
    constexpr int DIM = 3;
    const int D1D = T_D1D ? T_D1D : d1d;
    const int Q1D = T_Q1D ? T_Q1D : q1d;
 
-   const auto M0 = const_m0 ?
-                   Reshape(m0_.Read(), 1, 1, 1, 1) :
-                   Reshape(m0_.Read(), Q1D, Q1D, Q1D, NE);
+   const auto MC = const_m0 ?
+                   Reshape(mc_.Read(), 1, 1, 1, 1) :
+                   Reshape(mc_.Read(), Q1D, Q1D, Q1D, NE);
    const auto b = Reshape(b_.Read(), Q1D, D1D);
    const auto g = Reshape(g_.Read(), Q1D, D1D);
    const auto W = Reshape(w_.Read(), Q1D, Q1D, Q1D);
@@ -375,7 +375,7 @@ MFEM_REGISTER_TMOP_KERNELS(void, SetupGradPA_3D,
             {
                const double *Jtr = &J(0,0,qx,qy,qz,e);
                const double detJtr = kernels::Det<3>(Jtr);
-               const double m_coef = const_m0 ? M0(0,0,0,0) : M0(qx,qy,qz,e);
+               const double m_coef = const_m0 ? MC(0,0,0,0) : MC(qx,qy,qz,e);
                const double weight = metric_normal * m_coef *
                                      W(qx,qy,qz) * detJtr;
 
@@ -446,7 +446,7 @@ void TMOP_Integrator::AssembleGradPA_3D(const Vector &X) const
    const int M = metric->Id();
    const int id = (D1D << 4 ) | Q1D;
    const double mn = metric_normal;
-   const Vector &M0 = PA.MC;
+   const Vector &MC = PA.MC;
    const DenseTensor &J = PA.Jtr;
    const Array<double> &W = PA.ir->GetWeights();
    const Array<double> &B = PA.maps->B;
@@ -459,7 +459,7 @@ void TMOP_Integrator::AssembleGradPA_3D(const Vector &X) const
       m->GetWeights(mp);
    }
 
-   MFEM_LAUNCH_TMOP_KERNEL(SetupGradPA_3D,id,mn,M0,mp,M,X,N,W,B,G,J,H);
+   MFEM_LAUNCH_TMOP_KERNEL(SetupGradPA_3D,id,mn,MC,mp,M,X,N,W,B,G,J,H);
 }
 
 } // namespace mfem

--- a/fem/tmop/tmop_pa_p2.cpp
+++ b/fem/tmop/tmop_pa_p2.cpp
@@ -98,6 +98,7 @@ void EvalP_094(const double *Jpt, const double *w, double *P)
 
 MFEM_REGISTER_TMOP_KERNELS(void, AddMultPA_Kernel_2D,
                            const double metric_normal,
+                           const double metric_coeff,
                            const Array<double> &metric_param,
                            const int mid,
                            const int NE,
@@ -154,7 +155,8 @@ MFEM_REGISTER_TMOP_KERNELS(void, AddMultPA_Kernel_2D,
          {
             const double *Jtr = &J(0,0,qx,qy,e);
             const double detJtr = kernels::Det<2>(Jtr);
-            const double weight = metric_normal * W(qx,qy) * detJtr;
+            const double weight = metric_normal * metric_coeff *
+                                  W(qx,qy) * detJtr;
 
             // Jrt = Jtr^{-1}
             double Jrt[4];
@@ -204,6 +206,7 @@ void TMOP_Integrator::AddMultPA_2D(const Vector &X, Vector &Y) const
    const Array<double> &B = PA.maps->B;
    const Array<double> &G = PA.maps->G;
    const double mn = metric_normal;
+   const double mc = PA.metric_coeff_val;
 
    Array<double> mp;
    if (auto m = dynamic_cast<TMOP_Combo_QualityMetric *>(metric))
@@ -211,7 +214,7 @@ void TMOP_Integrator::AddMultPA_2D(const Vector &X, Vector &Y) const
       m->GetWeights(mp);
    }
 
-   MFEM_LAUNCH_TMOP_KERNEL(AddMultPA_Kernel_2D,id,mn,mp,M,N,J,W,B,G,X,Y);
+   MFEM_LAUNCH_TMOP_KERNEL(AddMultPA_Kernel_2D,id,mn,mc,mp,M,N,J,W,B,G,X,Y);
 }
 
 } // namespace mfem

--- a/fem/tmop/tmop_pa_p2.cpp
+++ b/fem/tmop/tmop_pa_p2.cpp
@@ -98,7 +98,7 @@ void EvalP_094(const double *Jpt, const double *w, double *P)
 
 MFEM_REGISTER_TMOP_KERNELS(void, AddMultPA_Kernel_2D,
                            const double metric_normal,
-                           const double metric_coeff,
+                           const Vector &m0_,
                            const Array<double> &metric_param,
                            const int mid,
                            const int NE,
@@ -115,12 +115,17 @@ MFEM_REGISTER_TMOP_KERNELS(void, AddMultPA_Kernel_2D,
                || mid == 80 || mid == 94,
                "2D metric not yet implemented!");
 
+   const bool const_m0 = m0_.Size() == 1;
+
    constexpr int DIM = 2;
    constexpr int NBZ = 1;
 
    const int D1D = T_D1D ? T_D1D : d1d;
    const int Q1D = T_Q1D ? T_Q1D : q1d;
 
+   const auto M0 = const_m0 ?
+                   Reshape(m0_.Read(), 1, 1, 1) :
+                   Reshape(m0_.Read(), Q1D, Q1D, NE);
    const auto J = Reshape(j_.Read(), DIM, DIM, Q1D, Q1D, NE);
    const auto W = Reshape(w_.Read(), Q1D, Q1D);
    const auto b = Reshape(b_.Read(), Q1D, D1D);
@@ -155,7 +160,8 @@ MFEM_REGISTER_TMOP_KERNELS(void, AddMultPA_Kernel_2D,
          {
             const double *Jtr = &J(0,0,qx,qy,e);
             const double detJtr = kernels::Det<2>(Jtr);
-            const double weight = metric_normal * metric_coeff *
+            const double m_coef = const_m0 ? M0(0,0,0) : M0(qx,qy,e);
+            const double weight = metric_normal * m_coef *
                                   W(qx,qy) * detJtr;
 
             // Jrt = Jtr^{-1}
@@ -206,7 +212,7 @@ void TMOP_Integrator::AddMultPA_2D(const Vector &X, Vector &Y) const
    const Array<double> &B = PA.maps->B;
    const Array<double> &G = PA.maps->G;
    const double mn = metric_normal;
-   const double mc = PA.metric_coeff_val;
+   const Vector &M0 = PA.MC;
 
    Array<double> mp;
    if (auto m = dynamic_cast<TMOP_Combo_QualityMetric *>(metric))
@@ -214,7 +220,7 @@ void TMOP_Integrator::AddMultPA_2D(const Vector &X, Vector &Y) const
       m->GetWeights(mp);
    }
 
-   MFEM_LAUNCH_TMOP_KERNEL(AddMultPA_Kernel_2D,id,mn,mc,mp,M,N,J,W,B,G,X,Y);
+   MFEM_LAUNCH_TMOP_KERNEL(AddMultPA_Kernel_2D,id,mn,M0,mp,M,N,J,W,B,G,X,Y);
 }
 
 } // namespace mfem

--- a/fem/tmop/tmop_pa_p3.cpp
+++ b/fem/tmop/tmop_pa_p3.cpp
@@ -131,7 +131,7 @@ void EvalP_338(const double *J, const double *w, double *P)
 
 MFEM_REGISTER_TMOP_KERNELS(void, AddMultPA_Kernel_3D,
                            const double metric_normal,
-                           const Vector &m0_,
+                           const Vector &mc_,
                            const Array<double> &metric_param,
                            const int mid,
                            const int NE,
@@ -148,15 +148,15 @@ MFEM_REGISTER_TMOP_KERNELS(void, AddMultPA_Kernel_3D,
                mid == 321 || mid == 332 || mid == 338,
                "3D metric not yet implemented!");
 
-   const bool const_m0 = m0_.Size() == 1;
+   const bool const_m0 = mc_.Size() == 1;
 
    constexpr int DIM = 3;
    const int D1D = T_D1D ? T_D1D : d1d;
    const int Q1D = T_Q1D ? T_Q1D : q1d;
 
-   const auto M0 = const_m0 ?
-                   Reshape(m0_.Read(), 1, 1, 1, 1) :
-                   Reshape(m0_.Read(), Q1D, Q1D, Q1D, NE);
+   const auto MC = const_m0 ?
+                   Reshape(mc_.Read(), 1, 1, 1, 1) :
+                   Reshape(mc_.Read(), Q1D, Q1D, Q1D, NE);
    const auto J = Reshape(j_.Read(), DIM, DIM, Q1D, Q1D, Q1D, NE);
    const auto W = Reshape(w_.Read(), Q1D, Q1D, Q1D);
    const auto b = Reshape(b_.Read(), Q1D, D1D);
@@ -194,7 +194,7 @@ MFEM_REGISTER_TMOP_KERNELS(void, AddMultPA_Kernel_3D,
             {
                const double *Jtr = &J(0,0,qx,qy,qz,e);
                const double detJtr = kernels::Det<3>(Jtr);
-               const double m_coef = const_m0 ? M0(0,0,0,0) : M0(qx,qy,qz,e);
+               const double m_coef = const_m0 ? MC(0,0,0,0) : MC(qx,qy,qz,e);
                const double weight = metric_normal * m_coef *
                                      W(qx,qy,qz) * detJtr;
 
@@ -248,7 +248,7 @@ void TMOP_Integrator::AddMultPA_3D(const Vector &X, Vector &Y) const
    const Array<double> &B = PA.maps->B;
    const Array<double> &G = PA.maps->G;
    const double mn = metric_normal;
-   const Vector &M0 = PA.MC;
+   const Vector &MC = PA.MC;
 
    Array<double> mp;
    if (auto m = dynamic_cast<TMOP_Combo_QualityMetric *>(metric))
@@ -256,7 +256,7 @@ void TMOP_Integrator::AddMultPA_3D(const Vector &X, Vector &Y) const
       m->GetWeights(mp);
    }
 
-   MFEM_LAUNCH_TMOP_KERNEL(AddMultPA_Kernel_3D,id,mn,M0,mp,M,N,J,W,B,G,X,Y);
+   MFEM_LAUNCH_TMOP_KERNEL(AddMultPA_Kernel_3D,id,mn,MC,mp,M,N,J,W,B,G,X,Y);
 }
 
 } // namespace mfem

--- a/fem/tmop/tmop_pa_p3.cpp
+++ b/fem/tmop/tmop_pa_p3.cpp
@@ -131,6 +131,7 @@ void EvalP_338(const double *J, const double *w, double *P)
 
 MFEM_REGISTER_TMOP_KERNELS(void, AddMultPA_Kernel_3D,
                            const double metric_normal,
+                           const double metric_coeff,
                            const Array<double> &metric_param,
                            const int mid,
                            const int NE,
@@ -188,7 +189,8 @@ MFEM_REGISTER_TMOP_KERNELS(void, AddMultPA_Kernel_3D,
             {
                const double *Jtr = &J(0,0,qx,qy,qz,e);
                const double detJtr = kernels::Det<3>(Jtr);
-               const double weight = metric_normal * W(qx,qy,qz) * detJtr;
+               const double weight = metric_normal * metric_coeff *
+                                     W(qx,qy,qz) * detJtr;
 
                // Jrt = Jtr^{-1}
                double Jrt[9];
@@ -240,6 +242,7 @@ void TMOP_Integrator::AddMultPA_3D(const Vector &X, Vector &Y) const
    const Array<double> &B = PA.maps->B;
    const Array<double> &G = PA.maps->G;
    const double mn = metric_normal;
+   const double mc = PA.metric_coeff_val;
 
    Array<double> mp;
    if (auto m = dynamic_cast<TMOP_Combo_QualityMetric *>(metric))
@@ -247,7 +250,7 @@ void TMOP_Integrator::AddMultPA_3D(const Vector &X, Vector &Y) const
       m->GetWeights(mp);
    }
 
-   MFEM_LAUNCH_TMOP_KERNEL(AddMultPA_Kernel_3D,id,mn,mp,M,N,J,W,B,G,X,Y);
+   MFEM_LAUNCH_TMOP_KERNEL(AddMultPA_Kernel_3D,id,mn,mc,mp,M,N,J,W,B,G,X,Y);
 }
 
 } // namespace mfem

--- a/fem/tmop/tmop_pa_w2.cpp
+++ b/fem/tmop/tmop_pa_w2.cpp
@@ -73,7 +73,7 @@ double EvalW_094(const double *Jpt, const double *w)
 
 MFEM_REGISTER_TMOP_KERNELS(double, EnergyPA_2D,
                            const double metric_normal,
-                           const double metric_coeff,
+                           const Vector &m0_,
                            const Array<double> &metric_param,
                            const int mid,
                            const int NE,
@@ -91,12 +91,17 @@ MFEM_REGISTER_TMOP_KERNELS(double, EnergyPA_2D,
                || mid == 80 || mid == 94,
                "2D metric not yet implemented!");
 
+   const bool const_m0 = m0_.Size() == 1;
+
    constexpr int DIM = 2;
    constexpr int NBZ = 1;
 
    const int D1D = T_D1D ? T_D1D : d1d;
    const int Q1D = T_Q1D ? T_Q1D : q1d;
 
+   const auto M0 = const_m0 ?
+                   Reshape(m0_.Read(), 1, 1, 1) :
+                   Reshape(m0_.Read(), Q1D, Q1D, NE);
    const auto J = Reshape(j_.Read(), DIM, DIM, Q1D, Q1D, NE);
    const auto b = Reshape(b_.Read(), Q1D, D1D);
    const auto g = Reshape(g_.Read(), Q1D, D1D);
@@ -132,8 +137,8 @@ MFEM_REGISTER_TMOP_KERNELS(double, EnergyPA_2D,
          {
             const double *Jtr = &J(0,0,qx,qy,e);
             const double detJtr = kernels::Det<2>(Jtr);
-            const double weight = metric_normal * metric_coeff *
-                                  W(qx,qy) * detJtr;
+            const double m_coef = const_m0 ? M0(0,0,0) : M0(qx,qy,e);
+            const double weight = metric_normal * m_coef * W(qx,qy) * detJtr;
 
             // Jrt = Jtr^{-1}
             double Jrt[4];
@@ -171,7 +176,7 @@ double TMOP_Integrator::GetLocalStateEnergyPA_2D(const Vector &X) const
    const int Q1D = PA.maps->nqpt;
    const int id = (D1D << 4 ) | Q1D;
    const double mn = metric_normal;
-   const double mc = PA.metric_coeff_val;
+   const Vector &M0 = PA.MC;
    const DenseTensor &J = PA.Jtr;
    const Array<double> &W = PA.ir->GetWeights();
    const Array<double> &B = PA.maps->B;
@@ -185,7 +190,7 @@ double TMOP_Integrator::GetLocalStateEnergyPA_2D(const Vector &X) const
       m->GetWeights(mp);
    }
 
-   MFEM_LAUNCH_TMOP_KERNEL(EnergyPA_2D,id,mn,mc,mp,M,N,J,W,B,G,X,O,E);
+   MFEM_LAUNCH_TMOP_KERNEL(EnergyPA_2D,id,mn,M0,mp,M,N,J,W,B,G,X,O,E);
 }
 
 } // namespace mfem

--- a/fem/tmop/tmop_pa_w2.cpp
+++ b/fem/tmop/tmop_pa_w2.cpp
@@ -73,6 +73,7 @@ double EvalW_094(const double *Jpt, const double *w)
 
 MFEM_REGISTER_TMOP_KERNELS(double, EnergyPA_2D,
                            const double metric_normal,
+                           const double metric_coeff,
                            const Array<double> &metric_param,
                            const int mid,
                            const int NE,
@@ -131,7 +132,8 @@ MFEM_REGISTER_TMOP_KERNELS(double, EnergyPA_2D,
          {
             const double *Jtr = &J(0,0,qx,qy,e);
             const double detJtr = kernels::Det<2>(Jtr);
-            const double weight = metric_normal * W(qx,qy) * detJtr;
+            const double weight = metric_normal * metric_coeff *
+                                  W(qx,qy) * detJtr;
 
             // Jrt = Jtr^{-1}
             double Jrt[4];
@@ -169,6 +171,7 @@ double TMOP_Integrator::GetLocalStateEnergyPA_2D(const Vector &X) const
    const int Q1D = PA.maps->nqpt;
    const int id = (D1D << 4 ) | Q1D;
    const double mn = metric_normal;
+   const double mc = PA.metric_coeff_val;
    const DenseTensor &J = PA.Jtr;
    const Array<double> &W = PA.ir->GetWeights();
    const Array<double> &B = PA.maps->B;
@@ -182,7 +185,7 @@ double TMOP_Integrator::GetLocalStateEnergyPA_2D(const Vector &X) const
       m->GetWeights(mp);
    }
 
-   MFEM_LAUNCH_TMOP_KERNEL(EnergyPA_2D,id,mn,mp,M,N,J,W,B,G,X,O,E);
+   MFEM_LAUNCH_TMOP_KERNEL(EnergyPA_2D,id,mn,mc,mp,M,N,J,W,B,G,X,O,E);
 }
 
 } // namespace mfem

--- a/fem/tmop/tmop_pa_w2.cpp
+++ b/fem/tmop/tmop_pa_w2.cpp
@@ -73,7 +73,7 @@ double EvalW_094(const double *Jpt, const double *w)
 
 MFEM_REGISTER_TMOP_KERNELS(double, EnergyPA_2D,
                            const double metric_normal,
-                           const Vector &m0_,
+                           const Vector &mc_,
                            const Array<double> &metric_param,
                            const int mid,
                            const int NE,
@@ -91,7 +91,7 @@ MFEM_REGISTER_TMOP_KERNELS(double, EnergyPA_2D,
                || mid == 80 || mid == 94,
                "2D metric not yet implemented!");
 
-   const bool const_m0 = m0_.Size() == 1;
+   const bool const_m0 = mc_.Size() == 1;
 
    constexpr int DIM = 2;
    constexpr int NBZ = 1;
@@ -99,9 +99,9 @@ MFEM_REGISTER_TMOP_KERNELS(double, EnergyPA_2D,
    const int D1D = T_D1D ? T_D1D : d1d;
    const int Q1D = T_Q1D ? T_Q1D : q1d;
 
-   const auto M0 = const_m0 ?
-                   Reshape(m0_.Read(), 1, 1, 1) :
-                   Reshape(m0_.Read(), Q1D, Q1D, NE);
+   const auto MC = const_m0 ?
+                   Reshape(mc_.Read(), 1, 1, 1) :
+                   Reshape(mc_.Read(), Q1D, Q1D, NE);
    const auto J = Reshape(j_.Read(), DIM, DIM, Q1D, Q1D, NE);
    const auto b = Reshape(b_.Read(), Q1D, D1D);
    const auto g = Reshape(g_.Read(), Q1D, D1D);
@@ -137,7 +137,7 @@ MFEM_REGISTER_TMOP_KERNELS(double, EnergyPA_2D,
          {
             const double *Jtr = &J(0,0,qx,qy,e);
             const double detJtr = kernels::Det<2>(Jtr);
-            const double m_coef = const_m0 ? M0(0,0,0) : M0(qx,qy,e);
+            const double m_coef = const_m0 ? MC(0,0,0) : MC(qx,qy,e);
             const double weight = metric_normal * m_coef * W(qx,qy) * detJtr;
 
             // Jrt = Jtr^{-1}
@@ -176,7 +176,7 @@ double TMOP_Integrator::GetLocalStateEnergyPA_2D(const Vector &X) const
    const int Q1D = PA.maps->nqpt;
    const int id = (D1D << 4 ) | Q1D;
    const double mn = metric_normal;
-   const Vector &M0 = PA.MC;
+   const Vector &MC = PA.MC;
    const DenseTensor &J = PA.Jtr;
    const Array<double> &W = PA.ir->GetWeights();
    const Array<double> &B = PA.maps->B;
@@ -190,7 +190,7 @@ double TMOP_Integrator::GetLocalStateEnergyPA_2D(const Vector &X) const
       m->GetWeights(mp);
    }
 
-   MFEM_LAUNCH_TMOP_KERNEL(EnergyPA_2D,id,mn,M0,mp,M,N,J,W,B,G,X,O,E);
+   MFEM_LAUNCH_TMOP_KERNEL(EnergyPA_2D,id,mn,MC,mp,M,N,J,W,B,G,X,O,E);
 }
 
 } // namespace mfem

--- a/fem/tmop/tmop_pa_w3.cpp
+++ b/fem/tmop/tmop_pa_w3.cpp
@@ -82,6 +82,7 @@ double EvalW_338(const double *J, const double *w)
 
 MFEM_REGISTER_TMOP_KERNELS(double, EnergyPA_3D,
                            const double metric_normal,
+                           const double metric_coeff,
                            const Array<double> &metric_param,
                            const int mid,
                            const int NE,
@@ -141,7 +142,8 @@ MFEM_REGISTER_TMOP_KERNELS(double, EnergyPA_3D,
             {
                const double *Jtr = &J(0,0,qx,qy,qz,e);
                const double detJtr = kernels::Det<3>(Jtr);
-               const double weight = metric_normal * W(qx,qy,qz) * detJtr;
+               const double weight = metric_normal * metric_coeff *
+                                     W(qx,qy,qz) * detJtr;
 
                // Jrt = Jtr^{-1}
                double Jrt[9];
@@ -181,6 +183,7 @@ double TMOP_Integrator::GetLocalStateEnergyPA_3D(const Vector &X) const
    const int Q1D = PA.maps->nqpt;
    const int id = (D1D << 4 ) | Q1D;
    const double mn = metric_normal;
+   const double mc = PA.metric_coeff_val;
    const DenseTensor &J = PA.Jtr;
    const Array<double> &W = PA.ir->GetWeights();
    const Array<double> &B = PA.maps->B;
@@ -194,7 +197,7 @@ double TMOP_Integrator::GetLocalStateEnergyPA_3D(const Vector &X) const
       m->GetWeights(mp);
    }
 
-   MFEM_LAUNCH_TMOP_KERNEL(EnergyPA_3D,id,mn,mp,M,N,J,W,B,G,O,X,E);
+   MFEM_LAUNCH_TMOP_KERNEL(EnergyPA_3D,id,mn,mc,mp,M,N,J,W,B,G,O,X,E);
 }
 
 } // namespace mfem

--- a/fem/tmop/tmop_pa_w3.cpp
+++ b/fem/tmop/tmop_pa_w3.cpp
@@ -82,7 +82,7 @@ double EvalW_338(const double *J, const double *w)
 
 MFEM_REGISTER_TMOP_KERNELS(double, EnergyPA_3D,
                            const double metric_normal,
-                           const Vector &m0_,
+                           const Vector &mc_,
                            const Array<double> &metric_param,
                            const int mid,
                            const int NE,
@@ -100,15 +100,15 @@ MFEM_REGISTER_TMOP_KERNELS(double, EnergyPA_3D,
                mid == 321 || mid == 332 || mid == 338,
                "3D metric not yet implemented!");
 
-   const bool const_m0 = m0_.Size() == 1;
+   const bool const_m0 = mc_.Size() == 1;
 
    constexpr int DIM = 3;
    const int D1D = T_D1D ? T_D1D : d1d;
    const int Q1D = T_Q1D ? T_Q1D : q1d;
 
-   const auto M0 = const_m0 ?
-                   Reshape(m0_.Read(), 1, 1, 1, 1) :
-                   Reshape(m0_.Read(), Q1D, Q1D, Q1D, NE);
+   const auto MC = const_m0 ?
+                   Reshape(mc_.Read(), 1, 1, 1, 1) :
+                   Reshape(mc_.Read(), Q1D, Q1D, Q1D, NE);
    const auto J = Reshape(j_.Read(), DIM, DIM, Q1D, Q1D, Q1D, NE);
    const auto b = Reshape(b_.Read(), Q1D, D1D);
    const auto g = Reshape(g_.Read(), Q1D, D1D);
@@ -147,7 +147,7 @@ MFEM_REGISTER_TMOP_KERNELS(double, EnergyPA_3D,
             {
                const double *Jtr = &J(0,0,qx,qy,qz,e);
                const double detJtr = kernels::Det<3>(Jtr);
-               const double m_coef = const_m0 ? M0(0,0,0,0) : M0(qx,qy,qz,e);
+               const double m_coef = const_m0 ? MC(0,0,0,0) : MC(qx,qy,qz,e);
                const double weight = metric_normal * m_coef *
                                      W(qx,qy,qz) * detJtr;
 
@@ -189,7 +189,7 @@ double TMOP_Integrator::GetLocalStateEnergyPA_3D(const Vector &X) const
    const int Q1D = PA.maps->nqpt;
    const int id = (D1D << 4 ) | Q1D;
    const double mn = metric_normal;
-   const Vector &M0 = PA.MC;
+   const Vector &MC = PA.MC;
    const DenseTensor &J = PA.Jtr;
    const Array<double> &W = PA.ir->GetWeights();
    const Array<double> &B = PA.maps->B;
@@ -203,7 +203,7 @@ double TMOP_Integrator::GetLocalStateEnergyPA_3D(const Vector &X) const
       m->GetWeights(mp);
    }
 
-   MFEM_LAUNCH_TMOP_KERNEL(EnergyPA_3D,id,mn,M0,mp,M,N,J,W,B,G,O,X,E);
+   MFEM_LAUNCH_TMOP_KERNEL(EnergyPA_3D,id,mn,MC,mp,M,N,J,W,B,G,O,X,E);
 }
 
 } // namespace mfem

--- a/fem/tmop/tmop_pa_w3.cpp
+++ b/fem/tmop/tmop_pa_w3.cpp
@@ -82,7 +82,7 @@ double EvalW_338(const double *J, const double *w)
 
 MFEM_REGISTER_TMOP_KERNELS(double, EnergyPA_3D,
                            const double metric_normal,
-                           const double metric_coeff,
+                           const Vector &m0_,
                            const Array<double> &metric_param,
                            const int mid,
                            const int NE,
@@ -100,10 +100,15 @@ MFEM_REGISTER_TMOP_KERNELS(double, EnergyPA_3D,
                mid == 321 || mid == 332 || mid == 338,
                "3D metric not yet implemented!");
 
+   const bool const_m0 = m0_.Size() == 1;
+
    constexpr int DIM = 3;
    const int D1D = T_D1D ? T_D1D : d1d;
    const int Q1D = T_Q1D ? T_Q1D : q1d;
 
+   const auto M0 = const_m0 ?
+                   Reshape(m0_.Read(), 1, 1, 1, 1) :
+                   Reshape(m0_.Read(), Q1D, Q1D, Q1D, NE);
    const auto J = Reshape(j_.Read(), DIM, DIM, Q1D, Q1D, Q1D, NE);
    const auto b = Reshape(b_.Read(), Q1D, D1D);
    const auto g = Reshape(g_.Read(), Q1D, D1D);
@@ -142,7 +147,8 @@ MFEM_REGISTER_TMOP_KERNELS(double, EnergyPA_3D,
             {
                const double *Jtr = &J(0,0,qx,qy,qz,e);
                const double detJtr = kernels::Det<3>(Jtr);
-               const double weight = metric_normal * metric_coeff *
+               const double m_coef = const_m0 ? M0(0,0,0,0) : M0(qx,qy,qz,e);
+               const double weight = metric_normal * m_coef *
                                      W(qx,qy,qz) * detJtr;
 
                // Jrt = Jtr^{-1}
@@ -183,7 +189,7 @@ double TMOP_Integrator::GetLocalStateEnergyPA_3D(const Vector &X) const
    const int Q1D = PA.maps->nqpt;
    const int id = (D1D << 4 ) | Q1D;
    const double mn = metric_normal;
-   const double mc = PA.metric_coeff_val;
+   const Vector &M0 = PA.MC;
    const DenseTensor &J = PA.Jtr;
    const Array<double> &W = PA.ir->GetWeights();
    const Array<double> &B = PA.maps->B;
@@ -197,7 +203,7 @@ double TMOP_Integrator::GetLocalStateEnergyPA_3D(const Vector &X) const
       m->GetWeights(mp);
    }
 
-   MFEM_LAUNCH_TMOP_KERNEL(EnergyPA_3D,id,mn,mc,mp,M,N,J,W,B,G,O,X,E);
+   MFEM_LAUNCH_TMOP_KERNEL(EnergyPA_3D,id,mn,M0,mp,M,N,J,W,B,G,O,X,E);
 }
 
 } // namespace mfem

--- a/tests/unit/miniapps/test_tmop_pa.cpp
+++ b/tests/unit/miniapps/test_tmop_pa.cpp
@@ -294,7 +294,8 @@ int tmop(int id, Req &res, int argc, char *argv[])
    ParGridFunction dist(&dist_fes);
    dist = 1.0;
    if (normalization == 1) { dist = small_phys_size; }
-   ConstantCoefficient lim_coeff(lim_const);
+   auto coeff_lim_func = [&](const Vector &x) { return x(0) + lim_const; };
+   FunctionCoefficient lim_coeff(coeff_lim_func);
    if (lim_const != 0.0)
    {
       if (lim_type == 0)

--- a/tests/unit/miniapps/test_tmop_pa.cpp
+++ b/tests/unit/miniapps/test_tmop_pa.cpp
@@ -311,14 +311,15 @@ int tmop(int id, Req &res, int argc, char *argv[])
    ParNonlinearForm nlf(&fes);
    nlf.SetAssemblyLevel(pa ? AssemblyLevel::PARTIAL : AssemblyLevel::LEGACY);
 
-   ConstantCoefficient *coeff1 = nullptr;
+   FunctionCoefficient *coeff1 = nullptr;
    TMOP_QualityMetric *metric2 = nullptr;
    TargetConstructor *target_c2 = nullptr;
    FunctionCoefficient coeff2(weight_fun);
    if (combo > 0)
    {
       // First metric.
-      coeff1 = new ConstantCoefficient(10.0);
+      auto coeff_1_func = [&](const Vector &x) { return x(0) + 10.0; };
+      coeff1 = new FunctionCoefficient(coeff_1_func);
       he_nlf_integ->SetCoefficient(*coeff1);
       // Second metric.
       if (dim == 2) { metric2 = new TMOP_Metric_077; }

--- a/tests/unit/miniapps/test_tmop_pa.cpp
+++ b/tests/unit/miniapps/test_tmop_pa.cpp
@@ -318,7 +318,7 @@ int tmop(int id, Req &res, int argc, char *argv[])
    if (combo > 0)
    {
       // First metric.
-      coeff1 = new ConstantCoefficient(1.0);
+      coeff1 = new ConstantCoefficient(10.0);
       he_nlf_integ->SetCoefficient(*coeff1);
       // Second metric.
       if (dim == 2) { metric2 = new TMOP_Metric_077; }


### PR DESCRIPTION
It turned out that `TMOP_Integrator::SetCoefficient()` was ignored by the PA code (it always assumed the coefficient was 1). It also adds the missing updates of the metric and limiting `Coefficients`, when the nodes move.

The tmop unit tests are slightly modified to catch these.

<!--GHEX{"author":"vladotomov","assignment":"2023-11-27T16:41:29","editor":"tzanio","id":3995,"reviewers":["camierjs","kmittal2"],"merge":"2023-12-06T19:30:13","approval":"2023-12-04T16:30:43"}XEHG-->
<!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge|
 | --- | --- | --- | --- | --- | --- | --- |
| [#3995](https://github.com/mfem/mfem/pull/3995) | @vladotomov | @tzanio | @camierjs + @kmittal2 | 11/27/23 | 12/4/23 | 12/6/23 | |
<!--ELBATXEHG-->
<details>
<summary>PR Checklist</summary>
    
- [ ] Code builds.
- [ ] Code passes `make style`.
- [ ] Update `CHANGELOG`:
    - [ ] Is this a new feature users need to be aware of? New or updated example or miniapp?
    - [ ] Does it make sense to create a new section in the `CHANGELOG` to group with other related features?
- [ ] Update `INSTALL`:
    - [ ] Had a new optional library been added? If so, what range of versions of this library are required? (*Make sure the external library is compatible with our BSD license, e.g. it is not licensed under GPL!*)
    - [ ] Have the version ranges for any required or optional libraries changed?
    - [ ] Does `make` or `cmake` have a new target?
    - [ ] Did the requirements or the installation process change? *(rare)*
- [ ] Update continuous integration server configurations if necessary (e.g. with new version requirements for each of MFEM's dependencies)
    - [ ] `.github`
    - [ ] `.appveyor.yml`
- [ ] Update `.gitignore`:
    - [ ] Check if `make distclean; git status` shows any files that were generated from the source by the project (not an IDE) but we don't want to track in the repository.
    - [ ] Add new patterns (just for the new files above) and re-run the above test.
- [ ] New examples:
    - [ ] All sample runs at the top of the example source file work.
    - [ ] Update `examples/makefile`:
      - [ ] Add the example code to the appropriate `SEQ_EXAMPLES` and `PAR_EXAMPLES` variables.
      - [ ] Add any files generated by it to the `clean` target.
      - [ ] Add the example binary and any files generated by it to the top-level `.gitignore` file.
    - [ ] Update `examples/CMakeLists.txt`:
      - [ ] Add the example code to the `ALL_EXE_SRCS` variable.
      - [ ] Make sure `THIS_TEST_OPTIONS` is set correctly for the new example.
   - [ ] List the new example in `doc/CodeDocumentation.dox`.
   - [ ] If new examples directory (e.g.`examples/pumi`), list it in `doc/CodeDocumentation.conf.in`
   - [ ] Companion pull request for documentation in [mfem/web](https://github.com/mfem/web) repo:
      - [ ] Update or add example-specific documentation, see e.g. the `src/examples.md`.
      - [ ] Add the description, labels and screenshots in `src/examples.md` and `src/img`.
      - [ ] In `examples.md`, list the example under the appropriate categories, add new categories if necessary.
      - [ ] Add a short description of the example in the "Extensive Examples" section of `features.md`.
- [ ] New miniapps:
   - [ ] All sample runs at the top of the miniapp source file work.
   - [ ] Update top-level `makefile` and `makefile` in corresponding miniapp directory.
   - [ ] Add the miniapp binary and any files generated by it to the top-level `.gitignore` file.
   - [ ] Update CMake build system:
      - [ ] Update the `CMakeLists.txt` file in the `miniapps` directory, if the new miniapp is in a new directory.
      - [ ] Add/update the `CMakeLists.txt` file in the new miniapp directory.
      - [ ] Consider adding a new test for the new miniapp.
   - [ ] List the new miniapp in `doc/CodeDocumentation.dox`
   - [ ] If new miniapps directory (e.g.`miniapps/nurbs`), add it to `MINIAPP_SUBDIRS` in the `makefile`.
   - [ ] If new miniapps directory (e.g.`miniapps/nurbs`), list it in `doc/CodeDocumentation.conf.in`
   - [ ] Companion pull request for documentation in [mfem/web](https://github.com/mfem/web) repo:
     - [ ] Update or add miniapp-specific documentation, see e.g. the `src/meshing.md` and `src/electromagnetics.md` files.
     - [ ] Add the description, labels and screenshots in `src/examples.md` and `src/img`.
     - [ ] The miniapps go at the end of the page, and are usually listed only under a specific "Application (PDE)" category.
     - [ ] Add a short description of the miniapp in the "Extensive Examples" section of `features.md`.
- [ ] New capability:
   - [ ] All new public, protected, and private classes, methods, data members, and functions have full Doxygen-style documentation in source comments. Documentation should include descriptions of member data, function arguments and return values, template parameters, and prerequisites for calling new functions.
   - [ ] Pointer arguments and return values must specify whether ownership is being transferred or lent with the call.
   - [ ] Any new functions should include descriptions of their intended use e.g. for internal use only, user-facing, etc., along with references to example code whenever possible/appropriate.
   - [ ] Consider adding new sample runs in existing examples to highlight the new capability.
   - [ ] Consider saving cool simulation pictures with the new capability in the Confluence gallery (LLNL only) or submitting them, via pull request, to the gallery section of the `mfem/web` repo.
   - [ ] If this is a major new feature, consider mentioning it in the short summary inside `README` *(rare)*.
   - [ ] List major new classes in `doc/CodeDocumentation.dox` *(rare)*.
- [ ] Update this checklist, if the new pull request affects it.
- [ ] Run `make unittest` to make sure all unit tests pass.
- [ ] Run the tests in `tests/scripts`.
- [ ] (LLNL only) After merging:
   - [ ] Update internal tests to include the new features.
</details>
