### PR TITLE
TMOP correction for background grids

### DIFF
--- a/fem/fespace.cpp
+++ b/fem/fespace.cpp
@@ -3835,18 +3835,18 @@ void FiniteElementSpace::UpdateMeshPointer(Mesh *new_mesh)
 }
 
 void FiniteElementSpace::GetNodePositions(const Vector &mesh_nodes,
-                                          Vector &fes_nodes,
+                                          Vector &fes_node_pos,
                                           int fes_nodes_ordering) const
 {
    Mesh *m = GetMesh();
    const int NE = m->GetNE();
 
-   if (NE == 0) { fes_nodes.SetSize(0); return; }
+   if (NE == 0) { fes_node_pos.SetSize(0); return; }
 
    const int dim   = m->Dimension();
    Array<int> dofs;
    Vector e_xyz;
-   fes_nodes.SetSize(GetNDofs() * dim);
+   fes_node_pos.SetSize(GetNDofs() * dim);
    const FiniteElementSpace *mesh_fes = m->GetNodalFESpace();
    FiniteElementSpace vector_fes(m, FEColl(), dim, fes_nodes_ordering);
 
@@ -3871,7 +3871,7 @@ void FiniteElementSpace::GetNodePositions(const Vector &mesh_nodes,
 
       // reuse/resize dofs.
       vector_fes.GetElementVDofs(e, dofs);
-      fes_nodes.SetSubVector(dofs, gf_xyz);
+      fes_node_pos.SetSubVector(dofs, gf_xyz);
    }
 }
 

--- a/fem/fespace.cpp
+++ b/fem/fespace.cpp
@@ -3843,7 +3843,7 @@ void FiniteElementSpace::GetNodePositions(const Vector &mesh_nodes,
 
    if (NE == 0) { fes_node_pos.SetSize(0); return; }
 
-   const int dim   = m->Dimension();
+   const int dim = m->Dimension();
    Array<int> dofs;
    Vector e_xyz;
    fes_node_pos.SetSize(GetNDofs() * dim);

--- a/fem/fespace.hpp
+++ b/fem/fespace.hpp
@@ -1369,6 +1369,14 @@ public:
       Update(false);
    }
 
+   /// Compute the space's node positions w.r.t. given mesh positions.
+   /** Assumes the Vector @mesh_nodes has the same topology & ordering as the
+       mesh of the FE space, i.e, same size as this->GetMesh()->GetNodes().
+       The computation is done using FiniteElement::GetNodes() to obtain the
+       reference DOF positions of each finite element. */
+   void GetNodePositions(const Vector &mesh_nodes, Vector &fes_nodes,
+                         int fes_nodes_ordering = Ordering::byNODES) const;
+
    /// Save finite element space to output stream @a out.
    void Save(std::ostream &out) const;
 

--- a/fem/fespace.hpp
+++ b/fem/fespace.hpp
@@ -1374,7 +1374,7 @@ public:
        mesh of the FE space, i.e, same size as this->GetMesh()->GetNodes().
        The computation is done using FiniteElement::GetNodes() to obtain the
        reference DOF positions of each finite element. */
-   void GetNodePositions(const Vector &mesh_nodes, Vector &fes_nodes,
+   void GetNodePositions(const Vector &mesh_nodes, Vector &fes_node_pos,
                          int fes_nodes_ordering = Ordering::byNODES) const;
 
    /// Save finite element space to output stream @a out.

--- a/fem/fespace.hpp
+++ b/fem/fespace.hpp
@@ -1370,6 +1370,8 @@ public:
    }
 
    /** @brief Compute the space's node positions w.r.t. given mesh positions.
+       The function uses FiniteElement::GetNodes() to obtain the reference DOF
+       positions of each finite element.
 
        @param[in]  mesh_nodes   Mesh positions. Assumes that it has the same
                                 topology & ordering as the mesh of the FE space,

--- a/fem/fespace.hpp
+++ b/fem/fespace.hpp
@@ -1369,11 +1369,13 @@ public:
       Update(false);
    }
 
-   /// Compute the space's node positions w.r.t. given mesh positions.
-   /** Assumes the Vector @mesh_nodes has the same topology & ordering as the
-       mesh of the FE space, i.e, same size as this->GetMesh()->GetNodes().
-       The computation is done using FiniteElement::GetNodes() to obtain the
-       reference DOF positions of each finite element. */
+   /** @brief Compute the space's node positions w.r.t. given mesh positions.
+
+       @param[in]  mesh_nodes   Mesh positions. Assumes that it has the same
+                                topology & ordering as the mesh of the FE space,
+                                i.e, same size as this->GetMesh()->GetNodes().
+       @param[out] fes_node_pos Positions of the FE space's nodes.
+       @param[in]  fes_nodes_ordering  Ordering of fes_node_pos.     */
    void GetNodePositions(const Vector &mesh_nodes, Vector &fes_node_pos,
                          int fes_nodes_ordering = Ordering::byNODES) const;
 

