### PR TITLE
[WIP] Enhance VisIt Data Collection to write out field basis names [task/JustinPrivitera/05_14_24/visit_data_coll_write_out_basis_name]

### DIFF
--- a/fem/datacollection.hpp
+++ b/fem/datacollection.hpp
@@ -408,11 +408,12 @@ class VisItFieldInfo
 {
 public:
    std::string association;
+   std::string basis;
    int num_components;
    int lod;
-   VisItFieldInfo() { association = ""; num_components = 0; lod = 1;}
-   VisItFieldInfo(std::string association_, int num_components_, int lod_ = 1)
-   { association = association_; num_components = num_components_; lod =lod_;}
+   VisItFieldInfo() { association = ""; basis = ""; num_components = 0; lod = 1;}
+   VisItFieldInfo(std::string association_, std::string basis_, int num_components_, int lod_ = 1)
+   { association = association_; basis = basis_; num_components = num_components_; lod =lod_;}
 };
 
 /// Data collection with VisIt I/O routines


### PR DESCRIPTION
Pull request for comments about the integration of task/JustinPrivitera/05_14_24/visit_data_coll_write_out_basis_name into master.
 - Add `basis` string to the `VisItFieldInfo` class.
 - Add logic to handle `basis` string where appropriate.

These changes should bring the VisIt Data Collection more on par with the Conduit Data Collection. Once this feature is added, I will make changes within the MFEM reader inside VisIt to look for the basis name and use it to make appropriate choices about how to represent MFEM data, which will address this issue: https://github.com/visit-dav/visit/issues/19469.

TODO
 - [ ] understand what is the best path for quadrature elements. What should be provided as the basis name? An empty string? They are already element associated, which leads me to think that they have never worked with VisIt. If that's true, that sounds like a separate issue. What should we do in the meantime?
 - [ ] how can I test these changes?