### PR TITLE
Make Coefficient `Eval` const + Other `const`-Related Updates for Coefficients [constcoeff-dev]

### DIFF
--- a/examples/ex10.cpp
+++ b/examples/ex10.cpp
@@ -136,12 +136,12 @@ class ElasticEnergyCoefficient : public Coefficient
 private:
    HyperelasticModel  &model;
    const GridFunction &x;
-   DenseMatrix         J;
+   mutable DenseMatrix         J;
 
 public:
    ElasticEnergyCoefficient(HyperelasticModel &m, const GridFunction &x_)
       : model(m), x(x_) { }
-   virtual double Eval(ElementTransformation &T, const IntegrationPoint &ip);
+   virtual double Eval(ElementTransformation &T, const IntegrationPoint &ip) const;
    virtual ~ElasticEnergyCoefficient() { }
 };
 
@@ -582,7 +582,7 @@ HyperelasticOperator::~HyperelasticOperator()
 
 
 double ElasticEnergyCoefficient::Eval(ElementTransformation &T,
-                                      const IntegrationPoint &ip)
+                                      const IntegrationPoint &ip) const
 {
    model.SetTransformation(T);
    x.GetVectorGradient(T, J);

--- a/examples/ex10p.cpp
+++ b/examples/ex10p.cpp
@@ -141,12 +141,12 @@ class ElasticEnergyCoefficient : public Coefficient
 private:
    HyperelasticModel     &model;
    const ParGridFunction &x;
-   DenseMatrix            J;
+   mutable DenseMatrix            J;
 
 public:
    ElasticEnergyCoefficient(HyperelasticModel &m, const ParGridFunction &x_)
       : model(m), x(x_) { }
-   virtual double Eval(ElementTransformation &T, const IntegrationPoint &ip);
+   virtual double Eval(ElementTransformation &T, const IntegrationPoint &ip) const;
    virtual ~ElasticEnergyCoefficient() { }
 };
 
@@ -661,7 +661,7 @@ HyperelasticOperator::~HyperelasticOperator()
 
 
 double ElasticEnergyCoefficient::Eval(ElementTransformation &T,
-                                      const IntegrationPoint &ip)
+                                      const IntegrationPoint &ip) const
 {
    model.SetTransformation(T);
    x.GetVectorGradient(T, J);

--- a/examples/ex17.cpp
+++ b/examples/ex17.cpp
@@ -60,7 +60,7 @@ protected:
    GridFunction *u; // displacement
    int si, sj; // component of the stress to evaluate, 0 <= si,sj < dim
 
-   DenseMatrix grad; // auxiliary matrix, used in Eval
+   mutable DenseMatrix grad; // auxiliary matrix, used in Eval
 
 public:
    StressCoefficient(Coefficient &lambda_, Coefficient &mu_)
@@ -69,7 +69,7 @@ public:
    void SetDisplacement(GridFunction &u_) { u = &u_; }
    void SetComponent(int i, int j) { si = i; sj = j; }
 
-   virtual double Eval(ElementTransformation &T, const IntegrationPoint &ip);
+   virtual double Eval(ElementTransformation &T, const IntegrationPoint &ip) const;
 };
 
 // Simple GLVis visualization manager.
@@ -338,7 +338,7 @@ void InitDisplacement(const Vector &x, Vector &u)
 
 
 double StressCoefficient::Eval(ElementTransformation &T,
-                               const IntegrationPoint &ip)
+                               const IntegrationPoint &ip) const
 {
    MFEM_ASSERT(u != NULL, "displacement field is not set");
 

--- a/examples/ex17p.cpp
+++ b/examples/ex17p.cpp
@@ -60,7 +60,7 @@ protected:
    GridFunction *u; // displacement
    int si, sj; // component of the stress to evaluate, 0 <= si,sj < dim
 
-   DenseMatrix grad; // auxiliary matrix, used in Eval
+   mutable DenseMatrix grad; // auxiliary matrix, used in Eval
 
 public:
    StressCoefficient(Coefficient &lambda_, Coefficient &mu_)
@@ -69,7 +69,7 @@ public:
    void SetDisplacement(GridFunction &u_) { u = &u_; }
    void SetComponent(int i, int j) { si = i; sj = j; }
 
-   virtual double Eval(ElementTransformation &T, const IntegrationPoint &ip);
+   virtual double Eval(ElementTransformation &T, const IntegrationPoint &ip) const;
 };
 
 // Simple GLVis visualization manager.
@@ -377,7 +377,7 @@ void InitDisplacement(const Vector &x, Vector &u)
 
 
 double StressCoefficient::Eval(ElementTransformation &T,
-                               const IntegrationPoint &ip)
+                               const IntegrationPoint &ip) const
 {
    MFEM_ASSERT(u != NULL, "displacement field is not set");
 

--- a/examples/ex25.cpp
+++ b/examples/ex25.cpp
@@ -104,7 +104,7 @@ public:
    using VectorCoefficient::Eval;
 
    virtual void Eval(Vector &K, ElementTransformation &T,
-                     const IntegrationPoint &ip)
+                     const IntegrationPoint &ip) const
    {
       double x[3];
       Vector transip(x, 3);

--- a/examples/ex25p.cpp
+++ b/examples/ex25p.cpp
@@ -103,7 +103,7 @@ public:
    using VectorCoefficient::Eval;
 
    virtual void Eval(Vector &K, ElementTransformation &T,
-                     const IntegrationPoint &ip)
+                     const IntegrationPoint &ip) const
    {
       double x[3];
       Vector transip(x, 3);

--- a/examples/ex36.cpp
+++ b/examples/ex36.cpp
@@ -53,7 +53,7 @@ public:
                                     double min_val_=-36)
       : u(&u_), obstacle(&obst_), min_val(min_val_) { }
 
-   virtual double Eval(ElementTransformation &T, const IntegrationPoint &ip);
+   virtual double Eval(ElementTransformation &T, const IntegrationPoint &ip) const;
 };
 
 class ExponentialGridFunctionCoefficient : public Coefficient
@@ -69,7 +69,7 @@ public:
                                       double min_val_=0.0, double max_val_=1e6)
       : u(&u_), obstacle(&obst_), min_val(min_val_), max_val(max_val_) { }
 
-   virtual double Eval(ElementTransformation &T, const IntegrationPoint &ip);
+   virtual double Eval(ElementTransformation &T, const IntegrationPoint &ip) const;
 };
 
 int main(int argc, char *argv[])
@@ -381,7 +381,7 @@ int main(int argc, char *argv[])
 }
 
 double LogarithmGridFunctionCoefficient::Eval(ElementTransformation &T,
-                                              const IntegrationPoint &ip)
+                                              const IntegrationPoint &ip) const
 {
    MFEM_ASSERT(u != NULL, "grid function is not set");
 
@@ -390,7 +390,7 @@ double LogarithmGridFunctionCoefficient::Eval(ElementTransformation &T,
 }
 
 double ExponentialGridFunctionCoefficient::Eval(ElementTransformation &T,
-                                                const IntegrationPoint &ip)
+                                                const IntegrationPoint &ip) const
 {
    MFEM_ASSERT(u != NULL, "grid function is not set");
 

--- a/examples/ex36p.cpp
+++ b/examples/ex36p.cpp
@@ -53,7 +53,7 @@ public:
                                     double min_val_=-36)
       : u(&u_), obstacle(&obst_), min_val(min_val_) { }
 
-   virtual double Eval(ElementTransformation &T, const IntegrationPoint &ip);
+   virtual double Eval(ElementTransformation &T, const IntegrationPoint &ip) const;
 };
 
 class ExponentialGridFunctionCoefficient : public Coefficient
@@ -69,7 +69,7 @@ public:
                                       double min_val_=0.0, double max_val_=1e6)
       : u(&u_), obstacle(&obst_), min_val(min_val_), max_val(max_val_) { }
 
-   virtual double Eval(ElementTransformation &T, const IntegrationPoint &ip);
+   virtual double Eval(ElementTransformation &T, const IntegrationPoint &ip) const;
 };
 
 int main(int argc, char *argv[])
@@ -445,7 +445,7 @@ int main(int argc, char *argv[])
 }
 
 double LogarithmGridFunctionCoefficient::Eval(ElementTransformation &T,
-                                              const IntegrationPoint &ip)
+                                              const IntegrationPoint &ip) const
 {
    MFEM_ASSERT(u != NULL, "grid function is not set");
 
@@ -454,7 +454,7 @@ double LogarithmGridFunctionCoefficient::Eval(ElementTransformation &T,
 }
 
 double ExponentialGridFunctionCoefficient::Eval(ElementTransformation &T,
-                                                const IntegrationPoint &ip)
+                                                const IntegrationPoint &ip) const
 {
    MFEM_ASSERT(u != NULL, "grid function is not set");
 

--- a/examples/ex37.hpp
+++ b/examples/ex37.hpp
@@ -53,7 +53,7 @@ public:
 
 
    virtual double Eval(ElementTransformation &T,
-                       const IntegrationPoint &ip)
+                       const IntegrationPoint &ip) const
    {
       return fun(GridFunctionCoefficient::Eval(T, ip));
    }
@@ -84,7 +84,7 @@ public:
        fun(fun_) {}
 
    virtual double Eval(ElementTransformation &T,
-                       const IntegrationPoint &ip)
+                       const IntegrationPoint &ip) const
    {
       const double value1 = fun(GridFunctionCoefficient::Eval(T, ip));
       const double value2 = fun(OtherGridF_cf.Eval(T, ip));
@@ -108,7 +108,7 @@ public:
       : rho_filter(rho_filter_), min_val(min_val_), max_val(max_val_),
         exponent(exponent_) { }
 
-   virtual double Eval(ElementTransformation &T, const IntegrationPoint &ip)
+   virtual double Eval(ElementTransformation &T, const IntegrationPoint &ip) const
    {
       double val = rho_filter->GetValue(T, ip);
       double coeff = min_val + pow(val,exponent)*(max_val-min_val);
@@ -125,7 +125,7 @@ protected:
    Coefficient * mu=nullptr;
    GridFunction *u = nullptr; // displacement
    GridFunction *rho_filter = nullptr; // filter density
-   DenseMatrix grad; // auxiliary matrix, used in Eval
+   mutable DenseMatrix grad; // auxiliary matrix, used in Eval
    double exponent;
    double rho_min;
 
@@ -142,7 +142,7 @@ public:
       MFEM_ASSERT(rho_filter, "density field is not set");
    }
 
-   virtual double Eval(ElementTransformation &T, const IntegrationPoint &ip)
+   virtual double Eval(ElementTransformation &T, const IntegrationPoint &ip) const
    {
       double L = lambda->Eval(T, ip);
       double M = mu->Eval(T, ip);
@@ -177,7 +177,7 @@ public:
    using VectorCoefficient::Eval;
 
    virtual void Eval(Vector &V, ElementTransformation &T,
-                     const IntegrationPoint &ip)
+                     const IntegrationPoint &ip) const
    {
       Vector xx; xx.SetSize(T.GetDimension());
       T.Transform(ip,xx);

--- a/examples/petsc/ex10p.cpp
+++ b/examples/petsc/ex10p.cpp
@@ -170,7 +170,7 @@ private:
 public:
    ElasticEnergyCoefficient(HyperelasticModel &m, const ParGridFunction &x_)
       : model(m), x(x_) { }
-   virtual double Eval(ElementTransformation &T, const IntegrationPoint &ip);
+   virtual double Eval(ElementTransformation &T, const IntegrationPoint &ip) const;
    virtual ~ElasticEnergyCoefficient() { }
 };
 
@@ -743,7 +743,7 @@ Solver* PreconditionerFactory::NewPreconditioner(const mfem::OperatorHandle& oh)
 }
 
 double ElasticEnergyCoefficient::Eval(ElementTransformation &T,
-                                      const IntegrationPoint &ip)
+                                      const IntegrationPoint &ip) const
 {
    model.SetTransformation(T);
    x.GetVectorGradient(T, J);

--- a/examples/sundials/ex10.cpp
+++ b/examples/sundials/ex10.cpp
@@ -195,7 +195,7 @@ private:
 public:
    ElasticEnergyCoefficient(HyperelasticModel &m, const GridFunction &x_)
       : model(m), x(x_) { }
-   virtual double Eval(ElementTransformation &T, const IntegrationPoint &ip);
+   virtual double Eval(ElementTransformation &T, const IntegrationPoint &ip) const;
    virtual ~ElasticEnergyCoefficient() { }
 };
 
@@ -798,7 +798,7 @@ HyperelasticOperator::~HyperelasticOperator()
 
 
 double ElasticEnergyCoefficient::Eval(ElementTransformation &T,
-                                      const IntegrationPoint &ip)
+                                      const IntegrationPoint &ip) const
 {
    model.SetTransformation(T);
    x.GetVectorGradient(T, J);

--- a/examples/sundials/ex10p.cpp
+++ b/examples/sundials/ex10p.cpp
@@ -200,7 +200,7 @@ private:
 public:
    ElasticEnergyCoefficient(HyperelasticModel &m, const ParGridFunction &x_)
       : model(m), x(x_) { }
-   virtual double Eval(ElementTransformation &T, const IntegrationPoint &ip);
+   virtual double Eval(ElementTransformation &T, const IntegrationPoint &ip) const;
    virtual ~ElasticEnergyCoefficient() { }
 };
 
