### PR TITLE
Fix libCEED compilation after `CeedChk` removal

### DIFF
--- a/fem/ceed/interface/ceed.hpp
+++ b/fem/ceed/interface/ceed.hpp
@@ -12,8 +12,12 @@
 #ifndef MFEM_LIBCEED_CEED
 #define MFEM_LIBCEED_CEED
 
+#include "../../../config/config.hpp"
+
 #ifdef MFEM_USE_CEED
+
 #include <ceed.h>
+
 #if !CEED_VERSION_GE(0,10,0)
 #error MFEM requires a libCEED version >= 0.10.0
 #endif

--- a/fem/ceed/interface/util.cpp
+++ b/fem/ceed/interface/util.cpp
@@ -132,24 +132,24 @@ int CeedOperatorGetActiveField(CeedOperator oper, CeedOperatorField *field)
 {
    int ierr;
    Ceed ceed;
-   ierr = CeedOperatorGetCeed(oper, &ceed); CeedChk(ierr);
+   ierr = CeedOperatorGetCeed(oper, &ceed); PCeedChk(ierr);
 
    CeedQFunction qf;
    bool isComposite;
-   ierr = CeedOperatorIsComposite(oper, &isComposite); CeedChk(ierr);
+   ierr = CeedOperatorIsComposite(oper, &isComposite); PCeedChk(ierr);
    CeedOperator *subops;
    if (isComposite)
    {
 #if CEED_VERSION_GE(0, 10, 2)
-      ierr = CeedCompositeOperatorGetSubList(oper, &subops); CeedChk(ierr);
+      ierr = CeedCompositeOperatorGetSubList(oper, &subops); PCeedChk(ierr);
 #else
-      ierr = CeedOperatorGetSubList(oper, &subops); CeedChk(ierr);
+      ierr = CeedOperatorGetSubList(oper, &subops); PCeedChk(ierr);
 #endif
-      ierr = CeedOperatorGetQFunction(subops[0], &qf); CeedChk(ierr);
+      ierr = CeedOperatorGetQFunction(subops[0], &qf); PCeedChk(ierr);
    }
    else
    {
-      ierr = CeedOperatorGetQFunction(oper, &qf); CeedChk(ierr);
+      ierr = CeedOperatorGetQFunction(oper, &qf); PCeedChk(ierr);
    }
    CeedInt numinputfields, numoutputfields;
    ierr = CeedQFunctionGetNumArgs(qf, &numinputfields, &numoutputfields);
@@ -157,12 +157,12 @@ int CeedOperatorGetActiveField(CeedOperator oper, CeedOperatorField *field)
    if (isComposite)
    {
       ierr = CeedOperatorGetFields(subops[0], &numinputfields, &inputfields,
-                                   &numoutputfields, NULL); CeedChk(ierr);
+                                   &numoutputfields, NULL); PCeedChk(ierr);
    }
    else
    {
       ierr = CeedOperatorGetFields(oper, &numinputfields, &inputfields,
-                                   &numoutputfields, NULL); CeedChk(ierr);
+                                   &numoutputfields, NULL); PCeedChk(ierr);
    }
 
    CeedVector if_vector;
@@ -170,7 +170,7 @@ int CeedOperatorGetActiveField(CeedOperator oper, CeedOperatorField *field)
    int found_index = -1;
    for (int i = 0; i < numinputfields; ++i)
    {
-      ierr = CeedOperatorFieldGetVector(inputfields[i], &if_vector); CeedChk(ierr);
+      ierr = CeedOperatorFieldGetVector(inputfields[i], &if_vector); PCeedChk(ierr);
       if (if_vector == CEED_VECTOR_ACTIVE)
       {
          if (found)

--- a/fem/ceed/interface/util.hpp
+++ b/fem/ceed/interface/util.hpp
@@ -13,12 +13,15 @@
 #define MFEM_LIBCEED_UTIL
 
 #include "../../../config/config.hpp"
+#include "../../../general/error.hpp"
+
 #include <functional>
 #include <string>
 #include <tuple>
 #include <unordered_map>
 
 #include "ceed.hpp"
+
 #ifdef MFEM_USE_CEED
 #include <ceed/backend.h>  // for CeedOperatorField
 #endif
@@ -170,10 +173,12 @@ namespace internal
 {
 
 #ifdef MFEM_USE_CEED
+
 /** @warning These maps have a tendency to create bugs when adding new "types"
     of CeedBasis and CeedElemRestriction. */
 extern ceed::BasisMap ceed_basis_map;
 extern ceed::RestrMap ceed_restr_map;
+
 #endif
 
 } // namespace internal

--- a/fem/ceed/solvers/algebraic.cpp
+++ b/fem/ceed/solvers/algebraic.cpp
@@ -99,7 +99,7 @@ int CeedOperatorGetSize(CeedOperator oper, CeedInt * size)
 {
    CeedSize in_len, out_len;
    int ierr = CeedOperatorGetActiveVectorLengths(oper, &in_len, &out_len);
-   CeedChk(ierr);
+   PCeedChk(ierr);
    *size = (CeedInt)in_len;
    MFEM_VERIFY(in_len == out_len, "not a square CeedOperator");
    MFEM_VERIFY(in_len == *size, "size overflow");
@@ -378,67 +378,68 @@ int AlgebraicInterpolation::Initialize(
 
    CeedSize height, width;
    ierr = CeedElemRestrictionGetLVectorSize(erestrictu_coarse, &width);
-   CeedChk(ierr);
+   PCeedChk(ierr);
    ierr = CeedElemRestrictionGetLVectorSize(erestrictu_fine, &height);
-   CeedChk(ierr);
+   PCeedChk(ierr);
 
    // interpolation qfunction
    const int bp3_ncompu = 1;
    CeedQFunction l_qf_restrict, l_qf_prolong;
    ierr = CeedQFunctionCreateIdentity(ceed, bp3_ncompu, CEED_EVAL_NONE,
-                                      CEED_EVAL_INTERP, &l_qf_restrict); CeedChk(ierr);
+                                      CEED_EVAL_INTERP, &l_qf_restrict); PCeedChk(ierr);
    ierr = CeedQFunctionCreateIdentity(ceed, bp3_ncompu, CEED_EVAL_INTERP,
-                                      CEED_EVAL_NONE, &l_qf_prolong); CeedChk(ierr);
+                                      CEED_EVAL_NONE, &l_qf_prolong); PCeedChk(ierr);
 
    qf_restrict = l_qf_restrict;
    qf_prolong = l_qf_prolong;
 
    CeedVector c_fine_multiplicity;
-   ierr = CeedVectorCreate(ceed, height, &c_fine_multiplicity); CeedChk(ierr);
-   ierr = CeedVectorSetValue(c_fine_multiplicity, 0.0); CeedChk(ierr);
+   ierr = CeedVectorCreate(ceed, height, &c_fine_multiplicity); PCeedChk(ierr);
+   ierr = CeedVectorSetValue(c_fine_multiplicity, 0.0); PCeedChk(ierr);
 
    // Create the restriction operator
    // Restriction - Fine to coarse
    ierr = CeedOperatorCreate(ceed, qf_restrict, CEED_QFUNCTION_NONE,
-                             CEED_QFUNCTION_NONE, &op_restrict); CeedChk(ierr);
+                             CEED_QFUNCTION_NONE, &op_restrict); PCeedChk(ierr);
    ierr = CeedOperatorSetField(op_restrict, "input", erestrictu_fine,
-                               CEED_BASIS_COLLOCATED, CEED_VECTOR_ACTIVE); CeedChk(ierr);
+                               CEED_BASIS_COLLOCATED, CEED_VECTOR_ACTIVE); PCeedChk(ierr);
    ierr = CeedOperatorSetField(op_restrict, "output", erestrictu_coarse,
-                               basisctof, CEED_VECTOR_ACTIVE); CeedChk(ierr);
+                               basisctof, CEED_VECTOR_ACTIVE); PCeedChk(ierr);
 
    // Interpolation - Coarse to fine
    // Create the prolongation operator
    ierr =  CeedOperatorCreate(ceed, qf_prolong, CEED_QFUNCTION_NONE,
-                              CEED_QFUNCTION_NONE, &op_interp); CeedChk(ierr);
+                              CEED_QFUNCTION_NONE, &op_interp); PCeedChk(ierr);
    ierr =  CeedOperatorSetField(op_interp, "input", erestrictu_coarse,
-                                basisctof, CEED_VECTOR_ACTIVE); CeedChk(ierr);
+                                basisctof, CEED_VECTOR_ACTIVE); PCeedChk(ierr);
    ierr = CeedOperatorSetField(op_interp, "output", erestrictu_fine,
-                               CEED_BASIS_COLLOCATED, CEED_VECTOR_ACTIVE); CeedChk(ierr);
+                               CEED_BASIS_COLLOCATED, CEED_VECTOR_ACTIVE); PCeedChk(ierr);
 
    ierr = CeedElemRestrictionGetMultiplicity(erestrictu_fine,
-                                             c_fine_multiplicity); CeedChk(ierr);
-   ierr = CeedVectorCreate(ceed, height, &fine_multiplicity_r); CeedChk(ierr);
+                                             c_fine_multiplicity); PCeedChk(ierr);
+   ierr = CeedVectorCreate(ceed, height, &fine_multiplicity_r); PCeedChk(ierr);
 
    CeedScalar* fine_r_data;
    const CeedScalar* fine_data;
    ierr = CeedVectorGetArrayWrite(fine_multiplicity_r, CEED_MEM_HOST,
-                                  &fine_r_data); CeedChk(ierr);
+                                  &fine_r_data); PCeedChk(ierr);
    ierr = CeedVectorGetArrayRead(c_fine_multiplicity, CEED_MEM_HOST,
-                                 &fine_data); CeedChk(ierr);
+                                 &fine_data); PCeedChk(ierr);
    for (CeedSize i = 0; i < height; ++i)
    {
       fine_r_data[i] = 1.0 / fine_data[i];
    }
 
