### PR TITLE
Move VectorDim, CurlDim to FiniteElementSpace

### DIFF
--- a/fem/fespace.cpp
+++ b/fem/fespace.cpp
@@ -1358,6 +1358,46 @@ int FiniteElementSpace::GetNConformingDofs() const
    return P ? (P->Width() / vdim) : ndofs;
 }
 
+int FiniteElementSpace::GetVectorDim() const
+{
+   const FiniteElement *fe;
+   if (!GetNE())
+   {
+      static const Geometry::Type geoms[3] =
+      { Geometry::SEGMENT, Geometry::TRIANGLE, Geometry::TETRAHEDRON };
+      fe = FEColl()->FiniteElementForGeometry(geoms[GetMesh()->Dimension()-1]);
+   }
+   else
+   {
+      fe = GetFE(0);
+   }
+   if (!fe || fe->GetRangeType() == FiniteElement::SCALAR)
+   {
+      return GetVDim();
+   }
+   return GetVDim()*std::max(GetMesh()->SpaceDimension(), fe->GetRangeDim());
+}
+
+int FiniteElementSpace::GetCurlDim() const
+{
+   const FiniteElement *fe;
+   if (!GetNE())
+   {
+      static const Geometry::Type geoms[3] =
+      { Geometry::SEGMENT, Geometry::TRIANGLE, Geometry::TETRAHEDRON };
+      fe = FEColl()->FiniteElementForGeometry(geoms[GetMesh()->Dimension()-1]);
+   }
+   else
+   {
+      fe = GetFE(0);
+   }
+   if (!fe || fe->GetRangeType() == FiniteElement::SCALAR)
+   {
+      return 2 * GetMesh()->SpaceDimension() - 3;
+   }
+   return GetVDim()*fe->GetCurlDim();
+}
+
 const ElementRestrictionOperator *FiniteElementSpace::GetElementRestriction(
    ElementDofOrdering e_ordering) const
 {

--- a/fem/fespace.hpp
+++ b/fem/fespace.hpp
@@ -427,6 +427,7 @@ protected:
    /// Replicate 'mat' in the vector dimension, according to vdim ordering mode.
    void MakeVDimMatrix(SparseMatrix &mat) const;
 
+
    /// GridFunction interpolation operator applicable after mesh refinement.
    class RefinementOperator : public Operator
    {
@@ -747,6 +748,13 @@ public:
    int GetNConformingDofs() const;
 
    int GetConformingVSize() const { return vdim * GetNConformingDofs(); }
+
+   /// Return the dimension of an vector in the space, including if elements
+   /// are vector-valued
+   int GetVectorDim() const;
+
+   /// Return dimension of curl
+   int GetCurlDim() const;
 
    /// Return the ordering method.
    inline Ordering::Type GetOrdering() const { return ordering; }

--- a/fem/gridfunc.cpp
+++ b/fem/gridfunc.cpp
@@ -324,45 +324,12 @@ void GridFunction::ComputeFlux(BilinearFormIntegrator &blfi,
 
 int GridFunction::VectorDim() const
 {
-   const FiniteElement *fe;
-   if (!fes->GetNE())
-   {
-      static const Geometry::Type geoms[3] =
-      { Geometry::SEGMENT, Geometry::TRIANGLE, Geometry::TETRAHEDRON };
-      fe = fes->FEColl()->
-           FiniteElementForGeometry(geoms[fes->GetMesh()->Dimension()-1]);
-   }
-   else
-   {
-      fe = fes->GetFE(0);
-   }
-   if (!fe || fe->GetRangeType() == FiniteElement::SCALAR)
-   {
-      return fes->GetVDim();
-   }
-   return fes->GetVDim()*std::max(fes->GetMesh()->SpaceDimension(),
-                                  fe->GetRangeDim());
+   return fes->GetVectorDim();
 }
 
 int GridFunction::CurlDim() const
 {
-   const FiniteElement *fe;
-   if (!fes->GetNE())
-   {
-      static const Geometry::Type geoms[3] =
-      { Geometry::SEGMENT, Geometry::TRIANGLE, Geometry::TETRAHEDRON };
-      fe = fes->FEColl()->
-           FiniteElementForGeometry(geoms[fes->GetMesh()->Dimension()-1]);
-   }
-   else
-   {
-      fe = fes->GetFE(0);
-   }
-   if (!fe || fe->GetRangeType() == FiniteElement::SCALAR)
-   {
-      return 2 * fes->GetMesh()->SpaceDimension() - 3;
-   }
-   return fes->GetVDim()*fe->GetCurlDim();
+   return fes->GetCurlDim();
 }
 
 void GridFunction::GetTrueDofs(Vector &tv) const


### PR DESCRIPTION
Dear all,

[This is my first MFEM PR. I am in the same group as @hughcars and now working on code using MFEM].

This is a mini-PR that just moves existing functions. Specifically, `VectorDim` and `CurlDim` are defined in `GridFunction`, but only depend on the underlying `FiniteElementSpace`. We want to pre-allocate some memory that the depends on the actual vector size and where we know the FES, but not the gridfunction yet. 

Would it be ok to move those functions to `FiniteElementSpace`?

Two small points:
1. I've renamed these functions `GetVectorDim` and `GetCurlDim` to match the style of similar functions in `FiniteElementSpace`, but left them as is in `GridFunction` for backwards compatibility. Is this ok?
2. I've added short docstrings that were missing, so could you please check these are understandable? Especially to distinguish this function from `GetVDim`.

Thanks!