### PR TITLE
Added general GPU and CUDA/HIP-specific unit tests

### DIFF
--- a/general/device.cpp
+++ b/general/device.cpp
@@ -199,6 +199,29 @@ void Device::Configure(const std::string &device, const int device_id)
    {
       bmap[internal::backend_name[i]] = internal::backend_list[i];
    }
+   // auto-detect GPU configurations
+   // assumes only one of HIP or CUDA are available
+#ifdef MFEM_USE_HIP
+   bmap["gpu"] = Backend::HIP;
+#ifdef MFEM_USE_RAJA
+   bmap["raja-gpu"] = Backend::RAJA_HIP;
+#endif
+#ifdef MFEM_USE_CEED
+   bmap["ceed-gpu"] = Backend::CEED_HIP;
+#endif
+   // no OCCA+HIP?
+#elif defined(MFEM_USE_CUDA)
+   bmap["gpu"] = Backend::CUDA;
+#ifdef MFEM_USE_RAJA
+   bmap["raja-gpu"] = Backend::RAJA_CUDA;
+#endif
+#ifdef MFEM_USE_CEED
+   bmap["ceed-gpu"] = Backend::CEED_CUDA;
+#endif
+#ifdef MFEM_USE_OCCA
+   bmap["occa-gpu"] = Backend::OCCA_CUDA;
+#endif
+#endif
    std::string::size_type beg = 0, end, option;
    while (1)
    {

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -168,10 +168,11 @@ if (MFEM_USE_DOUBLE) # otherwise returns MFEM_SKIP_RETURN_VALUE
 endif()
 
 #-----------------------------------------------------------
-# SERIAL CUDA TESTS: cunit_tests
+# SERIAL CUDA TESTS: cunit_tests and gpu_unit_tests
 #-----------------------------------------------------------
-# Create CUDA 'cunit_tests' executable and test
+# Create CUDA executable and test
 if (MFEM_USE_CUDA)
+   # cunit_tests
    set(CUNIT_TESTS_SRCS cunit_test_main.cpp)
    set_property(SOURCE ${CUNIT_TESTS_SRCS} PROPERTY LANGUAGE CUDA)
    mfem_add_executable(cunit_tests ${CUNIT_TESTS_SRCS} ${UNIT_TESTS_SRCS})
@@ -180,6 +181,41 @@ if (MFEM_USE_CUDA)
    add_dependencies(${MFEM_ALL_TESTS_TARGET_NAME} cunit_tests)
    if (MFEM_USE_DOUBLE) # otherwise returns MFEM_SKIP_RETURN_VALUE
       add_test(NAME cunit_tests COMMAND cunit_tests)
+   endif()
+   # gpu_unit_tests
+   set(GPU_UNIT_TESTS_SRCS gpu_unit_test_main.cpp)
+   set_property(SOURCE ${GPU_UNIT_TESTS_SRCS} PROPERTY LANGUAGE CUDA)
+   mfem_add_executable(gpu_unit_tests ${GPU_UNIT_TESTS_SRCS} ${UNIT_TESTS_SRCS})
+   target_link_libraries(gpu_unit_tests mfem)
+   add_dependencies(gpu_unit_tests copy_data)
+   add_dependencies(${MFEM_ALL_TESTS_TARGET_NAME} gpu_unit_tests)
+   if (MFEM_USE_DOUBLE) # otherwise returns MFEM_SKIP_RETURN_VALUE
+      add_test(NAME gpu_unit_tests COMMAND gpu_unit_tests)
+   endif()
+endif()
+
+#-----------------------------------------------------------
+# SERIAL HIP TESTS: gpu_unit_tests
+#-----------------------------------------------------------
+# Create HIP 'gpu_unit_tests' executable and test
+if (MFEM_USE_HIP)
+   # hip_unit_tests
+   set(HIP_UNIT_TESTS_SRCS hunit_test_main.cpp)
+   mfem_add_executable(hunit_tests ${HIP_UNIT_TESTS_SRCS} ${UNIT_TESTS_SRCS})
+   target_link_libraries(hunit_tests mfem)
+   add_dependencies(hunit_tests copy_data)
+   add_dependencies(${MFEM_ALL_TESTS_TARGET_NAME} hunit_tests)
+   if (MFEM_USE_DOUBLE) # otherwise returns MFEM_SKIP_RETURN_VALUE
+      add_test(NAME hunit_tests COMMAND hunit_tests)
+   endif()
+   # gpu_unit_tests
+   set(GPU_UNIT_TESTS_SRCS gpu_unit_test_main.cpp)
+   mfem_add_executable(gpu_unit_tests ${GPU_UNIT_TESTS_SRCS} ${UNIT_TESTS_SRCS})
+   target_link_libraries(gpu_unit_tests mfem)
+   add_dependencies(gpu_unit_tests copy_data)
+   add_dependencies(${MFEM_ALL_TESTS_TARGET_NAME} gpu_unit_tests)
+   if (MFEM_USE_DOUBLE) # otherwise returns MFEM_SKIP_RETURN_VALUE
+      add_test(NAME gpu_unit_tests COMMAND gpu_unit_tests)
    endif()
 endif()
 
@@ -271,10 +307,11 @@ if (MFEM_USE_CEED)
 endif()
 
 #-----------------------------------------------------------
-# PARALLEL CPU AND CUDA TESTS: {p,pc}unit_tests
+# PARALLEL CPU AND CUDA TESTS: {p,pc}unit_tests and pgpu_unit_tests
 #-----------------------------------------------------------
-# Define executables and tests 'punit_tests' and 'pcunit_tests'
+# Define executables and tests
 if (MFEM_USE_MPI)
+   # punit_tests
    if (MFEM_USE_CUDA)
       set_property(SOURCE punit_test_main.cpp PROPERTY LANGUAGE CUDA)
    endif()
@@ -290,6 +327,7 @@ if (MFEM_USE_MPI)
       endif()
    endforeach()
    if (MFEM_USE_CUDA)
+      # pcunit_tests
       set(PCUNIT_TESTS_SRCS pcunit_test_main.cpp)
       set_property(SOURCE ${PCUNIT_TESTS_SRCS} PROPERTY LANGUAGE CUDA)
       mfem_add_executable(pcunit_tests ${PCUNIT_TESTS_SRCS} ${UNIT_TESTS_SRCS})
@@ -303,7 +341,53 @@ if (MFEM_USE_MPI)
                      ${MPIEXEC_PREFLAGS} $<TARGET_FILE:pcunit_tests>
                      ${MPIEXEC_POSTFLAGS})
          endif()
