### PR TITLE
Make `BlockOperator` own the offset arrays

### DIFF
--- a/linalg/blockoperator.cpp
+++ b/linalg/blockoperator.cpp
@@ -23,14 +23,12 @@ BlockOperator::BlockOperator(const Array<int> & offsets)
      owns_blocks(0),
      nRowBlocks(offsets.Size() - 1),
      nColBlocks(offsets.Size() - 1),
-     row_offsets(0),
-     col_offsets(0),
+     row_offsets(offsets),
+     col_offsets(offsets),
      op(nRowBlocks, nRowBlocks),
      coef(nRowBlocks, nColBlocks)
 {
    op = static_cast<Operator *>(NULL);
-   row_offsets.MakeRef(offsets);
-   col_offsets.MakeRef(offsets);
 }
 
 BlockOperator::BlockOperator(const Array<int> & row_offsets_,
@@ -39,14 +37,12 @@ BlockOperator::BlockOperator(const Array<int> & row_offsets_,
      owns_blocks(0),
      nRowBlocks(row_offsets_.Size()-1),
      nColBlocks(col_offsets_.Size()-1),
-     row_offsets(0),
-     col_offsets(0),
+     row_offsets(row_offsets_),
+     col_offsets(col_offsets_),
      op(nRowBlocks, nColBlocks),
      coef(nRowBlocks, nColBlocks)
 {
    op = static_cast<Operator *>(NULL);
-   row_offsets.MakeRef(row_offsets_);
-   col_offsets.MakeRef(col_offsets_);
 }
 
 void BlockOperator::SetDiagonalBlock(int iblock, Operator *opt, double c)

--- a/linalg/blockoperator.hpp
+++ b/linalg/blockoperator.hpp
@@ -38,16 +38,14 @@ public:
    //! columns.
    /**
     *  offsets: offsets that mark the start of each row/column block (size
-    *  nRowBlocks+1).  Note: BlockOperator will not own/copy the data contained
-    *  in offsets.
+    *  nRowBlocks+1).
     */
    BlockOperator(const Array<int> & offsets);
    //! Constructor for general BlockOperators.
    /**
     *  row_offsets: offsets that mark the start of each row block (size
     *  nRowBlocks+1).  col_offsets: offsets that mark the start of each column
-    *  block (size nColBlocks+1).  Note: BlockOperator will not own/copy the
-    *  data contained in offsets.
+    *  block (size nColBlocks+1).
     */
    BlockOperator(const Array<int> & row_offsets, const Array<int> & col_offsets);
 


### PR DESCRIPTION
Currently, `BlockOperator` does not own the offsets provided to the constructor, and instead hold references to them. I think it should own copies of the offsets for the following reasons:

- The offsets can dangle which is unexpected. The lack of ownership is documented, but this leads to more bookkeeping for the client to keep the offsets alive. The same will hold for any class that inherits from `BlockOperator`.
- The `height` and `width` of the operator are set at construction only, so the client should not hold the copy of offsets referenced by the object. Client code could change the referenced offset values after construction and lead to unexpected behavior.
- The offsets should usually be just a handful of `int`s, so it's cheap to copy.

Note: This was originally addressed in #3806 but I reverted it to make that PR more focused.
<!--GHEX{"author":"victor-decaria-nnl","assignment":"2023-12-19T00:08:57","editor":"pazner","id":4037,"reviewers":["pazner","sebastiangrimberg"],"merge":"2023-12-21T18:45:11","approval":"2023-12-19T05:26:14"}XEHG-->
<!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge|
 | --- | --- | --- | --- | --- | --- | --- |
| [#4037](https://github.com/mfem/mfem/pull/4037) | @victor-decaria-nnl | @pazner | @pazner + @sebastiangrimberg | 12/18/23 | 12/18/23 | 12/21/23 | |
<!--ELBATXEHG-->
<details>
<summary>PR Checklist</summary>
    
- [ ] Code builds.
- [ ] Code passes `make style`.
- [ ] Update `CHANGELOG`:
    - [ ] Is this a new feature users need to be aware of? New or updated example or miniapp?
    - [ ] Does it make sense to create a new section in the `CHANGELOG` to group with other related features?
- [ ] Update `INSTALL`:
    - [ ] Had a new optional library been added? If so, what range of versions of this library are required? (*Make sure the external library is compatible with our BSD license, e.g. it is not licensed under GPL!*)
    - [ ] Have the version ranges for any required or optional libraries changed?
    - [ ] Does `make` or `cmake` have a new target?
    - [ ] Did the requirements or the installation process change? *(rare)*
- [ ] Update continuous integration server configurations if necessary (e.g. with new version requirements for each of MFEM's dependencies)
    - [ ] `.github`
    - [ ] `.appveyor.yml`
- [ ] Update `.gitignore`:
    - [ ] Check if `make distclean; git status` shows any files that were generated from the source by the project (not an IDE) but we don't want to track in the repository.
    - [ ] Add new patterns (just for the new files above) and re-run the above test.
- [ ] New examples:
    - [ ] All sample runs at the top of the example source file work.
    - [ ] Update `examples/makefile`:
      - [ ] Add the example code to the appropriate `SEQ_EXAMPLES` and `PAR_EXAMPLES` variables.
      - [ ] Add any files generated by it to the `clean` target.
      - [ ] Add the example binary and any files generated by it to the top-level `.gitignore` file.
    - [ ] Update `examples/CMakeLists.txt`:
      - [ ] Add the example code to the `ALL_EXE_SRCS` variable.
      - [ ] Make sure `THIS_TEST_OPTIONS` is set correctly for the new example.
   - [ ] List the new example in `doc/CodeDocumentation.dox`.
   - [ ] If new examples directory (e.g.`examples/pumi`), list it in `doc/CodeDocumentation.conf.in`
   - [ ] Companion pull request for documentation in [mfem/web](https://github.com/mfem/web) repo:
      - [ ] Update or add example-specific documentation, see e.g. the `src/examples.md`.
      - [ ] Add the description, labels and screenshots in `src/examples.md` and `src/img`.
      - [ ] In `examples.md`, list the example under the appropriate categories, add new categories if necessary.
      - [ ] Add a short description of the example in the "Extensive Examples" section of `features.md`.
- [ ] New miniapps:
   - [ ] All sample runs at the top of the miniapp source file work.
   - [ ] Update top-level `makefile` and `makefile` in corresponding miniapp directory.
   - [ ] Add the miniapp binary and any files generated by it to the top-level `.gitignore` file.
   - [ ] Update CMake build system:
      - [ ] Update the `CMakeLists.txt` file in the `miniapps` directory, if the new miniapp is in a new directory.
      - [ ] Add/update the `CMakeLists.txt` file in the new miniapp directory.
      - [ ] Consider adding a new test for the new miniapp.
   - [ ] List the new miniapp in `doc/CodeDocumentation.dox`
   - [ ] If new miniapps directory (e.g.`miniapps/nurbs`), add it to `MINIAPP_SUBDIRS` in the `makefile`.
   - [ ] If new miniapps directory (e.g.`miniapps/nurbs`), list it in `doc/CodeDocumentation.conf.in`
   - [ ] Companion pull request for documentation in [mfem/web](https://github.com/mfem/web) repo:
     - [ ] Update or add miniapp-specific documentation, see e.g. the `src/meshing.md` and `src/electromagnetics.md` files.
     - [ ] Add the description, labels and screenshots in `src/examples.md` and `src/img`.
     - [ ] The miniapps go at the end of the page, and are usually listed only under a specific "Application (PDE)" category.
     - [ ] Add a short description of the miniapp in the "Extensive Examples" section of `features.md`.
- [ ] New capability:
   - [ ] All new public, protected, and private classes, methods, data members, and functions have full Doxygen-style documentation in source comments. Documentation should include descriptions of member data, function arguments and return values, template parameters, and prerequisites for calling new functions.
   - [ ] Pointer arguments and return values must specify whether ownership is being transferred or lent with the call.
   - [ ] Any new functions should include descriptions of their intended use e.g. for internal use only, user-facing, etc., along with references to example code whenever possible/appropriate.
   - [ ] Consider adding new sample runs in existing examples to highlight the new capability.
   - [ ] Consider saving cool simulation pictures with the new capability in the Confluence gallery (LLNL only) or submitting them, via pull request, to the gallery section of the `mfem/web` repo.
   - [ ] If this is a major new feature, consider mentioning it in the short summary inside `README` *(rare)*.
   - [ ] List major new classes in `doc/CodeDocumentation.dox` *(rare)*.
- [ ] Update this checklist, if the new pull request affects it.
- [ ] Run `make unittest` to make sure all unit tests pass.
- [ ] Run the tests in `tests/scripts`.
- [ ] (LLNL only) After merging:
   - [ ] Update internal tests to include the new features.
</details>