@@ -883,7 +883,7 @@ HyperelasticOperator::~HyperelasticOperator()
 
 
 double ElasticEnergyCoefficient::Eval(ElementTransformation &T,
-                                      const IntegrationPoint &ip)
+                                      const IntegrationPoint &ip) const
 {
    model.SetTransformation(T);
    x.GetVectorGradient(T, J);

--- a/fem/bilininteg.cpp
+++ b/fem/bilininteg.cpp
@@ -4351,7 +4351,7 @@ ScalarVectorProductInterpolator::AssembleElementMatrix2(
 
       VShapeCoefficient(Coefficient &q, const FiniteElement &fe_, int sdim)
          : MatrixCoefficient(fe_.GetDof(), sdim), Q(q), fe(fe_) { }
-
+      using MatrixCoefficient::Eval;
       virtual void Eval(DenseMatrix &M, ElementTransformation &T,
                         const IntegrationPoint &ip) const
       {
@@ -4390,6 +4390,7 @@ VectorScalarProductInterpolator::AssembleElementMatrix2(
          : MatrixCoefficient(fe_.GetDof(), vq.GetVDim()), VQ(vq), fe(fe_),
            vc(width), shape(height) { }
 
+      using MatrixCoefficient::Eval;
       virtual void Eval(DenseMatrix &M, ElementTransformation &T,
                         const IntegrationPoint &ip) const
       {
@@ -4475,7 +4476,8 @@ VectorCrossProductInterpolator::AssembleElementMatrix2(
       {
          MFEM_ASSERT(width == 3, "");
       }
-
+      
+      using MatrixCoefficient::Eval;
       virtual void Eval(DenseMatrix &M, ElementTransformation &T,
                         const IntegrationPoint &ip) const
       {

--- a/fem/bilininteg.cpp
+++ b/fem/bilininteg.cpp
@@ -4310,7 +4310,7 @@ struct ShapeCoefficient : public VectorCoefficient
 
    using VectorCoefficient::Eval;
    virtual void Eval(Vector &V, ElementTransformation &T,
-                     const IntegrationPoint &ip)
+                     const IntegrationPoint &ip) const
    {
       V.SetSize(vdim);
       fe.CalcPhysShape(T, V);
@@ -4353,7 +4353,7 @@ ScalarVectorProductInterpolator::AssembleElementMatrix2(
          : MatrixCoefficient(fe_.GetDof(), sdim), Q(q), fe(fe_) { }
 
       virtual void Eval(DenseMatrix &M, ElementTransformation &T,
-                        const IntegrationPoint &ip)
+                        const IntegrationPoint &ip) const
       {
          M.SetSize(height, width);
          fe.CalcPhysVShape(T, M);
@@ -4383,14 +4383,15 @@ VectorScalarProductInterpolator::AssembleElementMatrix2(
    {
       VectorCoefficient &VQ;
       const FiniteElement &fe;
-      Vector vc, shape;
+      
+      mutable Vector vc, shape;
 
       VecShapeCoefficient(VectorCoefficient &vq, const FiniteElement &fe_)
          : MatrixCoefficient(fe_.GetDof(), vq.GetVDim()), VQ(vq), fe(fe_),
            vc(width), shape(height) { }
 
       virtual void Eval(DenseMatrix &M, ElementTransformation &T,
-                        const IntegrationPoint &ip)
+                        const IntegrationPoint &ip) const
       {
          M.SetSize(height, width);
          VQ.Eval(vc, T, ip);
@@ -4421,8 +4422,9 @@ ScalarCrossProductInterpolator::AssembleElementMatrix2(
    {
       VectorCoefficient &VQ;
       const FiniteElement &fe;
-      DenseMatrix vshape;
-      Vector vc;
+      
+      mutable DenseMatrix vshape;
+      mutable Vector vc;
 
       VCrossVShapeCoefficient(VectorCoefficient &vq, const FiniteElement &fe_)
          : VectorCoefficient(fe_.GetDof()), VQ(vq), fe(fe_),
@@ -4430,7 +4432,7 @@ ScalarCrossProductInterpolator::AssembleElementMatrix2(
 
       using VectorCoefficient::Eval;
       virtual void Eval(Vector &V, ElementTransformation &T,
-                        const IntegrationPoint &ip)
+                        const IntegrationPoint &ip) const
       {
          V.SetSize(vdim);
          VQ.Eval(vc, T, ip);
@@ -4463,8 +4465,9 @@ VectorCrossProductInterpolator::AssembleElementMatrix2(
    {
       VectorCoefficient &VQ;
       const FiniteElement &fe;
-      DenseMatrix vshape;
-      Vector vc;
+      
+      mutable DenseMatrix vshape;
+      mutable Vector vc;
 
       VCrossVShapeCoefficient(VectorCoefficient &vq, const FiniteElement &fe_)
          : MatrixCoefficient(fe_.GetDof(), vq.GetVDim()), VQ(vq), fe(fe_),
@@ -4474,7 +4477,7 @@ VectorCrossProductInterpolator::AssembleElementMatrix2(
       }
 
       virtual void Eval(DenseMatrix &M, ElementTransformation &T,
-                        const IntegrationPoint &ip)
+                        const IntegrationPoint &ip) const
       {
          M.SetSize(height, width);
          VQ.Eval(vc, T, ip);
@@ -4514,8 +4517,9 @@ struct VDotVShapeCoefficient : public VectorCoefficient
 {
    VectorCoefficient &VQ;
    const FiniteElement &fe;
-   DenseMatrix vshape;
-   Vector vc;
+   
+   mutable DenseMatrix vshape;
+   mutable Vector vc;
 
    VDotVShapeCoefficient(VectorCoefficient &vq, const FiniteElement &fe_)
       : VectorCoefficient(fe_.GetDof()), VQ(vq), fe(fe_),
@@ -4523,7 +4527,7 @@ struct VDotVShapeCoefficient : public VectorCoefficient
 
    using VectorCoefficient::Eval;
    virtual void Eval(Vector &V, ElementTransformation &T,
-                     const IntegrationPoint &ip)
+                     const IntegrationPoint &ip) const
    {
       V.SetSize(vdim);
       VQ.Eval(vc, T, ip);

--- a/fem/bilininteg.cpp
+++ b/fem/bilininteg.cpp
@@ -4476,7 +4476,7 @@ VectorCrossProductInterpolator::AssembleElementMatrix2(
       {
          MFEM_ASSERT(width == 3, "");
       }
-      
+
       using MatrixCoefficient::Eval;
       virtual void Eval(DenseMatrix &M, ElementTransformation &T,
                         const IntegrationPoint &ip) const

--- a/fem/bilininteg.cpp
+++ b/fem/bilininteg.cpp
@@ -4383,7 +4383,7 @@ VectorScalarProductInterpolator::AssembleElementMatrix2(
    {
       VectorCoefficient &VQ;
       const FiniteElement &fe;
-      
+
       mutable Vector vc, shape;
 
       VecShapeCoefficient(VectorCoefficient &vq, const FiniteElement &fe_)
@@ -4422,7 +4422,7 @@ ScalarCrossProductInterpolator::AssembleElementMatrix2(
    {
       VectorCoefficient &VQ;
       const FiniteElement &fe;
-      
+
       mutable DenseMatrix vshape;
       mutable Vector vc;
 
@@ -4465,7 +4465,7 @@ VectorCrossProductInterpolator::AssembleElementMatrix2(
    {
       VectorCoefficient &VQ;
       const FiniteElement &fe;
-      
+
       mutable DenseMatrix vshape;
       mutable Vector vc;
 
@@ -4517,7 +4517,7 @@ struct VDotVShapeCoefficient : public VectorCoefficient
 {
    VectorCoefficient &VQ;
    const FiniteElement &fe;
-   
+
    mutable DenseMatrix vshape;
    mutable Vector vc;
 

--- a/fem/coefficient.cpp
+++ b/fem/coefficient.cpp
@@ -220,12 +220,12 @@ double TransformedCoefficient::Eval(ElementTransformation &T,
 {
    if (Q2)
    {
-      return Transform2(Q1->Eval(T, ip, GetTime()),
-                        Q2->Eval(T, ip, GetTime()));
+      return Transform2(Q1->Eval(T, ip),
+                        Q2->Eval(T, ip));
    }
    else
    {
-      return Transform1(Q1->Eval(T, ip, GetTime()));
+      return Transform1(Q1->Eval(T, ip));
    }
 }
 
@@ -253,7 +253,7 @@ double DeltaCoefficient::EvalDelta(ElementTransformation &T,
                                    const IntegrationPoint &ip) const
 {
    double w = Scale();
-   return weight ? weight->Eval(T, ip, GetTime())*w : w;
+   return weight ? weight->Eval(T, ip)*w : w;
 }
 
 void RestrictedCoefficient::SetTime(double t)
@@ -382,7 +382,7 @@ void VectorFunctionCoefficient::Eval(Vector &V, ElementTransformation &T,
    }
    if (Q)
    {
-      V *= Q->Eval(T, ip, GetTime());
+      V *= Q->Eval(T, ip);
    }
 }
 
@@ -600,7 +600,6 @@ void VectorRestrictedCoefficient::Eval(Vector &V, ElementTransformation &T,
    V.SetSize(vdim);
    if (active_attr[T.Attribute-1])
    {
-      c->SetTime(GetTime());
       c->Eval(V, T, ip);
    }
    else
@@ -614,7 +613,6 @@ void VectorRestrictedCoefficient::Eval(
 {
    if (active_attr[T.Attribute-1])
    {
-      c->SetTime(GetTime());
       c->Eval(M, T, ir);
    }
    else
@@ -770,7 +768,7 @@ void MatrixFunctionCoefficient::Eval(DenseMatrix &K, ElementTransformation &T,
 
    if (Q)
    {
-      K *= Q->Eval(T, ip, GetTime());
+      K *= Q->Eval(T, ip);
    }
 }
 
@@ -870,7 +868,7 @@ void SymmetricMatrixFunctionCoefficient::Eval(DenseSymmetricMatrix &K,
 
    if (Q)
    {
-      K *= Q->Eval(T, ip, GetTime());
+      K *= Q->Eval(T, ip);
    }
 }
 
@@ -934,7 +932,6 @@ void MatrixRestrictedCoefficient::Eval(DenseMatrix &K, ElementTransformation &T,
 {
    if (active_attr[T.Attribute-1])
    {
-      c->SetTime(GetTime());
       c->Eval(K, T, ip);
    }
    else

--- a/fem/coefficient.cpp
+++ b/fem/coefficient.cpp
@@ -363,6 +363,12 @@ void PositionVectorCoefficient::Eval(Vector &V, ElementTransformation &T,
    T.Transform(ip, V);
 }
 
+void VectorFunctionCoefficient::SetTime(double t)
+{
+    if (Q) Q->SetTime(t);
+    this->VectorCoefficient::SetTime(t);
+}
+
 void VectorFunctionCoefficient::Eval(Vector &V, ElementTransformation &T,
                                      const IntegrationPoint &ip) const
 {

--- a/fem/coefficient.cpp
+++ b/fem/coefficient.cpp
@@ -48,7 +48,7 @@ ElementTransformation *RefinedToCoarse(
    return coarse_T;
 }
 
-void Coefficient::Project(QuadratureFunction &qf)
+void Coefficient::Project(QuadratureFunction &qf) const
 {
    QuadratureSpaceBase &qspace = *qf.GetSpace();
    const int ne = qspace.GetNE();
@@ -68,13 +68,13 @@ void Coefficient::Project(QuadratureFunction &qf)
    }
 }
 
-void ConstantCoefficient::Project(QuadratureFunction &qf)
+void ConstantCoefficient::Project(QuadratureFunction &qf) const
 {
    qf = constant;
 }
 
 double PWConstCoefficient::Eval(ElementTransformation & T,
-                                const IntegrationPoint & ip)
+                                const IntegrationPoint & ip) const
 {
    int att = T.Attribute;
    return (constants(att-1));
@@ -112,7 +112,7 @@ void PWCoefficient::SetTime(double t)
 }
 
 double PWCoefficient::Eval(ElementTransformation &T,
-                           const IntegrationPoint &ip)
+                           const IntegrationPoint &ip) const
 {
    const int att = T.Attribute;
    std::map<int, Coefficient*>::const_iterator p = pieces.find(att);
@@ -127,7 +127,7 @@ double PWCoefficient::Eval(ElementTransformation &T,
 }
 
 double FunctionCoefficient::Eval(ElementTransformation & T,
-                                 const IntegrationPoint & ip)
+                                 const IntegrationPoint & ip) const
 {
    double x[3];
    Vector transip(x, 3);
@@ -145,42 +145,42 @@ double FunctionCoefficient::Eval(ElementTransformation & T,
 }
 
 double CartesianCoefficient::Eval(ElementTransformation & T,
-                                  const IntegrationPoint & ip)
+                                  const IntegrationPoint & ip) const
 {
    T.Transform(ip, transip);
    return transip[comp];
 }
 
 double CylindricalRadialCoefficient::Eval(ElementTransformation & T,
-                                          const IntegrationPoint & ip)
+                                          const IntegrationPoint & ip) const
 {
    T.Transform(ip, transip);
    return sqrt(transip[0] * transip[0] + transip[1] * transip[1]);
 }
 
 double CylindricalAzimuthalCoefficient::Eval(ElementTransformation & T,
-                                             const IntegrationPoint & ip)
+                                             const IntegrationPoint & ip) const
 {
    T.Transform(ip, transip);
    return atan2(transip[1], transip[0]);
 }
 
 double SphericalRadialCoefficient::Eval(ElementTransformation & T,
-                                        const IntegrationPoint & ip)
+                                        const IntegrationPoint & ip) const
 {
    T.Transform(ip, transip);
    return sqrt(transip * transip);
 }
 
 double SphericalAzimuthalCoefficient::Eval(ElementTransformation & T,
-                                           const IntegrationPoint & ip)
+                                           const IntegrationPoint & ip) const
 {
    T.Transform(ip, transip);
    return atan2(transip[1], transip[0]);
 }
 
 double SphericalPolarCoefficient::Eval(ElementTransformation & T,
-                                       const IntegrationPoint & ip)
+                                       const IntegrationPoint & ip) const
 {
    T.Transform(ip, transip);
    return atan2(sqrt(transip[0] * transip[0] + transip[1] * transip[1]),
@@ -188,7 +188,7 @@ double SphericalPolarCoefficient::Eval(ElementTransformation & T,
 }
 
 double GridFunctionCoefficient::Eval (ElementTransformation &T,
-                                      const IntegrationPoint &ip)
+                                      const IntegrationPoint &ip) const
 {
    Mesh *gf_mesh = GridF->FESpace()->GetMesh();
    if (T.mesh->GetNE() == gf_mesh->GetNE())
@@ -203,7 +203,7 @@ double GridFunctionCoefficient::Eval (ElementTransformation &T,
    }
 }
 
-void GridFunctionCoefficient::Project(QuadratureFunction &qf)
+void GridFunctionCoefficient::Project(QuadratureFunction &qf) const
 {
    qf.ProjectGridFunction(*GridF);
 }
@@ -216,7 +216,7 @@ void TransformedCoefficient::SetTime(double t)
 }
 
 double TransformedCoefficient::Eval(ElementTransformation &T,
-                                    const IntegrationPoint &ip)
+                                    const IntegrationPoint &ip) const
 {
    if (Q2)
    {
@@ -243,14 +243,14 @@ void DeltaCoefficient::SetDeltaCenter(const Vector& vcenter)
    sdim = vcenter.Size();
 }
 
-void DeltaCoefficient::GetDeltaCenter(Vector& vcenter)
+void DeltaCoefficient::GetDeltaCenter(Vector& vcenter) const
 {
    vcenter.SetSize(sdim);
    vcenter = center;
 }
 
 double DeltaCoefficient::EvalDelta(ElementTransformation &T,
-                                   const IntegrationPoint &ip)
+                                   const IntegrationPoint &ip) const
 {
    double w = Scale();
    return weight ? weight->Eval(T, ip, GetTime())*w : w;
@@ -263,7 +263,7 @@ void RestrictedCoefficient::SetTime(double t)
 }
 
 void VectorCoefficient::Eval(DenseMatrix &M, ElementTransformation &T,
-                             const IntegrationRule &ir)
+                             const IntegrationRule &ir) const
 {
    Vector Mi;
    M.SetSize(vdim, ir.GetNPoints());
@@ -276,7 +276,7 @@ void VectorCoefficient::Eval(DenseMatrix &M, ElementTransformation &T,
    }
 }
 
-void VectorCoefficient::Project(QuadratureFunction &qf)
+void VectorCoefficient::Project(QuadratureFunction &qf) const
 {
    MFEM_VERIFY(vdim == qf.GetVDim(), "Wrong sizes.");
    QuadratureSpaceBase &qspace = *qf.GetSpace();
@@ -339,7 +339,7 @@ void PWVectorCoefficient::SetTime(double t)
 }
 
 void PWVectorCoefficient::Eval(Vector &V, ElementTransformation &T,
-                               const IntegrationPoint &ip)
+                               const IntegrationPoint &ip) const
 {
    const int att = T.Attribute;
    std::map<int, VectorCoefficient*>::const_iterator p = pieces.find(att);
@@ -357,14 +357,14 @@ void PWVectorCoefficient::Eval(Vector &V, ElementTransformation &T,
 }
 
 void PositionVectorCoefficient::Eval(Vector &V, ElementTransformation &T,
-                                     const IntegrationPoint &ip)
+                                     const IntegrationPoint &ip) const
 {
    V.SetSize(vdim);
    T.Transform(ip, V);
 }
 
 void VectorFunctionCoefficient::Eval(Vector &V, ElementTransformation &T,
-                                     const IntegrationPoint &ip)
+                                     const IntegrationPoint &ip) const
 {
    double x[3];
    Vector transip(x, 3);
@@ -421,7 +421,7 @@ VectorArrayCoefficient::~VectorArrayCoefficient()
 }
 
 void VectorArrayCoefficient::Eval(Vector &V, ElementTransformation &T,
-                                  const IntegrationPoint &ip)
+                                  const IntegrationPoint &ip) const
 {
    V.SetSize(vdim);
    for (int i = 0; i < vdim; i++)
@@ -443,7 +443,7 @@ void VectorGridFunctionCoefficient::SetGridFunction(const GridFunction *gf)
 }
 
 void VectorGridFunctionCoefficient::Eval(Vector &V, ElementTransformation &T,
-                                         const IntegrationPoint &ip)
+                                         const IntegrationPoint &ip) const
 {
    Mesh *gf_mesh = GridFunc->FESpace()->GetMesh();
    if (T.mesh->GetNE() == gf_mesh->GetNE())
@@ -459,7 +459,7 @@ void VectorGridFunctionCoefficient::Eval(Vector &V, ElementTransformation &T,
 }
 
 void VectorGridFunctionCoefficient::Eval(
-   DenseMatrix &M, ElementTransformation &T, const IntegrationRule &ir)
+   DenseMatrix &M, ElementTransformation &T, const IntegrationRule &ir) const
 {
    if (T.mesh == GridFunc->FESpace()->GetMesh())
    {
@@ -471,7 +471,7 @@ void VectorGridFunctionCoefficient::Eval(
    }
 }
 
-void VectorGridFunctionCoefficient::Project(QuadratureFunction &qf)
+void VectorGridFunctionCoefficient::Project(QuadratureFunction &qf) const
 {
    qf.ProjectGridFunction(*GridFunc);
 }
@@ -491,7 +491,7 @@ void GradientGridFunctionCoefficient::SetGridFunction(const GridFunction *gf)
 }
 
 void GradientGridFunctionCoefficient::Eval(Vector &V, ElementTransformation &T,
-                                           const IntegrationPoint &ip)
+                                           const IntegrationPoint &ip) const
 {
    Mesh *gf_mesh = GridFunc->FESpace()->GetMesh();
    if (T.mesh->GetNE() == gf_mesh->GetNE())
@@ -507,7 +507,7 @@ void GradientGridFunctionCoefficient::Eval(Vector &V, ElementTransformation &T,
 }
 
 void GradientGridFunctionCoefficient::Eval(
-   DenseMatrix &M, ElementTransformation &T, const IntegrationRule &ir)
+   DenseMatrix &M, ElementTransformation &T, const IntegrationRule &ir) const
 {
    if (T.mesh == GridFunc->FESpace()->GetMesh())
    {
@@ -532,7 +532,7 @@ void CurlGridFunctionCoefficient::SetGridFunction(const GridFunction *gf)
 }
 
 void CurlGridFunctionCoefficient::Eval(Vector &V, ElementTransformation &T,
-                                       const IntegrationPoint &ip)
+                                       const IntegrationPoint &ip) const
 {
    Mesh *gf_mesh = GridFunc->FESpace()->GetMesh();
    if (T.mesh->GetNE() == gf_mesh->GetNE())
@@ -554,7 +554,7 @@ DivergenceGridFunctionCoefficient::DivergenceGridFunctionCoefficient (
 }
 
 double DivergenceGridFunctionCoefficient::Eval(ElementTransformation &T,
-                                               const IntegrationPoint &ip)
+                                               const IntegrationPoint &ip) const
 {
    Mesh *gf_mesh = GridFunc->FESpace()->GetMesh();
    if (T.mesh->GetNE() == gf_mesh->GetNE())
@@ -582,10 +582,9 @@ void VectorDeltaCoefficient::SetDirection(const Vector &d_)
 }
 
 void VectorDeltaCoefficient::EvalDelta(
-   Vector &V, ElementTransformation &T, const IntegrationPoint &ip)
+   Vector &V, ElementTransformation &T, const IntegrationPoint &ip) const
 {
    V = dir;
-   d.SetTime(GetTime());
    V *= d.EvalDelta(T, ip);
 }
 
@@ -596,7 +595,7 @@ void VectorRestrictedCoefficient::SetTime(double t)
 }
 
 void VectorRestrictedCoefficient::Eval(Vector &V, ElementTransformation &T,
-                                       const IntegrationPoint &ip)
+                                       const IntegrationPoint &ip) const
 {
    V.SetSize(vdim);
    if (active_attr[T.Attribute-1])
@@ -611,7 +610,7 @@ void VectorRestrictedCoefficient::Eval(Vector &V, ElementTransformation &T,
 }
 
 void VectorRestrictedCoefficient::Eval(
-   DenseMatrix &M, ElementTransformation &T, const IntegrationRule &ir)
+   DenseMatrix &M, ElementTransformation &T, const IntegrationRule &ir) const
 {
    if (active_attr[T.Attribute-1])
    {
@@ -625,7 +624,7 @@ void VectorRestrictedCoefficient::Eval(
    }
 }
 
-void MatrixCoefficient::Project(QuadratureFunction &qf, bool transpose)
+void MatrixCoefficient::Project(QuadratureFunction &qf, bool transpose) const
 {
    MFEM_VERIFY(qf.GetVDim() == height*width, "Wrong sizes.");
    QuadratureSpaceBase &qspace = *qf.GetSpace();
@@ -697,7 +696,7 @@ void PWMatrixCoefficient::SetTime(double t)
 }
 
 void PWMatrixCoefficient::Eval(DenseMatrix &K, ElementTransformation &T,
-                               const IntegrationPoint &ip)
+                               const IntegrationPoint &ip) const
 {
    const int att = T.Attribute;
    std::map<int, MatrixCoefficient*>::const_iterator p = pieces.find(att);
@@ -721,7 +720,7 @@ void MatrixFunctionCoefficient::SetTime(double t)
 }
 
 void MatrixFunctionCoefficient::Eval(DenseMatrix &K, ElementTransformation &T,
-                                     const IntegrationPoint &ip)
+                                     const IntegrationPoint &ip) const
 {
    double x[3];
    Vector transip(x, 3);
@@ -826,7 +825,7 @@ void SymmetricMatrixCoefficient::ProjectSymmetric(QuadratureFunction &qf)
 
 
 void SymmetricMatrixCoefficient::Eval(DenseMatrix &K, ElementTransformation &T,
-                                      const IntegrationPoint &ip)
+                                      const IntegrationPoint &ip) const
 {
    mat.SetSize(height);
    Eval(mat, T, ip);
@@ -847,7 +846,7 @@ void SymmetricMatrixFunctionCoefficient::SetTime(double t)
 
 void SymmetricMatrixFunctionCoefficient::Eval(DenseSymmetricMatrix &K,
                                               ElementTransformation &T,
-                                              const IntegrationPoint &ip)
+                                              const IntegrationPoint &ip) const
 {
    double x[3];
    Vector transip(x, 3);
@@ -912,7 +911,7 @@ MatrixArrayCoefficient::~MatrixArrayCoefficient ()
 }
 
 void MatrixArrayCoefficient::Eval(DenseMatrix &K, ElementTransformation &T,
-                                  const IntegrationPoint &ip)
+                                  const IntegrationPoint &ip) const
 {
    K.SetSize(height, width);
    for (int i = 0; i < height; i++)
@@ -931,7 +930,7 @@ void MatrixRestrictedCoefficient::SetTime(double t)
 }
 
 void MatrixRestrictedCoefficient::Eval(DenseMatrix &K, ElementTransformation &T,
-                                       const IntegrationPoint &ip)
+                                       const IntegrationPoint &ip) const
 {
    if (active_attr[T.Attribute-1])
    {
@@ -989,7 +988,7 @@ void InnerProductCoefficient::SetTime(double t)
 }
 
 double InnerProductCoefficient::Eval(ElementTransformation &T,
-                                     const IntegrationPoint &ip)
+                                     const IntegrationPoint &ip) const
 {
    a->Eval(va, T, ip);
    b->Eval(vb, T, ip);
@@ -1013,7 +1012,7 @@ void VectorRotProductCoefficient::SetTime(double t)
 }
 
 double VectorRotProductCoefficient::Eval(ElementTransformation &T,
-                                         const IntegrationPoint &ip)
+                                         const IntegrationPoint &ip) const
 {
    a->Eval(va, T, ip);
    b->Eval(vb, T, ip);
@@ -1035,7 +1034,7 @@ void DeterminantCoefficient::SetTime(double t)
 }
 
 double DeterminantCoefficient::Eval(ElementTransformation &T,
-                                    const IntegrationPoint &ip)
+                                    const IntegrationPoint &ip) const
 {
    a->Eval(ma, T, ip);
    return ma.Det();
@@ -1092,7 +1091,7 @@ void VectorSumCoefficient::SetTime(double t)
 }
 
 void VectorSumCoefficient::Eval(Vector &V, ElementTransformation &T,
-                                const IntegrationPoint &ip)
+                                const IntegrationPoint &ip) const
 {
    V.SetSize(A.Size());
    if (    ACoef) { ACoef->Eval(A, T, ip); }
@@ -1122,7 +1121,7 @@ void ScalarVectorProductCoefficient::SetTime(double t)
 }
 
 void ScalarVectorProductCoefficient::Eval(Vector &V, ElementTransformation &T,
-                                          const IntegrationPoint &ip)
+                                          const IntegrationPoint &ip) const
 {
    double sa = (a == NULL) ? aConst : a->Eval(T, ip);
    b->Eval(V, T, ip);
@@ -1141,7 +1140,7 @@ void NormalizedVectorCoefficient::SetTime(double t)
 }
 
 void NormalizedVectorCoefficient::Eval(Vector &V, ElementTransformation &T,
-                                       const IntegrationPoint &ip)
+                                       const IntegrationPoint &ip) const
 {
    a->Eval(V, T, ip);
    double nv = V.Norml2();
@@ -1166,7 +1165,7 @@ void VectorCrossProductCoefficient::SetTime(double t)
 }
 
 void VectorCrossProductCoefficient::Eval(Vector &V, ElementTransformation &T,
-                                         const IntegrationPoint &ip)
+                                         const IntegrationPoint &ip) const
 {
    a->Eval(va, T, ip);
    b->Eval(vb, T, ip);
@@ -1194,7 +1193,7 @@ void MatrixVectorProductCoefficient::SetTime(double t)
 }
 
 void MatrixVectorProductCoefficient::Eval(Vector &V, ElementTransformation &T,
-                                          const IntegrationPoint &ip)
+                                          const IntegrationPoint &ip) const
 {
    a->Eval(ma, T, ip);
    b->Eval(vb, T, ip);
@@ -1203,7 +1202,7 @@ void MatrixVectorProductCoefficient::Eval(Vector &V, ElementTransformation &T,
 }
 
 void IdentityMatrixCoefficient::Eval(DenseMatrix &M, ElementTransformation &T,
-                                     const IntegrationPoint &ip)
+                                     const IntegrationPoint &ip) const
 {
    M.SetSize(dim);
    M = 0.0;
@@ -1230,7 +1229,7 @@ void MatrixSumCoefficient::SetTime(double t)
 }
 
 void MatrixSumCoefficient::Eval(DenseMatrix &M, ElementTransformation &T,
-                                const IntegrationPoint &ip)
+                                const IntegrationPoint &ip) const
 {
    b->Eval(M, T, ip);
    if ( beta != 1.0 ) { M *= beta; }
@@ -1251,7 +1250,7 @@ MatrixProductCoefficient::MatrixProductCoefficient(MatrixCoefficient &A,
 }
 
 void MatrixProductCoefficient::Eval(DenseMatrix &M, ElementTransformation &T,
-                                    const IntegrationPoint &ip)
+                                    const IntegrationPoint &ip) const
 {
    a->Eval(ma, T, ip);
    b->Eval(mb, T, ip);
@@ -1279,7 +1278,7 @@ void ScalarMatrixProductCoefficient::SetTime(double t)
 
 void ScalarMatrixProductCoefficient::Eval(DenseMatrix &M,
                                           ElementTransformation &T,
-                                          const IntegrationPoint &ip)
+                                          const IntegrationPoint &ip) const
 {
    double sa = (a == NULL) ? aConst : a->Eval(T, ip);
    b->Eval(M, T, ip);
@@ -1298,7 +1297,7 @@ void TransposeMatrixCoefficient::SetTime(double t)
 
 void TransposeMatrixCoefficient::Eval(DenseMatrix &M,
                                       ElementTransformation &T,
-                                      const IntegrationPoint &ip)
+                                      const IntegrationPoint &ip) const
 {
    a->Eval(M, T, ip);
    M.Transpose();
@@ -1320,7 +1319,7 @@ void InverseMatrixCoefficient::SetTime(double t)
 
 void InverseMatrixCoefficient::Eval(DenseMatrix &M,
                                     ElementTransformation &T,
-                                    const IntegrationPoint &ip)
+                                    const IntegrationPoint &ip) const
 {
    a->Eval(M, T, ip);
    M.Invert();
@@ -1340,7 +1339,7 @@ void OuterProductCoefficient::SetTime(double t)
 }
 
 void OuterProductCoefficient::Eval(DenseMatrix &M, ElementTransformation &T,
-                                   const IntegrationPoint &ip)
+                                   const IntegrationPoint &ip) const
 {
    a->Eval(va, T, ip);
    b->Eval(vb, T, ip);
@@ -1373,7 +1372,7 @@ void CrossCrossCoefficient::SetTime(double t)
 }
 
 void CrossCrossCoefficient::Eval(DenseMatrix &M, ElementTransformation &T,
-                                 const IntegrationPoint &ip)
+                                 const IntegrationPoint &ip) const
 {
    k->Eval(vk, T, ip);
    M.SetSize(vk.Size(), vk.Size());
@@ -1587,7 +1586,7 @@ void VectorQuadratureFunctionCoefficient::SetComponent(int index_, int length_)
 
 void VectorQuadratureFunctionCoefficient::Eval(Vector &V,
                                                ElementTransformation &T,
-                                               const IntegrationPoint &ip)
+                                               const IntegrationPoint &ip) const
 {
    QuadF.HostRead();
 
@@ -1616,7 +1615,7 @@ void VectorQuadratureFunctionCoefficient::Eval(Vector &V,
    return;
 }
 
-void VectorQuadratureFunctionCoefficient::Project(QuadratureFunction &qf)
+void VectorQuadratureFunctionCoefficient::Project(QuadratureFunction &qf) const
 {
    qf = QuadF;
 }
@@ -1628,7 +1627,7 @@ QuadratureFunctionCoefficient::QuadratureFunctionCoefficient(
 }
 
 double QuadratureFunctionCoefficient::Eval(ElementTransformation &T,
-                                           const IntegrationPoint &ip)
+                                           const IntegrationPoint &ip) const
 {
    QuadF.HostRead();
    Vector temp(1);
@@ -1641,7 +1640,7 @@ double QuadratureFunctionCoefficient::Eval(ElementTransformation &T,
    return temp[0];
 }
 
-void QuadratureFunctionCoefficient::Project(QuadratureFunction &qf)
+void QuadratureFunctionCoefficient::Project(QuadratureFunction &qf) const
 {
    qf = QuadF;
 }

--- a/fem/coefficient.cpp
+++ b/fem/coefficient.cpp
@@ -365,8 +365,8 @@ void PositionVectorCoefficient::Eval(Vector &V, ElementTransformation &T,
 
 void VectorFunctionCoefficient::SetTime(double t)
 {
-    if (Q) Q->SetTime(t);
-    this->VectorCoefficient::SetTime(t);
+   if (Q) { Q->SetTime(t); }
+   this->VectorCoefficient::SetTime(t);
 }
 
 void VectorFunctionCoefficient::Eval(Vector &V, ElementTransformation &T,

--- a/fem/coefficient.hpp
+++ b/fem/coefficient.hpp
@@ -763,6 +763,9 @@ public:
       : VectorCoefficient(dim), TDFunction(std::move(TDF)), Q(q)
    { }
 
+   /// Set the time for time dependent coefficients
+   virtual void SetTime(double t);
+
    using VectorCoefficient::Eval;
    /// Evaluate the vector coefficient at @a ip.
    virtual void Eval(Vector &V, ElementTransformation &T,

--- a/fem/coefficient.hpp
+++ b/fem/coefficient.hpp
@@ -58,8 +58,19 @@ public:
        IntegrationPoint associated with @a T is the same as @a ip. This can be
        achieved by calling T.SetIntPoint(&ip). */
    virtual double Eval(ElementTransformation &T,
-                       const IntegrationPoint &ip) const = 0;
+                       const IntegrationPoint &ip) const
+   {
+      mfem_error ("Coefficient::Eval(...) const\n"
+               "   is not implemented for this class.");
+      return 0.0;
+   }
 
+   /** @deprecated Overload the const- version of this member function instead*/
+   virtual double Eval(ElementTransformation &T, const IntegrationPoint &ip)
+   {
+      return const_cast<const Coefficient*>(this)->Eval(T,ip);
+   }
+   
    /** @brief Evaluate the coefficient in the element described by @a T at the
        point @a ip at time @a t. */
    /** @note When this method is called, the caller must make sure that the
@@ -588,7 +599,18 @@ public:
        IntegrationPoint associated with @a T is the same as @a ip. This can be
        achieved by calling T.SetIntPoint(&ip). */
    virtual void Eval(Vector &V, ElementTransformation &T,
-                     const IntegrationPoint &ip) const = 0;
+                     const IntegrationPoint &ip) const
+   {
+      mfem_error ("VectorCoefficient::Eval(...) const\n"
+               "   is not implemented for this class.");
+   }
+
+   /** @deprecated Use/overload the const- version of this member function instead */
+   virtual void Eval(Vector &V, ElementTransformation &T,
+                     const IntegrationPoint &ip)
+   {
+      const_cast<const VectorCoefficient*>(this)->Eval(V, T, ip);
+   } 
 
    /** @brief Evaluate the vector coefficient in the element described by @a T
        at all points of @a ir, storing the result in @a M. */
@@ -1080,8 +1102,18 @@ public:
        IntegrationPoint associated with @a T is the same as @a ip. This can be
        achieved by calling T.SetIntPoint(&ip). */
    virtual void Eval(DenseMatrix &K, ElementTransformation &T,
-                     const IntegrationPoint &ip) const = 0;
+                     const IntegrationPoint &ip) const
+    {
+        mfem_error ("MatrixCoefficient::Eval(...) const\n"
+               "   is not implemented for this class.");
+    }
 
+   /** @deprecated Use/overload the const- version of this member function instead*/
+   virtual void Eval(DenseMatrix &K, ElementTransformation &T,
+                     const IntegrationPoint &ip)
+   {
+      const_cast<const MatrixCoefficient*>(this)->Eval(K, T, ip);
+   }
    /// @brief Fill the QuadratureFunction @a qf by evaluating the coefficient at
    /// the quadrature points. The matrix will be transposed or not according to
    /// the boolean argument @a transpose.

--- a/fem/coefficient.hpp
+++ b/fem/coefficient.hpp
@@ -61,7 +61,7 @@ public:
                        const IntegrationPoint &ip) const
    {
       mfem_error ("Coefficient::Eval(...) const\n"
-               "   is not implemented for this class.");
+                  "   is not implemented for this class.");
       return 0.0;
    }
 
