### PR TITLE
Add error checks for projecting scalar coefficients onto a vector GridFunction

### DIFF
--- a/fem/gridfunc.cpp
+++ b/fem/gridfunc.cpp
@@ -2359,6 +2359,9 @@ void GridFunction::ProjectDeltaCoefficient(DeltaCoefficient &delta_coeff,
 
 void GridFunction::ProjectCoefficient(Coefficient &coeff)
 {
+   MFEM_VERIFY(
+      fes->GetVDim() == 1,
+      "Cannot project scalar DeltaCoefficient onto vector GridFunction");
    DeltaCoefficient *delta_c = dynamic_cast<DeltaCoefficient *>(&coeff);
    DofTransformation * doftrans = NULL;
 
@@ -2627,6 +2630,10 @@ void GridFunction::ProjectDiscCoefficient(Coefficient &coeff, AvgType type)
 {
    // Harmonic  (x1 ... xn) = [ (1/x1 + ... + 1/xn) / n ]^-1.
    // Arithmetic(x1 ... xn) = (x1 + ... + xn) / n.
+
+   MFEM_VERIFY(
+      fes->GetVDim() == 1,
+      "Cannot project a scalar coefficient onto a vector GridFunction");
 
    Array<int> zones_per_vdof;
    AccumulateAndCountZones(coeff, type, zones_per_vdof);

--- a/fem/pgridfunc.cpp
+++ b/fem/pgridfunc.cpp
@@ -566,6 +566,8 @@ void ParGridFunction::GetElementDofValues(int el, Vector &dof_vals) const
 
 void ParGridFunction::ProjectCoefficient(Coefficient &coeff)
 {
+   MFEM_VERIFY(fes->GetVDim() == 1,
+               "Cannot project scalar coefficient onto vector ParGridFunction");
    DeltaCoefficient *delta_c = dynamic_cast<DeltaCoefficient *>(&coeff);
 
    if (delta_c == NULL)
@@ -632,6 +634,9 @@ void ParGridFunction::ProjectDiscCoefficient(VectorCoefficient &coeff)
 
 void ParGridFunction::ProjectDiscCoefficient(Coefficient &coeff, AvgType type)
 {
+   MFEM_VERIFY(
+      fes->GetVDim() == 1,
+      "Cannot project scalar coefficient onto a vector ParGridFunction");
    // Harmonic  (x1 ... xn) = [ (1/x1 + ... + 1/xn) / n ]^-1.
    // Arithmetic(x1 ... xn) = (x1 + ... + xn) / n.
 


### PR DESCRIPTION
Doing this currently will result in uninitialized memory being read and used to set some components of the GridFunction.

These checks make finding bugs in user code easier.