### PR TITLE
Fix error in MFEM_ABORT in MMA with LAPACK

### DIFF
--- a/linalg/mma.cpp
+++ b/linalg/mma.cpp
@@ -706,7 +706,8 @@ void MMA::MMASubSvanberg::Update(const real_t* dfdx,
                }
                else
                {
-                  MFEM_ABORT("MMA: Argument %d in linear system solve has illegal value.", info);
+                  MFEM_ABORT("MMA: Argument " << info <<
+                             " in linear system solve has illegal value");
                }
 #else
                solveLU(ncon, AA1, bb1);


### PR DESCRIPTION
Fixes compilation error when compiling with LAPACK enabled:
```
linalg/mma.cpp:709:92: error: too many arguments provided to function-like macro invocation
  709 |                   MFEM_ABORT("MMA: Argument %d in linear system solve has illegal value.", info);
```