@@ -70,14 +70,14 @@ public:
    {
       return const_cast<const Coefficient*>(this)->Eval(T,ip);
    }
-   
+
    /** @brief Evaluate the coefficient in the element described by @a T at the
        point @a ip at time @a t. */
    /** @note When this method is called, the caller must make sure that the
        IntegrationPoint associated with @a T is the same as @a ip. This can be
        achieved by calling T.SetIntPoint(&ip). */
    double Eval(ElementTransformation &T,
-               const IntegrationPoint &ip, double t) 
+               const IntegrationPoint &ip, double t)
    {
       SetTime(t);
       return Eval(T, ip);
@@ -542,7 +542,8 @@ public:
    void GetDeltaCenter(Vector& center) const;
 
    /// The value of the function assuming we are evaluating at the delta center.
-   virtual double EvalDelta(ElementTransformation &T, const IntegrationPoint &ip) const;
+   virtual double EvalDelta(ElementTransformation &T,
+                            const IntegrationPoint &ip) const;
    /** @brief A DeltaFunction cannot be evaluated. Calling this method will
        cause an MFEM error, terminating the application. */
    virtual double Eval(ElementTransformation &T, const IntegrationPoint &ip) const
@@ -602,7 +603,7 @@ public:
                      const IntegrationPoint &ip) const
    {
       mfem_error ("VectorCoefficient::Eval(...) const\n"
-               "   is not implemented for this class.");
+                  "   is not implemented for this class.");
    }
 
    /** @deprecated Use/overload the const- version of this member function instead */
