### PR TITLE
Fixes for GLVis support of RT/ND_R1/2D elements.

### DIFF
--- a/examples/ex31.cpp
+++ b/examples/ex31.cpp
@@ -187,18 +187,7 @@ int main(int argc, char *argv[])
    {
       ofstream mesh_ofs("refined.mesh");
       mesh_ofs.precision(8);
-      if (dim < 3 && mesh.SpaceDimension() < 3)
-      {
-         //When using ND_R1D or ND_R2D elements, embed the 1D/2D mesh in 3D
-         //space using SetCurvature.
-         mfem::Mesh mesh_3d(mesh);
-         mesh_3d.SetCurvature(order,false,3);
-         mesh_3d.Print(mesh_ofs);
-      }
-      else
-      {
-         mesh.Print(mesh_ofs);
-      }
+      mesh.Print(mesh_ofs);
       ofstream sol_ofs("sol.gf");
       sol_ofs.precision(8);
       sol.Save(sol_ofs);

--- a/examples/ex31p.cpp
+++ b/examples/ex31p.cpp
@@ -241,18 +241,7 @@ int main(int argc, char *argv[])
 
       ofstream mesh_ofs(mesh_name.str().c_str());
       mesh_ofs.precision(8);
-      if (dim < 3 && pmesh.SpaceDimension() < 3)
-      {
-         //When using ND_R1D or ND_R2D elements, embed the 1D/2D mesh in 3D
-         //space using SetCurvature.
-         mfem::ParMesh mesh_3d(pmesh);
-         mesh_3d.SetCurvature(order,false,3);
-         mesh_3d.Print(mesh_ofs);
-      }
-      else
-      {
-         pmesh.Print(mesh_ofs);
-      }
+      pmesh.Print(mesh_ofs);
 
       ofstream sol_ofs(sol_name.str().c_str());
       sol_ofs.precision(8);

--- a/examples/ex32p.cpp
+++ b/examples/ex32p.cpp
@@ -223,18 +223,7 @@ int main(int argc, char *argv[])
 
       ofstream mesh_ofs(mesh_name.str().c_str());
       mesh_ofs.precision(8);
-      if (dim < 3 && pmesh.SpaceDimension() < 3)
-      {
-         //When using ND_R1D or ND_R2D elements, embed the 1D/2D mesh in 3D
-         //space using SetCurvature.
-         mfem::ParMesh mesh_3d(pmesh);
-         mesh_3d.SetCurvature(order,false,3);
-         mesh_3d.Print(mesh_ofs);
-      }
-      else
-      {
-         pmesh.Print(mesh_ofs);
-      }
+      pmesh.Print(mesh_ofs);
 
       for (int i=0; i<nev; i++)
       {

--- a/fem/gridfunc.cpp
+++ b/fem/gridfunc.cpp
@@ -1304,12 +1304,9 @@ void GridFunction::ProjectVectorFieldOn(GridFunction &vec_field, int comp)
       {
          for (int k = 0; k < dof; k++)
          {
-            int ind = new_vdofs[dof*d+k];
-            if (ind < 0)
-            {
-               ind = -1-ind, vals(k, d) = - vals(k, d);
-            }
-            vec_field(ind) += vals(k, d);
+            real_t s;
+            int ind = FiniteElementSpace::DecodeDof(new_vdofs[dof*d+k], s);
+            vec_field(ind) += s * vals(k, d);
             overlap[ind]++;
          }
       }

--- a/fem/gridfunc.cpp
+++ b/fem/gridfunc.cpp
@@ -1194,31 +1194,30 @@ void GridFunction::GetVectorFieldValues(
    Array<int> vdofs;
    ElementTransformation *transf;
 
-   int d, k, n, sdim, dof;
-
-   n = ir.GetNPoints();
+   const int n = ir.GetNPoints();
    DofTransformation * doftrans = fes->GetElementVDofs(i, vdofs);
    const FiniteElement *fe = fes->GetFE(i);
-   dof = fe->GetDof();
-   sdim = fes->GetMesh()->SpaceDimension();
+   const int dof = fe->GetDof();
+   const int sdim = fes->GetMesh()->SpaceDimension();
+   const int vdim = std::max(sdim, fe->GetRangeDim());
    // int *dofs = &vdofs[comp*dof];
    transf = fes->GetElementTransformation(i);
    transf->Transform(ir, tr);
-   vals.SetSize(n, sdim);
-   DenseMatrix vshape(dof, sdim);
-   Vector loc_data, val(sdim);
+   vals.SetSize(n, vdim);
+   DenseMatrix vshape(dof, vdim);
+   Vector loc_data, val(vdim);
    GetSubVector(vdofs, loc_data);
    if (doftrans)
    {
       doftrans->InvTransformPrimal(loc_data);
    }
-   for (k = 0; k < n; k++)
+   for (int k = 0; k < n; k++)
    {
       const IntegrationPoint &ip = ir.IntPoint(k);
       transf->SetIntPoint(&ip);
       fe->CalcVShape(*transf, vshape);
       vshape.MultTranspose(loc_data, val);
-      for (d = 0; d < sdim; d++)
+      for (int d = 0; d < vdim; d++)
       {
          vals(k,d) = val(d);
       }
@@ -1287,27 +1286,26 @@ void GridFunction::ProjectVectorFieldOn(GridFunction &vec_field, int comp)
 {
    FiniteElementSpace *new_fes = vec_field.FESpace();
 
-   int d, i, k, ind, dof, sdim;
    Array<int> overlap(new_fes->GetVSize());
    Array<int> new_vdofs;
    DenseMatrix vals, tr;
 
-   sdim = fes->GetMesh()->SpaceDimension();
    overlap = 0;
    vec_field = 0.0;
 
-   for (i = 0; i < new_fes->GetNE(); i++)
+   for (int i = 0; i < new_fes->GetNE(); i++)
    {
       const FiniteElement *fe = new_fes->GetFE(i);
       const IntegrationRule &ir = fe->GetNodes();
       GetVectorFieldValues(i, ir, vals, tr, comp);
       new_fes->GetElementVDofs(i, new_vdofs);
-      dof = fe->GetDof();
-      for (d = 0; d < sdim; d++)
+      const int dof = fe->GetDof();
+      for (int d = 0; d < vals.Width(); d++)
       {
-         for (k = 0; k < dof; k++)
+         for (int k = 0; k < dof; k++)
          {
-            if ( (ind=new_vdofs[dof*d+k]) < 0 )
+            int ind = new_vdofs[dof*d+k];
+            if (ind < 0)
             {
                ind = -1-ind, vals(k, d) = - vals(k, d);
             }
@@ -1317,7 +1315,7 @@ void GridFunction::ProjectVectorFieldOn(GridFunction &vec_field, int comp)
       }
    }
 
-   for (i = 0; i < overlap.Size(); i++)
+   for (int i = 0; i < overlap.Size(); i++)
    {
       vec_field(i) /= overlap[i];
    }

--- a/mesh/mesh.cpp
+++ b/mesh/mesh.cpp
@@ -6230,8 +6230,16 @@ void Mesh::SetCurvature(int order, bool discont, int space_dim, int ordering)
    }
    FiniteElementSpace* nfes = new FiniteElementSpace(this, nfec, space_dim,
                                                      ordering);
+
+   const int old_space_dim = spaceDim;
    SetNodalFESpace(nfes);
    Nodes->MakeOwner(nfec);
+
+   if (spaceDim != old_space_dim)
+   {
+      // Fix dimension of the vertices if the space dimension changes
+      SetVerticesFromNodes(Nodes);
+   }
 }
 
 void Mesh::SetVerticesFromNodes(const GridFunction *nodes)


### PR DESCRIPTION
These fixes in `GridFunction` and `Mesh` are required for GLVis to support visualization of RT/ND_R1/2D elements following PR GlVis/glvis#327 .