### PR TITLE
Cleaner initialization of shared structures in ParMesh

### DIFF
--- a/mesh/mesh.cpp
+++ b/mesh/mesh.cpp
@@ -3291,6 +3291,8 @@ void Mesh::Finalize(bool refine, bool fix_orientation)
 
       // TODO: maybe introduce Mesh::NODE_REORDER operation and FESpace::
       // NodeReorderMatrix and do Nodes->Update() instead of DoNodeReorder?
+
+      UpdatedTopology();
    }
 
    // check and fix boundary element orientation

--- a/mesh/mesh.hpp
+++ b/mesh/mesh.hpp
@@ -550,6 +550,9 @@ protected:
    // Used in the methods FinalizeXXXMesh() and FinalizeTopology()
    void FinalizeCheck();
 
+   /// Used in Finalize() after the topology changes
+   virtual void UpdatedTopology() { }
+
    void Loader(std::istream &input, int generate_edges = 0,
                std::string parse_tag = "");
 

--- a/mesh/pmesh.cpp
+++ b/mesh/pmesh.cpp
@@ -1133,6 +1133,9 @@ void ParMesh::LoadSharedEntities(istream &input)
          group_squad.GetJ()[i] = i;
       }
    }
+
+   // Setup secondary parallel mesh data: sedge_ledge, sface_lface
+   FinalizeParTopo();
 }
 
 ParMesh::ParMesh(ParMesh *orig_mesh, int ref_factor, int ref_type)
@@ -1533,9 +1536,6 @@ void ParMesh::Finalize(bool refine, bool fix_orientation)
    meshgen = meshgen_save;
    // Note: if Mesh::Finalize() calls MarkTetMeshForRefinement() then the
    //       shared_trias have been rotated as necessary.
-
-   // Setup secondary parallel mesh data: sedge_ledge, sface_lface
-   FinalizeParTopo();
 }
 
 int ParMesh::GetLocalElementNum(long long global_element_num) const

--- a/mesh/pmesh.hpp
+++ b/mesh/pmesh.hpp
@@ -106,6 +106,9 @@ protected:
    // Convert the local 'meshgen' to a global one.
    void ReduceMeshGen();
 
+   /// Used in Finalize() after the topology changes
+   void UpdatedTopology() override { FinalizeParTopo(); }
+
    // Determine sedge_ledge and sface_lface.
    void FinalizeParTopo();
 

--- a/mesh/pncmesh.cpp
+++ b/mesh/pncmesh.cpp
@@ -923,6 +923,9 @@ void ParNCMesh::GetConformingSharedStructures(ParMesh &pmesh)
       entity_conf_group[ent].DeleteAll();
       entity_elem_local[ent].DeleteAll();
    }
+
+   // Setup secondary parallel mesh data: sedge_ledge, sface_lface
+   pmesh.FinalizeParTopo();
 }
 
 void ParNCMesh::GetFaceNeighbors(ParMesh &pmesh)


### PR DESCRIPTION
This PR was separated from #4128 . It moves the initialization of the structures for shared edges (`sedge_ledge`, `sface_lface`) through `FinalizeParTopo()` from `Finalize()` directly to the methods allocating these structures, which were leaving them uninitialized before. This makes the code cleaner, better maintainable and less prone to bugs 😉 . However, it poses a slight risk if someone uses in a very-nonstandard way or overrides the protected methods and `Finalize` directly. This also avoids double update of these structures in `Load()` unless necessary.