### PR TITLE
Fix [[noreturn]] for MFEM_ABORT with Intel compilers

### DIFF
--- a/general/error.hpp
+++ b/general/error.hpp
@@ -84,16 +84,13 @@ static void* __enzyme_inactive_global_warn = (void*)mfem_warning;
    "\n ... in file: " << __FILE__ << ':' << __LINE__ << '\n'
 
 // Common error message and abort macro
-#define _MFEM_MESSAGE(msg, warn)                                        \
+#define _MFEM_MESSAGE(msg, fn)                                          \
    {                                                                    \
       std::ostringstream mfemMsgStream;                                 \
       mfemMsgStream << std::setprecision(16);                           \
       mfemMsgStream << std::setiosflags(std::ios_base::scientific);     \
       mfemMsgStream << msg << MFEM_LOCATION;                            \
-      if (!(warn))                                                      \
-         mfem::mfem_error(mfemMsgStream.str().c_str());                 \
-      else                                                              \
-         mfem::mfem_warning(mfemMsgStream.str().c_str());               \
+      mfem::fn(mfemMsgStream.str().c_str());                            \
    }
 
 // Outputs lots of useful information and aborts.
@@ -101,14 +98,14 @@ static void* __enzyme_inactive_global_warn = (void*)mfem_warning;
 // write useful (if complicated) error messages instead of writing
 // out to the screen first, then calling abort.  For example:
 // MFEM_ABORT( "Unknown geometry type: " << type );
