### PR TITLE
Fix TransferMap between surface and volume submesh

### DIFF
--- a/mesh/submesh/submesh.cpp
+++ b/mesh/submesh/submesh.cpp
@@ -31,7 +31,7 @@ SubMesh SubMesh::CreateFromBoundary(const Mesh &parent,
 SubMesh::SubMesh(const Mesh &parent, From from,
                  Array<int> attributes) : parent_(parent), from_(from), attributes_(attributes)
 {
-   if (Nonconforming())
+   if (parent.Nonconforming())
    {
       MFEM_ABORT("SubMesh does not support non-conforming meshes");
    }
@@ -192,8 +192,6 @@ SubMesh::SubMesh(const Mesh &parent, From from,
    SetAttributes();
    Finalize();
 }
-
-SubMesh::~SubMesh() {}
 
 void SubMesh::Transfer(const GridFunction &src, GridFunction &dst)
 {

--- a/mesh/submesh/submesh.hpp
+++ b/mesh/submesh/submesh.hpp
@@ -174,8 +174,6 @@ public:
       return dynamic_cast<const SubMesh *>(m) != nullptr;
    }
 
-   ~SubMesh();
-
 private:
    /// Private constructor
    SubMesh(const Mesh &parent, From from, Array<int> attributes);

--- a/mesh/submesh/submesh_utils.cpp
+++ b/mesh/submesh/submesh_utils.cpp
@@ -174,7 +174,8 @@ void BuildVdofToVdofMap(const FiniteElementSpace& subfes,
       Array<int> sub_vdofs;
       subfes.GetElementVDofs(i, sub_vdofs);
 
-      MFEM_ASSERT(parent_vdofs.Size() == sub_vdofs.Size(), "internal error");
+      MFEM_ASSERT(parent_vdofs.Size() == sub_vdofs.Size(),
+                  "elem " << i << ' ' << parent_vdofs.Size() << ' ' << sub_vdofs.Size());
       for (int j = 0; j < parent_vdofs.Size(); j++)
       {
          real_t sub_sign = 1.0;

--- a/mesh/submesh/transfermap.cpp
+++ b/mesh/submesh/transfermap.cpp
@@ -92,10 +92,13 @@ TransferMap::TransferMap(const GridFunction &src,
 
          if (!root_fes_reset)
          {
+            const FiniteElementCollection *src_fec = src.FESpace()->FEColl();
+            const FiniteElementCollection *dst_fec = dst.FESpace()->FEColl();
+            auto *root_fec = src_sm_dim == parent_dim ? src_fec : dst_fec;
+
             root_fes_.reset(new FiniteElementSpace(
-                               *src.FESpace(),
                                const_cast<Mesh *>(
-                                  SubMeshUtils::GetRootParent(*src_sm))));
+                                  SubMeshUtils::GetRootParent(*src_sm)), root_fec));
          }
       }
 

--- a/tests/unit/mesh/mesh_test_utils.cpp
+++ b/tests/unit/mesh/mesh_test_utils.cpp
@@ -164,9 +164,10 @@ Mesh TetStarMesh()
    return mesh;
 }
 
