### PR TITLE
Update base dockerfile to radiuss-docker

### DIFF
--- a/config/docker/Dockerfile.base
+++ b/config/docker/Dockerfile.base
@@ -1,4 +1,4 @@
-FROM ghcr.io/rse-ops/cuda-ubuntu-20.04:cuda-11.0.3
+FROM ghcr.io/llnl/radiuss:ubuntu-22.04-cuda-11-0
 
 # docker build -f Dockerfile.base -t ghcr.io/mfem/mfem-ubuntu-base .
 


### PR DESCRIPTION
Looks like the old repo rse-ops is [deprecated](https://github.com/rse-ops/docker-images/issues/112)  and is now [llnl/radiuss-docker](https://github.com/LLNL/radiuss-docker). Updating since `Ubuntu 20.04` will not be supported by GitHub soon.