### PR TITLE
Refactoring Ex18 with preassembly option

### DIFF
--- a/examples/ex18.cpp
+++ b/examples/ex18.cpp
@@ -169,7 +169,7 @@ int main(int argc, char *argv[])
                                                         gas_constant);
    GridFunction sol(&vfes);
    sol.ProjectCoefficient(u0);
-   GridFunction mom(&dfes, sol.GetData());
+   GridFunction mom(&dfes, sol.GetData() + fes.GetNDofs());
    // Output the initial solution.
    {
       ostringstream mesh_name;

--- a/examples/ex18.cpp
+++ b/examples/ex18.cpp
@@ -103,7 +103,7 @@ int main(int argc, char *argv[])
    args.AddOption(&preassembleWeakDiv, "-ea", "--element-assembly-divergence",
                   "-mf", "--matrix-free-divergence",
                   "Weak divergence assembly level\n"
-                  "    ea - Element assembly with linearized F\n"
+                  "    ea - Element assembly with interpolated F\n"
                   "    mf - Nonlinear assembly in matrix-free manner");
    args.AddOption(&vis_steps, "-vs", "--visualization-steps",
                   "Visualize every n-th timestep.");

--- a/examples/ex18.hpp
+++ b/examples/ex18.hpp
@@ -169,7 +169,7 @@ void DGHyperbolicConservationLaws::Mult(const Vector &x, Vector &y) const
    // 1. Create the vector z with the face terms (F(u), grad v) - <F.n(u), [w]>.
    //    If weak divergence is pre-assembled, <F.n(u), [w]>
    nonlinearForm->Mult(x, z);
-   if (!weakdiv.empty()) // if weak divergence is pre-assembled
+   if (!weakdiv.empty()) // if weak divergence is not pre-assembled
    {
       Vector current_state;
       DenseMatrix flux; // element flux value. Whose column is ordered by dim.

--- a/examples/ex18.hpp
+++ b/examples/ex18.hpp
@@ -180,7 +180,7 @@ void DGHyperbolicConservationLaws::Mult(const Vector &x, Vector &y) const
       Vector xval, zval;
       for (int i=0; i<vfes.GetNE(); i++)
       {
-         auto Tr = vfes.GetElementTransformation(i);
+         ElementTransformation* Tr = vfes.GetElementTransformation(i);
          int dof = vfes.GetFE(i)->GetDof();
          vfes.GetElementVDofs(i, vdofs);
          x.GetSubVector(vdofs, xval);

--- a/examples/ex18.hpp
+++ b/examples/ex18.hpp
@@ -52,11 +52,6 @@ private:
    // Compute element-wise weak-divergence matrix
    void ComputeWeakDivergence();
 
-   /// @brief Compute flux for rows of states
-   /// @param state state stored row-wise
-   /// @param Fu flux for each state
-   void ComputeFlux(const DenseMatrix &state, DenseTensor &Fu) const;
-
 public:
    /**
     * @brief Construct a new DGHyperbolicConservationLaws object
@@ -229,35 +224,6 @@ void DGHyperbolicConservationLaws::Mult(const Vector &x, Vector &y) const
       }
    }
    max_char_speed = formIntegrator->GetMaxCharSpeed();
-}
-
-void DGHyperbolicConservationLaws::ComputeFlux(const DenseMatrix &state,
-                                               DenseTensor &Fu) const
-{
-   const int total_dof = state.Height();
-   const int num_equations = state.Width();
-   Vector current_state;
-   DenseMatrix current_flux(num_equations, dim);
-   const FluxFunction &fluxFunction = formIntegrator->GetFluxFunction();
-   int idx = 0;
-   for (int i=0; i<vfes.GetNE(); i++)
-   {
-      auto Tr = vfes.GetElementTransformation(i);
-      int dof = vfes.GetFE(i)->GetDof();
-      for (int j=0; j<dof; j++)
-      {
-         state.GetRow(idx + j, current_state);
-         fluxFunction.ComputeFlux(current_state, *Tr, current_flux);
-         for (int d = 0; d < dim; d++)
-         {
-            for (int k=0; k<num_equations; k++)
-            {
-               Fu(idx + j, d, k) = current_flux(k, d);
-            }
-         }
-      }
-      idx += dof;
-   }
 }
 
 void DGHyperbolicConservationLaws::Update()

--- a/examples/ex18.hpp
+++ b/examples/ex18.hpp
@@ -45,7 +45,6 @@ private:
    mutable double max_char_speed;
    // auxiliary variable used in Mult
    mutable Vector z;
-   mutable DenseMatrix flux;
 
    // Compute element-wise inverse mass matrix
    void ComputeInvMass();
@@ -173,7 +172,7 @@ void DGHyperbolicConservationLaws::Mult(const Vector &x, Vector &y) const
    if (!weakdiv.empty()) // if weak divergence is pre-assembled
    {
       Vector current_state;
-      DenseMatrix flux_; // element flux value. Whose column is ordered by dim.
+      DenseMatrix flux; // element flux value. Whose column is ordered by dim.
       DenseMatrix current_flux; // node flux value.
       const FluxFunction &fluxFunction = formIntegrator->GetFluxFunction();
       DenseMatrix current_zmat, current_ymat, current_xmat;
@@ -186,11 +185,11 @@ void DGHyperbolicConservationLaws::Mult(const Vector &x, Vector &y) const
          vfes.GetElementVDofs(i, vdofs);
          x.GetSubVector(vdofs, xval);
          current_xmat.UseExternalData(xval.GetData(), dof, num_equations);
-         flux_.SetSize(num_equations, dim*dof);
+         flux.SetSize(num_equations, dim*dof);
          for (int j=0; j<dof; j++)
          {
             current_xmat.GetRow(j, current_state);
-            current_flux.UseExternalData(flux_.GetData() + num_equations*dim*j,
+            current_flux.UseExternalData(flux.GetData() + num_equations*dim*j,
                                          num_equations, dof);
             fluxFunction.ComputeFlux(current_state, *Tr, current_flux);
          }
@@ -198,7 +197,7 @@ void DGHyperbolicConservationLaws::Mult(const Vector &x, Vector &y) const
          current_zmat.UseExternalData(zval.GetData(), dof, num_equations);
          // Recalling that weakdiv is reordered by dim, we can apply
          // weak-divergence to the transpose of flux.
-         mfem::AddMult_a_ABt(1.0, weakdiv[i], flux_, current_zmat);
+         mfem::AddMult_a_ABt(1.0, weakdiv[i], flux, current_zmat);
          current_ymat.SetSize(dof, num_equations);
          mfem::Mult(invmass[i], current_zmat, current_ymat);
          y.SetSubVector(vdofs, current_ymat.GetData());

--- a/examples/ex18p.cpp
+++ b/examples/ex18p.cpp
@@ -111,7 +111,7 @@ int main(int argc, char *argv[])
    args.AddOption(&preassembleWeakDiv, "-ea", "--element-assembly-divergence",
                   "-mf", "--matrix-free-divergence",
                   "Weak divergence assembly level\n"
-                  "    ea - Element assembly with linearized F\n"
+                  "    ea - Element assembly with interpolated F\n"
                   "    mf - Nonlinear assembly in matrix-free manner");
    args.AddOption(&vis_steps, "-vs", "--visualization-steps",
                   "Visualize every n-th timestep.");

--- a/examples/ex18p.cpp
+++ b/examples/ex18p.cpp
@@ -65,7 +65,7 @@ int main(int argc, char *argv[])
    const double gas_constant = 1.0;
 
    string mesh_file = "";
-   int IntOrderOffset = 3;
+   int IntOrderOffset = 1;
    int ser_ref_levels = 0;
    int par_ref_levels = 1;
    int order = 3;
@@ -74,6 +74,7 @@ int main(int argc, char *argv[])
    double dt = -0.01;
    double cfl = 0.3;
    bool visualization = true;
+   bool preassemble = false;
    int vis_steps = 50;
 
    int precision = 8;
@@ -102,6 +103,9 @@ int main(int argc, char *argv[])
    args.AddOption(&visualization, "-vis", "--visualization", "-no-vis",
                   "--no-visualization",
                   "Enable or disable GLVis visualization.");
+   args.AddOption(&preassemble, "-pa", "--preassemble", "-mf",
+                  "--matrix-free",
+                  "Preassemble weak-divergence assuming F(u) is linear");
    args.AddOption(&vis_steps, "-vs", "--visualization-steps",
                   "Visualize every n-th timestep.");
    args.ParseCheck();
@@ -211,7 +215,7 @@ int main(int argc, char *argv[])
    RusanovFlux numericalFlux(flux);
    DGHyperbolicConservationLaws euler(
       vfes, std::unique_ptr<HyperbolicFormIntegrator>(
-         new HyperbolicFormIntegrator(numericalFlux, IntOrderOffset)));
+         new HyperbolicFormIntegrator(numericalFlux, IntOrderOffset)), preassemble);
 
    // Visualize the density
    socketstream sout;

--- a/examples/ex18p.cpp
+++ b/examples/ex18p.cpp
@@ -7,8 +7,8 @@
 //       mpirun -np 4 ex18p -p 1 -rs 2 -rp 1 -o 1 -s 3
 //       mpirun -np 4 ex18p -p 1 -rs 1 -rp 1 -o 3 -s 4
 //       mpirun -np 4 ex18p -p 1 -rs 1 -rp 1 -o 5 -s 6
-//       mpirun -np 4 ex18p -p 2 -rs 1 -rp 1 -o 1 -s 3
-//       mpirun -np 4 ex18p -p 2 -rs 1 -rp 1 -o 3 -s 3
+//       mpirun -np 4 ex18p -p 2 -rs 1 -rp 1 -o 1 -s 3 -mf
+//       mpirun -np 4 ex18p -p 2 -rs 1 -rp 1 -o 3 -s 3 -mf
 //
 // Description:  This example code solves the compressible Euler system of
 //               equations, a model nonlinear hyperbolic PDE, with a
@@ -37,6 +37,11 @@
 //               that wraps NonlinearFormIntegrators containing element and face
 //               integration schemes. In this case the system also involves an
 //               external approximate Riemann solver for the DG interface flux.
+//               By default, weak-divergence is pre-assembled in element-wise
+//               manner, which corresponds to (I_h(F(u_h)), ∇ v). This yields
+//               better performance and similar accuracy for the included test
+//               problems. This can be turned off and use nonlinear assembly
+//               similar to matrix-free assembly when -mf flag is provided.
 //               It also demonstrates how to use GLVis for in-situ visualization
 //               of vector grid function and how to set top-view.
 //
@@ -74,7 +79,7 @@ int main(int argc, char *argv[])
    double dt = -0.01;
    double cfl = 0.3;
    bool visualization = true;
-   bool preassemble = true;
+   bool preassembleWeakDiv = true;
    int vis_steps = 50;
 
    int precision = 8;
@@ -103,9 +108,11 @@ int main(int argc, char *argv[])
    args.AddOption(&visualization, "-vis", "--visualization", "-no-vis",
                   "--no-visualization",
                   "Enable or disable GLVis visualization.");
-   args.AddOption(&preassemble, "-pa", "--preassemble", "-mf",
-                  "--matrix-free",
-                  "Preassemble weak-divergence assuming F(u) is linear");
+   args.AddOption(&preassembleWeakDiv, "-ea", "--element-assembly-divergence",
+                  "-mf", "--matrix-free-divergence",
+                  "Weak divergence assembly level\n"
+                  "    ea - Element assembly with linearized F\n"
+                  "    mf - Nonlinear assembly in matrix-free manner");
    args.AddOption(&vis_steps, "-vs", "--visualization-steps",
                   "Visualize every n-th timestep.");
    args.ParseCheck();
@@ -216,7 +223,8 @@ int main(int argc, char *argv[])
    RusanovFlux numericalFlux(flux);
    DGHyperbolicConservationLaws euler(
       vfes, std::unique_ptr<HyperbolicFormIntegrator>(
-         new HyperbolicFormIntegrator(numericalFlux, IntOrderOffset)), preassemble);
+         new HyperbolicFormIntegrator(numericalFlux, IntOrderOffset)),
+      preassembleWeakDiv);
 
    // Visualize the density
    socketstream sout;

--- a/examples/ex18p.cpp
+++ b/examples/ex18p.cpp
@@ -74,7 +74,7 @@ int main(int argc, char *argv[])
    double dt = -0.01;
    double cfl = 0.3;
    bool visualization = true;
-   bool preassemble = false;
+   bool preassemble = true;
    int vis_steps = 50;
 
    int precision = 8;

--- a/examples/ex18p.cpp
+++ b/examples/ex18p.cpp
@@ -188,6 +188,7 @@ int main(int argc, char *argv[])
                                                         gas_constant);
    ParGridFunction sol(&vfes);
    sol.ProjectCoefficient(u0);
+   ParGridFunction mom(&dfes, sol.GetData());
 
    // Output the initial solution.
    {
@@ -237,7 +238,6 @@ int main(int argc, char *argv[])
       }
       else
       {
-         ParGridFunction mom(&dfes, sol.GetData());
          sout << "parallel " << numProcs << " " << myRank << "\n";
          sout.precision(precision);
          sout << "solution\n" << pmesh << mom;
@@ -313,7 +313,6 @@ int main(int argc, char *argv[])
          }
          if (visualization)
          {
-            ParGridFunction mom(&dfes, sol.GetData());
             sout << "parallel " << numProcs << " " << myRank << "\n";
             sout << "solution\n" << pmesh << mom;
             sout << "window_title 't = " << t << "'" << flush;

--- a/examples/ex18p.cpp
+++ b/examples/ex18p.cpp
@@ -195,7 +195,7 @@ int main(int argc, char *argv[])
                                                         gas_constant);
    ParGridFunction sol(&vfes);
    sol.ProjectCoefficient(u0);
-   ParGridFunction mom(&dfes, sol.GetData());
+   ParGridFunction mom(&dfes, sol.GetData() + fes.GetNDofs());
 
    // Output the initial solution.
    {

--- a/fem/hyperbolic.cpp
+++ b/fem/hyperbolic.cpp
@@ -202,7 +202,7 @@ double RusanovFlux::Eval(const Vector &state1, const Vector &state2,
    // NOTE: nor in general is not a unit normal
    const double maxE = std::max(speed1, speed2);
    // here, std::sqrt(nor*nor) is multiplied to match the scale with fluxN
-   const double scaledMaxE = maxE*sqrt(nor*nor);
+   const double scaledMaxE = maxE*std::sqrt(nor*nor);
    for (int i=0; i<state1.Size(); i++)
    {
       flux[i] = 0.5*(scaledMaxE*(state1[i] - state2[i]) + (fluxN1[i] + fluxN2[i]));
@@ -277,7 +277,7 @@ double ShallowWaterFlux::ComputeFluxDotN(const Vector &U,
    }
 
    const double sound = std::sqrt(g * height);
-   const double vel = std::fabs(h_vel * normal / normal.Norml2()) / height;
+   const double vel = std::fabs(normal_vel) / std::sqrt(normal*normal);
 
    return vel + sound;
 }

--- a/fem/hyperbolic.cpp
+++ b/fem/hyperbolic.cpp
@@ -369,7 +369,7 @@ double EulerFlux::ComputeFluxDotN(const Vector &x,
    // sound speed, √(γ p / ρ)
    const double sound = std::sqrt(specific_heat_ratio * pressure / density);
    // fluid speed |u|
-   const double speed = std::fabs(momentum * normal / normal.Norml2()) / density;
+   const double speed = std::fabs(normal_velocity) / std::sqrt(normal*normal);
    // max characteristic speed = fluid speed + sound speed
    return speed + sound;
 }

--- a/fem/hyperbolic.hpp
+++ b/fem/hyperbolic.hpp
@@ -208,7 +208,7 @@ public:
                                          const ElementTransformation &Tr,
                                          const int IntOrderOffset_)
    {
-      const int order = 2 * el.GetOrder() + Tr.OrderW() + IntOrderOffset_;
+      const int order = 2 * el.GetOrder() + Tr.OrderJ() + IntOrderOffset_;
       return IntRules.Get(Tr.GetGeometryType(), order);
    }
 


### PR DESCRIPTION
This PR is a sub-PR of #3598 with additional functionality, `preassembly` that linearize weak divergence for better performance in terms of computational time.

Preassembly turned on by default, and you can use `-mf` option to switch to nonlinear assembly.