### PR TITLE
Fix uninitialized variables in pmesh-fitting

### DIFF
--- a/miniapps/meshing/pmesh-fitting.cpp
+++ b/miniapps/meshing/pmesh-fitting.cpp
@@ -514,19 +514,17 @@ int main (int argc, char *argv[])
       surf_fit_mat_gf.SetFromTrueVector();
 
       // Set DOFs for fitting
+      surf_fit_marker = false;
+      surf_fit_mat_gf = 0.;
+
       // Strategy 1: Choose face between elements of different attributes.
       if (marking_type == 0)
       {
          mat.ExchangeFaceNbrData();
          const Vector &FaceNbrData = mat.FaceNbrData();
-         for (int j = 0; j < surf_fit_marker.Size(); j++)
-         {
-            surf_fit_marker[j] = false;
-         }
-         surf_fit_mat_gf = 0.0;
-
          Array<int> dof_list;
          Array<int> dofs;
+
          for (int i = 0; i < pmesh->GetNumFaces(); i++)
          {
             auto tr = pmesh->GetInteriorFaceTransformations(i);
@@ -565,9 +563,6 @@ int main (int argc, char *argv[])
       // Strategy 2: Mark all boundaries with attribute marking_type
       else if (marking_type > 0)
       {
-         surf_fit_marker = false;
-         surf_fit_mat_gf = 0.;
-
          for (int i = 0; i < pmesh->GetNBE(); i++)
          {
             const int attr = pmesh->GetBdrElement(i)->GetAttribute();

--- a/miniapps/meshing/pmesh-fitting.cpp
+++ b/miniapps/meshing/pmesh-fitting.cpp
@@ -565,6 +565,9 @@ int main (int argc, char *argv[])
       // Strategy 2: Mark all boundaries with attribute marking_type
       else if (marking_type > 0)
       {
+         surf_fit_marker = false;
+         surf_fit_mat_gf = 0.;
+
          for (int i = 0; i < pmesh->GetNBE(); i++)
          {
             const int attr = pmesh->GetBdrElement(i)->GetAttribute();


### PR DESCRIPTION
Dear mfem developers,
while playing with `pmesh-fitting`, I faced some random bugs that I could trace to uninitialized variables in the case where surface marking is done through attributes (strategy 2).

It also seems to me that lines 561 to 564 could be simply replaced by means of a one line call to `operator=`. Furthermore, `surf_fit_mat_gf` and `surf_fit_marker` could maybe be initialized before choosing between strategy 1 and 2, as the initialization is now done in the two branches of the test.

If you think this is worthwhile, I can update the PR.

T.
<!--GHEX{"author":"tsokar","assignment":"2024-09-06T19:38:25","editor":"tzanio","id":4474,"reviewers":["vladotomov","kmittal2"],"merge":"2024-09-08T22:35:59","approval":"2024-09-06T19:39:00"}XEHG-->
<!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge|
 | --- | --- | --- | --- | --- | --- | --- |
| [#4474](https://github.com/mfem/mfem/pull/4474) | @tsokar | @tzanio | @vladotomov + @kmittal2 | 9/6/24 | 9/6/24 | 9/8/24 | |
<!--ELBATXEHG-->
<details>
<summary>PR Checklist</summary>
    
- [ ] Code builds.
- [ ] Code passes `make style`.
- [ ] Update `CHANGELOG`:
    - [ ] Is this a new feature users need to be aware of? New or updated example or miniapp?
    - [ ] Does it make sense to create a new section in the `CHANGELOG` to group with other related features?
- [ ] Update `INSTALL`:
    - [ ] Had a new optional library been added? If so, what range of versions of this library are required? (*Make sure the external library is compatible with our BSD license, e.g. it is not licensed under GPL!*)
    - [ ] Have the version ranges for any required or optional libraries changed?
    - [ ] Does `make` or `cmake` have a new target?
    - [ ] Did the requirements or the installation process change? *(rare)*
- [ ] Update continuous integration server configurations if necessary (e.g. with new version requirements for each of MFEM's dependencies)
    - [ ] `.github`
    - [ ] `.appveyor.yml`
- [ ] Update `.gitignore`:
    - [ ] Check if `make distclean; git status` shows any files that were generated from the source by the project (not an IDE) but we don't want to track in the repository.
    - [ ] Add new patterns (just for the new files above) and re-run the above test.
- [ ] New examples:
    - [ ] All sample runs at the top of the example source file work.
    - [ ] Update `examples/makefile`:
      - [ ] Add the example code to the appropriate `SEQ_EXAMPLES` and `PAR_EXAMPLES` variables.
      - [ ] Add any files generated by it to the `clean` target.
      - [ ] Add the example binary and any files generated by it to the top-level `.gitignore` file.
    - [ ] Update `examples/CMakeLists.txt`:
      - [ ] Add the example code to the `ALL_EXE_SRCS` variable.
      - [ ] Make sure `THIS_TEST_OPTIONS` is set correctly for the new example.
   - [ ] List the new example in `doc/CodeDocumentation.dox`.
   - [ ] If new examples directory (e.g.`examples/pumi`), list it in `doc/CodeDocumentation.conf.in`
   - [ ] Companion pull request for documentation in [mfem/web](https://github.com/mfem/web) repo:
      - [ ] Update or add example-specific documentation, see e.g. the `src/examples.md`.
      - [ ] Add the description, labels and screenshots in `src/examples.md` and `src/img`.
      - [ ] In `examples.md`, list the example under the appropriate categories, add new categories if necessary.
      - [ ] Add a short description of the example in the "Extensive Examples" section of `features.md`.
- [ ] New miniapps:
   - [ ] All sample runs at the top of the miniapp source file work.
   - [ ] Update top-level `makefile` and `makefile` in corresponding miniapp directory.
   - [ ] Add the miniapp binary and any files generated by it to the top-level `.gitignore` file.
   - [ ] Update CMake build system:
      - [ ] Update the `CMakeLists.txt` file in the `miniapps` directory, if the new miniapp is in a new directory.
      - [ ] Add/update the `CMakeLists.txt` file in the new miniapp directory.
      - [ ] Consider adding a new test for the new miniapp.
   - [ ] List the new miniapp in `doc/CodeDocumentation.dox`
   - [ ] If new miniapps directory (e.g.`miniapps/nurbs`), add it to `MINIAPP_SUBDIRS` in the `makefile`.
   - [ ] If new miniapps directory (e.g.`miniapps/nurbs`), list it in `doc/CodeDocumentation.conf.in`
   - [ ] Companion pull request for documentation in [mfem/web](https://github.com/mfem/web) repo:
     - [ ] Update or add miniapp-specific documentation, see e.g. the `src/meshing.md` and `src/electromagnetics.md` files.
     - [ ] Add the description, labels and screenshots in `src/examples.md` and `src/img`.
     - [ ] The miniapps go at the end of the page, and are usually listed only under a specific "Application (PDE)" category.
     - [ ] Add a short description of the miniapp in the "Extensive Examples" section of `features.md`.
- [ ] New capability:
   - [ ] All new public, protected, and private classes, methods, data members, and functions have full Doxygen-style documentation in source comments. Documentation should include descriptions of member data, function arguments and return values, template parameters, and prerequisites for calling new functions.
   - [ ] Pointer arguments and return values must specify whether ownership is being transferred or lent with the call.
   - [ ] Any new functions should include descriptions of their intended use e.g. for internal use only, user-facing, etc., along with references to example code whenever possible/appropriate.
   - [ ] Consider adding new sample runs in existing examples to highlight the new capability.
   - [ ] Consider saving cool simulation pictures with the new capability in the Confluence gallery (LLNL only) or submitting them, via pull request, to the gallery section of the `mfem/web` repo.
   - [ ] If this is a major new feature, consider mentioning it in the short summary inside `README` *(rare)*.
   - [ ] List major new classes in `doc/CodeDocumentation.dox` *(rare)*.
- [ ] Update this checklist, if the new pull request affects it.
- [ ] Run `make unittest` to make sure all unit tests pass.
- [ ] Run the tests in `tests/scripts`.
- [ ] (LLNL only) After merging:
   - [ ] Update internal tests to include the new features.
</details>
