### PR TITLE
Add component labels to ParaView VTU output

### DIFF
--- a/fem/datacollection.cpp
+++ b/fem/datacollection.cpp
@@ -943,6 +943,7 @@ void ParaViewDataCollection::Save()
             pvtu_out << "<PDataArray type=\"" << GetDataTypeString()
                      << "\" Name=\"" << field_it.first
                      << "\" NumberOfComponents=\"" << vec_dim << "\" "
+                     << VTKComponentLabels(vec_dim) << " "
                      << "format=\"" << GetDataFormatString() << "\" />\n";
          }
          pvtu_out << "</PPointData>\n";
@@ -977,6 +978,7 @@ void ParaViewDataCollection::Save()
          pvtu_out << "<PDataArray type=\"" << GetDataTypeString()
                   << "\" Name=\"" << q_field_name
                   << "\" NumberOfComponents=\"" << vec_dim << "\" "
+                  << VTKComponentLabels(vec_dim) << " "
                   << "format=\"" << GetDataFormatString() << "\" />\n";
          pvtu_out << "</PPointData>\n";
          WritePVTUFooter(pvtu_out, q_field_name);
@@ -1069,8 +1071,9 @@ void ParaViewDataCollection::SaveGFieldVTU(std::ostream &os, int ref_,
    int vec_dim = it->second->VectorDim();
    os << "<DataArray type=\"" << GetDataTypeString()
       << "\" Name=\"" << it->first
-      << "\" NumberOfComponents=\"" << vec_dim << "\""
-      << " format=\"" << GetDataFormatString() << "\" >" << '\n';
+      << "\" NumberOfComponents=\"" << vec_dim << "\" "
+      << VTKComponentLabels(vec_dim) << " "
+      << "format=\"" << GetDataFormatString() << "\" >" << '\n';
    if (vec_dim == 1)
    {
       // scalar data

--- a/fem/qfunction.cpp
+++ b/fem/qfunction.cpp
@@ -208,6 +208,7 @@ void QuadratureFunction::SaveVTU(std::ostream &os, VTKFormat format,
    os << "<PointData>\n";
    os << "<DataArray type=\"" << type_str << "\" Name=\"" << field_name
       << "\" format=\"" << fmt_str << "\" NumberOfComponents=\"" << vdim
+      << VTKComponentLabels(vdim) << " "
       << "\">\n";
    for (int i = 0; i < ne; i++)
    {

--- a/fem/qfunction.cpp
+++ b/fem/qfunction.cpp
@@ -207,9 +207,9 @@ void QuadratureFunction::SaveVTU(std::ostream &os, VTKFormat format,
 
    os << "<PointData>\n";
    os << "<DataArray type=\"" << type_str << "\" Name=\"" << field_name
-      << "\" format=\"" << fmt_str << "\" NumberOfComponents=\"" << vdim
+      << "\" format=\"" << fmt_str << "\" NumberOfComponents=\"" << vdim << "\" "
       << VTKComponentLabels(vdim) << " "
-      << "\">\n";
+      << ">\n";
    for (int i = 0; i < ne; i++)
    {
       DenseMatrix vals;

--- a/mesh/vtk.cpp
+++ b/mesh/vtk.cpp
@@ -659,4 +659,22 @@ void WriteBase64WithSizeAndClear(std::ostream &os, std::vector<char> &buf,
    buf.clear();
 }
 
+std::string VTKComponentLabels(int vdim)
+{
+   if (vdim == 1)
+   {
+      return "";
+   }
+   else
+   {
+      std::stringstream s;
+      for (int i = 0; i < vdim; ++i)
+      {
+         s << "ComponentName" << i << "=\"" << i << "\"";
+         if (i < vdim - 1) { s << " "; }
+      }
+      return s.str();
+   }
+}
+
 } // namespace mfem

--- a/mesh/vtk.hpp
+++ b/mesh/vtk.hpp
@@ -13,6 +13,7 @@
 #define MFEM_VTK
 
 #include <cstdint>
+#include <string>
 
 #include "../fem/geom.hpp"
 #include "../general/binaryio.hpp"
@@ -184,6 +185,10 @@ void WriteBinaryOrASCII<float>(std::ostream &os, std::vector<char> &buf,
 /// @sa WriteVTKEncodedCompressed.
 void WriteBase64WithSizeAndClear(std::ostream &os, std::vector<char> &buf,
                                  int compression_level);
+
+/// @brief Returns a string defining the component labels for vector-valued data
+/// arrays for use in XML VTU files.
+std::string VTKComponentLabels(int vdim);
 
 } // namespace mfem
 


### PR DESCRIPTION
Vector components are now labeled in ParaView output (they are labeled sequentially starting at 0).

Note that this means that 2D and 3D vectors have components labeled "0, 1" and "0, 1, 2" instead of "X, Y" and "X, Y, Z", as was the case before. If we prefer the old behavior, we can make that change.

Resolves #4398.
<!--GHEX{"author":"pazner","assignment":"2024-07-16T17:11:47","editor":"tzanio","id":4405,"reviewers":["rcarson3","jandrej","bslazarov"],"merge":"2024-08-10T19:22:40","approval":"2024-08-03T17:17:45"}XEHG-->
<!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge|
 | --- | --- | --- | --- | --- | --- | --- |
| [#4405](https://github.com/mfem/mfem/pull/4405) | @pazner | @tzanio | @rcarson3 + @jandrej + @bslazarov | 7/16/24 | 8/3/24 | 8/10/24 | |
<!--ELBATXEHG-->
<details>
<summary>PR Checklist</summary>
    
- [ ] Code builds.
- [ ] Code passes `make style`.
- [ ] Update `CHANGELOG`:
    - [ ] Is this a new feature users need to be aware of? New or updated example or miniapp?
    - [ ] Does it make sense to create a new section in the `CHANGELOG` to group with other related features?
- [ ] Update `INSTALL`:
    - [ ] Had a new optional library been added? If so, what range of versions of this library are required? (*Make sure the external library is compatible with our BSD license, e.g. it is not licensed under GPL!*)
    - [ ] Have the version ranges for any required or optional libraries changed?
    - [ ] Does `make` or `cmake` have a new target?
    - [ ] Did the requirements or the installation process change? *(rare)*
- [ ] Update continuous integration server configurations if necessary (e.g. with new version requirements for each of MFEM's dependencies)
    - [ ] `.github`
    - [ ] `.appveyor.yml`
- [ ] Update `.gitignore`:
    - [ ] Check if `make distclean; git status` shows any files that were generated from the source by the project (not an IDE) but we don't want to track in the repository.
    - [ ] Add new patterns (just for the new files above) and re-run the above test.
- [ ] New examples:
    - [ ] All sample runs at the top of the example source file work.
    - [ ] Update `examples/makefile`:
      - [ ] Add the example code to the appropriate `SEQ_EXAMPLES` and `PAR_EXAMPLES` variables.
      - [ ] Add any files generated by it to the `clean` target.
      - [ ] Add the example binary and any files generated by it to the top-level `.gitignore` file.
    - [ ] Update `examples/CMakeLists.txt`:
      - [ ] Add the example code to the `ALL_EXE_SRCS` variable.
      - [ ] Make sure `THIS_TEST_OPTIONS` is set correctly for the new example.
   - [ ] List the new example in `doc/CodeDocumentation.dox`.
   - [ ] If new examples directory (e.g.`examples/pumi`), list it in `doc/CodeDocumentation.conf.in`
   - [ ] Companion pull request for documentation in [mfem/web](https://github.com/mfem/web) repo:
      - [ ] Update or add example-specific documentation, see e.g. the `src/examples.md`.
      - [ ] Add the description, labels and screenshots in `src/examples.md` and `src/img`.
      - [ ] In `examples.md`, list the example under the appropriate categories, add new categories if necessary.
      - [ ] Add a short description of the example in the "Extensive Examples" section of `features.md`.
- [ ] New miniapps:
   - [ ] All sample runs at the top of the miniapp source file work.
   - [ ] Update top-level `makefile` and `makefile` in corresponding miniapp directory.
   - [ ] Add the miniapp binary and any files generated by it to the top-level `.gitignore` file.
   - [ ] Update CMake build system:
      - [ ] Update the `CMakeLists.txt` file in the `miniapps` directory, if the new miniapp is in a new directory.
      - [ ] Add/update the `CMakeLists.txt` file in the new miniapp directory.
      - [ ] Consider adding a new test for the new miniapp.
   - [ ] List the new miniapp in `doc/CodeDocumentation.dox`
   - [ ] If new miniapps directory (e.g.`miniapps/nurbs`), add it to `MINIAPP_SUBDIRS` in the `makefile`.
   - [ ] If new miniapps directory (e.g.`miniapps/nurbs`), list it in `doc/CodeDocumentation.conf.in`
   - [ ] Companion pull request for documentation in [mfem/web](https://github.com/mfem/web) repo:
     - [ ] Update or add miniapp-specific documentation, see e.g. the `src/meshing.md` and `src/electromagnetics.md` files.
     - [ ] Add the description, labels and screenshots in `src/examples.md` and `src/img`.
     - [ ] The miniapps go at the end of the page, and are usually listed only under a specific "Application (PDE)" category.
     - [ ] Add a short description of the miniapp in the "Extensive Examples" section of `features.md`.
- [ ] New capability:
   - [ ] All new public, protected, and private classes, methods, data members, and functions have full Doxygen-style documentation in source comments. Documentation should include descriptions of member data, function arguments and return values, template parameters, and prerequisites for calling new functions.
   - [ ] Pointer arguments and return values must specify whether ownership is being transferred or lent with the call.
   - [ ] Any new functions should include descriptions of their intended use e.g. for internal use only, user-facing, etc., along with references to example code whenever possible/appropriate.
   - [ ] Consider adding new sample runs in existing examples to highlight the new capability.
   - [ ] Consider saving cool simulation pictures with the new capability in the Confluence gallery (LLNL only) or submitting them, via pull request, to the gallery section of the `mfem/web` repo.
   - [ ] If this is a major new feature, consider mentioning it in the short summary inside `README` *(rare)*.
   - [ ] List major new classes in `doc/CodeDocumentation.dox` *(rare)*.
- [ ] Update this checklist, if the new pull request affects it.
- [ ] Run `make unittest` to make sure all unit tests pass.
- [ ] Run the tests in `tests/scripts`.
- [ ] (LLNL only) After merging:
   - [ ] Update internal tests to include the new features.
</details>