@@ -610,7 +611,7 @@ public:
                      const IntegrationPoint &ip)
    {
       const_cast<const VectorCoefficient*>(this)->Eval(V, T, ip);
-   } 
+   }
 
    /** @brief Evaluate the vector coefficient in the element described by @a T
        at all points of @a ir, storing the result in @a M. */
@@ -1103,10 +1104,10 @@ public:
        achieved by calling T.SetIntPoint(&ip). */
    virtual void Eval(DenseMatrix &K, ElementTransformation &T,
                      const IntegrationPoint &ip) const
-    {
-        mfem_error ("MatrixCoefficient::Eval(...) const\n"
-               "   is not implemented for this class.");
-    }
+   {
+      mfem_error ("MatrixCoefficient::Eval(...) const\n"
+                  "   is not implemented for this class.");
+   }
 
    /** @deprecated Use/overload the const- version of this member function instead*/
    virtual void Eval(DenseMatrix &K, ElementTransformation &T,
@@ -1359,7 +1360,8 @@ public:
 
    /// Evaluate coefficient located at (i,j) in the matrix using integration
    /// point @a ip.
-   double Eval(int i, int j, ElementTransformation &T, const IntegrationPoint &ip) const
+   double Eval(int i, int j, ElementTransformation &T,
+               const IntegrationPoint &ip) const
    { return Coeff[i*width+j] ? Coeff[i*width+j] -> Eval(T, ip, GetTime()) : 0.0; }
 
    /// Evaluate the matrix coefficient @a ip.
@@ -1750,7 +1752,7 @@ public:
    const VectorCoefficient * GetBCoef() const { return b; }
    /// Return the second vector coefficient in the inner product
    VectorCoefficient * GetBCoef() { return b; }
-   
+
    /// Evaluate the coefficient at @a ip.
    virtual double Eval(ElementTransformation &T,
                        const IntegrationPoint &ip) const;

--- a/fem/coefficient.hpp
+++ b/fem/coefficient.hpp
@@ -1794,14 +1794,14 @@ private:
    VectorCoefficient * ACoef;
    VectorCoefficient * BCoef;
 
-   Vector A;
-   Vector B;
+   mutable Vector A;
+   mutable Vector B;
 
    Coefficient * alphaCoef;
    Coefficient * betaCoef;
 
-   double alpha;
-   double beta;
+   mutable double alpha;
+   mutable double beta;
 
    mutable Vector va;
 

--- a/fem/coefficient.hpp
+++ b/fem/coefficient.hpp
@@ -1116,7 +1116,7 @@ public:
 
    /** @deprecated Use SymmetricMatrixCoefficient instead */
    bool IsSymmetric() const { return symmetric; }
-   
+
    /** @brief Evaluate the matrix coefficient in the element described by @a T
        at the point @a ip, storing the result in @a K. */
    /** @note When this method is called, the caller must make sure that the
@@ -1385,7 +1385,7 @@ public:
    double Eval(int i, int j, ElementTransformation &T,
                const IntegrationPoint &ip) const
    { return Coeff[i*width+j] ? Coeff[i*width+j] -> Eval(T, ip, GetTime()) : 0.0; }
-   
+
    /// Evaluate the matrix coefficient @a ip.
    virtual void Eval(DenseMatrix &K, ElementTransformation &T,
                      const IntegrationPoint &ip) const;

--- a/fem/coefficient.hpp
+++ b/fem/coefficient.hpp
@@ -50,7 +50,7 @@ public:
    virtual void SetTime(double t) { time = t; }
 
    /// Get the time for time dependent coefficients
-   double GetTime() { return time; }
+   double GetTime() const { return time; }
 
    /** @brief Evaluate the coefficient in the element described by @a T at the
        point @a ip. */
@@ -58,7 +58,7 @@ public:
        IntegrationPoint associated with @a T is the same as @a ip. This can be
        achieved by calling T.SetIntPoint(&ip). */
    virtual double Eval(ElementTransformation &T,
-                       const IntegrationPoint &ip) = 0;
+                       const IntegrationPoint &ip) const = 0;
 
    /** @brief Evaluate the coefficient in the element described by @a T at the
        point @a ip at time @a t. */
@@ -66,7 +66,7 @@ public:
        IntegrationPoint associated with @a T is the same as @a ip. This can be
        achieved by calling T.SetIntPoint(&ip). */
    double Eval(ElementTransformation &T,
-               const IntegrationPoint &ip, double t)
+               const IntegrationPoint &ip, double t) 
    {
       SetTime(t);
       return Eval(T, ip);
@@ -74,7 +74,7 @@ public:
 
    /// @brief Fill the QuadratureFunction @a qf by evaluating the coefficient at
    /// the quadrature points.
-   virtual void Project(QuadratureFunction &qf);
+   virtual void Project(QuadratureFunction &qf) const;
 
    virtual ~Coefficient() { }
 };
@@ -91,11 +91,11 @@ public:
 
    /// Evaluate the coefficient at @a ip.
    virtual double Eval(ElementTransformation &T,
-                       const IntegrationPoint &ip)
+                       const IntegrationPoint &ip) const
    { return (constant); }
 
    /// Fill the QuadratureFunction @a qf with the constant value.
-   void Project(QuadratureFunction &qf);
+   void Project(QuadratureFunction &qf) const;
 };
 
 /** @brief A piecewise constant coefficient with the constants keyed
@@ -127,11 +127,11 @@ public:
    void operator=(double c) { constants = c; }
 
    /// Returns the number of constants representing different attributes.
-   int GetNConst() { return constants.Size(); }
+   int GetNConst() const { return constants.Size(); }
 
    /// Evaluate the coefficient.
    virtual double Eval(ElementTransformation &T,
-                       const IntegrationPoint &ip);
+                       const IntegrationPoint &ip) const;
 };
 
 /** @brief A piecewise coefficient with the pieces keyed off the element
@@ -212,7 +212,7 @@ public:
 
    /// Evaluate the coefficient.
    virtual double Eval(ElementTransformation &T,
-                       const IntegrationPoint &ip);
+                       const IntegrationPoint &ip) const;
 };
 
 /// A general function coefficient
@@ -255,7 +255,7 @@ public:
 
    /// Evaluate the coefficient at @a ip.
    virtual double Eval(ElementTransformation &T,
-                       const IntegrationPoint &ip);
+                       const IntegrationPoint &ip) const;
 };
 
 /// A common base class for returning individual components of the domain's
@@ -272,7 +272,7 @@ protected:
 public:
    /// Evaluate the coefficient at @a ip.
    virtual double Eval(ElementTransformation &T,
-                       const IntegrationPoint &ip);
+                       const IntegrationPoint &ip) const;
 };
 
 /// Scalar coefficient which returns the x-component of the evaluation point
@@ -308,7 +308,7 @@ public:
 
    /// Evaluate the coefficient at @a ip.
    virtual double Eval(ElementTransformation &T,
-                       const IntegrationPoint &ip);
+                       const IntegrationPoint &ip) const;
 };
 
 /// Scalar coefficient which returns the angular position or azimuth (often
@@ -324,7 +324,7 @@ public:
 
    /// Evaluate the coefficient at @a ip.
    virtual double Eval(ElementTransformation &T,
-                       const IntegrationPoint &ip);
+                       const IntegrationPoint &ip) const;
 };
 
 /// Scalar coefficient which returns the height or altitude of
@@ -343,7 +343,7 @@ public:
 
    /// Evaluate the coefficient at @a ip.
    virtual double Eval(ElementTransformation &T,
-                       const IntegrationPoint &ip);
+                       const IntegrationPoint &ip) const;
 };
 
 /// Scalar coefficient which returns the azimuthal angle (often denoted by phi)
@@ -358,7 +358,7 @@ public:
 
    /// Evaluate the coefficient at @a ip.
    virtual double Eval(ElementTransformation &T,
-                       const IntegrationPoint &ip);
+                       const IntegrationPoint &ip) const;
 };
 
 /// Scalar coefficient which returns the polar angle (often denoted by theta)
@@ -373,7 +373,7 @@ public:
 
    /// Evaluate the coefficient at @a ip.
    virtual double Eval(ElementTransformation &T,
-                       const IntegrationPoint &ip);
+                       const IntegrationPoint &ip) const;
 };
 
 class GridFunction;
@@ -400,14 +400,14 @@ public:
 
    /// Evaluate the coefficient at @a ip.
    virtual double Eval(ElementTransformation &T,
-                       const IntegrationPoint &ip);
+                       const IntegrationPoint &ip) const;
 
    /// @brief Fill the QuadratureFunction @a qf by evaluating the coefficient at
    /// the quadrature points.
    ///
    /// This function uses the efficient QuadratureFunction::ProjectGridFunction
    /// to fill the QuadratureFunction.
-   virtual void Project(QuadratureFunction &qf);
+   virtual void Project(QuadratureFunction &qf) const;
 };
 
 
@@ -436,7 +436,7 @@ public:
    void SetTime(double t);
 
    /// Evaluate the coefficient at @a ip.
-   virtual double Eval(ElementTransformation &T, const IntegrationPoint &ip);
+   virtual double Eval(ElementTransformation &T, const IntegrationPoint &ip) const;
 };
 
 /** @brief Delta function coefficient optionally multiplied by a weight
@@ -519,22 +519,22 @@ public:
    /** @brief Return the scale factor times the optional time dependent
        function.  Returns $ s T(t) $ with $ T(t) = 1 $ when
        not set by the user. */
-   double Scale() { return tdf ? (*tdf)(GetTime())*scale : scale; }
+   double Scale() const { return tdf ? (*tdf)(GetTime())*scale : scale; }
 
    /// Return the tolerance used to identify the mesh vertices
-   double Tol() { return tol; }
+   double Tol() const { return tol; }
 
    /// See SetWeight() for description of the weight Coefficient.
    Coefficient *Weight() { return weight; }
 
    /// Write the center of the delta function into @a center.
-   void GetDeltaCenter(Vector& center);
+   void GetDeltaCenter(Vector& center) const;
 
    /// The value of the function assuming we are evaluating at the delta center.
-   virtual double EvalDelta(ElementTransformation &T, const IntegrationPoint &ip);
+   virtual double EvalDelta(ElementTransformation &T, const IntegrationPoint &ip) const;
    /** @brief A DeltaFunction cannot be evaluated. Calling this method will
        cause an MFEM error, terminating the application. */
-   virtual double Eval(ElementTransformation &T, const IntegrationPoint &ip)
+   virtual double Eval(ElementTransformation &T, const IntegrationPoint &ip) const
    { mfem_error("DeltaCoefficient::Eval"); return 0.; }
    virtual ~DeltaCoefficient() { delete weight; }
 };
@@ -558,7 +558,7 @@ public:
    void SetTime(double t);
 
    /// Evaluate the coefficient at @a ip.
-   virtual double Eval(ElementTransformation &T, const IntegrationPoint &ip)
+   virtual double Eval(ElementTransformation &T, const IntegrationPoint &ip) const
    { return active_attr[T.Attribute-1] ? c->Eval(T, ip, GetTime()) : 0.0; }
 };
 
@@ -577,10 +577,10 @@ public:
    virtual void SetTime(double t) { time = t; }
 
    /// Get the time for time dependent coefficients
-   double GetTime() { return time; }
+   double GetTime() const { return time; }
 
    /// Returns dimension of the vector.
-   int GetVDim() { return vdim; }
+   int GetVDim() const { return vdim; }
 
    /** @brief Evaluate the vector coefficient in the element described by @a T
        at the point @a ip, storing the result in @a V. */
@@ -588,7 +588,7 @@ public:
        IntegrationPoint associated with @a T is the same as @a ip. This can be
        achieved by calling T.SetIntPoint(&ip). */
    virtual void Eval(Vector &V, ElementTransformation &T,
-                     const IntegrationPoint &ip) = 0;
+                     const IntegrationPoint &ip) const = 0;
 
    /** @brief Evaluate the vector coefficient in the element described by @a T
        at all points of @a ir, storing the result in @a M. */
@@ -603,14 +603,14 @@ public:
        method will generally modify this IntegrationPoint associated with @a T.
    */
    virtual void Eval(DenseMatrix &M, ElementTransformation &T,
-                     const IntegrationRule &ir);
+                     const IntegrationRule &ir) const;
 
    /// @brief Fill the QuadratureFunction @a qf by evaluating the coefficient at
    /// the quadrature points.
    ///
    /// The @a vdim of the VectorCoefficient should be equal to the @a vdim of
    /// the QuadratureFunction.
-   virtual void Project(QuadratureFunction &qf);
+   virtual void Project(QuadratureFunction &qf) const;
 
    virtual ~VectorCoefficient() { }
 };
@@ -629,7 +629,7 @@ public:
 
    ///  Evaluate the vector coefficient at @a ip.
    virtual void Eval(Vector &V, ElementTransformation &T,
-                     const IntegrationPoint &ip) { V = vec; }
+                     const IntegrationPoint &ip) const { V = vec; }
 
    /// Return a reference to the constant vector in this class.
    const Vector& GetVec() const { return vec; }
@@ -714,7 +714,7 @@ public:
 
    /// Evaluate the coefficient.
    virtual void Eval(Vector &V, ElementTransformation &T,
-                     const IntegrationPoint &ip);
+                     const IntegrationPoint &ip) const;
    using VectorCoefficient::Eval;
 };
 
@@ -729,7 +729,7 @@ public:
    using VectorCoefficient::Eval;
    /// Evaluate the vector coefficient at @a ip.
    virtual void Eval(Vector &V, ElementTransformation &T,
-                     const IntegrationPoint &ip);
+                     const IntegrationPoint &ip) const;
 
    virtual ~PositionVectorCoefficient() { }
 };
@@ -766,7 +766,7 @@ public:
    using VectorCoefficient::Eval;
    /// Evaluate the vector coefficient at @a ip.
    virtual void Eval(Vector &V, ElementTransformation &T,
-                     const IntegrationPoint &ip);
+                     const IntegrationPoint &ip) const;
 
    virtual ~VectorFunctionCoefficient() { }
 };
@@ -800,14 +800,14 @@ public:
 
    /// Evaluates i'th component of the vector of coefficients and returns the
    /// value.
-   double Eval(int i, ElementTransformation &T, const IntegrationPoint &ip)
+   double Eval(int i, ElementTransformation &T, const IntegrationPoint &ip) const
    { return Coeff[i] ? Coeff[i]->Eval(T, ip, GetTime()) : 0.0; }
 
    using VectorCoefficient::Eval;
    /** @brief Evaluate the coefficient. Each element of vector V comes from the
        associated array of scalar coefficients. */
    virtual void Eval(Vector &V, ElementTransformation &T,
-                     const IntegrationPoint &ip);
+                     const IntegrationPoint &ip) const;
 
    /// Destroys vector coefficient.
    virtual ~VectorArrayCoefficient();
@@ -837,20 +837,20 @@ public:
 
    /// Evaluate the vector coefficient at @a ip.
    virtual void Eval(Vector &V, ElementTransformation &T,
-                     const IntegrationPoint &ip);
+                     const IntegrationPoint &ip) const;
 
    /** @brief Evaluate the vector coefficients at all of the locations in the
        integration rule and write the vectors into the columns of matrix @a
        M. */
    virtual void Eval(DenseMatrix &M, ElementTransformation &T,
-                     const IntegrationRule &ir);
+                     const IntegrationRule &ir) const;
 
    /// @brief Fill the QuadratureFunction @a qf by evaluating the coefficient at
    /// the quadrature points.
    ///
    /// This function uses the efficient QuadratureFunction::ProjectGridFunction
    /// to fill the QuadratureFunction.
-   virtual void Project(QuadratureFunction &qf);
+   virtual void Project(QuadratureFunction &qf) const;
 
    virtual ~VectorGridFunctionCoefficient() { }
 };
@@ -875,13 +875,13 @@ public:
 
    /// Evaluate the gradient vector coefficient at @a ip.
    virtual void Eval(Vector &V, ElementTransformation &T,
-                     const IntegrationPoint &ip);
+                     const IntegrationPoint &ip) const;
 
    /** @brief Evaluate the gradient vector coefficient at all of the locations
        in the integration rule and write the vectors into columns of matrix @a
        M. */
    virtual void Eval(DenseMatrix &M, ElementTransformation &T,
-                     const IntegrationRule &ir);
+                     const IntegrationRule &ir) const;
 
    virtual ~GradientGridFunctionCoefficient() { }
 };
@@ -906,7 +906,7 @@ public:
    using VectorCoefficient::Eval;
    /// Evaluate the vector curl coefficient at @a ip.
    virtual void Eval(Vector &V, ElementTransformation &T,
-                     const IntegrationPoint &ip);
+                     const IntegrationPoint &ip) const;
 
    virtual ~CurlGridFunctionCoefficient() { }
 };
