### PR TITLE
Put AmgX's dependencies in the correct order

### DIFF
--- a/config/defaults.mk
+++ b/config/defaults.mk
@@ -388,7 +388,7 @@ GINKGO_LIB = $(XLINKER)-rpath,$(GINKGO_LINK_LIB_DIR) -L$(GINKGO_LINK_LIB_DIR)\
 # AmgX library configuration
 AMGX_DIR = @MFEM_DIR@/../amgx
 AMGX_OPT = -I$(AMGX_DIR)/include
-AMGX_LIB = -lcusparse -lcusolver -lcublas -lnvToolsExt -L$(AMGX_DIR)/lib -lamgx
+AMGX_LIB = -L$(AMGX_DIR)/lib -lamgx -lcusparse -lcusolver -lcublas -lnvToolsExt
 
 # GnuTLS library configuration
 GNUTLS_OPT =


### PR DESCRIPTION
@samuelpmishLLNL  ran into a link issue related to AmgX on his Ubuntu 22.04 machine. This oddly does not show up on LC's BlueOS machines but I assume the symbols snuck in somewhere.

Here is the link error:

```
/usr/bin/g++-12 -Wall -Wextra      -Wshadow -Wdouble-promotion -Wconversion -Wundef -Wnull-dereference -Wold-style-cast  -g -rdynamic    -fopenmp -L/usr/local/cuda/lib64 -Wl,-Bsymbolic-functions examples/simple_conduction/CMakeFiles/simple_conduction_without_input_file.dir/without_input_file.cpp.o CMakeFiles/simple_conduction_without_input_file.dir/cmake_device_link.o -o examples/simple_conduction_without_input_file -L/usr/local/cuda/targets/x86_64-linux/lib/stubs   -L/usr/local/cuda/targets/x86_64-linux/lib -Wl,-rpath,/home/sam/code/serac_libs_cuda_4_30_2024/spack/opt/spack/linux-ubuntu22.04-skylake/gcc-12.3.0/serac-develop-arqj3wn7fh7kwfq4zqh56tj63ohratrb/lib:/home/sam/code/serac_libs_cuda_4_30_2024/spack/opt/spack/linux-ubuntu22.04-skylake/gcc-12.3.0/serac-develop-arqj3wn7fh7kwfq4zqh56tj63ohratrb/lib64:/home/sam/code/serac_libs_cuda_4_30_2024/spack/opt/spack/linux-ubuntu22.04-skylake/gcc-12.3.0/amgx-2.3.0.1-bgapfufnnvyhomg2knyo24svuocelcnw/lib:/home/sam/code/serac_libs_cuda_4_30_2024/spack/opt/spack/linux-ubuntu22.04-skylake/gcc-12.3.0/gcc-runtime-12.3.0-hio32wyqn5x36c23fldc5sxlcvkvsc6t/lib:/home/sam/code/serac_libs_cuda_4_30_2024/spack/opt/spack/linux-ubuntu22.04-skylake/gcc-12.3.0/axom-0.9.0.1-xedxtprfh42igx27dsyadyp2o2mg4mjs/lib:/home/sam/code/serac_libs_cuda_4_30_2024/spack/opt/spack/linux-ubuntu22.04-skylake/gcc-12.3.0/conduit-0.9.1-fdle5ykhzyve3ltgg4kyqqieenipeamf/lib:/home/sam/code/serac_libs_cuda_4_30_2024/spack/opt/spack/linux-ubuntu22.04-skylake/gcc-12.3.0/hdf5-1.8.23-wuxgpyfxukz4hy6mrs2wulptpihvtfad/lib:/home/sam/code/serac_libs_cuda_4_30_2024/spack/opt/spack/linux-ubuntu22.04-skylake/gcc-12.3.0/zlib-ng-2.1.6-lzstgsbitxrugm2veu3hsvu6knjqkuwd/lib:/home/sam/code/serac_libs_cuda_4_30_2024/spack/opt/spack/linux-ubuntu22.04-skylake/gcc-12.3.0/metis-5.1.0-my43hh2r636htpgacvxd7i3wgswb7a4d/lib:/home/sam/code/serac_libs_cuda_4_30_2024/spack/opt/spack/linux-ubuntu22.04-skylake/gcc-12.3.0/parmetis-4.0.3-tdfzc3tyxr6to6j2rdt3eiiuoh6gykpy/lib:/home/sam/code/serac_libs_cuda_4_30_2024/spack/opt/spack/linux-ubuntu22.04-skylake/gcc-12.3.0/lua-5.4.6-sapqeyah462eyfek57wphfah2ibs7xwv/lib:/home/sam/code/serac_libs_cuda_4_30_2024/spack/opt/spack/linux-ubuntu22.04-skylake/gcc-12.3.0/readline-8.2-hppwzcut7bb54vqvelfnj4az2b6tcxnd/lib:/home/sam/code/serac_libs_cuda_4_30_2024/spack/opt/spack/linux-ubuntu22.04-skylake/gcc-12.3.0/mfem-4.6.2.4-hgffss6egy6b2jb6zx43aqzfjuherw5d/lib:/home/sam/code/serac_libs_cuda_4_30_2024/spack/opt/spack/linux-ubuntu22.04-skylake/gcc-12.3.0/hypre-2.26.0-ncfa2miwza7t7a4gadov6hyxi2z24akx/lib:/home/sam/code/serac_libs_cuda_4_30_2024/spack/opt/spack/linux-ubuntu22.04-skylake/gcc-12.3.0/openblas-0.3.26-wfq52jjryfenk54kf3qqgndee7vgmsh3/lib:/home/sam/code/serac_libs_cuda_4_30_2024/spack/opt/spack/linux-ubuntu22.04-skylake/gcc-12.3.0/netcdf-c-4.7.4-s5yyz4ucrkdi4s3q2yodm4ux5oomjzmg/lib:/home/sam/code/serac_libs_cuda_4_30_2024/spack/opt/spack/linux-ubuntu22.04-skylake/gcc-12.3.0/petsc-3.21.0-ptibifyjbacj32mrwrzsmuxzpvekgff3/lib:/home/sam/code/serac_libs_cuda_4_30_2024/spack/opt/spack/linux-ubuntu22.04-skylake/gcc-12.3.0/superlu-dist-8.1.2-fuk2t2gyjpag5rljesc4akeg4l3hoooj/lib:/home/sam/code/serac_libs_cuda_4_30_2024/spack/opt/spack/linux-ubuntu22.04-skylake/gcc-12.3.0/strumpack-7.2.0-tmcxhaoexzq7stfxcs6qund7k5j4tx7y/lib:/home/sam/code/serac_libs_cuda_4_30_2024/spack/opt/spack/linux-ubuntu22.04-skylake/gcc-12.3.0/netlib-scalapack-2.2.0-qcuv2i6kxjkqw7mtoehmptoaobzty3ss/lib:/home/sam/code/serac_libs_cuda_4_30_2024/spack/opt/spack/linux-ubuntu22.04-skylake/gcc-12.3.0/sundials-6.7.0-sxcdkg2pvyhiawtf2tcy2u5gtawjiqxy/lib:/home/sam/code/serac_libs_cuda_4_30_2024/spack/opt/spack/linux-ubuntu22.04-skylake/gcc-12.3.0/raja-2024.02.0-2jc6syt3fqeovfjljuwlfivedbkvxg3u/lib:/home/sam/code/serac_libs_cuda_4_30_2024/spack/opt/spack/linux-ubuntu22.04-skylake/gcc-12.3.0/camp-2024.02.0-o2xfmsdbh5ojxuosjqnldypfwwdlzha4/lib:/home/sam/code/serac_libs_cuda_4_30_2024/spack/opt/spack/linux-ubuntu22.04-skylake/gcc-12.3.0/umpire-2024.02.0-dw7tediw4pw3v5b2kcbwufoolcwzsw2n/lib:/home/sam/code/serac_libs_cuda_4_30_2024/spack/opt/spack/linux-ubuntu22.04-skylake/gcc-12.3.0/fmt-10.2.1-qug2m6e5qfdo2lya2nbelsclw6qrqxp4/lib:/home/sam/.local/lib:/home/sam/code/serac_libs_cuda_4_30_2024/spack/opt/spack/linux-ubuntu22.04-skylake/gcc-12.3.0/tribol-0.1.0.15-jgh4rgy2b2wbx55fa2d4uwlqas4s7irv/lib:/usr/local/cuda/lib64  lib/libserac_physics.a  lib/libserac_mesh.a  lib/libserac_functional.a  lib/libserac_boundary_conditions.a  lib/libserac_state.a  lib/libserac_contact.a  lib/libserac_numerics.a  lib/libserac_physics_materials.a  lib/libserac_functional.a  lib/libserac_mesh.a  lib/libserac_infrastructure.a  /home/sam/code/serac_libs_cuda_4_30_2024/spack/opt/spack/linux-ubuntu22.04-skylake/gcc-12.3.0/tribol-0.1.0.15-jgh4rgy2b2wbx55fa2d4uwlqas4s7irv/lib/libtribol.a  /home/sam/code/serac_libs_cuda_4_30_2024/spack/opt/spack/linux-ubuntu22.04-skylake/gcc-12.3.0/tribol-0.1.0.15-jgh4rgy2b2wbx55fa2d4uwlqas4s7irv/lib/libredecomp.a  -Xlinker -rpath -Xlinker /home/sam/code/serac_libs_cuda_4_30_2024/spack/opt/spack/linux-ubuntu22.04-skylake/gcc-12.3.0/hypre-2.26.0-ncfa2miwza7t7a4gadov6hyxi2z24akx/lib -Xlinker -rpath -Xlinker /home/sam/code/serac_libs_cuda_4_30_2024/spack/opt/spack/linux-ubuntu22.04-skylake/gcc-12.3.0/openblas-0.3.26-wfq52jjryfenk54kf3qqgndee7vgmsh3/lib -L/home/sam/code/serac_libs_cuda_4_30_2024/spack/opt/spack/linux-ubuntu22.04-skylake/gcc-12.3.0/hypre-2.26.0-ncfa2miwza7t7a4gadov6hyxi2z24akx/lib -L/home/sam/code/serac_libs_cuda_4_30_2024/spack/opt/spack/linux-ubuntu22.04-skylake/gcc-12.3.0/openblas-0.3.26-wfq52jjryfenk54kf3qqgndee7vgmsh3/lib -lHYPRE -lopenblas -Xlinker -rpath -Xlinker /home/sam/code/serac_libs_cuda_4_30_2024/spack/opt/spack/linux-ubuntu22.04-skylake/gcc-12.3.0/superlu-dist-8.1.2-fuk2t2gyjpag5rljesc4akeg4l3hoooj/lib -Xlinker -rpath -Xlinker /home/sam/code/serac_libs_cuda_4_30_2024/spack/opt/spack/linux-ubuntu22.04-skylake/gcc-12.3.0/parmetis-4.0.3-tdfzc3tyxr6to6j2rdt3eiiuoh6gykpy/lib -L/home/sam/code/serac_libs_cuda_4_30_2024/spack/opt/spack/linux-ubuntu22.04-skylake/gcc-12.3.0/superlu-dist-8.1.2-fuk2t2gyjpag5rljesc4akeg4l3hoooj/lib -L/home/sam/code/serac_libs_cuda_4_30_2024/spack/opt/spack/linux-ubuntu22.04-skylake/gcc-12.3.0/parmetis-4.0.3-tdfzc3tyxr6to6j2rdt3eiiuoh6gykpy/lib -lsuperlu_dist -lparmetis -Xlinker -rpath -Xlinker /home/sam/code/serac_libs_cuda_4_30_2024/spack/opt/spack/linux-ubuntu22.04-skylake/gcc-12.3.0/openblas-0.3.26-wfq52jjryfenk54kf3qqgndee7vgmsh3/lib -L/home/sam/code/serac_libs_cuda_4_30_2024/spack/opt/spack/linux-ubuntu22.04-skylake/gcc-12.3.0/openblas-0.3.26-wfq52jjryfenk54kf3qqgndee7vgmsh3/lib -lopenblas -Xlinker -rpath -Xlinker /home/sam/code/serac_libs_cuda_4_30_2024/spack/opt/spack/linux-ubuntu22.04-skylake/gcc-12.3.0/metis-5.1.0-my43hh2r636htpgacvxd7i3wgswb7a4d/lib -L/home/sam/code/serac_libs_cuda_4_30_2024/spack/opt/spack/linux-ubuntu22.04-skylake/gcc-12.3.0/metis-5.1.0-my43hh2r636htpgacvxd7i3wgswb7a4d/lib -lmetis -Xlinker -rpath -Xlinker /home/sam/code/serac_libs_cuda_4_30_2024/spack/opt/spack/linux-ubuntu22.04-skylake/gcc-12.3.0/openblas-0.3.26-wfq52jjryfenk54kf3qqgndee7vgmsh3/lib -L/home/sam/code/serac_libs_cuda_4_30_2024/spack/opt/spack/linux-ubuntu22.04-skylake/gcc-12.3.0/openblas-0.3.26-wfq52jjryfenk54kf3qqgndee7vgmsh3/lib -lopenblas -Xlinker -rpath -Xlinker /home/sam/code/serac_libs_cuda_4_30_2024/spack/opt/spack/linux-ubuntu22.04-skylake/gcc-12.3.0/sundials-6.7.0-sxcdkg2pvyhiawtf2tcy2u5gtawjiqxy/lib -L/home/sam/code/serac_libs_cuda_4_30_2024/spack/opt/spack/linux-ubuntu22.04-skylake/gcc-12.3.0/sundials-6.7.0-sxcdkg2pvyhiawtf2tcy2u5gtawjiqxy/lib -lsundials_arkode -lsundials_cvodes -lsundials_nvecserial -lsundials_kinsol -lsundials_nvecparallel -lsundials_nvecmpiplusx -lsundials_nveccuda -Xlinker -rpath -Xlinker /home/sam/code/serac_libs_cuda_4_30_2024/spack/opt/spack/linux-ubuntu22.04-skylake/gcc-12.3.0/strumpack-7.2.0-tmcxhaoexzq7stfxcs6qund7k5j4tx7y/lib -L/home/sam/code/serac_libs_cuda_4_30_2024/spack/opt/spack/linux-ubuntu22.04-skylake/gcc-12.3.0/strumpack-7.2.0-tmcxhaoexzq7stfxcs6qund7k5j4tx7y/lib -lstrumpack -Xlinker -rpath -Xlinker /usr/lib/gcc/x86_64-linux-gnu/12 -L/usr/lib/gcc/x86_64-linux-gnu/12 -lgfortran -lmpifort -Xlinker -rpath -Xlinker /home/sam/code/serac_libs_cuda_4_30_2024/spack/opt/spack/linux-ubuntu22.04-skylake/gcc-12.3.0/parmetis-4.0.3-tdfzc3tyxr6to6j2rdt3eiiuoh6gykpy/lib -L/home/sam/code/serac_libs_cuda_4_30_2024/spack/opt/spack/linux-ubuntu22.04-skylake/gcc-12.3.0/parmetis-4.0.3-tdfzc3tyxr6to6j2rdt3eiiuoh6gykpy/lib -lparmetis -Xlinker -rpath -Xlinker /home/sam/code/serac_libs_cuda_4_30_2024/spack/opt/spack/linux-ubuntu22.04-skylake/gcc-12.3.0/netlib-scalapack-2.2.0-qcuv2i6kxjkqw7mtoehmptoaobzty3ss/lib -L/home/sam/code/serac_libs_cuda_4_30_2024/spack/opt/spack/linux-ubuntu22.04-skylake/gcc-12.3.0/netlib-scalapack-2.2.0-qcuv2i6kxjkqw7mtoehmptoaobzty3ss/lib -lscalapack -lcusolver -lcublas -Xlinker -rpath -Xlinker /home/sam/code/serac_libs_cuda_4_30_2024/spack/opt/spack/linux-ubuntu22.04-skylake/gcc-12.3.0/netcdf-c-4.7.4-s5yyz4ucrkdi4s3q2yodm4ux5oomjzmg/lib -L/home/sam/code/serac_libs_cuda_4_30_2024/spack/opt/spack/linux-ubuntu22.04-skylake/gcc-12.3.0/netcdf-c-4.7.4-s5yyz4ucrkdi4s3q2yodm4ux5oomjzmg/lib -lnetcdf -Xlinker -rpath -Xlinker /home/sam/code/serac_libs_cuda_4_30_2024/spack/opt/spack/linux-ubuntu22.04-skylake/gcc-12.3.0/hdf5-1.8.23-wuxgpyfxukz4hy6mrs2wulptpihvtfad/lib -L/home/sam/code/serac_libs_cuda_4_30_2024/spack/opt/spack/linux-ubuntu22.04-skylake/gcc-12.3.0/hdf5-1.8.23-wuxgpyfxukz4hy6mrs2wulptpihvtfad/lib -lhdf5_hl -lhdf5 -Xlinker -rpath -Xlinker /home/sam/code/serac_libs_cuda_4_30_2024/spack/opt/spack/linux-ubuntu22.04-skylake/gcc-12.3.0/petsc-3.21.0-ptibifyjbacj32mrwrzsmuxzpvekgff3/lib -L/home/sam/code/serac_libs_cuda_4_30_2024/spack/opt/spack/linux-ubuntu22.04-skylake/gcc-12.3.0/petsc-3.21.0-ptibifyjbacj32mrwrzsmuxzpvekgff3/lib -lpetsc -Xlinker -rpath -Xlinker /home/sam/code/serac_libs_cuda_4_30_2024/spack/opt/spack/linux-ubuntu22.04-skylake/gcc-12.3.0/hypre-2.26.0-ncfa2miwza7t7a4gadov6hyxi2z24akx/lib -L/home/sam/code/serac_libs_cuda_4_30_2024/spack/opt/spack/linux-ubuntu22.04-skylake/gcc-12.3.0/hypre-2.26.0-ncfa2miwza7t7a4gadov6hyxi2z24akx/lib -Xlinker -rpath -Xlinker /home/sam/code/serac_libs_cuda_4_30_2024/spack/opt/spack/linux-ubuntu22.04-skylake/gcc-12.3.0/superlu-dist-8.1.2-fuk2t2gyjpag5rljesc4akeg4l3hoooj/lib -L/home/sam/code/serac_libs_cuda_4_30_2024/spack/opt/spack/linux-ubuntu22.04-skylake/gcc-12.3.0/superlu-dist-8.1.2-fuk2t2gyjpag5rljesc4akeg4l3hoooj/lib -Xlinker -rpath -Xlinker /home/sam/code/serac_libs_cuda_4_30_2024/spack/opt/spack/linux-ubuntu22.04-skylake/gcc-12.3.0/openblas-0.3.26-wfq52jjryfenk54kf3qqgndee7vgmsh3/lib -L/home/sam/code/serac_libs_cuda_4_30_2024/spack/opt/spack/linux-ubuntu22.04-skylake/gcc-12.3.0/openblas-0.3.26-wfq52jjryfenk54kf3qqgndee7vgmsh3/lib -Xlinker -rpath -Xlinker /home/sam/code/serac_libs_cuda_4_30_2024/spack/opt/spack/linux-ubuntu22.04-skylake/gcc-12.3.0/parmetis-4.0.3-tdfzc3tyxr6to6j2rdt3eiiuoh6gykpy/lib -L/home/sam/code/serac_libs_cuda_4_30_2024/spack/opt/spack/linux-ubuntu22.04-skylake/gcc-12.3.0/parmetis-4.0.3-tdfzc3tyxr6to6j2rdt3eiiuoh6gykpy/lib -Xlinker -rpath -Xlinker /home/sam/code/serac_libs_cuda_4_30_2024/spack/opt/spack/linux-ubuntu22.04-skylake/gcc-12.3.0/metis-5.1.0-my43hh2r636htpgacvxd7i3wgswb7a4d/lib -L/home/sam/code/serac_libs_cuda_4_30_2024/spack/opt/spack/linux-ubuntu22.04-skylake/gcc-12.3.0/metis-5.1.0-my43hh2r636htpgacvxd7i3wgswb7a4d/lib -Xlinker -rpath -Xlinker /usr/lib/gcc/x86_64-linux-gnu/12 -L/usr/lib/gcc/x86_64-linux-gnu/12 -lHYPRE -lsuperlu_dist -lopenblas -lparmetis -lmetis -lm -lmpichfort -lmpich -lgfortran -lm -lgfortran -lm -lgcc_s -lquadmath -lstdc++ -lquadmath -lcusparse -lcusolver -lcublas -lnvToolsExt -L/home/sam/code/serac_libs_cuda_4_30_2024/spack/opt/spack/linux-ubuntu22.04-skylake/gcc-12.3.0/amgx-2.3.0.1-bgapfufnnvyhomg2knyo24svuocelcnw/lib -lamgx -lcusparse -lrt -Xlinker -rpath -Xlinker /home/sam/code/serac_libs_cuda_4_30_2024/spack/opt/spack/linux-ubuntu22.04-skylake/gcc-12.3.0/zlib-ng-2.1.6-lzstgsbitxrugm2veu3hsvu6knjqkuwd/lib -L/home/sam/code/serac_libs_cuda_4_30_2024/spack/opt/spack/linux-ubuntu22.04-skylake/gcc-12.3.0/zlib-ng-2.1.6-lzstgsbitxrugm2veu3hsvu6knjqkuwd/lib -lz  /home/sam/code/serac_libs_cuda_4_30_2024/spack/opt/spack/linux-ubuntu22.04-skylake/gcc-12.3.0/axom-0.9.0.1-xedxtprfh42igx27dsyadyp2o2mg4mjs/lib/libaxom_quest.a  /home/sam/code/serac_libs_cuda_4_30_2024/spack/opt/spack/linux-ubuntu22.04-skylake/gcc-12.3.0/axom-0.9.0.1-xedxtprfh42igx27dsyadyp2o2mg4mjs/lib/libaxom_slam.a  /home/sam/code/serac_libs_cuda_4_30_2024/spack/opt/spack/linux-ubuntu22.04-skylake/gcc-12.3.0/axom-0.9.0.1-xedxtprfh42igx27dsyadyp2o2mg4mjs/lib/libaxom_mint.a  /home/sam/code/serac_libs_cuda_4_30_2024/spack/opt/spack/linux-ubuntu22.04-skylake/gcc-12.3.0/axom-0.9.0.1-xedxtprfh42igx27dsyadyp2o2mg4mjs/lib/libaxom_klee.a  /home/sam/code/serac_libs_cuda_4_30_2024/spack/opt/spack/linux-ubuntu22.04-skylake/gcc-12.3.0/axom-0.9.0.1-xedxtprfh42igx27dsyadyp2o2mg4mjs/lib/libaxom_inlet.a  /home/sam/code/serac_libs_cuda_4_30_2024/spack/opt/spack/linux-ubuntu22.04-skylake/gcc-12.3.0/axom-0.9.0.1-xedxtprfh42igx27dsyadyp2o2mg4mjs/lib/libaxom_sidre.a  /home/sam/code/serac_libs_cuda_4_30_2024/spack/opt/spack/linux-ubuntu22.04-skylake/gcc-12.3.0/axom-0.9.0.1-xedxtprfh42igx27dsyadyp2o2mg4mjs/lib/libaxom_slic.a  /home/sam/code/serac_libs_cuda_4_30_2024/spack/opt/spack/linux-ubuntu22.04-skylake/gcc-12.3.0/axom-0.9.0.1-xedxtprfh42igx27dsyadyp2o2mg4mjs/lib/libaxom_lumberjack.a  /home/sam/code/serac_libs_cuda_4_30_2024/spack/opt/spack/linux-ubuntu22.04-skylake/gcc-12.3.0/axom-0.9.0.1-xedxtprfh42igx27dsyadyp2o2mg4mjs/lib/libaxom_core.a  /home/sam/code/serac_libs_cuda_4_30_2024/spack/opt/spack/linux-ubuntu22.04-skylake/gcc-12.3.0/umpire-2024.02.0-dw7tediw4pw3v5b2kcbwufoolcwzsw2n/lib/libumpire.a  /home/sam/code/serac_libs_cuda_4_30_2024/spack/opt/spack/linux-ubuntu22.04-skylake/gcc-12.3.0/fmt-10.2.1-qug2m6e5qfdo2lya2nbelsclw6qrqxp4/lib/libfmt.a  /home/sam/code/serac_libs_cuda_4_30_2024/spack/opt/spack/linux-ubuntu22.04-skylake/gcc-12.3.0/raja-2024.02.0-2jc6syt3fqeovfjljuwlfivedbkvxg3u/lib/libRAJA.a  -lnvToolsExt  /home/sam/code/serac_libs_cuda_4_30_2024/spack/opt/spack/linux-ubuntu22.04-skylake/gcc-12.3.0/camp-2024.02.0-o2xfmsdbh5ojxuosjqnldypfwwdlzha4/lib/libcamp.a  /home/sam/code/serac_libs_cuda_4_30_2024/spack/opt/spack/linux-ubuntu22.04-skylake/gcc-12.3.0/conduit-0.9.1-fdle5ykhzyve3ltgg4kyqqieenipeamf/lib/libconduit_relay_mpi_io.a  /home/sam/code/serac_libs_cuda_4_30_2024/spack/opt/spack/linux-ubuntu22.04-skylake/gcc-12.3.0/conduit-0.9.1-fdle5ykhzyve3ltgg4kyqqieenipeamf/lib/libconduit_relay.a  -lrt  /home/sam/code/serac_libs_cuda_4_30_2024/spack/opt/spack/linux-ubuntu22.04-skylake/gcc-12.3.0/hdf5-1.8.23-wuxgpyfxukz4hy6mrs2wulptpihvtfad/lib/libhdf5.a  /home/sam/code/serac_libs_cuda_4_30_2024/spack/opt/spack/linux-ubuntu22.04-skylake/gcc-12.3.0/conduit-0.9.1-fdle5ykhzyve3ltgg4kyqqieenipeamf/lib/libconduit_blueprint_mpi.a  /home/sam/code/serac_libs_cuda_4_30_2024/spack/opt/spack/linux-ubuntu22.04-skylake/gcc-12.3.0/conduit-0.9.1-fdle5ykhzyve3ltgg4kyqqieenipeamf/lib/libconduit_blueprint.a  /home/sam/code/serac_libs_cuda_4_30_2024/spack/opt/spack/linux-ubuntu22.04-skylake/gcc-12.3.0/conduit-0.9.1-fdle5ykhzyve3ltgg4kyqqieenipeamf/lib/libconduit_relay_mpi.a  /home/sam/code/serac_libs_cuda_4_30_2024/spack/opt/spack/linux-ubuntu22.04-skylake/gcc-12.3.0/conduit-0.9.1-fdle5ykhzyve3ltgg4kyqqieenipeamf/lib/libconduit.a  /home/sam/code/serac_libs_cuda_4_30_2024/spack/opt/spack/linux-ubuntu22.04-skylake/gcc-12.3.0/parmetis-4.0.3-tdfzc3tyxr6to6j2rdt3eiiuoh6gykpy/lib/libparmetis.a  /home/sam/code/serac_libs_cuda_4_30_2024/spack/opt/spack/linux-ubuntu22.04-skylake/gcc-12.3.0/metis-5.1.0-my43hh2r636htpgacvxd7i3wgswb7a4d/lib/libmetis.a  /home/sam/code/serac_libs_cuda_4_30_2024/spack/opt/spack/linux-ubuntu22.04-skylake/gcc-12.3.0/hdf5-1.8.23-wuxgpyfxukz4hy6mrs2wulptpihvtfad/lib/libhdf5.a  -lm  /home/sam/code/serac_libs_cuda_4_30_2024/spack/opt/spack/linux-ubuntu22.04-skylake/gcc-12.3.0/zlib-ng-2.1.6-lzstgsbitxrugm2veu3hsvu6knjqkuwd/lib/libz.so  /home/sam/code/serac_libs_cuda_4_30_2024/spack/opt/spack/linux-ubuntu22.04-skylake/gcc-12.3.0/lua-5.4.6-sapqeyah462eyfek57wphfah2ibs7xwv/lib/liblua54.so  -lm  /home/sam/code/serac_libs_cuda_4_30_2024/spack/opt/spack/linux-ubuntu22.04-skylake/gcc-12.3.0/mfem-4.6.2.4-hgffss6egy6b2jb6zx43aqzfjuherw5d/lib/libmfem.a  /usr/local/cuda/lib64/libcudart_static.a  -ldl  /usr/lib/x86_64-linux-gnu/librt.a  -L/home/sam/code/serac_libs_cuda_4_30_2024/spack/opt/spack/linux-ubuntu22.04-skylake/gcc-12.3.0/hypre-2.26.0-ncfa2miwza7t7a4gadov6hyxi2z24akx/lib -L/home/sam/code/serac_libs_cuda_4_30_2024/spack/opt/spack/linux-ubuntu22.04-skylake/gcc-12.3.0/openblas-0.3.26-wfq52jjryfenk54kf3qqgndee7vgmsh3/lib -lHYPRE -lopenblas -L/home/sam/code/serac_libs_cuda_4_30_2024/spack/opt/spack/linux-ubuntu22.04-skylake/gcc-12.3.0/superlu-dist-8.1.2-fuk2t2gyjpag5rljesc4akeg4l3hoooj/lib -L/home/sam/code/serac_libs_cuda_4_30_2024/spack/opt/spack/linux-ubuntu22.04-skylake/gcc-12.3.0/parmetis-4.0.3-tdfzc3tyxr6to6j2rdt3eiiuoh6gykpy/lib -lsuperlu_dist -lparmetis -L/home/sam/code/serac_libs_cuda_4_30_2024/spack/opt/spack/linux-ubuntu22.04-skylake/gcc-12.3.0/openblas-0.3.26-wfq52jjryfenk54kf3qqgndee7vgmsh3/lib -lopenblas -L/home/sam/code/serac_libs_cuda_4_30_2024/spack/opt/spack/linux-ubuntu22.04-skylake/gcc-12.3.0/metis-5.1.0-my43hh2r636htpgacvxd7i3wgswb7a4d/lib -lmetis -L/home/sam/code/serac_libs_cuda_4_30_2024/spack/opt/spack/linux-ubuntu22.04-skylake/gcc-12.3.0/openblas-0.3.26-wfq52jjryfenk54kf3qqgndee7vgmsh3/lib -lopenblas -L/home/sam/code/serac_libs_cuda_4_30_2024/spack/opt/spack/linux-ubuntu22.04-skylake/gcc-12.3.0/sundials-6.7.0-sxcdkg2pvyhiawtf2tcy2u5gtawjiqxy/lib -lsundials_arkode -lsundials_cvodes -lsundials_nvecserial -lsundials_kinsol -lsundials_nvecparallel -lsundials_nvecmpiplusx -lsundials_nveccuda -L/home/sam/code/serac_libs_cuda_4_30_2024/spack/opt/spack/linux-ubuntu22.04-skylake/gcc-12.3.0/strumpack-7.2.0-tmcxhaoexzq7stfxcs6qund7k5j4tx7y/lib -lstrumpack -L/usr/lib/gcc/x86_64-linux-gnu/12 -lgfortran -lmpifort -L/home/sam/code/serac_libs_cuda_4_30_2024/spack/opt/spack/linux-ubuntu22.04-skylake/gcc-12.3.0/parmetis-4.0.3-tdfzc3tyxr6to6j2rdt3eiiuoh6gykpy/lib -lparmetis -L/home/sam/code/serac_libs_cuda_4_30_2024/spack/opt/spack/linux-ubuntu22.04-skylake/gcc-12.3.0/netlib-scalapack-2.2.0-qcuv2i6kxjkqw7mtoehmptoaobzty3ss/lib -lscalapack -lcusolver -lcublas -L/home/sam/code/serac_libs_cuda_4_30_2024/spack/opt/spack/linux-ubuntu22.04-skylake/gcc-12.3.0/netcdf-c-4.7.4-s5yyz4ucrkdi4s3q2yodm4ux5oomjzmg/lib -lnetcdf -L/home/sam/code/serac_libs_cuda_4_30_2024/spack/opt/spack/linux-ubuntu22.04-skylake/gcc-12.3.0/hdf5-1.8.23-wuxgpyfxukz4hy6mrs2wulptpihvtfad/lib -lhdf5_hl -lhdf5 -L/home/sam/code/serac_libs_cuda_4_30_2024/spack/opt/spack/linux-ubuntu22.04-skylake/gcc-12.3.0/petsc-3.21.0-ptibifyjbacj32mrwrzsmuxzpvekgff3/lib -lpetsc -L/home/sam/code/serac_libs_cuda_4_30_2024/spack/opt/spack/linux-ubuntu22.04-skylake/gcc-12.3.0/hypre-2.26.0-ncfa2miwza7t7a4gadov6hyxi2z24akx/lib -L/home/sam/code/serac_libs_cuda_4_30_2024/spack/opt/spack/linux-ubuntu22.04-skylake/gcc-12.3.0/superlu-dist-8.1.2-fuk2t2gyjpag5rljesc4akeg4l3hoooj/lib -L/home/sam/code/serac_libs_cuda_4_30_2024/spack/opt/spack/linux-ubuntu22.04-skylake/gcc-12.3.0/openblas-0.3.26-wfq52jjryfenk54kf3qqgndee7vgmsh3/lib -L/home/sam/code/serac_libs_cuda_4_30_2024/spack/opt/spack/linux-ubuntu22.04-skylake/gcc-12.3.0/parmetis-4.0.3-tdfzc3tyxr6to6j2rdt3eiiuoh6gykpy/lib -L/home/sam/code/serac_libs_cuda_4_30_2024/spack/opt/spack/linux-ubuntu22.04-skylake/gcc-12.3.0/metis-5.1.0-my43hh2r636htpgacvxd7i3wgswb7a4d/lib -L/usr/lib/gcc/x86_64-linux-gnu/12 -lHYPRE -lsuperlu_dist -lopenblas -lparmetis -lmetis -lm -lmpichfort -lmpich -lgfortran -lm -lgfortran -lm -lgcc_s -lquadmath -lstdc++ -lquadmath -lcusparse -lcusolver -lcublas -lnvToolsExt -L/home/sam/code/serac_libs_cuda_4_30_2024/spack/opt/spack/linux-ubuntu22.04-skylake/gcc-12.3.0/amgx-2.3.0.1-bgapfufnnvyhomg2knyo24svuocelcnw/lib -lamgx -lcusparse -lrt -L/home/sam/code/serac_libs_cuda_4_30_2024/spack/opt/spack/linux-ubuntu22.04-skylake/gcc-12.3.0/zlib-ng-2.1.6-lzstgsbitxrugm2veu3hsvu6knjqkuwd/lib -lz  -L/usr/local/cuda/lib64  /usr/local/cuda/lib64/libcublas.so  /usr/local/cuda/lib64/libcusolver.so  /usr/lib/x86_64-linux-gnu/libmpich.so  /usr/lib/x86_64-linux-gnu/libmpichcxx.so  -lcudadevrt  -lcudart_static  -lrt  -lpthread  -ldl && :
[build] /usr/bin/ld: /home/sam/code/serac_libs_cuda_4_30_2024/spack/opt/spack/linux-ubuntu22.04-skylake/gcc-12.3.0/amgx-2.3.0.1-bgapfufnnvyhomg2knyo24svuocelcnw/lib/libamgx.a(amgx_timer.cu.o): in function `amgx::nvtxRange::nvtxRange(char const*, int)':
[build] tmpxft_0025de4d_00000000-6_amgx_timer.cudafe1.cpp:(.text+0xae): undefined reference to `nvtxRangePushEx'
[build] /usr/bin/ld: /home/sam/code/serac_libs_cuda_4_30_2024/spack/opt/spack/linux-ubuntu22.04-skylake/gcc-12.3.0/amgx-2.3.0.1-bgapfufnnvyhomg2knyo24svuocelcnw/lib/libamgx.a(amgx_timer.cu.o): in function `amgx::nvtxRange::~nvtxRange()':
[build] tmpxft_0025de4d_00000000-6_amgx_timer.cudafe1.cpp:(.text+0xd9): undefined reference to `nvtxRangePop'
```