-#define MFEM_ABORT(msg) _MFEM_MESSAGE("MFEM abort: " << msg, 0)
+#define MFEM_ABORT(msg) _MFEM_MESSAGE("MFEM abort: " << msg, mfem_error)
 
 // Does a check, and then outputs lots of useful information if the test fails
 #define MFEM_VERIFY(x, msg)                             \
    if (!(x))                                            \
    {                                                    \
       _MFEM_MESSAGE("Verification failed: ("            \
-                    << #x << ") is false:\n --> " << msg, 0); \
+                    << #x << ") is false:\n --> " << msg, mfem_error); \
    }
 
 // Use this if the only place your variable is used is in ASSERTs
@@ -126,7 +123,7 @@ static void* __enzyme_inactive_global_warn = (void*)mfem_warning;
    if (!(x))                                            \
    {                                                    \
       _MFEM_MESSAGE("Assertion failed: ("               \
-                    << #x << ") is false:\n --> " << msg, 0); \
+                    << #x << ") is false:\n --> " << msg, mfem_error); \
    }
 
 // A macro that exposes its argument in debug mode only.
@@ -143,7 +140,7 @@ static void* __enzyme_inactive_global_warn = (void*)mfem_warning;
 #endif
 
 // Generate a warning message - always generated, regardless of MFEM_DEBUG.
-#define MFEM_WARNING(msg) _MFEM_MESSAGE("MFEM Warning: " << msg, 1)
+#define MFEM_WARNING(msg) _MFEM_MESSAGE("MFEM Warning: " << msg, mfem_warning)
 
 // Macro that checks (in MFEM_DEBUG mode) that i is in the range [imin,imax).
 #define MFEM_ASSERT_INDEX_IN_RANGE(i,imin,imax) \

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -18,6 +18,7 @@ include_directories(BEFORE ${CMAKE_CURRENT_SOURCE_DIR})
 #    for d in general linalg mesh fem enzyme; do ls -1 $d/*.cpp; done
 set(UNIT_TESTS_SRCS
   general/test_array.cpp
+  general/test_error.cpp
   general/test_mem.cpp
   general/test_text.cpp
   general/test_umpire_mem.cpp

--- a/tests/unit/general/test_error.cpp
+++ b/tests/unit/general/test_error.cpp
@@ -1,0 +1,26 @@
+// Copyright (c) 2010-2023, Lawrence Livermore National Security, LLC. Produced
+// at the Lawrence Livermore National Laboratory. All Rights reserved. See files
+// LICENSE and NOTICE for details. LLNL-CODE-806117.
+//
+// This file is part of the MFEM library. For more information and source code
+// availability visit https://mfem.org.
+//
+// MFEM is free software; you can redistribute it and/or modify it under the
+// terms of the BSD-3 license. We welcome feedback and contributions, see file
+// CONTRIBUTING.md for details.
+
+#include "mfem.hpp"
+#include "unit_tests.hpp"
+
+using namespace mfem;
+
+TEST_CASE("MFEM_ABORT noreturn", "[General]")
+{
+   // Make sure that the compiler does not complain here, since MFEM_ABORT
+   // calls mfem_error, which is marked [[noreturn]].
+   auto lambda = []() -> int
+   {
+      MFEM_ABORT("");
+   };
+   MFEM_CONTRACT_VAR(lambda);
+}


### PR DESCRIPTION
The Intel compiler isn't smart enough not to warn in the following case:
```cpp
int f()
{
   if (true) { std::abort(); }
   else { }
}
```
even though `std::abort` is `[[noreturn]]`.

This PR fixes this behavior for `MFEM_ABORT`, resolving an autotest warning. (Follow up to #4021).
<!--GHEX{"author":"pazner","assignment":"2024-01-15T01:37:33","editor":"tzanio","id":4069,"reviewers":["v-dobrev","tzanio"],"merge":"2024-01-18T12:37:57","approval":"2024-01-16T19:42:35"}XEHG-->
<!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge|
 | --- | --- | --- | --- | --- | --- | --- |
| [#4069](https://github.com/mfem/mfem/pull/4069) | @pazner | @tzanio | @v-dobrev + @tzanio | 1/14/24 | 1/16/24 | 1/18/24 | |
<!--ELBATXEHG-->
<details>
<summary>PR Checklist</summary>
    
- [ ] Code builds.
- [ ] Code passes `make style`.
- [ ] Update `CHANGELOG`:
    - [ ] Is this a new feature users need to be aware of? New or updated example or miniapp?
    - [ ] Does it make sense to create a new section in the `CHANGELOG` to group with other related features?
- [ ] Update `INSTALL`:
    - [ ] Had a new optional library been added? If so, what range of versions of this library are required? (*Make sure the external library is compatible with our BSD license, e.g. it is not licensed under GPL!*)
    - [ ] Have the version ranges for any required or optional libraries changed?
    - [ ] Does `make` or `cmake` have a new target?
    - [ ] Did the requirements or the installation process change? *(rare)*
- [ ] Update continuous integration server configurations if necessary (e.g. with new version requirements for each of MFEM's dependencies)
    - [ ] `.github`
    - [ ] `.appveyor.yml`
- [ ] Update `.gitignore`:
    - [ ] Check if `make distclean; git status` shows any files that were generated from the source by the project (not an IDE) but we don't want to track in the repository.
    - [ ] Add new patterns (just for the new files above) and re-run the above test.
- [ ] New examples:
    - [ ] All sample runs at the top of the example source file work.
    - [ ] Update `examples/makefile`:
      - [ ] Add the example code to the appropriate `SEQ_EXAMPLES` and `PAR_EXAMPLES` variables.
      - [ ] Add any files generated by it to the `clean` target.
      - [ ] Add the example binary and any files generated by it to the top-level `.gitignore` file.
    - [ ] Update `examples/CMakeLists.txt`:
      - [ ] Add the example code to the `ALL_EXE_SRCS` variable.
      - [ ] Make sure `THIS_TEST_OPTIONS` is set correctly for the new example.
   - [ ] List the new example in `doc/CodeDocumentation.dox`.
   - [ ] If new examples directory (e.g.`examples/pumi`), list it in `doc/CodeDocumentation.conf.in`
   - [ ] Companion pull request for documentation in [mfem/web](https://github.com/mfem/web) repo:
      - [ ] Update or add example-specific documentation, see e.g. the `src/examples.md`.
      - [ ] Add the description, labels and screenshots in `src/examples.md` and `src/img`.
      - [ ] In `examples.md`, list the example under the appropriate categories, add new categories if necessary.
      - [ ] Add a short description of the example in the "Extensive Examples" section of `features.md`.
- [ ] New miniapps:
   - [ ] All sample runs at the top of the miniapp source file work.
   - [ ] Update top-level `makefile` and `makefile` in corresponding miniapp directory.
   - [ ] Add the miniapp binary and any files generated by it to the top-level `.gitignore` file.
   - [ ] Update CMake build system:
      - [ ] Update the `CMakeLists.txt` file in the `miniapps` directory, if the new miniapp is in a new directory.
      - [ ] Add/update the `CMakeLists.txt` file in the new miniapp directory.
      - [ ] Consider adding a new test for the new miniapp.
   - [ ] List the new miniapp in `doc/CodeDocumentation.dox`
   - [ ] If new miniapps directory (e.g.`miniapps/nurbs`), add it to `MINIAPP_SUBDIRS` in the `makefile`.
   - [ ] If new miniapps directory (e.g.`miniapps/nurbs`), list it in `doc/CodeDocumentation.conf.in`
   - [ ] Companion pull request for documentation in [mfem/web](https://github.com/mfem/web) repo:
     - [ ] Update or add miniapp-specific documentation, see e.g. the `src/meshing.md` and `src/electromagnetics.md` files.
     - [ ] Add the description, labels and screenshots in `src/examples.md` and `src/img`.
     - [ ] The miniapps go at the end of the page, and are usually listed only under a specific "Application (PDE)" category.
     - [ ] Add a short description of the miniapp in the "Extensive Examples" section of `features.md`.
- [ ] New capability:
   - [ ] All new public, protected, and private classes, methods, data members, and functions have full Doxygen-style documentation in source comments. Documentation should include descriptions of member data, function arguments and return values, template parameters, and prerequisites for calling new functions.
   - [ ] Pointer arguments and return values must specify whether ownership is being transferred or lent with the call.
   - [ ] Any new functions should include descriptions of their intended use e.g. for internal use only, user-facing, etc., along with references to example code whenever possible/appropriate.
   - [ ] Consider adding new sample runs in existing examples to highlight the new capability.
   - [ ] Consider saving cool simulation pictures with the new capability in the Confluence gallery (LLNL only) or submitting them, via pull request, to the gallery section of the `mfem/web` repo.
   - [ ] If this is a major new feature, consider mentioning it in the short summary inside `README` *(rare)*.
   - [ ] List major new classes in `doc/CodeDocumentation.dox` *(rare)*.
- [ ] Update this checklist, if the new pull request affects it.
- [ ] Run `make unittest` to make sure all unit tests pass.
- [ ] Run the tests in `tests/scripts`.
- [ ] (LLNL only) After merging:
   - [ ] Update internal tests to include the new features.
</details>
