### PR TITLE
Bug fix and improvements to (Par)TransferMap

### DIFF
--- a/mesh/submesh/ptransfermap.cpp
+++ b/mesh/submesh/ptransfermap.cpp
@@ -19,17 +19,14 @@
 
 using namespace mfem;
 
-ParTransferMap::ParTransferMap(const ParGridFunction &src,
-                               const ParGridFunction &dst)
+ParTransferMap::ParTransferMap(const ParFiniteElementSpace &src,
+                               const ParFiniteElementSpace &dst)
 {
-   const ParFiniteElementSpace *parentfes = nullptr, *subfes1 = nullptr,
-                                *subfes2 = nullptr;
-
-   if (ParSubMesh::IsParSubMesh(src.ParFESpace()->GetParMesh()) &&
-       ParSubMesh::IsParSubMesh(dst.ParFESpace()->GetParMesh()))
+   if (ParSubMesh::IsParSubMesh(src.GetParMesh()) &&
+       ParSubMesh::IsParSubMesh(dst.GetParMesh()))
    {
-      ParSubMesh* src_sm = static_cast<ParSubMesh*>(src.ParFESpace()->GetParMesh());
-      ParSubMesh* dst_sm = static_cast<ParSubMesh*>(dst.ParFESpace()->GetParMesh());
+      ParSubMesh* src_sm = static_cast<ParSubMesh*>(src.GetParMesh());
+      ParSubMesh* dst_sm = static_cast<ParSubMesh*>(dst.GetParMesh());
 
       // There is no immediate relation and both src and dst come from a
       // SubMesh, check if they have an equivalent root parent.
@@ -52,11 +49,8 @@ ParTransferMap::ParTransferMap(const ParGridFunction &src,
          bool root_fes_reset = false;
          if (src_sm_dim == parent_dim - 1 && dst_sm_dim == parent_dim - 1)
          {
-            const ParFiniteElementSpace *src_fes = src.ParFESpace();
-            const ParFiniteElementSpace *dst_fes = dst.ParFESpace();
-
-            const FiniteElementCollection *src_fec = src_fes->FEColl();
-            const FiniteElementCollection *dst_fec = dst_fes->FEColl();
+            const FiniteElementCollection *src_fec = src.FEColl();
+            const FiniteElementCollection *dst_fec = dst.FEColl();
 
             const L2_FECollection *src_l2_fec =
                dynamic_cast<const L2_FECollection*>(src_fec);
@@ -97,58 +91,42 @@ ParTransferMap::ParTransferMap(const ParGridFunction &src,
          if (!root_fes_reset)
          {
             root_fes_.reset(new ParFiniteElementSpace(
-                               *src.ParFESpace(),
+                               src,
                                const_cast<ParMesh *>(
                                   SubMeshUtils::GetRootParent(*src_sm))));
          }
       }
 
-      subfes1 = src.ParFESpace();
-      subfes2 = dst.ParFESpace();
-
-      SubMeshUtils::BuildVdofToVdofMap(*subfes1,
-                                       *root_fes_,
-                                       src_sm->GetFrom(),
-                                       src_sm->GetParentElementIDMap(),
-                                       sub1_to_parent_map_);
-
-      SubMeshUtils::BuildVdofToVdofMap(*subfes2,
-                                       *root_fes_,
-                                       dst_sm->GetFrom(),
-                                       dst_sm->GetParentElementIDMap(),
-                                       sub2_to_parent_map_);
-
-      root_gc_ = &root_fes_->GroupComm();
-      CommunicateIndicesSet(sub1_to_parent_map_, root_fes_->GetVSize());
+      src_to_parent.reset(new ParTransferMap(src, *root_fes_));
+      dst_to_parent.reset(new ParTransferMap(dst, *root_fes_));
+      parent_to_dst.reset(new ParTransferMap(*root_fes_, dst));
 
       z_.SetSize(root_fes_->GetVSize());
    }
-   else if (ParSubMesh::IsParSubMesh(src.ParFESpace()->GetParMesh()))
+   else if (ParSubMesh::IsParSubMesh(src.GetParMesh()))
    {
       category_ = TransferCategory::SubMeshToParent;
-      ParSubMesh* src_sm = static_cast<ParSubMesh*>(src.ParFESpace()->GetParMesh());
-      subfes1 = src.ParFESpace();
-      parentfes = dst.ParFESpace();
-      SubMeshUtils::BuildVdofToVdofMap(*subfes1,
-                                       *parentfes,
+      ParSubMesh* src_sm = static_cast<ParSubMesh*>(src.GetParMesh());
+      SubMeshUtils::BuildVdofToVdofMap(src,
+                                       dst,
                                        src_sm->GetFrom(),
                                        src_sm->GetParentElementIDMap(),
-                                       sub1_to_parent_map_);
+                                       sub_to_parent_map_);
 
-      root_gc_ = &parentfes->GroupComm();
-      CommunicateIndicesSet(sub1_to_parent_map_, dst.Size());
+      root_gc_ = &dst.GroupComm();
+      CommunicateIndicesSet(sub_to_parent_map_, dst.GetVSize());
+      sub_fes_ = &src;
    }
-   else if (ParSubMesh::IsParSubMesh(dst.ParFESpace()->GetParMesh()))
+   else if (ParSubMesh::IsParSubMesh(dst.GetParMesh()))
    {
       category_ = TransferCategory::ParentToSubMesh;
-      ParSubMesh* dst_sm = static_cast<ParSubMesh*>(dst.ParFESpace()->GetParMesh());
-      subfes1 = dst.ParFESpace();
-      parentfes = src.ParFESpace();
-      SubMeshUtils::BuildVdofToVdofMap(*subfes1,
-                                       *parentfes,
+      ParSubMesh* dst_sm = static_cast<ParSubMesh*>(dst.GetParMesh());
+      SubMeshUtils::BuildVdofToVdofMap(dst,
+                                       src,
                                        dst_sm->GetFrom(),
                                        dst_sm->GetParentElementIDMap(),
-                                       sub1_to_parent_map_);
+                                       sub_to_parent_map_);
+      sub_fes_ = &dst;
    }
    else
    {
@@ -156,22 +134,27 @@ ParTransferMap::ParTransferMap(const ParGridFunction &src,
    }
 }
 
-void ParTransferMap::Transfer(const ParGridFunction &src,
-                              ParGridFunction &dst) const
+ParTransferMap::ParTransferMap(const ParGridFunction &src,
+                               const ParGridFunction &dst)
+   : ParTransferMap(*src.ParFESpace(), *dst.ParFESpace())
+{ }
+
+void ParTransferMap::Transfer(const Vector &src,
+                              Vector &dst) const
 {
    if (category_ == TransferCategory::ParentToSubMesh)
    {
       // dst = S1^T src
       src.HostRead();
       dst.HostWrite(); // dst is fully overwritten
-      for (int i = 0; i < sub1_to_parent_map_.Size(); i++)
+      for (int i = 0; i < sub_to_parent_map_.Size(); i++)
       {
          real_t s = 1.0;
-         int j = FiniteElementSpace::DecodeDof(sub1_to_parent_map_[i], s);
+         int j = FiniteElementSpace::DecodeDof(sub_to_parent_map_[i], s);
          dst(i) = s * src(j);
       }
 
-      CorrectFaceOrientations(*dst.ParFESpace(), src, dst);
+      CorrectFaceOrientations(*sub_fes_, src, dst);
    }
    else if (category_ == TransferCategory::SubMeshToParent)
    {
@@ -182,59 +165,23 @@ void ParTransferMap::Transfer(const ParGridFunction &src,
 
       src.HostRead();
       dst.HostReadWrite(); // dst is only partially overwritten
-      for (int i = 0; i < sub1_to_parent_map_.Size(); i++)
+      for (int i = 0; i < sub_to_parent_map_.Size(); i++)
       {
          real_t s = 1.0;
-         int j = FiniteElementSpace::DecodeDof(sub1_to_parent_map_[i], s);
+         int j = FiniteElementSpace::DecodeDof(sub_to_parent_map_[i], s);
          dst(j) = s * src(i);
       }
 
-      CorrectFaceOrientations(*src.ParFESpace(), src, dst,
-                              &sub1_to_parent_map_);
+      CorrectFaceOrientations(*sub_fes_, src, dst,
+                              &sub_to_parent_map_);
 
       CommunicateSharedVdofs(dst);
    }
    else if (category_ == TransferCategory::SubMeshToSubMesh)
    {
-      // dst = S2^T G (S1 src (*) S2 dst)
-      //
-      // G is identity if the partitioning matches
-
-      src.HostRead();
-      dst.HostReadWrite();
-
-      z_ = 0.0;
-
-      for (int i = 0; i < sub2_to_parent_map_.Size(); i++)
-      {
-         real_t s = 1.0;
-         int j = FiniteElementSpace::DecodeDof(sub2_to_parent_map_[i], s);
-         z_(j) = s * dst(i);
-      }
-
-      CorrectFaceOrientations(*dst.ParFESpace(), dst, z_,
-                              &sub2_to_parent_map_);
-
-      for (int i = 0; i < sub1_to_parent_map_.Size(); i++)
-      {
-         real_t s = 1.0;
-         int j = FiniteElementSpace::DecodeDof(sub1_to_parent_map_[i], s);
-         z_(j) = s * src(i);
-      }
-
-      CorrectFaceOrientations(*src.ParFESpace(), src, z_,
-                              &sub1_to_parent_map_);
-
-      CommunicateSharedVdofs(z_);
-
-      for (int i = 0; i < sub2_to_parent_map_.Size(); i++)
-      {
-         real_t s = 1.0;
-         int j = FiniteElementSpace::DecodeDof(sub2_to_parent_map_[i], s);
-         dst(i) = s * z_(j);
-      }
-
-      CorrectFaceOrientations(*dst.ParFESpace(), z_, dst);
+      dst_to_parent->Transfer(dst, z_);
+      src_to_parent->Transfer(src, z_);
+      parent_to_dst->Transfer(z_, dst);
    }
    else
    {

--- a/mesh/submesh/ptransfermap.cpp
+++ b/mesh/submesh/ptransfermap.cpp
@@ -101,7 +101,7 @@ ParTransferMap::ParTransferMap(const ParFiniteElementSpace &src,
       dst_to_parent.reset(new ParTransferMap(dst, *root_fes_));
       parent_to_dst.reset(new ParTransferMap(*root_fes_, dst));
 
-      z_.SetSize(root_fes_->GetVSize());
+      z_.SetSpace(root_fes_.get());
    }
    else if (ParSubMesh::IsParSubMesh(src.GetParMesh()))
    {
@@ -139,8 +139,8 @@ ParTransferMap::ParTransferMap(const ParGridFunction &src,
    : ParTransferMap(*src.ParFESpace(), *dst.ParFESpace())
 { }
 
-void ParTransferMap::Transfer(const Vector &src,
-                              Vector &dst) const
+void ParTransferMap::Transfer(const ParGridFunction &src,
+                              ParGridFunction &dst) const
 {
    if (category_ == TransferCategory::ParentToSubMesh)
    {

--- a/mesh/submesh/ptransfermap.hpp
+++ b/mesh/submesh/ptransfermap.hpp
@@ -53,19 +53,18 @@ public:
     * @param src The source ParGridFunction
     * @param dst The destination ParGridFunction
     */
-   ParTransferMap(const ParGridFunction &src,
-                  const ParGridFunction &dst);
+   ParTransferMap(const ParGridFunction &src, const ParGridFunction &dst);
 
    /**
-    * @brief Transfer the source Vector to the destination Vector.
+    * @brief Transfer the source ParGridFunction to the destination
+    * ParGridFunction.
     *
-    * Uses the precomputed maps for the transfer. The input and output should
-    * both be L-vectors, e.g. ParGridFunction%s.
+    * Uses the precomputed maps for the transfer.
     *
-    * @param src The source Vector
-    * @param dst The destination Vector
+    * @param src The source ParGridFunction
+    * @param dst The destination ParGridFunction
     */
-   void Transfer(const Vector &src, Vector &dst) const;
+   void Transfer(const ParGridFunction &src, ParGridFunction &dst) const;
 
 private:
    /**
@@ -143,7 +142,7 @@ private:
    ///@}
 
    /// Temporary vector
-   mutable Vector z_;
+   mutable ParGridFunction z_;
 };
 
 } // namespace mfem

--- a/mesh/submesh/transfermap.cpp
+++ b/mesh/submesh/transfermap.cpp
@@ -15,17 +15,14 @@
 
 using namespace mfem;
 
-TransferMap::TransferMap(const GridFunction &src,
-                         const GridFunction &dst)
+TransferMap::TransferMap(const FiniteElementSpace &src,
+                         const FiniteElementSpace &dst)
 {
-   const FiniteElementSpace *parentfes = nullptr, *subfes1 = nullptr,
-                             *subfes2 = nullptr;
-
-   if (SubMesh::IsSubMesh(src.FESpace()->GetMesh()) &&
-       SubMesh::IsSubMesh(dst.FESpace()->GetMesh()))
+   if (SubMesh::IsSubMesh(src.GetMesh()) &&
+       SubMesh::IsSubMesh(dst.GetMesh()))
    {
-      SubMesh* src_sm = static_cast<SubMesh*>(src.FESpace()->GetMesh());
-      SubMesh* dst_sm = static_cast<SubMesh*>(dst.FESpace()->GetMesh());
+      SubMesh* src_sm = static_cast<SubMesh*>(src.GetMesh());
+      SubMesh* dst_sm = static_cast<SubMesh*>(dst.GetMesh());
 
       // There is no immediate relation and both src and dst come from a
       // SubMesh, check if they have an equivalent root parent.
@@ -48,11 +45,8 @@ TransferMap::TransferMap(const GridFunction &src,
          bool root_fes_reset = false;
          if (src_sm_dim == parent_dim - 1 && dst_sm_dim == parent_dim - 1)
          {
-            const FiniteElementSpace *src_fes = src.FESpace();
-            const FiniteElementSpace *dst_fes = dst.FESpace();
-
-            const FiniteElementCollection *src_fec = src_fes->FEColl();
-            const FiniteElementCollection *dst_fec = dst_fes->FEColl();
+            const FiniteElementCollection *src_fec = src.FEColl();
+            const FiniteElementCollection *dst_fec = dst.FEColl();
 
             const L2_FECollection *src_l2_fec =
                dynamic_cast<const L2_FECollection*>(src_fec);
@@ -92,8 +86,8 @@ TransferMap::TransferMap(const GridFunction &src,
 
          if (!root_fes_reset)
          {
-            const FiniteElementCollection *src_fec = src.FESpace()->FEColl();
-            const FiniteElementCollection *dst_fec = dst.FESpace()->FEColl();
+            const FiniteElementCollection *src_fec = src.FEColl();
+            const FiniteElementCollection *dst_fec = dst.FEColl();
             auto *root_fec = src_sm_dim == parent_dim ? src_fec : dst_fec;
 
             root_fes_.reset(new FiniteElementSpace(
@@ -102,46 +96,33 @@ TransferMap::TransferMap(const GridFunction &src,
          }
       }
 
-      subfes1 = src.FESpace();
-      subfes2 = dst.FESpace();
-
-      SubMeshUtils::BuildVdofToVdofMap(*subfes1,
-                                       *root_fes_,
-                                       src_sm->GetFrom(),
-                                       src_sm->GetParentElementIDMap(),
-                                       sub1_to_parent_map_);
-
-      SubMeshUtils::BuildVdofToVdofMap(*subfes2,
-                                       *root_fes_,
-                                       dst_sm->GetFrom(),
-                                       dst_sm->GetParentElementIDMap(),
-                                       sub2_to_parent_map_);
+      src_to_parent.reset(new TransferMap(src, *root_fes_));
+      dst_to_parent.reset(new TransferMap(dst, *root_fes_));
+      parent_to_dst.reset(new TransferMap(*root_fes_, dst));
 
       z_.SetSize(root_fes_->GetVSize());
    }
-   else if (SubMesh::IsSubMesh(src.FESpace()->GetMesh()))
+   else if (SubMesh::IsSubMesh(src.GetMesh()))
    {
       category_ = TransferCategory::SubMeshToParent;
-      SubMesh* src_sm = static_cast<SubMesh*>(src.FESpace()->GetMesh());
-      subfes1 = src.FESpace();
-      parentfes = dst.FESpace();
-      SubMeshUtils::BuildVdofToVdofMap(*subfes1,
-                                       *parentfes,
+      SubMesh* src_sm = static_cast<SubMesh*>(src.GetMesh());
+      SubMeshUtils::BuildVdofToVdofMap(src,
+                                       dst,
                                        src_sm->GetFrom(),
                                        src_sm->GetParentElementIDMap(),
-                                       sub1_to_parent_map_);
+                                       sub_to_parent_map_);
+      sub_fes_ = &src;
    }
-   else if (SubMesh::IsSubMesh(dst.FESpace()->GetMesh()))
+   else if (SubMesh::IsSubMesh(dst.GetMesh()))
    {
       category_ = TransferCategory::ParentToSubMesh;
-      SubMesh* dst_sm = static_cast<SubMesh*>(dst.FESpace()->GetMesh());
-      subfes1 = dst.FESpace();
-      parentfes = src.FESpace();
-      SubMeshUtils::BuildVdofToVdofMap(*subfes1,
-                                       *parentfes,
+      SubMesh* dst_sm = static_cast<SubMesh*>(dst.GetMesh());
+      SubMeshUtils::BuildVdofToVdofMap(dst,
+                                       src,
                                        dst_sm->GetFrom(),
                                        dst_sm->GetParentElementIDMap(),
-                                       sub1_to_parent_map_);
+                                       sub_to_parent_map_);
+      sub_fes_ = &dst;
    }
    else
    {
@@ -149,22 +130,26 @@ TransferMap::TransferMap(const GridFunction &src,
    }
 }
 
-void TransferMap::Transfer(const GridFunction &src,
-                           GridFunction &dst) const
+TransferMap::TransferMap(const GridFunction &src,
+                         const GridFunction &dst)
+   : TransferMap(*src.FESpace(), *dst.FESpace())
+{ }
+
+void TransferMap::Transfer(const Vector &src, Vector &dst) const
 {
    if (category_ == TransferCategory::ParentToSubMesh)
    {
       // dst = S1^T src
       src.HostRead();
       dst.HostWrite(); // dst is fully overwritten
-      for (int i = 0; i < sub1_to_parent_map_.Size(); i++)
+      for (int i = 0; i < sub_to_parent_map_.Size(); i++)
       {
          real_t s = 1.0;
-         int j = FiniteElementSpace::DecodeDof(sub1_to_parent_map_[i], s);
+         int j = FiniteElementSpace::DecodeDof(sub_to_parent_map_[i], s);
          dst(i) = s * src(j);
       }
 
-      CorrectFaceOrientations(*dst.FESpace(), src, dst);
+      CorrectFaceOrientations(*sub_fes_, src, dst);
    }
    else if (category_ == TransferCategory::SubMeshToParent)
    {
@@ -175,55 +160,21 @@ void TransferMap::Transfer(const GridFunction &src,
 
       src.HostRead();
       dst.HostReadWrite(); // dst is only partially overwritten
-      for (int i = 0; i < sub1_to_parent_map_.Size(); i++)
+      for (int i = 0; i < sub_to_parent_map_.Size(); i++)
       {
          real_t s = 1.0;
-         int j = FiniteElementSpace::DecodeDof(sub1_to_parent_map_[i], s);
+         int j = FiniteElementSpace::DecodeDof(sub_to_parent_map_[i], s);
          dst(j) = s * src(i);
       }
 
-      CorrectFaceOrientations(*src.FESpace(), src, dst,
-                              &sub1_to_parent_map_);
+      CorrectFaceOrientations(*sub_fes_, src, dst,
+                              &sub_to_parent_map_);
    }
    else if (category_ == TransferCategory::SubMeshToSubMesh)
    {
-      // dst = S2^T G (S1 src (*) S2 dst)
-      //
-      // G is identity if the partitioning matches
-
-      src.HostRead();
-      dst.HostReadWrite();
-
-      z_ = 0.0;
-
-      for (int i = 0; i < sub2_to_parent_map_.Size(); i++)
-      {
-         real_t s = 1.0;
-         int j = FiniteElementSpace::DecodeDof(sub2_to_parent_map_[i], s);
-         z_(j) = s * dst(i);
-      }
-
-      CorrectFaceOrientations(*dst.FESpace(), dst, z_,
-                              &sub2_to_parent_map_);
-
-      for (int i = 0; i < sub1_to_parent_map_.Size(); i++)
-      {
-         real_t s = 1.0;
-         int j = FiniteElementSpace::DecodeDof(sub1_to_parent_map_[i], s);
-         z_(j) = s * src(i);
-      }
-
-      CorrectFaceOrientations(*src.FESpace(), src, z_,
-                              &sub1_to_parent_map_);
-
-      for (int i = 0; i < sub2_to_parent_map_.Size(); i++)
-      {
-         real_t s = 1.0;
-         int j = FiniteElementSpace::DecodeDof(sub2_to_parent_map_[i], s);
-         dst(i) = s * z_(j);
-      }
-
-      CorrectFaceOrientations(*dst.FESpace(), z_, dst);
+      dst_to_parent->Transfer(dst, z_);
+      src_to_parent->Transfer(src, z_);
+      parent_to_dst->Transfer(z_, dst);
    }
    else
    {

--- a/mesh/submesh/transfermap.cpp
+++ b/mesh/submesh/transfermap.cpp
@@ -100,7 +100,7 @@ TransferMap::TransferMap(const FiniteElementSpace &src,
       dst_to_parent.reset(new TransferMap(dst, *root_fes_));
       parent_to_dst.reset(new TransferMap(*root_fes_, dst));
 
-      z_.SetSize(root_fes_->GetVSize());
+      z_.SetSpace(root_fes_.get());
    }
    else if (SubMesh::IsSubMesh(src.GetMesh()))
    {
@@ -135,7 +135,7 @@ TransferMap::TransferMap(const GridFunction &src,
    : TransferMap(*src.FESpace(), *dst.FESpace())
 { }
 
-void TransferMap::Transfer(const Vector &src, Vector &dst) const
+void TransferMap::Transfer(const GridFunction &src, GridFunction &dst) const
 {
    if (category_ == TransferCategory::ParentToSubMesh)
    {

--- a/mesh/submesh/transfermap.hpp
+++ b/mesh/submesh/transfermap.hpp
@@ -33,7 +33,21 @@ class TransferMap
 public:
    /**
     * @brief Construct a new TransferMap object which transfers degrees of
+    * freedom from the source FiniteElementSpace to the destination
+    * FiniteElementSpace.
+    *
+    * @param src The source FiniteElementSpace
+    * @param dst The destination FiniteElementSpace
+    */
+   TransferMap(const FiniteElementSpace &src,
+               const FiniteElementSpace &dst);
+
+   /**
+    * @brief Construct a new TransferMap object which transfers degrees of
     * freedom from the source GridFunction to the destination GridFunction.
+    *
+    * Equivalent to creating the TransferMap from the finite element spaces of
+    * each of the GridFunction%s.
     *
     * @param src The source GridFunction
     * @param dst The destination GridFunction
@@ -42,14 +56,15 @@ public:
                const GridFunction &dst);
 
    /**
-    * @brief Transfer the source GridFunction to the destination GridFunction.
+    * @brief Transfer the source Vector to the destination Vector.
     *
-    * Uses the precomputed maps for the transfer.
+    * Uses the precomputed maps for the transfer. The source and destination
+    * should be L-vectors (e.g. GridFunction%s).
     *
-    * @param src The source GridFunction
-    * @param dst The destination GridFunction
+    * @param src The source Vector
+    * @param dst The destination Vector
     */
-   void Transfer(const GridFunction &src, GridFunction &dst) const;
+   void Transfer(const Vector &src, Vector &dst) const;
 
 private:
 
@@ -62,24 +77,40 @@ private:
 
    /// Mapping of the GridFunction defined on the SubMesh to the GridFunction
    /// of its parent Mesh.
-   Array<int> sub1_to_parent_map_;
+   Array<int> sub_to_parent_map_;
 
-   /// Mapping of the GridFunction defined on the second SubMesh to the
-   /// GridFunction of its parent Mesh. This is only used if this TransferMap
-   /// represents a SubMesh to SubMesh transfer.
-   Array<int> sub2_to_parent_map_;
+   /// Pointer to the finite element space defined on the SubMesh.
+   const FiniteElementSpace *sub_fes_ = nullptr;
+
+   /// @name Needed for SubMesh-to-SubMesh transfer
+   ///@{
 
    /// Pointer to the supplemental FiniteElementSpace on the common root parent
    /// Mesh. This is only used if this TransferMap represents a SubMesh to
    /// SubMesh transfer.
-   std::unique_ptr<const FiniteElementSpace> root_fes_;
+   std::unique_ptr<FiniteElementSpace> root_fes_;
 
    /// Pointer to the supplemental FiniteElementCollection used with root_fes_.
-   /// This is only used if this TransferMap represents a SubMesh to
-   /// SubMesh transfer where the root requires a different type of collection
-   /// than the SubMesh objects. For example, when the subpaces are L2 on
-   /// boundaries of the parent mesh and the root space can be RT.
+   /// This is only used if this TransferMap represents a SubMesh to SubMesh
+   /// transfer where the root requires a different type of collection than the
+   /// SubMesh objects. For example, when the subpaces are L2 on boundaries of
+   /// the parent mesh and the root space can be RT.
    std::unique_ptr<const FiniteElementCollection> root_fec_;
+
+   /// Transfer mapping from the source to the parent (root).
+   std::unique_ptr<TransferMap> src_to_parent;
+
+   /// @brief Transfer mapping from the destination to the parent (root).
+   ///
+   /// SubMesh-to-SubMesh transfer works by bringing both the source and
+   /// destination data to their common parent, and then transferring back to
+   /// the destination.
+   std::unique_ptr<TransferMap> dst_to_parent;
+
+   /// Transfer mapping from the parent to the destination.
+   std::unique_ptr<TransferMap> parent_to_dst;
+
+   ///@}
 
    /// Temporary vector
    mutable Vector z_;

--- a/mesh/submesh/transfermap.hpp
+++ b/mesh/submesh/transfermap.hpp
@@ -39,8 +39,7 @@ public:
     * @param src The source FiniteElementSpace
     * @param dst The destination FiniteElementSpace
     */
-   TransferMap(const FiniteElementSpace &src,
-               const FiniteElementSpace &dst);
+   TransferMap(const FiniteElementSpace &src, const FiniteElementSpace &dst);
 
    /**
     * @brief Construct a new TransferMap object which transfers degrees of
@@ -52,19 +51,17 @@ public:
     * @param src The source GridFunction
     * @param dst The destination GridFunction
     */
-   TransferMap(const GridFunction &src,
-               const GridFunction &dst);
+   TransferMap(const GridFunction &src, const GridFunction &dst);
 
    /**
-    * @brief Transfer the source Vector to the destination Vector.
+    * @brief Transfer the source GridFunction to the destination GridFunction.
     *
-    * Uses the precomputed maps for the transfer. The source and destination
-    * should be L-vectors (e.g. GridFunction%s).
+    * Uses the precomputed maps for the transfer.
     *
-    * @param src The source Vector
-    * @param dst The destination Vector
+    * @param src The source GridFunction
+    * @param dst The destination GridFunction
     */
-   void Transfer(const Vector &src, Vector &dst) const;
+   void Transfer(const GridFunction &src, GridFunction &dst) const;
 
 private:
 
@@ -113,7 +110,7 @@ private:
    ///@}
 
    /// Temporary vector
-   mutable Vector z_;
+   mutable GridFunction z_;
 };
 
 } // namespace mfem


### PR DESCRIPTION
- Fixes a bug in ParSubMesh-to-ParSubMesh ParTransferMap.
   - Implement submesh-to-submesh transfer using composition of transfer maps.
- Allow creation of transfer maps from finite element spaces (rather than grid functions).
- ~Allow transfer of L-vectors (rather than just grid functions).~

Resolves #4591.
<!--GHEX{"author":"pazner","assignment":"2025-01-16T19:51:03","editor":"tzanio","id":4666,"reviewers":["mlstowell","jandrej"],"merge":"2025-03-29T19:57:32","approval":"2025-03-27T21:38:53"}XEHG-->
<!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge|
 | --- | --- | --- | --- | --- | --- | --- |
| [#4666](https://github.com/mfem/mfem/pull/4666) | @pazner | @tzanio | @mlstowell + @jandrej | 1/16/25 | 3/27/25 | 3/29/25 | |
<!--ELBATXEHG-->
<details>
<summary>PR Checklist</summary>
    
- [ ] Code builds.
- [ ] Code passes `make style`.
- [ ] Update `CHANGELOG`:
    - [ ] Is this a new feature users need to be aware of? New or updated example or miniapp?
    - [ ] Does it make sense to create a new section in the `CHANGELOG` to group with other related features?
- [ ] Update `INSTALL`:
    - [ ] Had a new optional library been added? If so, what range of versions of this library are required? (*Make sure the external library is compatible with our BSD license, e.g. it is not licensed under GPL!*)
    - [ ] Have the version ranges for any required or optional libraries changed?
    - [ ] Does `make` or `cmake` have a new target?
    - [ ] Did the requirements or the installation process change? *(rare)*
- [ ] Update continuous integration server configurations if necessary (e.g. with new version requirements for each of MFEM's dependencies)
    - [ ] `.github`
    - [ ] `.appveyor.yml`
- [ ] Update `.gitignore`:
    - [ ] Check if `make distclean; git status` shows any files that were generated from the source by the project (not an IDE) but we don't want to track in the repository.
    - [ ] Add new patterns (just for the new files above) and re-run the above test.
- [ ] New examples:
    - [ ] All sample runs at the top of the example source file work.
    - [ ] Update `examples/makefile`:
      - [ ] Add the example code to the appropriate `SEQ_EXAMPLES` and `PAR_EXAMPLES` variables.
      - [ ] Add any files generated by it to the `clean` target.
      - [ ] Add the example binary and any files generated by it to the top-level `.gitignore` file.
    - [ ] Update `examples/CMakeLists.txt`:
      - [ ] Add the example code to the `ALL_EXE_SRCS` variable.
      - [ ] Make sure `THIS_TEST_OPTIONS` is set correctly for the new example.
   - [ ] List the new example in `doc/CodeDocumentation.dox`.
   - [ ] If new examples directory (e.g.`examples/pumi`), list it in `doc/CodeDocumentation.conf.in`
   - [ ] Companion pull request for documentation in [mfem/web](https://github.com/mfem/web) repo:
      - [ ] Update or add example-specific documentation, see e.g. the `src/examples.md`.
      - [ ] Add the description, labels and screenshots in `src/examples.md` and `src/img`.
      - [ ] In `examples.md`, list the example under the appropriate categories, add new categories if necessary.
      - [ ] Add a short description of the example in the "Extensive Examples" section of `features.md`.
- [ ] New miniapps:
   - [ ] All sample runs at the top of the miniapp source file work.
   - [ ] Update top-level `makefile` and `makefile` in corresponding miniapp directory.
   - [ ] Add the miniapp binary and any files generated by it to the top-level `.gitignore` file.
   - [ ] Update CMake build system:
      - [ ] Update the `CMakeLists.txt` file in the `miniapps` directory, if the new miniapp is in a new directory.
      - [ ] Add/update the `CMakeLists.txt` file in the new miniapp directory.
      - [ ] Consider adding a new test for the new miniapp.
   - [ ] List the new miniapp in `doc/CodeDocumentation.dox`
   - [ ] If new miniapps directory (e.g.`miniapps/nurbs`), add it to `MINIAPP_SUBDIRS` in the `makefile`.
   - [ ] If new miniapps directory (e.g.`miniapps/nurbs`), list it in `doc/CodeDocumentation.conf.in`
   - [ ] Companion pull request for documentation in [mfem/web](https://github.com/mfem/web) repo:
     - [ ] Update or add miniapp-specific documentation, see e.g. the `src/meshing.md` and `src/electromagnetics.md` files.
     - [ ] Add the description, labels and screenshots in `src/examples.md` and `src/img`.
     - [ ] The miniapps go at the end of the page, and are usually listed only under a specific "Application (PDE)" category.
     - [ ] Add a short description of the miniapp in the "Extensive Examples" section of `features.md`.
- [ ] New capability:
   - [ ] All new public, protected, and private classes, methods, data members, and functions have full Doxygen-style documentation in source comments. Documentation should include descriptions of member data, function arguments and return values, template parameters, and prerequisites for calling new functions.
   - [ ] Pointer arguments and return values must specify whether ownership is being transferred or lent with the call.
   - [ ] Any new functions should include descriptions of their intended use e.g. for internal use only, user-facing, etc., along with references to example code whenever possible/appropriate.
   - [ ] Consider adding new sample runs in existing examples to highlight the new capability.
   - [ ] Consider saving cool simulation pictures with the new capability in the Confluence gallery (LLNL only) or submitting them, via pull request, to the gallery section of the `mfem/web` repo.
   - [ ] If this is a major new feature, consider mentioning it in the short summary inside `README` *(rare)*.
   - [ ] List major new classes in `doc/CodeDocumentation.dox` *(rare)*.
- [ ] Update this checklist, if the new pull request affects it.
- [ ] Run `make unittest` to make sure all unit tests pass.
- [ ] Run the tests in `tests/scripts`.
- [ ] (LLNL only) After merging:
   - [ ] Update internal tests to include the new features.
</details>