If you have a different/better fix, I can test it to ensure it works for us.
<!--GHEX{"author":"white238","assignment":"2024-05-02T01:08:18","editor":"tzanio","id":4276,"reviewers":["tzanio","v-dobrev","artv3"],"merge":"2024-05-02T20:48:20","approval":"2024-05-02T01:20:49"}XEHG-->
<!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge|
 | --- | --- | --- | --- | --- | --- | --- |
| [#4276](https://github.com/mfem/mfem/pull/4276) | @white238 | @tzanio | @tzanio + @v-dobrev + @artv3 | 5/1/24 | 5/1/24 | 5/2/24 | |
<!--ELBATXEHG-->
<details>
<summary>PR Checklist</summary>
    
- [ ] Code builds.
- [ ] Code passes `make style`.
- [ ] Update `CHANGELOG`:
    - [ ] Is this a new feature users need to be aware of? New or updated example or miniapp?
    - [ ] Does it make sense to create a new section in the `CHANGELOG` to group with other related features?
- [ ] Update `INSTALL`:
    - [ ] Had a new optional library been added? If so, what range of versions of this library are required? (*Make sure the external library is compatible with our BSD license, e.g. it is not licensed under GPL!*)
    - [ ] Have the version ranges for any required or optional libraries changed?
    - [ ] Does `make` or `cmake` have a new target?
    - [ ] Did the requirements or the installation process change? *(rare)*
- [ ] Update continuous integration server configurations if necessary (e.g. with new version requirements for each of MFEM's dependencies)
    - [ ] `.github`
    - [ ] `.appveyor.yml`
- [ ] Update `.gitignore`:
    - [ ] Check if `make distclean; git status` shows any files that were generated from the source by the project (not an IDE) but we don't want to track in the repository.
    - [ ] Add new patterns (just for the new files above) and re-run the above test.
- [ ] New examples:
    - [ ] All sample runs at the top of the example source file work.
    - [ ] Update `examples/makefile`:
      - [ ] Add the example code to the appropriate `SEQ_EXAMPLES` and `PAR_EXAMPLES` variables.
      - [ ] Add any files generated by it to the `clean` target.
      - [ ] Add the example binary and any files generated by it to the top-level `.gitignore` file.
    - [ ] Update `examples/CMakeLists.txt`:
      - [ ] Add the example code to the `ALL_EXE_SRCS` variable.
      - [ ] Make sure `THIS_TEST_OPTIONS` is set correctly for the new example.
   - [ ] List the new example in `doc/CodeDocumentation.dox`.
   - [ ] If new examples directory (e.g.`examples/pumi`), list it in `doc/CodeDocumentation.conf.in`
   - [ ] Companion pull request for documentation in [mfem/web](https://github.com/mfem/web) repo:
      - [ ] Update or add example-specific documentation, see e.g. the `src/examples.md`.
      - [ ] Add the description, labels and screenshots in `src/examples.md` and `src/img`.
      - [ ] In `examples.md`, list the example under the appropriate categories, add new categories if necessary.
      - [ ] Add a short description of the example in the "Extensive Examples" section of `features.md`.
- [ ] New miniapps:
   - [ ] All sample runs at the top of the miniapp source file work.
   - [ ] Update top-level `makefile` and `makefile` in corresponding miniapp directory.
   - [ ] Add the miniapp binary and any files generated by it to the top-level `.gitignore` file.
   - [ ] Update CMake build system:
      - [ ] Update the `CMakeLists.txt` file in the `miniapps` directory, if the new miniapp is in a new directory.
      - [ ] Add/update the `CMakeLists.txt` file in the new miniapp directory.
      - [ ] Consider adding a new test for the new miniapp.
   - [ ] List the new miniapp in `doc/CodeDocumentation.dox`
   - [ ] If new miniapps directory (e.g.`miniapps/nurbs`), add it to `MINIAPP_SUBDIRS` in the `makefile`.
   - [ ] If new miniapps directory (e.g.`miniapps/nurbs`), list it in `doc/CodeDocumentation.conf.in`
   - [ ] Companion pull request for documentation in [mfem/web](https://github.com/mfem/web) repo:
     - [ ] Update or add miniapp-specific documentation, see e.g. the `src/meshing.md` and `src/electromagnetics.md` files.
     - [ ] Add the description, labels and screenshots in `src/examples.md` and `src/img`.
     - [ ] The miniapps go at the end of the page, and are usually listed only under a specific "Application (PDE)" category.
     - [ ] Add a short description of the miniapp in the "Extensive Examples" section of `features.md`.
- [ ] New capability:
   - [ ] All new public, protected, and private classes, methods, data members, and functions have full Doxygen-style documentation in source comments. Documentation should include descriptions of member data, function arguments and return values, template parameters, and prerequisites for calling new functions.
   - [ ] Pointer arguments and return values must specify whether ownership is being transferred or lent with the call.
   - [ ] Any new functions should include descriptions of their intended use e.g. for internal use only, user-facing, etc., along with references to example code whenever possible/appropriate.
   - [ ] Consider adding new sample runs in existing examples to highlight the new capability.
   - [ ] Consider saving cool simulation pictures with the new capability in the Confluence gallery (LLNL only) or submitting them, via pull request, to the gallery section of the `mfem/web` repo.
   - [ ] If this is a major new feature, consider mentioning it in the short summary inside `README` *(rare)*.
   - [ ] List major new classes in `doc/CodeDocumentation.dox` *(rare)*.
- [ ] Update this checklist, if the new pull request affects it.
- [ ] Run `make unittest` to make sure all unit tests pass.
- [ ] Run the tests in `tests/scripts`.
- [ ] (LLNL only) After merging:
   - [ ] Update internal tests to include the new features.
</details>