@@ -930,7 +930,7 @@ public:
 
    /// Evaluate the scalar divergence coefficient at @a ip.
    virtual double Eval(ElementTransformation &T,
-                       const IntegrationPoint &ip);
+                       const IntegrationPoint &ip) const;
 
    virtual ~DivergenceGridFunctionCoefficient() { }
 };
@@ -987,19 +987,19 @@ public:
    void SetDirection(const Vector& d_);
 
    void SetDeltaCenter(const Vector& center) { d.SetDeltaCenter(center); }
-   void GetDeltaCenter(Vector& center) { d.GetDeltaCenter(center); }
+   void GetDeltaCenter(Vector& center) const { d.GetDeltaCenter(center); }
 
    /** @brief Return the specified direction vector multiplied by the value
        returned by DeltaCoefficient::EvalDelta() of the associated scalar
        DeltaCoefficient. */
    virtual void EvalDelta(Vector &V, ElementTransformation &T,
-                          const IntegrationPoint &ip);
+                          const IntegrationPoint &ip) const;
 
    using VectorCoefficient::Eval;
    /** @brief A VectorDeltaFunction cannot be evaluated. Calling this method
        will cause an MFEM error, terminating the application. */
    virtual void Eval(Vector &V, ElementTransformation &T,
-                     const IntegrationPoint &ip)
+                     const IntegrationPoint &ip) const
    { mfem_error("VectorDeltaCoefficient::Eval"); }
    virtual ~VectorDeltaCoefficient() { }
 };
@@ -1025,13 +1025,13 @@ public:
 
    /// Evaluate the vector coefficient at @a ip.
    virtual void Eval(Vector &V, ElementTransformation &T,
-                     const IntegrationPoint &ip);
+                     const IntegrationPoint &ip) const;
 
    /** @brief Evaluate the vector coefficient at all of the locations in the
        integration rule and write the vectors into the columns of matrix @a
        M. */
    virtual void Eval(DenseMatrix &M, ElementTransformation &T,
-                     const IntegrationRule &ir);
+                     const IntegrationRule &ir) const;
 };
 
 typedef VectorCoefficient DiagonalMatrixCoefficient;
@@ -1057,7 +1057,7 @@ public:
    virtual void SetTime(double t) { time = t; }
 
    /// Get the time for time dependent coefficients
-   double GetTime() { return time; }
+   double GetTime() const { return time; }
 
    /// Get the height of the matrix.
    int GetHeight() const { return height; }
@@ -1077,7 +1077,7 @@ public:
        IntegrationPoint associated with @a T is the same as @a ip. This can be
        achieved by calling T.SetIntPoint(&ip). */
    virtual void Eval(DenseMatrix &K, ElementTransformation &T,
-                     const IntegrationPoint &ip) = 0;
+                     const IntegrationPoint &ip) const = 0;
 
    /// @brief Fill the QuadratureFunction @a qf by evaluating the coefficient at
    /// the quadrature points. The matrix will be transposed or not according to
@@ -1085,7 +1085,7 @@ public:
    ///
    /// The @a vdim of the QuadratureFunction should be equal to the height times
    /// the width of the matrix.
-   virtual void Project(QuadratureFunction &qf, bool transpose=false);
+   virtual void Project(QuadratureFunction &qf, bool transpose=false) const;
 
    /// (DEPRECATED) Evaluate a symmetric matrix coefficient.
    /** @brief Evaluate the upper triangular entries of the matrix coefficient
@@ -1114,7 +1114,7 @@ public:
    using MatrixCoefficient::Eval;
    /// Evaluate the matrix coefficient at @a ip.
    virtual void Eval(DenseMatrix &M, ElementTransformation &T,
-                     const IntegrationPoint &ip) { M = mat; }
+                     const IntegrationPoint &ip) const { M = mat; }
    /// Return a reference to the constant matrix.
    const DenseMatrix& GetMatrix() { return mat; }
 };
@@ -1223,7 +1223,7 @@ public:
 
    /// Evaluate the coefficient.
    virtual void Eval(DenseMatrix &K, ElementTransformation &T,
-                     const IntegrationPoint &ip);
+                     const IntegrationPoint &ip) const;
 };
 
 /** @brief A matrix coefficient with an optional scalar coefficient multiplier
@@ -1284,7 +1284,7 @@ public:
 
    /// Evaluate the matrix coefficient at @a ip.
    virtual void Eval(DenseMatrix &K, ElementTransformation &T,
-                     const IntegrationPoint &ip);
+                     const IntegrationPoint &ip) const;
 
    /// (DEPRECATED) Evaluate the symmetric matrix coefficient at @a ip.
    /** @deprecated Use Eval() instead. */
@@ -1324,12 +1324,12 @@ public:
 
    /// Evaluate coefficient located at (i,j) in the matrix using integration
    /// point @a ip.
-   double Eval(int i, int j, ElementTransformation &T, const IntegrationPoint &ip)
+   double Eval(int i, int j, ElementTransformation &T, const IntegrationPoint &ip) const
    { return Coeff[i*width+j] ? Coeff[i*width+j] -> Eval(T, ip, GetTime()) : 0.0; }
 
    /// Evaluate the matrix coefficient @a ip.
    virtual void Eval(DenseMatrix &K, ElementTransformation &T,
-                     const IntegrationPoint &ip);
+                     const IntegrationPoint &ip) const;
 
    virtual ~MatrixArrayCoefficient();
 };
@@ -1356,7 +1356,7 @@ public:
 
    /// Evaluate the matrix coefficient at @a ip.
    virtual void Eval(DenseMatrix &K, ElementTransformation &T,
-                     const IntegrationPoint &ip);
+                     const IntegrationPoint &ip) const;
 };
 
 /// Coefficients based on sums, products, or other functions of coefficients.
@@ -1414,7 +1414,7 @@ public:
 
    /// Evaluate the coefficient at @a ip.
    virtual double Eval(ElementTransformation &T,
-                       const IntegrationPoint &ip)
+                       const IntegrationPoint &ip) const
    {
       return alpha * ((a == NULL ) ? aConst : a->Eval(T, ip) )
              + beta * b->Eval(T, ip);
@@ -1451,7 +1451,7 @@ public:
        IntegrationPoint associated with @a T is the same as @a ip. This can be
        achieved by calling T.SetIntPoint(&ip). */
    virtual void Eval(DenseSymmetricMatrix &K, ElementTransformation &T,
-                     const IntegrationPoint &ip) = 0;
+                     const IntegrationPoint &ip) const = 0;
 
    /** @brief Evaluate the matrix coefficient in the element described by @a T
        at the point @a ip, storing the result as a dense matrix @a K. */
@@ -1462,10 +1462,10 @@ public:
        IntegrationPoint associated with @a T is the same as @a ip. This can be
        achieved by calling T.SetIntPoint(&ip). */
    virtual void Eval(DenseMatrix &K, ElementTransformation &T,
-                     const IntegrationPoint &ip);
+                     const IntegrationPoint &ip) const;
 
    /// Return a reference to the constant matrix.
-   const DenseSymmetricMatrix& GetMatrix() { return mat; }
+   const DenseSymmetricMatrix& GetMatrix() const { return mat; }
 
    virtual ~SymmetricMatrixCoefficient() { }
 };
@@ -1484,7 +1484,7 @@ public:
    using SymmetricMatrixCoefficient::Eval;
    /// Evaluate the matrix coefficient at @a ip.
    virtual void Eval(DenseSymmetricMatrix &M, ElementTransformation &T,
-                     const IntegrationPoint &ip) { M = mat; }
+                     const IntegrationPoint &ip) const { M = mat; }
 };
 
 
@@ -1535,7 +1535,7 @@ public:
    using SymmetricMatrixCoefficient::Eval;
    /// Evaluate the matrix coefficient at @a ip.
    virtual void Eval(DenseSymmetricMatrix &K, ElementTransformation &T,
-                     const IntegrationPoint &ip);
+                     const IntegrationPoint &ip) const;
 
    virtual ~SymmetricMatrixFunctionCoefficient() { }
 };
@@ -1579,7 +1579,7 @@ public:
 
    /// Evaluate the coefficient at @a ip.
    virtual double Eval(ElementTransformation &T,
-                       const IntegrationPoint &ip)
+                       const IntegrationPoint &ip) const
    { return ((a == NULL ) ? aConst : a->Eval(T, ip) ) * b->Eval(T, ip); }
 };
 
@@ -1632,7 +1632,7 @@ public:
 
    /// Evaluate the coefficient
    virtual double Eval(ElementTransformation &T,
-                       const IntegrationPoint &ip)
+                       const IntegrationPoint &ip) const
    {
       double den = (b == NULL ) ? bConst : b->Eval(T, ip);
       MFEM_ASSERT(den != 0.0, "Division by zero in RatioCoefficient");
@@ -1668,7 +1668,7 @@ public:
 
    /// Evaluate the coefficient at @a ip.
    virtual double Eval(ElementTransformation &T,
-                       const IntegrationPoint &ip)
+                       const IntegrationPoint &ip) const
    { return pow(a->Eval(T, ip), p); }
 };
 
@@ -1701,7 +1701,7 @@ public:
 
    /// Evaluate the coefficient at @a ip.
    virtual double Eval(ElementTransformation &T,
-                       const IntegrationPoint &ip);
+                       const IntegrationPoint &ip) const;
 };
 
 /// Scalar coefficient defined as a cross product of two vectors in the xy-plane.
@@ -1733,7 +1733,7 @@ public:
 
    /// Evaluate the coefficient at @a ip.
    virtual double Eval(ElementTransformation &T,
-                       const IntegrationPoint &ip);
+                       const IntegrationPoint &ip) const;
 };
 
 /// Scalar coefficient defined as the determinant of a matrix coefficient
@@ -1758,7 +1758,7 @@ public:
 
    /// Evaluate the determinant coefficient at @a ip.
    virtual double Eval(ElementTransformation &T,
-                       const IntegrationPoint &ip);
+                       const IntegrationPoint &ip) const;
 };
 
 /// Vector coefficient defined as the linear combination of two vectors
@@ -1839,7 +1839,7 @@ public:
 
    /// Evaluate the coefficient at @a ip.
    virtual void Eval(Vector &V, ElementTransformation &T,
-                     const IntegrationPoint &ip);
+                     const IntegrationPoint &ip) const;
    using VectorCoefficient::Eval;
 };
 
@@ -1878,7 +1878,7 @@ public:
 
    /// Evaluate the coefficient at @a ip.
    virtual void Eval(Vector &V, ElementTransformation &T,
-                     const IntegrationPoint &ip);
+                     const IntegrationPoint &ip) const;
    using VectorCoefficient::Eval;
 };
 
@@ -1909,7 +1909,7 @@ public:
 
    /// Evaluate the coefficient at @a ip.
    virtual void Eval(Vector &V, ElementTransformation &T,
-                     const IntegrationPoint &ip);
+                     const IntegrationPoint &ip) const;
    using VectorCoefficient::Eval;
 };
 
@@ -1942,7 +1942,7 @@ public:
 
    /// Evaluate the coefficient at @a ip.
    virtual void Eval(Vector &V, ElementTransformation &T,
-                     const IntegrationPoint &ip);
+                     const IntegrationPoint &ip) const;
    using VectorCoefficient::Eval;
 };
 
@@ -1976,7 +1976,7 @@ public:
 
    /// Evaluate the vector coefficient at @a ip.
    virtual void Eval(Vector &V, ElementTransformation &T,
-                     const IntegrationPoint &ip);
+                     const IntegrationPoint &ip) const;
    using VectorCoefficient::Eval;
 };
 
@@ -1996,7 +1996,7 @@ public:
 
    /// Evaluate the matrix coefficient at @a ip.
    virtual void Eval(DenseMatrix &M, ElementTransformation &T,
-                     const IntegrationPoint &ip);
+                     const IntegrationPoint &ip) const;
 };
 
 /// Matrix coefficient defined as the linear combination of two matrices
@@ -2041,7 +2041,7 @@ public:
 
    /// Evaluate the matrix coefficient at @a ip.
    virtual void Eval(DenseMatrix &M, ElementTransformation &T,
-                     const IntegrationPoint &ip);
+                     const IntegrationPoint &ip) const;
 };
 
 /// Matrix coefficient defined as the product of two matrices
@@ -2070,7 +2070,7 @@ public:
 
    /// Evaluate the matrix coefficient at @a ip.
    virtual void Eval(DenseMatrix &M, ElementTransformation &T,
-                     const IntegrationPoint &ip);
+                     const IntegrationPoint &ip) const;
 };
 
 /** @brief Matrix coefficient defined as a product of a scalar coefficient and a
@@ -2109,7 +2109,7 @@ public:
 
    /// Evaluate the matrix coefficient at @a ip.
    virtual void Eval(DenseMatrix &M, ElementTransformation &T,
-                     const IntegrationPoint &ip);
+                     const IntegrationPoint &ip) const;
 };
 
 /// Matrix coefficient defined as the transpose a matrix coefficient
@@ -2132,7 +2132,7 @@ public:
 
    /// Evaluate the matrix coefficient at @a ip.
    virtual void Eval(DenseMatrix &M, ElementTransformation &T,
-                     const IntegrationPoint &ip);
+                     const IntegrationPoint &ip) const;
 };
 
 /// Matrix coefficient defined as the inverse a matrix coefficient.
@@ -2155,7 +2155,7 @@ public:
 
    /// Evaluate the matrix coefficient at @a ip.
    virtual void Eval(DenseMatrix &M, ElementTransformation &T,
-                     const IntegrationPoint &ip);
+                     const IntegrationPoint &ip) const;
 };
 
 /// Matrix coefficient defined as the outer product of two vector coefficients.
@@ -2187,7 +2187,7 @@ public:
 
    /// Evaluate the matrix coefficient at @a ip.
    virtual void Eval(DenseMatrix &M, ElementTransformation &T,
-                     const IntegrationPoint &ip);
+                     const IntegrationPoint &ip) const;
 };
 
 /** @brief Matrix coefficient defined as -a k x k x, for a vector k and scalar a
@@ -2230,7 +2230,7 @@ public:
 
    /// Evaluate the matrix coefficient at @a ip.
    virtual void Eval(DenseMatrix &M, ElementTransformation &T,
-                     const IntegrationPoint &ip);
+                     const IntegrationPoint &ip) const;
 };
 ///@}
 
@@ -2256,9 +2256,9 @@ public:
 
    using VectorCoefficient::Eval;
    virtual void Eval(Vector &V, ElementTransformation &T,
-                     const IntegrationPoint &ip);
+                     const IntegrationPoint &ip) const;
 
-   virtual void Project(QuadratureFunction &qf);
+   virtual void Project(QuadratureFunction &qf) const;
 
    virtual ~VectorQuadratureFunctionCoefficient() { }
 };
@@ -2277,9 +2277,9 @@ public:
 
    const QuadratureFunction& GetQuadFunction() const { return QuadF; }
 
-   virtual double Eval(ElementTransformation &T, const IntegrationPoint &ip);
+   virtual double Eval(ElementTransformation &T, const IntegrationPoint &ip) const;
 
-   virtual void Project(QuadratureFunction &qf);
+   virtual void Project(QuadratureFunction &qf) const;
 
    virtual ~QuadratureFunctionCoefficient() { }
 };

--- a/fem/coefficient.hpp
+++ b/fem/coefficient.hpp
@@ -1516,7 +1516,18 @@ public:
        IntegrationPoint associated with @a T is the same as @a ip. This can be
        achieved by calling T.SetIntPoint(&ip). */
    virtual void Eval(DenseSymmetricMatrix &K, ElementTransformation &T,
-                     const IntegrationPoint &ip) const = 0;
+                     const IntegrationPoint &ip) const
+   {
+      mfem_error ("SymmetricMatrixCoefficient::Eval(...) const\n"
+                  "   is not implemented for this class.");
+   }
+
+   /** @deprecated Use/overload the const- version of this member function instead*/
+   virtual void Eval(DenseSymmetricMatrix &K, ElementTransformation &T,
+                     const IntegrationPoint &ip)
+   {
+      const_cast<const SymmetricMatrixCoefficient*>(this)->Eval(K, T, ip);
+   }
 
    using MatrixCoefficient::Eval;
    /** @brief Evaluate the matrix coefficient in the element described by @a T

--- a/fem/coefficient.hpp
+++ b/fem/coefficient.hpp
@@ -100,6 +100,7 @@ public:
    /// c is value of constant function
    explicit ConstantCoefficient(double c = 1.0) { constant=c; }
 
+   using Coefficient::Eval;
    /// Evaluate the coefficient at @a ip.
    virtual double Eval(ElementTransformation &T,
                        const IntegrationPoint &ip) const
@@ -140,6 +141,7 @@ public:
    /// Returns the number of constants representing different attributes.
    int GetNConst() const { return constants.Size(); }
 
+   using Coefficient::Eval;
    /// Evaluate the coefficient.
    virtual double Eval(ElementTransformation &T,
                        const IntegrationPoint &ip) const;
@@ -221,6 +223,7 @@ public:
    void ZeroCoefficient(int attr)
    { pieces.erase(attr); }
 
+   using Coefficient::Eval;
    /// Evaluate the coefficient.
    virtual double Eval(ElementTransformation &T,
                        const IntegrationPoint &ip) const;
@@ -264,6 +267,7 @@ public:
       TDFunction = reinterpret_cast<double(*)(const Vector&,double)>(tdf);
    }
 
+   using Coefficient::Eval;
    /// Evaluate the coefficient at @a ip.
    virtual double Eval(ElementTransformation &T,
                        const IntegrationPoint &ip) const;
@@ -281,6 +285,7 @@ protected:
    CartesianCoefficient(int comp_) : comp(comp_), transip(3) {}
 
 public:
+   using Coefficient::Eval;
    /// Evaluate the coefficient at @a ip.
    virtual double Eval(ElementTransformation &T,
                        const IntegrationPoint &ip) const;
@@ -317,6 +322,7 @@ private:
 public:
    CylindricalRadialCoefficient() : transip(3) {}
 
+   using Coefficient::Eval;
    /// Evaluate the coefficient at @a ip.
    virtual double Eval(ElementTransformation &T,
                        const IntegrationPoint &ip) const;
@@ -333,6 +339,7 @@ private:
 public:
    CylindricalAzimuthalCoefficient() : transip(3) {}
 
+   using Coefficient::Eval;
    /// Evaluate the coefficient at @a ip.
    virtual double Eval(ElementTransformation &T,
                        const IntegrationPoint &ip) const;
@@ -352,6 +359,7 @@ private:
 public:
    SphericalRadialCoefficient() : transip(3) {}
 
+   using Coefficient::Eval;
    /// Evaluate the coefficient at @a ip.
    virtual double Eval(ElementTransformation &T,
                        const IntegrationPoint &ip) const;
@@ -367,6 +375,7 @@ private:
 public:
    SphericalAzimuthalCoefficient() : transip(3) {}
 
+   using Coefficient::Eval;
    /// Evaluate the coefficient at @a ip.
    virtual double Eval(ElementTransformation &T,
                        const IntegrationPoint &ip) const;
@@ -382,6 +391,7 @@ private:
 public:
    SphericalPolarCoefficient() : transip(3) {}
 
+   using Coefficient::Eval;
    /// Evaluate the coefficient at @a ip.
    virtual double Eval(ElementTransformation &T,
                        const IntegrationPoint &ip) const;
@@ -409,6 +419,7 @@ public:
    /// Get the internal GridFunction
    const GridFunction * GetGridFunction() const { return GridF; }
 
+   using Coefficient::Eval;
    /// Evaluate the coefficient at @a ip.
    virtual double Eval(ElementTransformation &T,
                        const IntegrationPoint &ip) const;
@@ -446,6 +457,7 @@ public:
    /// Set the time for internally stored coefficients
    void SetTime(double t);
 
+   using Coefficient::Eval;
    /// Evaluate the coefficient at @a ip.
    virtual double Eval(ElementTransformation &T, const IntegrationPoint &ip) const;
 };
@@ -544,6 +556,8 @@ public:
    /// The value of the function assuming we are evaluating at the delta center.
    virtual double EvalDelta(ElementTransformation &T,
                             const IntegrationPoint &ip) const;
+
+   using Coefficient::Eval;
    /** @brief A DeltaFunction cannot be evaluated. Calling this method will
        cause an MFEM error, terminating the application. */
    virtual double Eval(ElementTransformation &T, const IntegrationPoint &ip) const
