### PR TITLE
Elimination of essential DOFs/BCs in MixedBilinearForm

### DIFF
--- a/examples/ex36.cpp
+++ b/examples/ex36.cpp
@@ -258,7 +258,7 @@ int main(int argc, char *argv[])
          MixedBilinearForm a10(&H1fes,&L2fes);
          a10.AddDomainIntegrator(new MixedScalarMassIntegrator());
          a10.Assemble();
-         a10.EliminateTrialDofs(ess_bdr, x.GetBlock(0), rhs.GetBlock(1));
+         a10.EliminateTrialEssentialBC(ess_bdr, x.GetBlock(0), rhs.GetBlock(1));
          a10.Finalize();
          SparseMatrix &A10 = a10.SpMat();
 

--- a/examples/ex8.cpp
+++ b/examples/ex8.cpp
@@ -157,7 +157,7 @@ int main(int argc, char *argv[])
    MixedBilinearForm *B0 = new MixedBilinearForm(x0_space,test_space);
    B0->AddDomainIntegrator(new DiffusionIntegrator(one));
    B0->Assemble();
-   B0->EliminateTrialDofs(ess_bdr, x.GetBlock(x0_var), F);
+   B0->EliminateTrialEssentialBC(ess_bdr, x.GetBlock(x0_var), F);
    B0->Finalize();
 
    MixedBilinearForm *Bhat = new MixedBilinearForm(xhat_space,test_space);

--- a/fem/bilinearform.cpp
+++ b/fem/bilinearform.cpp
@@ -1780,36 +1780,57 @@ void MixedBilinearForm::AssembleBdrElementMatrix(
    mat->AddSubMatrix(test_vdofs_, trial_vdofs_, elmat, skip_zeros);
 }
 
