### PR TITLE
Mark mfem_error as [[noreturn]]

### DIFF
--- a/general/error.cpp
+++ b/general/error.cpp
@@ -151,7 +151,7 @@ void mfem_backtrace(int mode, int depth)
 #endif // MFEM_USE_LIBUNWIND
 }
 
-[[noreturn]] void mfem_error(const char *msg)
+void mfem_error(const char *msg)
 {
    std::ostream &merr = internal::mfem_err_initialized ? mfem::err : std::cerr;
    if (msg)

--- a/general/error.cpp
+++ b/general/error.cpp
@@ -151,7 +151,7 @@ void mfem_backtrace(int mode, int depth)
 #endif // MFEM_USE_LIBUNWIND
 }
 
-void mfem_error(const char *msg)
+[[noreturn]] void mfem_error(const char *msg)
 {
    std::ostream &merr = internal::mfem_err_initialized ? mfem::err : std::cerr;
    if (msg)

--- a/general/error.hpp
+++ b/general/error.hpp
@@ -56,7 +56,7 @@ void mfem_backtrace(int mode = 0, int depth = -1);
 
 /** @brief Function called when an error is encountered. Used by the macros
     MFEM_ABORT, MFEM_ASSERT, MFEM_VERIFY. */
-void mfem_error(const char *msg = NULL);
+[[noreturn]] void mfem_error(const char *msg = NULL);
 
 /// Function called by the macro MFEM_WARNING.
 void mfem_warning(const char *msg = NULL);


### PR DESCRIPTION
If a function has a non-void return type, the compiler will complain if there is not a return value in all control paths. This can generate a warning if, for example, `MFEM_ABORT` is called in the `default` case of a switch statement, or in the else branch of an if-else statement.

Since C++11, functions can be marked as [`[[noreturn]]`](https://en.cppreference.com/w/cpp/language/attributes/noreturn), which tells the compiler they never return. `mfem_error` is one such function, since it calls `std::abort`. This PR marks `mfem_error` as `[[noreturn]]`, which should silence unnecessary compiler warnings.

For example:

```cpp
#include "mfem.hpp"
#include <iostream>

using namespace std;
using namespace mfem;

int f(int x)
{
   if (x == 1) { return 1; }
   else { MFEM_ABORT(""); }
}

int main(int argc, char *argv[])
{
   int x = 1;
   OptionsParser args(argc, argv);
   args.AddOption(&x, "-x", "--x", "x");
   args.ParseCheck();
   cout << f(x) << '\n';
   return 0;
}
```

On master, this code will generate the warning `non-void function does not return a value in all control paths [-Wreturn-type]` (clang version 15.0.0). On this branch, it compiles cleanly.
<!--GHEX{"author":"pazner","assignment":"2023-12-07T20:49:32","editor":"tzanio","id":4021,"reviewers":["sebastiangrimberg","aschaf"],"merge":"2023-12-12T22:07:05","approval":"2023-12-11T19:58:10"}XEHG-->
<!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge|
 | --- | --- | --- | --- | --- | --- | --- |
| [#4021](https://github.com/mfem/mfem/pull/4021) | @pazner | @tzanio | @sebastiangrimberg + @aschaf | 12/7/23 | 12/11/23 | 12/12/23 | |
<!--ELBATXEHG-->
<details>
<summary>PR Checklist</summary>
    
- [ ] Code builds.
- [ ] Code passes `make style`.
- [ ] Update `CHANGELOG`:
    - [ ] Is this a new feature users need to be aware of? New or updated example or miniapp?
    - [ ] Does it make sense to create a new section in the `CHANGELOG` to group with other related features?
- [ ] Update `INSTALL`:
    - [ ] Had a new optional library been added? If so, what range of versions of this library are required? (*Make sure the external library is compatible with our BSD license, e.g. it is not licensed under GPL!*)
    - [ ] Have the version ranges for any required or optional libraries changed?
    - [ ] Does `make` or `cmake` have a new target?
    - [ ] Did the requirements or the installation process change? *(rare)*
- [ ] Update continuous integration server configurations if necessary (e.g. with new version requirements for each of MFEM's dependencies)
    - [ ] `.github`
    - [ ] `.appveyor.yml`
- [ ] Update `.gitignore`:
    - [ ] Check if `make distclean; git status` shows any files that were generated from the source by the project (not an IDE) but we don't want to track in the repository.
    - [ ] Add new patterns (just for the new files above) and re-run the above test.
- [ ] New examples:
    - [ ] All sample runs at the top of the example source file work.
    - [ ] Update `examples/makefile`:
      - [ ] Add the example code to the appropriate `SEQ_EXAMPLES` and `PAR_EXAMPLES` variables.
      - [ ] Add any files generated by it to the `clean` target.
      - [ ] Add the example binary and any files generated by it to the top-level `.gitignore` file.
    - [ ] Update `examples/CMakeLists.txt`:
      - [ ] Add the example code to the `ALL_EXE_SRCS` variable.
      - [ ] Make sure `THIS_TEST_OPTIONS` is set correctly for the new example.
   - [ ] List the new example in `doc/CodeDocumentation.dox`.
   - [ ] If new examples directory (e.g.`examples/pumi`), list it in `doc/CodeDocumentation.conf.in`
   - [ ] Companion pull request for documentation in [mfem/web](https://github.com/mfem/web) repo:
      - [ ] Update or add example-specific documentation, see e.g. the `src/examples.md`.
      - [ ] Add the description, labels and screenshots in `src/examples.md` and `src/img`.
      - [ ] In `examples.md`, list the example under the appropriate categories, add new categories if necessary.
      - [ ] Add a short description of the example in the "Extensive Examples" section of `features.md`.
- [ ] New miniapps:
   - [ ] All sample runs at the top of the miniapp source file work.
   - [ ] Update top-level `makefile` and `makefile` in corresponding miniapp directory.
   - [ ] Add the miniapp binary and any files generated by it to the top-level `.gitignore` file.
   - [ ] Update CMake build system:
      - [ ] Update the `CMakeLists.txt` file in the `miniapps` directory, if the new miniapp is in a new directory.
      - [ ] Add/update the `CMakeLists.txt` file in the new miniapp directory.
      - [ ] Consider adding a new test for the new miniapp.
   - [ ] List the new miniapp in `doc/CodeDocumentation.dox`
   - [ ] If new miniapps directory (e.g.`miniapps/nurbs`), add it to `MINIAPP_SUBDIRS` in the `makefile`.
   - [ ] If new miniapps directory (e.g.`miniapps/nurbs`), list it in `doc/CodeDocumentation.conf.in`
   - [ ] Companion pull request for documentation in [mfem/web](https://github.com/mfem/web) repo:
     - [ ] Update or add miniapp-specific documentation, see e.g. the `src/meshing.md` and `src/electromagnetics.md` files.
     - [ ] Add the description, labels and screenshots in `src/examples.md` and `src/img`.
     - [ ] The miniapps go at the end of the page, and are usually listed only under a specific "Application (PDE)" category.
     - [ ] Add a short description of the miniapp in the "Extensive Examples" section of `features.md`.
- [ ] New capability:
   - [ ] All new public, protected, and private classes, methods, data members, and functions have full Doxygen-style documentation in source comments. Documentation should include descriptions of member data, function arguments and return values, template parameters, and prerequisites for calling new functions.
   - [ ] Pointer arguments and return values must specify whether ownership is being transferred or lent with the call.
   - [ ] Any new functions should include descriptions of their intended use e.g. for internal use only, user-facing, etc., along with references to example code whenever possible/appropriate.
   - [ ] Consider adding new sample runs in existing examples to highlight the new capability.
   - [ ] Consider saving cool simulation pictures with the new capability in the Confluence gallery (LLNL only) or submitting them, via pull request, to the gallery section of the `mfem/web` repo.
   - [ ] If this is a major new feature, consider mentioning it in the short summary inside `README` *(rare)*.
   - [ ] List major new classes in `doc/CodeDocumentation.dox` *(rare)*.
- [ ] Update this checklist, if the new pull request affects it.
- [ ] Run `make unittest` to make sure all unit tests pass.
- [ ] Run the tests in `tests/scripts`.
- [ ] (LLNL only) After merging:
   - [ ] Update internal tests to include the new features.
</details>
