### PR TITLE
[v4.7.1] Remove MesquiteSmooth which is not implemented

### DIFF
--- a/mesh/mesh.hpp
+++ b/mesh/mesh.hpp
@@ -2442,9 +2442,6 @@ public:
    void GetElementColoring(Array<int> &colors, int el0 = 0);
 
    /// @todo This method needs a proper description
-   void MesquiteSmooth(const int mesquite_option = 0);
-
-   /// @todo This method needs a proper description
    void CheckDisplacements(const Vector &displacements, real_t &tmax);
 
    /// @}


### PR DESCRIPTION
@mkovaxx  and I are working on Rust bindings to mfem, using version 4.7.  However, that version declares the function
```c++
void MesquiteSmooth(const int mesquite_option = 0);
```
which is not implemented.   Linux and MacOS don't mind but unfortunately it [causes linking errors on windows](https://github.com/mkovaxx/mfem-rs/actions/runs/13214556095/job/36892262260#step:5:59).  This was later fixed in commit 3303e5892.  Would it be possible to make a version 4.7.1 so that we can [depend on a released version](https://github.com/mkovaxx/mfem-rs/pull/11#issuecomment-2645116205) rather than a commit?

Thanks.