-void MixedBilinearForm::EliminateTrialDofs (
+void MixedBilinearForm::EliminateTrialEssentialBC (
    const Array<int> &bdr_attr_is_ess, const Vector &sol, Vector &rhs )
 {
-   int i, j, k;
-   Array<int> tr_vdofs, cols_marker (trial_fes -> GetVSize());
-
-   cols_marker = 0;
-   for (i = 0; i < trial_fes -> GetNBE(); i++)
-      if (bdr_attr_is_ess[trial_fes -> GetBdrAttribute (i)-1])
-      {
-         trial_fes -> GetBdrElementVDofs (i, tr_vdofs);
-         for (j = 0; j < tr_vdofs.Size(); j++)
-         {
-            if ( (k = tr_vdofs[j]) < 0 )
-            {
-               k = -1-k;
-            }
-            cols_marker[k] = 1;
-         }
-      }
-   mat -> EliminateCols (cols_marker, &sol, &rhs);
+   Array<int> trial_ess_dofs;
+   trial_fes->GetEssentialVDofs(bdr_attr_is_ess, trial_ess_dofs);
+   mat -> EliminateCols (trial_ess_dofs, &sol, &rhs);
 }
 
-void MixedBilinearForm::EliminateEssentialBCFromTrialDofs (
+void MixedBilinearForm::EliminateTrialEssentialBC(const Array<int>
+                                                  &bdr_attr_is_ess)
+{
+   Array<int> trial_ess_dofs;
+   trial_fes->GetEssentialVDofs(bdr_attr_is_ess, trial_ess_dofs);
+   mat->EliminateCols(trial_ess_dofs);
+}
+
+void MixedBilinearForm::EliminateTrialVDofs(const Array<int> &trial_vdofs,
+                                            const Vector &sol, Vector &rhs)
+{
+   Array<int> trial_vdofs_marker;
+   FiniteElementSpace::ListToMarker(trial_vdofs, mat->Width(), trial_vdofs_marker);
+   mat->EliminateCols(trial_vdofs_marker, &sol, &rhs);
+}
+
+void MixedBilinearForm::EliminateTrialVDofs(const Array<int> &trial_vdofs)
+{
+   if (mat_e == NULL)
+   {
+      mat_e = new SparseMatrix(mat->Height(), mat->Width());
+   }
+
+   Array<int> trial_vdofs_marker;
+   FiniteElementSpace::ListToMarker(trial_vdofs, mat->Width(), trial_vdofs_marker);
+   mat->EliminateCols(trial_vdofs_marker, *mat_e);
+   mat_e->Finalize();
+}
+
+void MixedBilinearForm::EliminateTrialVDofsInRHS(const Array<int> &trial_vdofs,
+                                                 const Vector &x, Vector &b)
+{
+   mat_e->AddMult(x, b, -1.);
+}
+
+void MixedBilinearForm::EliminateEssentialBCFromTrialDofs(
    const Array<int> &marked_vdofs, const Vector &sol, Vector &rhs)
 {
    mat -> EliminateCols (marked_vdofs, &sol, &rhs);
 }
 
-void MixedBilinearForm::EliminateTestDofs (const Array<int> &bdr_attr_is_ess)
+void MixedBilinearForm::EliminateTestEssentialBC(const Array<int>
+                                                 &bdr_attr_is_ess)
 {
    int i, j, k;
    Array<int> te_vdofs;
@@ -1827,6 +1848,14 @@ void MixedBilinearForm::EliminateTestDofs (const Array<int> &bdr_attr_is_ess)
             mat -> EliminateRow (k);
          }
       }
+}
+
+void MixedBilinearForm::EliminateTestVDofs(const Array<int> &test_vdofs)
+{
+   for (int i=0; i<test_vdofs.Size(); ++i)
+   {
+      mat->EliminateRow(test_vdofs[i]);
+   }
 }
 
 void MixedBilinearForm::FormRectangularSystemMatrix(
@@ -1865,20 +1894,9 @@ void MixedBilinearForm::FormRectangularSystemMatrix(
       mat = m;
    }
 
-   Array<int> ess_trial_tdof_marker, ess_test_tdof_marker;
-   FiniteElementSpace::ListToMarker(trial_tdof_list, trial_fes->GetTrueVSize(),
-                                    ess_trial_tdof_marker);
-   FiniteElementSpace::ListToMarker(test_tdof_list, test_fes->GetTrueVSize(),
-                                    ess_test_tdof_marker);
+   EliminateTrialVDofs(trial_tdof_list);
+   EliminateTestVDofs(test_tdof_list);
 
-   mat_e = new SparseMatrix(mat->Height(), mat->Width());
-   mat->EliminateCols(ess_trial_tdof_marker, *mat_e);
-
-   for (int i=0; i<test_tdof_list.Size(); ++i)
-   {
-      mat->EliminateRow(test_tdof_list[i]);
-   }
-   mat_e->Finalize();
    A.Reset(mat, false);
 }
 
@@ -1907,7 +1925,7 @@ void MixedBilinearForm::FormRectangularLinearSystem(
                                   A); // Set A = mat_e
    }
    // Eliminate essential BCs with B -= Ab xb
-   mat_e->AddMult(X, B, -1.0);
+   EliminateTrialVDofsInRHS(trial_tdof_list, X, B);
 
    B.SetSubVector(test_tdof_list, 0.0);
 }

--- a/fem/bilinearform.cpp
+++ b/fem/bilinearform.cpp
@@ -1780,12 +1780,12 @@ void MixedBilinearForm::AssembleBdrElementMatrix(
    mat->AddSubMatrix(test_vdofs_, trial_vdofs_, elmat, skip_zeros);
 }
 
