### PR TITLE
Correct scaling for VectorDiffusionIntegrator

### DIFF
--- a/fem/bilininteg.cpp
+++ b/fem/bilininteg.cpp
@@ -3090,10 +3090,9 @@ void VectorDiffusionIntegrator::AssembleElementVector(
          VQ->Eval(vcoeff, Tr, ip);
          for (int k = 0; k < vdim; ++k)
          {
-            pelmat *= w*vcoeff(k);
             const Vector vec_in(mat_in.GetColumn(k), dof);
             Vector vec_out(mat_out.GetColumn(k), dof);
-            pelmat.AddMult(vec_in, vec_out);
+            pelmat.AddMult_a(w*vcoeff(k), vec_in, vec_out);
          }
       }
       else if (MQ)
@@ -3104,9 +3103,8 @@ void VectorDiffusionIntegrator::AssembleElementVector(
             Vector vec_out(mat_out.GetColumn(ii), dof);
             for (int jj = 0; jj < vdim; ++jj)
             {
-               pelmat *= w*mcoeff(ii,jj);
                const Vector vec_in(mat_in.GetColumn(jj), dof);
-               pelmat.Mult(vec_in, vec_out);
+               pelmat.AddMult_a(w*mcoeff(ii,jj), vec_in, vec_out);
             }
          }
       }


### PR DESCRIPTION
This corrects the scaling for VectorCoefficient and MatrixCoefficient in the AssembleElementVector member function for VectorDiffusionIntegrator. The integration was incorrect before due to the wrong scaling.

This resolves issue #4570