@@ -569,6 +583,7 @@ public:
    /// Set the time for internally stored coefficients
    void SetTime(double t);
 
+   using Coefficient::Eval;
    /// Evaluate the coefficient at @a ip.
    virtual double Eval(ElementTransformation &T, const IntegrationPoint &ip) const
    { return active_attr[T.Attribute-1] ? c->Eval(T, ip, GetTime()) : 0.0; }
@@ -612,6 +627,7 @@ public:
    {
       const_cast<const VectorCoefficient*>(this)->Eval(V, T, ip);
    }
+
 
    /** @brief Evaluate the vector coefficient in the element described by @a T
        at all points of @a ir, storing the result in @a M. */
@@ -861,6 +877,7 @@ public:
    ///  Returns a pointer to the grid function in this Coefficient
    const GridFunction * GetGridFunction() const { return GridFunc; }
 
+   using VectorCoefficient::Eval;
    /// Evaluate the vector coefficient at @a ip.
    virtual void Eval(Vector &V, ElementTransformation &T,
                      const IntegrationPoint &ip) const;
@@ -899,6 +916,7 @@ public:
    ///Get the scalar grid function.
    const GridFunction * GetGridFunction() const { return GridFunc; }
 
+   using VectorCoefficient::Eval;
    /// Evaluate the gradient vector coefficient at @a ip.
    virtual void Eval(Vector &V, ElementTransformation &T,
                      const IntegrationPoint &ip) const;
@@ -954,6 +972,7 @@ public:
    /// Get the vector grid function.
    const GridFunction * GetGridFunction() const { return GridFunc; }
 
+   using Coefficient::Eval;
    /// Evaluate the scalar divergence coefficient at @a ip.
    virtual double Eval(ElementTransformation &T,
                        const IntegrationPoint &ip) const;
@@ -1049,6 +1068,7 @@ public:
    /// Set the time for internally stored coefficients
    void SetTime(double t);
 
+   using VectorCoefficient::Eval;
    /// Evaluate the vector coefficient at @a ip.
    virtual void Eval(Vector &V, ElementTransformation &T,
                      const IntegrationPoint &ip) const;
@@ -1096,7 +1116,7 @@ public:
 
    /** @deprecated Use SymmetricMatrixCoefficient instead */
    bool IsSymmetric() const { return symmetric; }
