### PR TITLE
Exodus II output from mesh-explorer

### DIFF
--- a/miniapps/meshing/mesh-explorer.cpp
+++ b/miniapps/meshing/mesh-explorer.cpp
@@ -1299,7 +1299,7 @@ int main (int argc, char *argv[])
          cout << "New Exodus II mesh file: " << omesh_file << endl;
       }
 #endif
-      
+
       if (mk == 'D')
       {
          cout << "What type of DataCollection?\n"

--- a/miniapps/meshing/mesh-explorer.cpp
+++ b/miniapps/meshing/mesh-explorer.cpp
@@ -386,6 +386,9 @@ int main (int argc, char *argv[])
            "S) Save in MFEM serial format\n"
            "T) Save in MFEM parallel format using the current partitioning\n"
            "V) Save in VTK format (only linear and quadratic meshes)\n"
+#ifdef MFEM_USE_NETCDF
+           "X) Save in Exodus II format (only linear and quadratic meshes)\n"
+#endif
            "D) Save as a DataCollection\n"
            "q) Quit\n"
 #ifdef MFEM_USE_ZLIB
@@ -1288,6 +1291,15 @@ int main (int argc, char *argv[])
          cout << "New VTK mesh file: " << omesh_file << endl;
       }
 
+#ifdef MFEM_USE_NETCDF
+      if (mk == 'X')
+      {
+         const char omesh_file[] = "mesh-explorer.e";
+         mesh->PrintExodusII(omesh_file);
+         cout << "New Exodus II mesh file: " << omesh_file << endl;
+      }
+#endif
+      
       if (mk == 'D')
       {
          cout << "What type of DataCollection?\n"


### PR DESCRIPTION
Simple proposed addition to exodus-writer-dev branch.

These changes add a 'X' option to the main menu of `mesh-explorer` which simply calls the new Exodus II writer. The new output file is called `mesh-explorer.e`.

@EdwardPalmer99, this is completely optional but I think people may find it useful. Please feel free to alter this in any manner that you see fit.