-      endforeach()
+       endforeach()
+
+       # pgpu_unit_tests
+       set(PGPU_UNIT_TESTS_SRCS pgpu_unit_test_main.cpp)
+       set_property(SOURCE ${PGPU_UNIT_TESTS_SRCS} PROPERTY LANGUAGE CUDA)
+       mfem_add_executable(pgpu_unit_tests ${PGPU_UNIT_TESTS_SRCS} ${UNIT_TESTS_SRCS})
+       add_dependencies(pgpu_unit_tests copy_data)
+       target_link_libraries(pgpu_unit_tests mfem)
+       add_dependencies(${MFEM_ALL_TESTS_TARGET_NAME} pgpu_unit_tests)
+       foreach(np 1 ${MFEM_MPI_NP})
+          if (MFEM_USE_DOUBLE) # otherwise returns MFEM_SKIP_RETURN_VALUE
+             add_test(NAME pgpu_unit_tests_np=${np}
+                      COMMAND ${MPIEXEC} ${MPIEXEC_NUMPROC_FLAG} ${np}
+                      ${MPIEXEC_PREFLAGS} $<TARGET_FILE:pgpu_unit_tests>
+                      ${MPIEXEC_POSTFLAGS})
+          endif()
+       endforeach()
+    endif()
+    if (MFEM_USE_HIP)
+       # phunit_tests
+       set(PHUNIT_TESTS_SRCS phunit_test_main.cpp)
+       mfem_add_executable(phunit_tests ${PHUNIT_TESTS_SRCS} ${UNIT_TESTS_SRCS})
+       add_dependencies(phunit_tests copy_data)
+       target_link_libraries(phunit_tests mfem)
+       add_dependencies(${MFEM_ALL_TESTS_TARGET_NAME} phunit_tests)
+       foreach(np 1 ${MFEM_MPI_NP})
+          if (MFEM_USE_DOUBLE) # otherwise returns MFEM_SKIP_RETURN_VALUE
+             add_test(NAME phunit_tests_np=${np}
+                      COMMAND ${MPIEXEC} ${MPIEXEC_NUMPROC_FLAG} ${np}
+                      ${MPIEXEC_PREFLAGS} $<TARGET_FILE:phunit_tests>
+                      ${MPIEXEC_POSTFLAGS})
+          endif()
+       endforeach()
+       # pgpu_unit_tests
+       set(PGPU_UNIT_TESTS_SRCS pgpu_unit_test_main.cpp)
+       mfem_add_executable(pgpu_unit_tests ${PGPU_UNIT_TESTS_SRCS} ${UNIT_TESTS_SRCS})
+       add_dependencies(pgpu_unit_tests copy_data)
+       target_link_libraries(pgpu_unit_tests mfem)
+       add_dependencies(${MFEM_ALL_TESTS_TARGET_NAME} pgpu_unit_tests)
+       foreach(np 1 ${MFEM_MPI_NP})
+          if (MFEM_USE_DOUBLE) # otherwise returns MFEM_SKIP_RETURN_VALUE
+             add_test(NAME pgpu_unit_tests_np=${np}
+                      COMMAND ${MPIEXEC} ${MPIEXEC_NUMPROC_FLAG} ${np}
+                      ${MPIEXEC_PREFLAGS} $<TARGET_FILE:pgpu_unit_tests>
+                      ${MPIEXEC_POSTFLAGS})
+          endif()
+       endforeach()
    endif()
 endif(MFEM_USE_MPI)
 

--- a/tests/unit/README.md
+++ b/tests/unit/README.md
@@ -67,11 +67,21 @@ and those are:
   serial test executables, and will only be tested with the parallel executable
   (e.g. `punit_tests`). `punit_tests` will only run tests marked with
   `[Parallel]`.
+* `[GPU]`, which indicates that a test will be tested with the GPU executables
+  (e.g. `gpu_unit_tests`). These tests will still be run by the standard (CPU)
+  executables. `gpu_unit_tests` will only run tests marked with `[GPU]`, and its
+  parallel version `pgpu_unit_tests` will only run tests marked with _both_
+  `[GPU]` and `[Parallel]`.
 * `[CUDA]`, which indicates that a test will be tested with the CUDA executables
   (e.g. `cunit_tests`). These tests will still be run by the standard (CPU)
   executables. `cunit_tests` will only run tests marked with `[CUDA]`, and its
   parallel version `pcunit_tests` will only run tests marked with _both_
   `[CUDA]` and `[Parallel]`.
