### PR TITLE
Add attribute marker support for AssembleDiagonalPA

### DIFF
--- a/fem/bilinearform_ext.cpp
+++ b/fem/bilinearform_ext.cpp
@@ -382,15 +382,44 @@ void PABilinearFormExtension::AssembleDiagonal(Vector &y) const
 {
    Array<BilinearFormIntegrator*> &integrators = *a->GetDBFI();
 
+   auto assemble_diagonal_with_markers = [&](BilinearFormIntegrator &integ,
+                                             const Array<int> *markers,
+                                             const Array<int> &attributes,
+                                             Vector &d)
+   {
+      integ.AssembleDiagonalPA(d);
+      if (markers)
+      {
+         const int ne = attributes.Size();
+         const int nd = d.Size() / ne;
+         const auto d_attr = Reshape(attributes.Read(), ne);
+         const auto d_m = Reshape(markers->Read(), markers->Size());
+         auto d_d = Reshape(d.ReadWrite(), nd, ne);
+         mfem::forall(ne, [=] MFEM_HOST_DEVICE (int e)
+         {
+            const int attr = d_attr[e];
+            if (d_m[attr - 1] == 0)
+            {
+               for (int i = 0; i < nd; ++i)
+               {
+                  d_d(i, e) = 0.0;
+               }
+            }
+         });
+      }
+   };
+
    const int iSz = integrators.Size();
    if (elem_restrict && !DeviceCanUseCeed())
    {
       if (iSz > 0)
       {
          localY = 0.0;
+         Array<Array<int>*> &elem_markers = *a->GetDBFI_Marker();
          for (int i = 0; i < iSz; ++i)
          {
-            integrators[i]->AssembleDiagonalPA(localY);
+            assemble_diagonal_with_markers(*integrators[i], elem_markers[i],
+                                           elem_attributes, localY);
          }
          const ElementRestriction* H1elem_restrict =
             dynamic_cast<const ElementRestriction*>(elem_restrict);
@@ -410,11 +439,13 @@ void PABilinearFormExtension::AssembleDiagonal(Vector &y) const
    }
    else
    {
+      Array<Array<int>*> &elem_markers = *a->GetDBFI_Marker();
       y.UseDevice(true); // typically this is a large vector, so store on device
       y = 0.0;
       for (int i = 0; i < iSz; ++i)
       {
-         integrators[i]->AssembleDiagonalPA(y);
+         assemble_diagonal_with_markers(*integrators[i], elem_markers[i],
+                                        elem_attributes, localY);
       }
    }
 
@@ -422,10 +453,12 @@ void PABilinearFormExtension::AssembleDiagonal(Vector &y) const
    const int n_bdr_integs = bdr_integs.Size();
    if (bdr_face_restrict_lex && n_bdr_integs > 0)
    {
+      Array<Array<int>*> &bdr_markers = *a->GetBBFI_Marker();
       bdr_face_Y = 0.0;
       for (int i = 0; i < n_bdr_integs; ++i)
       {
-         bdr_integs[i]->AssembleDiagonalPA(bdr_face_Y);
+         assemble_diagonal_with_markers(*bdr_integs[i], bdr_markers[i],
+                                        bdr_attributes, bdr_face_Y);
       }
       bdr_face_restrict_lex->AddMultTransposeUnsigned(bdr_face_Y, y);
    }

--- a/fem/bilinearform_ext.cpp
+++ b/fem/bilinearform_ext.cpp
@@ -445,7 +445,7 @@ void PABilinearFormExtension::AssembleDiagonal(Vector &y) const
       for (int i = 0; i < iSz; ++i)
       {
          assemble_diagonal_with_markers(*integrators[i], elem_markers[i],
-                                        elem_attributes, localY);
+                                        elem_attributes, y);
       }
    }
 

