### PR TITLE
Fix CUDA-enabled HYPRE finalization order issue

### DIFF
--- a/general/device.cpp
+++ b/general/device.cpp
@@ -178,6 +178,7 @@ Device::~Device()
    Get().host_mem_class = MemoryClass::HOST;
    Get().device_mem_type = MemoryType::HOST;
    Get().device_mem_class = MemoryClass::HOST;
+   Hypre::Finalize();
 }
 
 void Device::Configure(const std::string &device, const int device_id)


### PR DESCRIPTION
Resolves #4503.

This ensures that Hypre is finalized when `mfem::Device` goes out of scope in the main function.