-   ierr = CeedVectorRestoreArray(fine_multiplicity_r, &fine_r_data); CeedChk(ierr);
+   ierr = CeedVectorRestoreArray(fine_multiplicity_r, &fine_r_data);
+   PCeedChk(ierr);
    ierr = CeedVectorRestoreArrayRead(c_fine_multiplicity, &fine_data);
-   CeedChk(ierr);
-   ierr = CeedVectorDestroy(&c_fine_multiplicity); CeedChk(ierr);
+   PCeedChk(ierr);
+   ierr = CeedVectorDestroy(&c_fine_multiplicity); PCeedChk(ierr);
 
-   ierr = CeedVectorCreate(ceed, height, &fine_work); CeedChk(ierr);
+   ierr = CeedVectorCreate(ceed, height, &fine_work); PCeedChk(ierr);
 
-   ierr = CeedVectorCreate(ceed, height, &v_); CeedChk(ierr);
-   ierr = CeedVectorCreate(ceed, width, &u_); CeedChk(ierr);
+   ierr = CeedVectorCreate(ceed, height, &v_); PCeedChk(ierr);
+   ierr = CeedVectorCreate(ceed, width, &u_); PCeedChk(ierr);
 
    return 0;
 }
@@ -447,12 +448,12 @@ int AlgebraicInterpolation::Finalize()
 {
    int ierr;
 
-   ierr = CeedQFunctionDestroy(&qf_restrict); CeedChk(ierr);
-   ierr = CeedQFunctionDestroy(&qf_prolong); CeedChk(ierr);
-   ierr = CeedOperatorDestroy(&op_interp); CeedChk(ierr);
-   ierr = CeedOperatorDestroy(&op_restrict); CeedChk(ierr);
-   ierr = CeedVectorDestroy(&fine_multiplicity_r); CeedChk(ierr);
-   ierr = CeedVectorDestroy(&fine_work); CeedChk(ierr);
+   ierr = CeedQFunctionDestroy(&qf_restrict); PCeedChk(ierr);
+   ierr = CeedQFunctionDestroy(&qf_prolong); PCeedChk(ierr);
+   ierr = CeedOperatorDestroy(&op_interp); PCeedChk(ierr);
+   ierr = CeedOperatorDestroy(&op_restrict); PCeedChk(ierr);
+   ierr = CeedVectorDestroy(&fine_multiplicity_r); PCeedChk(ierr);
+   ierr = CeedVectorDestroy(&fine_work); PCeedChk(ierr);
 
    return 0;
 }
@@ -498,8 +499,8 @@ int CeedVectorPointwiseMult(CeedVector a, const CeedVector b)
    CeedVectorGetCeed(a, &ceed);
 
    CeedSize length, length2;
-   ierr = CeedVectorGetLength(a, &length); CeedChk(ierr);
-   ierr = CeedVectorGetLength(b, &length2); CeedChk(ierr);
+   ierr = CeedVectorGetLength(a, &length); PCeedChk(ierr);
+   ierr = CeedVectorGetLength(b, &length2); PCeedChk(ierr);
    if (length != length2)
    {
       return CeedError(ceed, 1, "Vector sizes don't match");
@@ -516,14 +517,14 @@ int CeedVectorPointwiseMult(CeedVector a, const CeedVector b)
    }
    CeedScalar *a_data;
    const CeedScalar *b_data;
-   ierr = CeedVectorGetArray(a, mem, &a_data); CeedChk(ierr);
-   ierr = CeedVectorGetArrayRead(b, mem, &b_data); CeedChk(ierr);
+   ierr = CeedVectorGetArray(a, mem, &a_data); PCeedChk(ierr);
+   ierr = CeedVectorGetArrayRead(b, mem, &b_data); PCeedChk(ierr);
    MFEM_VERIFY(int(length) == length, "length overflow");
    mfem::forall(length, [=] MFEM_HOST_DEVICE (int i)
    {a_data[i] *= b_data[i];});
 