-void MixedBilinearForm::EliminateTrialEssentialBC (
+void MixedBilinearForm::EliminateTrialEssentialBC(
    const Array<int> &bdr_attr_is_ess, const Vector &sol, Vector &rhs )
 {
    Array<int> trial_ess_dofs;
    trial_fes->GetEssentialVDofs(bdr_attr_is_ess, trial_ess_dofs);
-   mat -> EliminateCols (trial_ess_dofs, &sol, &rhs);
+   mat->EliminateCols(trial_ess_dofs, &sol, &rhs);
 }
 
 void MixedBilinearForm::EliminateTrialEssentialBC(const Array<int>
@@ -1826,7 +1826,7 @@ void MixedBilinearForm::EliminateTrialVDofsInRHS(const Array<int> &trial_vdofs,
 void MixedBilinearForm::EliminateEssentialBCFromTrialDofs(
    const Array<int> &marked_vdofs, const Vector &sol, Vector &rhs)
 {
-   mat -> EliminateCols (marked_vdofs, &sol, &rhs);
+   mat->EliminateCols(marked_vdofs, &sol, &rhs);
 }
 
 void MixedBilinearForm::EliminateTestEssentialBC(const Array<int>

--- a/fem/bilinearform.cpp
+++ b/fem/bilinearform.cpp
@@ -1796,15 +1796,16 @@ void MixedBilinearForm::EliminateTrialEssentialBC(const Array<int>
    mat->EliminateCols(trial_ess_dofs);
 }
 
-void MixedBilinearForm::EliminateTrialVDofs(const Array<int> &trial_vdofs,
+void MixedBilinearForm::EliminateTrialVDofs(const Array<int> &trial_vdofs_,
                                             const Vector &sol, Vector &rhs)
 {
    Array<int> trial_vdofs_marker;
-   FiniteElementSpace::ListToMarker(trial_vdofs, mat->Width(), trial_vdofs_marker);
+   FiniteElementSpace::ListToMarker(trial_vdofs_, mat->Width(),
+                                    trial_vdofs_marker);
    mat->EliminateCols(trial_vdofs_marker, &sol, &rhs);
 }
 
-void MixedBilinearForm::EliminateTrialVDofs(const Array<int> &trial_vdofs)
+void MixedBilinearForm::EliminateTrialVDofs(const Array<int> &trial_vdofs_)
 {
    if (mat_e == NULL)
    {
@@ -1812,12 +1813,13 @@ void MixedBilinearForm::EliminateTrialVDofs(const Array<int> &trial_vdofs)
    }
 
    Array<int> trial_vdofs_marker;
-   FiniteElementSpace::ListToMarker(trial_vdofs, mat->Width(), trial_vdofs_marker);
+   FiniteElementSpace::ListToMarker(trial_vdofs_, mat->Width(),
+                                    trial_vdofs_marker);
    mat->EliminateCols(trial_vdofs_marker, *mat_e);
    mat_e->Finalize();
 }
 
-void MixedBilinearForm::EliminateTrialVDofsInRHS(const Array<int> &trial_vdofs,
+void MixedBilinearForm::EliminateTrialVDofsInRHS(const Array<int> &trial_vdofs_,
                                                  const Vector &x, Vector &b)
 {
    mat_e->AddMult(x, b, -1.);
@@ -1850,11 +1852,11 @@ void MixedBilinearForm::EliminateTestEssentialBC(const Array<int>
       }
 }
 
-void MixedBilinearForm::EliminateTestVDofs(const Array<int> &test_vdofs)
+void MixedBilinearForm::EliminateTestVDofs(const Array<int> &test_vdofs_)
 {
-   for (int i=0; i<test_vdofs.Size(); ++i)
+   for (int i=0; i<test_vdofs_.Size(); ++i)
    {
-      mat->EliminateRow(test_vdofs[i]);
+      mat->EliminateRow(test_vdofs_[i]);
    }
 }
 

--- a/fem/bilinearform.hpp
+++ b/fem/bilinearform.hpp
@@ -848,10 +848,10 @@ public:
         to it.  Used for transferring ownership. */
    SparseMatrix *LoseMat() { SparseMatrix *tmp = mat; mat = NULL; return tmp; }
 
-   /// Returns a const reference to the sparse matrix of eliminated b.c.:  \f$ M_e \f$
+   /// Returns a const reference to the sparse matrix of eliminated b.c.:  $ M_e $
    const SparseMatrix &SpMatElim() const { return *mat_e; }
 
-   /// Returns a reference to the sparse matrix of eliminated b.c.:  \f$ M_e \f$
+   /// Returns a reference to the sparse matrix of eliminated b.c.:  $ M_e $
    SparseMatrix &SpMatElim() { return *mat_e; }
 
    /// Adds a domain integrator. Assumes ownership of @a bfi.
@@ -1012,12 +1012,12 @@ public:
    { EliminateTrialEssentialBC(bdr_attr_is_ess, sol, rhs); }
 
    /// Eliminate the given trial @a vdofs. NOTE: here, @a vdofs is a list of DOFs.
-   /** In this case the eliminations are applied to the internal \f$ M \f$
-       and @a rhs without storing the elimination matrix \f$ M_e \f$. */
+   /** In this case the eliminations are applied to the internal $ M $
+       and @a rhs without storing the elimination matrix $ M_e $. */
    void EliminateTrialVDofs(const Array<int> &vdofs, const Vector &sol,
                             Vector &rhs);
 
-   /// Eliminate the given trial @a vdofs, storing the eliminated part internally in \f$ M_e \f$.
+   /// Eliminate the given trial @a vdofs, storing the eliminated part internally in $ M_e $.
    /** This method works in conjunction with EliminateVDofsInRHS() and allows
        elimination of boundary conditions in multiple right-hand sides. In this
        method, @a vdofs is a list of DOFs. */

--- a/fem/bilinearform.hpp
+++ b/fem/bilinearform.hpp
@@ -1002,11 +1002,12 @@ public:
                                   const Vector &sol, Vector &rhs);
 
    /// Eliminate essential boundary trial DOFs from the system matrix.
+   /** The array @a bdr_attr_is_ess marks boundary attributes that constitute
+       the essential part of the boundary. */
    void EliminateTrialEssentialBC(const Array<int> &bdr_attr_is_ess);
 
    /// (DEPRECATED) Eliminate essential boundary trial DOFs from the system.
-   /** The array @a bdr_attr_is_ess marks boundary attributes that constitute
-       the essential part of the boundary. */
+   /** @see EliminateTrialEssentialBC() */
    MFEM_DEPRECATED void EliminateTrialDofs(const Array<int> &bdr_attr_is_ess,
                                            const Vector &sol, Vector &rhs)
    { EliminateTrialEssentialBC(bdr_attr_is_ess, sol, rhs); }
@@ -1018,13 +1019,13 @@ public:
                             Vector &rhs);
 
    /// Eliminate the given trial @a vdofs, storing the eliminated part internally in $ M_e $.
-   /** This method works in conjunction with EliminateVDofsInRHS() and allows
+   /** This method works in conjunction with EliminateTrialVDofsInRHS() and allows
        elimination of boundary conditions in multiple right-hand sides. In this
        method, @a vdofs is a list of DOFs. */
    void EliminateTrialVDofs(const Array<int> &vdofs);
 
    /** @brief Use the stored eliminated part of the matrix (see
-       EliminateTrialVDofs(const Array<int> &, DiagonalPolicy)) to modify the r.h.s.
+       EliminateTrialVDofs(const Array<int> &)) to modify the r.h.s.
        @a b; @a vdofs is a list of DOFs (non-directional, i.e. >= 0). */
    void EliminateTrialVDofsInRHS(const Array<int> &vdofs, const Vector &x,
                                  Vector &b);
@@ -1037,11 +1038,12 @@ public:
                                           const Vector &sol, Vector &rhs);
 
    /// Eliminate essential boundary test DOFs from the system matrix.
+   /** The array @a bdr_attr_is_ess marks boundary attributes that constitute
+       the essential part of the boundary. */
    void EliminateTestEssentialBC(const Array<int> &bdr_attr_is_ess);
 
    /// (DEPRECATED) Eliminate essential boundary test DOFs from the system.
-   /** The array @a bdr_attr_is_ess marks boundary attributes that constitute
-       the essential part of the boundary. */
+   /** @see EliminateTestEssentialBC() */
    MFEM_DEPRECATED virtual void EliminateTestDofs(const Array<int>
                                                   &bdr_attr_is_ess)
    { EliminateTestEssentialBC(bdr_attr_is_ess); }

--- a/fem/bilinearform.hpp
+++ b/fem/bilinearform.hpp
@@ -839,20 +839,36 @@ public:
    /** This will segfault if the usual sparse mat is not defined
        like when static condensation is being used or AllocMat() has
        not yet been called. */
-   const SparseMatrix &SpMat() const { return *mat; }
+   const SparseMatrix &SpMat() const
+   {
+      MFEM_VERIFY(mat, "mat is NULL and can't be dereferenced");
+      return *mat;
+   }
 
    /// Returns a reference to the sparse matrix:  $ M $
-   SparseMatrix &SpMat() { return *mat; }
+   SparseMatrix &SpMat()
+   {
+      MFEM_VERIFY(mat, "mat is NULL and can't be dereferenced");
+      return *mat;
+   }
 
    /**  @brief Nullifies the internal matrix $ M $ and returns a pointer
         to it.  Used for transferring ownership. */
    SparseMatrix *LoseMat() { SparseMatrix *tmp = mat; mat = NULL; return tmp; }
 
    /// Returns a const reference to the sparse matrix of eliminated b.c.:  $ M_e $
-   const SparseMatrix &SpMatElim() const { return *mat_e; }
+   const SparseMatrix &SpMatElim() const
+   {
+      MFEM_VERIFY(mat_e, "mat_e is NULL and can't be dereferenced");
+      return *mat_e;
+   }
 
    /// Returns a reference to the sparse matrix of eliminated b.c.:  $ M_e $
-   SparseMatrix &SpMatElim() { return *mat_e; }
+   SparseMatrix &SpMatElim()
+   {
+      MFEM_VERIFY(mat_e, "mat_e is NULL and can't be dereferenced");
+      return *mat_e;
+   }
 
    /// Adds a domain integrator. Assumes ownership of @a bfi.
    void AddDomainIntegrator(BilinearFormIntegrator *bfi);

--- a/miniapps/solvers/block-solvers.cpp
+++ b/miniapps/solvers/block-solvers.cpp
@@ -168,7 +168,7 @@ DarcyProblem::DarcyProblem(Mesh &mesh, int num_refs, int order,
    bVarf_->AddDomainIntegrator(new VectorFEDivergenceIntegrator);
    bVarf_->Assemble();
    bVarf_->SpMat() *= -1.0;
-   bVarf_->EliminateTrialDofs(ess_bdr, u_, gform);
+   bVarf_->EliminateTrialEssentialBC(ess_bdr, u_, gform);
    bVarf_->Finalize();
    B_.Reset(bVarf_->ParallelAssemble());
 


### PR DESCRIPTION
This PR makes `MixedBilinearForm` more consistent with `BilinearForm` in terms of how elimination of essential DOFs/BCs is handled. Not only the naming is unified, but also new methods are introduced using the "eliminated" matrix `M_e` similarly to `BilinearForm`. These methods are then used in `FormRectangularSystemMatrix()`, cleaning the code and also serving as a self-contained test :wink:.
<!--GHEX{"author":"najlkin","assignment":"2024-07-16T18:38:16","editor":"tzanio","id":4356,"reviewers":["mlstowell","justinlaughlin","tzanio"],"merge":"2024-09-26T01:42:37","approval":"2024-09-15T21:19:44"}XEHG-->
<!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge|
 | --- | --- | --- | --- | --- | --- | --- |
| [#4356](https://github.com/mfem/mfem/pull/4356) | @najlkin | @tzanio | @mlstowell + @justinlaughlin + @tzanio | 7/16/24 | 9/15/24 | 9/25/24 | |
<!--ELBATXEHG-->
<details>
<summary>PR Checklist</summary>
    
- [ ] Code builds.
- [ ] Code passes `make style`.
- [ ] Update `CHANGELOG`:
    - [ ] Is this a new feature users need to be aware of? New or updated example or miniapp?
    - [ ] Does it make sense to create a new section in the `CHANGELOG` to group with other related features?
- [ ] Update `INSTALL`:
    - [ ] Had a new optional library been added? If so, what range of versions of this library are required? (*Make sure the external library is compatible with our BSD license, e.g. it is not licensed under GPL!*)
    - [ ] Have the version ranges for any required or optional libraries changed?
    - [ ] Does `make` or `cmake` have a new target?
    - [ ] Did the requirements or the installation process change? *(rare)*
- [ ] Update continuous integration server configurations if necessary (e.g. with new version requirements for each of MFEM's dependencies)
    - [ ] `.github`
    - [ ] `.appveyor.yml`
- [ ] Update `.gitignore`:
    - [ ] Check if `make distclean; git status` shows any files that were generated from the source by the project (not an IDE) but we don't want to track in the repository.
    - [ ] Add new patterns (just for the new files above) and re-run the above test.
- [ ] New examples:
    - [ ] All sample runs at the top of the example source file work.
    - [ ] Update `examples/makefile`:
      - [ ] Add the example code to the appropriate `SEQ_EXAMPLES` and `PAR_EXAMPLES` variables.
      - [ ] Add any files generated by it to the `clean` target.
      - [ ] Add the example binary and any files generated by it to the top-level `.gitignore` file.
    - [ ] Update `examples/CMakeLists.txt`:
      - [ ] Add the example code to the `ALL_EXE_SRCS` variable.
      - [ ] Make sure `THIS_TEST_OPTIONS` is set correctly for the new example.
   - [ ] List the new example in `doc/CodeDocumentation.dox`.
   - [ ] If new examples directory (e.g.`examples/pumi`), list it in `doc/CodeDocumentation.conf.in`
   - [ ] Companion pull request for documentation in [mfem/web](https://github.com/mfem/web) repo:
      - [ ] Update or add example-specific documentation, see e.g. the `src/examples.md`.
      - [ ] Add the description, labels and screenshots in `src/examples.md` and `src/img`.
      - [ ] In `examples.md`, list the example under the appropriate categories, add new categories if necessary.
      - [ ] Add a short description of the example in the "Extensive Examples" section of `features.md`.
- [ ] New miniapps:
   - [ ] All sample runs at the top of the miniapp source file work.
   - [ ] Update top-level `makefile` and `makefile` in corresponding miniapp directory.
   - [ ] Add the miniapp binary and any files generated by it to the top-level `.gitignore` file.
   - [ ] Update CMake build system:
      - [ ] Update the `CMakeLists.txt` file in the `miniapps` directory, if the new miniapp is in a new directory.
      - [ ] Add/update the `CMakeLists.txt` file in the new miniapp directory.
      - [ ] Consider adding a new test for the new miniapp.
   - [ ] List the new miniapp in `doc/CodeDocumentation.dox`
   - [ ] If new miniapps directory (e.g.`miniapps/nurbs`), add it to `MINIAPP_SUBDIRS` in the `makefile`.
   - [ ] If new miniapps directory (e.g.`miniapps/nurbs`), list it in `doc/CodeDocumentation.conf.in`
   - [ ] Companion pull request for documentation in [mfem/web](https://github.com/mfem/web) repo:
     - [ ] Update or add miniapp-specific documentation, see e.g. the `src/meshing.md` and `src/electromagnetics.md` files.
     - [ ] Add the description, labels and screenshots in `src/examples.md` and `src/img`.
     - [ ] The miniapps go at the end of the page, and are usually listed only under a specific "Application (PDE)" category.
     - [ ] Add a short description of the miniapp in the "Extensive Examples" section of `features.md`.
- [ ] New capability:
   - [ ] All new public, protected, and private classes, methods, data members, and functions have full Doxygen-style documentation in source comments. Documentation should include descriptions of member data, function arguments and return values, template parameters, and prerequisites for calling new functions.
   - [ ] Pointer arguments and return values must specify whether ownership is being transferred or lent with the call.
   - [ ] Any new functions should include descriptions of their intended use e.g. for internal use only, user-facing, etc., along with references to example code whenever possible/appropriate.
   - [ ] Consider adding new sample runs in existing examples to highlight the new capability.
   - [ ] Consider saving cool simulation pictures with the new capability in the Confluence gallery (LLNL only) or submitting them, via pull request, to the gallery section of the `mfem/web` repo.
   - [ ] If this is a major new feature, consider mentioning it in the short summary inside `README` *(rare)*.
   - [ ] List major new classes in `doc/CodeDocumentation.dox` *(rare)*.
- [ ] Update this checklist, if the new pull request affects it.
- [ ] Run `make unittest` to make sure all unit tests pass.
- [ ] Run the tests in `tests/scripts`.
- [ ] (LLNL only) After merging:
   - [ ] Update internal tests to include the new features.
</details>
