### PR TITLE
Fix Mesh::MakeSimplicial for surface in 3D

### DIFF
--- a/mesh/mesh.cpp
+++ b/mesh/mesh.cpp
@@ -5452,7 +5452,7 @@ void Mesh::MakeSimplicial_(const Mesh &orig_mesh, int *vglobal)
    NumOfVertices = nv;
    for (int i=0; i<nv; ++i)
    {
-      vertices[i].SetCoords(dim, orig_mesh.vertices[i]());
+      vertices[i].SetCoords(sdim, orig_mesh.vertices[i]());
    }
 
    // We need a global vertex numbering to identify which diagonals to split

--- a/tests/unit/mesh/test_mesh.cpp
+++ b/tests/unit/mesh/test_mesh.cpp
@@ -181,6 +181,30 @@ TEST_CASE("MakeSimplicial", "[Mesh]")
    REQUIRE(simplex_mesh.GetNE() == orig_mesh.GetNE()*factor);
 }
 
+TEST_CASE("MakeSimplicialSurfaceIn3D", "[Mesh]")
+{
+   // Note: create a 2D surface mesh surface in 3D space dimension composed of a
+   // single quad. The quad is offset in Z, and check that the vertices of the
+   // simplicial mesh are identical.
+   Mesh orig_mesh(2, 3, 1, 0, 3);
+   orig_mesh.AddVertex(Vector({1.0, 1.0, 1.0}));
+   orig_mesh.AddVertex(Vector({2.0, 1.0, 1.0}));
+   orig_mesh.AddVertex(Vector({2.0, 2.0, 1.0}));
+   orig_mesh.AddVertex(Vector({1.0, 2.0, 1.0}));
+   orig_mesh.AddQuad(0, 1, 2, 3);
+   orig_mesh.Finalize();
+   Mesh simplex_mesh = Mesh::MakeSimplicial(orig_mesh);
+   REQUIRE(simplex_mesh.GetNE() == orig_mesh.GetNE()*2);
+   REQUIRE(simplex_mesh.GetNV() == orig_mesh.GetNV());
+   for (int i = 0; i < orig_mesh.GetNV(); ++i)
+   {
+      for (int j = 0; j < 3; ++j)
+      {
+         REQUIRE(simplex_mesh.GetVertex(i)[j] == orig_mesh.GetVertex(i)[j]);
+      }
+   }
+}
+
 TEST_CASE("MakeNurbs", "[Mesh]")
 {
    Array<real_t> intervals_array({1, 1, 1});


### PR DESCRIPTION
The Z dimension of a surface mesh was lost when converting it to simplex.

Add a test checking all vertices after the conversion. We create a special mesh for this specific case.

Close #4455

NB: is the test overkill for this fix?