### PR TITLE
Restored external boundary constraints integrators in [gpu-hybridization]

### DIFF
--- a/fem/hybridization.cpp
+++ b/fem/hybridization.cpp
@@ -41,7 +41,7 @@ Hybridization::~Hybridization()
 {
    if (!extern_bdr_constr_integs)
    {
-      for (int k=0; k < boundary_constraint_integs.Size(); k++)
+      for (size_t k=0; k < boundary_constraint_integs.size(); k++)
       { delete boundary_constraint_integs[k]; }
    }
 }
@@ -138,7 +138,7 @@ void Hybridization::ConstructC()
          Ct->AddSubMatrix(vdofs, c_vdofs, elmat, skip_zeros);
       }
 
-      if (boundary_constraint_integs.Size())
+      if (!boundary_constraint_integs.empty())
       {
          const FiniteElement *fe1, *fe2;
          const FiniteElement *face_el;
@@ -147,7 +147,7 @@ void Hybridization::ConstructC()
          Array<int> bdr_attr_marker(mesh->bdr_attributes.Size() ?
                                     mesh->bdr_attributes.Max() : 0);
          bdr_attr_marker = 0;
-         for (int k = 0; k < boundary_constraint_integs.Size(); k++)
+         for (size_t k = 0; k < boundary_constraint_integs.size(); k++)
          {
             if (boundary_constraint_integs_marker[k] == NULL)
             {
@@ -188,7 +188,7 @@ void Hybridization::ConstructC()
             // but we can't dereference a NULL pointer, and we don't want to
             // actually make a fake element.
             fe2 = fe1;
-            for (int k = 0; k < boundary_constraint_integs.Size(); k++)
+            for (size_t k = 0; k < boundary_constraint_integs.size(); k++)
             {
                if (boundary_constraint_integs_marker[k] &&
                    (*boundary_constraint_integs_marker[k])[bdr_attr-1] == 0) { continue; }

--- a/fem/hybridization.cpp
+++ b/fem/hybridization.cpp
@@ -37,6 +37,15 @@ Hybridization::Hybridization(FiniteElementSpace *fespace,
 #endif
 }
 
+Hybridization::~Hybridization()
+{
+   if (!extern_bdr_constr_integs)
+   {
+      for (int k=0; k < boundary_constraint_integs.Size(); k++)
+      { delete boundary_constraint_integs[k]; }
+   }
+}
+
 void Hybridization::EnableDeviceExecution()
 {
    ext.reset(new HybridizationExtension(*this));
@@ -129,7 +138,7 @@ void Hybridization::ConstructC()
          Ct->AddSubMatrix(vdofs, c_vdofs, elmat, skip_zeros);
       }
 
-      if (!boundary_constraint_integs.empty())
+      if (boundary_constraint_integs.Size())
       {
          const FiniteElement *fe1, *fe2;
          const FiniteElement *face_el;
@@ -138,7 +147,7 @@ void Hybridization::ConstructC()
          Array<int> bdr_attr_marker(mesh->bdr_attributes.Size() ?
                                     mesh->bdr_attributes.Max() : 0);
          bdr_attr_marker = 0;
-         for (size_t k = 0; k < boundary_constraint_integs.size(); k++)
+         for (int k = 0; k < boundary_constraint_integs.Size(); k++)
          {
             if (boundary_constraint_integs_marker[k] == NULL)
             {
@@ -179,7 +188,7 @@ void Hybridization::ConstructC()
             // but we can't dereference a NULL pointer, and we don't want to
             // actually make a fake element.
             fe2 = fe1;
-            for (size_t k = 0; k < boundary_constraint_integs.size(); k++)
+            for (int k = 0; k < boundary_constraint_integs.Size(); k++)
             {
                if (boundary_constraint_integs_marker[k] &&
                    (*boundary_constraint_integs_marker[k])[bdr_attr-1] == 0) { continue; }
@@ -1003,9 +1012,5 @@ void Hybridization::Reset()
 #endif
    if (ext) { ext->Reset(); }
 }
-
-// Set to default in cpp file because of use of incomplete type
-// (HybridizationExtension) in unique_ptr member data.
-Hybridization::~Hybridization() = default;
 
 }

--- a/fem/hybridization.hpp
+++ b/fem/hybridization.hpp
@@ -70,9 +70,9 @@ protected:
    /// The constraint integrator.
    std::unique_ptr<BilinearFormIntegrator> c_bfi;
    /// The constraint boundary face integrators
-   Array<BilinearFormIntegrator*> boundary_constraint_integs;
+   std::vector<BilinearFormIntegrator*> boundary_constraint_integs;
    /// Boundary markers for constraint face integrators
-   Array<Array<int>*> boundary_constraint_integs_marker;
+   std::vector<Array<int>*> boundary_constraint_integs_marker;
    /// Indicates if the boundary_constraint_integs integrators are owned externally
    bool extern_bdr_constr_integs{false};
 
@@ -136,15 +136,14 @@ public:
        integrator, i.e. it will delete the integrator when destroyed. */
    void AddBdrConstraintIntegrator(BilinearFormIntegrator *c_integ)
    {
-      boundary_constraint_integs.Append(c_integ);
-      boundary_constraint_integs_marker.Append(
-         NULL); // NULL marker means apply everywhere
+      boundary_constraint_integs.push_back(c_integ);
+      boundary_constraint_integs_marker.push_back(nullptr);
    }
    void AddBdrConstraintIntegrator(BilinearFormIntegrator *c_integ,
                                    Array<int> &bdr_marker)
    {
-      boundary_constraint_integs.Append(c_integ);
-      boundary_constraint_integs_marker.Append(&bdr_marker);
+      boundary_constraint_integs.push_back(c_integ);
+      boundary_constraint_integs_marker.push_back(&bdr_marker);
    }
 
    /// Access all integrators added with AddBdrConstraintIntegrator().


### PR DESCRIPTION
A partial revert in `gpu-hybridization` to restore the functionality of external boundary constraint integrators in `Hybridization`.