--- a/tests/unit/fem/test_assemblediagonalpa.cpp
+++ b/tests/unit/fem/test_assemblediagonalpa.cpp
@@ -91,51 +91,53 @@ void symmetricMatrixCoeffFunction(const Vector & x, DenseSymmetricMatrix & f)
 
 TEST_CASE("Mass Diagonal PA", "[PartialAssembly][AssembleDiagonal]")
 {
-   for (int dimension = 2; dimension < 4; ++dimension)
+   const int dimension = GENERATE(2, 3);
+   const int order = GENERATE(1, 2, 3, 4);
+   const int ne = 3;
+
+   CAPTURE(dimension, order);
+
+   Mesh mesh;
+   if (dimension == 2)
    {
-      for (int ne = 1; ne < 3; ++ne)
-      {
-         const int n_elements = pow(ne, dimension);
-         CAPTURE(dimension, n_elements);
-         for (int order = 1; order < 5; ++order)
-         {
-            Mesh mesh;
-            if (dimension == 2)
-            {
-               mesh = Mesh::MakeCartesian2D(
-                         ne, ne, Element::QUADRILATERAL, 1, 1.0, 1.0);
-            }
-            else
-            {
-               mesh = Mesh::MakeCartesian3D(
-                         ne, ne, ne, Element::HEXAHEDRON, 1.0, 1.0, 1.0);
-            }
-            FiniteElementCollection *h1_fec = new H1_FECollection(order, dimension);
-            FiniteElementSpace h1_fespace(&mesh, h1_fec);
-            BilinearForm paform(&h1_fespace);
-            ConstantCoefficient one(1.0);
-            paform.SetAssemblyLevel(AssemblyLevel::PARTIAL);
-            paform.AddDomainIntegrator(new MassIntegrator(one));
-            paform.Assemble();
-            Vector pa_diag(h1_fespace.GetVSize());
-            paform.AssembleDiagonal(pa_diag);
-
-            BilinearForm faform(&h1_fespace);
-            faform.AddDomainIntegrator(new MassIntegrator(one));
-            faform.Assemble();
-            faform.Finalize();
-            Vector assembly_diag(h1_fespace.GetVSize());
-            faform.SpMat().GetDiag(assembly_diag);
-
-            assembly_diag -= pa_diag;
-            double error = assembly_diag.Norml2();
-            CAPTURE(order, error);
-            REQUIRE(assembly_diag.Norml2() < 1.e-12);
-
-            delete h1_fec;
-         }
-      }
+      mesh = Mesh::MakeCartesian2D(
+                ne, ne, Element::QUADRILATERAL, 1, 1.0, 1.0);
    }
+   else
+   {
+      mesh = Mesh::MakeCartesian3D(
+                ne, ne, ne, Element::HEXAHEDRON, 1.0, 1.0, 1.0);
+   }
+
+   for (int i = 0; i < mesh.GetNE(); ++i)
+   {
+      mesh.SetAttribute(i, i%2 + 1);
+   }
+   mesh.SetAttributes();
+
+   Array<int> bdr(mesh.attributes.Size());
+   bdr[0] = 0;
+   bdr[1] = 1;
+
+   H1_FECollection h1_fec(order, dimension);
+   FiniteElementSpace h1_fespace(&mesh, &h1_fec);
+   BilinearForm paform(&h1_fespace);
+   ConstantCoefficient one(1.0);
+   paform.SetAssemblyLevel(AssemblyLevel::PARTIAL);
+   paform.AddDomainIntegrator(new MassIntegrator(one), bdr);
+   paform.Assemble();
+   Vector pa_diag(h1_fespace.GetVSize());
+   paform.AssembleDiagonal(pa_diag);
+
+   BilinearForm faform(&h1_fespace);
+   faform.AddDomainIntegrator(new MassIntegrator(one), bdr);
+   faform.Assemble();
+   faform.Finalize();
+   Vector assembly_diag(h1_fespace.GetVSize());
+   faform.SpMat().GetDiag(assembly_diag);
+
+   assembly_diag -= pa_diag;
+   REQUIRE(assembly_diag.Normlinf() == MFEM_Approx(0.0));
 }
 
 TEST_CASE("Mass Boundary Diagonal PA", "[PartialAssembly][AssembleDiagonal]")
@@ -155,17 +157,20 @@ TEST_CASE("Mass Boundary Diagonal PA", "[PartialAssembly][AssembleDiagonal]")
 
    FunctionCoefficient coeff(coeffFunction);
 
+   Array<int> bdr(mesh.bdr_attributes.Size());
+   for (int i = 0; i < bdr.Size(); ++i) { bdr[i] = i%2; }
+
    Vector diag_fa(fes.GetTrueVSize()), diag_pa(fes.GetTrueVSize());
 
    BilinearForm blf_fa(&fes);
-   blf_fa.AddBoundaryIntegrator(new MassIntegrator(coeff));
+   blf_fa.AddBoundaryIntegrator(new MassIntegrator(coeff), bdr);
    blf_fa.Assemble();
    blf_fa.Finalize();
    blf_fa.SpMat().GetDiag(diag_fa);
 
    BilinearForm blf_pa(&fes);
    blf_pa.SetAssemblyLevel(AssemblyLevel::PARTIAL);
-   blf_pa.AddBoundaryIntegrator(new MassIntegrator(coeff));
+   blf_pa.AddBoundaryIntegrator(new MassIntegrator(coeff), bdr);
    blf_pa.Assemble();
    blf_pa.AssembleDiagonal(diag_pa);
 


### PR DESCRIPTION
`AssembleDiagonal` with partial assembly now properly supports element and boundary attribute markers. The existing unit tests are extended to test this functionality.

Resolves #3998.

<!--GHEX{"author":"pazner","assignment":"2024-01-16T20:36:08","editor":"tzanio","id":4067,"reviewers":["tzanio","sohailreddy"],"merge":"2024-03-14T16:12:23","approval":"2024-03-12T19:02:32"}XEHG-->
<!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge|
 | --- | --- | --- | --- | --- | --- | --- |
