### PR TITLE
Fixed Point default attribute.

### DIFF
--- a/mesh/point.hpp
+++ b/mesh/point.hpp
@@ -30,7 +30,7 @@ public:
    Point() : Element(Geometry::POINT) {}
 
    /// Constructs point by specifying the indices and the attribute.
-   Point( const int *ind, int attr = -1 );
+   Point(const int *ind, int attr = 1);
 
    /// Return element's type.
    Type GetType() const override { return Element::POINT; }
@@ -42,7 +42,7 @@ public:
    void SetVertices(const Array<int> &v) override;
 
    /// @note The returned array should NOT be deleted by the caller.
-   int * GetVertices () override { return indices; }
+   int *GetVertices() override { return indices; }
 
    /// Set the vertices according to the given input.
    void SetVertices(const int *ind) override;
@@ -64,7 +64,7 @@ public:
    const int *GetFaceVertices(int fi) const override { return NULL; }
 
    Element *Duplicate(Mesh *m) const override
-   { return new Point (indices, attribute); }
+   { return new Point(indices, attribute); }
 
    virtual ~Point() = default;
 };


### PR DESCRIPTION
This PR fixes `Point`'s default attribute, which was -1 and not 1 like for other geometrical primitives. This causes problems when the boundaries are automatically generated in `Mesh::GenerateBoundaryElement()` and the attribute is copied to them, which triggers warning in `Mesh::FinalizeTopology()` as boundary attributes are not supposed to be negative.
This seems to a forgotten change in version 1.2 ( https://github.com/mfem/mfem/commit/29ae8fb6ac9fce927fdfd01ef796f9df38f76e97 ). It is a slightly breaking change, but hopefully not too much 🙂 .

❔ This was found in #4416 .