### PR TITLE
Added CMake dependencies on individual data files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -673,7 +673,7 @@ if (NOT ("${PROJECT_SOURCE_DIR}" STREQUAL "${PROJECT_BINARY_DIR}"))
 #include \"${PROJECT_SOURCE_DIR}/${Header}\"
 ")
 
-    execute_process(COMMAND ${CMAKE_COMMAND} -E copy_if_different 
+    execute_process(COMMAND ${CMAKE_COMMAND} -E copy_if_different
       "${PROJECT_BINARY_DIR}/${Header}.tmp"
       "${PROJECT_BINARY_DIR}/${Header}"
     )
@@ -687,7 +687,7 @@ if (NOT ("${PROJECT_SOURCE_DIR}" STREQUAL "${PROJECT_BINARY_DIR}"))
 #include \"mfem/${Header}\"
 ")
 
-    execute_process(COMMAND ${CMAKE_COMMAND} -E copy_if_different 
+    execute_process(COMMAND ${CMAKE_COMMAND} -E copy_if_different
       "${PROJECT_BINARY_DIR}/InstallHeaders/${Header}.tmp"
       "${PROJECT_BINARY_DIR}/InstallHeaders/${Header}"
     )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -748,15 +748,11 @@ add_dependencies(exec
 #  - https://gitlab.kitware.com/cmake/cmake/issues/8438
 #  - https://cmake.org/Bug/view.php?id=8438
 
-# Add a target to copy the mfem data directory to the build directory
-add_custom_command(OUTPUT data_is_copied
-  COMMAND ${CMAKE_COMMAND} -E copy_directory ${PROJECT_SOURCE_DIR}/data data
-  COMMAND ${CMAKE_COMMAND} -E touch data_is_copied
-  COMMENT "Copying the data directory ...")
-add_custom_target(copy_data DEPENDS data_is_copied)
-# Add 'copy_data' as a prerequisite for all executables, if the source and the
-# build directories are not the same.
+# If the source and the build directories are not the same, add data directory
+# that defines 'copy_data' target to copy data directory contents to the build
+# directory
 if (NOT ("${PROJECT_SOURCE_DIR}" STREQUAL "${PROJECT_BINARY_DIR}"))
+  add_subdirectory(data)
   add_dependencies(${MFEM_EXEC_PREREQUISITES_TARGET_NAME} copy_data)
 endif()
 

--- a/data/CMakeLists.txt
+++ b/data/CMakeLists.txt
@@ -1,0 +1,118 @@
+list(APPEND DATA_FILES
+  amr-hex.mesh
+  amr-quad.mesh
+  ball-nurbs.mesh
+  beam-hex-nurbs.mesh
+  beam-hex.mesh
+  beam-hex.vtk
+  beam-quad-amr.mesh
+  beam-quad-nurbs-sf.mesh
+  beam-quad-nurbs.mesh
+  beam-quad.mesh
+  beam-quad.vtk
+  beam-tet.mesh
+  beam-tet.vtk
+  beam-tri.mesh
+  beam-tri.vtk
+  beam-wedge.mesh
+  beam-wedge.vtk
+  compass.geo
+  compass.mesh
+  compass.msh
+  cube-nurbs.mesh
+  diag-segment-2d.mesh
+  diag-segment-3d.mesh
+  disc-nurbs.mesh
+  escher-p2.mesh
+  escher-p2.vtk
+  escher-p3.mesh
+  escher.mesh
+  escher.vtk
+  fichera-amr.mesh
+  fichera-mixed-p2.mesh
+  fichera-mixed-p2.vtk
+  fichera-mixed.mesh
+  fichera-q2.mesh
+  fichera-q2.vtk
+  fichera-q3.mesh
+  fichera-quad-mixed.mesh
+  fichera-quad.mesh
+  fichera.mesh
+  fichera.vtk
+  hexagon.mesh
+  inline-hex.mesh
+  inline-pyramid.mesh
+  inline-quad.mesh
+  inline-segment.mesh
+  inline-tet.mesh
+  inline-tri.mesh
+  inline-wedge.mesh
+  klein-bottle.mesh
+  klein-donut.mesh
+  l-shape.mesh
+  llnl-p3.mesh
+  mobius-strip.mesh
+  octahedron.mesh
+  periodic-annulus-sector.geo
+  periodic-annulus-sector.msh
+  periodic-cube.geo
+  periodic-cube.mesh
+  periodic-cube.msh
+  periodic-hexagon.mesh
+  periodic-segment.mesh
+  periodic-square.geo
+  periodic-square.mesh
+  periodic-square.msh
+  periodic-torus-sector.geo
+  periodic-torus-sector.msh
+  pipe-nurbs-2d.mesh
+  pipe-nurbs-log.mesh
+  pipe-nurbs.mesh
+  ref-cube.mesh
+  ref-prism.mesh
+  ref-pyramid.mesh
+  ref-segment.mesh
+  ref-square.mesh
+  ref-tetrahedron.mesh
+  ref-triangle.mesh
+  rt-2d-p4-tri.mesh
+  rt-2d-q3.mesh
+  segment-nurbs.mesh
+  square-disc-nurbs-patch.mesh
+  square-disc-nurbs.mesh
+  square-disc-p2.mesh
+  square-disc-p2.vtk
+  square-disc-p3.mesh
+  square-disc-surf.mesh
+  square-disc.mesh
+  square-disc.vtk
+  square-mixed.mesh
+  square-nurbs-pw.mesh
+  square-nurbs.mesh
+  star-hilbert.mesh
+  star-mixed-p2.mesh
+  star-mixed-p2.vtk
+  star-mixed.mesh
+  star-q2.mesh
+  star-q2.vtk
+  star-q3.fms
+  star-q3.mesh
+  star-surf.mesh
+  star.mesh
+  star.vtk
+  tinyzoo-3d.mesh
+  toroid-hex.mesh
+  toroid-wedge.mesh
+)
+
+foreach(DATA_FILE ${DATA_FILES})
+  set(SRC_DATA_FILE ${CMAKE_CURRENT_SOURCE_DIR}/${DATA_FILE})
+  set(GEN_DATA_FILE ${CMAKE_CURRENT_BINARY_DIR}/${DATA_FILE})
+  add_custom_command(
+    OUTPUT ${GEN_DATA_FILE}
+    DEPENDS ${SRC_DATA_FILE}
+    COMMAND ${CMAKE_COMMAND} -E copy ${SRC_DATA_FILE} ${GEN_DATA_FILE})
+  list(APPEND GENERATED_DATA_FILES ${GEN_DATA_FILE})
+endforeach()
+
+add_custom_target(copy_data DEPENDS ${GENERATED_DATA_FILES})


### PR DESCRIPTION
This PR is motivated by issues with the original `copy_data` target not properly capturing the dependencies on the contents of the `data` directory.  Specifically, modification to any of the data files (e.g., when fast-forwarding `main`) were ignored.  Granted, this approach requires any additions or renaming to be reflected in the new `data/CMakeLists.txt`, but I still see it as an improvement over the original approach.