### PR TITLE
fix missing std::array and std::ignore

### DIFF
--- a/linalg/dtensor.hpp
+++ b/linalg/dtensor.hpp
@@ -13,6 +13,8 @@
 #define MFEM_DTENSOR
 
 #include <numeric>
+#include <array>
+#include <tuple>
 
 #include "../config/config.hpp"
 


### PR DESCRIPTION
@jandrej 
Added missing includes for `std::array` and `std::ignore`. Idk why this was working without the includes on some compilers.