### PR TITLE
Various meshing related additions

### DIFF
--- a/fem/bilininteg.hpp
+++ b/fem/bilininteg.hpp
@@ -2824,8 +2824,8 @@ public:
 };
 
 /** Integrator for $(Q u, v)$, where $Q$ is an optional coefficient (of type scalar,
-    vector (diagonal matrix), or matrix), trial function $u$ is in $H(curl$ or
-    $H(div)$, and test function $v$ is in $H(curl$, $H(div)$, or $v=(v_1,\dots,v_n)$, where
+    vector (diagonal matrix), or matrix), trial function $u$ is in $H(curl)$ or
+    $H(div)$, and test function $v$ is in $H(curl)$, $H(div)$, or $v=(v_1,\dots,v_n)$, where
     $v_i$ are in $H^1$. */
 class VectorFEMassIntegrator: public BilinearFormIntegrator
 {
@@ -3619,7 +3619,7 @@ public:
 /** Integrator for the form: $\langle v, w \times n \rangle$ over a face (the interface)
  *  In 3D the trial variable $v$ is defined on the interface ($H^{-1/2}$(curl), trace of $H(curl$)
  *  In 2D it's defined on the interface ($H^{1/2}$, trace of $H^1$)
- *  The test variable $w$ is in an $H(curl$-conforming space. */
+ *  The test variable $w$ is in an $H(curl)$-conforming space. */
 class TangentTraceIntegrator : public BilinearFormIntegrator
 {
 private:

--- a/fem/coefficient.hpp
+++ b/fem/coefficient.hpp
@@ -562,6 +562,91 @@ public:
    { return active_attr[T.Attribute-1] ? c->Eval(T, ip, GetTime()) : 0.0; }
 };
 
+/** @brief Coefficient that evaluates a user specified scalar function of the
+    Jacobian of the mapping from the reference element (or the perfect element,
+    see Geometry::JacToPerfJac()) to the element described by the
+    ElementTransformation given to the Eval() method as input. */
+class JacobianFunctionCoefficient : public Coefficient
+{
+protected:
+   std::function<real_t(const DenseMatrix &)> JFunction;
+   bool use_perf_J;
+
+public:
+   /** @brief Construct a JacobianFunctionCoefficient that uses the perfect
+      Jacobian, when @a use_perf_J = true (default), or the reference Jacobian,
+      otherwise. */
+   JacobianFunctionCoefficient(std::function<real_t(const DenseMatrix &)> JF,
+                               bool use_perf_J = true)
+      : JFunction(std::move(JF)), use_perf_J(use_perf_J) { }
+
+   /// Evaluate the coefficient at the given point @a ip.
+   real_t Eval(ElementTransformation &T, const IntegrationPoint &ip) override;
+};
+
+/** @brief Coefficient that evaluates a user specified scalar function of the
+    mesh position and the Jacobian of the mapping from the reference element (or
+    the perfect element, see Geometry::JacToPerfJac()) to the element described
+    by the ElementTransformation given to the Eval() method as input. */
+class MeshFunctionCoefficient : public Coefficient
+{
+protected:
+   std::function<real_t(const Vector &, const DenseMatrix &)> XJFunction;
+   bool use_perf_J;
+
+public:
+   /** @brief Construct a MeshFunctionCoefficient that uses the perfect
+      Jacobian, when @a use_perf_J = true (default), or the reference Jacobian,
+      otherwise. */
+   MeshFunctionCoefficient(
+      std::function<real_t(const Vector &, const DenseMatrix &)> XJF,
+      bool use_perf_J = true)
+      : XJFunction(std::move(XJF)), use_perf_J(use_perf_J) { }
+
+   /// Evaluate the coefficient at the given point @a ip.
+   real_t Eval(ElementTransformation &T, const IntegrationPoint &ip) override;
+};
+
+/** @brief Coefficient that returns the Jacobian determinant (or integration
+    weight if the Jacobian is not square) of the mapping from the reference
+    element (or the perfect element, see Geometry::JacToPerfJac()) to the
+    element described by the ElementTransformation given to the Eval() method
+    as input. */
+class JacobianDeterminantCoefficient : public Coefficient
+{
+protected:
+   bool use_perf_J;
+
+public:
+   /** @brief Construct a JacobianDeterminantCoefficient that uses the perfect
+      Jacobian, when @a use_perf_J = true (default), or the reference Jacobian,
+      otherwise. */
+   JacobianDeterminantCoefficient(bool use_perf_J = true)
+      : use_perf_J(use_perf_J) { }
+
+   /// Evaluate the coefficient at the given point @a ip.
+   real_t Eval(ElementTransformation &T, const IntegrationPoint &ip) override;
+};
+
+/** @brief Coefficient that evaluates the pointwise mesh size as a function of
+    the Jacobian of the transformation from the perfect (unit) element. */
+class MeshSizeCoefficient : public Coefficient
+{
+protected:
+   int type;
+
+public:
+   /** @brief Construct a MeshSizeCoefficient of the given @a type. */
+   /** @param[in] type is one of:
+           - 0 - Jacobian determinant to the power 1/dim,
+           - 1 - h_min = minimal singular value of the Jacobian,
+           - 2 - h_max = maximal singular value of the Jacobian. */
+   MeshSizeCoefficient(int type = 0) : type(type) { }
+
+   /// Evaluate the coefficient at the given point @a ip.
+   real_t Eval(ElementTransformation &T, const IntegrationPoint &ip) override;
+};
+
 /// Base class for vector Coefficients that optionally depend on time and space.
 class VectorCoefficient
 {

--- a/fem/fe/fe_base.hpp
+++ b/fem/fe/fe_base.hpp
@@ -268,8 +268,8 @@ public:
       $ u(x) $ on a general physical element in following ways:
        - $ x = T(\hat x) $ is the image of the reference point $ \hat x $
        - $ J = J(\hat x) $ is the Jacobian matrix of the transformation T
-       - $ w = w(\hat x) = det(J) $ is the transformation weight factor for square J
-       - $ w = w(\hat x) = det(J^t J)^{1/2} $ is the transformation weight factor in general
+       - $ w = w(\hat x) = \det(J) $ is the transformation weight factor for square J
+       - $ w = w(\hat x) = \det(J^t J)^{1/2} $ is the transformation weight factor in general
    */
    enum MapType
    {

--- a/fem/fe_coll.hpp
+++ b/fem/fe_coll.hpp
@@ -264,6 +264,7 @@ protected:
    FiniteElement *H1_Elements[Geometry::NumGeom];
    int H1_dof[Geometry::NumGeom];
    int *SegDofOrd[2], *TriDofOrd[6], *QuadDofOrd[8], *TetDofOrd[24];
+   int *HexDofOrd[48], *PriDofOrd[12];
 
 public:
    explicit H1_FECollection(const int p, const int dim = 3,

--- a/fem/geom.cpp
+++ b/fem/geom.cpp
@@ -193,9 +193,9 @@ Geometry::Geometry()
    GeomCenter[PRISM].y = 1.0 / 3.0;
    GeomCenter[PRISM].z = 0.5;
 
-   GeomCenter[PYRAMID].x = 0.375;
-   GeomCenter[PYRAMID].y = 0.375;
-   GeomCenter[PYRAMID].z = 0.25;
+   GeomCenter[PYRAMID].x = 0.4;
+   GeomCenter[PYRAMID].y = 0.4;
+   GeomCenter[PYRAMID].z = 0.2;
 
    GeomToPerfGeomJac[POINT]       = NULL;
    GeomToPerfGeomJac[SEGMENT]     = new DenseMatrix(1);

--- a/fem/gridfunc.cpp
+++ b/fem/gridfunc.cpp
@@ -75,17 +75,18 @@ GridFunction::GridFunction(Mesh *m, std::istream &input)
    fes_sequence = fes->GetSequence();
 }
 
-GridFunction::GridFunction(Mesh *m, GridFunction *gf_array[], int num_pieces)
+GridFunction::GridFunction(Mesh *m, const GridFunction * const gf_array[],
+                           int num_pieces)
 {
    UseDevice(true);
 
    // all GridFunctions must have the same FE collection, vdim, ordering
    int vdim, ordering;
 
-   fes = gf_array[0]->FESpace();
-   fec_owned = FiniteElementCollection::New(fes->FEColl()->Name());
-   vdim = fes->GetVDim();
-   ordering = fes->GetOrdering();
+   const FiniteElementSpace *base_fes = gf_array[0]->FESpace();
+   fec_owned = FiniteElementCollection::New(base_fes->FEColl()->Name());
+   vdim = base_fes->GetVDim();
+   ordering = base_fes->GetOrdering();
    fes = new FiniteElementSpace(m, fec_owned, vdim, ordering);
    SetSize(fes->GetVSize());
 
@@ -104,7 +105,7 @@ GridFunction::GridFunction(Mesh *m, GridFunction *gf_array[], int num_pieces)
    vi = ei = fi = di = 0;
    for (int i = 0; i < num_pieces; i++)
    {
-      FiniteElementSpace *l_fes = gf_array[i]->FESpace();
+      const FiniteElementSpace *l_fes = gf_array[i]->FESpace();
       int l_ndofs  = l_fes->GetNDofs();
       int l_nvdofs = l_fes->GetNVDofs();
       int l_nedofs = l_fes->GetNEDofs();

--- a/fem/gridfunc.hpp
+++ b/fem/gridfunc.hpp
@@ -105,7 +105,7 @@ public:
        are owned by the GridFunction. */
    GridFunction(Mesh *m, std::istream &input);
 
-   GridFunction(Mesh *m, GridFunction *gf_array[], int num_pieces);
+   GridFunction(Mesh *m, const GridFunction * const gf_array[], int num_pieces);
 
    /// Copy assignment. Only the data of the base class Vector is copied.
    /** It is assumed that this object and @a rhs use FiniteElementSpace%s that

--- a/fem/tmop.cpp
+++ b/fem/tmop.cpp
@@ -3336,6 +3336,7 @@ real_t TMOP_Integrator::GetElementEnergy(const FiniteElement &el,
    for (int i = 0; i < ir.GetNPoints(); i++)
    {
       const IntegrationPoint &ip = ir.IntPoint(i);
+      if (Tpr) { Tpr->SetIntPoint(&ip); }
 
       metric->SetTargetJacobian(Jtr(i));
       CalcInverse(Jtr(i), Jrt);
@@ -3487,11 +3488,15 @@ real_t TMOP_Integrator::GetRefinementElementEnergy(const FiniteElement &el,
          Mult(Jpr, Jrt, Jpt);
 
          real_t val = metric_normal * h_metric->EvalW(Jpt);
-         if (metric_coeff) { val *= metric_coeff->Eval(*Tpr, ip); }
+         if (metric_coeff)
+         {
+            Tpr->SetIntPoint(&ip);
+            val *= metric_coeff->Eval(*Tpr, ip);
+         }
 
          el_energy += weight * val;
-         delete Tpr;
       }
+      delete Tpr;
       energy += el_energy;
    }
    energy /= NEsplit;
@@ -3546,7 +3551,11 @@ real_t TMOP_Integrator::GetDerefinementElementEnergy(const FiniteElement &el,
       Mult(Jpr, Jrt, Jpt);
 
       real_t val = metric_normal * h_metric->EvalW(Jpt);
-      if (metric_coeff) { val *= metric_coeff->Eval(*Tpr, ip); }
+      if (metric_coeff)
+      {
+         Tpr->SetIntPoint(&ip);
+         val *= metric_coeff->Eval(*Tpr, ip);
+      }
 
       energy += weight * val;
    }
@@ -3657,6 +3666,7 @@ void TMOP_Integrator::AssembleElementVectorExact(const FiniteElement &el,
    for (int q = 0; q < nqp; q++)
    {
       const IntegrationPoint &ip = ir.IntPoint(q);
+      if (Tpr) { Tpr->SetIntPoint(&ip); }
       metric->SetTargetJacobian(Jtr(q));
       CalcInverse(Jtr(q), Jrt);
       weights(q) = (integ_over_target) ? ip.weight * Jtr(q).Det() : ip.weight;

--- a/general/kdtree.hpp
+++ b/general/kdtree.hpp
@@ -287,13 +287,16 @@ public:
    void FindNeighborPoints(const PointND &pt,Tfloat R, std::vector<Tindex> & res,
                            std::vector<Tfloat> & dist)
    {
+      res.clear();
+      dist.clear();
       FindNeighborPoints(pt,R,data.begin(),data.end(),0,res,dist);
    }
 
    /// Finds all points within a distance R from point pt. The indices are
-   /// returned in the vector res and the correponding distances in vector dist.
+   /// returned in the vector res.
    void FindNeighborPoints(const PointND &pt,Tfloat R, std::vector<Tindex> & res)
    {
+      res.clear();
       FindNeighborPoints(pt,R,data.begin(),data.end(),0,res);
    }
 
@@ -302,6 +305,8 @@ public:
                                std::vector<Tindex> &res,
                                std::vector<Tfloat> &dist)
    {
+      res.clear();
+      dist.clear();
       Tfloat dd;
       for (auto iti=data.begin(); iti!=data.end(); iti++)
       {
@@ -318,6 +323,7 @@ public:
    void FindNeighborPointsSlow(const PointND &pt,Tfloat R,
                                std::vector<Tindex> &res)
    {
+      res.clear();
       Tfloat dd;
       for (auto iti=data.begin(); iti!=data.end(); iti++)
       {
@@ -537,7 +543,7 @@ private:
    }
 
    /// Finds the set of indices of points within a distance R of a point pt.
-   void FindNeighborPoints(PointND& pt, Tfloat R,
+   void FindNeighborPoints(const PointND& pt, Tfloat R,
                            typename std::vector<NodeND>::iterator itb,
                            typename std::vector<NodeND>::iterator ite,
                            size_t level,
@@ -586,7 +592,7 @@ private:
    }
 
    /// Finds the set of indices of points within a distance R of a point pt.
-   void FindNeighborPoints(PointND& pt, Tfloat R,
+   void FindNeighborPoints(const PointND& pt, Tfloat R,
                            typename std::vector<NodeND>::iterator itb,
                            typename std::vector<NodeND>::iterator ite,
                            size_t level,

--- a/linalg/densemat.cpp
+++ b/linalg/densemat.cpp
@@ -1329,6 +1329,20 @@ void DenseMatrix::CalcEigenvalues(real_t *lambda, real_t *vec) const
    }
 }
 
+real_t DenseMatrix::CalcConditionNumber() const
+{
+   if (width == 1) { return 1_r; }
+   if (width == 2 && height > 2)
+   {
+      real_t AtA_data[4], e_val[2], e_vec[4];
+      DenseMatrix AtA(AtA_data, 2, 2);
+      MultAtB(*this, *this, AtA);
+      AtA.CalcEigenvalues(e_val, e_vec);
+      return std::sqrt(e_val[1]/e_val[0]);
+   }
+   return CalcSingularvalue(0)/CalcSingularvalue(width-1);
+}
+
 void DenseMatrix::GetRow(int r, Vector &row) const
 {
    int m = Height();

--- a/linalg/densemat.hpp
+++ b/linalg/densemat.hpp
@@ -304,9 +304,14 @@ public:
    /// Return the i-th singular value (decreasing order) of NxN matrix, N=1,2,3.
    real_t CalcSingularvalue(const int i) const;
 
-   /** Return the eigenvalues (in increasing order) and eigenvectors of a
+   /** @brief Return the eigenvalues (in increasing order) and eigenvectors of a
        2x2 or 3x3 symmetric matrix. */
    void CalcEigenvalues(real_t *lambda, real_t *vec) const;
+
+   /** @brief Return the Euclidean, $\ell_2$, condition number of the matrix,
+       $\kappa = \sigma_{max}/\sigma_{min}$. Only small matrices are supported,
+       MxN with 1 <= N <= M <= 3. */
+   real_t CalcConditionNumber() const;
 
    void GetRow(int r, Vector &row) const;
    void GetColumn(int c, Vector &col) const;

--- a/linalg/kernels.hpp
+++ b/linalg/kernels.hpp
@@ -543,7 +543,7 @@ MFEM_HOST_DEVICE static inline
 void GetScalingFactor(const real_t &d_max, real_t &mult)
 {
    int d_exp;
-   if (d_max > 0.)
+   if (d_max > 0_r)
    {
       mult = frexp(d_max, &d_exp);
       if (d_exp == std::numeric_limits<real_t>::max_exponent)
@@ -554,7 +554,7 @@ void GetScalingFactor(const real_t &d_max, real_t &mult)
    }
    else
    {
-      mult = 1.;
+      mult = 1_r;
    }
    // mult = 2^d_exp is such that d_max/mult is in [0.5,1) or in other words
    // d_max is in the interval [0.5,1)*mult

--- a/linalg/sparsemat.cpp
+++ b/linalg/sparsemat.cpp
@@ -54,9 +54,9 @@ using namespace std;
 #ifdef MFEM_USE_CUDA_OR_HIP
 int SparseMatrix::SparseMatrixCount = 0;
 // doxygen doesn't like the macro-assisted typename so let's skip parsing it:
-// \cond false
+/// \cond Suppress_Doxygen_warnings
 MFEM_cu_or_hip(sparseHandle_t) SparseMatrix::handle = nullptr;
-// \endcond
+/// \endcond
 size_t SparseMatrix::bufferSize = 0;
 void * SparseMatrix::dBuffer = nullptr;
 #endif // MFEM_USE_CUDA_OR_HIP

--- a/mesh/nurbs.cpp
+++ b/mesh/nurbs.cpp
@@ -2319,7 +2319,7 @@ NURBSExtension::NURBSExtension(NURBSExtension *parent,
    ConnectBoundaries();
 }
 
-NURBSExtension::NURBSExtension(Mesh *mesh_array[], int num_pieces)
+NURBSExtension::NURBSExtension(const Mesh * const mesh_array[], int num_pieces)
 {
    NURBSExtension *parent = mesh_array[0]->NURBSext;
 
@@ -2861,7 +2861,8 @@ void NURBSExtension::GenerateActiveBdrElems()
 }
 
 
-void NURBSExtension::MergeWeights(Mesh *mesh_array[], int num_pieces)
+void NURBSExtension::MergeWeights(const Mesh * const mesh_array[],
+                                  int num_pieces)
 {
    Array<int> lelem_elem;
 
@@ -2887,7 +2888,7 @@ void NURBSExtension::MergeWeights(Mesh *mesh_array[], int num_pieces)
 }
 
 void NURBSExtension::MergeGridFunctions(
-   GridFunction *gf_array[], int num_pieces, GridFunction &merged)
+   const GridFunction * const gf_array[], int num_pieces, GridFunction &merged)
 {
    FiniteElementSpace *gfes = merged.FESpace();
    Array<int> lelem_elem, dofs;
@@ -2895,7 +2896,7 @@ void NURBSExtension::MergeGridFunctions(
 
    for (int i = 0; i < num_pieces; i++)
    {
-      FiniteElementSpace *lfes = gf_array[i]->FESpace();
+      const FiniteElementSpace *lfes = gf_array[i]->FESpace();
       NURBSExtension *lext = lfes->GetMesh()->NURBSext;
 
       lext->GetElementLocalToGlobal(lelem_elem);

--- a/mesh/nurbs.hpp
+++ b/mesh/nurbs.hpp
@@ -666,7 +666,7 @@ protected:
 
    /** @brief Set the weights in this object to values from active elements in
        @a num_pieces meshes in @a mesh_array. */
-   void MergeWeights(Mesh *mesh_array[], int num_pieces);
+   void MergeWeights(const Mesh * const mesh_array[], int num_pieces);
 
    /// Set @a patch_to_el.
    void SetPatchToElements();
@@ -696,7 +696,7 @@ public:
                   Mode mode = Mode::H_1);
    /// Construct a NURBSExtension by merging a partitioned NURBS mesh.
 
-   NURBSExtension(Mesh *mesh_array[], int num_pieces);
+   NURBSExtension(const Mesh * const mesh_array[], int num_pieces);
 
    NURBSExtension(const Mesh *patch_topology, const Array<const NURBSPatch*> p);
 
@@ -712,8 +712,8 @@ public:
 
    /** @brief Set the DOFs of @a merged to values from active elements in
        @a num_pieces of Gridfunctions @a gf_array. */
-   void MergeGridFunctions(GridFunction *gf_array[], int num_pieces,
-                           GridFunction &merged);
+   void MergeGridFunctions(const GridFunction * const gf_array[],
+                           int num_pieces, GridFunction &merged);
 
    /// Destroy a NURBSExtension.
    virtual ~NURBSExtension();


### PR DESCRIPTION
The following is from the commit message of 9fa89db5 with some additional formatting.

Various meshing related additions:
* Add `Mesh` methods `FindDuplicateVertices` and `ApplyVertexMap` which can be used to remove duplicate vertices from a `Mesh` when applied one after the other.
* `Mesh::CheckElementOrientation` will now try to fix the orientation of hex, prism and pyramid elements as well. The fix will be successful for an element if the determinant of the Jacobian in the element does not change sign.
* Add a minimal set of orientation handling for hex and prism elements (only orientations 0 and 1 are defined). This was needed to handle orientation fixing with high-order hex and prism meshes.
* Add convenience named constructors `Mesh::MakeUnion` where the input meshes and `Mesh`-arrays can be `const`. This required fixing `const` correctness in some existing methods which should be backward compatible.
* Add a method `Mesh::SetVerticesFromNodes` which may be needed in cases when the vertices of a `Mesh` with nodes are out-of-sync with the nodes.
* Add a convenience overload of the method `Mesh::Transform` that takes an `std::function` (e.g. lambda) as input.
* The method `Mesh::PrintCharacteristics` will now print the name of the nodal FE collection if the mesh has nodes.
* Add method `DenseMatrix::CalcConditionNumber` for small (including rectangular) matrices which is now used to compute `kappa`, i.e. mesh element anisotropy ratios in several places. This now allows us to compute element aspect ratios on surfaces.
* Add several mesh-related `Coefficient` classes:
  - `JacobianFunctionCoefficient`: based on `std::function`: J -> scalar
  - `MeshFunctionCoefficient`: based on `std::function`: (x,J) -> scalar
  - `JacobianDeterminantCoefficient`: returns det(J) or surface weight
  - `MeshSizeCoefficient`: returns a pointwise mesh size.
* In class `Geometry`, fix the center point definition for `PYRAMID`.
* In class `TMOP_Integrator`, fix the usage of the _ref->physical transformation_, `Tpr`, for cases where it is used with `Coefficient` that assume the `IntegrationPoint` of the transformation is set to be the same as the second argument of the coefficient's `Eval` method. Also fix the place where `Tpr` is deleted in the `TMOP_Integrator`'s method `GetRefinementElementEnergy`.
* In class `KDTree`, reset input content of `std::vector` parameters that are used as output -- previously the methods simply appended to the `std::vector` which was a bug. Also, fix the `const` correctness of the input `PointND` in two versions of `FindNeighborPoints`.
* In the `mesh-explorer` miniapp:
  - Add menu options `H` and `K` (similar to `h` and `k`) that visualize the pointwise element size and aspect ratio fields, respectively, projected to high-order FE spaces.
  - Improved the `l` menu option for plotting the function `f` to indicate that negative orders will be treated as DG space and to ask what DG basis to use for projecting.
* Fix a few doxygen comments.