-Mesh DividingPlaneMesh(bool tet_mesh, bool split)
+Mesh DividingPlaneMesh(bool tet_mesh, bool split, bool three_dim)
 {
-   auto mesh = Mesh("../../data/ref-cube.mesh");
+   auto mesh = three_dim ? Mesh("../../data/ref-cube.mesh") :
+               Mesh("../../data/ref-square.mesh");
    {
       Array<Refinement> refs;
       refs.Append(Refinement(0, Refinement::X));
@@ -202,6 +203,7 @@ Mesh DividingPlaneMesh(bool tet_mesh, bool split)
    mesh.Finalize(true, true);
    return mesh;
 }
+
 
 Mesh OrientedTriFaceMesh(int orientation, bool add_extbdr)
 {

--- a/tests/unit/mesh/mesh_test_utils.hpp
+++ b/tests/unit/mesh/mesh_test_utils.hpp
@@ -68,10 +68,12 @@ Mesh TetStarMesh();
  * with different volume attributes.
  *
  * @param tet_mesh Whether or not to split the generated mesh into tetrahedra.
- * @param split Whether to introduce the internal boundary,
+ * @param split Whether to introduce the internal boundary.
+ * @param three_dim Whether to generate a 3D mesh.
  * @return Mesh
  */
-Mesh DividingPlaneMesh(bool tet_mesh = true, bool split = true);
+Mesh DividingPlaneMesh(bool tet_mesh = true, bool split = true,
+                       bool three_dim = true);
 
 /**
  * @brief Create a mesh of two tetrahedra that share one triangular face at x=0.


### PR DESCRIPTION
Fixes a bug where the finite element collection for a common volume space was being incorrectly set using a surface finite element collection in the event of a submesh to submesh transfer.
<!--GHEX{"author":"hughcars","assignment":"2024-06-05T09:51:58","editor":"tzanio","id":4339,"reviewers":["jandrej","justinlaughlin","mlstowell"],"merge":"2024-06-25T19:13:50","approval":"2024-06-24T19:52:56"}XEHG-->
<!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge|
 | --- | --- | --- | --- | --- | --- | --- |
| [#4339](https://github.com/mfem/mfem/pull/4339) | @hughcars | @tzanio | @jandrej + @justinlaughlin + @mlstowell | 6/5/24 | 6/24/24 | 6/25/24 | |
<!--ELBATXEHG-->
<details>
<summary>PR Checklist</summary>
    
- [ ] Code builds.
- [ ] Code passes `make style`.
- [ ] Update `CHANGELOG`:
    - [ ] Is this a new feature users need to be aware of? New or updated example or miniapp?
    - [ ] Does it make sense to create a new section in the `CHANGELOG` to group with other related features?
- [ ] Update `INSTALL`:
    - [ ] Had a new optional library been added? If so, what range of versions of this library are required? (*Make sure the external library is compatible with our BSD license, e.g. it is not licensed under GPL!*)
    - [ ] Have the version ranges for any required or optional libraries changed?
    - [ ] Does `make` or `cmake` have a new target?
    - [ ] Did the requirements or the installation process change? *(rare)*
- [ ] Update continuous integration server configurations if necessary (e.g. with new version requirements for each of MFEM's dependencies)
    - [ ] `.github`
    - [ ] `.appveyor.yml`
- [ ] Update `.gitignore`:
    - [ ] Check if `make distclean; git status` shows any files that were generated from the source by the project (not an IDE) but we don't want to track in the repository.
    - [ ] Add new patterns (just for the new files above) and re-run the above test.
- [ ] New examples:
    - [ ] All sample runs at the top of the example source file work.
    - [ ] Update `examples/makefile`:
      - [ ] Add the example code to the appropriate `SEQ_EXAMPLES` and `PAR_EXAMPLES` variables.
      - [ ] Add any files generated by it to the `clean` target.
      - [ ] Add the example binary and any files generated by it to the top-level `.gitignore` file.
    - [ ] Update `examples/CMakeLists.txt`:
      - [ ] Add the example code to the `ALL_EXE_SRCS` variable.
      - [ ] Make sure `THIS_TEST_OPTIONS` is set correctly for the new example.
   - [ ] List the new example in `doc/CodeDocumentation.dox`.
   - [ ] If new examples directory (e.g.`examples/pumi`), list it in `doc/CodeDocumentation.conf.in`
   - [ ] Companion pull request for documentation in [mfem/web](https://github.com/mfem/web) repo:
      - [ ] Update or add example-specific documentation, see e.g. the `src/examples.md`.
      - [ ] Add the description, labels and screenshots in `src/examples.md` and `src/img`.
      - [ ] In `examples.md`, list the example under the appropriate categories, add new categories if necessary.
      - [ ] Add a short description of the example in the "Extensive Examples" section of `features.md`.
- [ ] New miniapps:
   - [ ] All sample runs at the top of the miniapp source file work.
   - [ ] Update top-level `makefile` and `makefile` in corresponding miniapp directory.
   - [ ] Add the miniapp binary and any files generated by it to the top-level `.gitignore` file.
   - [ ] Update CMake build system:
      - [ ] Update the `CMakeLists.txt` file in the `miniapps` directory, if the new miniapp is in a new directory.
      - [ ] Add/update the `CMakeLists.txt` file in the new miniapp directory.
      - [ ] Consider adding a new test for the new miniapp.
   - [ ] List the new miniapp in `doc/CodeDocumentation.dox`
   - [ ] If new miniapps directory (e.g.`miniapps/nurbs`), add it to `MINIAPP_SUBDIRS` in the `makefile`.
   - [ ] If new miniapps directory (e.g.`miniapps/nurbs`), list it in `doc/CodeDocumentation.conf.in`
   - [ ] Companion pull request for documentation in [mfem/web](https://github.com/mfem/web) repo:
     - [ ] Update or add miniapp-specific documentation, see e.g. the `src/meshing.md` and `src/electromagnetics.md` files.
     - [ ] Add the description, labels and screenshots in `src/examples.md` and `src/img`.
     - [ ] The miniapps go at the end of the page, and are usually listed only under a specific "Application (PDE)" category.
     - [ ] Add a short description of the miniapp in the "Extensive Examples" section of `features.md`.
- [ ] New capability:
   - [ ] All new public, protected, and private classes, methods, data members, and functions have full Doxygen-style documentation in source comments. Documentation should include descriptions of member data, function arguments and return values, template parameters, and prerequisites for calling new functions.
   - [ ] Pointer arguments and return values must specify whether ownership is being transferred or lent with the call.
   - [ ] Any new functions should include descriptions of their intended use e.g. for internal use only, user-facing, etc., along with references to example code whenever possible/appropriate.
   - [ ] Consider adding new sample runs in existing examples to highlight the new capability.
   - [ ] Consider saving cool simulation pictures with the new capability in the Confluence gallery (LLNL only) or submitting them, via pull request, to the gallery section of the `mfem/web` repo.
   - [ ] If this is a major new feature, consider mentioning it in the short summary inside `README` *(rare)*.
   - [ ] List major new classes in `doc/CodeDocumentation.dox` *(rare)*.
- [ ] Update this checklist, if the new pull request affects it.
- [ ] Run `make unittest` to make sure all unit tests pass.
- [ ] Run the tests in `tests/scripts`.
- [ ] (LLNL only) After merging:
   - [ ] Update internal tests to include the new features.
</details>
