### PR TITLE
Reverted the change of const qualifiers in BlockOperator

### DIFF
--- a/linalg/blockoperator.cpp
+++ b/linalg/blockoperator.cpp
@@ -45,12 +45,12 @@ BlockOperator::BlockOperator(const Array<int> & row_offsets_,
    op = static_cast<Operator *>(NULL);
 }
 
-void BlockOperator::SetDiagonalBlock(int iblock, const Operator *opt, real_t c)
+void BlockOperator::SetDiagonalBlock(int iblock, Operator *opt, real_t c)
 {
    SetBlock(iblock, iblock, opt, c);
 }
 
-void BlockOperator::SetBlock(int iRow, int iCol, const Operator *opt, real_t c)
+void BlockOperator::SetBlock(int iRow, int iCol, Operator *opt, real_t c)
 {
    if (owns_blocks && op(iRow, iCol))
    {

--- a/linalg/blockoperator.hpp
+++ b/linalg/blockoperator.hpp
@@ -61,14 +61,14 @@ public:
     * op: the Operator to be inserted.
     * c: optional scalar multiple for this block.
     */
-   void SetDiagonalBlock(int iblock, const Operator *op, real_t c = 1.0);
+   void SetDiagonalBlock(int iblock, Operator *op, real_t c = 1.0);
    //! Add a block op in the block-entry (iblock, jblock).
    /**
     * irow, icol: The block will be inserted in location (irow, icol).
     * op: the Operator to be inserted.
     * c: optional scalar multiple for this block.
     */
-   void SetBlock(int iRow, int iCol, const Operator *op, real_t c = 1.0);
+   void SetBlock(int iRow, int iCol, Operator *op, real_t c = 1.0);
 
    //! Return the number of row blocks
    int NumRowBlocks() const { return nRowBlocks; }
@@ -78,6 +78,9 @@ public:
    //! Check if block (i,j) is a zero block
    int IsZeroBlock(int i, int j) const { return (op(i,j)==NULL) ? 1 : 0; }
    //! Return a reference to block i,j
+   Operator & GetBlock(int i, int j)
+   { MFEM_VERIFY(op(i,j), ""); return *op(i,j); }
+   //! Return a reference to block i,j (const version)
    const Operator & GetBlock(int i, int j) const
    { MFEM_VERIFY(op(i,j), ""); return *op(i,j); }
    //! Return the coefficient for block i,j
@@ -120,7 +123,7 @@ private:
    //! Column offsets for the starting position of each block
    Array<int> col_offsets;
    //! 2D array that stores each block of the operator.
-   Array2D<const Operator *> op;
+   Array2D<Operator *> op;
    //! 2D array that stores a coefficient for each block of the operator.
    Array2D<real_t> coef;
 

--- a/linalg/blockoperator.hpp
+++ b/linalg/blockoperator.hpp
@@ -139,7 +139,7 @@ private:
  *
  * Usage:
  * - Use the constructors to define the block structure
- * - Use SetDiagonalBlock to fill the BlockOperator
+ * - Use SetDiagonalBlock to fill the BlockDiagonalPreconditioner
  * - Use the method Mult and MultTranspose to apply the operator to a vector.
  *
  * If a block is not set, it is assumed to be an identity block.
@@ -209,7 +209,7 @@ private:
  *
  * Usage:
  * - Use the constructors to define the block structure
- * - Use SetBlock() to fill the BlockOperator
+ * - Use SetBlock() to fill the BlockLowerTriangularOperator
  * - Diagonal blocks of the preconditioner should approximate the inverses of
  *   the diagonal block of the matrix
  * - Off-diagonal blocks of the preconditioner should match/approximate those of
@@ -223,7 +223,7 @@ private:
 class BlockLowerTriangularPreconditioner : public Solver
 {
 public:
-   //! Constructor for BlockLowerTriangularPreconditioners with the same
+   //! Constructor for BlockLowerTriangularPreconditioner%s with the same
    //! block-structure for rows and columns.
    /**
     *  @param offsets  Offsets that mark the start of each row/column block

--- a/miniapps/solvers/darcy_solver.cpp
+++ b/miniapps/solvers/darcy_solver.cpp
@@ -36,9 +36,9 @@ BDPMinresSolver::BDPMinresSolver(const HypreParMatrix& M,
    : DarcySolver(M.NumRows(), B.NumRows()), op_(offsets_), prec_(offsets_),
      BT_(B.Transpose()), solver_(M.GetComm())
 {
-   op_.SetBlock(0,0, &M);
+   op_.SetBlock(0,0, const_cast<HypreParMatrix*>(&M));
    op_.SetBlock(0,1, BT_.As<HypreParMatrix>());
-   op_.SetBlock(1,0, &B);
+   op_.SetBlock(1,0, const_cast<HypreParMatrix*>(&B));
 
    Vector Md;
    M.GetDiag(Md);


### PR DESCRIPTION
This PR reverts the changes of the interface of `BlockOperator` introduced in #4078 , i.e., the const qualifier of the `Operator` argument. It replaces #4136 based on the results of the poll #4223 🗳️ . It implies that `const_cast`s must be applied as before when constructing a `BlockOperator` from constant operators solely for multiplication. Secondly, static or C-style casts are necessary when modifying the stored operators.
<!--GHEX{"author":"najlkin","assignment":"2024-04-03T18:40:55","editor":"tzanio","id":4226,"reviewers":["v-dobrev","sebastiangrimberg","psocratis"],"merge":"2024-04-05T17:02:34","approval":"2024-04-04T00:20:46"}XEHG-->
<!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge|
 | --- | --- | --- | --- | --- | --- | --- |
| [#4226](https://github.com/mfem/mfem/pull/4226) | @najlkin | @tzanio | @v-dobrev + @sebastiangrimberg + @psocratis | 4/3/24 | 4/3/24 | 4/5/24 | |
<!--ELBATXEHG-->
<details>
<summary>PR Checklist</summary>
    
- [x] Code builds.
- [x] Code passes `make style`.
- [ ] Update `CHANGELOG`:
    - [ ] Is this a new feature users need to be aware of? New or updated example or miniapp?
    - [ ] Does it make sense to create a new section in the `CHANGELOG` to group with other related features?
- [ ] Update `INSTALL`:
    - [ ] Had a new optional library been added? If so, what range of versions of this library are required? (*Make sure the external library is compatible with our BSD license, e.g. it is not licensed under GPL!*)
    - [ ] Have the version ranges for any required or optional libraries changed?
    - [ ] Does `make` or `cmake` have a new target?
    - [ ] Did the requirements or the installation process change? *(rare)*
- [ ] Update continuous integration server configurations if necessary (e.g. with new version requirements for each of MFEM's dependencies)
    - [ ] `.github`
    - [ ] `.appveyor.yml`
- [ ] Update `.gitignore`:
    - [ ] Check if `make distclean; git status` shows any files that were generated from the source by the project (not an IDE) but we don't want to track in the repository.
    - [ ] Add new patterns (just for the new files above) and re-run the above test.
- [ ] New examples:
    - [ ] All sample runs at the top of the example source file work.
    - [ ] Update `examples/makefile`:
      - [ ] Add the example code to the appropriate `SEQ_EXAMPLES` and `PAR_EXAMPLES` variables.
      - [ ] Add any files generated by it to the `clean` target.
      - [ ] Add the example binary and any files generated by it to the top-level `.gitignore` file.
    - [ ] Update `examples/CMakeLists.txt`:
      - [ ] Add the example code to the `ALL_EXE_SRCS` variable.
      - [ ] Make sure `THIS_TEST_OPTIONS` is set correctly for the new example.
   - [ ] List the new example in `doc/CodeDocumentation.dox`.
   - [ ] If new examples directory (e.g.`examples/pumi`), list it in `doc/CodeDocumentation.conf.in`
   - [ ] Companion pull request for documentation in [mfem/web](https://github.com/mfem/web) repo:
      - [ ] Update or add example-specific documentation, see e.g. the `src/examples.md`.
      - [ ] Add the description, labels and screenshots in `src/examples.md` and `src/img`.
      - [ ] In `examples.md`, list the example under the appropriate categories, add new categories if necessary.
      - [ ] Add a short description of the example in the "Extensive Examples" section of `features.md`.
- [ ] New miniapps:
   - [ ] All sample runs at the top of the miniapp source file work.
   - [ ] Update top-level `makefile` and `makefile` in corresponding miniapp directory.
   - [ ] Add the miniapp binary and any files generated by it to the top-level `.gitignore` file.
   - [ ] Update CMake build system:
      - [ ] Update the `CMakeLists.txt` file in the `miniapps` directory, if the new miniapp is in a new directory.
      - [ ] Add/update the `CMakeLists.txt` file in the new miniapp directory.
      - [ ] Consider adding a new test for the new miniapp.
   - [ ] List the new miniapp in `doc/CodeDocumentation.dox`
   - [ ] If new miniapps directory (e.g.`miniapps/nurbs`), add it to `MINIAPP_SUBDIRS` in the `makefile`.
   - [ ] If new miniapps directory (e.g.`miniapps/nurbs`), list it in `doc/CodeDocumentation.conf.in`
   - [ ] Companion pull request for documentation in [mfem/web](https://github.com/mfem/web) repo:
     - [ ] Update or add miniapp-specific documentation, see e.g. the `src/meshing.md` and `src/electromagnetics.md` files.
     - [ ] Add the description, labels and screenshots in `src/examples.md` and `src/img`.
     - [ ] The miniapps go at the end of the page, and are usually listed only under a specific "Application (PDE)" category.
     - [ ] Add a short description of the miniapp in the "Extensive Examples" section of `features.md`.
- [ ] New capability:
   - [ ] All new public, protected, and private classes, methods, data members, and functions have full Doxygen-style documentation in source comments. Documentation should include descriptions of member data, function arguments and return values, template parameters, and prerequisites for calling new functions.
   - [ ] Pointer arguments and return values must specify whether ownership is being transferred or lent with the call.
   - [ ] Any new functions should include descriptions of their intended use e.g. for internal use only, user-facing, etc., along with references to example code whenever possible/appropriate.
   - [ ] Consider adding new sample runs in existing examples to highlight the new capability.
   - [ ] Consider saving cool simulation pictures with the new capability in the Confluence gallery (LLNL only) or submitting them, via pull request, to the gallery section of the `mfem/web` repo.
   - [ ] If this is a major new feature, consider mentioning it in the short summary inside `README` *(rare)*.
   - [ ] List major new classes in `doc/CodeDocumentation.dox` *(rare)*.
- [ ] Update this checklist, if the new pull request affects it.
- [x] Run `make unittest` to make sure all unit tests pass.
- [x] Run the tests in `tests/scripts`.
- [ ] (LLNL only) After merging:
   - [ ] Update internal tests to include the new features.
</details>