+* `[HIP]`, which indicates that a test will be tested with the HIP executables
+  (e.g. `hunit_tests`). These tests will still be run by the standard (CPU)
+  executables. `hunit_tests` will only run tests marked with `[HIP]`, and its
+  parallel version `phunit_tests` will only run tests marked with _both_
+  `[HIP]` and `[Parallel]`.
 * `[MFEMData]`, which indicates that a test requires access to a clone of the
   MFEM data repository (see the `--data` flag below), in order to run tests on
   some larger mesh files. By default, tests tagged with this tag are skipped,

--- a/tests/unit/fem/test_assemblediagonalpa.cpp
+++ b/tests/unit/fem/test_assemblediagonalpa.cpp
@@ -359,7 +359,7 @@ TEST_CASE("Vector Diffusion Diagonal PA",
 }
 
 TEST_CASE("Hcurl/Hdiv diagonal PA",
-          "[CUDA][PartialAssembly][AssembleDiagonal]")
+          "[GPU][PartialAssembly][AssembleDiagonal]")
 {
    for (int dimension = 2; dimension < 4; ++dimension)
    {

--- a/tests/unit/fem/test_assembly_levels.cpp
+++ b/tests/unit/fem/test_assembly_levels.cpp
@@ -172,7 +172,7 @@ void test_assembly_level(const char *meshname,
    delete fec;
 }
 
-TEST_CASE("H1 Assembly Levels", "[AssemblyLevel], [PartialAssembly], [CUDA]")
+TEST_CASE("H1 Assembly Levels", "[AssemblyLevel], [PartialAssembly], [GPU]")
 {
    const bool all_tests = launch_all_non_regression_tests;
 
@@ -228,7 +228,7 @@ TEST_CASE("H1 Assembly Levels", "[AssemblyLevel], [PartialAssembly], [CUDA]")
    }
 } // H1 Assembly Levels test case
 
-TEST_CASE("L2 Assembly Levels", "[AssemblyLevel], [PartialAssembly], [CUDA]")
+TEST_CASE("L2 Assembly Levels", "[AssemblyLevel], [PartialAssembly], [GPU]")
 {
    const bool dg = true;
    auto pb = GENERATE(Problem::Mass, Problem::Convection);
@@ -438,7 +438,7 @@ void TestH1FullAssembly(Mesh &mesh, int order)
    REQUIRE(B1.Normlinf() == MFEM_Approx(0.0));
 }
 
-TEST_CASE("Serial H1 Full Assembly", "[AssemblyLevel], [CUDA]")
+TEST_CASE("Serial H1 Full Assembly", "[AssemblyLevel], [GPU]")
 {
    auto order = GENERATE(1, 2, 3);
    auto mesh_fname = GENERATE(
@@ -449,7 +449,7 @@ TEST_CASE("Serial H1 Full Assembly", "[AssemblyLevel], [CUDA]")
    TestH1FullAssembly(mesh, order);
 }
 
-TEST_CASE("Full Assembly Connectivity", "[AssemblyLevel], [CUDA]")
+TEST_CASE("Full Assembly Connectivity", "[AssemblyLevel], [GPU]")
 {
    const int order = GENERATE(1, 2, 3);
    const int ne = GENERATE(4, 8, 16, 32);
@@ -479,7 +479,7 @@ TEST_CASE("Full Assembly Connectivity", "[AssemblyLevel], [CUDA]")
    TestH1FullAssembly(mesh, order);
 }
 
-TEST_CASE("Parallel H1 Full Assembly", "[AssemblyLevel], [Parallel], [CUDA]")
+TEST_CASE("Parallel H1 Full Assembly", "[AssemblyLevel], [Parallel], [GPU]")
 {
    auto order = GENERATE(1, 2, 3);
    auto mesh_fname = GENERATE(

--- a/tests/unit/fem/test_bilinearform.cpp
+++ b/tests/unit/fem/test_bilinearform.cpp
@@ -69,7 +69,7 @@ TEST_CASE("Test order of boundary integrators",
 
 TEST_CASE("FormLinearSystem/SolutionScope",
           "[BilinearForm]"
-          "[CUDA]")
+          "[GPU]")
 {
    // Create a simple mesh and FE space
    int dim = 2, nx = 2, ny = 2, order = 2;

--- a/tests/unit/fem/test_block_operators.cpp
+++ b/tests/unit/fem/test_block_operators.cpp
@@ -14,7 +14,7 @@
 
 using namespace mfem;
 
-TEST_CASE("BlockOperators", "[BlockOperators], [CUDA]")
+TEST_CASE("BlockOperators", "[BlockOperators], [GPU]")
 {
    const int dim = 2, nx = 3, ny = 3, order = 2;
    Element::Type e_type = Element::QUADRILATERAL;

--- a/tests/unit/fem/test_dgmassinv.cpp
+++ b/tests/unit/fem/test_dgmassinv.cpp
@@ -14,7 +14,7 @@
 
 using namespace mfem;
 
-TEST_CASE("DG Mass Inverse", "[CUDA]")
+TEST_CASE("DG Mass Inverse", "[GPU]")
 {
    auto mesh_filename = GENERATE(
                            "../../data/star.mesh",

--- a/tests/unit/fem/test_fa_determinism.cpp
+++ b/tests/unit/fem/test_fa_determinism.cpp
@@ -14,7 +14,7 @@
 
 using namespace mfem;
 
-TEST_CASE("FA Determinism", "[PartialAssembly][CUDA]")
+TEST_CASE("FA Determinism", "[PartialAssembly][GPU]")
 {
    const int order = 3;
    const char *mesh_filename = "../../data/star-q3.mesh";

--- a/tests/unit/fem/test_linearform_ext.cpp
+++ b/tests/unit/fem/test_linearform_ext.cpp
@@ -201,7 +201,7 @@ struct LinearFormExtTest
    }
 };
 
-TEST_CASE("Linear Form Extension", "[LinearFormExtension], [CUDA]")
+TEST_CASE("Linear Form Extension", "[LinearFormExtension], [GPU]")
 {
    const bool all = launch_all_non_regression_tests;
 
@@ -328,7 +328,7 @@ TEST_CASE("Linear Form Extension", "[LinearFormExtension], [CUDA]")
    }
 }
 
-TEST_CASE("H(div) Linear Form Extension", "[LinearFormExtension], [CUDA]")
+TEST_CASE("H(div) Linear Form Extension", "[LinearFormExtension], [GPU]")
 {
    const bool all = launch_all_non_regression_tests;
 

--- a/tests/unit/fem/test_lor_batched.cpp
+++ b/tests/unit/fem/test_lor_batched.cpp
@@ -140,17 +140,17 @@ void TestBatchedLOR()
    TestSameMatrices(A2, A1);
 }
 
-TEST_CASE("LOR Batched H1", "[LOR][BatchedLOR][CUDA]")
+TEST_CASE("LOR Batched H1", "[LOR][BatchedLOR][GPU]")
 {
    TestBatchedLOR<H1_FECollection,MassIntegrator,DiffusionIntegrator>();
 }
 
-TEST_CASE("LOR Batched ND", "[LOR][BatchedLOR][CUDA]")
+TEST_CASE("LOR Batched ND", "[LOR][BatchedLOR][GPU]")
 {
    TestBatchedLOR<ND_FECollection,VectorFEMassIntegrator,CurlCurlIntegrator>();
 }
 
-TEST_CASE("LOR Batched RT", "[LOR][BatchedLOR][CUDA]")
+TEST_CASE("LOR Batched RT", "[LOR][BatchedLOR][GPU]")
 {
    TestBatchedLOR<RT_FECollection,VectorFEMassIntegrator,DivDivIntegrator>();
 }
@@ -226,22 +226,22 @@ void ParTestBatchedLOR()
    TestSameMatrices(A2, A1);
 }
 
-TEST_CASE("Parallel LOR Batched H1", "[LOR][BatchedLOR][Parallel][CUDA]")
+TEST_CASE("Parallel LOR Batched H1", "[LOR][BatchedLOR][Parallel][GPU]")
 {
    ParTestBatchedLOR<H1_FECollection,MassIntegrator,DiffusionIntegrator>();
 }
 
-TEST_CASE("Parallel LOR Batched ND", "[LOR][BatchedLOR][Parallel][CUDA]")
+TEST_CASE("Parallel LOR Batched ND", "[LOR][BatchedLOR][Parallel][GPU]")
 {
    ParTestBatchedLOR<ND_FECollection,VectorFEMassIntegrator,CurlCurlIntegrator>();
 }
 
-TEST_CASE("Parallel LOR Batched RT", "[LOR][BatchedLOR][Parallel][CUDA]")
+TEST_CASE("Parallel LOR Batched RT", "[LOR][BatchedLOR][Parallel][GPU]")
 {
    ParTestBatchedLOR<RT_FECollection,VectorFEMassIntegrator,DivDivIntegrator>();
 }
 
-TEST_CASE("LOR AMS", "[LOR][BatchedLOR][AMS][Parallel][CUDA]")
+TEST_CASE("LOR AMS", "[LOR][BatchedLOR][AMS][Parallel][GPU]")
 {
    enum SpaceType { ND, RT };
    auto space_type = GENERATE(ND, RT);
@@ -313,7 +313,7 @@ TEST_CASE("LOR AMS", "[LOR][BatchedLOR][AMS][Parallel][CUDA]")
    }
 }
 
-TEST_CASE("LOR ADS", "[LOR][BatchedLOR][ADS][Parallel][CUDA]")
+TEST_CASE("LOR ADS", "[LOR][BatchedLOR][ADS][Parallel][GPU]")
 {
    // Only need to test ADS in 3D
    auto mesh_fname = GENERATE("../../data/fichera-q3.mesh");

--- a/tests/unit/fem/test_pa_coeff.cpp
+++ b/tests/unit/fem/test_pa_coeff.cpp
@@ -263,7 +263,7 @@ TEST_CASE("H1 PA Coefficient", "[PartialAssembly][Coefficient]")
 }
 
 TEST_CASE("Hcurl/Hdiv PA Coefficient",
-          "[CUDA][PartialAssembly][Coefficient]")
+          "[GPU][PartialAssembly][Coefficient]")
 {
    const bool all_tests = launch_all_non_regression_tests;
    enum MixedSpaces {Hcurl, Hdiv, HcurlHdiv, HdivHcurl, NumSpaceTypes};
@@ -510,7 +510,7 @@ TEST_CASE("Hcurl/Hdiv PA Coefficient",
 }
 
 TEST_CASE("Hcurl/Hdiv Mixed PA Coefficient",
-          "[CUDA][PartialAssembly][Coefficient]")
+          "[GPU][PartialAssembly][Coefficient]")
 {
    const real_t tol = 4e-12;
 

--- a/tests/unit/fem/test_pa_grad.cpp
+++ b/tests/unit/fem/test_pa_grad.cpp
@@ -113,7 +113,7 @@ real_t compare_pa_assembly(int dim, int num_elements, int order, bool transpose)
    return error;
 }
 
-TEST_CASE("PAGradient", "[CUDA]")
+TEST_CASE("PAGradient", "[GPU]")
 {
    auto transpose = GENERATE(true, false);
    auto order = GENERATE(1, 2, 3, 4);

--- a/tests/unit/fem/test_pa_idinterp.cpp
+++ b/tests/unit/fem/test_pa_idinterp.cpp
@@ -110,7 +110,7 @@ real_t compare_pa_id_assembly(int dim, int num_elements, int order,
    return error;
 }
 
-TEST_CASE("PAIdentityInterp", "[CUDA]")
+TEST_CASE("PAIdentityInterp", "[GPU]")
 {
    auto transpose = GENERATE(true, false);
    auto order = GENERATE(1, 2, 3, 4);

--- a/tests/unit/fem/test_pa_kernels.cpp
+++ b/tests/unit/fem/test_pa_kernels.cpp
@@ -188,7 +188,7 @@ void pa_divergence_transpose_testnd(int dim)
    pa_mixed_transpose_test<VectorDivergenceIntegrator>(fes1, fes2);
 }
 
-TEST_CASE("PA VectorDivergence", "[PartialAssembly], [CUDA]")
+TEST_CASE("PA VectorDivergence", "[PartialAssembly], [GPU]")
 {
    SECTION("2D")
    {
@@ -280,7 +280,7 @@ void pa_gradient_transpose_testnd(int dim, FECType fec_type)
    pa_mixed_transpose_test<GradientIntegrator>(fes1, fes2);
 }
 
-TEST_CASE("PA Gradient", "[PartialAssembly], [CUDA]")
+TEST_CASE("PA Gradient", "[PartialAssembly], [GPU]")
 {
    auto fec_type = GENERATE(FECType::H1, FECType::L2_VALUE,
                             FECType::L2_INTEGRAL);
@@ -329,7 +329,7 @@ real_t test_nl_convection_nd(int dim)
    return difference;
 }
 
-TEST_CASE("Nonlinear Convection", "[PartialAssembly], [NonlinearPA], [CUDA]")
+TEST_CASE("Nonlinear Convection", "[PartialAssembly], [NonlinearPA], [GPU]")
 {
    SECTION("2D")
    {
@@ -371,7 +371,7 @@ real_t test_vector_pa_integrator(int dim)
    return difference;
 }
 
-TEST_CASE("PA Vector Mass", "[PartialAssembly], [VectorPA], [CUDA]")
+TEST_CASE("PA Vector Mass", "[PartialAssembly], [VectorPA], [GPU]")
 {
    SECTION("2D")
    {
@@ -384,7 +384,7 @@ TEST_CASE("PA Vector Mass", "[PartialAssembly], [VectorPA], [CUDA]")
    }
 }
 
-TEST_CASE("PA Vector Diffusion", "[PartialAssembly], [VectorPA], [CUDA]")
+TEST_CASE("PA Vector Diffusion", "[PartialAssembly], [VectorPA], [GPU]")
 {
    SECTION("2D")
    {
@@ -507,7 +507,7 @@ void test_pa_convection(const std::string &meshname, int order, int prob,
 }
 
 // Basic unit tests for convection
-TEST_CASE("PA Convection", "[PartialAssembly], [CUDA]")
+TEST_CASE("PA Convection", "[PartialAssembly], [GPU]")
 {
    // prob:
    // - 0: CG,
@@ -533,7 +533,7 @@ TEST_CASE("PA Convection", "[PartialAssembly], [CUDA]")
 } // test case
 
 // Advanced unit tests for convection
-TEST_CASE("PA Convection advanced", "[PartialAssembly], [MFEMData], [CUDA]")
+TEST_CASE("PA Convection advanced", "[PartialAssembly], [MFEMData], [GPU]")
 {
    if (launch_all_non_regression_tests)
    {
@@ -612,17 +612,17 @@ static void test_pa_integrator()
    REQUIRE(y_fa.Normlinf() == MFEM_Approx(0.0));
 }
 
-TEST_CASE("PA Mass", "[PartialAssembly], [CUDA]")
+TEST_CASE("PA Mass", "[PartialAssembly], [GPU]")
 {
    test_pa_integrator<MassIntegrator>();
 } // PA Mass test case
 
-TEST_CASE("PA Diffusion", "[PartialAssembly], [CUDA]")
+TEST_CASE("PA Diffusion", "[PartialAssembly], [GPU]")
 {
    test_pa_integrator<DiffusionIntegrator>();
 } // PA Diffusion test case
 
-TEST_CASE("PA Markers", "[PartialAssembly], [CUDA]")
+TEST_CASE("PA Markers", "[PartialAssembly], [GPU]")
 {
    const bool all_tests = launch_all_non_regression_tests;
    auto fname = GENERATE("../../data/star.mesh", "../../data/star-q3.mesh",
@@ -678,7 +678,7 @@ TEST_CASE("PA Markers", "[PartialAssembly], [CUDA]")
    REQUIRE(y_fa.Normlinf() == MFEM_Approx(0.0));
 }
 
-TEST_CASE("PA Boundary Mass", "[PartialAssembly], [CUDA]")
+TEST_CASE("PA Boundary Mass", "[PartialAssembly], [GPU]")
 {
    const bool all_tests = launch_all_non_regression_tests;
 
@@ -792,7 +792,7 @@ std::vector<std::string> get_dg_test_meshes()
    return mesh_filenames;
 }
 
-TEST_CASE("PA DG Diffusion", "[PartialAssembly], [CUDA]")
+TEST_CASE("PA DG Diffusion", "[PartialAssembly], [GPU]")
 {
    const auto mesh_fname = GENERATE_COPY(from_range(get_dg_test_meshes()));
    const int order = GENERATE(1, 2);
@@ -809,7 +809,7 @@ TEST_CASE("PA DG Diffusion", "[PartialAssembly], [CUDA]")
 
 #ifdef MFEM_USE_MPI
 
-TEST_CASE("Parallel PA DG Diffusion", "[PartialAssembly][Parallel][CUDA]")
+TEST_CASE("Parallel PA DG Diffusion", "[PartialAssembly][Parallel][GPU]")
 {
    const auto mesh_fname = GENERATE_COPY(from_range(get_dg_test_meshes()));
    const int order = GENERATE(1, 2);

--- a/tests/unit/fem/test_quadf_coef.cpp
+++ b/tests/unit/fem/test_quadf_coef.cpp
@@ -155,7 +155,7 @@ TEST_CASE("Quadrature Function Coefficients",
    }
 }
 
-TEST_CASE("Quadrature Function Integration", "[QuadratureFunction][CUDA]")
+TEST_CASE("Quadrature Function Integration", "[QuadratureFunction][GPU]")
 {
    auto fname = GENERATE(
                    "../../data/star.mesh",

--- a/tests/unit/fem/test_quadinterpolator.cpp
+++ b/tests/unit/fem/test_quadinterpolator.cpp
@@ -236,7 +236,7 @@ static bool testQuadratureInterpolator(const int dim,
    return true;
 }
 
-TEST_CASE("QuadratureInterpolator", "[QuadratureInterpolator][CUDA]")
+TEST_CASE("QuadratureInterpolator", "[QuadratureInterpolator][GPU]")
 {
    SECTION("H1 tensor elements: compare tensor and non-tensor evaluations")
    {

--- a/tests/unit/general/test_mem.cpp
+++ b/tests/unit/general/test_mem.cpp
@@ -16,7 +16,7 @@ using namespace mfem;
 
 TEST_CASE("MemoryManager/Scopes",
           "[MemoryManager]"
-          "[CUDA]")
+          "[GPU]")
 {
    SECTION("WithNewMemoryAndSize")
    {

--- a/tests/unit/gpu_unit_test_main.cpp
+++ b/tests/unit/gpu_unit_test_main.cpp
@@ -1,0 +1,28 @@
+// Copyright (c) 2010-2025, Lawrence Livermore National Security, LLC. Produced
+// at the Lawrence Livermore National Laboratory. All Rights reserved. See files
+// LICENSE and NOTICE for details. LLNL-CODE-806117.
+//
+// This file is part of the MFEM library. For more information and source code
+// availability visit https://mfem.org.
+//
+// MFEM is free software; you can redistribute it and/or modify it under the
+// terms of the BSD-3 license. We welcome feedback and contributions, see file
+// CONTRIBUTING.md for details.
+
+#define CATCH_CONFIG_RUNNER
+#include "mfem.hpp"
+#include "run_unit_tests.hpp"
+
+int main(int argc, char *argv[])
+{
+#ifdef MFEM_USE_SINGLE
+   std::cout << "\nThe serial GPU unit tests are not supported in single"
+             " precision.\n\n";
+   return MFEM_SKIP_RETURN_VALUE;
+#endif
+
+   mfem::Device device("gpu");
+
+   // Include only tests labeled with GPU. Exclude parallel tests.
+   return RunCatchSession(argc, argv, {"[GPU]", "~[Parallel]"});
+}

--- a/tests/unit/hunit_test_main.cpp
+++ b/tests/unit/hunit_test_main.cpp
@@ -1,0 +1,28 @@
+// Copyright (c) 2010-2025, Lawrence Livermore National Security, LLC. Produced
+// at the Lawrence Livermore National Laboratory. All Rights reserved. See files
+// LICENSE and NOTICE for details. LLNL-CODE-806117.
+//
+// This file is part of the MFEM library. For more information and source code
+// availability visit https://mfem.org.
+//
+// MFEM is free software; you can redistribute it and/or modify it under the
+// terms of the BSD-3 license. We welcome feedback and contributions, see file
+// CONTRIBUTING.md for details.
+
+#define CATCH_CONFIG_RUNNER
+#include "mfem.hpp"
+#include "run_unit_tests.hpp"
+
+int main(int argc, char *argv[])
+{
+#ifdef MFEM_USE_SINGLE
+   std::cout << "\nThe serial HIP unit tests are not supported in single"
+             " precision.\n\n";
+   return MFEM_SKIP_RETURN_VALUE;
+#endif
+
+   mfem::Device device("hip");
+
+   // Include only tests labeled with CUDA. Exclude parallel tests.
+   return RunCatchSession(argc, argv, {"[HIP]", "~[Parallel]"});
+}

--- a/tests/unit/linalg/test_direct_solvers.cpp
+++ b/tests/unit/linalg/test_direct_solvers.cpp
@@ -98,7 +98,7 @@ double fexact(const Vector &x) // returns -\Delta u
 
 #ifdef DIRECT_SOLVE_SERIAL
 
-TEST_CASE("Serial Direct Solvers", "[CUDA]")
+TEST_CASE("Serial Direct Solvers", "[GPU]")
 {
    const int ne = 2;
    for (int dim = 1; dim < 4; ++dim)
@@ -186,7 +186,7 @@ TEST_CASE("Serial Direct Solvers", "[CUDA]")
 
 #ifdef DIRECT_SOLVE_PARALLEL
 
-TEST_CASE("Parallel Direct Solvers", "[Parallel], [CUDA]")
+TEST_CASE("Parallel Direct Solvers", "[Parallel], [GPU]")
 {
    int rank;
    MPI_Comm_rank(MPI_COMM_WORLD, &rank);

--- a/tests/unit/linalg/test_matrix_dense.cpp
+++ b/tests/unit/linalg/test_matrix_dense.cpp
@@ -359,7 +359,7 @@ TEST_CASE("LUFactors RightSolve", "[DenseMatrix]")
 }
 
 TEST_CASE("Batched Linear Algebra",
-          "[DenseMatrix][CUDA]")
+          "[DenseMatrix][GPU]")
 {
    auto backend = GENERATE(BatchedLinAlg::NATIVE,
                            BatchedLinAlg::GPU_BLAS,

--- a/tests/unit/linalg/test_matrix_hypre.cpp
+++ b/tests/unit/linalg/test_matrix_hypre.cpp
@@ -18,7 +18,7 @@ namespace mfem
 
 #ifdef MFEM_USE_MPI
 
-TEST_CASE("HypreParMatrixWrapConstructors-SyncChecks", "[Parallel], [CUDA]")
+TEST_CASE("HypreParMatrixWrapConstructors-SyncChecks", "[Parallel], [GPU]")
 {
    const int dim = 2;
    const int n1d = 6;

--- a/tests/unit/linalg/test_vector.cpp
+++ b/tests/unit/linalg/test_vector.cpp
@@ -235,7 +235,7 @@ TEST_CASE("Vector Tests", "[Vector]")
    }
 }
 
-TEST_CASE("Vector Sum", "[Vector],[CUDA]")
+TEST_CASE("Vector Sum", "[Vector],[GPU]")
 {
    Vector x(1024);
    x.Randomize(1);

--- a/tests/unit/makefile
+++ b/tests/unit/makefile
@@ -40,11 +40,16 @@ SEQ_MAIN_OBJ = unit_test_main.o
 PAR_MAIN_OBJ = punit_test_main.o
 CUDA_MAIN_OBJ = cunit_test_main.o
 PCUDA_MAIN_OBJ = pcunit_test_main.o
+HIP_MAIN_OBJ = hunit_test_main.o
+PHIP_MAIN_OBJ = phunit_test_main.o
+GPU_MAIN_OBJ = gpu_unit_test_main.o
+PGPU_MAIN_OBJ = pgpu_unit_test_main.o
 
 # Sedov numerical seq/par files and tests
 SEDOV_FILES = $(SRC)miniapps/test_sedov.cpp
 
 USE_CUDA := $(MFEM_USE_CUDA:NO=)
+USE_HIP := $(MFEM_USE_HIP:NO=)
 SEQ_SEDOV_TESTS = sedov_tests_cpu sedov_tests_debug
 SEQ_SEDOV_TESTS += $(if $(USE_CUDA),sedov_tests_cuda)
 SEQ_SEDOV_TESTS += $(if $(USE_CUDA),sedov_tests_cuda_uvm)
@@ -80,9 +85,9 @@ PAR_TMOP_CUDA_OBJ_FILES = $(if $(USE_CUDA),$(TMOP_FILES:$(SRC)%.cpp=%.pcuda.o))
 PAR_TMOP_CUDA_UVM_OBJ_FILES = $(if $(USE_CUDA),$(TMOP_FILES:$(SRC)%.cpp=%.pcuda_uvm.o))
 
 # seq/par files and tests
-SEQ_UNIT_TESTS = unit_tests $(if $(USE_CUDA),cunit_tests)
+SEQ_UNIT_TESTS = unit_tests $(if $(USE_CUDA),cunit_tests gpu_unit_tests) $(if $(USE_HIP),hunit_tests gpu_unit_tests)
 SEQ_UNIT_TESTS += $(SEQ_SEDOV_TESTS) $(SEQ_TMOP_TESTS)
-PAR_UNIT_TESTS = punit_tests $(if $(USE_CUDA),pcunit_tests)
+PAR_UNIT_TESTS = punit_tests $(if $(USE_CUDA),pcunit_tests pgpu_unit_tests) $(if $(USE_HIP),phunit_tests pgpu_unit_tests)
 PAR_UNIT_TESTS += $(PAR_SEDOV_TESTS) $(PAR_TMOP_TESTS)
 
 # Ceed tests
@@ -119,6 +124,19 @@ cunit_tests: $(CUDA_MAIN_OBJ) $(LIBTESTS_O) $(MFEM_LIB_FILE) $(CONFIG_MK) $(DATA
 
 pcunit_tests: $(PCUDA_MAIN_OBJ) $(LIBTESTS_O) $(MFEM_LIB_FILE) $(CONFIG_MK) $(DATA_DIR)
 	$(CCC) $(PCUDA_MAIN_OBJ) $(LIBTESTS_O) $(MFEM_LINK_FLAGS) $(MFEM_LIBS) -o $(@)
+
+hunit_tests: $(HIP_MAIN_OBJ) $(LIBTESTS_O) $(MFEM_LIB_FILE) $(CONFIG_MK) $(DATA_DIR)
+	$(CCC) $(HIP_MAIN_OBJ) $(LIBTESTS_O) $(MFEM_LINK_FLAGS) $(MFEM_LIBS) -o $(@)
+
+phunit_tests: $(PHIP_MAIN_OBJ) $(LIBTESTS_O) $(MFEM_LIB_FILE) $(CONFIG_MK) $(DATA_DIR)
+	$(CCC) $(PHIP_MAIN_OBJ) $(LIBTESTS_O) $(MFEM_LINK_FLAGS) $(MFEM_LIBS) -o $(@)
+
+
+gpu_unit_tests: $(GPU_MAIN_OBJ) $(LIBTESTS_O) $(MFEM_LIB_FILE) $(CONFIG_MK) $(DATA_DIR)
+	$(CCC) $(GPU_MAIN_OBJ) $(LIBTESTS_O) $(MFEM_LINK_FLAGS) $(MFEM_LIBS) -o $(@)
+
+pgpu_unit_tests: $(PGPU_MAIN_OBJ) $(LIBTESTS_O) $(MFEM_LIB_FILE) $(CONFIG_MK) $(DATA_DIR)
+	$(CCC) $(PGPU_MAIN_OBJ) $(LIBTESTS_O) $(MFEM_LINK_FLAGS) $(MFEM_LIBS) -o $(@)
 
 ceed_tests: $(CEED_OBJ) $(MFEM_LIB_FILE) $(CONFIG_MK) $(DATA_DIR)
 	$(CCC) $(CEED_OBJ) $(MFEM_LINK_FLAGS) $(MFEM_LIBS) -o $(@)

--- a/tests/unit/pgpu_unit_test_main.cpp
+++ b/tests/unit/pgpu_unit_test_main.cpp
@@ -1,0 +1,37 @@
+// Copyright (c) 2010-2025, Lawrence Livermore National Security, LLC. Produced
+// at the Lawrence Livermore National Laboratory. All Rights reserved. See files
+// LICENSE and NOTICE for details. LLNL-CODE-806117.
+//
+// This file is part of the MFEM library. For more information and source code
+// availability visit https://mfem.org.
+//
+// MFEM is free software; you can redistribute it and/or modify it under the
+// terms of the BSD-3 license. We welcome feedback and contributions, see file
+// CONTRIBUTING.md for details.
+
+#define CATCH_CONFIG_NOSTDOUT
+#define CATCH_CONFIG_RUNNER
+#include "mfem.hpp"
+#include "run_unit_tests.hpp"
+
+#ifndef MFEM_USE_MPI
+#error "This test should be disabled without MFEM_USE_MPI!"
+#endif
+
+int main(int argc, char *argv[])
+{
+#ifdef MFEM_USE_SINGLE
+   std::cout << "\nThe parallel GPU unit tests are not supported in single"
+             " precision.\n\n";
+   return MFEM_SKIP_RETURN_VALUE;
+#endif
+
+#ifdef MFEM_USE_MPI
+   mfem::Mpi::Init();
+   mfem::Hypre::Init();
+#endif
+   mfem::Device device("gpu");
+
+   // Include only tests that are labeled with both CUDA and Parallel.
+   return RunCatchSession(argc, argv, {"[GPU]","[Parallel]"}, Root());
+}

--- a/tests/unit/phunit_test_main.cpp
+++ b/tests/unit/phunit_test_main.cpp
@@ -1,0 +1,37 @@
+// Copyright (c) 2010-2025, Lawrence Livermore National Security, LLC. Produced
+// at the Lawrence Livermore National Laboratory. All Rights reserved. See files
+// LICENSE and NOTICE for details. LLNL-CODE-806117.
+//
+// This file is part of the MFEM library. For more information and source code
+// availability visit https://mfem.org.
+//
+// MFEM is free software; you can redistribute it and/or modify it under the
+// terms of the BSD-3 license. We welcome feedback and contributions, see file
+// CONTRIBUTING.md for details.
+
+#define CATCH_CONFIG_NOSTDOUT
+#define CATCH_CONFIG_RUNNER
+#include "mfem.hpp"
+#include "run_unit_tests.hpp"
+
+#ifndef MFEM_USE_MPI
+#error "This test should be disabled without MFEM_USE_MPI!"
+#endif
+
+int main(int argc, char *argv[])
+{
+#ifdef MFEM_USE_SINGLE
+   std::cout << "\nThe parallel HIP unit tests are not supported in single"
+             " precision.\n\n";
+   return MFEM_SKIP_RETURN_VALUE;
+#endif
+
+#ifdef MFEM_USE_MPI
+   mfem::Mpi::Init();
+   mfem::Hypre::Init();
+#endif
+   mfem::Device device("hip");
+
+   // Include only tests that are labeled with both HIP and Parallel.
+   return RunCatchSession(argc, argv, {"[HIP]","[Parallel]"}, Root());
+}


### PR DESCRIPTION
Added gpu_unit_tests and pgpu_unit_tests for generic (CUDA/HIP/etc.) unit tests.
Added hunit_tests and pcunit_tests for HIP-specific unit tests.
Changed cunit_tests and pcunit_tests to be CUDA-specific unit tests.

Added device configuration shortcuts "gpu", "raja-gpu", "ceed-gpu", and "occa-gpu" which will auto-detect the underlying GPU backend.