### PR TITLE
Treat FiniteElementCollection as immutable

### DIFF
--- a/examples/amgx/ex1.cpp
+++ b/examples/amgx/ex1.cpp
@@ -107,7 +107,7 @@ int main(int argc, char *argv[])
    // 5. Define a finite element space on the mesh. Here we use continuous
    //    Lagrange finite elements of the specified order. If order < 1, we
    //    instead use an isoparametric/isogeometric space.
-   FiniteElementCollection *fec;
+   const FiniteElementCollection *fec;
    bool delete_fec;
    if (order > 0)
    {

--- a/examples/amgx/ex1p.cpp
+++ b/examples/amgx/ex1p.cpp
@@ -134,7 +134,7 @@ int main(int argc, char *argv[])
    // 7. Define a parallel finite element space on the parallel mesh. Here we
    //    use continuous Lagrange finite elements of the specified order. If
    //    order < 1, we instead use an isoparametric/isogeometric space.
-   FiniteElementCollection *fec;
+   const FiniteElementCollection *fec;
    bool delete_fec;
    if (order > 0)
    {

--- a/examples/caliper/ex1.cpp
+++ b/examples/caliper/ex1.cpp
@@ -133,7 +133,7 @@ int main(int argc, char *argv[])
    // 5. Define a finite element space on the mesh. Here we use continuous
    //    Lagrange finite elements of the specified order. If order < 1, we
    //    instead use an isoparametric/isogeometric space.
-   FiniteElementCollection *fec;
+   const FiniteElementCollection *fec;
    bool delete_fec;
    if (order > 0)
    {

--- a/examples/caliper/ex1p.cpp
+++ b/examples/caliper/ex1p.cpp
@@ -152,7 +152,7 @@ int main(int argc, char *argv[])
    // 7. Define a parallel finite element space on the parallel mesh. Here we
    //    use continuous Lagrange finite elements of the specified order. If
    //    order < 1, we instead use an isoparametric/isogeometric space.
-   FiniteElementCollection *fec;
+   const FiniteElementCollection *fec;
    bool delete_fec;
    if (order > 0)
    {

--- a/examples/ex1.cpp
+++ b/examples/ex1.cpp
@@ -139,7 +139,7 @@ int main(int argc, char *argv[])
    // 5. Define a finite element space on the mesh. Here we use continuous
    //    Lagrange finite elements of the specified order. If order < 1, we
    //    instead use an isoparametric/isogeometric space.
-   FiniteElementCollection *fec;
+   const FiniteElementCollection *fec;
    bool delete_fec;
    if (order > 0)
    {

--- a/examples/ex11p.cpp
+++ b/examples/ex11p.cpp
@@ -159,7 +159,7 @@ int main(int argc, char *argv[])
    // 6. Define a parallel finite element space on the parallel mesh. Here we
    //    use continuous Lagrange finite elements of the specified order. If
    //    order < 1, we instead use an isoparametric/isogeometric space.
-   FiniteElementCollection *fec;
+   const FiniteElementCollection *fec;
    if (order > 0)
    {
       fec = new H1_FECollection(order, dim);

--- a/examples/ex12p.cpp
+++ b/examples/ex12p.cpp
@@ -150,7 +150,7 @@ int main(int argc, char *argv[])
    //    the FiniteElementSpace constructor) which is expected in the systems
    //    version of BoomerAMG preconditioner. For NURBS meshes, we use the
    //    (degree elevated) NURBS space associated with the mesh nodes.
-   FiniteElementCollection *fec;
+   const FiniteElementCollection *fec;
    ParFiniteElementSpace *fespace;
    const bool use_nodal_fespace = pmesh->NURBSext && !amg_elast;
    if (use_nodal_fespace)

--- a/examples/ex13p.cpp
+++ b/examples/ex13p.cpp
@@ -129,7 +129,7 @@ int main(int argc, char *argv[])
 
    // 7. Define a parallel finite element space on the parallel mesh. Here we
    //    use the Nedelec finite elements of the specified order.
-   FiniteElementCollection *fec = new ND_FECollection(order, dim);
+   const FiniteElementCollection *fec = new ND_FECollection(order, dim);
    ParFiniteElementSpace *fespace = new ParFiniteElementSpace(pmesh, fec);
    HYPRE_BigInt size = fespace->GlobalTrueVSize();
    if (myid == 0)

--- a/examples/ex1p.cpp
+++ b/examples/ex1p.cpp
@@ -160,7 +160,7 @@ int main(int argc, char *argv[])
    // 7. Define a parallel finite element space on the parallel mesh. Here we
    //    use continuous Lagrange finite elements of the specified order. If
    //    order < 1, we instead use an isoparametric/isogeometric space.
-   FiniteElementCollection *fec;
+   const FiniteElementCollection *fec;
    bool delete_fec;
    if (order > 0)
    {

--- a/examples/ex2.cpp
+++ b/examples/ex2.cpp
@@ -108,7 +108,7 @@ int main(int argc, char *argv[])
    //    dimension is specified by the last argument of the FiniteElementSpace
    //    constructor. For NURBS meshes, we use the (degree elevated) NURBS space
    //    associated with the mesh nodes.
-   FiniteElementCollection *fec;
+   const FiniteElementCollection *fec;
    FiniteElementSpace *fespace;
    if (mesh->NURBSext)
    {

--- a/examples/ex22.cpp
+++ b/examples/ex22.cpp
@@ -179,7 +179,7 @@ int main(int argc, char *argv[])
       prob = 0;
    }
 
-   FiniteElementCollection *fec = NULL;
+   const FiniteElementCollection *fec = NULL;
    switch (prob)
    {
       case 0:  fec = new H1_FECollection(order, dim);      break;

--- a/examples/ex22p.cpp
+++ b/examples/ex22p.cpp
@@ -205,7 +205,7 @@ int main(int argc, char *argv[])
       prob = 0;
    }
 
-   FiniteElementCollection *fec = NULL;
+   const FiniteElementCollection *fec = NULL;
    switch (prob)
    {
       case 0:  fec = new H1_FECollection(order, dim);      break;

--- a/examples/ex24.cpp
+++ b/examples/ex24.cpp
@@ -116,8 +116,8 @@ int main(int argc, char *argv[])
 
    // 5. Define a finite element space on the mesh. Here we use Nedelec or
    //    Raviart-Thomas finite elements of the specified order.
-   FiniteElementCollection *trial_fec = NULL;
-   FiniteElementCollection *test_fec = NULL;
+   const FiniteElementCollection *trial_fec = NULL;
+   const FiniteElementCollection *test_fec = NULL;
 
    if (prob == 0)
    {

--- a/examples/ex24p.cpp
+++ b/examples/ex24p.cpp
@@ -143,8 +143,8 @@ int main(int argc, char *argv[])
 
    // 7. Define a parallel finite element space on the parallel mesh. Here we
    //    use Nedelec or Raviart-Thomas finite elements of the specified order.
-   FiniteElementCollection *trial_fec = NULL;
-   FiniteElementCollection *test_fec = NULL;
+   const FiniteElementCollection *trial_fec = NULL;
+   const FiniteElementCollection *test_fec = NULL;
 
    if (prob == 0)
    {

--- a/examples/ex25.cpp
+++ b/examples/ex25.cpp
@@ -286,7 +286,7 @@ int main(int argc, char *argv[])
 
    // 7. Define a finite element space on the mesh. Here we use the Nedelec
    //    finite elements of the specified order.
-   FiniteElementCollection *fec = new ND_FECollection(order, dim);
+   const FiniteElementCollection *fec = new ND_FECollection(order, dim);
    FiniteElementSpace *fespace = new FiniteElementSpace(mesh, fec);
    int size = fespace->GetTrueVSize();
 

--- a/examples/ex25p.cpp
+++ b/examples/ex25p.cpp
@@ -329,7 +329,7 @@ int main(int argc, char *argv[])
 
    // 9. Define a parallel finite element space on the parallel mesh. Here we
    //    use the Nedelec finite elements of the specified order.
-   FiniteElementCollection *fec = new ND_FECollection(order, dim);
+   const FiniteElementCollection *fec = new ND_FECollection(order, dim);
    ParFiniteElementSpace *fespace = new ParFiniteElementSpace(pmesh, fec);
    HYPRE_BigInt size = fespace->GlobalTrueVSize();
    if (myid == 0)

--- a/examples/ex26.cpp
+++ b/examples/ex26.cpp
@@ -164,11 +164,11 @@ int main(int argc, char *argv[])
    //    coarse level and geometrically refine the spaces by the specified
    //    amount. Afterwards, we increase the order of the finite elements
    //    by a factor of 2 for each additional level.
-   FiniteElementCollection *fec = new H1_FECollection(1, dim);
+   const FiniteElementCollection *fec = new H1_FECollection(1, dim);
    FiniteElementSpace *coarse_fespace = new FiniteElementSpace(mesh, fec);
    FiniteElementSpaceHierarchy fespaces(mesh, coarse_fespace, true, true);
 
-   Array<FiniteElementCollection*> collections;
+   Array<const FiniteElementCollection*> collections;
    collections.Append(fec);
    for (int level = 0; level < geometric_refinements; ++level)
    {

--- a/examples/ex26p.cpp
+++ b/examples/ex26p.cpp
@@ -202,10 +202,10 @@ int main(int argc, char *argv[])
    //    on the coarse level and geometrically refine the spaces by the specified
    //    amount. Afterwards, we increase the order of the finite elements by a
    //    factor of 2 for each additional level.
-   FiniteElementCollection *fec = new H1_FECollection(1, dim);
+   const FiniteElementCollection *fec = new H1_FECollection(1, dim);
    ParFiniteElementSpace *coarse_fespace = new ParFiniteElementSpace(pmesh, fec);
 
-   Array<FiniteElementCollection*> collections;
+   Array<const FiniteElementCollection*> collections;
    collections.Append(fec);
    ParFiniteElementSpaceHierarchy* fespaces = new ParFiniteElementSpaceHierarchy(
       pmesh, coarse_fespace, true, true);

--- a/examples/ex27.cpp
+++ b/examples/ex27.cpp
@@ -155,9 +155,9 @@ int main(int argc, char *argv[])
    // 3. Define a finite element space on the serial mesh. Here we use either
    //    continuous Lagrange finite elements or discontinuous Galerkin finite
    //    elements of the specified order.
-   FiniteElementCollection *fec =
-      h1 ? (FiniteElementCollection*)new H1_FECollection(order, dim) :
-      (FiniteElementCollection*)new DG_FECollection(order, dim);
+   const FiniteElementCollection *fec =
+      h1 ? (const FiniteElementCollection*)new H1_FECollection(order, dim) :
+      (const FiniteElementCollection*)new DG_FECollection(order, dim);
    FiniteElementSpace fespace(mesh, fec);
    int size = fespace.GetTrueVSize();
    mfem::out << "Number of finite element unknowns: " << size << endl;

--- a/examples/ex27p.cpp
+++ b/examples/ex27p.cpp
@@ -173,9 +173,9 @@ int main(int argc, char *argv[])
    // 5. Define a parallel finite element space on the parallel mesh. Here we
    //    use either continuous Lagrange finite elements or discontinuous
    //    Galerkin finite elements of the specified order.
-   FiniteElementCollection *fec =
-      h1 ? (FiniteElementCollection*)new H1_FECollection(order, dim) :
-      (FiniteElementCollection*)new DG_FECollection(order, dim);
+   const FiniteElementCollection *fec =
+      h1 ? (const FiniteElementCollection*)new H1_FECollection(order, dim) :
+      (const FiniteElementCollection*)new DG_FECollection(order, dim);
    ParFiniteElementSpace fespace(&pmesh, fec);
    HYPRE_BigInt size = fespace.GlobalTrueVSize();
    mfem::out << "Number of finite element unknowns: " << size << endl;

--- a/examples/ex28.cpp
+++ b/examples/ex28.cpp
@@ -125,7 +125,7 @@ int main(int argc, char *argv[])
    //    elements, i.e. dim copies of a scalar finite element space. The vector
    //    dimension is specified by the last argument of the FiniteElementSpace
    //    constructor.
-   FiniteElementCollection *fec = new H1_FECollection(order, dim);
+   const FiniteElementCollection *fec = new H1_FECollection(order, dim);
    FiniteElementSpace *fespace = new FiniteElementSpace(mesh, fec, dim);
    cout << "Number of finite element unknowns: " << fespace->GetTrueVSize()
         << endl;

--- a/examples/ex28p.cpp
+++ b/examples/ex28p.cpp
@@ -167,7 +167,7 @@ int main(int argc, char *argv[])
    //    the FiniteElementSpace constructor) which is expected in the systems
    //    version of BoomerAMG preconditioner. For NURBS meshes, we use the
    //    (degree elevated) NURBS space associated with the mesh nodes.
-   FiniteElementCollection *fec;
+   const FiniteElementCollection *fec;
    ParFiniteElementSpace *fespace;
    const bool use_nodal_fespace = pmesh->NURBSext;
    if (use_nodal_fespace)

--- a/examples/ex2p.cpp
+++ b/examples/ex2p.cpp
@@ -154,7 +154,7 @@ int main(int argc, char *argv[])
    //    the FiniteElementSpace constructor) which is expected in the systems
    //    version of BoomerAMG preconditioner. For NURBS meshes, we use the
    //    (degree elevated) NURBS space associated with the mesh nodes.
-   FiniteElementCollection *fec;
+   const FiniteElementCollection *fec;
    ParFiniteElementSpace *fespace;
    const bool use_nodal_fespace = pmesh->NURBSext && !amg_elast;
    if (use_nodal_fespace)

--- a/examples/ex3.cpp
+++ b/examples/ex3.cpp
@@ -127,7 +127,7 @@ int main(int argc, char *argv[])
 
    // 5. Define a finite element space on the mesh. Here we use the Nedelec
    //    finite elements of the specified order.
-   FiniteElementCollection *fec = new ND_FECollection(order, dim);
+   const FiniteElementCollection *fec = new ND_FECollection(order, dim);
    FiniteElementSpace *fespace = new FiniteElementSpace(mesh, fec);
    cout << "Number of finite element unknowns: "
         << fespace->GetTrueVSize() << endl;

--- a/examples/ex31.cpp
+++ b/examples/ex31.cpp
@@ -82,7 +82,7 @@ int main(int argc, char *argv[])
    // 4. Define a finite element space on the mesh. Here we use the Nedelec
    //    finite elements of the specified order restricted to 1D, 2D, or 3D
    //    depending on the dimension of the given mesh file.
-   FiniteElementCollection *fec = NULL;
+   const FiniteElementCollection *fec = NULL;
    if (dim == 1)
    {
       fec = new ND_R1D_FECollection(order, dim);

--- a/examples/ex31p.cpp
+++ b/examples/ex31p.cpp
@@ -105,7 +105,7 @@ int main(int argc, char *argv[])
 
    // 6. Define a parallel finite element space on the parallel mesh. Here we
    //    use the Nedelec finite elements of the specified order.
-   FiniteElementCollection *fec = NULL;
+   const FiniteElementCollection *fec = NULL;
    if (dim == 1)
    {
       fec = new ND_R1D_FECollection(order, dim);

--- a/examples/ex32p.cpp
+++ b/examples/ex32p.cpp
@@ -102,8 +102,8 @@ int main(int argc, char *argv[])
 
    // 6. Define a parallel finite element space on the parallel mesh. Here we
    //    use the Nedelec finite elements of the specified order.
-   FiniteElementCollection *fec_nd = NULL;
-   FiniteElementCollection *fec_rt = NULL;
+   const FiniteElementCollection *fec_nd = NULL;
+   const FiniteElementCollection *fec_rt = NULL;
    if (dim == 1)
    {
       fec_nd = new ND_R1D_FECollection(order, dim);

--- a/examples/ex35p.cpp
+++ b/examples/ex35p.cpp
@@ -220,7 +220,7 @@ int main(int argc, char *argv[])
       prob = 0;
    }
 
-   FiniteElementCollection *fec = NULL;
+   const FiniteElementCollection *fec = NULL;
    switch (prob)
    {
       case 0:  fec = new H1_FECollection(order, dim);      break;
@@ -238,7 +238,7 @@ int main(int argc, char *argv[])
    // 7b. Define a parallel finite element space on the sub-mesh. Here we
    //    use continuous Lagrange, Nedelec, or L2 finite elements of
    //    the specified order.
-   FiniteElementCollection *fec_port = NULL;
+   const FiniteElementCollection *fec_port = NULL;
    switch (prob)
    {
       case 0:  fec_port = new H1_FECollection(order, dim-1);      break;

--- a/examples/ex37.hpp
+++ b/examples/ex37.hpp
@@ -228,7 +228,7 @@ private:
 
    // FEM solver
    int dim;
-   FiniteElementCollection * fec = nullptr;
+   const FiniteElementCollection * fec = nullptr;
    FiniteElementSpace * fes = nullptr;
    Array<int> ess_bdr;
    Array<int> neumann_bdr;
@@ -312,7 +312,7 @@ private:
 
    // FEM solver
    int dim;
-   FiniteElementCollection * fec = nullptr;
+   const FiniteElementCollection * fec = nullptr;
    FiniteElementSpace * fes = nullptr;
    Array<int> ess_bdr;
    Array<int> neumann_bdr;

--- a/examples/ex3p.cpp
+++ b/examples/ex3p.cpp
@@ -162,7 +162,7 @@ int main(int argc, char *argv[])
 
    // 7. Define a parallel finite element space on the parallel mesh. Here we
    //    use the Nedelec finite elements of the specified order.
-   FiniteElementCollection *fec = new ND_FECollection(order, dim);
+   const FiniteElementCollection *fec = new ND_FECollection(order, dim);
    ParFiniteElementSpace *fespace = new ParFiniteElementSpace(pmesh, fec);
    HYPRE_BigInt size = fespace->GlobalTrueVSize();
    if (myid == 0)

--- a/examples/ex4.cpp
+++ b/examples/ex4.cpp
@@ -121,7 +121,7 @@ int main(int argc, char *argv[])
 
    // 5. Define a finite element space on the mesh. Here we use the
    //    Raviart-Thomas finite elements of the specified order.
-   FiniteElementCollection *fec = new RT_FECollection(order-1, dim);
+   const FiniteElementCollection *fec = new RT_FECollection(order-1, dim);
    FiniteElementSpace *fespace = new FiniteElementSpace(mesh, fec);
    cout << "Number of finite element unknowns: "
         << fespace->GetTrueVSize() << endl;
@@ -171,7 +171,7 @@ int main(int argc, char *argv[])
    //    applying any necessary transformations such as: eliminating boundary
    //    conditions, applying conforming constraints for non-conforming AMR,
    //    static condensation, hybridization, etc.
-   FiniteElementCollection *hfec = NULL;
+   const FiniteElementCollection *hfec = NULL;
    FiniteElementSpace *hfes = NULL;
    if (static_cond)
    {

--- a/examples/ex4p.cpp
+++ b/examples/ex4p.cpp
@@ -140,7 +140,7 @@ int main(int argc, char *argv[])
 
    // 7. Define a parallel finite element space on the parallel mesh. Here we
    //    use the Raviart-Thomas finite elements of the specified order.
-   FiniteElementCollection *fec = new RT_FECollection(order-1, dim);
+   const FiniteElementCollection *fec = new RT_FECollection(order-1, dim);
    ParFiniteElementSpace *fespace = new ParFiniteElementSpace(pmesh, fec);
    HYPRE_BigInt size = fespace->GlobalTrueVSize();
    if (myid == 0)
@@ -194,7 +194,7 @@ int main(int argc, char *argv[])
    //     assembly, eliminating boundary conditions, applying conforming
    //     constraints for non-conforming AMR, static condensation,
    //     hybridization, etc.
-   FiniteElementCollection *hfec = NULL;
+   const FiniteElementCollection *hfec = NULL;
    ParFiniteElementSpace *hfes = NULL;
    if (static_cond)
    {

--- a/examples/ex5.cpp
+++ b/examples/ex5.cpp
@@ -107,8 +107,8 @@ int main(int argc, char *argv[])
 
    // 5. Define a finite element space on the mesh. Here we use the
    //    Raviart-Thomas finite elements of the specified order.
-   FiniteElementCollection *hdiv_coll(new RT_FECollection(order, dim));
-   FiniteElementCollection *l2_coll(new L2_FECollection(order, dim));
+   const FiniteElementCollection *hdiv_coll(new RT_FECollection(order, dim));
+   const FiniteElementCollection *l2_coll(new L2_FECollection(order, dim));
 
    FiniteElementSpace *R_space = new FiniteElementSpace(mesh, hdiv_coll);
    FiniteElementSpace *W_space = new FiniteElementSpace(mesh, l2_coll);

--- a/examples/ex5p.cpp
+++ b/examples/ex5p.cpp
@@ -148,8 +148,8 @@ int main(int argc, char *argv[])
 
    // 7. Define a parallel finite element space on the parallel mesh. Here we
    //    use the Raviart-Thomas finite elements of the specified order.
-   FiniteElementCollection *hdiv_coll(new RT_FECollection(order, dim));
-   FiniteElementCollection *l2_coll(new L2_FECollection(order, dim));
+   const FiniteElementCollection *hdiv_coll(new RT_FECollection(order, dim));
+   const FiniteElementCollection *l2_coll(new L2_FECollection(order, dim));
 
    ParFiniteElementSpace *R_space = new ParFiniteElementSpace(pmesh, hdiv_coll);
    ParFiniteElementSpace *W_space = new ParFiniteElementSpace(pmesh, l2_coll);

--- a/examples/ex6p.cpp
+++ b/examples/ex6p.cpp
@@ -257,7 +257,7 @@ int main(int argc, char *argv[])
    //     discontinuous flux (L2) and a space for the smoothed flux.
    L2_FECollection flux_fec(order, dim);
    ParFiniteElementSpace flux_fes(pmesh, &flux_fec, sdim);
-   FiniteElementCollection *smooth_flux_fec = NULL;
+   const FiniteElementCollection *smooth_flux_fec = NULL;
    ParFiniteElementSpace *smooth_flux_fes = NULL;
    if (smooth_rt && dim > 1)
    {

--- a/examples/ex8.cpp
+++ b/examples/ex8.cpp
@@ -100,7 +100,7 @@ int main(int argc, char *argv[])
       cerr << "Warning, test space not enriched enough to handle primal"
            << " trial space\n";
 
-   FiniteElementCollection *x0_fec, *xhat_fec, *test_fec;
+   const FiniteElementCollection *x0_fec, *xhat_fec, *test_fec;
 
    x0_fec   = new H1_FECollection(trial_order, dim);
    xhat_fec = new RT_Trace_FECollection(trace_order, dim);

--- a/examples/ex8p.cpp
+++ b/examples/ex8p.cpp
@@ -131,7 +131,7 @@ int main(int argc, char *argv[])
       }
    }
 
-   FiniteElementCollection *x0_fec, *xhat_fec, *test_fec;
+   const FiniteElementCollection *x0_fec, *xhat_fec, *test_fec;
 
    x0_fec   = new H1_FECollection(trial_order, dim);
    xhat_fec = new RT_Trace_FECollection(trace_order, dim);

--- a/examples/ginkgo/ex1.cpp
+++ b/examples/ginkgo/ex1.cpp
@@ -130,7 +130,7 @@ int main(int argc, char *argv[])
    // 5. Define a finite element space on the mesh. Here we use continuous
    //    Lagrange finite elements of the specified order. If order < 1, we
    //    instead use an isoparametric/isogeometric space.
-   FiniteElementCollection *fec;
+   const FiniteElementCollection *fec;
    if (order > 0)
    {
       fec = new H1_FECollection(order, dim);

--- a/examples/moonolith/ex1.cpp
+++ b/examples/moonolith/ex1.cpp
@@ -133,7 +133,7 @@ int main(int argc, char *argv[])
       dest_mesh->UniformRefinement();
    }
 
-   shared_ptr<FiniteElementCollection> src_fe_coll, dest_fe_coll;
+   shared_ptr<const FiniteElementCollection> src_fe_coll, dest_fe_coll;
 
    if (use_vector_fe)
    {

--- a/examples/moonolith/ex1p.cpp
+++ b/examples/moonolith/ex1p.cpp
@@ -158,7 +158,7 @@ int main(int argc, char *argv[])
    auto p_src_mesh = make_shared<ParMesh>(MPI_COMM_WORLD, *src_mesh);
    auto p_dest_mesh = make_shared<ParMesh>(MPI_COMM_WORLD, *dest_mesh);
 
-   shared_ptr<FiniteElementCollection> src_fe_coll, dest_fe_coll;
+   shared_ptr<const FiniteElementCollection> src_fe_coll, dest_fe_coll;
 
    if (use_vector_fe)
    {

--- a/examples/petsc/ex11p.cpp
+++ b/examples/petsc/ex11p.cpp
@@ -155,7 +155,7 @@ int main(int argc, char *argv[])
    // 6. Define a parallel finite element space on the parallel mesh. Here we
    //    use continuous Lagrange finite elements of the specified order. If
    //    order < 1, we instead use an isoparametric/isogeometric space.
-   FiniteElementCollection *fec;
+   const FiniteElementCollection *fec;
    if (order > 0)
    {
       fec = new H1_FECollection(order, dim);

--- a/examples/petsc/ex1p.cpp
+++ b/examples/petsc/ex1p.cpp
@@ -180,7 +180,7 @@ int main(int argc, char *argv[])
    // 7. Define a parallel finite element space on the parallel mesh. Here we
    //    use continuous Lagrange finite elements of the specified order. If
    //    order < 1, we instead use an isoparametric/isogeometric space.
-   FiniteElementCollection *fec;
+   const FiniteElementCollection *fec;
    bool delete_fec;
    if (order > 0)
    {

--- a/examples/petsc/ex2p.cpp
+++ b/examples/petsc/ex2p.cpp
@@ -173,7 +173,7 @@ int main(int argc, char *argv[])
    //    the FiniteElementSpace constructor) which is expected in the systems
    //    version of BoomerAMG preconditioner. For NURBS meshes, we use the
    //    (degree elevated) NURBS space associated with the mesh nodes.
-   FiniteElementCollection *fec;
+   const FiniteElementCollection *fec;
    ParFiniteElementSpace *fespace;
    const bool use_nodal_fespace = pmesh->NURBSext && !amg_elast;
    if (use_nodal_fespace)

--- a/examples/petsc/ex3p.cpp
+++ b/examples/petsc/ex3p.cpp
@@ -159,7 +159,7 @@ int main(int argc, char *argv[])
 
    // 6. Define a parallel finite element space on the parallel mesh. Here we
    //    use the Nedelec finite elements of the specified order.
-   FiniteElementCollection *fec = new ND_FECollection(order, dim);
+   const FiniteElementCollection *fec = new ND_FECollection(order, dim);
    ParFiniteElementSpace *fespace = new ParFiniteElementSpace(pmesh, fec);
    HYPRE_BigInt size = fespace->GlobalTrueVSize();
    if (myid == 0)

--- a/examples/petsc/ex4p.cpp
+++ b/examples/petsc/ex4p.cpp
@@ -150,7 +150,7 @@ int main(int argc, char *argv[])
 
    // 6. Define a parallel finite element space on the parallel mesh. Here we
    //    use the Raviart-Thomas finite elements of the specified order.
-   FiniteElementCollection *fec = new RT_FECollection(order-1, dim);
+   const FiniteElementCollection *fec = new RT_FECollection(order-1, dim);
    ParFiniteElementSpace *fespace = new ParFiniteElementSpace(pmesh, fec);
    HYPRE_BigInt size = fespace->GlobalTrueVSize();
    if (myid == 0)
@@ -202,7 +202,7 @@ int main(int argc, char *argv[])
    //     assembly, eliminating boundary conditions, applying conforming
    //     constraints for non-conforming AMR, static condensation,
    //     hybridization, etc.
-   FiniteElementCollection *hfec = NULL;
+   const FiniteElementCollection *hfec = NULL;
    ParFiniteElementSpace *hfes = NULL;
    if (static_cond)
    {

--- a/examples/petsc/ex5p.cpp
+++ b/examples/petsc/ex5p.cpp
@@ -156,8 +156,8 @@ int main(int argc, char *argv[])
 
    // 6. Define a parallel finite element space on the parallel mesh. Here we
    //    use the Raviart-Thomas finite elements of the specified order.
-   FiniteElementCollection *hdiv_coll(new RT_FECollection(order, dim));
-   FiniteElementCollection *l2_coll(new L2_FECollection(order, dim));
+   const FiniteElementCollection *hdiv_coll(new RT_FECollection(order, dim));
+   const FiniteElementCollection *l2_coll(new L2_FECollection(order, dim));
 
    ParFiniteElementSpace *R_space = new ParFiniteElementSpace(pmesh, hdiv_coll);
    ParFiniteElementSpace *W_space = new ParFiniteElementSpace(pmesh, l2_coll);

--- a/examples/pumi/ex1.cpp
+++ b/examples/pumi/ex1.cpp
@@ -153,7 +153,7 @@ int main(int argc, char *argv[])
    // 7. Define a finite element space on the mesh. Here we use continuous
    //    Lagrange finite elements of the specified order. If order < 1, we
    //    instead use an isoparametric/isogeometric space.
-   FiniteElementCollection *fec;
+   const FiniteElementCollection *fec;
    if (order > 0)
    {
       fec = new H1_FECollection(order, dim);

--- a/examples/pumi/ex1p.cpp
+++ b/examples/pumi/ex1p.cpp
@@ -166,7 +166,7 @@ int main(int argc, char *argv[])
    // 6. Define a parallel finite element space on the parallel mesh. Here we
    //    use continuous Lagrange finite elements of the specified order. If
    //    order < 1, we instead use an isoparametric/isogeometric space.
-   FiniteElementCollection *fec;
+   const FiniteElementCollection *fec;
    if (order > 0)
    {
       fec = new H1_FECollection(order, dim);

--- a/examples/pumi/ex2.cpp
+++ b/examples/pumi/ex2.cpp
@@ -257,7 +257,7 @@ int main(int argc, char *argv[])
    //    dimension is specified by the last argument of the FiniteElementSpace
    //    constructor. For NURBS meshes, we use the (degree elevated) NURBS space
    //    associated with the mesh nodes.
-   FiniteElementCollection *fec;
+   const FiniteElementCollection *fec;
    FiniteElementSpace *fespace;
    if (mesh->NURBSext)
    {

--- a/examples/pumi/ex6p.cpp
+++ b/examples/pumi/ex6p.cpp
@@ -171,7 +171,7 @@ int main(int argc, char *argv[])
    // 6. Define a parallel finite element space on the parallel mesh. Here we
    //    use continuous Lagrange finite elements of the specified order. If
    //    order < 1, we instead use an isoparametric/isogeometric space.
-   FiniteElementCollection *fec;
+   const FiniteElementCollection *fec;
    if (order > 0)
    {
       fec = new H1_FECollection(order, dim);

--- a/examples/superlu/ex1p.cpp
+++ b/examples/superlu/ex1p.cpp
@@ -146,7 +146,7 @@ int main(int argc, char *argv[])
    // 7. Define a parallel finite element space on the parallel mesh. Here we
    //    use continuous Lagrange finite elements of the specified order. If
    //    order < 1, we instead use an isoparametric/isogeometric space.
-   FiniteElementCollection *fec;
+   const FiniteElementCollection *fec;
    bool delete_fec;
    if (order > 0)
    {

--- a/fem/conduitdatacollection.cpp
+++ b/fem/conduitdatacollection.cpp
@@ -611,8 +611,8 @@ ConduitDataCollection::BlueprintFieldToGridFunction(Mesh *mesh,
    std::string fec_name = n_field["basis"].as_string();
 
    GridFunction *res = NULL;
-   mfem::FiniteElementCollection *fec = FiniteElementCollection::New(
-                                           fec_name.c_str());
+   const mfem::FiniteElementCollection *fec = FiniteElementCollection::New(
+                                                 fec_name.c_str());
    mfem::FiniteElementSpace *fes = new FiniteElementSpace(mesh,
                                                           fec,
                                                           vdim,

--- a/fem/fe_coll.cpp
+++ b/fem/fe_coll.cpp
@@ -115,7 +115,8 @@ int FiniteElementCollection::HasFaceDofs(Geometry::Type geom, int p) const
    return 0;
 }
 
-FiniteElementCollection *FiniteElementCollection::GetTraceCollection() const
+const FiniteElementCollection *FiniteElementCollection::GetTraceCollection()
+const
 {
    MFEM_ABORT("this method is not implemented in this derived class!");
    return NULL;
@@ -408,7 +409,7 @@ FiniteElementCollection *FiniteElementCollection::New(const char *name)
    return fec;
 }
 
-FiniteElementCollection *FiniteElementCollection::Clone(int p) const
+const FiniteElementCollection *FiniteElementCollection::Clone(int p) const
 {
    // default implementation for collections that don't care about variable p
    MFEM_ABORT("Collection " << Name() << " does not support variable orders.");
@@ -2045,7 +2046,7 @@ const int *H1_FECollection::DofOrderForOrientation(Geometry::Type GeomType,
    return NULL;
 }
 
-FiniteElementCollection *H1_FECollection::GetTraceCollection() const
+const FiniteElementCollection *H1_FECollection::GetTraceCollection() const
 {
    int tr_p = H1_dof[Geometry::SEGMENT] + 1;
    int tr_dim = -1;
@@ -2672,7 +2673,7 @@ const int *RT_FECollection::DofOrderForOrientation(Geometry::Type GeomType,
    return NULL;
 }
 
-FiniteElementCollection *RT_FECollection::GetTraceCollection() const
+const FiniteElementCollection *RT_FECollection::GetTraceCollection() const
 {
    int tr_dim, tr_p;
    if (!strncmp(rt_name, "RT_", 3))
@@ -2961,7 +2962,7 @@ const int *ND_FECollection::DofOrderForOrientation(Geometry::Type GeomType,
    return NULL;
 }
 
-FiniteElementCollection *ND_FECollection::GetTraceCollection() const
+const FiniteElementCollection *ND_FECollection::GetTraceCollection() const
 {
    int tr_p, tr_dim, tr_cb_type, tr_ob_type;
 
@@ -3067,7 +3068,7 @@ const int *ND_R1D_FECollection::DofOrderForOrientation(Geometry::Type GeomType,
    return NULL;
 }
 
-FiniteElementCollection *ND_R1D_FECollection::GetTraceCollection() const
+const FiniteElementCollection *ND_R1D_FECollection::GetTraceCollection() const
 {
    return NULL;
 }
@@ -3136,7 +3137,7 @@ const int *RT_R1D_FECollection::DofOrderForOrientation(Geometry::Type GeomType,
    return NULL;
 }
 
-FiniteElementCollection *RT_R1D_FECollection::GetTraceCollection() const
+const FiniteElementCollection *RT_R1D_FECollection::GetTraceCollection() const
 {
    MFEM_ABORT("this method is not implemented in RT_R1D_FECollection!");
    return NULL;
@@ -3244,7 +3245,7 @@ const int *ND_R2D_FECollection::DofOrderForOrientation(Geometry::Type GeomType,
    return NULL;
 }
 
-FiniteElementCollection *ND_R2D_FECollection::GetTraceCollection() const
+const FiniteElementCollection *ND_R2D_FECollection::GetTraceCollection() const
 {
    int p, dim, cb_type, ob_type;
 
@@ -3411,7 +3412,7 @@ const int *RT_R2D_FECollection::DofOrderForOrientation(Geometry::Type GeomType,
    return NULL;
 }
 
-FiniteElementCollection *RT_R2D_FECollection::GetTraceCollection() const
+const FiniteElementCollection *RT_R2D_FECollection::GetTraceCollection() const
 {
    int dim, p;
    if (!strncmp(rt_name, "RT_R2D_", 7))
@@ -3561,7 +3562,7 @@ const int *NURBSFECollection::DofOrderForOrientation(Geometry::Type GeomType,
    return NULL;
 }
 
-FiniteElementCollection *NURBSFECollection::GetTraceCollection() const
+const FiniteElementCollection *NURBSFECollection::GetTraceCollection() const
 {
    MFEM_ABORT("NURBS finite elements can not be statically condensed!");
    return NULL;
@@ -3654,7 +3655,8 @@ const int *NURBS_HDivFECollection::DofOrderForOrientation(
    return NULL;
 }
 
-FiniteElementCollection *NURBS_HDivFECollection::GetTraceCollection() const
+const FiniteElementCollection *NURBS_HDivFECollection::GetTraceCollection()
+const
 {
    MFEM_ABORT("NURBS finite elements can not be statically condensed!");
    return NULL;
@@ -3747,7 +3749,8 @@ const int *NURBS_HCurlFECollection::DofOrderForOrientation(
    return NULL;
 }
 
-FiniteElementCollection *NURBS_HCurlFECollection::GetTraceCollection() const
+const FiniteElementCollection *NURBS_HCurlFECollection::GetTraceCollection()
+const
 {
    MFEM_ABORT("NURBS finite elements can not be statically condensed!");
    return NULL;

--- a/fem/fe_coll.hpp
+++ b/fem/fe_coll.hpp
@@ -100,7 +100,7 @@ public:
       return FiniteElementForGeometry(GeomType);
    }
 
-   virtual FiniteElementCollection *GetTraceCollection() const;
+   virtual const FiniteElementCollection *GetTraceCollection() const;
 
    virtual ~FiniteElementCollection();
 
@@ -244,7 +244,7 @@ public:
        used by some of the constructors of derived classes. Instead, this @a p
        represents the order of the new FE collection as it will be returned by
        its GetOrder() method. */
-   virtual FiniteElementCollection *Clone(int p) const;
+   virtual const FiniteElementCollection *Clone(int p) const;
 
 protected:
    const int base_p; ///< Order as returned by GetOrder().
@@ -254,7 +254,7 @@ protected:
 
    void InitVarOrder(int p) const;
 
-   mutable Array<FiniteElementCollection*> var_orders;
+   mutable Array<const FiniteElementCollection*> var_orders;
 
    /// How to treat errors in FiniteElementForGeometry() calls.
    enum ErrorMode
@@ -300,14 +300,14 @@ public:
 
    int GetBasisType() const { return b_type; }
 
-   FiniteElementCollection *GetTraceCollection() const override;
+   const FiniteElementCollection *GetTraceCollection() const override;
 
    /// Get the Cartesian to local H1 dof map
    const int *GetDofMap(Geometry::Type GeomType) const;
    /// Variable order version of GetDofMap
    const int *GetDofMap(Geometry::Type GeomType, int p) const;
 
-   FiniteElementCollection *Clone(int p) const override
+   const FiniteElementCollection *Clone(int p) const override
    { return new H1_FECollection(p, dim, b_type); }
 
    virtual ~H1_FECollection();
@@ -389,7 +389,7 @@ public:
 
    int GetBasisType() const { return b_type; }
 
-   FiniteElementCollection *Clone(int p) const override
+   const FiniteElementCollection *Clone(int p) const override
    { return new L2_FECollection(p, dim, b_type, m_type); }
 
    virtual ~L2_FECollection();
@@ -444,12 +444,12 @@ public:
 
    int GetContType() const override { return NORMAL; }
 
-   FiniteElementCollection *GetTraceCollection() const override;
+   const FiniteElementCollection *GetTraceCollection() const override;
 
    int GetClosedBasisType() const { return cb_type; }
    int GetOpenBasisType() const { return ob_type; }
 
-   FiniteElementCollection *Clone(int p) const override
+   const FiniteElementCollection *Clone(int p) const override
    { return new RT_FECollection(p, dim, cb_type, ob_type); }
 
    virtual ~RT_FECollection();
@@ -510,12 +510,12 @@ public:
 
    int GetContType() const override { return TANGENTIAL; }
 
-   FiniteElementCollection *GetTraceCollection() const override;
+   const FiniteElementCollection *GetTraceCollection() const override;
 
    int GetClosedBasisType() const { return cb_type; }
    int GetOpenBasisType() const { return ob_type; }
 
-   FiniteElementCollection *Clone(int p) const override
+   const FiniteElementCollection *Clone(int p) const override
    { return new ND_FECollection(p, dim, cb_type, ob_type); }
 
    virtual ~ND_FECollection();
@@ -559,7 +559,7 @@ public:
 
    int GetContType() const override { return TANGENTIAL; }
 
-   FiniteElementCollection *GetTraceCollection() const override;
+   const FiniteElementCollection *GetTraceCollection() const override;
 
    virtual ~ND_R1D_FECollection();
 };
@@ -591,7 +591,7 @@ public:
 
    int GetContType() const override { return NORMAL; }
 
-   FiniteElementCollection *GetTraceCollection() const override;
+   const FiniteElementCollection *GetTraceCollection() const override;
 
    virtual ~RT_R1D_FECollection();
 };
@@ -624,7 +624,7 @@ public:
 
    int GetContType() const override { return TANGENTIAL; }
 
-   FiniteElementCollection *GetTraceCollection() const override;
+   const FiniteElementCollection *GetTraceCollection() const override;
 
    virtual ~ND_R2D_FECollection();
 };
@@ -678,7 +678,7 @@ public:
 
    int GetContType() const override { return NORMAL; }
 
-   FiniteElementCollection *GetTraceCollection() const override;
+   const FiniteElementCollection *GetTraceCollection() const override;
 
    virtual ~RT_R2D_FECollection();
 };
@@ -748,7 +748,7 @@ public:
 
    int GetContType() const override { return CONTINUOUS; }
 
-   FiniteElementCollection *GetTraceCollection() const override;
+   const FiniteElementCollection *GetTraceCollection() const override;
 
    virtual ~NURBSFECollection();
 };
@@ -800,7 +800,7 @@ public:
 
    int GetContType() const override { return CONTINUOUS; }
 
-   FiniteElementCollection *GetTraceCollection() const override;
+   const FiniteElementCollection *GetTraceCollection() const override;
 
    virtual ~NURBS_HDivFECollection();
 };
@@ -851,7 +851,7 @@ public:
 
    int GetContType() const override { return CONTINUOUS; }
 
-   FiniteElementCollection *GetTraceCollection() const override;
+   const FiniteElementCollection *GetTraceCollection() const override;
 
    virtual ~NURBS_HCurlFECollection();
 };

--- a/fem/fespace.cpp
+++ b/fem/fespace.cpp
@@ -4491,7 +4491,8 @@ void FiniteElementSpace
    }
 }
 
-FiniteElementCollection *FiniteElementSpace::Load(Mesh *m, std::istream &input)
+const FiniteElementCollection *FiniteElementSpace::Load(Mesh *m,
+                                                        std::istream &input)
 {
    string buff;
    int fes_format = 0, ord;
@@ -4515,7 +4516,8 @@ FiniteElementCollection *FiniteElementSpace::Load(Mesh *m, std::istream &input)
    getline(input, buff, ' '); // 'Ordering:'
    input >> ord;
 
-   NURBSFECollection *nurbs_fec = dynamic_cast<NURBSFECollection*>(r_fec);
+   NURBSFECollection *nurbs_fec = dynamic_cast<NURBSFECollection*>
+                                  (r_fec);
    if (nurbs_fec) { nurbs_fec->SetDim(m->Dimension()); }
    NURBSExtension *nurbs_ext = NULL;
    if (fes_format == 90) // original format, v0.9

--- a/fem/fespace.hpp
+++ b/fem/fespace.hpp
@@ -1545,7 +1545,7 @@ public:
 
    /** @brief Read a FiniteElementSpace from a stream. The returned
        FiniteElementCollection is owned by the caller. */
-   FiniteElementCollection *Load(Mesh *m, std::istream &input);
+   const FiniteElementCollection *Load(Mesh *m, std::istream &input);
 
    virtual ~FiniteElementSpace();
 };

--- a/fem/fespacehierarchy.cpp
+++ b/fem/fespacehierarchy.cpp
@@ -83,7 +83,8 @@ void FiniteElementSpaceHierarchy::AddUniformlyRefinedLevel(int dim,
    AddLevel(mesh, fineFEspace, P, true, true, true);
 }
 
-void FiniteElementSpaceHierarchy::AddOrderRefinedLevel(FiniteElementCollection*
+void FiniteElementSpaceHierarchy::AddOrderRefinedLevel(const
+                                                       FiniteElementCollection*
                                                        fec, int dim,
                                                        int ordering)
 {
@@ -150,7 +151,7 @@ void ParFiniteElementSpaceHierarchy::AddUniformlyRefinedLevel(int dim,
 }
 
 void ParFiniteElementSpaceHierarchy::AddOrderRefinedLevel(
-   FiniteElementCollection* fec,
+   const FiniteElementCollection* fec,
    int dim, int ordering)
 {
    ParMesh* mesh = GetFinestFESpace().GetParMesh();

--- a/fem/fespacehierarchy.hpp
+++ b/fem/fespacehierarchy.hpp
@@ -67,7 +67,8 @@ public:
 
    /// @brief Adds one level to the hierarchy by using a different finite element
    /// order defined through FiniteElementCollection
-   virtual void AddOrderRefinedLevel(FiniteElementCollection* fec, int dim = 1,
+   virtual void AddOrderRefinedLevel(const FiniteElementCollection* fec,
+                                     int dim = 1,
                                      int ordering = Ordering::byVDIM);
 
    /// Returns the finite element space at the given level
@@ -107,7 +108,7 @@ public:
 
    /// @brief Adds one level to the hierarchy by using a different finite element
    /// order defined through FiniteElementCollection
-   void AddOrderRefinedLevel(FiniteElementCollection* fec, int dim = 1,
+   void AddOrderRefinedLevel(const FiniteElementCollection* fec, int dim = 1,
                              int ordering = Ordering::byVDIM) override;
 
    /// Returns the finite element space at the given level

--- a/fem/fmsconvert.cpp
+++ b/fem/fmsconvert.cpp
@@ -192,7 +192,7 @@ FmsFieldToGridFunction(FmsMesh fms_mesh, FmsField f, Mesh *mesh,
       // We could assemble a name based on fe_coll.hpp rules and pass to
       // FiniteElementCollection::New()
 
-      mfem::FiniteElementCollection *fec = nullptr;
+      const mfem::FiniteElementCollection *fec = nullptr;
       switch (f_field_type)
       {
          case FMS_DISCONTINUOUS:

--- a/fem/gridfunc.cpp
+++ b/fem/gridfunc.cpp
@@ -4008,7 +4008,7 @@ std::unique_ptr<GridFunction> GridFunction::ProlongateToMaxOrder() const
    int maxOrder = fes->GetMaxElementOrder();
 
    // Create a space of maximum order over all elements for output
-   FiniteElementCollection *fecMax = fesc->Clone(maxOrder);
+   const FiniteElementCollection *fecMax = fesc->Clone(maxOrder);
    FiniteElementSpace *fesMax = new FiniteElementSpace(mesh, fecMax, vdim,
                                                        fes->GetOrdering());
 
@@ -4551,7 +4551,7 @@ GridFunction *Extrude1DGridFunction(Mesh *mesh, Mesh *mesh2d,
 {
    GridFunction *sol2d;
 
-   FiniteElementCollection *solfec2d;
+   const FiniteElementCollection *solfec2d;
    const char *name = sol->FESpace()->FEColl()->Name();
    string cname = name;
    if (cname == "Linear")

--- a/fem/gridfunc.hpp
+++ b/fem/gridfunc.hpp
@@ -37,7 +37,7 @@ protected:
        set explicitly, see MakeOwner().
 
        If not NULL, this pointer is owned by the GridFunction. */
-   FiniteElementCollection *fec_owned;
+   const FiniteElementCollection *fec_owned;
 
    long fes_sequence; // see FiniteElementSpace::sequence, Mesh::sequence
 
@@ -119,9 +119,9 @@ public:
    /// Make the GridFunction the owner of #fec_owned and #fes.
    /** If the new FiniteElementCollection, @a fec_, is NULL, ownership of #fec_owned
        and #fes is taken away. */
-   void MakeOwner(FiniteElementCollection *fec_) { fec_owned = fec_; }
+   void MakeOwner(const FiniteElementCollection *fec_) { fec_owned = fec_; }
 
-   FiniteElementCollection *OwnFEC() { return fec_owned; }
+   const FiniteElementCollection *OwnFEC() { return fec_owned; }
 
    /// Shortcut for calling FiniteElementSpace::GetVectorDim() on the underlying #fes
    int VectorDim() const;

--- a/fem/gslib.hpp
+++ b/fem/gslib.hpp
@@ -76,7 +76,7 @@ protected:
    Array<IntegrationRule *> ir_split;
    Array<FiniteElementSpace *> fes_rst_map; //FESpaces to map Quad/Hex->Simplex
    Array<GridFunction *> gf_rst_map; // GridFunctions to map Quad/Hex->Simplex
-   FiniteElementCollection *fec_map_lin;
+   const FiniteElementCollection *fec_map_lin;
    void *fdataD;
    struct gslib::crystal *cr;             // gslib's internal data
    struct gslib::comm *gsl_comm;          // gslib's internal data

--- a/fem/lor/lor.hpp
+++ b/fem/lor/lor.hpp
@@ -65,7 +65,7 @@ protected:
    int ref_type;
    FiniteElementSpace &fes_ho;
    Mesh *mesh = nullptr;
-   FiniteElementCollection *fec = nullptr;
+   const FiniteElementCollection *fec = nullptr;
    FiniteElementSpace *fes = nullptr;
    BilinearForm *a = nullptr;
    class BatchedLORAssembly *batched_lor = nullptr;

--- a/fem/moonolith/pmortarassembler.cpp
+++ b/fem/moonolith/pmortarassembler.cpp
@@ -316,7 +316,7 @@ public:
    ~Spaces()
    {
       Mesh *m = nullptr;
-      FiniteElementCollection *fec = nullptr;
+      const FiniteElementCollection *fec = nullptr;
 
       for (int i = 0; i < spaces_.size(); ++i)
       {

--- a/fem/pgridfunc.cpp
+++ b/fem/pgridfunc.cpp
@@ -1307,7 +1307,7 @@ std::unique_ptr<ParGridFunction> ParGridFunction::ProlongateToMaxOrder() const
    const int maxOrder = pfes->GetMaxElementOrder();
 
    // Create a visualization space of max order for all elements
-   FiniteElementCollection *fecMax = pfesc->Clone(maxOrder);
+   const FiniteElementCollection *fecMax = pfesc->Clone(maxOrder);
    ParFiniteElementSpace *pfesMax = new ParFiniteElementSpace(mesh, fecMax, vdim,
                                                               pfes->GetOrdering());
 

--- a/fem/staticcond.hpp
+++ b/fem/staticcond.hpp
@@ -65,7 +65,7 @@ namespace mfem
 class StaticCondensation
 {
    FiniteElementSpace *fes, *tr_fes;
-   FiniteElementCollection *tr_fec;
+   const FiniteElementCollection *tr_fec;
    Table elem_pdof;           // Element to private dof
    int npdofs;                // Number of private dofs
    Array<int> rdof_edof;      // Map from reduced dofs to exposed dofs

--- a/mesh/mesh.cpp
+++ b/mesh/mesh.cpp
@@ -4423,7 +4423,7 @@ Mesh::Mesh(const Mesh &mesh, bool copy_nodes)
    {
       FiniteElementSpace *fes = mesh.Nodes->FESpace();
       const FiniteElementCollection *fec = fes->FEColl();
-      FiniteElementCollection *fec_copy =
+      const FiniteElementCollection *fec_copy =
          FiniteElementCollection::New(fec->Name());
       FiniteElementSpace *fes_copy =
          new FiniteElementSpace(*fes, this, fec_copy);

--- a/miniapps/dpg/acoustics.cpp
+++ b/miniapps/dpg/acoustics.cpp
@@ -171,25 +171,26 @@ int main(int argc, char *argv[])
    };
 
    // L2 space for p
-   FiniteElementCollection *p_fec = new L2_FECollection(order-1,dim);
+   const FiniteElementCollection *p_fec = new L2_FECollection(order-1,dim);
    FiniteElementSpace *p_fes = new FiniteElementSpace(&mesh,p_fec);
 
    // Vector L2 space for u
-   FiniteElementCollection *u_fec = new L2_FECollection(order-1,dim);
+   const FiniteElementCollection *u_fec = new L2_FECollection(order-1,dim);
    FiniteElementSpace *u_fes = new FiniteElementSpace(&mesh,u_fec, dim);
 
    // H^1/2 space for p̂
-   FiniteElementCollection * hatp_fec = new H1_Trace_FECollection(order,dim);
+   const FiniteElementCollection * hatp_fec = new H1_Trace_FECollection(order,dim);
    FiniteElementSpace *hatp_fes = new FiniteElementSpace(&mesh,hatp_fec);
 
    // H^-1/2 space for û
-   FiniteElementCollection * hatu_fec = new RT_Trace_FECollection(order-1,dim);
+   const FiniteElementCollection * hatu_fec = new RT_Trace_FECollection(order-1,
+                                                                        dim);
    FiniteElementSpace *hatu_fes = new FiniteElementSpace(&mesh,hatu_fec);
 
    // testspace fe collections
    int test_order = order+delta_order;
-   FiniteElementCollection * q_fec = new H1_FECollection(test_order, dim);
-   FiniteElementCollection * v_fec = new RT_FECollection(test_order-1, dim);
+   const FiniteElementCollection * q_fec = new H1_FECollection(test_order, dim);
+   const FiniteElementCollection * v_fec = new RT_FECollection(test_order-1, dim);
 
    // Coefficients
    ConstantCoefficient one(1.0);
@@ -202,7 +203,7 @@ int main(int argc, char *argv[])
    ConstantCoefficient negomeg(-omega);
 
    Array<FiniteElementSpace * > trial_fes;
-   Array<FiniteElementCollection * > test_fec;
+   Array<const FiniteElementCollection * > test_fec;
 
    trial_fes.Append(p_fes);
    trial_fes.Append(u_fes);

--- a/miniapps/dpg/convection-diffusion.cpp
+++ b/miniapps/dpg/convection-diffusion.cpp
@@ -170,25 +170,27 @@ int main(int argc, char *argv[])
       tau_space = 1
    };
    // L2 space for u
-   FiniteElementCollection *u_fec = new L2_FECollection(order-1,dim);
+   const FiniteElementCollection *u_fec = new L2_FECollection(order-1,dim);
    FiniteElementSpace *u_fes = new FiniteElementSpace(&mesh,u_fec);
 
    // Vector L2 space for σ
-   FiniteElementCollection *sigma_fec = new L2_FECollection(order-1,dim);
+   const FiniteElementCollection *sigma_fec = new L2_FECollection(order-1,dim);
    FiniteElementSpace *sigma_fes = new FiniteElementSpace(&mesh,sigma_fec, dim);
 
    // H^1/2 space for û
-   FiniteElementCollection * hatu_fec = new H1_Trace_FECollection(order,dim);
+   const FiniteElementCollection * hatu_fec = new H1_Trace_FECollection(order,dim);
    FiniteElementSpace *hatu_fes = new FiniteElementSpace(&mesh,hatu_fec);
 
    // H^-1/2 space for σ̂
-   FiniteElementCollection * hatf_fec = new RT_Trace_FECollection(order-1,dim);
+   const FiniteElementCollection * hatf_fec = new RT_Trace_FECollection(order-1,
+                                                                        dim);
    FiniteElementSpace *hatf_fes = new FiniteElementSpace(&mesh,hatf_fec);
 
    // testspace fe collections
    int test_order = order+delta_order;
-   FiniteElementCollection * v_fec = new H1_FECollection(test_order, dim);
-   FiniteElementCollection * tau_fec = new RT_FECollection(test_order-1, dim);
+   const FiniteElementCollection * v_fec = new H1_FECollection(test_order, dim);
+   const FiniteElementCollection * tau_fec = new RT_FECollection(test_order-1,
+                                                                 dim);
 
    // Coefficients
    ConstantCoefficient one(1.0);
@@ -207,7 +209,7 @@ int main(int argc, char *argv[])
    VectorConstantCoefficient negbetacoeff(negbeta);
 
    Array<FiniteElementSpace * > trial_fes;
-   Array<FiniteElementCollection * > test_fec;
+   Array<const FiniteElementCollection * > test_fec;
 
    trial_fes.Append(u_fes);
    trial_fes.Append(sigma_fes);
@@ -216,7 +218,7 @@ int main(int argc, char *argv[])
    test_fec.Append(v_fec);
    test_fec.Append(tau_fec);
 
-   FiniteElementCollection *coeff_fec = new L2_FECollection(0,dim);
+   const FiniteElementCollection *coeff_fec = new L2_FECollection(0,dim);
    FiniteElementSpace *coeff_fes = new FiniteElementSpace(&mesh,coeff_fec);
    GridFunction c1_gf, c2_gf;
    GridFunctionCoefficient c1_coeff(&c1_gf);

--- a/miniapps/dpg/diffusion.cpp
+++ b/miniapps/dpg/diffusion.cpp
@@ -147,28 +147,30 @@ int main(int argc, char *argv[])
       v_space   = 1
    };
    // L2 space for u
-   FiniteElementCollection *u_fec = new L2_FECollection(order-1,dim);
+   const FiniteElementCollection *u_fec = new L2_FECollection(order-1,dim);
    FiniteElementSpace *u_fes = new FiniteElementSpace(&mesh,u_fec);
 
    // Vector L2 space for σ
-   FiniteElementCollection *sigma_fec = new L2_FECollection(order-1,dim);
+   const FiniteElementCollection *sigma_fec = new L2_FECollection(order-1,dim);
    FiniteElementSpace *sigma_fes = new FiniteElementSpace(&mesh,sigma_fec, dim);
 
    // H^1/2 space for û
-   FiniteElementCollection * hatu_fec = new H1_Trace_FECollection(order,dim);
+   const FiniteElementCollection * hatu_fec = new H1_Trace_FECollection(order,dim);
    FiniteElementSpace *hatu_fes = new FiniteElementSpace(&mesh,hatu_fec);
 
    // H^-1/2 space for σ̂
-   FiniteElementCollection * hatsigma_fec = new RT_Trace_FECollection(order-1,dim);
+   const FiniteElementCollection * hatsigma_fec = new RT_Trace_FECollection(
+      order-1,dim);
    FiniteElementSpace *hatsigma_fes = new FiniteElementSpace(&mesh,hatsigma_fec);
 
    // test space fe collections
    int test_order = order+delta_order;
-   FiniteElementCollection * tau_fec = new RT_FECollection(test_order-1, dim);
-   FiniteElementCollection * v_fec = new H1_FECollection(test_order, dim);
+   const FiniteElementCollection * tau_fec = new RT_FECollection(test_order-1,
+                                                                 dim);
+   const FiniteElementCollection * v_fec = new H1_FECollection(test_order, dim);
 
    Array<FiniteElementSpace * > trial_fes;
-   Array<FiniteElementCollection * > test_fec;
+   Array<const FiniteElementCollection * > test_fec;
 
    trial_fes.Append(u_fes);
    trial_fes.Append(sigma_fes);

--- a/miniapps/dpg/maxwell.cpp
+++ b/miniapps/dpg/maxwell.cpp
@@ -188,17 +188,17 @@ int main(int argc, char *argv[])
       G_space = 1
    };
    // L2 space for E
-   FiniteElementCollection *E_fec = new L2_FECollection(order-1,dim);
+   const FiniteElementCollection *E_fec = new L2_FECollection(order-1,dim);
    FiniteElementSpace *E_fes = new FiniteElementSpace(&mesh,E_fec,dim);
 
    // Vector L2 space for H
-   FiniteElementCollection *H_fec = new L2_FECollection(order-1,dim);
+   const FiniteElementCollection *H_fec = new L2_FECollection(order-1,dim);
    FiniteElementSpace *H_fes = new FiniteElementSpace(&mesh,H_fec, dimc);
 
    // H^-1/2 (curl) space for Ê
-   FiniteElementCollection * hatE_fec = nullptr;
-   FiniteElementCollection * hatH_fec = nullptr;
-   FiniteElementCollection * F_fec = nullptr;
+   const FiniteElementCollection * hatE_fec = nullptr;
+   const FiniteElementCollection * hatH_fec = nullptr;
+   const FiniteElementCollection * F_fec = nullptr;
    if (dim == 3)
    {
       hatE_fec = new ND_Trace_FECollection(order,dim);
@@ -213,7 +213,7 @@ int main(int argc, char *argv[])
    }
    FiniteElementSpace *hatE_fes = new FiniteElementSpace(&mesh,hatE_fec);
    FiniteElementSpace *hatH_fes = new FiniteElementSpace(&mesh,hatH_fec);
-   FiniteElementCollection * G_fec = new ND_FECollection(test_order, dim);
+   const FiniteElementCollection * G_fec = new ND_FECollection(test_order, dim);
 
    // Coefficients
    ConstantCoefficient one(1.0);
@@ -232,7 +232,7 @@ int main(int argc, char *argv[])
    ScalarMatrixProductCoefficient negepsrot(negepsomeg,rot);
 
    Array<FiniteElementSpace * > trial_fes;
-   Array<FiniteElementCollection * > test_fec;
+   Array<const FiniteElementCollection * > test_fec;
 
    trial_fes.Append(E_fes);
    trial_fes.Append(H_fes);

--- a/miniapps/dpg/pacoustics.cpp
+++ b/miniapps/dpg/pacoustics.cpp
@@ -295,28 +295,29 @@ int main(int argc, char *argv[])
    };
 
    // L2 space for p
-   FiniteElementCollection *p_fec = new L2_FECollection(order-1,dim);
+   const FiniteElementCollection *p_fec = new L2_FECollection(order-1,dim);
    ParFiniteElementSpace *p_fes = new ParFiniteElementSpace(&pmesh,p_fec);
 
    // Vector L2 space for u
-   FiniteElementCollection *u_fec = new L2_FECollection(order-1,dim);
+   const FiniteElementCollection *u_fec = new L2_FECollection(order-1,dim);
    ParFiniteElementSpace *u_fes = new ParFiniteElementSpace(&pmesh,u_fec, dim);
 
    // H^1/2 space for p̂
-   FiniteElementCollection * hatp_fec = new H1_Trace_FECollection(order,dim);
+   const FiniteElementCollection * hatp_fec = new H1_Trace_FECollection(order,dim);
    ParFiniteElementSpace *hatp_fes = new ParFiniteElementSpace(&pmesh,hatp_fec);
 
    // H^-1/2 space for û
-   FiniteElementCollection * hatu_fec = new RT_Trace_FECollection(order-1,dim);
+   const FiniteElementCollection * hatu_fec = new RT_Trace_FECollection(order-1,
+                                                                        dim);
    ParFiniteElementSpace *hatu_fes = new ParFiniteElementSpace(&pmesh,hatu_fec);
 
    // testspace fe collections
    int test_order = order+delta_order;
-   FiniteElementCollection * q_fec = new H1_FECollection(test_order, dim);
-   FiniteElementCollection * v_fec = new RT_FECollection(test_order-1, dim);
+   const FiniteElementCollection * q_fec = new H1_FECollection(test_order, dim);
+   const FiniteElementCollection * v_fec = new RT_FECollection(test_order-1, dim);
 
    Array<ParFiniteElementSpace * > trial_fes;
-   Array<FiniteElementCollection * > test_fec;
+   Array<const FiniteElementCollection * > test_fec;
    trial_fes.Append(p_fes);
    trial_fes.Append(u_fes);
    trial_fes.Append(hatp_fes);

--- a/miniapps/dpg/pconvection-diffusion.cpp
+++ b/miniapps/dpg/pconvection-diffusion.cpp
@@ -226,26 +226,28 @@ int main(int argc, char *argv[])
       tau_space = 1
    };
    // L2 space for u
-   FiniteElementCollection *u_fec = new L2_FECollection(order-1,dim);
+   const FiniteElementCollection *u_fec = new L2_FECollection(order-1,dim);
    ParFiniteElementSpace *u_fes = new ParFiniteElementSpace(&pmesh,u_fec);
 
    // Vector L2 space for σ
-   FiniteElementCollection *sigma_fec = new L2_FECollection(order-1,dim);
+   const FiniteElementCollection *sigma_fec = new L2_FECollection(order-1,dim);
    ParFiniteElementSpace *sigma_fes = new ParFiniteElementSpace(&pmesh,sigma_fec,
                                                                 dim);
 
    // H^1/2 space for û
-   FiniteElementCollection * hatu_fec = new H1_Trace_FECollection(order,dim);
+   const FiniteElementCollection * hatu_fec = new H1_Trace_FECollection(order,dim);
    ParFiniteElementSpace *hatu_fes = new ParFiniteElementSpace(&pmesh,hatu_fec);
 
    // H^-1/2 space for σ̂
-   FiniteElementCollection * hatf_fec = new RT_Trace_FECollection(order-1,dim);
+   const FiniteElementCollection * hatf_fec = new RT_Trace_FECollection(order-1,
+                                                                        dim);
    ParFiniteElementSpace *hatf_fes = new ParFiniteElementSpace(&pmesh,hatf_fec);
 
    // testspace fe collections
    int test_order = order+delta_order;
-   FiniteElementCollection * v_fec = new H1_FECollection(test_order, dim);
-   FiniteElementCollection * tau_fec = new RT_FECollection(test_order-1, dim);
+   const FiniteElementCollection * v_fec = new H1_FECollection(test_order, dim);
+   const FiniteElementCollection * tau_fec = new RT_FECollection(test_order-1,
+                                                                 dim);
 
    // Coefficients
    ConstantCoefficient one(1.0);
@@ -262,7 +264,7 @@ int main(int argc, char *argv[])
 
    // Normal equation weak formulation
    Array<ParFiniteElementSpace * > trial_fes;
-   Array<FiniteElementCollection * > test_fec;
+   Array<const FiniteElementCollection * > test_fec;
 
    trial_fes.Append(u_fes);
    trial_fes.Append(sigma_fes);
@@ -299,7 +301,7 @@ int main(int argc, char *argv[])
                          TrialSpace::hatf_space, TestSpace::v_space);
 
 
-   FiniteElementCollection *coeff_fec = new L2_FECollection(0,dim);
+   const FiniteElementCollection *coeff_fec = new L2_FECollection(0,dim);
    ParFiniteElementSpace *coeff_fes = new ParFiniteElementSpace(&pmesh,coeff_fec);
    ParGridFunction c1_gf, c2_gf;
    GridFunctionCoefficient c1_coeff(&c1_gf);

--- a/miniapps/dpg/pdiffusion.cpp
+++ b/miniapps/dpg/pdiffusion.cpp
@@ -211,30 +211,32 @@ int main(int argc, char *argv[])
       v_space   = 1
    };
    // L2 space for u
-   FiniteElementCollection *u_fec = new L2_FECollection(order-1,dim);
+   const FiniteElementCollection *u_fec = new L2_FECollection(order-1,dim);
    ParFiniteElementSpace *u_fes = new ParFiniteElementSpace(&pmesh,u_fec);
 
    // Vector L2 space for σ
-   FiniteElementCollection *sigma_fec = new L2_FECollection(order-1,dim);
+   const FiniteElementCollection *sigma_fec = new L2_FECollection(order-1,dim);
    ParFiniteElementSpace *sigma_fes = new ParFiniteElementSpace(&pmesh,sigma_fec,
                                                                 dim);
 
    // H^1/2 space for û
-   FiniteElementCollection * hatu_fec = new H1_Trace_FECollection(order,dim);
+   const FiniteElementCollection * hatu_fec = new H1_Trace_FECollection(order,dim);
    ParFiniteElementSpace *hatu_fes = new ParFiniteElementSpace(&pmesh,hatu_fec);
 
    // H^-1/2 space for σ̂
-   FiniteElementCollection * hatsigma_fec = new RT_Trace_FECollection(order-1,dim);
+   const FiniteElementCollection * hatsigma_fec = new RT_Trace_FECollection(
+      order-1,dim);
    ParFiniteElementSpace *hatsigma_fes = new ParFiniteElementSpace(&pmesh,
                                                                    hatsigma_fec);
 
    // testspace fe collections
    int test_order = order+delta_order;
-   FiniteElementCollection * tau_fec = new RT_FECollection(test_order-1, dim);
-   FiniteElementCollection * v_fec = new H1_FECollection(test_order, dim);
+   const FiniteElementCollection * tau_fec = new RT_FECollection(test_order-1,
+                                                                 dim);
+   const FiniteElementCollection * v_fec = new H1_FECollection(test_order, dim);
 
    Array<ParFiniteElementSpace * > trial_fes;
-   Array<FiniteElementCollection * > test_fec;
+   Array<const FiniteElementCollection * > test_fec;
 
    trial_fes.Append(u_fes);
    trial_fes.Append(sigma_fes);

--- a/miniapps/dpg/pmaxwell.cpp
+++ b/miniapps/dpg/pmaxwell.cpp
@@ -346,17 +346,17 @@ int main(int argc, char *argv[])
       G_space = 1
    };
    // L2 space for E
-   FiniteElementCollection *E_fec = new L2_FECollection(order-1,dim);
+   const FiniteElementCollection *E_fec = new L2_FECollection(order-1,dim);
    ParFiniteElementSpace *E_fes = new ParFiniteElementSpace(&pmesh,E_fec,dim);
 
    // Vector L2 space for H
-   FiniteElementCollection *H_fec = new L2_FECollection(order-1,dim);
+   const FiniteElementCollection *H_fec = new L2_FECollection(order-1,dim);
    ParFiniteElementSpace *H_fes = new ParFiniteElementSpace(&pmesh,H_fec, dimc);
 
    // H^-1/2 (curl) space for Ê
-   FiniteElementCollection * hatE_fec = nullptr;
-   FiniteElementCollection * hatH_fec = nullptr;
-   FiniteElementCollection * F_fec = nullptr;
+   const FiniteElementCollection * hatE_fec = nullptr;
+   const FiniteElementCollection * hatH_fec = nullptr;
+   const FiniteElementCollection * F_fec = nullptr;
    int test_order = order+delta_order;
    if (dim == 3)
    {
@@ -372,10 +372,10 @@ int main(int argc, char *argv[])
    }
    ParFiniteElementSpace *hatE_fes = new ParFiniteElementSpace(&pmesh,hatE_fec);
    ParFiniteElementSpace *hatH_fes = new ParFiniteElementSpace(&pmesh,hatH_fec);
-   FiniteElementCollection * G_fec = new ND_FECollection(test_order, dim);
+   const FiniteElementCollection * G_fec = new ND_FECollection(test_order, dim);
 
    Array<ParFiniteElementSpace * > trial_fes;
-   Array<FiniteElementCollection * > test_fec;
+   Array<const FiniteElementCollection * > test_fec;
    trial_fes.Append(E_fes);
    trial_fes.Append(H_fes);
    trial_fes.Append(hatE_fes);

--- a/miniapps/dpg/util/complexweakform.hpp
+++ b/miniapps/dpg/util/complexweakform.hpp
@@ -58,7 +58,7 @@ protected:
    Array<int> IsTraceFes;
 
    /// Test FE Collections (Broken)
-   Array<FiniteElementCollection *> test_fecols;
+   Array<const FiniteElementCollection *> test_fecols;
    Array<int> test_fecols_vdims;
 
    /// Set of Trial Integrators to be applied for matrix B
@@ -112,7 +112,7 @@ public:
 
    /// Creates bilinear form associated with FE spaces @a fes_.
    ComplexDPGWeakForm(Array<FiniteElementSpace* > & fes_,
-                      Array<FiniteElementCollection *> & fecol_)
+                      Array<const FiniteElementCollection *> & fecol_)
    {
       SetSpaces(fes_,fecol_);
    }
@@ -123,7 +123,7 @@ public:
    }
 
    void SetSpaces(Array<FiniteElementSpace* > & fes_,
-                  Array<FiniteElementCollection *> & fecol_)
+                  Array<const FiniteElementCollection *> & fecol_)
    {
       trial_fes = fes_;
       test_fecols = fecol_;

--- a/miniapps/dpg/util/pcomplexweakform.hpp
+++ b/miniapps/dpg/util/pcomplexweakform.hpp
@@ -55,14 +55,14 @@ public:
 
    /// Creates bilinear form associated with FE spaces @a trial_pfes_.
    ParComplexDPGWeakForm(Array<ParFiniteElementSpace* > & trial_pfes_,
-                         Array<FiniteElementCollection* > & fecol_)
+                         Array<const FiniteElementCollection* > & fecol_)
       : ComplexDPGWeakForm()
    {
       SetParSpaces(trial_pfes_,fecol_);
    }
 
    void SetParSpaces(Array<ParFiniteElementSpace* > & trial_pfes_,
-                     Array<FiniteElementCollection* > & fecol_)
+                     Array<const FiniteElementCollection* > & fecol_)
    {
       trial_pfes = trial_pfes_;
       ess_tdofs.SetSize(trial_pfes.Size());

--- a/miniapps/dpg/util/pweakform.hpp
+++ b/miniapps/dpg/util/pweakform.hpp
@@ -54,14 +54,14 @@ public:
 
    /// Creates bilinear form associated with FE spaces @a trial_pfes_.
    ParDPGWeakForm(Array<ParFiniteElementSpace* > & trial_pfes_,
-                  Array<FiniteElementCollection* > & fecol_)
+                  Array<const FiniteElementCollection* > & fecol_)
       : DPGWeakForm()
    {
       SetParSpaces(trial_pfes_,fecol_);
    }
 
    void SetParSpaces(Array<ParFiniteElementSpace* > & trial_pfes_,
-                     Array<FiniteElementCollection* > & fecol_)
+                     Array<const FiniteElementCollection* > & fecol_)
    {
       trial_pfes = trial_pfes_;
       ess_tdofs.SetSize(trial_pfes.Size());

--- a/miniapps/dpg/util/weakform.hpp
+++ b/miniapps/dpg/util/weakform.hpp
@@ -63,7 +63,7 @@ protected:
    Array<int> IsTraceFes;
 
    /// Test FE Collections (Broken)
-   Array<FiniteElementCollection *> test_fecols;
+   Array<const FiniteElementCollection *> test_fecols;
    Array<int> test_fecols_vdims;
 
    /// Set of Trial Integrators to be applied for matrix B.
@@ -112,7 +112,7 @@ public:
 
    /// Creates bilinear form associated with FE spaces @a fes_.
    DPGWeakForm(Array<FiniteElementSpace* > & fes_,
-               Array<FiniteElementCollection *> & fecol_)
+               Array<const FiniteElementCollection *> & fecol_)
    {
       SetSpaces(fes_,fecol_);
    }
@@ -123,7 +123,7 @@ public:
    }
 
    void SetSpaces(Array<FiniteElementSpace* > & fes_,
-                  Array<FiniteElementCollection *> & fecol_)
+                  Array<const FiniteElementCollection *> & fecol_)
    {
       trial_fes = fes_;
       test_fecols = fecol_;

--- a/miniapps/gslib/field-interp.cpp
+++ b/miniapps/gslib/field-interp.cpp
@@ -132,7 +132,7 @@ int main (int argc, char *argv[])
         << mesh_2.GetNodes()->OwnFEC()->Name() << endl;
 
    int src_vdim = src_ncomp;
-   FiniteElementCollection *src_fec = NULL;
+   const FiniteElementCollection *src_fec = NULL;
    FiniteElementSpace *src_fes = NULL;
    GridFunction *func_source = NULL;
    if (src_fieldtype < 0) // use src_sltn_file
@@ -227,7 +227,7 @@ int main (int argc, char *argv[])
    if (fieldtype < 0) { fieldtype = src_fieldtype; }
 
    // Setup the FiniteElementSpace and GridFunction on the target mesh.
-   FiniteElementCollection *tar_fec = NULL;
+   const FiniteElementCollection *tar_fec = NULL;
    FiniteElementSpace *tar_fes = NULL;
 
    int tar_vdim = src_vdim;

--- a/miniapps/gslib/findpts.cpp
+++ b/miniapps/gslib/findpts.cpp
@@ -195,7 +195,7 @@ int main (int argc, char *argv[])
 
    MFEM_VERIFY(ncomp > 0, "Invalid number of components.");
    int vec_dim = ncomp;
-   FiniteElementCollection *fec = NULL;
+   const FiniteElementCollection *fec = NULL;
    if (fieldtype == 0)
    {
       fec = new H1_FECollection(order, dim);

--- a/miniapps/gslib/pfindpts.cpp
+++ b/miniapps/gslib/pfindpts.cpp
@@ -222,7 +222,7 @@ int main (int argc, char *argv[])
 
    MFEM_VERIFY(ncomp > 0, "Invalid number of components.");
    int vec_dim = ncomp;
-   FiniteElementCollection *fec = NULL;
+   const FiniteElementCollection *fec = NULL;
    if (fieldtype == 0)
    {
       fec = new H1_FECollection(order, dim);

--- a/miniapps/gslib/schwarz_ex1p.cpp
+++ b/miniapps/gslib/schwarz_ex1p.cpp
@@ -198,7 +198,7 @@ int main(int argc, char *argv[])
    // Define a finite element space on the mesh. Here we use continuous
    // Lagrange finite elements of the specified order. If order < 1, we
    // instead use an isoparametric/isogeometric space.
-   FiniteElementCollection *fec;
+   const FiniteElementCollection *fec;
    if (order > 0)
    {
       fec = new H1_FECollection(order, dim);

--- a/miniapps/meshing/hpref_serial.cpp
+++ b/miniapps/meshing/hpref_serial.cpp
@@ -1,12 +1,12 @@
 //                       Serial hp-refinement example
 //
-// Compile with: make hpref
+// Compile with: make hpref_serial
 //
-// Sample runs:  hpref -dim 2 -n 1000
-//               hpref -dim 3 -n 500
+// Sample runs:  hpref_serial -dim 2 -n 1000
+//               hpref_serial -dim 3 -n 500
 //
 // Description:  This example demonstrates h- and p-refinement in a serial
-//               finite element discretization of the Poisson problem (cf. ex1)
+//               finite element discretization of the Laplace problem (cf. ex1)
 //               -Delta u = 1 with homogeneous Dirichlet boundary conditions.
 //               Refinements are performed iteratively, each iteration having h-
 //               or p-refinements. For simplicity, we randomly choose the
@@ -14,7 +14,7 @@
 //               practice, these choices may be made in a problem-dependent way,
 //               but this example serves only to illustrate the capabilities of
 //               hp-refinement.
-//
+
 //               We recommend viewing Example 1 before viewing this example.
 
 #include "mfem.hpp"

--- a/miniapps/meshing/mesh-explorer.cpp
+++ b/miniapps/meshing/mesh-explorer.cpp
@@ -219,7 +219,7 @@ Mesh *skin_mesh(Mesh *mesh)
       const FiniteElementCollection *fec = fes->FEColl();
       if (dynamic_cast<const H1_FECollection*>(fec))
       {
-         FiniteElementCollection *fec_copy =
+         const FiniteElementCollection *fec_copy =
             FiniteElementCollection::New(fec->Name());
          FiniteElementSpace *fes_copy =
             new FiniteElementSpace(*fes, bmesh, fec_copy);
@@ -326,8 +326,8 @@ int main (int argc, char *argv[])
    int dim  = mesh->Dimension();
    int sdim = mesh->SpaceDimension();
 
-   FiniteElementCollection *bdr_attr_fec = NULL;
-   FiniteElementCollection *attr_fec;
+   const FiniteElementCollection *bdr_attr_fec = NULL;
+   const FiniteElementCollection *attr_fec;
    if (dim == 2)
    {
       attr_fec = new Const2DFECollection;
@@ -1261,7 +1261,7 @@ int main (int argc, char *argv[])
       {
          // Project and plot the function 'f'
          int p;
-         FiniteElementCollection *fec = NULL;
+         const FiniteElementCollection *fec = NULL;
          cout << "Enter projection space order: " << flush;
          cin >> p;
          if (p >= 1)

--- a/miniapps/meshing/mesh-optimizer.cpp
+++ b/miniapps/meshing/mesh-optimizer.cpp
@@ -348,7 +348,7 @@ int main(int argc, char *argv[])
    // also be used to represent the nodal positions of the mesh. We use a vector
    // FE space which is a tensor product of a scalar FE space. The number of
    // components in the vector finite element space matches the dimension.
-   FiniteElementCollection *fec;
+   const FiniteElementCollection *fec;
    if (mesh_poly_deg <= 0) { mesh_poly_deg = 2; }
    if (periodic)
    {

--- a/miniapps/meshing/phpref.cpp
+++ b/miniapps/meshing/phpref.cpp
@@ -118,7 +118,7 @@ int main(int argc, char *argv[])
    // 6. Define a parallel finite element space on the parallel mesh. Here we
    //    use continuous Lagrange finite elements of the specified order. If
    //    order < 1, we instead use an isoparametric/isogeometric space.
-   FiniteElementCollection *fec;
+   const FiniteElementCollection *fec;
    bool delete_fec;
    if (order > 0)
    {

--- a/miniapps/meshing/pmesh-fitting.cpp
+++ b/miniapps/meshing/pmesh-fitting.cpp
@@ -253,7 +253,7 @@ int main (int argc, char *argv[])
    // elements which are tensor products of quadratic finite elements. The
    // number of components in the vector finite element space is specified by
    // the last parameter of the FiniteElementSpace constructor.
-   FiniteElementCollection *fec;
+   const FiniteElementCollection *fec;
    if (mesh_poly_deg <= 0)
    {
       fec = new QuadraticPosFECollection;

--- a/miniapps/meshing/pmesh-optimizer.cpp
+++ b/miniapps/meshing/pmesh-optimizer.cpp
@@ -366,7 +366,7 @@ int main (int argc, char *argv[])
    // also be used to represent the nodal positions of the mesh. We use a vector
    // FE space which is a tensor product of a scalar FE space. The number of
    // components in the vector finite element space matches the dimension.
-   FiniteElementCollection *fec;
+   const FiniteElementCollection *fec;
    if (mesh_poly_deg <= 0) { mesh_poly_deg = 2; }
    if (periodic)
    {

--- a/miniapps/navier/navier_solver.hpp
+++ b/miniapps/navier/navier_solver.hpp
@@ -331,10 +331,10 @@ protected:
    IntegrationRules gll_rules;
 
    /// Velocity $H^1$ finite element collection.
-   FiniteElementCollection *vfec = nullptr;
+   const FiniteElementCollection *vfec = nullptr;
 
    /// Pressure $H^1$ finite element collection.
-   FiniteElementCollection *pfec = nullptr;
+   const FiniteElementCollection *pfec = nullptr;
 
    /// Velocity $(H^1)^d$ finite element space.
    ParFiniteElementSpace *vfes = nullptr;
@@ -466,7 +466,7 @@ protected:
    // Filter-based stabilization
    int filter_cutoff_modes = 1;
    real_t filter_alpha = 0.0;
-   FiniteElementCollection *vfec_filter = nullptr;
+   const FiniteElementCollection *vfec_filter = nullptr;
    ParFiniteElementSpace *vfes_filter = nullptr;
    ParGridFunction un_NM1_gf;
    ParGridFunction un_filtered_gf;

--- a/miniapps/nurbs/nurbs_ex1.cpp
+++ b/miniapps/nurbs/nurbs_ex1.cpp
@@ -239,7 +239,7 @@ int main(int argc, char *argv[])
    // 4. Define a finite element space on the mesh. Here we use continuous
    //    Lagrange finite elements of the specified order. If order < 1, we
    //    instead use an isoparametric/isogeometric space.
-   FiniteElementCollection *fec;
+   const FiniteElementCollection *fec;
    NURBSExtension *NURBSext = NULL;
    int own_fec = 0;
 

--- a/miniapps/nurbs/nurbs_ex11p.cpp
+++ b/miniapps/nurbs/nurbs_ex11p.cpp
@@ -147,7 +147,7 @@ int main(int argc, char *argv[])
    // 6. Define a parallel finite element space on the parallel mesh. Here we
    //    use continuous Lagrange finite elements of the specified order. If
    //    order < 1, we instead use an isoparametric/isogeometric space.
-   FiniteElementCollection *fec;
+   const FiniteElementCollection *fec;
    NURBSExtension *NURBSext = NULL;
    int own_fec = 0;
 

--- a/miniapps/nurbs/nurbs_ex1p.cpp
+++ b/miniapps/nurbs/nurbs_ex1p.cpp
@@ -246,7 +246,7 @@ int main(int argc, char *argv[])
    // 6. Define a parallel finite element space on the parallel mesh. Here we
    //    use continuous Lagrange finite elements of the specified order. If
    //    order < 1, we instead use an isoparametric/isogeometric space.
-   FiniteElementCollection *fec;
+   const FiniteElementCollection *fec;
    NURBSExtension *NURBSext = NULL;
    int own_fec = 0;
 

--- a/miniapps/nurbs/nurbs_ex24.cpp
+++ b/miniapps/nurbs/nurbs_ex24.cpp
@@ -130,8 +130,8 @@ int main(int argc, char *argv[])
 
    // 5. Define a finite element space on the mesh. Here we use Nedelec or
    //    Raviart-Thomas finite elements of the specified order.
-   FiniteElementCollection *trial_fec = nullptr;
-   FiniteElementCollection *test_fec = nullptr;
+   const FiniteElementCollection *trial_fec = nullptr;
+   const FiniteElementCollection *test_fec = nullptr;
    NURBSExtension *NURBSext = nullptr;
    if (mesh->NURBSext && NURBS)
    {

--- a/miniapps/nurbs/nurbs_ex3.cpp
+++ b/miniapps/nurbs/nurbs_ex3.cpp
@@ -110,7 +110,7 @@ int main(int argc, char *argv[])
 
    // 5. Define a finite element space on the mesh. Here we use the
    //    Raviart-Thomas finite elements of the specified order.
-   FiniteElementCollection *fec = nullptr;
+   const FiniteElementCollection *fec = nullptr;
    NURBSExtension *NURBSext = nullptr;
 
    if (mesh->NURBSext && NURBS)

--- a/miniapps/nurbs/nurbs_ex5.cpp
+++ b/miniapps/nurbs/nurbs_ex5.cpp
@@ -121,8 +121,8 @@ int main(int argc, char *argv[])
 
    // 5. Define a finite element space on the mesh. Here we use the
    //    Raviart-Thomas finite elements of the specified order.
-   FiniteElementCollection *hdiv_coll = nullptr;
-   FiniteElementCollection *l2_coll = nullptr;
+   const FiniteElementCollection *hdiv_coll = nullptr;
+   const FiniteElementCollection *l2_coll = nullptr;
    NURBSExtension *NURBSext = nullptr;
 
    if (mesh->NURBSext && !pa)

--- a/miniapps/nurbs/nurbs_patch_ex1.cpp
+++ b/miniapps/nurbs/nurbs_patch_ex1.cpp
@@ -105,7 +105,7 @@ int main(int argc, char *argv[])
    }
 
    // 5. Define an isoparametric/isogeometric finite element space on the mesh.
-   FiniteElementCollection *fec = nullptr;
+   const FiniteElementCollection *fec = nullptr;
    bool delete_fec;
    if (mesh.GetNodes())
    {

--- a/miniapps/nurbs/nurbs_solenoidal.cpp
+++ b/miniapps/nurbs/nurbs_solenoidal.cpp
@@ -152,8 +152,8 @@ int main(int argc, char *argv[])
 
    // 5. Define a finite element space on the mesh. Here we use the
    //    Raviart-Thomas finite elements of the specified order.
-   FiniteElementCollection *hdiv_coll = nullptr;
-   FiniteElementCollection *l2_coll = nullptr;
+   const FiniteElementCollection *hdiv_coll = nullptr;
+   const FiniteElementCollection *l2_coll = nullptr;
    NURBSExtension *NURBSext = nullptr;
 
    if (mesh->NURBSext&& NURBS)

--- a/miniapps/performance/ex1.cpp
+++ b/miniapps/performance/ex1.cpp
@@ -228,7 +228,7 @@ int ex1_t<dim>::run(Mesh *mesh, int ref_levels, int order, int basis,
    // 5. Define a finite element space on the mesh. Here we use continuous
    //    Lagrange finite elements of the specified order. If order < 1, we
    //    instead use an isoparametric/isogeometric space.
-   FiniteElementCollection *fec;
+   const FiniteElementCollection *fec;
    if (order > 0)
    {
       fec = new H1_FECollection(order, dim, basis);
@@ -249,7 +249,7 @@ int ex1_t<dim>::run(Mesh *mesh, int ref_levels, int order, int basis,
    // Create the LOR mesh and finite element space. In the settings of this
    // example, we can transfer between HO and LOR with the identity operator.
    Mesh mesh_lor;
-   FiniteElementCollection *fec_lor = NULL;
+   const FiniteElementCollection *fec_lor = NULL;
    FiniteElementSpace *fespace_lor = NULL;
    if (pc_choice == PCType::LOR)
    {

--- a/miniapps/performance/ex1p.cpp
+++ b/miniapps/performance/ex1p.cpp
@@ -292,7 +292,7 @@ int ex1_t<dim>::run(Mesh *mesh, int ser_ref_levels, int par_ref_levels,
    // 7. Define a parallel finite element space on the parallel mesh. Here we
    //    use continuous Lagrange finite elements of the specified order. If
    //    order < 1, we instead use an isoparametric/isogeometric space.
-   FiniteElementCollection *fec;
+   const FiniteElementCollection *fec;
    if (order > 0)
    {
       fec = new H1_FECollection(order, dim, basis);
@@ -317,7 +317,7 @@ int ex1_t<dim>::run(Mesh *mesh, int ser_ref_levels, int par_ref_levels,
    }
 
    ParMesh pmesh_lor;
-   FiniteElementCollection *fec_lor = NULL;
+   const FiniteElementCollection *fec_lor = NULL;
    ParFiniteElementSpace *fespace_lor = NULL;
    if (pc_choice == PCType::LOR)
    {

--- a/miniapps/tools/display-basis.cpp
+++ b/miniapps/tools/display-basis.cpp
@@ -733,7 +733,7 @@ update_basis(vector<socketstream*> & sock,  const VisWinLayout & vwl,
       mesh->Transform(defCoef);
    }
 
-   FiniteElementCollection * FEC = NULL;
+   const FiniteElementCollection * FEC = NULL;
    switch (bType)
    {
       case 'h':

--- a/miniapps/tools/lor-transfer.cpp
+++ b/miniapps/tools/lor-transfer.cpp
@@ -116,7 +116,7 @@ int main(int argc, char *argv[])
    Mesh mesh_lor = Mesh::MakeRefined(mesh, lref, basis_lor);
 
    // Create spaces
-   FiniteElementCollection *fec, *fec_lor;
+   const FiniteElementCollection *fec, *fec_lor;
    if (useH1)
    {
       space = "H1";

--- a/miniapps/tools/plor-transfer.cpp
+++ b/miniapps/tools/plor-transfer.cpp
@@ -129,7 +129,7 @@ int main(int argc, char *argv[])
    ParMesh mesh_lor = ParMesh::MakeRefined(mesh, lref, basis_lor);
 
    // Create spaces
-   FiniteElementCollection *fec, *fec_lor;
+   const FiniteElementCollection *fec, *fec_lor;
    if (useH1)
    {
       space = "H1";

--- a/miniapps/toys/automata.cpp
+++ b/miniapps/toys/automata.cpp
@@ -72,7 +72,7 @@ int main(int argc, char *argv[])
    // 3. Define a finite element space on the mesh. Here we use discontinuous
    //    Lagrange finite elements of order zero i.e. piecewise constant basis
    //    functions.
-   FiniteElementCollection *fec = new L2_FECollection(0, 2);
+   const FiniteElementCollection *fec = new L2_FECollection(0, 2);
    FiniteElementSpace *fespace = new FiniteElementSpace(&mesh, fec);
 
    // 4. Initialize a pair of bit arrays to store two rows in the evolution


### PR DESCRIPTION
Indicate in the types that `FiniteElementCollection` is not meant to be mutated.

CC: @mkovaxx 