-   ierr = CeedVectorRestoreArray(a, &a_data); CeedChk(ierr);
-   ierr = CeedVectorRestoreArrayRead(b, &b_data); CeedChk(ierr);
+   ierr = CeedVectorRestoreArray(a, &a_data); PCeedChk(ierr);
+   ierr = CeedVectorRestoreArrayRead(b, &b_data); PCeedChk(ierr);
 
    return 0;
 }

--- a/fem/ceed/solvers/full-assembly.cpp
+++ b/fem/ceed/solvers/full-assembly.cpp
@@ -45,32 +45,32 @@ int CeedSingleOperatorFullAssemble(CeedOperator op, SparseMatrix *out)
 {
    int ierr;
    Ceed ceed;
-   ierr = CeedOperatorGetCeed(op, &ceed); CeedChk(ierr);
+   ierr = CeedOperatorGetCeed(op, &ceed); PCeedChk(ierr);
 
    // Assemble QFunction
    CeedQFunction qf;
-   ierr = CeedOperatorGetQFunction(op, &qf); CeedChk(ierr);
+   ierr = CeedOperatorGetQFunction(op, &qf); PCeedChk(ierr);
    CeedInt numinputfields, numoutputfields;
-   CeedChk(ierr);
+   PCeedChk(ierr);
    CeedVector assembledqf;
    CeedElemRestriction rstr_q;
    ierr = CeedOperatorLinearAssembleQFunction(
-             op, &assembledqf, &rstr_q, CEED_REQUEST_IMMEDIATE); CeedChk(ierr);
+             op, &assembledqf, &rstr_q, CEED_REQUEST_IMMEDIATE); PCeedChk(ierr);
 
    CeedSize qflength;
-   ierr = CeedVectorGetLength(assembledqf, &qflength); CeedChk(ierr);
+   ierr = CeedVectorGetLength(assembledqf, &qflength); PCeedChk(ierr);
 
    CeedOperatorField *input_fields;
    CeedOperatorField *output_fields;
    ierr = CeedOperatorGetFields(op, &numinputfields, &input_fields,
                                 &numoutputfields, &output_fields);
-   CeedChk(ierr);
+   PCeedChk(ierr);
 
    // Determine active input basis
    CeedQFunctionField *qffields;
    ierr = CeedQFunctionGetFields(qf, &numinputfields, &qffields,
                                  &numoutputfields, NULL);
-   CeedChk(ierr);
+   PCeedChk(ierr);
    CeedInt numemodein = 0, ncomp, dim = 1;
    CeedEvalMode *emodein = NULL;
    CeedBasis basisin = NULL;
