### PR TITLE
Add additional debug info to try and catch an illusive github CI bug

### DIFF
--- a/tests/unit/fem/test_pgridfunc_save_serial.cpp
+++ b/tests/unit/fem/test_pgridfunc_save_serial.cpp
@@ -78,7 +78,12 @@ TEST_CASE("ParGridFunction in Serial", "[ParGridFunction][Parallel]")
    if (my_rank == save_rank)
    {
       // Clean up
-      REQUIRE(std::remove("parallel_in_serial.mesh") == 0);
+      auto tmp = std::remove("parallel_in_serial.mesh");
+      if (tmp)
+      {
+         CAPTURE(std::strerror(errno));
+         REQUIRE(tmp == 0);
+      }
       REQUIRE(std::remove("parallel_in_serial.gf") == 0);
    }
 }


### PR DESCRIPTION
Try to catch and debug the illusive failure in `punit_tests` removing `parallel_in_serial.mesh` in github CI.