-
+   
    /** @brief Evaluate the matrix coefficient in the element described by @a T
        at the point @a ip, storing the result in @a K. */
    /** @note When this method is called, the caller must make sure that the
@@ -1257,6 +1277,7 @@ public:
    void ZeroCoefficient(int attr)
    { pieces.erase(attr); }
 
+   using MatrixCoefficient::Eval;
    /// Evaluate the coefficient.
    virtual void Eval(DenseMatrix &K, ElementTransformation &T,
                      const IntegrationPoint &ip) const;
@@ -1318,6 +1339,7 @@ public:
    /// Set the time for internally stored coefficients
    void SetTime(double t);
 
+   using MatrixCoefficient::Eval;
    /// Evaluate the matrix coefficient at @a ip.
    virtual void Eval(DenseMatrix &K, ElementTransformation &T,
                      const IntegrationPoint &ip) const;
@@ -1363,7 +1385,7 @@ public:
    double Eval(int i, int j, ElementTransformation &T,
                const IntegrationPoint &ip) const
    { return Coeff[i*width+j] ? Coeff[i*width+j] -> Eval(T, ip, GetTime()) : 0.0; }
-
+   
    /// Evaluate the matrix coefficient @a ip.
    virtual void Eval(DenseMatrix &K, ElementTransformation &T,
                      const IntegrationPoint &ip) const;
@@ -1391,6 +1413,7 @@ public:
    /// Set the time for internally stored coefficients
    void SetTime(double t);
 
+   using MatrixCoefficient::Eval;
    /// Evaluate the matrix coefficient at @a ip.
    virtual void Eval(DenseMatrix &K, ElementTransformation &T,
                      const IntegrationPoint &ip) const;
@@ -1453,6 +1476,7 @@ public:
    /// Return the factor in front of the second term in the linear combination
    double GetBeta() const { return beta; }
 
+   using Coefficient::Eval;
    /// Evaluate the coefficient at @a ip.
    virtual double Eval(ElementTransformation &T,
                        const IntegrationPoint &ip) const
@@ -1494,6 +1518,7 @@ public:
    virtual void Eval(DenseSymmetricMatrix &K, ElementTransformation &T,
                      const IntegrationPoint &ip) const = 0;
 
+   using MatrixCoefficient::Eval;
    /** @brief Evaluate the matrix coefficient in the element described by @a T
        at the point @a ip, storing the result as a dense matrix @a K. */
    /** This function allows the use of SymmetricMatrixCoefficient in situations
@@ -1622,6 +1647,7 @@ public:
    /// Return the second term in the product
    Coefficient * GetBCoef() { return b; }
 
+   using Coefficient::Eval;
    /// Evaluate the coefficient at @a ip.
    virtual double Eval(ElementTransformation &T,
                        const IntegrationPoint &ip) const
@@ -1679,6 +1705,7 @@ public:
    /// Return the denominator of the ratio
    Coefficient * GetBCoef() { return b; }
 
+   using Coefficient::Eval;
    /// Evaluate the coefficient
    virtual double Eval(ElementTransformation &T,
                        const IntegrationPoint &ip) const
@@ -1716,6 +1743,7 @@ public:
    /// Return the exponent
    double GetExponent() const { return p; }
 
+   using Coefficient::Eval;
    /// Evaluate the coefficient at @a ip.
    virtual double Eval(ElementTransformation &T,
                        const IntegrationPoint &ip) const
@@ -1753,6 +1781,7 @@ public:
    /// Return the second vector coefficient in the inner product
    VectorCoefficient * GetBCoef() { return b; }
 
+   using Coefficient::Eval;
    /// Evaluate the coefficient at @a ip.
    virtual double Eval(ElementTransformation &T,
                        const IntegrationPoint &ip) const;
@@ -1789,6 +1818,7 @@ public:
    /// Return the second vector of the product
    VectorCoefficient * GetBCoef() { return b; }
 
+   using Coefficient::Eval;
    /// Evaluate the coefficient at @a ip.
    virtual double Eval(ElementTransformation &T,
                        const IntegrationPoint &ip) const;
@@ -1816,6 +1846,7 @@ public:
    /// Return the matrix coefficient
    MatrixCoefficient * GetACoef() { return a; }
 
+   using Coefficient::Eval;
    /// Evaluate the determinant coefficient at @a ip.
    virtual double Eval(ElementTransformation &T,
                        const IntegrationPoint &ip) const;
@@ -2076,6 +2107,7 @@ public:
    IdentityMatrixCoefficient(int d)
       : MatrixCoefficient(d, d), dim(d) { }
 
+   using MatrixCoefficient::Eval;
    /// Evaluate the matrix coefficient at @a ip.
    virtual void Eval(DenseMatrix &M, ElementTransformation &T,
                      const IntegrationPoint &ip) const;
@@ -2125,6 +2157,7 @@ public:
    /// Return the factor in front of the second matrix coefficient
    double GetBeta() const { return beta; }
 
+   using MatrixCoefficient::Eval;
    /// Evaluate the matrix coefficient at @a ip.
    virtual void Eval(DenseMatrix &M, ElementTransformation &T,
                      const IntegrationPoint &ip) const;
@@ -2158,6 +2191,7 @@ public:
    /// Return the second matrix coefficient
    MatrixCoefficient * GetBCoef() { return b; }
 
+   using MatrixCoefficient::Eval;
    /// Evaluate the matrix coefficient at @a ip.
    virtual void Eval(DenseMatrix &M, ElementTransformation &T,
                      const IntegrationPoint &ip) const;
@@ -2201,6 +2235,7 @@ public:
    /// Return the matrix factor
    MatrixCoefficient * GetBCoef() { return b; }
 
+   using MatrixCoefficient::Eval;
    /// Evaluate the matrix coefficient at @a ip.
    virtual void Eval(DenseMatrix &M, ElementTransformation &T,
                      const IntegrationPoint &ip) const;
@@ -2226,6 +2261,7 @@ public:
    /// Return the matrix coefficient
    MatrixCoefficient * GetACoef() { return a; }
 
+   using MatrixCoefficient::Eval;
    /// Evaluate the matrix coefficient at @a ip.
    virtual void Eval(DenseMatrix &M, ElementTransformation &T,
                      const IntegrationPoint &ip) const;
@@ -2251,6 +2287,7 @@ public:
    /// Return the matrix coefficient
    MatrixCoefficient * GetACoef() { return a; }
 
+   using MatrixCoefficient::Eval;
    /// Evaluate the matrix coefficient at @a ip.
    virtual void Eval(DenseMatrix &M, ElementTransformation &T,
                      const IntegrationPoint &ip) const;
@@ -2287,6 +2324,7 @@ public:
    /// Return the second vector coefficient in the outer product
    VectorCoefficient * GetBCoef() { return b; }
 
+   using MatrixCoefficient::Eval;
    /// Evaluate the matrix coefficient at @a ip.
    virtual void Eval(DenseMatrix &M, ElementTransformation &T,
                      const IntegrationPoint &ip) const;
@@ -2334,6 +2372,7 @@ public:
    /// Return the vector factor
    VectorCoefficient * GetKCoef() { return k; }
 
+   using MatrixCoefficient::Eval;
    /// Evaluate the matrix coefficient at @a ip.
    virtual void Eval(DenseMatrix &M, ElementTransformation &T,
                      const IntegrationPoint &ip) const;
@@ -2383,6 +2422,7 @@ public:
 
    const QuadratureFunction& GetQuadFunction() const { return QuadF; }
 
+   using Coefficient::Eval;
    virtual double Eval(ElementTransformation &T, const IntegrationPoint &ip) const;
 
    virtual void Project(QuadratureFunction &qf) const;

--- a/fem/coefficient.hpp
+++ b/fem/coefficient.hpp
@@ -1398,12 +1398,16 @@ public:
    /// Reset the first term in the linear combination
    void SetACoef(Coefficient &A) { a = &A; }
    /// Return the first term in the linear combination
-   Coefficient * GetACoef() const { return a; }
+   const Coefficient * GetACoef() const { return a; }
+   /// Return the first term in the linear combination
+   Coefficient * GetACoef() { return a; }
 
    /// Reset the second term in the linear combination
    void SetBCoef(Coefficient &B) { b = &B; }
    /// Return the second term in the linear combination
-   Coefficient * GetBCoef() const { return b; }
+   const Coefficient * GetBCoef() const { return b; }
+   /// Return the second term in the linear combination
+   Coefficient * GetBCoef() { return b; }
 
    /// Reset the factor in front of the first term in the linear combination
    void SetAlpha(double alpha_) { alpha = alpha_; }
@@ -1430,7 +1434,7 @@ class SymmetricMatrixCoefficient : public MatrixCoefficient
 {
 protected:
    /// Internal matrix used when evaluating this coefficient as a DenseMatrix.
-   DenseSymmetricMatrix mat;
+   mutable DenseSymmetricMatrix mat;
 public:
    /// Construct a dim x dim matrix coefficient.
    explicit SymmetricMatrixCoefficient(int dimension)
@@ -1573,12 +1577,16 @@ public:
    /// Reset the first term in the product
    void SetACoef(Coefficient &A) { a = &A; }
    /// Return the first term in the product
-   Coefficient * GetACoef() const { return a; }
+   const Coefficient * GetACoef() const { return a; }
+   /// Return the first term in the product
+   Coefficient * GetACoef() { return a; }
 
    /// Reset the second term in the product
    void SetBCoef(Coefficient &B) { b = &B; }
    /// Return the second term in the product
-   Coefficient * GetBCoef() const { return b; }
+   const Coefficient * GetBCoef() const { return b; }
+   /// Return the second term in the product
+   Coefficient * GetBCoef() { return b; }
 
    /// Evaluate the coefficient at @a ip.
    virtual double Eval(ElementTransformation &T,
@@ -1626,12 +1634,16 @@ public:
    /// Reset the numerator in the ratio
    void SetACoef(Coefficient &A) { a = &A; }
    /// Return the numerator of the ratio
-   Coefficient * GetACoef() const { return a; }
+   const Coefficient * GetACoef() const { return a; }
+   /// Return the numerator of the ratio
+   Coefficient * GetACoef() { return a; }
 
    /// Reset the denominator in the ratio
    void SetBCoef(Coefficient &B) { b = &B; }
    /// Return the denominator of the ratio
-   Coefficient * GetBCoef() const { return b; }
+   const Coefficient * GetBCoef() const { return b; }
+   /// Return the denominator of the ratio
+   Coefficient * GetBCoef() { return b; }
 
    /// Evaluate the coefficient
    virtual double Eval(ElementTransformation &T,
@@ -1662,8 +1674,9 @@ public:
    /// Reset the base coefficient
    void SetACoef(Coefficient &A) { a = &A; }
    /// Return the base coefficient
-   Coefficient * GetACoef() const { return a; }
-
+   const Coefficient * GetACoef() const { return a; }
+   /// Return the base coefficient
+   Coefficient * GetACoef() { return a; }
    /// Reset the exponent
    void SetExponent(double p_) { p = p_; }
    /// Return the exponent
@@ -1695,13 +1708,17 @@ public:
    /// Reset the first vector in the inner product
    void SetACoef(VectorCoefficient &A) { a = &A; }
    /// Return the first vector coefficient in the inner product
-   VectorCoefficient * GetACoef() const { return a; }
+   const VectorCoefficient * GetACoef() const { return a; }
+   /// Return the first vector coefficient in the inner product
+   VectorCoefficient * GetACoef() { return a; }
 
    /// Reset the second vector in the inner product
    void SetBCoef(VectorCoefficient &B) { b = &B; }
    /// Return the second vector coefficient in the inner product
-   VectorCoefficient * GetBCoef() const { return b; }
-
+   const VectorCoefficient * GetBCoef() const { return b; }
+   /// Return the second vector coefficient in the inner product
+   VectorCoefficient * GetBCoef() { return b; }
+   
    /// Evaluate the coefficient at @a ip.
    virtual double Eval(ElementTransformation &T,
                        const IntegrationPoint &ip) const;
@@ -1727,12 +1744,16 @@ public:
    /// Reset the first vector in the product
    void SetACoef(VectorCoefficient &A) { a = &A; }
    /// Return the first vector of the product
-   VectorCoefficient * GetACoef() const { return a; }
+   const VectorCoefficient * GetACoef() const { return a; }
+   /// Return the first vector of the product
+   VectorCoefficient * GetACoef() { return a; }
 
    /// Reset the second vector in the product
    void SetBCoef(VectorCoefficient &B) { b = &B; }
    /// Return the second vector of the product
-   VectorCoefficient * GetBCoef() const { return b; }
+   const VectorCoefficient * GetBCoef() const { return b; }
+   /// Return the second vector of the product
+   VectorCoefficient * GetBCoef() { return b; }
 
    /// Evaluate the coefficient at @a ip.
    virtual double Eval(ElementTransformation &T,
@@ -1757,7 +1778,9 @@ public:
    /// Reset the matrix coefficient
    void SetACoef(MatrixCoefficient &A) { a = &A; }
    /// Return the matrix coefficient
-   MatrixCoefficient * GetACoef() const { return a; }
+   const MatrixCoefficient * GetACoef() const { return a; }
+   /// Return the matrix coefficient
+   MatrixCoefficient * GetACoef() { return a; }
 
    /// Evaluate the determinant coefficient at @a ip.
    virtual double Eval(ElementTransformation &T,
@@ -1803,22 +1826,30 @@ public:
    /// Reset the first vector coefficient
    void SetACoef(VectorCoefficient &A_) { ACoef = &A_; }
    /// Return the first vector coefficient
-   VectorCoefficient * GetACoef() const { return ACoef; }
+   const VectorCoefficient * GetACoef() const { return ACoef; }
+   /// Return the first vector coefficient
+   VectorCoefficient * GetACoef() { return ACoef; }
 
    /// Reset the second vector coefficient
    void SetBCoef(VectorCoefficient &B_) { BCoef = &B_; }
    /// Return the second vector coefficient
-   VectorCoefficient * GetBCoef() const { return BCoef; }
+   const VectorCoefficient * GetBCoef() const { return BCoef; }
+   /// Return the second vector coefficient
+   VectorCoefficient * GetBCoef() { return BCoef; }
 
    /// Reset the factor in front of the first vector coefficient
    void SetAlphaCoef(Coefficient &A_) { alphaCoef = &A_; }
    /// Return the factor in front of the first vector coefficient
-   Coefficient * GetAlphaCoef() const { return alphaCoef; }
+   const Coefficient * GetAlphaCoef() const { return alphaCoef; }
+   /// Return the factor in front of the first vector coefficient
+   Coefficient * GetAlphaCoef() { return alphaCoef; }
 
    /// Reset the factor in front of the second vector coefficient
    void SetBetaCoef(Coefficient &B_) { betaCoef = &B_; }
    /// Return the factor in front of the second vector coefficient
-   Coefficient * GetBetaCoef() const { return betaCoef; }
+   const Coefficient * GetBetaCoef() const { return betaCoef; }
+   /// Return the factor in front of the second vector coefficient
+   Coefficient * GetBetaCoef() { return betaCoef; }
 
    /// Reset the first vector as a constant
    void SetA(const Vector &A_) { A = A_; ACoef = NULL; }
@@ -1872,12 +1903,16 @@ public:
    /// Reset the scalar factor
    void SetACoef(Coefficient &A) { a = &A; }
    /// Return the scalar factor
-   Coefficient * GetACoef() const { return a; }
+   const Coefficient * GetACoef() const { return a; }
+   /// Return the scalar factor
+   Coefficient * GetACoef() { return a; }
 
    /// Reset the vector factor
    void SetBCoef(VectorCoefficient &B) { b = &B; }
    /// Return the vector factor
-   VectorCoefficient * GetBCoef() const { return b; }
+   const VectorCoefficient * GetBCoef() const { return b; }
+   /// Return the vector factor
+   VectorCoefficient * GetBCoef() { return b; }
 
    /// Evaluate the coefficient at @a ip.
    virtual void Eval(Vector &V, ElementTransformation &T,
@@ -1908,7 +1943,9 @@ public:
    /// Reset the vector coefficient
    void SetACoef(VectorCoefficient &A) { a = &A; }
    /// Return the vector coefficient
-   VectorCoefficient * GetACoef() const { return a; }
+   const VectorCoefficient * GetACoef() const { return a; }
+   /// Return the vector coefficient
+   VectorCoefficient * GetACoef() { return a; }
 
    /// Evaluate the coefficient at @a ip.
    virtual void Eval(Vector &V, ElementTransformation &T,
@@ -1936,12 +1973,16 @@ public:
    /// Reset the first term in the product
    void SetACoef(VectorCoefficient &A) { a = &A; }
    /// Return the first term in the product
-   VectorCoefficient * GetACoef() const { return a; }
+   const VectorCoefficient * GetACoef() const { return a; }
+   /// Return the first term in the product
+   VectorCoefficient * GetACoef() { return a; }
 
    /// Reset the second term in the product
    void SetBCoef(VectorCoefficient &B) { b = &B; }
    /// Return the second term in the product
-   VectorCoefficient * GetBCoef() const { return b; }
+   const VectorCoefficient * GetBCoef() const { return b; }
+   /// Return the second term in the product
+   VectorCoefficient * GetBCoef() { return b; }
 
    /// Evaluate the coefficient at @a ip.
    virtual void Eval(Vector &V, ElementTransformation &T,
@@ -1970,12 +2011,16 @@ public:
    /// Reset the matrix coefficient
    void SetACoef(MatrixCoefficient &A) { a = &A; }
    /// Return the matrix coefficient
-   MatrixCoefficient * GetACoef() const { return a; }
+   const MatrixCoefficient * GetACoef() const { return a; }
+   /// Return the matrix coefficient
+   MatrixCoefficient * GetACoef() { return a; }
 
    /// Reset the vector coefficient
    void SetBCoef(VectorCoefficient &B) { b = &B; }
    /// Return the vector coefficient
-   VectorCoefficient * GetBCoef() const { return b; }
+   const VectorCoefficient * GetBCoef() const { return b; }
+   /// Return the vector coefficient
+   VectorCoefficient * GetBCoef() { return b; }
 
    /// Evaluate the vector coefficient at @a ip.
    virtual void Eval(Vector &V, ElementTransformation &T,
@@ -2025,12 +2070,16 @@ public:
    /// Reset the first matrix coefficient
    void SetACoef(MatrixCoefficient &A) { a = &A; }
    /// Return the first matrix coefficient
-   MatrixCoefficient * GetACoef() const { return a; }
+   const MatrixCoefficient * GetACoef() const { return a; }
+   /// Return the first matrix coefficient
+   MatrixCoefficient * GetACoef() { return a; }
 
    /// Reset the second matrix coefficient
    void SetBCoef(MatrixCoefficient &B) { b = &B; }
    /// Return the second matrix coefficient
-   MatrixCoefficient * GetBCoef() const { return b; }
+   const MatrixCoefficient * GetBCoef() const { return b; }
+   /// Return the second matrix coefficient
+   MatrixCoefficient * GetBCoef() { return b; }
 
    /// Reset the factor in front of the first matrix coefficient
    void SetAlpha(double alpha_) { alpha = alpha_; }
@@ -2064,12 +2113,16 @@ public:
    /// Reset the first matrix coefficient
    void SetACoef(MatrixCoefficient &A) { a = &A; }
    /// Return the first matrix coefficient
-   MatrixCoefficient * GetACoef() const { return a; }
+   const MatrixCoefficient * GetACoef() const { return a; }
+   /// Return the first matrix coefficient
+   MatrixCoefficient * GetACoef() { return a; }
 
    /// Reset the second matrix coefficient
    void SetBCoef(MatrixCoefficient &B) { b = &B; }
    /// Return the second matrix coefficient
-   MatrixCoefficient * GetBCoef() const { return b; }
+   const MatrixCoefficient * GetBCoef() const { return b; }
+   /// Return the second matrix coefficient
+   MatrixCoefficient * GetBCoef() { return b; }
 
    /// Evaluate the matrix coefficient at @a ip.
    virtual void Eval(DenseMatrix &M, ElementTransformation &T,
@@ -2103,12 +2156,16 @@ public:
    /// Reset the scalar factor
    void SetACoef(Coefficient &A) { a = &A; }
    /// Return the scalar factor
-   Coefficient * GetACoef() const { return a; }
+   const Coefficient * GetACoef() const { return a; }
+   /// Return the scalar factor
+   Coefficient * GetACoef() { return a; }
 
    /// Reset the matrix factor
    void SetBCoef(MatrixCoefficient &B) { b = &B; }
    /// Return the matrix factor
-   MatrixCoefficient * GetBCoef() const { return b; }
+   const MatrixCoefficient * GetBCoef() const { return b; }
+   /// Return the matrix factor
+   MatrixCoefficient * GetBCoef() { return b; }
 
    /// Evaluate the matrix coefficient at @a ip.
    virtual void Eval(DenseMatrix &M, ElementTransformation &T,
@@ -2131,7 +2188,9 @@ public:
    /// Reset the matrix coefficient
    void SetACoef(MatrixCoefficient &A) { a = &A; }
    /// Return the matrix coefficient
-   MatrixCoefficient * GetACoef() const { return a; }
+   const MatrixCoefficient * GetACoef() const { return a; }
+   /// Return the matrix coefficient
+   MatrixCoefficient * GetACoef() { return a; }
 
    /// Evaluate the matrix coefficient at @a ip.
    virtual void Eval(DenseMatrix &M, ElementTransformation &T,
@@ -2154,7 +2213,9 @@ public:
    /// Reset the matrix coefficient
    void SetACoef(MatrixCoefficient &A) { a = &A; }
    /// Return the matrix coefficient
-   MatrixCoefficient * GetACoef() const { return a; }
+   const MatrixCoefficient * GetACoef() const { return a; }
+   /// Return the matrix coefficient
+   MatrixCoefficient * GetACoef() { return a; }
 
    /// Evaluate the matrix coefficient at @a ip.
    virtual void Eval(DenseMatrix &M, ElementTransformation &T,
@@ -2181,12 +2242,16 @@ public:
    /// Reset the first vector in the outer product
    void SetACoef(VectorCoefficient &A) { a = &A; }
    /// Return the first vector coefficient in the outer product
-   VectorCoefficient * GetACoef() const { return a; }
+   const VectorCoefficient * GetACoef() const { return a; }
+   /// Return the first vector coefficient in the outer product
+   VectorCoefficient * GetACoef() { return a; }
 
    /// Reset the second vector in the outer product
    void SetBCoef(VectorCoefficient &B) { b = &B; }
    /// Return the second vector coefficient in the outer product
-   VectorCoefficient * GetBCoef() const { return b; }
+   const VectorCoefficient * GetBCoef() const { return b; }
+   /// Return the second vector coefficient in the outer product
+   VectorCoefficient * GetBCoef() { return b; }
 
    /// Evaluate the matrix coefficient at @a ip.
    virtual void Eval(DenseMatrix &M, ElementTransformation &T,
@@ -2224,12 +2289,16 @@ public:
    /// Reset the scalar factor
    void SetACoef(Coefficient &A) { a = &A; }
    /// Return the scalar factor
-   Coefficient * GetACoef() const { return a; }
+   const Coefficient * GetACoef() const { return a; }
+   /// Return the scalar factor
+   Coefficient * GetACoef() { return a; }
 
    /// Reset the vector factor
    void SetKCoef(VectorCoefficient &K) { k = &K; }
    /// Return the vector factor
-   VectorCoefficient * GetKCoef() const { return k; }
+   const VectorCoefficient * GetKCoef() const { return k; }
+   /// Return the vector factor
+   VectorCoefficient * GetKCoef() { return k; }
 
    /// Evaluate the matrix coefficient at @a ip.
    virtual void Eval(DenseMatrix &M, ElementTransformation &T,

--- a/fem/gridfunc.cpp
+++ b/fem/gridfunc.cpp
@@ -4449,7 +4449,7 @@ double ComputeElementLpDistance(double p, int i,
 
 
 double ExtrudeCoefficient::Eval(ElementTransformation &T,
-                                const IntegrationPoint &ip)
+                                const IntegrationPoint &ip) const
 {
    ElementTransformation *T_in =
       mesh_in->GetElementTransformation(T.ElementNo / n);

--- a/fem/gridfunc.hpp
+++ b/fem/gridfunc.hpp
@@ -874,7 +874,7 @@ private:
 public:
    ExtrudeCoefficient(Mesh *m, Coefficient &s, int n_)
       : n(n_), mesh_in(m), sol_in(s) { }
-   virtual double Eval(ElementTransformation &T, const IntegrationPoint &ip);
+   virtual double Eval(ElementTransformation &T, const IntegrationPoint &ip) const;
    virtual ~ExtrudeCoefficient() { }
 };
 

--- a/fem/gridfunc.hpp
+++ b/fem/gridfunc.hpp
@@ -874,6 +874,7 @@ private:
 public:
    ExtrudeCoefficient(Mesh *m, Coefficient &s, int n_)
       : n(n_), mesh_in(m), sol_in(s) { }
+   using Coefficient::Eval;
    virtual double Eval(ElementTransformation &T, const IntegrationPoint &ip) const;
    virtual ~ExtrudeCoefficient() { }
 };

--- a/mesh/mesh.cpp
+++ b/mesh/mesh.cpp
@@ -13398,7 +13398,7 @@ NodeExtrudeCoefficient::NodeExtrudeCoefficient(const int dim, const int n_,
 }
 
 void NodeExtrudeCoefficient::Eval(Vector &V, ElementTransformation &T,
-                                  const IntegrationPoint &ip)
+                                  const IntegrationPoint &ip) const
 {
    V.SetSize(vdim);
    T.Transform(ip, tip);

--- a/mesh/mesh.hpp
+++ b/mesh/mesh.hpp
@@ -2550,7 +2550,8 @@ class NodeExtrudeCoefficient : public VectorCoefficient
 private:
    int n, layer;
    double p[2], s;
-   Vector tip;
+   
+   mutable Vector tip;
 public:
    NodeExtrudeCoefficient(const int dim, const int n_, const double s_);
    void SetLayer(const int l) { layer = l; }

--- a/mesh/mesh.hpp
+++ b/mesh/mesh.hpp
@@ -2550,7 +2550,7 @@ class NodeExtrudeCoefficient : public VectorCoefficient
 private:
    int n, layer;
    double p[2], s;
-   
+
    mutable Vector tip;
 public:
    NodeExtrudeCoefficient(const int dim, const int n_, const double s_);

--- a/mesh/mesh.hpp
+++ b/mesh/mesh.hpp
@@ -2556,7 +2556,7 @@ public:
    void SetLayer(const int l) { layer = l; }
    using VectorCoefficient::Eval;
    virtual void Eval(Vector &V, ElementTransformation &T,
-                     const IntegrationPoint &ip);
+                     const IntegrationPoint &ip) const;
    virtual ~NodeExtrudeCoefficient() { }
 };
 

--- a/miniapps/common/dist_solver.cpp
+++ b/miniapps/common/dist_solver.cpp
@@ -285,7 +285,7 @@ void HeatDistanceSolver::ComputeScalarDistance(Coefficient &zero_level_set,
 }
 
 double NormalizationDistanceSolver::NormalizationCoeff::
-Eval(ElementTransformation &T,const IntegrationPoint &ip)
+Eval(ElementTransformation &T,const IntegrationPoint &ip) const
 {
    T.SetIntPoint(&ip);
    Vector u_grad;

--- a/miniapps/common/dist_solver.hpp
+++ b/miniapps/common/dist_solver.hpp
@@ -90,7 +90,7 @@ private:
 
    public:
       NormalizationCoeff(ParGridFunction &u_gf) : u(u_gf) { }
-      virtual double Eval(ElementTransformation &T, const IntegrationPoint &ip);
+      virtual double Eval(ElementTransformation &T, const IntegrationPoint &ip) const;
    };
 
 public:
@@ -132,7 +132,7 @@ public:
 
    using VectorCoefficient::Eval;
 
-   void Eval(Vector &V, ElementTransformation &T, const IntegrationPoint &ip)
+   void Eval(Vector &V, ElementTransformation &T, const IntegrationPoint &ip) const
    {
       T.SetIntPoint(&ip);
 
@@ -153,7 +153,7 @@ public:
    PProductCoefficient(Coefficient& basec_, Coefficient& corrc_)
       : basef(basec_), corrf(corrc_) { }
 
-   virtual double Eval(ElementTransformation &T, const IntegrationPoint &ip)
+   virtual double Eval(ElementTransformation &T, const IntegrationPoint &ip) const
    {
       T.SetIntPoint(&ip);
       double u = basef.Eval(T,ip);

--- a/miniapps/common/mesh_extras.cpp
+++ b/miniapps/common/mesh_extras.cpp
@@ -235,7 +235,7 @@ void AttrToMarker(int max_attr, const Array<int> &attrs, Array<int> &marker)
 }
 
 void KershawTransformation::Eval(Vector &V, ElementTransformation &T,
-                                 const IntegrationPoint &ip)
+                                 const IntegrationPoint &ip) const
 {
    V = 0.0;
    Vector pos(dim);

--- a/miniapps/common/mesh_extras.hpp
+++ b/miniapps/common/mesh_extras.hpp
@@ -76,20 +76,20 @@ public:
    }
 
    // 1D transformation at the right boundary.
-   double right(const double eps, const double x)
+   double right(const double eps, const double x) const
    {
       return (x <= 0.5) ? (2-eps) * x : 1 + eps*(x-1);
    }
 
    // 1D transformation at the left boundary
-   double left(const double eps, const double x)
+   double left(const double eps, const double x) const
    {
       return 1-right(eps,1-x);
    }
 
    // Transition from a value of "a" for x=0, to a value of "b" for x=1.
    // Controlled through "smooth" parameter.
-   double step(const double a, const double b, double x)
+   double step(const double a, const double b, double x) const
    {
       if (x <= 0) { return a; }
       if (x >= 1) { return b; }
@@ -99,7 +99,7 @@ public:
    }
 
    virtual void Eval(Vector &V, ElementTransformation &T,
-                     const IntegrationPoint &ip);
+                     const IntegrationPoint &ip) const;
 
    using VectorCoefficient::Eval;
 };

--- a/miniapps/dpg/util/pml.hpp
+++ b/miniapps/dpg/util/pml.hpp
@@ -81,7 +81,7 @@ public:
    PmlCoefficient(double (*F)(const Vector &, CartesianPML *), CartesianPML * pml_)
       : pml(pml_), Function(F)
    {}
-   virtual double Eval(ElementTransformation &T, const IntegrationPoint &ip)
+   virtual double Eval(ElementTransformation &T, const IntegrationPoint &ip) const
    {
       double x[3];
       Vector transip(x, 3);
@@ -102,7 +102,7 @@ public:
       : MatrixCoefficient(dim), pml(pml_), Function(F)
    {}
    virtual void Eval(DenseMatrix &K, ElementTransformation &T,
-                     const IntegrationPoint &ip)
+                     const IntegrationPoint &ip) const
    {
       double x[3];
       Vector transip(x, 3);

--- a/miniapps/electromagnetics/joule_solver.cpp
+++ b/miniapps/electromagnetics/joule_solver.cpp
@@ -902,7 +902,7 @@ void MagneticDiffusionEOperator::Debug(const char *base, double)
 }
 
 double JouleHeatingCoefficient::Eval(ElementTransformation &T,
-                                     const IntegrationPoint &ip)
+                                     const IntegrationPoint &ip) const
 {
    Vector E;
    double thisSigma;
@@ -930,7 +930,7 @@ MeshDependentCoefficient::MeshDependentCoefficient(
 }
 
 double MeshDependentCoefficient::Eval(ElementTransformation &T,
-                                      const IntegrationPoint &ip)
+                                      const IntegrationPoint &ip) const
 {
    // given the attribute, extract the coefficient value from the map
    std::map<int, double>::iterator it;
@@ -957,7 +957,7 @@ ScaledGFCoefficient::ScaledGFCoefficient(GridFunction *gf,
    : GridFunctionCoefficient(gf), mdc(input_mdc) {}
 
 double ScaledGFCoefficient::Eval(ElementTransformation &T,
-                                 const IntegrationPoint &ip)
+                                 const IntegrationPoint &ip) const
 {
    return mdc.Eval(T,ip) * GridFunctionCoefficient::Eval(T,ip);
 }

--- a/miniapps/electromagnetics/joule_solver.hpp
+++ b/miniapps/electromagnetics/joule_solver.hpp
@@ -53,7 +53,7 @@ public:
    MeshDependentCoefficient(const std::map<int, double> &inputMap,
                             double scale = 1.0);
    MeshDependentCoefficient(const MeshDependentCoefficient &cloneMe);
-   virtual double Eval(ElementTransformation &T, const IntegrationPoint &ip);
+   virtual double Eval(ElementTransformation &T, const IntegrationPoint &ip) const;
    void SetScaleFactor(const double &scale) { scaleFactor = scale; }
    virtual ~MeshDependentCoefficient()
    {
@@ -70,7 +70,7 @@ private:
    MeshDependentCoefficient mdc;
 public:
    ScaledGFCoefficient(GridFunction *gf, MeshDependentCoefficient &input_mdc);
-   virtual double Eval(ElementTransformation &T, const IntegrationPoint &ip);
+   virtual double Eval(ElementTransformation &T, const IntegrationPoint &ip) const;
    void SetMDC(const MeshDependentCoefficient &input_mdc) { mdc = input_mdc; }
    virtual ~ScaledGFCoefficient() {}
 };
@@ -235,7 +235,7 @@ public:
    JouleHeatingCoefficient(const MeshDependentCoefficient &sigma_,
                            ParGridFunction &E_gf_)
       : E_gf(E_gf_), sigma(sigma_) {}
-   virtual double Eval(ElementTransformation &T, const IntegrationPoint &ip);
+   virtual double Eval(ElementTransformation &T, const IntegrationPoint &ip) const;
    virtual ~JouleHeatingCoefficient() {}
 };
 

--- a/miniapps/meshing/mesh-optimizer.hpp
+++ b/miniapps/meshing/mesh-optimizer.hpp
@@ -139,7 +139,7 @@ public:
       : TMOPMatrixCoefficient(dim), metric(metric_id) { }
 
    virtual void Eval(DenseMatrix &K, ElementTransformation &T,
-                     const IntegrationPoint &ip)
+                     const IntegrationPoint &ip) const
    {
       Vector pos(3);
       T.Transform(ip, pos);
@@ -250,7 +250,7 @@ public:
         hr_target_type(hr_target_type_) { }
 
    virtual void Eval(DenseMatrix &K, ElementTransformation &T,
-                     const IntegrationPoint &ip)
+                     const IntegrationPoint &ip) const
    {
       Vector pos(3);
       T.Transform(ip, pos);

--- a/miniapps/meshing/reflector.cpp
+++ b/miniapps/meshing/reflector.cpp
@@ -68,13 +68,13 @@ public:
    { }
 
    virtual void Eval(Vector &V, ElementTransformation &T,
-                     const IntegrationPoint &ip);
+                     const IntegrationPoint &ip) const;
 
    using VectorCoefficient::Eval;
 };
 
 void ReflectedCoefficient::Eval(Vector &V, ElementTransformation &T,
-                                const IntegrationPoint &ip)
+                                const IntegrationPoint &ip) const
 {
    double x[3];
    Vector transip(x, 3);

--- a/miniapps/shifted/distance.cpp
+++ b/miniapps/shifted/distance.cpp
@@ -138,7 +138,7 @@ public:
    ExactDistSphereLoc(ParGridFunction &d)
       : dist(d), dx(dist.ParFESpace()->GetParMesh()->GetElementSize(0)) { }
 
-   virtual double Eval(ElementTransformation &T, const IntegrationPoint &ip)
+   virtual double Eval(ElementTransformation &T, const IntegrationPoint &ip) const
    {
       Vector pos(T.GetDimension());
       T.Transform(ip, pos);

--- a/miniapps/shifted/extrapolator.hpp
+++ b/miniapps/shifted/extrapolator.hpp
@@ -93,7 +93,7 @@ public:
    using VectorCoefficient::Eval;
 
    virtual void Eval(Vector &V, ElementTransformation &T,
-                     const IntegrationPoint &ip)
+                     const IntegrationPoint &ip) const
    {
       Vector grad_ls(vdim), n(vdim);
       ls_gf.GetGradient(T, grad_ls);
@@ -116,7 +116,7 @@ private:
 public:
    GradComponentCoeff(const ParGridFunction &u, int c) : u_gf(u), comp(c) { }
 
-   virtual double Eval(ElementTransformation &T, const IntegrationPoint &ip)
+   virtual double Eval(ElementTransformation &T, const IntegrationPoint &ip) const
    {
       Vector grad_u(T.GetDimension());
       u_gf.GetGradient(T, grad_u);
@@ -134,7 +134,7 @@ public:
    NormalGradCoeff(const ParGridFunction &u, VectorCoefficient &n)
       : u_gf(u), n_coeff(n) { }
 
-   virtual double Eval(ElementTransformation &T, const IntegrationPoint &ip)
+   virtual double Eval(ElementTransformation &T, const IntegrationPoint &ip) const
    {
       const int dim = T.GetDimension();
       Vector n(dim), grad_u(dim);
@@ -155,7 +155,7 @@ public:
                             const ParGridFunction &dy, VectorCoefficient &n)
       : du_dx(dx), du_dy(dy), n_coeff(n) { }
 
-   virtual double Eval(ElementTransformation &T, const IntegrationPoint &ip)
+   virtual double Eval(ElementTransformation &T, const IntegrationPoint &ip) const
    {
       const int dim = T.GetDimension();
       Vector n(dim), grad_u(dim);

--- a/miniapps/shifted/sbm_aux.hpp
+++ b/miniapps/shifted/sbm_aux.hpp
@@ -143,7 +143,7 @@ public:
    Dist_Level_Set_Coefficient(int type_)
       : Coefficient(), type(type_) { }
 
-   virtual double Eval(ElementTransformation &T, const IntegrationPoint &ip)
+   virtual double Eval(ElementTransformation &T, const IntegrationPoint &ip) const
    {
       Vector x(3);
       T.Transform(ip, x);
@@ -166,7 +166,7 @@ public:
 
    int GetNLevelSets() { return dls.Size(); }
 
-   virtual double Eval(ElementTransformation &T, const IntegrationPoint &ip)
+   virtual double Eval(ElementTransformation &T, const IntegrationPoint &ip) const
    {
       MFEM_VERIFY(dls.Size() > 0,
                   "Add at least 1 Dist_level_Set_Coefficient to the Combo.");
@@ -192,7 +192,7 @@ public:
    using VectorCoefficient::Eval;
 
    virtual void Eval(Vector &p, ElementTransformation &T,
-                     const IntegrationPoint &ip)
+                     const IntegrationPoint &ip) const
    {
       Vector x;
       T.Transform(ip, x);

--- a/miniapps/shifted/sbm_solver.cpp
+++ b/miniapps/shifted/sbm_solver.cpp
@@ -16,7 +16,7 @@ namespace mfem
 
 double ShiftedFunctionCoefficient::Eval(ElementTransformation & T,
                                         const IntegrationPoint & ip,
-                                        const Vector &D)
+                                        const Vector &D) const
 {
    if (constantcoefficient) { return constant; }
 
@@ -33,7 +33,7 @@ double ShiftedFunctionCoefficient::Eval(ElementTransformation & T,
 void ShiftedVectorFunctionCoefficient::Eval(Vector &V,
                                             ElementTransformation & T,
                                             const IntegrationPoint & ip,
-                                            const Vector &D)
+                                            const Vector &D) const
 {
    Vector transip;
    T.Transform(ip, transip);

--- a/miniapps/shifted/sbm_solver.hpp
+++ b/miniapps/shifted/sbm_solver.hpp
@@ -33,7 +33,7 @@ public:
    ShiftedFunctionCoefficient(double constant_)
       : constant(constant_), constantcoefficient(true) { }
 
-   virtual double Eval(ElementTransformation &T, const IntegrationPoint &ip)
+   virtual double Eval(ElementTransformation &T, const IntegrationPoint &ip) const
    {
       if (constantcoefficient) { return constant; }
 
@@ -45,7 +45,7 @@ public:
    /// Evaluate the coefficient at @a ip + @a D.
    double Eval(ElementTransformation &T,
                const IntegrationPoint &ip,
-               const Vector &D);
+               const Vector &D) const;
 };
 
 class ShiftedVectorFunctionCoefficient : public VectorCoefficient
@@ -60,7 +60,7 @@ public:
 
    using VectorCoefficient::Eval;
    virtual void Eval(Vector &V, ElementTransformation &T,
-                     const IntegrationPoint &ip)
+                     const IntegrationPoint &ip) const
    {
       Vector D(vdim);
       D = 0.;
@@ -71,7 +71,7 @@ public:
    void Eval(Vector &V,
              ElementTransformation &T,
              const IntegrationPoint &ip,
-             const Vector &D);
+             const Vector &D) const;
 };
 
 /// BilinearFormIntegrator for the high-order extension of shifted boundary

--- a/miniapps/tools/display-basis.cpp
+++ b/miniapps/tools/display-basis.cpp
@@ -79,7 +79,8 @@ public:
    Deformation(int dim, DefType dType, const DeformationData & data)
       : VectorCoefficient(dim), dim_(dim), dType_(dType), data_(data) {}
 
-   void Eval(Vector &v, ElementTransformation &T, const IntegrationPoint &ip) const;
+   void Eval(Vector &v, ElementTransformation &T,
+             const IntegrationPoint &ip) const;
    using VectorCoefficient::Eval;
 private:
    void Def1D(const Vector & u, Vector & v) const;

--- a/miniapps/tools/display-basis.cpp
+++ b/miniapps/tools/display-basis.cpp
@@ -79,12 +79,12 @@ public:
    Deformation(int dim, DefType dType, const DeformationData & data)
       : VectorCoefficient(dim), dim_(dim), dType_(dType), data_(data) {}
 
-   void Eval(Vector &v, ElementTransformation &T, const IntegrationPoint &ip);
+   void Eval(Vector &v, ElementTransformation &T, const IntegrationPoint &ip) const;
    using VectorCoefficient::Eval;
 private:
-   void Def1D(const Vector & u, Vector & v);
-   void Def2D(const Vector & u, Vector & v);
-   void Def3D(const Vector & u, Vector & v);
+   void Def1D(const Vector & u, Vector & v) const;
+   void Def2D(const Vector & u, Vector & v) const;
+   void Def3D(const Vector & u, Vector & v) const;
 
    int     dim_;
    DefType dType_;
@@ -623,7 +623,7 @@ mapTypeStr(int mType)
 
 void
 Deformation::Eval(Vector &v, ElementTransformation &T,
-                  const IntegrationPoint &ip)
+                  const IntegrationPoint &ip) const
 {
    Vector u(dim_);
    T.Transform(ip, u);
@@ -643,7 +643,7 @@ Deformation::Eval(Vector &v, ElementTransformation &T,
 }
 
 void
-Deformation::Def1D(const Vector & u, Vector & v)
+Deformation::Def1D(const Vector & u, Vector & v) const
 {
    v = u;
    if ( dType_ == UNIFORM )
@@ -653,7 +653,7 @@ Deformation::Def1D(const Vector & u, Vector & v)
 }
 
 void
-Deformation::Def2D(const Vector & u, Vector & v)
+Deformation::Def2D(const Vector & u, Vector & v) const
 {
    switch (dType_)
    {
@@ -676,7 +676,7 @@ Deformation::Def2D(const Vector & u, Vector & v)
 }
 
 void
-Deformation::Def3D(const Vector & u, Vector & v)
+Deformation::Def3D(const Vector & u, Vector & v) const
 {
    switch (dType_)
    {

--- a/miniapps/tools/nodal-transfer.cpp
+++ b/miniapps/tools/nodal-transfer.cpp
@@ -47,7 +47,7 @@ public:
 
    virtual
    double Eval(ElementTransformation &T,
-               const IntegrationPoint &ip)
+               const IntegrationPoint &ip) const
    {
       if (T.GetSpaceDim()==3)
       {


### PR DESCRIPTION
In the context of #4171, it doesn't make sense for `Eval` (and `Project`) to not have `const` qualifiers, as calls to them should not be altering the state of the coefficient objects (except for the `Coefficient::Eval(...., double time)`, where a SetTime is called prior to Eval).

Because `Eval` is not constant, there are a variety of situations where a coefficient must be passed as a non-const argument to a function that should not change the state of the coefficient at all, like `GridFunction::Project_____` and to linear form and bilinear form integrator constructors. This makes it difficult if one wants to pass a coefficient as const to a class such as an operator that may use it but does not change it.

This PR makes Eval, Project, and a variety of other member functions (such as `PWConstCoefficient::GetNConst`) const that should be const. Additionally, noted in the commit message for af29df2b4d302bc891646ccd833cad12230fcfff , some member functions that are declared as constant allowed access to non-const member variable references - this PR fixes that as well, which may be a breaking change.

Lastly, `VectorSumCoefficient` posed some troubles in implementing this as the Vector and double member variables are updated in Eval. More details are explained in the commit message for 841a546bfa9290a20e160ba073446e207a454eff, but the current PR simply just sets these member variables as mutable. Punchline is that it's not the cleanest solution, but an alternative approach would be to use separate auxiliary variables in Eval which *may* lead to a loss in backward compatibility.

Because it is very common in codes using MFEM to define a custom coefficient, the non-const `Eval` is kept in to maintain backwards compatibility. **The ultimate goal after this PR would be to update existing functions in the code that call `Eval` (and/or `Project`) to accept `const` coefficient types only to ensure that the `Eval(...) const` is called (or if it is preferable, I can return this PR to draft and include that as well).** 