--- a/fem/tmop.cpp
+++ b/fem/tmop.cpp
@@ -4525,8 +4525,8 @@ void TMOP_Integrator::RemapSurfaceFittingLevelSetAtNodes(const Vector &new_x,
 
       // Interpolate values of the LS.
       Vector surf_fit_gf_int, surf_fit_grad_int, surf_fit_hess_int;
-      surf_fit_eval->ComputeAtNewPosition(new_x_sorted, surf_fit_gf_int,
-                                          new_x_ordering);
+      surf_fit_eval->ComputeAtGivenPositions(new_x_sorted, surf_fit_gf_int,
+                                             new_x_ordering);
       for (int i = 0; i < cnt; i++)
       {
          int dof_index = surf_fit_marker_dof_index[i];
@@ -4534,8 +4534,9 @@ void TMOP_Integrator::RemapSurfaceFittingLevelSetAtNodes(const Vector &new_x,
       }
 
       // Interpolate gradients of the LS.
-      surf_fit_eval_grad->ComputeAtNewPosition(new_x_sorted, surf_fit_grad_int,
-                                               new_x_ordering);
+      surf_fit_eval_grad->ComputeAtGivenPositions(new_x_sorted,
+                                                  surf_fit_grad_int,
+                                                  new_x_ordering);
       // Assumes surf_fit_grad and surf_fit_gf share the same space
       const int grad_dim = surf_fit_grad->VectorDim();
       const int grad_cnt = surf_fit_grad->Size()/grad_dim;
@@ -4565,8 +4566,9 @@ void TMOP_Integrator::RemapSurfaceFittingLevelSetAtNodes(const Vector &new_x,
       }
 
       // Interpolate Hessians of the LS.
-      surf_fit_eval_hess->ComputeAtNewPosition(new_x_sorted, surf_fit_hess_int,
-                                               new_x_ordering);
+      surf_fit_eval_hess->ComputeAtGivenPositions(new_x_sorted,
+                                                  surf_fit_hess_int,
+                                                  new_x_ordering);
       // Assumes surf_fit_hess and surf_fit_gf share the same space
       const int hess_dim = surf_fit_hess->VectorDim();
       const int hess_cnt = surf_fit_hess->Size()/hess_dim;

--- a/fem/tmop.cpp
+++ b/fem/tmop.cpp
@@ -3122,12 +3122,6 @@ void TMOP_Integrator::EnableSurfaceFittingFromSource(
    MFEM_ABORT("Surface fitting from source requires GSLIB!");
 #endif
 
-   auto ae_ifp  = dynamic_cast<InterpolatorFP *>(&ae),
-        age_ifp = dynamic_cast<InterpolatorFP *>(&age),
-        ahe_ifp = dynamic_cast<InterpolatorFP *>(&ahe);
-   MFEM_VERIFY(ae_ifp && age_ifp && ahe_ifp,
-               "Fitting through background grids requires InterpolatorFP.");
-
    // Setup for level set function
    delete surf_fit_gf;
    surf_fit_gf = new GridFunction(s0);
@@ -3138,7 +3132,7 @@ void TMOP_Integrator::EnableSurfaceFittingFromSource(
                                  *s_bg.ParFESpace());
    surf_fit_eval->SetInitialField
    (*s_bg.FESpace()->GetMesh()->GetNodes(), s_bg);
-   ae_ifp->SetNewFieldFESpace(*surf_fit_gf->FESpace());
+   surf_fit_eval->SetNewFieldFESpace(*surf_fit_gf->FESpace());
    GridFunction *nodes = s0.FESpace()->GetMesh()->GetNodes();
    surf_fit_eval->ComputeAtNewPosition(*nodes, *surf_fit_gf,
                                        nodes->FESpace()->GetOrdering());
@@ -3152,12 +3146,11 @@ void TMOP_Integrator::EnableSurfaceFittingFromSource(
    surf_fit_grad = new GridFunction(s0_grad);
    *surf_fit_grad = 0.0;
    surf_fit_eval_grad = &age;
-   surf_fit_eval_hess = &ahe;
    surf_fit_eval_grad->SetParMetaInfo(*s_bg_grad.ParFESpace()->GetParMesh(),
                                       *s_bg_grad.ParFESpace());
    surf_fit_eval_grad->SetInitialField
    (*s_bg_grad.FESpace()->GetMesh()->GetNodes(), s_bg_grad);
-   age_ifp->SetNewFieldFESpace(*surf_fit_grad->FESpace());
+   surf_fit_eval_grad->SetNewFieldFESpace(*surf_fit_grad->FESpace());
 
    // Setup for Hessian on background mesh
    MFEM_VERIFY(s_bg_hess.ParFESpace()->GetOrdering() ==
@@ -3167,11 +3160,12 @@ void TMOP_Integrator::EnableSurfaceFittingFromSource(
    delete surf_fit_hess;
    surf_fit_hess = new GridFunction(s0_hess);
    *surf_fit_hess = 0.0;
+   surf_fit_eval_hess = &ahe;
    surf_fit_eval_hess->SetParMetaInfo(*s_bg_hess.ParFESpace()->GetParMesh(),
                                       *s_bg_hess.ParFESpace());
    surf_fit_eval_hess->SetInitialField
    (*s_bg_hess.FESpace()->GetMesh()->GetNodes(), s_bg_hess);
-   ahe_ifp->SetNewFieldFESpace(*surf_fit_hess->FESpace());
+   surf_fit_eval_hess->SetNewFieldFESpace(*surf_fit_hess->FESpace());
 
    // Count number of zones that share each of the DOFs
    s0.CountElementsPerVDof(surf_fit_dof_count);

--- a/fem/tmop.hpp
+++ b/fem/tmop.hpp
@@ -1314,8 +1314,8 @@ public:
    }
    virtual ~AdaptivityEvaluator();
 
-   /** Specifies the Mesh and FiniteElementSpace of the solution that will
-       be evaluated. The given mesh will be copied into the internal object. */
+   /// Specifies the Mesh and FiniteElementSpace of the solution that will
+   /// be evaluated. The given mesh will be copied into the internal object.
    void SetSerialMetaInfo(const Mesh &m,
                           const FiniteElementSpace &f);
 
@@ -1330,6 +1330,10 @@ public:
    virtual void SetInitialField(const Vector &init_nodes,
                                 const Vector &init_field) = 0;
 
+   /// Called when the FE space of the final field is different than
+   /// the FE space of the initial field.
+   virtual void SetNewFieldFESpace(const FiniteElementSpace &fes) = 0;
+
    /** @brief Perform field transfer between the original and a new mesh. The
               source mesh and field are given by SetInitialField().
 
@@ -1340,6 +1344,16 @@ public:
    virtual void ComputeAtNewPosition(const Vector &new_mesh_nodes,
                                      Vector &new_field,
                                      int nodes_ordering = Ordering::byNODES) = 0;
+
+   /** @brief Using the source mesh and field given by SetInitialField(),
+              compute corresponding values at specified physical positions.
+
+       @param[in]  positions   Physical positions to compute values.
+       @param[out] values      Computed field values.
+       @param[in]  p_ordering  Ordering of the positions Vector.     */
+   virtual void ComputeAtGivenPositions(const Vector &positions,
+                                        Vector &values,
+                                        int p_ordering = Ordering::byNODES) = 0;
 
    void ClearGeometricFactors();
 };

--- a/fem/tmop.hpp
+++ b/fem/tmop.hpp
@@ -1331,7 +1331,7 @@ public:
 
    virtual void ComputeAtNewPosition(const Vector &new_nodes,
                                      Vector &new_field,
-                                     int new_nodes_ordering = Ordering::byNODES) = 0;
+                                     int nodes_ordering = Ordering::byNODES) = 0;
 
    void ClearGeometricFactors();
 };

--- a/fem/tmop.hpp
+++ b/fem/tmop.hpp
@@ -1325,11 +1325,19 @@ public:
                        const ParFiniteElementSpace &f);
 #endif
 
-   // TODO use GridFunctions to make clear it's on the ldofs?
+   // TODO use GridFunctions to make clear it's on the ldofs? Then do we
+   // need the SetMetaInfo at all -- the space and mesh can be extracted?
    virtual void SetInitialField(const Vector &init_nodes,
                                 const Vector &init_field) = 0;
 
-   virtual void ComputeAtNewPosition(const Vector &new_nodes,
+   /** @brief Perform field transfer between the original and a new mesh. The
+              source mesh and field are given by SetInitialField().
+
+       @param[in]  new_mesh_nodes  Mesh node positions of the new mesh (ldofs).
+                                   It is assumed that this is the field's mesh.
+       @param[out] new_field       Result of the transfer (ldofs).
+       @param[in]  nodes_ordering  Ordering of new_mesh_nodes.      */
+   virtual void ComputeAtNewPosition(const Vector &new_mesh_nodes,
                                      Vector &new_field,
                                      int nodes_ordering = Ordering::byNODES) = 0;
 

--- a/fem/tmop_tools.cpp
+++ b/fem/tmop_tools.cpp
@@ -402,7 +402,7 @@ void InterpolatorFP::ComputeAtNewPosition(const Vector &new_mesh_nodes,
    }
 
    const FiniteElementSpace *fes_sltn =
-       (fes_new_field) ? fes_new_field : field0_gf.FESpace();
+      (fes_new_field) ? fes_new_field : field0_gf.FESpace();
    const int dim = fes_sltn->GetMesh()->Dimension();
 
    if (new_mesh_nodes.Size() / dim != fes_sltn->GetNDofs())

--- a/fem/tmop_tools.cpp
+++ b/fem/tmop_tools.cpp
@@ -401,15 +401,15 @@ void InterpolatorFP::ComputeAtNewPosition(const Vector &new_mesh_nodes,
       return;
    }
 
-   const FiniteElementSpace *fes_sltn =
+   const FiniteElementSpace *fes_field =
       (fes_new_field) ? fes_new_field : field0_gf.FESpace();
-   const int dim = fes_sltn->GetMesh()->Dimension();
+   const int dim = fes_field->GetMesh()->Dimension();
 
-   if (new_mesh_nodes.Size() / dim != fes_sltn->GetNDofs())
+   if (new_mesh_nodes.Size() / dim != fes_field->GetNDofs())
    {
       // The nodes of the FE space don't coincide with the mesh nodes.
       Vector mapped_nodes;
-      fes_sltn->GetNodePositions(new_mesh_nodes, mapped_nodes);
+      fes_field->GetNodePositions(new_mesh_nodes, mapped_nodes);
       finder->Interpolate(mapped_nodes, field0_gf, new_field);
    }
    else

--- a/fem/tmop_tools.cpp
+++ b/fem/tmop_tools.cpp
@@ -389,14 +389,12 @@ void InterpolatorFP::SetInitialField(const Vector &init_nodes,
 }
 
 void InterpolatorFP::ComputeAtNewPosition(const Vector &new_mesh_nodes,
-                                          Vector &new_field,
-                                          int nodes_ordering)
+                                          Vector &new_field, int nodes_ordering)
 {
    const FiniteElementSpace *fes_sltn =
        (fes_new_field) ? fes_new_field : field0_gf.FESpace();
    const int dim = fes_sltn->GetMesh()->Dimension();
 
-   std::cout << new_mesh_nodes.Size() / dim << " " << fes_sltn->GetNDofs() << std::endl;
    if (new_mesh_nodes.Size() / dim != fes_sltn->GetNDofs())
    {
       // The nodes of the FE space don't coincide with the mesh nodes.
@@ -408,6 +406,12 @@ void InterpolatorFP::ComputeAtNewPosition(const Vector &new_mesh_nodes,
    {
       finder->Interpolate(new_mesh_nodes, field0_gf, new_field, nodes_ordering);
    }
+}
+
+void InterpolatorFP::ComputeAtGivenPositions(const Vector &positions,
+                                             Vector &values, int p_ordering)
+{
+   finder->Interpolate(positions, field0_gf, values, p_ordering);
 }
 
 #endif

--- a/fem/tmop_tools.cpp
+++ b/fem/tmop_tools.cpp
@@ -377,15 +377,6 @@ void InterpolatorFP::SetInitialField(const Vector &init_nodes,
 
    field0_gf.SetSpace(f);
    field0_gf = init_field;
-
-   // Check if the mesh nodes and the field nodes coincide.
-   const bool nodes_mismatch = init_nodes.Size() / m->Dimension() !=
-                               field0_gf.Size()  / f->GetVDim();
-   if (nodes_mismatch)
-   {
-      delete fes_new_field;
-      fes_new_field = new FiniteElementSpace(m, f->FEColl(), m->Dimension());
-   }
 }
 
 void InterpolatorFP::ComputeAtNewPosition(const Vector &new_mesh_nodes,

--- a/fem/tmop_tools.cpp
+++ b/fem/tmop_tools.cpp
@@ -391,6 +391,16 @@ void InterpolatorFP::SetInitialField(const Vector &init_nodes,
 void InterpolatorFP::ComputeAtNewPosition(const Vector &new_mesh_nodes,
                                           Vector &new_field, int nodes_ordering)
 {
+   // TODO - this is here only to prevent breaking user codes. To be removed.
+   // If the meshes are different, one has to call SetNewFieldFESpace().
+   // If only some positions are interpolated, use ComputeAtGivenPositions().
+   if (fes_new_field == nullptr && new_mesh_nodes.Size() != nodes0.Size())
+   {
+      MFEM_WARNING("Deprecated -- use ComputeAtGivenPositions() instead!");
+      ComputeAtGivenPositions(new_mesh_nodes, new_field, nodes_ordering);
+      return;
+   }
+
    const FiniteElementSpace *fes_sltn =
        (fes_new_field) ? fes_new_field : field0_gf.FESpace();
    const int dim = fes_sltn->GetMesh()->Dimension();

--- a/fem/tmop_tools.hpp
+++ b/fem/tmop_tools.hpp
@@ -43,12 +43,24 @@ public:
    void SetInitialField(const Vector &init_nodes,
                         const Vector &init_field) override;
 
+   void SetNewFieldFESpace(const FiniteElementSpace &fes) override
+   {
+      MFEM_ABORT("Not supported by AdvectorCG.");
+   }
+
    /// Perform advection-based remap. Assumptions:
    /// nodes0 and new_mesh_nodes have the same topology;
    /// new_field is of the same FE space as field0.
    void ComputeAtNewPosition(const Vector &new_mesh_nodes,
                              Vector &new_field,
                              int nodes_ordering = Ordering::byNODES) override;
+
+   void ComputeAtGivenPositions(const Vector &positions,
+                                Vector &values,
+                                int p_ordering = Ordering::byNODES) override
+   {
+      MFEM_ABORT("Not supported by AdvectorCG.");
+   }
 
    /// Set the memory type used for large memory allocations. This memory type
    /// is used when constructing the AdvectorCGOper but currently only for the
@@ -75,7 +87,7 @@ public:
    /// Must be called when the FE space of the final field is different than
    /// the FE space of the initial field. This also includes the case when
    /// the initial and final fields are on different meshes.
-   void SetNewFieldFESpace(const FiniteElementSpace &fes)
+   virtual void SetNewFieldFESpace(const FiniteElementSpace &fes) override
    {
       fes_new_field = &fes;
    }
@@ -87,6 +99,11 @@ public:
                              Vector &new_field,
                              int nodes_ordering = Ordering::byNODES) override;
 
+   /// Direct interpolation of field0_gf at the given positions.
+   void ComputeAtGivenPositions(const Vector &positions,
+                                Vector &values,
+                                int p_ordering = Ordering::byNODES) override;
+
    const FindPointsGSLIB *GetFindPointsGSLIB() const
    {
       return finder;
@@ -96,7 +113,6 @@ public:
    {
       finder->FreeData();
       delete finder;
-      delete fes_new_field;
    }
 };
 #endif

--- a/fem/tmop_tools.hpp
+++ b/fem/tmop_tools.hpp
@@ -66,9 +66,6 @@ private:
    // FE space for the nodes of the solution GridFunction, not owned.
    const FiniteElementSpace *fes_new_field;
 
-   void GetFieldNodesPosition(const Vector &mesh_nodes,
-                              Vector &nodes_pos) const;
-
 public:
    InterpolatorFP() : finder(NULL), fes_new_field(NULL) { }
 
@@ -78,7 +75,10 @@ public:
    /// Must be called when the FE space of the final field is different than
    /// the FE space of the initial field. This also includes the case when
    /// the initial and final fields are on different meshes.
-   void SetNewFieldFESpace(const FiniteElementSpace &fes);
+   void SetNewFieldFESpace(const FiniteElementSpace &fes)
+   {
+      fes_new_field = &fes;
+   }
 
    /// Perform interpolation-based remap.
    /// Assumptions when SetNewFieldFESpace() has not been called:

--- a/fem/tmop_tools.hpp
+++ b/fem/tmop_tools.hpp
@@ -31,7 +31,9 @@ private:
    const AssemblyLevel al;
    MemoryType opt_mt = MemoryType::DEFAULT;
 
-   void ComputeAtNewPositionScalar(const Vector &new_nodes, Vector &new_field);
+   void ComputeAtNewPositionScalar(const Vector &new_mesh_nodes,
+                                   Vector &new_field);
+
 public:
    AdvectorCG(AssemblyLevel al = AssemblyLevel::LEGACY,
               real_t timestep_scale = 0.5)
@@ -41,9 +43,13 @@ public:
    void SetInitialField(const Vector &init_nodes,
                         const Vector &init_field) override;
 
-   void ComputeAtNewPosition(const Vector &new_nodes,
+   /// Perform advection-based remap.
+   /// Source: field0, of the fes/pfes FE space, defined on nodes0.
+   /// Result: new_field, of the FE same space, defined on new_mesh_nodes.
+   /// Assumes that nodes0 and new_mesh_nodes have the same topology.
+   void ComputeAtNewPosition(const Vector &new_mesh_nodes,
                              Vector &new_field,
-                             int new_nodes_ordering = Ordering::byNODES) override;
+                             int nodes_ordering = Ordering::byNODES) override;
 
    /// Set the memory type used for large memory allocations. This memory type
    /// is used when constructing the AdvectorCGOper but currently only for the
@@ -70,9 +76,14 @@ public:
    void SetInitialField(const Vector &init_nodes,
                         const Vector &init_field) override;
 
-   void ComputeAtNewPosition(const Vector &new_nodes,
+   /// Perform interpolation-based remap.
+   /// Source: field0, of the fes/pfes FE space, defined on nodes0.
+   /// Result: new_field, whose node positions are given by new_field_nodes.
+   /// This function does not care what is the FE space of new_field, nor
+   /// what is the underlying mesh of new_field.
+   void ComputeAtNewPosition(const Vector &new_field_nodes,
                              Vector &new_field,
-                             int new_nodes_ordering = Ordering::byNODES) override;
+                             int nodes_ordering = Ordering::byNODES) override;
 
    const FindPointsGSLIB *GetFindPointsGSLIB() const
    {

--- a/fem/tmop_tools.hpp
+++ b/fem/tmop_tools.hpp
@@ -78,7 +78,7 @@ public:
 
    /// Perform interpolation-based remap.
    /// Source: field0, of the fes/pfes FE space, defined on nodes0.
-   /// Result: new_field, whose node positions are given by new_field_nodes.
+   /// Result: new_field, whose DOF node positions are given by new_field_nodes.
    /// This function does not care what is the FE space of new_field, nor
    /// what is the underlying mesh of new_field.
    void ComputeAtNewPosition(const Vector &new_field_nodes,


### PR DESCRIPTION
Some bugs appeared for fitting with background grids after the merge of `tmop-ae-space` #4600, this should fix them.
<!--GHEX{"author":"vladotomov","assignment":"2024-12-09T03:25:24","editor":"tzanio","id":4619,"reviewers":["v-dobrev","tzanio"],"merge":"2025-01-08T01:14:02","approval":"2025-01-05T02:55:04"}XEHG-->
<!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge|
 | --- | --- | --- | --- | --- | --- | --- |
| [#4619](https://github.com/mfem/mfem/pull/4619) | @vladotomov | @tzanio | @v-dobrev + @tzanio | 12/8/24 | 1/4/25 | 1/7/25 | |
<!--ELBATXEHG-->
<details>
<summary>PR Checklist</summary>
    
- [ ] Code builds.
- [ ] Code passes `make style`.
- [ ] Update `CHANGELOG`:
    - [ ] Is this a new feature users need to be aware of? New or updated example or miniapp?
    - [ ] Does it make sense to create a new section in the `CHANGELOG` to group with other related features?
- [ ] Update `INSTALL`:
    - [ ] Had a new optional library been added? If so, what range of versions of this library are required? (*Make sure the external library is compatible with our BSD license, e.g. it is not licensed under GPL!*)
    - [ ] Have the version ranges for any required or optional libraries changed?
    - [ ] Does `make` or `cmake` have a new target?
    - [ ] Did the requirements or the installation process change? *(rare)*
- [ ] Update continuous integration server configurations if necessary (e.g. with new version requirements for each of MFEM's dependencies)
    - [ ] `.github`
    - [ ] `.appveyor.yml`
- [ ] Update `.gitignore`:
    - [ ] Check if `make distclean; git status` shows any files that were generated from the source by the project (not an IDE) but we don't want to track in the repository.
    - [ ] Add new patterns (just for the new files above) and re-run the above test.
- [ ] New examples:
    - [ ] All sample runs at the top of the example source file work.
    - [ ] Update `examples/makefile`:
      - [ ] Add the example code to the appropriate `SEQ_EXAMPLES` and `PAR_EXAMPLES` variables.
      - [ ] Add any files generated by it to the `clean` target.
      - [ ] Add the example binary and any files generated by it to the top-level `.gitignore` file.
    - [ ] Update `examples/CMakeLists.txt`:
      - [ ] Add the example code to the `ALL_EXE_SRCS` variable.
      - [ ] Make sure `THIS_TEST_OPTIONS` is set correctly for the new example.
   - [ ] List the new example in `doc/CodeDocumentation.dox`.
   - [ ] If new examples directory (e.g.`examples/pumi`), list it in `doc/CodeDocumentation.conf.in`
   - [ ] Companion pull request for documentation in [mfem/web](https://github.com/mfem/web) repo:
      - [ ] Update or add example-specific documentation, see e.g. the `src/examples.md`.
      - [ ] Add the description, labels and screenshots in `src/examples.md` and `src/img`.
      - [ ] In `examples.md`, list the example under the appropriate categories, add new categories if necessary.
      - [ ] Add a short description of the example in the "Extensive Examples" section of `features.md`.
- [ ] New miniapps:
   - [ ] All sample runs at the top of the miniapp source file work.
   - [ ] Update top-level `makefile` and `makefile` in corresponding miniapp directory.
   - [ ] Add the miniapp binary and any files generated by it to the top-level `.gitignore` file.
   - [ ] Update CMake build system:
      - [ ] Update the `CMakeLists.txt` file in the `miniapps` directory, if the new miniapp is in a new directory.
      - [ ] Add/update the `CMakeLists.txt` file in the new miniapp directory.
      - [ ] Consider adding a new test for the new miniapp.
   - [ ] List the new miniapp in `doc/CodeDocumentation.dox`
   - [ ] If new miniapps directory (e.g.`miniapps/nurbs`), add it to `MINIAPP_SUBDIRS` in the `makefile`.
   - [ ] If new miniapps directory (e.g.`miniapps/nurbs`), list it in `doc/CodeDocumentation.conf.in`
   - [ ] Companion pull request for documentation in [mfem/web](https://github.com/mfem/web) repo:
     - [ ] Update or add miniapp-specific documentation, see e.g. the `src/meshing.md` and `src/electromagnetics.md` files.
     - [ ] Add the description, labels and screenshots in `src/examples.md` and `src/img`.
     - [ ] The miniapps go at the end of the page, and are usually listed only under a specific "Application (PDE)" category.
     - [ ] Add a short description of the miniapp in the "Extensive Examples" section of `features.md`.
- [ ] New capability:
   - [ ] All new public, protected, and private classes, methods, data members, and functions have full Doxygen-style documentation in source comments. Documentation should include descriptions of member data, function arguments and return values, template parameters, and prerequisites for calling new functions.
   - [ ] Pointer arguments and return values must specify whether ownership is being transferred or lent with the call.
   - [ ] Any new functions should include descriptions of their intended use e.g. for internal use only, user-facing, etc., along with references to example code whenever possible/appropriate.
   - [ ] Consider adding new sample runs in existing examples to highlight the new capability.
   - [ ] Consider saving cool simulation pictures with the new capability in the Confluence gallery (LLNL only) or submitting them, via pull request, to the gallery section of the `mfem/web` repo.
   - [ ] If this is a major new feature, consider mentioning it in the short summary inside `README` *(rare)*.
   - [ ] List major new classes in `doc/CodeDocumentation.dox` *(rare)*.
- [ ] Update this checklist, if the new pull request affects it.
- [ ] Run `make unittest` to make sure all unit tests pass.
- [ ] Run the tests in `tests/scripts`.
- [ ] (LLNL only) After merging:
   - [ ] Update internal tests to include the new features.
</details>
