### PR TITLE
Proposed changes for PR #3806

### DIFF
--- a/fem/bilininteg.hpp
+++ b/fem/bilininteg.hpp
@@ -3065,6 +3065,9 @@ public:
                                     Vector &flux, Vector *d_energy = NULL);
 };
 
+/// @brief Integrator that computes the PA action of one of the blocks in an
+/// ElasticityIntegrator, considering the elasticity operator as a dim x dim
+/// block operator.
 class ElasticityComponentIntegrator : public BilinearFormIntegrator
 {
    ElasticityIntegrator &parent;

--- a/fem/bilininteg.hpp
+++ b/fem/bilininteg.hpp
@@ -16,6 +16,7 @@
 #include "nonlininteg.hpp"
 #include "fespace.hpp"
 #include "ceed/interface/util.hpp"
+#include "qfunction.hpp"
 #include <memory>
 
 namespace mfem
@@ -2978,10 +2979,6 @@ public:
    bool SupportsCeed() const { return DeviceCanUseCeed(); }
 };
 
-// Forward declarations
-class CoefficientVector;
-class QuadratureFunction;
-
 /** Integrator for the linear elasticity form:
     a(u,v) = (lambda div(u), div(v)) + (2 mu e(u), e(v)),
     where e(v) = (1/2) (grad(v) + grad(v)^T).
@@ -2989,6 +2986,8 @@ class QuadratureFunction;
     using multiple copies of a scalar FE space. */
 class ElasticityIntegrator : public BilinearFormIntegrator
 {
+   friend class ElasticityComponentIntegrator;
+
 protected:
    double q_lambda, q_mu;
    Coefficient *lambda, *mu;
@@ -3001,22 +3000,20 @@ private:
 #endif
 
    // PA extension
-   std::shared_ptr<CoefficientVector> lambda_quad, mu_quad;
-   std::shared_ptr<QuadratureFunction> q_vec;
-   std::shared_ptr<QuadratureSpace> quad_space;
 
    const DofToQuad *maps;         ///< Not owned
    const GeometricFactors *geom;  ///< Not owned
    int vdim, ndofs;
    const FiniteElementSpace *fespace;   ///< Not owned.
 
-   //Component integrator
-   int IBlock = -1;
-   int JBlock = -1;
-   /// @brief Pointer to an integrator from which a component integrator is
-   /// derived. Should be nullptr for the original integrator. Not owned.
-   ElasticityIntegrator *parent = nullptr;
-   std::shared_ptr<const FiniteElementSpace> componentFESpace = nullptr;
+   std::unique_ptr<QuadratureSpace> q_space;
+   /// Coefficients projected onto q_space
+   std::unique_ptr<CoefficientVector> lambda_quad, mu_quad;
+   /// Workspace vector
+   std::unique_ptr<QuadratureFunction> q_vec;
+
+   /// Set up the quadrature space and project lambda and mu coefficients
+   void SetUpQuadratureSpaceAndCoefficients(const FiniteElementSpace &fes);
 
 public:
    ElasticityIntegrator(Coefficient &l, Coefficient &m)
@@ -3026,19 +3023,11 @@ public:
    ElasticityIntegrator(Coefficient &m, double q_l, double q_m)
    { lambda = NULL; mu = &m; q_lambda = q_l; q_mu = q_m; }
 
-   virtual void AssembleElementMatrix(const FiniteElement &,
-                                      ElementTransformation &,
-                                      DenseMatrix &);
+   virtual void AssembleElementMatrix(const FiniteElement &el,
+                                      ElementTransformation &Tr,
+                                      DenseMatrix &elmat);
 
-   /** \brief Interpolate the coefficient onto a QuadratureFunction. This is
-    * performed on host for now, since coefficients do not run on device.
-    */
    virtual void AssemblePA(const FiniteElementSpace &fes);
-
-   /** \brief Only valid for a component version of ElasticityIntegrator.
-    */
-   virtual void AssembleEA(const FiniteElementSpace &fes, Vector &emat,
-                           const bool add = true);
 
    virtual void AssembleDiagonalPA(Vector &diag);
 
@@ -3046,19 +3035,6 @@ public:
 
    virtual void AddMultTransposePA(const Vector &x, Vector &y) const;
 
-   /** @brief Get a scalar component of a vector integrator.
-
-       For BilinearFormIntegrators which are written for finite element spaces
-       that are copies of scalar elements, this creates a new integrator for
-       the \f$(I,J)\f$th component block where \f$0 \leq I,J \leq \text{dim} - 1\f$. The caller
-       assumes ownership of the returned BilinearFormIntegrator.
-
-       @param[in] I  Row component block index.
-       @param[in] J  Column component block index.
-       @returns Integrator of \f$(I,J)\f$th component block.
-    */
-   BilinearFormIntegrator* ComponentIntegrator(const int I,
-                                               const int J);
    /** Compute the stress corresponding to the local displacement @a u and
        interpolate it at the nodes of the given @a fluxelem. Only the symmetric
        part of the stress is stored, so that the size of @a flux is equal to
@@ -3087,10 +3063,34 @@ public:
    virtual double ComputeFluxEnergy(const FiniteElement &fluxelem,
                                     ElementTransformation &Trans,
                                     Vector &flux, Vector *d_energy = NULL);
+};
 
-   //This would be generally useful for these "component integrators". Starting
-   //to look like this should be a child class.
-   const FiniteElementSpace* GetFESpace() const;
+class ElasticityComponentIntegrator : public BilinearFormIntegrator
+{
+   ElasticityIntegrator &parent;
+   const int i_block;
+   const int j_block;
+
+   const DofToQuad *maps;         ///< Not owned
+   const GeometricFactors *geom;  ///< Not owned
+   const FiniteElementSpace *fespace;   ///< Not owned.
+
+public:
+   /// @brief Given an ElasticityIntegrator, create an integrator that
+   /// represents the \f$(i,j)\f$th component block.
+   ///
+   /// @note The parent ElasticityIntegrator must remain valid throughout the
+   /// lifetime of this integrator.
+   ElasticityComponentIntegrator(ElasticityIntegrator &parent_, int i_, int j_);
+
+   virtual void AssemblePA(const FiniteElementSpace &fes);
+
+   virtual void AssembleEA(const FiniteElementSpace &fes, Vector &emat,
+                           const bool add = true);
+
+   virtual void AddMultPA(const Vector &x, Vector &y) const;
+
+   virtual void AddMultTransposePA(const Vector &x, Vector &y) const;
 };
 
 /** Integrator for the DG form:

--- a/fem/integ/bilininteg_diffusion_patch.cpp
+++ b/fem/integ/bilininteg_diffusion_patch.cpp
@@ -12,7 +12,6 @@
 
 #include "../fem.hpp"
 #include "../../mesh/nurbs.hpp"
-#include "../../general/tic_toc.hpp"
 
 #include "../../linalg/dtensor.hpp"  // For Reshape
 #include "../../general/forall.hpp"

--- a/fem/integ/bilininteg_elasticity_ea.cpp
+++ b/fem/integ/bilininteg_elasticity_ea.cpp
@@ -15,16 +15,14 @@
 
 namespace mfem
 {
-void ElasticityIntegrator::AssembleEA(const FiniteElementSpace &fes,
-                                      Vector &emat,
-                                      const bool add)
+void ElasticityComponentIntegrator::AssembleEA(const FiniteElementSpace &fes,
+                                               Vector &emat,
+                                               const bool add)
 {
-   MFEM_VERIFY(parent, "Element level assembly for component version only");
-   MFEM_VERIFY(fespace, "Need initialized FiniteElementSpace.");
-   MFEM_VERIFY(!add, "AssembleEA not implemented for add yet.");
-   AssemblePA(*fespace);
-   const auto &ir = q_vec->GetIntRule(0);
-   internal::ElasticityAssembleEA(vdim, IBlock, JBlock, ndofs, ir, *fespace,
-                                  *lambda_quad, *mu_quad, *geom, *maps, emat);
+   AssemblePA(fes);
+   const auto &ir = parent.q_space->GetIntRule(0);
+   internal::ElasticityAssembleEA(parent.vdim, i_block, j_block, parent.ndofs, ir,
+                                  *parent.lambda_quad, *parent.mu_quad,
+                                  *geom, *maps, emat);
 }
 }

--- a/miniapps/solvers/lor_elast.cpp
+++ b/miniapps/solvers/lor_elast.cpp
@@ -84,14 +84,13 @@ int main(int argc, char *argv[])
 {
    // 1. Initialize MPI and HYPRE.
    Mpi::Init(argc, argv);
-   int myid = Mpi::WorldRank();
    Hypre::Init();
 
    // 2. Parse command-line options.
    const char *mesh_file = "../../data/beam-tri.mesh";
    int order = 1;
    bool pa = false;
-   bool paraview = false;
+   bool visualization = false;
    bool amg_elast = 0;
    bool reorder_space = true;
    const char *device_config = "cpu";
@@ -122,27 +121,15 @@ int main(int argc, char *argv[])
    args.AddOption(&componentwise_action, "-ca", "--component-action", "-no-ca",
                   "--no-component-action",
                   "Uses partial assembly with a block operator of components instead of the monolithic vector integrator.");
-   args.AddOption(&paraview, "-vis", "--visualization", "-no-vis",
+   args.AddOption(&visualization, "-vis", "--visualization", "-no-vis",
                   "--no-visualization",
-                  "Enable or disable Paraview output.");
-   args.Parse();
-   if (!args.Good())
-   {
-      if (myid == 0)
-      {
-         args.PrintUsage(cout);
-      }
-      return 1;
-   }
-   if (myid == 0)
-   {
-      args.PrintOptions(cout);
-   }
+                  "Enable or disable ParaView and GLVis output.");
+   args.ParseCheck();
 
    // 3. Enable hardware devices such as GPUs, and programming models such as
    //    CUDA, OCCA, RAJA and OpenMP based on command line options.
    Device device(device_config);
-   if (myid == 0) { device.Print(); }
+   if (Mpi::Root()) { device.Print(); }
    // 4. Read the (serial) mesh from the given mesh file on all processors.  We
    //    can handle triangular, quadrilateral, tetrahedral, hexahedral, surface
    //    and volume meshes with the same code.
@@ -151,19 +138,19 @@ int main(int argc, char *argv[])
 
    if (mesh.attributes.Max() < 2 || mesh.bdr_attributes.Max() < 2)
    {
-      if (myid == 0)
+      if (Mpi::Root())
+      {
          cerr << "\nInput mesh should have at least two materials and "
               << "two boundary attributes! (See schematic in ex2.cpp)\n"
               << endl;
+      }
       return 3;
    }
 
    // 5. Refine the serial mesh on all processors to increase the resolution.
+   for (int l = 0; l < ref_levels; l++)
    {
-      for (int l = 0; l < ref_levels; l++)
-      {
-         mesh.UniformRefinement();
-      }
+      mesh.UniformRefinement();
    }
 
    // 6. Define a parallel mesh by a partitioning of the serial mesh.
@@ -183,7 +170,7 @@ int main(int argc, char *argv[])
       LOR_disc->GetParFESpace();
    }
    HYPRE_BigInt size = fespace.GlobalTrueVSize();
-   if (myid == 0)
+   if (Mpi::Root())
    {
       cout << "Number of finite element unknowns: " << size << endl
            << "Assembling: " << flush;
@@ -220,7 +207,7 @@ int main(int argc, char *argv[])
 
    ParLinearForm b(&fespace);
    b.AddBoundaryIntegrator(new VectorBoundaryLFIntegrator(f));
-   if (myid == 0)
+   if (Mpi::Root())
    {
       cout << "r.h.s. ... " << flush;
    }
@@ -258,9 +245,9 @@ int main(int argc, char *argv[])
    //     system, applying any necessary transformations such as: parallel
    //     assembly, eliminating boundary conditions, applying conforming
    //     constraints for non-conforming AMR, static condensation, etc.
-   if (myid == 0) { cout << "matrix ... " << flush; }
-   StopWatch total_timer{};
-   StopWatch assembly_timer{};
+   if (Mpi::Root()) { cout << "matrix ... " << flush; }
+   StopWatch total_timer;
+   StopWatch assembly_timer;
    assembly_timer.Start();
    total_timer.Start();
    a.Assemble();
@@ -271,7 +258,7 @@ int main(int argc, char *argv[])
    {
       a.FormLinearSystem(ess_tdof_list, x, b, A, X, B);
    }
-   if (myid == 0)
+   if (Mpi::Root())
    {
       cout << "done." << endl;
       cout << "Size of linear system: " << fespace.GlobalTrueVSize() << endl;
@@ -287,27 +274,19 @@ int main(int argc, char *argv[])
    //     on the LOR space. If additionally "-ss" is enabled, create the
    //     block CG solvers and the high order, partially assembled components.
    vector<unique_ptr<ParBilinearForm>> bilinear_forms;
-   bilinear_forms.reserve(dim);
    vector<unique_ptr<HypreParMatrix>> lor_block;
-   lor_block.reserve(dim);
    //amg_blocks stores preconditioners of lor_block.
-   vector<HypreBoomerAMG> amg_blocks;
-   amg_blocks.reserve(dim);
+   vector<unique_ptr<HypreBoomerAMG>> amg_blocks;
    //cg_blocks only gets used if -ss is enabled.
    vector<unique_ptr<CGSolver>> cg_blocks;
-   cg_blocks.reserve(dim);
    //diag_ho only used if -hoa enabled. The high order partial assembled operators
    //with the essential dofs eliminated and constrained to one.
    vector<unique_ptr<ParBilinearForm>> ho_bilinear_form_blocks;
-   ho_bilinear_form_blocks.reserve(dim);
    vector<unique_ptr<ConstrainedOperator>> diag_ho;
-   diag_ho.reserve(dim);
    //If -ca is used, component bilinear forms are stored in pa_components, and
    //pointers to fespaces.
    vector<unique_ptr<ParBilinearForm>> pa_components;
-   pa_components.reserve(dim*dim);
    vector<const FiniteElementSpace*> fespaces;
-   fespaces.reserve(dim);
    //get block essential boundary info.
    //need to allocate here since constrained operator will not own essential dofs.
    Array<int> ess_tdof_list_block_ho, ess_bdr_block_ho(pmesh.bdr_attributes.Max());
@@ -340,11 +319,11 @@ int main(int argc, char *argv[])
          lor_block.emplace_back(bilinear_forms[j]->ParallelAssemble());
          lor_block[j]->EliminateBC(ess_tdof_list_block,
                                    Operator::DiagonalPolicy::DIAG_ONE);//not sure which diagonal policy to use
-         amg_blocks.emplace_back();
-         amg_blocks[j].SetStrengthThresh(0.25);
-         amg_blocks[j].SetRelaxType(16);  //Chebyshev
-         amg_blocks[j].SetOperator(*lor_block[j]);
-         block_offsets[j+1] = amg_blocks[j].Height();
+         amg_blocks.emplace_back(new HypreBoomerAMG);
+         amg_blocks[j]->SetStrengthThresh(0.25);
+         amg_blocks[j]->SetRelaxType(16);  //Chebyshev
+         amg_blocks[j]->SetOperator(*lor_block[j]);
+         block_offsets[j+1] = amg_blocks[j]->Height();
          // 13(b) If needed, create the block components for operator action.
          if (componentwise_action)
          {
@@ -395,7 +374,7 @@ int main(int argc, char *argv[])
             cg_blocks.emplace_back(new CGSolver(MPI_COMM_WORLD));
             cg_blocks[i]->iterative_mode = false;
             cg_blocks[i]->SetOperator(*diag_ho[i]);
-            cg_blocks[i]->SetPreconditioner(amg_blocks[i]);
+            cg_blocks[i]->SetPreconditioner(*amg_blocks[i]);
             cg_blocks[i]->SetMaxIter(30);
             cg_blocks[i]->SetRelTol(1e-8);
          }
@@ -409,7 +388,7 @@ int main(int argc, char *argv[])
          }
          else
          {
-            blockDiag->SetDiagonalBlock(i, &amg_blocks[i]);
+            blockDiag->SetDiagonalBlock(i, amg_blocks[i].get());
          }
       }
       prec.reset(blockDiag);
@@ -455,13 +434,23 @@ int main(int argc, char *argv[])
    solver.SetPrintLevel(1);
    if (prec) { solver.SetPreconditioner(*prec); }
    solver.SetOperator(A_components ? *A_components : *A);
-   StopWatch linear_solve_timer{};
+
+   StopWatch linear_solve_timer;
    linear_solve_timer.Start();
    solver.Mult(B, X);
    linear_solve_timer.Stop();
 
    a_lhs->RecoverFEMSolution(X, b, x);
    total_timer.Stop();
+
+   // Print run times
+   if (Mpi::Root())
+   {
+      cout << "Elapsed Times\n";
+      cout << "Assembly (s) = " << assembly_timer.RealTime() << endl;
+      cout << "Linear Solve (s) = " << linear_solve_timer.RealTime() << endl;
+      cout << "Total Solve (s) " << total_timer.RealTime() << endl;
+   }
 
    // 15. For non-NURBS meshes, make the mesh curved based on the finite element
    //     space. This means that we define the mesh elements through a fespace
@@ -472,17 +461,21 @@ int main(int argc, char *argv[])
    //     space.
    pmesh.SetNodalFESpace(&fespace);
 
-   // 16. Save in parallel the displaced mesh and the inverted solution (which
-   //     gives the backward displacements to the original grid). This output
-   //     can be viewed later using GLVis: "glvis -np <np> -m mesh -g sol".
+   // 16. If visualization is enabled, Save in parallel the displaced mesh and
+   //     the inverted solution (which gives the backward displacements to the
+   //     original grid). This output can be viewed later using GLVis: "glvis
+   //     -np <np> -m mesh -g sol".
+   //
+   //     Also, save the displacement, with dispaced mesh, to VTK.
+   if (visualization)
    {
       GridFunction *nodes = pmesh.GetNodes();
       *nodes += x;
       x *= -1;
 
       ostringstream mesh_name, sol_name;
-      mesh_name << "mesh." << setfill('0') << setw(6) << myid;
-      sol_name << "sol." << setfill('0') << setw(6) << myid;
+      mesh_name << "mesh." << setfill('0') << setw(6) << Mpi::WorldRank();
+      sol_name << "sol." << setfill('0') << setw(6) << Mpi::WorldRank();
 
       ofstream mesh_ofs(mesh_name.str().c_str());
       mesh_ofs.precision(8);
@@ -491,13 +484,9 @@ int main(int argc, char *argv[])
       ofstream sol_ofs(sol_name.str().c_str());
       sol_ofs.precision(8);
       x.Save(sol_ofs);
-   }
 
-   // 17. Save the displacement, with dispaced mesh, to VTK.
-
-   if (paraview)
-   {
-      ParaViewDataCollection pd("lor_elast_vtk", &pmesh);
+      ParaViewDataCollection pd("LOR_Elasticity", &pmesh);
+      pd.SetPrefixPath("ParaView");
       pd.RegisterField("displacement", &x);
       pd.SetLevelsOfDetail(order);
       pd.SetDataFormat(VTKFormat::BINARY);
@@ -505,15 +494,6 @@ int main(int argc, char *argv[])
       pd.SetCycle(0);
       pd.SetTime(0.0);
       pd.Save();
-   }
-
-   //Print times
-   if (myid == 0)
-   {
-      cout << "Elapsed Times\n";
-      cout << "Assembly (s) = " << assembly_timer.RealTime()<< endl;
-      cout << "Linear Solve (s) = " << linear_solve_timer.RealTime() << endl;
-      cout << "Total Solve (s) " << total_timer.RealTime() << endl;
    }
 
    return 0;


### PR DESCRIPTION
Breaks out the individual component integrators in `ElasticityIntegrator` to a separate class `ElasticityComponentIntegrator`. Simplifies some of the surrounding logic and miniapp example code.

If this looks OK to you @victor-decaria-nnl, please feel free to merge this PR into your branch.