### PR TITLE
Update to newest DenseMatrixSVD

### DIFF
--- a/examples/ex33.cpp
+++ b/examples/ex33.cpp
@@ -19,8 +19,11 @@
 //    ex33 -m ../data/amr-quad.mesh -ver -alpha 2.6 -o 2 -r 2
 //    ex33 -m ../data/inline-hex.mesh -ver -alpha 0.3 -o 2 -r 1
 //
-//  Note: the analytic solution to this problem is u = ∏_{i=0}^{dim-1} sin(π x_i)
-//        for all alpha.
+//  Note: The manufactured solution used in this problem is
+//
+//            u = ∏_{i=0}^{dim-1} sin(π x_i) ,
+//
+//        regardless of the value of alpha.
 //
 // Description:
 //
@@ -114,7 +117,8 @@ int main(int argc, char *argv[])
                   "Enable or disable GLVis visualization.");
    args.AddOption(&verification, "-ver", "--verification", "-no-ver",
                   "--no-verification",
-                  "Use sinusoidal function (f) for analytic comparison.");
+                  "Use sinusoidal function (f) for manufactured "
+                  "solution test.");
    args.Parse();
    if (!args.Good())
    {
@@ -163,7 +167,7 @@ int main(int argc, char *argv[])
    // 5. Define a finite element space on the mesh.
    H1_FECollection fec(order, dim);
    FiniteElementSpace fespace(&mesh, &fec);
-   cout << "Number of finite element unknowns: "
+   cout << "Number of degrees of freedom: "
         << fespace.GetTrueVSize() << endl;
 
    // 6. Determine the list of true (i.e. conforming) essential boundary dofs.
@@ -379,29 +383,29 @@ int main(int argc, char *argv[])
       FunctionCoefficient sol(solution);
       real_t l2_error = u.ComputeL2Error(sol);
 
-      string analytic_solution,expected_mesh;
+      string manufactured_solution,expected_mesh;
       switch (dim)
       {
          case 1:
-            analytic_solution = "sin(π x)";
+            manufactured_solution = "sin(π x)";
             expected_mesh = "inline_segment.mesh";
             break;
          case 2:
-            analytic_solution = "sin(π x) sin(π y)";
+            manufactured_solution = "sin(π x) sin(π y)";
             expected_mesh = "inline_quad.mesh";
             break;
          default:
-            analytic_solution = "sin(π x) sin(π y) sin(π z)";
+            manufactured_solution = "sin(π x) sin(π y) sin(π z)";
             expected_mesh = "inline_hex.mesh";
             break;
       }
 
       mfem::out << "\n" << string(80,'=')
                 << "\n\nSolution Verification in "<< dim << "D \n\n"
-                << "Analytic solution : " << analytic_solution << "\n"
-                << "Expected mesh     : " << expected_mesh <<"\n"
-                << "Your mesh         : " << mesh_file << "\n"
-                << "L2 error          : " << l2_error << "\n\n"
+                << "Manufactured solution : " << manufactured_solution << "\n"
+                << "Expected mesh         : " << expected_mesh <<"\n"
+                << "Your mesh             : " << mesh_file << "\n"
+                << "L2 error              : " << l2_error << "\n\n"
                 << string(80,'=') << endl;
    }
 

