### PR TITLE
Tribol miniapp update

### DIFF
--- a/miniapps/tribol/contact-patch-test.cpp
+++ b/miniapps/tribol/contact-patch-test.cpp
@@ -373,7 +373,7 @@ int main(int argc, char *argv[])
       visit_surf_dc.RegisterField("pressure", &pressure);
       visit_surf_dc.Save();
    }
-   // #7: Tribol cleanup: deletes coupling schemes and clears associated memory
+   // #6: Tribol cleanup: deletes coupling schemes and clears associated memory
    tribol::finalize();
 
    return 0;


### PR DESCRIPTION
Removing a tribol::initialize call that Tribol no longer requires and which produces a warning message.