| [#4067](https://github.com/mfem/mfem/pull/4067) | @pazner | @tzanio | @tzanio + @sohailreddy | 1/16/24 | 3/12/24 | 3/14/24 | |
<!--ELBATXEHG-->
<details>
<summary>PR Checklist</summary>
    
- [ ] Code builds.
- [ ] Code passes `make style`.
- [ ] Update `CHANGELOG`:
    - [ ] Is this a new feature users need to be aware of? New or updated example or miniapp?
    - [ ] Does it make sense to create a new section in the `CHANGELOG` to group with other related features?
- [ ] Update `INSTALL`:
    - [ ] Had a new optional library been added? If so, what range of versions of this library are required? (*Make sure the external library is compatible with our BSD license, e.g. it is not licensed under GPL!*)
    - [ ] Have the version ranges for any required or optional libraries changed?
    - [ ] Does `make` or `cmake` have a new target?
    - [ ] Did the requirements or the installation process change? *(rare)*
- [ ] Update continuous integration server configurations if necessary (e.g. with new version requirements for each of MFEM's dependencies)
    - [ ] `.github`
    - [ ] `.appveyor.yml`
- [ ] Update `.gitignore`:
    - [ ] Check if `make distclean; git status` shows any files that were generated from the source by the project (not an IDE) but we don't want to track in the repository.
    - [ ] Add new patterns (just for the new files above) and re-run the above test.
- [ ] New examples:
    - [ ] All sample runs at the top of the example source file work.
    - [ ] Update `examples/makefile`:
      - [ ] Add the example code to the appropriate `SEQ_EXAMPLES` and `PAR_EXAMPLES` variables.
      - [ ] Add any files generated by it to the `clean` target.
      - [ ] Add the example binary and any files generated by it to the top-level `.gitignore` file.
    - [ ] Update `examples/CMakeLists.txt`:
      - [ ] Add the example code to the `ALL_EXE_SRCS` variable.
      - [ ] Make sure `THIS_TEST_OPTIONS` is set correctly for the new example.
   - [ ] List the new example in `doc/CodeDocumentation.dox`.
   - [ ] If new examples directory (e.g.`examples/pumi`), list it in `doc/CodeDocumentation.conf.in`
   - [ ] Companion pull request for documentation in [mfem/web](https://github.com/mfem/web) repo:
      - [ ] Update or add example-specific documentation, see e.g. the `src/examples.md`.
      - [ ] Add the description, labels and screenshots in `src/examples.md` and `src/img`.
      - [ ] In `examples.md`, list the example under the appropriate categories, add new categories if necessary.
      - [ ] Add a short description of the example in the "Extensive Examples" section of `features.md`.
- [ ] New miniapps:
   - [ ] All sample runs at the top of the miniapp source file work.
   - [ ] Update top-level `makefile` and `makefile` in corresponding miniapp directory.
   - [ ] Add the miniapp binary and any files generated by it to the top-level `.gitignore` file.
   - [ ] Update CMake build system:
      - [ ] Update the `CMakeLists.txt` file in the `miniapps` directory, if the new miniapp is in a new directory.
      - [ ] Add/update the `CMakeLists.txt` file in the new miniapp directory.
      - [ ] Consider adding a new test for the new miniapp.
   - [ ] List the new miniapp in `doc/CodeDocumentation.dox`
   - [ ] If new miniapps directory (e.g.`miniapps/nurbs`), add it to `MINIAPP_SUBDIRS` in the `makefile`.
   - [ ] If new miniapps directory (e.g.`miniapps/nurbs`), list it in `doc/CodeDocumentation.conf.in`
   - [ ] Companion pull request for documentation in [mfem/web](https://github.com/mfem/web) repo:
     - [ ] Update or add miniapp-specific documentation, see e.g. the `src/meshing.md` and `src/electromagnetics.md` files.
     - [ ] Add the description, labels and screenshots in `src/examples.md` and `src/img`.
     - [ ] The miniapps go at the end of the page, and are usually listed only under a specific "Application (PDE)" category.
     - [ ] Add a short description of the miniapp in the "Extensive Examples" section of `features.md`.
- [ ] New capability:
   - [ ] All new public, protected, and private classes, methods, data members, and functions have full Doxygen-style documentation in source comments. Documentation should include descriptions of member data, function arguments and return values, template parameters, and prerequisites for calling new functions.
   - [ ] Pointer arguments and return values must specify whether ownership is being transferred or lent with the call.
   - [ ] Any new functions should include descriptions of their intended use e.g. for internal use only, user-facing, etc., along with references to example code whenever possible/appropriate.
   - [ ] Consider adding new sample runs in existing examples to highlight the new capability.
   - [ ] Consider saving cool simulation pictures with the new capability in the Confluence gallery (LLNL only) or submitting them, via pull request, to the gallery section of the `mfem/web` repo.
   - [ ] If this is a major new feature, consider mentioning it in the short summary inside `README` *(rare)*.
   - [ ] List major new classes in `doc/CodeDocumentation.dox` *(rare)*.
- [ ] Update this checklist, if the new pull request affects it.
- [ ] Run `make unittest` to make sure all unit tests pass.
- [ ] Run the tests in `tests/scripts`.
- [ ] (LLNL only) After merging:
   - [ ] Update internal tests to include the new features.
</details>
