### PR TITLE
Fix for mfem v13 mesh format reader

### DIFF
--- a/examples/makefile
+++ b/examples/makefile
@@ -155,6 +155,8 @@ ex27p-test-par: ex27p
 	@$(call mfem-test,$<, $(RUN_MPI), Parallel example,-dg)
 ex37-test-seq: ex37
 	@$(call mfem-test,$<,, Serial example,-mi 3)
+ex39-test-seq: ex39
+	@$(call mfem-test,$<,, Serial example,-m ../data/compass.mesh)
 ex37p-test-par: ex37p
 	@$(call mfem-test,$<, $(RUN_MPI), Parallel example,-mi 3)
 # Testing: optional tests

--- a/general/arrays_by_name.hpp
+++ b/general/arrays_by_name.hpp
@@ -279,8 +279,9 @@ void ArraysByName<T>::Load(std::istream &in)
          ArrayName = ArrayLine.substr(0,q1-1);
       }
 
-      // Ignore the remainder of the line which may contain explanatory comments
-      data[ArrayName].Load(in, 0);
+      std::istringstream iss(ArrayLine.substr(q1 + 1));
+
+      data[ArrayName].Load(iss, 0);
    }
 
 }


### PR DESCRIPTION
Follow-up fix for the discussion [here](https://github.com/mfem/mfem/issues/4625).

Given that attribute naming can include whitespaces we use std::istringstream to pass in a substring. Alternatively we could consider adding `std::string_view` support to `mfem::Array` to parse the data to avoid a copy.

I have removed the comment:
>       // Ignore the remainder of the line which may contain explanatory comments
as it is not clear to me what is means. Based on [mesh v13](https://mfem.org/mesh-format-v1.0/#mfem-mesh-v13) the attirbute set line should not contain any comments.