@@ -78,28 +78,28 @@ int CeedSingleOperatorFullAssemble(CeedOperator op, SparseMatrix *out)
    for (CeedInt i=0; i<numinputfields; i++)
    {
       CeedVector vec;
-      ierr = CeedOperatorFieldGetVector(input_fields[i], &vec); CeedChk(ierr);
+      ierr = CeedOperatorFieldGetVector(input_fields[i], &vec); PCeedChk(ierr);
       if (vec == CEED_VECTOR_ACTIVE)
       {
          ierr = CeedOperatorFieldGetBasis(input_fields[i], &basisin);
-         CeedChk(ierr);
-         ierr = CeedBasisGetNumComponents(basisin, &ncomp); CeedChk(ierr);
-         ierr = CeedBasisGetDimension(basisin, &dim); CeedChk(ierr);
+         PCeedChk(ierr);
+         ierr = CeedBasisGetNumComponents(basisin, &ncomp); PCeedChk(ierr);
+         ierr = CeedBasisGetDimension(basisin, &dim); PCeedChk(ierr);
          ierr = CeedOperatorFieldGetElemRestriction(input_fields[i], &rstrin);
-         CeedChk(ierr);
+         PCeedChk(ierr);
          CeedEvalMode emode;
          ierr = CeedQFunctionFieldGetEvalMode(qffields[i], &emode);
-         CeedChk(ierr);
+         PCeedChk(ierr);
          switch (emode)
          {
             case CEED_EVAL_NONE:
             case CEED_EVAL_INTERP:
-               ierr = CeedHackRealloc(numemodein + 1, &emodein); CeedChk(ierr);
+               ierr = CeedHackRealloc(numemodein + 1, &emodein); PCeedChk(ierr);
                emodein[numemodein] = emode;
                numemodein += 1;
                break;
             case CEED_EVAL_GRAD:
-               ierr = CeedHackRealloc(numemodein + dim, &emodein); CeedChk(ierr);
+               ierr = CeedHackRealloc(numemodein + dim, &emodein); PCeedChk(ierr);
                for (CeedInt d=0; d<dim; d++)
                {
                   emodein[numemodein+d] = emode;
@@ -116,7 +116,7 @@ int CeedSingleOperatorFullAssemble(CeedOperator op, SparseMatrix *out)
 
    // Determine active output basis
    ierr = CeedQFunctionGetFields(qf, &numinputfields, NULL, &numoutputfields,
-                                 &qffields); CeedChk(ierr);
+                                 &qffields); PCeedChk(ierr);
    CeedInt numemodeout = 0;
    CeedEvalMode *emodeout = NULL;
    CeedBasis basisout = NULL;
@@ -124,27 +124,27 @@ int CeedSingleOperatorFullAssemble(CeedOperator op, SparseMatrix *out)
    for (CeedInt i=0; i<numoutputfields; i++)
    {
       CeedVector vec;
-      ierr = CeedOperatorFieldGetVector(output_fields[i], &vec); CeedChk(ierr);
+      ierr = CeedOperatorFieldGetVector(output_fields[i], &vec); PCeedChk(ierr);
       if (vec == CEED_VECTOR_ACTIVE)
       {
          ierr = CeedOperatorFieldGetBasis(output_fields[i], &basisout);
-         CeedChk(ierr);
+         PCeedChk(ierr);
          ierr = CeedOperatorFieldGetElemRestriction(output_fields[i], &rstrout);
-         CeedChk(ierr);
-         CeedChk(ierr);
+         PCeedChk(ierr);
+         PCeedChk(ierr);
          CeedEvalMode emode;
          ierr = CeedQFunctionFieldGetEvalMode(qffields[i], &emode);
-         CeedChk(ierr);
+         PCeedChk(ierr);
          switch (emode)
          {
             case CEED_EVAL_NONE:
             case CEED_EVAL_INTERP:
-               ierr = CeedHackRealloc(numemodeout + 1, &emodeout); CeedChk(ierr);
+               ierr = CeedHackRealloc(numemodeout + 1, &emodeout); PCeedChk(ierr);
                emodeout[numemodeout] = emode;
                numemodeout += 1;
                break;
             case CEED_EVAL_GRAD:
-               ierr = CeedHackRealloc(numemodeout + dim, &emodeout); CeedChk(ierr);
+               ierr = CeedHackRealloc(numemodeout + dim, &emodeout); PCeedChk(ierr);
                for (CeedInt d=0; d<dim; d++)
                {
                   emodeout[numemodeout+d] = emode;
@@ -161,47 +161,47 @@ int CeedSingleOperatorFullAssemble(CeedOperator op, SparseMatrix *out)
 
    CeedInt nelem, elemsize, nqpts;
    CeedSize nnodes;
-   ierr = CeedElemRestrictionGetNumElements(rstrin, &nelem); CeedChk(ierr);
-   ierr = CeedElemRestrictionGetElementSize(rstrin, &elemsize); CeedChk(ierr);
-   ierr = CeedElemRestrictionGetLVectorSize(rstrin, &nnodes); CeedChk(ierr);
-   ierr = CeedBasisGetNumQuadraturePoints(basisin, &nqpts); CeedChk(ierr);
+   ierr = CeedElemRestrictionGetNumElements(rstrin, &nelem); PCeedChk(ierr);
+   ierr = CeedElemRestrictionGetElementSize(rstrin, &elemsize); PCeedChk(ierr);
+   ierr = CeedElemRestrictionGetLVectorSize(rstrin, &nnodes); PCeedChk(ierr);
+   ierr = CeedBasisGetNumQuadraturePoints(basisin, &nqpts); PCeedChk(ierr);
 
    // Determine elem_dof relation
    CeedVector index_vec;
-   ierr = CeedVectorCreate(ceed, nnodes, &index_vec); CeedChk(ierr);
+   ierr = CeedVectorCreate(ceed, nnodes, &index_vec); PCeedChk(ierr);
    CeedScalar *array;
    ierr = CeedVectorGetArrayWrite(index_vec, CEED_MEM_HOST, &array);
-   CeedChk(ierr);
+   PCeedChk(ierr);
    for (CeedSize i = 0; i < nnodes; ++i)
    {
       array[i] = i;
    }
-   ierr = CeedVectorRestoreArray(index_vec, &array); CeedChk(ierr);
+   ierr = CeedVectorRestoreArray(index_vec, &array); PCeedChk(ierr);
    CeedVector elem_dof;
-   ierr = CeedVectorCreate(ceed, nelem * elemsize, &elem_dof); CeedChk(ierr);
-   ierr = CeedVectorSetValue(elem_dof, 0.0); CeedChk(ierr);
+   ierr = CeedVectorCreate(ceed, nelem * elemsize, &elem_dof); PCeedChk(ierr);
+   ierr = CeedVectorSetValue(elem_dof, 0.0); PCeedChk(ierr);
    CeedElemRestrictionApply(rstrin, CEED_NOTRANSPOSE, index_vec,
-                            elem_dof, CEED_REQUEST_IMMEDIATE); CeedChk(ierr);
+                            elem_dof, CEED_REQUEST_IMMEDIATE); PCeedChk(ierr);
    const CeedScalar * elem_dof_a;
    ierr = CeedVectorGetArrayRead(elem_dof, CEED_MEM_HOST, &elem_dof_a);
-   CeedChk(ierr);
-   ierr = CeedVectorDestroy(&index_vec); CeedChk(ierr);
+   PCeedChk(ierr);
+   ierr = CeedVectorDestroy(&index_vec); PCeedChk(ierr);
 
    // loop over elements and put in SparseMatrix
    // SparseMatrix * out = new SparseMatrix(nnodes, nnodes);
    MFEM_ASSERT(out->Height() == nnodes, "Sizes don't match!");
    MFEM_ASSERT(out->Width() == nnodes, "Sizes don't match!");
    const CeedScalar *interpin, *gradin;
-   ierr = CeedBasisGetInterp(basisin, &interpin); CeedChk(ierr);
-   ierr = CeedBasisGetGrad(basisin, &gradin); CeedChk(ierr);
+   ierr = CeedBasisGetInterp(basisin, &interpin); PCeedChk(ierr);
+   ierr = CeedBasisGetGrad(basisin, &gradin); PCeedChk(ierr);
 
    const CeedScalar * assembledqfarray;
    ierr = CeedVectorGetArrayRead(assembledqf, CEED_MEM_HOST, &assembledqfarray);
-   CeedChk(ierr);
+   PCeedChk(ierr);
 
    CeedInt layout[3];
-   ierr = CeedElemRestrictionGetELayout(rstr_q, &layout); CeedChk(ierr);
-   ierr = CeedElemRestrictionDestroy(&rstr_q); CeedChk(ierr);
+   ierr = CeedElemRestrictionGetELayout(rstr_q, &layout); PCeedChk(ierr);
+   ierr = CeedElemRestrictionDestroy(&rstr_q); PCeedChk(ierr);
 
    // enforce structurally symmetric for later elimination
    const int skip_zeros = 0;
@@ -280,13 +280,13 @@ int CeedSingleOperatorFullAssemble(CeedOperator op, SparseMatrix *out)
       out->AddSubMatrix(rows, rows, elem_mat, skip_zeros);
    }
 
-   ierr = CeedVectorRestoreArrayRead(elem_dof, &elem_dof_a); CeedChk(ierr);
-   ierr = CeedVectorDestroy(&elem_dof); CeedChk(ierr);
+   ierr = CeedVectorRestoreArrayRead(elem_dof, &elem_dof_a); PCeedChk(ierr);
+   ierr = CeedVectorDestroy(&elem_dof); PCeedChk(ierr);
    ierr = CeedVectorRestoreArrayRead(assembledqf, &assembledqfarray);
-   CeedChk(ierr);
-   ierr = CeedVectorDestroy(&assembledqf); CeedChk(ierr);
-   ierr = CeedHackFree(&emodein); CeedChk(ierr);
-   ierr = CeedHackFree(&emodeout); CeedChk(ierr);
+   PCeedChk(ierr);
+   ierr = CeedVectorDestroy(&assembledqf); PCeedChk(ierr);
+   ierr = CeedHackFree(&emodein); PCeedChk(ierr);
+   ierr = CeedHackFree(&emodeout); PCeedChk(ierr);
 
    return 0;
 }
@@ -297,7 +297,7 @@ int CeedOperatorFullAssemble(CeedOperator op, SparseMatrix **mat)
 
    CeedSize in_len, out_len;
    ierr = CeedOperatorGetActiveVectorLengths(op, &in_len, &out_len);
-   CeedChk(ierr);
+   PCeedChk(ierr);
    const int nnodes = in_len;
    MFEM_VERIFY(in_len == out_len, "not a square CeedOperator");
    MFEM_VERIFY(in_len == nnodes, "size overflow");
@@ -305,26 +305,26 @@ int CeedOperatorFullAssemble(CeedOperator op, SparseMatrix **mat)
    SparseMatrix *out = new SparseMatrix(nnodes, nnodes);
 
    bool isComposite;
-   ierr = CeedOperatorIsComposite(op, &isComposite); CeedChk(ierr);
+   ierr = CeedOperatorIsComposite(op, &isComposite); PCeedChk(ierr);
    if (isComposite)
    {
       CeedInt numsub;
       CeedOperator *subops;
 #if CEED_VERSION_GE(0, 10, 2)
       CeedCompositeOperatorGetNumSub(op, &numsub);
-      ierr = CeedCompositeOperatorGetSubList(op, &subops); CeedChk(ierr);
+      ierr = CeedCompositeOperatorGetSubList(op, &subops); PCeedChk(ierr);
 #else
       CeedOperatorGetNumSub(op, &numsub);
-      ierr = CeedOperatorGetSubList(op, &subops); CeedChk(ierr);
+      ierr = CeedOperatorGetSubList(op, &subops); PCeedChk(ierr);
 #endif
       for (int i = 0; i < numsub; ++i)
       {
-         ierr = CeedSingleOperatorFullAssemble(subops[i], out); CeedChk(ierr);
+         ierr = CeedSingleOperatorFullAssemble(subops[i], out); PCeedChk(ierr);
       }
    }
    else
    {
-      ierr = CeedSingleOperatorFullAssemble(op, out); CeedChk(ierr);
+      ierr = CeedSingleOperatorFullAssemble(op, out); PCeedChk(ierr);
    }
    // enforce structurally symmetric for later elimination
    const int skip_zeros = 0;

--- a/fem/ceed/solvers/full-assembly.cpp
+++ b/fem/ceed/solvers/full-assembly.cpp
@@ -11,11 +11,11 @@
 
 #include "full-assembly.hpp"
 
+#ifdef MFEM_USE_CEED
+
 #include "../../../linalg/sparsemat.hpp"
 #include "../interface/util.hpp"
 #include "../interface/ceed.hpp"
-
-#ifdef MFEM_USE_CEED
 
 namespace mfem
 {
@@ -338,4 +338,4 @@ int CeedOperatorFullAssemble(CeedOperator op, SparseMatrix **mat)
 
 } // namespace mfem
 
-#endif
+#endif // MFEM_USE_CEED

--- a/fem/ceed/solvers/full-assembly.hpp
+++ b/fem/ceed/solvers/full-assembly.hpp
@@ -19,6 +19,8 @@
 namespace mfem
 {
 
+class SparseMatrix;
+
 namespace ceed
 {
 
@@ -34,6 +36,6 @@ int CeedOperatorFullAssemble(CeedOperator op, SparseMatrix **mat);
 
 } // namespace mfem
 
-#endif
+#endif // MFEM_USE_CEED
 
-#endif
+#endif // MFEM_CEED_ASSEMBLE_HPP

--- a/fem/ceed/solvers/solvers-atpmg.cpp
+++ b/fem/ceed/solvers/solvers-atpmg.cpp
@@ -15,8 +15,8 @@
 #include "../interface/util.hpp"
 
 #ifdef MFEM_USE_CEED
-#include <ceed/backend.h>
 
+#include <ceed/backend.h>
 #include <math.h>
 // todo: should probably use Ceed memory wrappers instead of calloc/free?
 #include <stdlib.h>

--- a/fem/ceed/solvers/solvers-atpmg.cpp
+++ b/fem/ceed/solvers/solvers-atpmg.cpp
@@ -86,14 +86,14 @@ int CeedATPMGElemRestriction(int order,
 {
    int ierr;
    Ceed ceed;
-   ierr = CeedElemRestrictionGetCeed(er_in, &ceed); CeedChk(ierr);
+   ierr = CeedElemRestrictionGetCeed(er_in, &ceed); PCeedChk(ierr);
 
    CeedInt numelem, numcomp, elemsize;
    CeedSize numnodes;
-   ierr = CeedElemRestrictionGetNumElements(er_in, &numelem); CeedChk(ierr);
-   ierr = CeedElemRestrictionGetLVectorSize(er_in, &numnodes); CeedChk(ierr);
-   ierr = CeedElemRestrictionGetElementSize(er_in, &elemsize); CeedChk(ierr);
-   ierr = CeedElemRestrictionGetNumComponents(er_in, &numcomp); CeedChk(ierr);
+   ierr = CeedElemRestrictionGetNumElements(er_in, &numelem); PCeedChk(ierr);
+   ierr = CeedElemRestrictionGetLVectorSize(er_in, &numnodes); PCeedChk(ierr);
+   ierr = CeedElemRestrictionGetElementSize(er_in, &elemsize); PCeedChk(ierr);
+   ierr = CeedElemRestrictionGetNumComponents(er_in, &numcomp); PCeedChk(ierr);
    if (numcomp != 1)
    {
       // todo: multi-component will require more thought
@@ -107,31 +107,31 @@ int CeedATPMGElemRestriction(int order,
 
    CeedVector in_lvec, in_evec;
    ierr = CeedElemRestrictionCreateVector(er_in, &in_lvec, &in_evec);
-   CeedChk(ierr);
+   PCeedChk(ierr);
 
    // Create the elem_dof array from the given high-order ElemRestriction
    // by using it to map the L-vector indices to an E-vector
    CeedScalar * lvec_data;
    ierr = CeedVectorGetArrayWrite(in_lvec, CEED_MEM_HOST, &lvec_data);
-   CeedChk(ierr);
+   PCeedChk(ierr);
    for (CeedSize i = 0; i < numnodes; ++i)
    {
       lvec_data[i] = (CeedScalar) i;
    }
-   ierr = CeedVectorRestoreArray(in_lvec, &lvec_data); CeedChk(ierr);
+   ierr = CeedVectorRestoreArray(in_lvec, &lvec_data); PCeedChk(ierr);
    CeedInt in_layout[3];
-   ierr = CeedElemRestrictionGetELayout(er_in, &in_layout); CeedChk(ierr);
+   ierr = CeedElemRestrictionGetELayout(er_in, &in_layout); PCeedChk(ierr);
    if (in_layout[0] == 0 && in_layout[1] == 0 && in_layout[2] == 0)
    {
       return CeedError(ceed, 1, "Cannot interpret e-vector ordering of given"
                        "CeedElemRestriction!");
    }
    ierr = CeedElemRestrictionApply(er_in, CEED_NOTRANSPOSE, in_lvec, in_evec,
-                                   CEED_REQUEST_IMMEDIATE); CeedChk(ierr);
-   ierr = CeedVectorDestroy(&in_lvec); CeedChk(ierr);
+                                   CEED_REQUEST_IMMEDIATE); PCeedChk(ierr);
+   ierr = CeedVectorDestroy(&in_lvec); PCeedChk(ierr);
    const CeedScalar * in_elem_dof;
    ierr = CeedVectorGetArrayRead(in_evec, CEED_MEM_HOST, &in_elem_dof);
-   CeedChk(ierr);
+   PCeedChk(ierr);
 
    // Create a map (dof_map) that maps high-order ldof indices to
    // low-order ldof indices, with -1 indicating no correspondence
@@ -469,13 +469,13 @@ int CeedATPMGElemRestriction(int order,
                        "CeedATPMGElemRestriction does not yet support this dimension.");
    }
 
-   ierr = CeedVectorRestoreArrayRead(in_evec, &in_elem_dof); CeedChk(ierr);
-   ierr = CeedVectorDestroy(&in_evec); CeedChk(ierr);
+   ierr = CeedVectorRestoreArrayRead(in_evec, &in_elem_dof); PCeedChk(ierr);
+   ierr = CeedVectorDestroy(&in_evec); PCeedChk(ierr);
 
    ierr = CeedElemRestrictionCreate(ceed, numelem, coarse_elemsize, numcomp,
                                     0, running_out_ldof_count,
                                     CEED_MEM_HOST, CEED_COPY_VALUES, out_elem_dof,
-                                    er_out); CeedChk(ierr);
+                                    er_out); PCeedChk(ierr);
 
    delete [] out_elem_dof;
 
@@ -491,7 +491,7 @@ int CeedBasisATPMGCoarseToFine(Ceed ceed, int P1d, int dim, int order_reduction,
    // calling the following Ceed function)
    int ierr;
    ierr = CeedBasisCreateTensorH1Lagrange(ceed, dim, 1, P1d - order_reduction, P1d,
-                                          CEED_GAUSS_LOBATTO, basisc2f); CeedChk(ierr);
+                                          CEED_GAUSS_LOBATTO, basisc2f); PCeedChk(ierr);
    return 0;
 }
 
@@ -501,13 +501,13 @@ int CeedBasisATPMGCoarseToFine(CeedBasis basisin,
 {
    int ierr;
    Ceed ceed;
-   ierr = CeedBasisGetCeed(basisin, &ceed); CeedChk(ierr);
+   ierr = CeedBasisGetCeed(basisin, &ceed); PCeedChk(ierr);
 
    CeedInt dim, P1d;
-   ierr = CeedBasisGetDimension(basisin, &dim); CeedChk(ierr);
-   ierr = CeedBasisGetNumNodes1D(basisin, &P1d); CeedChk(ierr);
+   ierr = CeedBasisGetDimension(basisin, &dim); PCeedChk(ierr);
+   ierr = CeedBasisGetNumNodes1D(basisin, &P1d); PCeedChk(ierr);
    ierr = CeedBasisATPMGCoarseToFine(ceed, P1d, dim, order_reduction,
-                                     basisc2f); CeedChk(ierr);
+                                     basisc2f); PCeedChk(ierr);
    return 0;
 }
 
@@ -518,20 +518,20 @@ int CeedBasisATPMGCoarsen(CeedBasis basisin,
 {
    int ierr;
    Ceed ceed;
-   ierr = CeedBasisGetCeed(basisin, &ceed); CeedChk(ierr);
+   ierr = CeedBasisGetCeed(basisin, &ceed); PCeedChk(ierr);
 
    CeedInt dim, ncomp, P1d, Q1d;
-   ierr = CeedBasisGetDimension(basisin, &dim); CeedChk(ierr);
-   ierr = CeedBasisGetNumComponents(basisin, &ncomp); CeedChk(ierr);
-   ierr = CeedBasisGetNumNodes1D(basisin, &P1d); CeedChk(ierr);
-   ierr = CeedBasisGetNumQuadraturePoints1D(basisin, &Q1d); CeedChk(ierr);
+   ierr = CeedBasisGetDimension(basisin, &dim); PCeedChk(ierr);
+   ierr = CeedBasisGetNumComponents(basisin, &ncomp); PCeedChk(ierr);
+   ierr = CeedBasisGetNumNodes1D(basisin, &P1d); PCeedChk(ierr);
+   ierr = CeedBasisGetNumQuadraturePoints1D(basisin, &Q1d); PCeedChk(ierr);
 
    CeedInt coarse_P1d = P1d - order_reduction;
 
    const CeedScalar *interp1d;
-   ierr = CeedBasisGetInterp1D(basisin, &interp1d); CeedChk(ierr);
+   ierr = CeedBasisGetInterp1D(basisin, &interp1d); PCeedChk(ierr);
    const CeedScalar * grad1d;
-   ierr = CeedBasisGetGrad1D(basisin, &grad1d); CeedChk(ierr);
+   ierr = CeedBasisGetGrad1D(basisin, &grad1d); PCeedChk(ierr);
 
    CeedScalar * coarse_interp1d = new CeedScalar[coarse_P1d * Q1d];
    CeedScalar * coarse_grad1d = new CeedScalar[coarse_P1d * Q1d];
@@ -542,14 +542,14 @@ int CeedBasisATPMGCoarsen(CeedBasis basisin,
    /* one way you might be able to tell is to just run this algorithm
       with coarse_P1d = 2 (i.e., linear) and look for symmetry in the coarse
       basis matrix? */
-   ierr = CeedLobattoQuadrature(P1d, fine_nodal_points, NULL); CeedChk(ierr);
+   ierr = CeedLobattoQuadrature(P1d, fine_nodal_points, NULL); PCeedChk(ierr);
    for (int i = 0; i < P1d; ++i)
    {
       fine_nodal_points[i] = 0.5 * fine_nodal_points[i] + 0.5; // cheating
    }
 
    const CeedScalar *interp_ctof;
-   ierr = CeedBasisGetInterp1D(basisc2f, &interp_ctof); CeedChk(ierr);
+   ierr = CeedBasisGetInterp1D(basisc2f, &interp_ctof); PCeedChk(ierr);
 
    for (int i = 0; i < Q1d; ++i)
    {
@@ -568,12 +568,12 @@ int CeedBasisATPMGCoarsen(CeedBasis basisin,
    }
 
    const CeedScalar * qref1d;
-   ierr = CeedBasisGetQRef(basisin, &qref1d); CeedChk(ierr);
+   ierr = CeedBasisGetQRef(basisin, &qref1d); PCeedChk(ierr);
    const CeedScalar * qweight1d;
-   ierr = CeedBasisGetQWeights(basisin, &qweight1d); CeedChk(ierr);
+   ierr = CeedBasisGetQWeights(basisin, &qweight1d); PCeedChk(ierr);
    ierr = CeedBasisCreateTensorH1(ceed, dim, ncomp,
                                   coarse_P1d, Q1d, coarse_interp1d, coarse_grad1d,
-                                  qref1d, qweight1d, basisout); CeedChk(ierr);
+                                  qref1d, qweight1d, basisout); PCeedChk(ierr);
 
    delete [] fine_nodal_points;
    delete [] coarse_interp1d;
@@ -593,19 +593,19 @@ int CeedATPMGOperator(CeedOperator oper, int order_reduction,
 
    int ierr;
    Ceed ceed;
-   ierr = CeedOperatorGetCeed(oper, &ceed); CeedChk(ierr);
+   ierr = CeedOperatorGetCeed(oper, &ceed); PCeedChk(ierr);
 
    CeedQFunction qf;
-   ierr = CeedOperatorGetQFunction(oper, &qf); CeedChk(ierr);
+   ierr = CeedOperatorGetQFunction(oper, &qf); PCeedChk(ierr);
    CeedInt numinputfields, numoutputfields;
    CeedQFunctionField *inputqfields, *outputqfields;
    ierr = CeedQFunctionGetFields(qf, &numinputfields, &inputqfields,
                                  &numoutputfields, &outputqfields);
-   CeedChk(ierr);
+   PCeedChk(ierr);
    CeedOperatorField *inputfields, *outputfields;
    ierr = CeedOperatorGetFields(oper, &numinputfields, &inputfields,
                                 &numoutputfields, &outputfields);
-   CeedChk(ierr);
+   PCeedChk(ierr);
 
    CeedElemRestriction * er_input = new CeedElemRestriction[numinputfields];
    CeedElemRestriction * er_output = new CeedElemRestriction[numoutputfields];
@@ -619,10 +619,11 @@ int CeedATPMGOperator(CeedOperator oper, int order_reduction,
    for (int i = 0; i < numinputfields; ++i)
    {
       ierr = CeedOperatorFieldGetElemRestriction(inputfields[i],
-                                                 &er_input[i]); CeedChk(ierr);
-      ierr = CeedOperatorFieldGetVector(inputfields[i], &if_vector[i]); CeedChk(ierr);
+                                                 &er_input[i]); PCeedChk(ierr);
+      ierr = CeedOperatorFieldGetVector(inputfields[i], &if_vector[i]);
+      PCeedChk(ierr);
       ierr = CeedOperatorFieldGetBasis(inputfields[i], &basis_input[i]);
-      CeedChk(ierr);
+      PCeedChk(ierr);
       if (if_vector[i] == CEED_VECTOR_ACTIVE)
       {
          if (active_input_basis < 0)
@@ -638,11 +639,11 @@ int CeedATPMGOperator(CeedOperator oper, int order_reduction,
    for (int i = 0; i < numoutputfields; ++i)
    {
       ierr = CeedOperatorFieldGetElemRestriction(outputfields[i],
-                                                 &er_output[i]); CeedChk(ierr);
+                                                 &er_output[i]); PCeedChk(ierr);
       ierr = CeedOperatorFieldGetVector(outputfields[i], &of_vector[i]);
-      CeedChk(ierr);
+      PCeedChk(ierr);
       ierr = CeedOperatorFieldGetBasis(outputfields[i], &basis_output[i]);
-      CeedChk(ierr);
+      PCeedChk(ierr);
       if (of_vector[i] == CEED_VECTOR_ACTIVE)
       {
          // should already be coarsened
@@ -659,36 +660,36 @@ int CeedATPMGOperator(CeedOperator oper, int order_reduction,
 
    CeedOperator coper;
    ierr = CeedOperatorCreate(ceed, qf, CEED_QFUNCTION_NONE, CEED_QFUNCTION_NONE,
-                             &coper); CeedChk(ierr);
+                             &coper); PCeedChk(ierr);
 
    for (int i = 0; i < numinputfields; ++i)
    {
       char * fieldname;
-      ierr = CeedQFunctionFieldGetName(inputqfields[i], &fieldname); CeedChk(ierr);
+      ierr = CeedQFunctionFieldGetName(inputqfields[i], &fieldname); PCeedChk(ierr);
       if (if_vector[i] == CEED_VECTOR_ACTIVE)
       {
          ierr = CeedOperatorSetField(coper, fieldname, coarse_er, cbasis,
-                                     if_vector[i]); CeedChk(ierr);
+                                     if_vector[i]); PCeedChk(ierr);
       }
       else
       {
          ierr = CeedOperatorSetField(coper, fieldname, er_input[i], basis_input[i],
-                                     if_vector[i]); CeedChk(ierr);
+                                     if_vector[i]); PCeedChk(ierr);
       }
    }
    for (int i = 0; i < numoutputfields; ++i)
    {
       char * fieldname;
-      ierr = CeedQFunctionFieldGetName(outputqfields[i], &fieldname); CeedChk(ierr);
+      ierr = CeedQFunctionFieldGetName(outputqfields[i], &fieldname); PCeedChk(ierr);
       if (of_vector[i] == CEED_VECTOR_ACTIVE)
       {
          ierr = CeedOperatorSetField(coper, fieldname, coarse_er, cbasis,
-                                     of_vector[i]); CeedChk(ierr);
+                                     of_vector[i]); PCeedChk(ierr);
       }
       else
       {
          ierr = CeedOperatorSetField(coper, fieldname, er_output[i], basis_output[i],
-                                     of_vector[i]); CeedChk(ierr);
+                                     of_vector[i]); PCeedChk(ierr);
       }
    }
    delete [] er_input;
@@ -711,21 +712,21 @@ int CeedATPMGOperator(CeedOperator oper, int order_reduction,
    int ierr;
 
    CeedQFunction qf;
-   ierr = CeedOperatorGetQFunction(oper, &qf); CeedChk(ierr);
+   ierr = CeedOperatorGetQFunction(oper, &qf); PCeedChk(ierr);
    CeedInt numinputfields, numoutputfields;
    CeedOperatorField *inputfields;
    ierr = CeedOperatorGetFields(oper, &numinputfields, &inputfields,
                                 &numoutputfields, NULL);
-   CeedChk(ierr);
+   PCeedChk(ierr);
 
    CeedBasis basis;
-   ierr = CeedOperatorGetActiveBasis(oper, &basis); CeedChk(ierr);
+   ierr = CeedOperatorGetActiveBasis(oper, &basis); PCeedChk(ierr);
    ierr = CeedBasisATPMGCoarseToFine(basis, basis_ctof_out, order_reduction);
-   CeedChk(ierr);
+   PCeedChk(ierr);
    ierr = CeedBasisATPMGCoarsen(basis, *basis_ctof_out, coarse_basis_out,
-                                order_reduction); CeedChk(ierr);
+                                order_reduction); PCeedChk(ierr);
    ierr = CeedATPMGOperator(oper, order_reduction, coarse_er, *coarse_basis_out,
-                            *basis_ctof_out, out); CeedChk(ierr);
+                            *basis_ctof_out, out); PCeedChk(ierr);
    return 0;
 }
 
@@ -734,11 +735,11 @@ int CeedOperatorGetOrder(CeedOperator oper, CeedInt * order)
    int ierr;
 
    CeedOperatorField active_field;
-   ierr = CeedOperatorGetActiveField(oper, &active_field); CeedChk(ierr);
+   ierr = CeedOperatorGetActiveField(oper, &active_field); PCeedChk(ierr);
    CeedBasis basis;
-   ierr = CeedOperatorFieldGetBasis(active_field, &basis); CeedChk(ierr);
+   ierr = CeedOperatorFieldGetBasis(active_field, &basis); PCeedChk(ierr);
    int P1d;
-   ierr = CeedBasisGetNumNodes1D(basis, &P1d); CeedChk(ierr);
+   ierr = CeedBasisGetNumNodes1D(basis, &P1d); PCeedChk(ierr);
    *order = P1d - 1;
 
    return 0;
@@ -753,13 +754,13 @@ int CeedATPMGBundle(CeedOperator oper, int order_reduction,
 {
    int ierr;
    CeedInt order;
-   ierr = CeedOperatorGetOrder(oper, &order); CeedChk(ierr);
+   ierr = CeedOperatorGetOrder(oper, &order); PCeedChk(ierr);
    CeedElemRestriction ho_er;
-   ierr = CeedOperatorGetActiveElemRestriction(oper, &ho_er); CeedChk(ierr);
+   ierr = CeedOperatorGetActiveElemRestriction(oper, &ho_er); PCeedChk(ierr);
    ierr = CeedATPMGElemRestriction(order, order_reduction, ho_er, er_out, dof_map);
-   CeedChk(ierr);
+   PCeedChk(ierr);
    ierr = CeedATPMGOperator(oper, order_reduction, *er_out, coarse_basis_out,
-                            basis_ctof_out, coarse_oper); CeedChk(ierr);
+                            basis_ctof_out, coarse_oper); PCeedChk(ierr);
    return 0;
 }
 


### PR DESCRIPTION
Probably the MFEM code should not have been using the internal `CeedChk` method in the first place, there was already a `PCeedChk` wrapper which handled libCEED error codes correctly. This PR makes the change to the MFEM `PCeedChk` wrapper everywhere it had been missed, after https://github.com/CEED/libCEED/pull/1398.

Resolves https://github.com/mfem/mfem/issues/4031<!--GHEX{"author":"sebastiangrimberg","assignment":"2023-12-15T19:55:23","editor":"pazner","id":4032,"reviewers":["YohannDudouit","pazner"],"merge":"2023-12-21T18:45:03","approval":"2023-12-15T21:54:37"}XEHG-->
<!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge|
 | --- | --- | --- | --- | --- | --- | --- |
| [#4032](https://github.com/mfem/mfem/pull/4032) | @sebastiangrimberg | @pazner | @YohannDudouit + @pazner | 12/15/23 | 12/15/23 | 12/21/23 | |
<!--ELBATXEHG-->
<details>
<summary>PR Checklist</summary>
    
- [ ] Code builds.
- [ ] Code passes `make style`.
- [ ] Update `CHANGELOG`:
    - [ ] Is this a new feature users need to be aware of? New or updated example or miniapp?
    - [ ] Does it make sense to create a new section in the `CHANGELOG` to group with other related features?
- [ ] Update `INSTALL`:
    - [ ] Had a new optional library been added? If so, what range of versions of this library are required? (*Make sure the external library is compatible with our BSD license, e.g. it is not licensed under GPL!*)
    - [ ] Have the version ranges for any required or optional libraries changed?
    - [ ] Does `make` or `cmake` have a new target?
    - [ ] Did the requirements or the installation process change? *(rare)*
- [ ] Update continuous integration server configurations if necessary (e.g. with new version requirements for each of MFEM's dependencies)
    - [ ] `.github`
    - [ ] `.appveyor.yml`
- [ ] Update `.gitignore`:
    - [ ] Check if `make distclean; git status` shows any files that were generated from the source by the project (not an IDE) but we don't want to track in the repository.
    - [ ] Add new patterns (just for the new files above) and re-run the above test.
- [ ] New examples:
    - [ ] All sample runs at the top of the example source file work.
    - [ ] Update `examples/makefile`:
      - [ ] Add the example code to the appropriate `SEQ_EXAMPLES` and `PAR_EXAMPLES` variables.
      - [ ] Add any files generated by it to the `clean` target.
      - [ ] Add the example binary and any files generated by it to the top-level `.gitignore` file.
    - [ ] Update `examples/CMakeLists.txt`:
      - [ ] Add the example code to the `ALL_EXE_SRCS` variable.
      - [ ] Make sure `THIS_TEST_OPTIONS` is set correctly for the new example.
   - [ ] List the new example in `doc/CodeDocumentation.dox`.
   - [ ] If new examples directory (e.g.`examples/pumi`), list it in `doc/CodeDocumentation.conf.in`
   - [ ] Companion pull request for documentation in [mfem/web](https://github.com/mfem/web) repo:
      - [ ] Update or add example-specific documentation, see e.g. the `src/examples.md`.
      - [ ] Add the description, labels and screenshots in `src/examples.md` and `src/img`.
      - [ ] In `examples.md`, list the example under the appropriate categories, add new categories if necessary.
      - [ ] Add a short description of the example in the "Extensive Examples" section of `features.md`.
- [ ] New miniapps:
   - [ ] All sample runs at the top of the miniapp source file work.
   - [ ] Update top-level `makefile` and `makefile` in corresponding miniapp directory.
   - [ ] Add the miniapp binary and any files generated by it to the top-level `.gitignore` file.
   - [ ] Update CMake build system:
      - [ ] Update the `CMakeLists.txt` file in the `miniapps` directory, if the new miniapp is in a new directory.
      - [ ] Add/update the `CMakeLists.txt` file in the new miniapp directory.
      - [ ] Consider adding a new test for the new miniapp.
   - [ ] List the new miniapp in `doc/CodeDocumentation.dox`
   - [ ] If new miniapps directory (e.g.`miniapps/nurbs`), add it to `MINIAPP_SUBDIRS` in the `makefile`.
   - [ ] If new miniapps directory (e.g.`miniapps/nurbs`), list it in `doc/CodeDocumentation.conf.in`
   - [ ] Companion pull request for documentation in [mfem/web](https://github.com/mfem/web) repo:
     - [ ] Update or add miniapp-specific documentation, see e.g. the `src/meshing.md` and `src/electromagnetics.md` files.
     - [ ] Add the description, labels and screenshots in `src/examples.md` and `src/img`.
     - [ ] The miniapps go at the end of the page, and are usually listed only under a specific "Application (PDE)" category.
     - [ ] Add a short description of the miniapp in the "Extensive Examples" section of `features.md`.
- [ ] New capability:
   - [ ] All new public, protected, and private classes, methods, data members, and functions have full Doxygen-style documentation in source comments. Documentation should include descriptions of member data, function arguments and return values, template parameters, and prerequisites for calling new functions.
   - [ ] Pointer arguments and return values must specify whether ownership is being transferred or lent with the call.
   - [ ] Any new functions should include descriptions of their intended use e.g. for internal use only, user-facing, etc., along with references to example code whenever possible/appropriate.
   - [ ] Consider adding new sample runs in existing examples to highlight the new capability.
   - [ ] Consider saving cool simulation pictures with the new capability in the Confluence gallery (LLNL only) or submitting them, via pull request, to the gallery section of the `mfem/web` repo.
   - [ ] If this is a major new feature, consider mentioning it in the short summary inside `README` *(rare)*.
   - [ ] List major new classes in `doc/CodeDocumentation.dox` *(rare)*.
- [ ] Update this checklist, if the new pull request affects it.
- [ ] Run `make unittest` to make sure all unit tests pass.
- [ ] Run the tests in `tests/scripts`.
- [ ] (LLNL only) After merging:
   - [ ] Update internal tests to include the new features.
</details>