--- a/examples/ex33.hpp
+++ b/examples/ex33.hpp
@@ -346,7 +346,7 @@ void ComputePartialFractionApproximation(real_t & alpha,
    }
    else
    {
-      if (abs(alpha - 0.5) > eps && print_warning)
+      if (abs(alpha - 0.5) > eps)
       {
          alpha = 0.5;
       }

--- a/examples/ex33.hpp
+++ b/examples/ex33.hpp
@@ -368,6 +368,8 @@ void ComputePartialFractionApproximation(real_t & alpha,
 
 
    return;
+#else
+   MFEM_CONTRACT_VAR(print_warning);
 #endif
 
    Vector x(npoints);

--- a/examples/ex33.hpp
+++ b/examples/ex33.hpp
@@ -131,7 +131,7 @@ void RationalApproximation_AAA(const Vector &val, const Vector &pt,
       }
 
 #ifdef MFEM_USE_LAPACK
-      DenseMatrixSVD svd(Am,false,true);
+      DenseMatrixSVD svd(Am,'N','A');
       svd.Eval(Am);
       DenseMatrix &v = svd.RightSingularvectors();
       v.GetRow(k,w);

--- a/examples/ex33p.cpp
+++ b/examples/ex33p.cpp
@@ -19,8 +19,11 @@
 //    mpirun -np 4 ex33p -m ../data/amr-quad.mesh -ver -alpha 2.6 -o 2 -r 2
 //    mpirun -np 4 ex33p -m ../data/inline-hex.mesh -ver -alpha 0.3 -o 2 -r 1
 
-//  Note: the analytic solution to this problem is u = ∏_{i=0}^{dim-1} sin(π x_i)
-//        for all alpha.
+//  Note: The manufactured solution used in this problem is
+//
+//            u = ∏_{i=0}^{dim-1} sin(π x_i) ,
+//
+//        regardless of the value of alpha.
 //
 // Description:
 //
@@ -120,7 +123,8 @@ int main(int argc, char *argv[])
                   "Enable or disable GLVis visualization.");
    args.AddOption(&verification, "-ver", "--verification", "-no-ver",
                   "--no-verification",
-                  "Use sinusoidal function (f) for analytic comparison.");
+                  "Use sinusoidal function (f) for manufactured "
+                  "solution test.");
    args.Parse();
    if (!args.Good())
    {
@@ -182,8 +186,8 @@ int main(int argc, char *argv[])
    ParFiniteElementSpace fespace(&pmesh, &fec);
    if (Mpi::Root())
    {
-      cout << "Number of finite element unknowns: "
-           << fespace.GetTrueVSize() << endl;
+      cout << "Number of degrees of freedom: "
+           << fespace.GlobalTrueVSize() << endl;
    }
 
    // 6. Determine the list of true (i.e. conforming) essential boundary dofs.
@@ -223,7 +227,7 @@ int main(int argc, char *argv[])
    if (verification)
    {
       // This statement is only relevant for the verification of the code. It
-      // uses a different f such that an analytic solution is known and easy
+      // uses a different f such that an manufactured solution is known and easy
       // to compare with the numerical one. The FPDE becomes:
       // (-Δ)^α u = (2\pi ^2)^α sin(\pi x) sin(\pi y) on [0,1]^2
       // -> u(x,y) = sin(\pi x) sin(\pi y)
@@ -415,29 +419,29 @@ int main(int argc, char *argv[])
 
       if (Mpi::Root())
       {
-         string analytic_solution,expected_mesh;
+         string manufactured_solution,expected_mesh;
          switch (dim)
          {
             case 1:
-               analytic_solution = "sin(π x)";
+               manufactured_solution = "sin(π x)";
                expected_mesh = "inline_segment.mesh";
                break;
             case 2:
-               analytic_solution = "sin(π x) sin(π y)";
+               manufactured_solution = "sin(π x) sin(π y)";
                expected_mesh = "inline_quad.mesh";
                break;
             default:
-               analytic_solution = "sin(π x) sin(π y) sin(π z)";
+               manufactured_solution = "sin(π x) sin(π y) sin(π z)";
                expected_mesh = "inline_hex.mesh";
                break;
          }
 
          mfem::out << "\n" << string(80,'=')
                    << "\n\nSolution Verification in "<< dim << "D \n\n"
-                   << "Analytic solution : " << analytic_solution << "\n"
-                   << "Expected mesh     : " << expected_mesh <<"\n"
-                   << "Your mesh         : " << mesh_file << "\n"
-                   << "L2 error          : " << l2_error << "\n\n"
+                   << "Manufactured solution : " << manufactured_solution << "\n"
+                   << "Expected mesh         : " << expected_mesh <<"\n"
+                   << "Your mesh             : " << mesh_file << "\n"
+                   << "L2 error              : " << l2_error << "\n\n"
                    << string(80,'=') << endl;
       }
    }

--- a/examples/ex33p.cpp
+++ b/examples/ex33p.cpp
@@ -184,10 +184,11 @@ int main(int argc, char *argv[])
    // 5. Define a finite element space on the mesh.
    H1_FECollection fec(order, dim);
    ParFiniteElementSpace fespace(&pmesh, &fec);
+   HYPRE_BigInt size = fespace.GlobalTrueVSize();
    if (Mpi::Root())
    {
       cout << "Number of degrees of freedom: "
-           << fespace.GlobalTrueVSize() << endl;
+           << size << endl;
    }
 
    // 6. Determine the list of true (i.e. conforming) essential boundary dofs.

--- a/examples/ex38.cpp
+++ b/examples/ex38.cpp
@@ -199,7 +199,6 @@ public:
       {
          mesh->GetElementTransformation(elem, &Tr);
          MFIRs.GetSurfaceIntegrationRule(Tr, ir);
-         Vector w;
          MFIRs.GetSurfaceWeights(Tr, ir, w);
          SurfaceWeights.SetCol(elem, w);
 

--- a/tests/unit/linalg/test_matrix_dense.cpp
+++ b/tests/unit/linalg/test_matrix_dense.cpp
@@ -674,7 +674,7 @@ TEST_CASE("Eigensystem Problems",
       break;
       case TestCase::SVD:
       {
-         DenseMatrixSVD svd(M,true,true);
+         DenseMatrixSVD svd(M,'A','A');
          svd.Eval(M);
          Vector &sigma = svd.Singularvalues();
          DenseMatrix &U = svd.LeftSingularvectors();


### PR DESCRIPTION
The `DenseMatrixSVD` constructor has changed.

This caused warnings when compiling `ex33` and `unit_tests` with LAPACK.

I also added some updates to `ex33`, which is the example first designed to use `DenseMatrixSVD` 
<!--GHEX{"author":"brendankeith","assignment":"2024-04-08T00:24:16","editor":"v-dobrev","id":4236,"reviewers":["TobiasDuswald","psocratis"],"merge":"2024-04-12T17:46:38","approval":"2024-04-09T21:14:18"}XEHG-->
<!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge|
 | --- | --- | --- | --- | --- | --- | --- |
| [#4236](https://github.com/mfem/mfem/pull/4236) | @brendankeith | @v-dobrev | @TobiasDuswald + @psocratis | 4/7/24 | 4/9/24 | 4/12/24 | |
<!--ELBATXEHG-->
<details>
<summary>PR Checklist</summary>
    
- [ ] Code builds.
- [ ] Code passes `make style`.
- [ ] Update `CHANGELOG`:
    - [ ] Is this a new feature users need to be aware of? New or updated example or miniapp?
    - [ ] Does it make sense to create a new section in the `CHANGELOG` to group with other related features?
- [ ] Update `INSTALL`:
    - [ ] Had a new optional library been added? If so, what range of versions of this library are required? (*Make sure the external library is compatible with our BSD license, e.g. it is not licensed under GPL!*)
    - [ ] Have the version ranges for any required or optional libraries changed?
    - [ ] Does `make` or `cmake` have a new target?
    - [ ] Did the requirements or the installation process change? *(rare)*
- [ ] Update continuous integration server configurations if necessary (e.g. with new version requirements for each of MFEM's dependencies)
    - [ ] `.github`
    - [ ] `.appveyor.yml`
- [ ] Update `.gitignore`:
    - [ ] Check if `make distclean; git status` shows any files that were generated from the source by the project (not an IDE) but we don't want to track in the repository.
    - [ ] Add new patterns (just for the new files above) and re-run the above test.
- [ ] New examples:
    - [ ] All sample runs at the top of the example source file work.
    - [ ] Update `examples/makefile`:
      - [ ] Add the example code to the appropriate `SEQ_EXAMPLES` and `PAR_EXAMPLES` variables.
      - [ ] Add any files generated by it to the `clean` target.
      - [ ] Add the example binary and any files generated by it to the top-level `.gitignore` file.
    - [ ] Update `examples/CMakeLists.txt`:
      - [ ] Add the example code to the `ALL_EXE_SRCS` variable.
      - [ ] Make sure `THIS_TEST_OPTIONS` is set correctly for the new example.
   - [ ] List the new example in `doc/CodeDocumentation.dox`.
   - [ ] If new examples directory (e.g.`examples/pumi`), list it in `doc/CodeDocumentation.conf.in`
   - [ ] Companion pull request for documentation in [mfem/web](https://github.com/mfem/web) repo:
      - [ ] Update or add example-specific documentation, see e.g. the `src/examples.md`.
      - [ ] Add the description, labels and screenshots in `src/examples.md` and `src/img`.
      - [ ] In `examples.md`, list the example under the appropriate categories, add new categories if necessary.
      - [ ] Add a short description of the example in the "Extensive Examples" section of `features.md`.
- [ ] New miniapps:
   - [ ] All sample runs at the top of the miniapp source file work.
   - [ ] Update top-level `makefile` and `makefile` in corresponding miniapp directory.
   - [ ] Add the miniapp binary and any files generated by it to the top-level `.gitignore` file.
   - [ ] Update CMake build system:
      - [ ] Update the `CMakeLists.txt` file in the `miniapps` directory, if the new miniapp is in a new directory.
      - [ ] Add/update the `CMakeLists.txt` file in the new miniapp directory.
      - [ ] Consider adding a new test for the new miniapp.
   - [ ] List the new miniapp in `doc/CodeDocumentation.dox`
   - [ ] If new miniapps directory (e.g.`miniapps/nurbs`), add it to `MINIAPP_SUBDIRS` in the `makefile`.
   - [ ] If new miniapps directory (e.g.`miniapps/nurbs`), list it in `doc/CodeDocumentation.conf.in`
   - [ ] Companion pull request for documentation in [mfem/web](https://github.com/mfem/web) repo:
     - [ ] Update or add miniapp-specific documentation, see e.g. the `src/meshing.md` and `src/electromagnetics.md` files.
     - [ ] Add the description, labels and screenshots in `src/examples.md` and `src/img`.
     - [ ] The miniapps go at the end of the page, and are usually listed only under a specific "Application (PDE)" category.
     - [ ] Add a short description of the miniapp in the "Extensive Examples" section of `features.md`.
- [ ] New capability:
   - [ ] All new public, protected, and private classes, methods, data members, and functions have full Doxygen-style documentation in source comments. Documentation should include descriptions of member data, function arguments and return values, template parameters, and prerequisites for calling new functions.
   - [ ] Pointer arguments and return values must specify whether ownership is being transferred or lent with the call.
   - [ ] Any new functions should include descriptions of their intended use e.g. for internal use only, user-facing, etc., along with references to example code whenever possible/appropriate.
   - [ ] Consider adding new sample runs in existing examples to highlight the new capability.
   - [ ] Consider saving cool simulation pictures with the new capability in the Confluence gallery (LLNL only) or submitting them, via pull request, to the gallery section of the `mfem/web` repo.
   - [ ] If this is a major new feature, consider mentioning it in the short summary inside `README` *(rare)*.
   - [ ] List major new classes in `doc/CodeDocumentation.dox` *(rare)*.
- [ ] Update this checklist, if the new pull request affects it.
- [ ] Run `make unittest` to make sure all unit tests pass.
- [ ] Run the tests in `tests/scripts`.
- [ ] (LLNL only) After merging:
   - [ ] Update internal tests to include the new features.
</details>
