### PR TITLE
Format the comments for better doxygen rendering and add more details

### DIFF
--- a/linalg/mma.hpp
+++ b/linalg/mma.hpp
@@ -25,12 +25,24 @@ namespace mfem
 // forward declaration
 class Vector;
 
-/** \brief MMA (Method of Moving Asymptotes) solves an optimization problem
- *         of the form:
+/** \brief MMA (Method of Moving Asymptotes) solves a nonlinear optimization problem
+ *         involving an objective function, inequality constraints, and
+ *         variable bounds.
  *
- *    Find       x that minimizes the objective function F(x),
- *    subject to C(x)_i <= 0,         for all i = 1, ... m
- *               x_lo <= x <= x_hi.
+ *  \details
+ *  This class finds \f${\bf x} \in R^n\f$ that solves the following nonlinear
+ *  program:
+ *   \f{eqnarray*}{
+ *    \min_{{\bf x} \in R^n} & & F({\bf x})\\
+ *     \textrm{subject to}&&C({\bf x})_i \leq 0,\quad \textrm{for all} i =
+ *      1,\ldots m\\
+ *   & & {\bf x}_{\textrm{lo}} \leq {\bf x} \leq {\bf x}_{\textrm{hi}}.
+ *   \f}
+ *   Here \f$F : R^n \to R\f$ is the objective function, and
+ *   \f$C : R^n \to R^m\f$ is a set of \f$m\f$ inequality constraints. By
+ *   convention, the routine seeks \f${\bf x}\f$ that minimizes the
+ *   objective function, \f$F\f$. Maximization problems should be
+ *   reformulated as a minimization of \f$-F\f$.
  *
  *    The objective functions are replaced by convex functions
  *    chosen based on gradient information, and solved using a dual method.
@@ -42,8 +54,9 @@ class Vector;
  *  construct the "moving asymptotes". The design variables, objective function,
  *  constraints are passed to an approximating subproblem. The design variables
  *  are updated and returned. Its implementation closely follows the original
- *  formulation of 'Svanberg, K. (2007). MMA and GCMMA-two methods
- *  for nonlinear optimization. vol, 1, 1-15.'
+ *  formulation of <a
+ *  href="https://people.kth.se/~krille/mmagcmma.pdf">'Svanberg,  K. (2007).
+ *  MMA and GCMMA-two methods for nonlinear optimization. vol, 1, 1-15.'</a>
  *
  *  When used in parallel, all Vectors are assumed to be true dof vectors,
  *  and the operators are expected to be defined for tdof vectors.
@@ -52,46 +65,160 @@ class Vector;
 class MMA
 {
 public:
-   /// Serial constructor:
-   /// nVar - number of design parameters;
-   /// nCon - number of constraints;
-   /// xval[nVar] - initial parameter values
+   /**
+    * \brief Serial constructor
+    * \param nVar   total number of design parameters
+    * \param nCon   number of inequality constraints (i.e., \f$C\f$)
+    * \param xval   initial values for design parameters (a pointer
+    *               to \p nVar doubles). Caller retains ownership of
+    *               this pointer/data.
+    * \param iterationNumber the starting iteration number
+    */
    MMA(int nVar, int nCon, real_t *xval, int iterationNumber = 0);
+
+   /**
+    * \brief Serial constructor
+    * \param nVar   total number of design parameters
+    * \param nCon   number of inequality constraints (i.e., \f$C\f$)
+    * \param xval   initial values for design parameters (size should
+    *               be \p nVar). Caller retains ownership of
+    *               this Vector.
+    * \param iterationNumber the starting iteration number
+    */
    MMA(const int nVar, int nCon, Vector & xval, int iterationNumber = 0);
 
 #ifdef MFEM_USE_MPI
-   /// Parallel constructor:
-   /// comm_ - communicator
+   /**
+    * \brief Parallel constructor
+    * \param comm_  the MPI communicator participating in the NLP solve
+    * \param nVar   number of design parameters on this MPI rank
+    * \param nCon   total number of inequality constraints (i.e., \f$C\f$).
+    *               Every MPI rank provides the same value here.
+    * \param xval   initial values for design parameters on this MPI rank
+    *               (a pointer to \p nVar doubles). Caller retains ownership
+    *               of this pointer/data.
+    * \param iterationNumber the starting iteration number. All MPI ranks
+    *               should pass in the same value here.
+    *
+    * \details
+    * Each MPI rank has a subset of the total design variable vector, and
+    * calls for that MPI rank always address its subset of the design
+    * variable vector and gradients with respect to its subset of the design
+    * variable vector.
+    *
+    * If you wanted to determine the global number of design variables, it
+    * would be determined as follows:
+    * \code{.cpp}
+    * int globalDesignVars;
+    * MPI_Allreduce(&nVar, &globalDesignVars, 1, MPI_INT, MPI_SUM, comm_);
+    * \endcode
+    */
    MMA(MPI_Comm comm_, int nVar, int nCon, real_t *xval,
        int iterationNumber = 0);
-   MMA(MPI_Comm comm_, const int & nVar, const int & nCon, const Vector & xval,
+   /**
+    * \brief Parallel constructor
+    * \param comm_  the MPI communicator participating in the NLP solve
+    * \param nVar   number of design parameters on this MPI rank
+    * \param nCon   total number of inequality constraints (i.e., \f$C\f$).
+    *               Every MPI rank provides the same value here.
+    * \param xval   initial values for design parameters (size should
+    *               be \p nVar). Caller retains ownership of
+    *               this Vector.
+    * \param iterationNumber the starting iteration number. All MPI ranks
+    *               should pass in the same value here.
+    *
+    * \details
+    * Each MPI rank has a subset of the total design variable vector, and
+    * calls for that MPI rank always address its subset of the design
+    * variable vector and gradients with respect to its subset of the design
+    * variable vector.
+    *
+    * If you wanted to determine the global number of design variables, it
+    * would be determined as follows:
+    * \code{.cpp}
+    * int globalDesignVars;
+    * MPI_Allreduce(&nVar, &globalDesignVars, 1, MPI_INT, MPI_SUM, comm_);
+    * \endcode
+    */
+   MMA(MPI_Comm comm_, const int nVar, const int nCon, const Vector & xval,
        int iterationNumber = 0);
 #endif
 
    /// Destructor
    ~MMA();
 
-   /// Update the optimization parameters
-   /// dfdx[nVar] - gradients of the objective
-   /// gx[nCon] - values of the constraints
-   /// dgdx[nCon*nVar] - gradients of the constraints ordered
-   ///                   constraint by constraint, e.g. {dg0dx0, dg0dx1, ... ,}
-   ///                                                  {dg1dx0, dg1dx1, ... ,}
-   /// xmin[nVar] - lower bounds
-   /// xmax[nVar] - upper bounds
-   /// xval[nVar] - input/output for optimization parameters
+   /**
+    * \brief Update the optimization parameters for a constrained
+    *        nonlinear program
+    * \param dfdx    vector of size nVar holding the gradients of the
+    *                objective function with respect to
+    *                the design variables,
+    *                \f$\frac{\partial F}{\partial {\bf x}_i}\f$
+    *                for each variable on this rank.
+    * \param gx      vector of size nCon holding the values of the
+    *                inequality constraints. Every MPI rank should
+    *                pass in the same values here.
+    * \param dgdx    vector of size \f$\textrm{nCon}\cdot\textrm{nVar}\f$
+    *                holding the gradients of the constraints in
+    *                row-major order. For example, {dg0dx0, dg0dx1, ...,}
+    *                {dg1dx0, dg1dx1, ..., }.
+    * \param xmin    vector of size nVar holding the lower bounds on
+    *                the design values
+    * \param xmax    vector of size nVar holding the upper bounds on
+    *                the design values
+    * \param xval    vector of size nVar. On entry, this holds the
+    *                value of the design variables where the objective,
+    *                constraints, and their gradients were evaluated.
+    *                On exit, this holds the result of the MMA iteration,
+    *                the next design variable value to use.
+    *
+    * \details
+    * The caller returns ownership of all Vectors passed into this method.
+    */
    void Update(const Vector& dfdx,
                const Vector& gx, const Vector& dgdx,
                const Vector& xmin, const Vector& xmax,
                Vector& xval);
-   /// Unconstrained
+
+   /**
+    * \brief Update the optimization parameters for an unconstrained
+    *        nonlinear program
+    * \param dfdx    vector of size nVar holding the gradients of the
+    *                objective function with respect to
+    *                the design variables,
+    *                \f$\frac{\partial F}{\partial {\bf x}_i}\f$
+    *                for each variable on this rank.
+    * \param xmin    vector of size nVar holding the lower bounds on
+    *                the design values
+    * \param xmax    vector of size nVar holding the upper bounds on
+    *                the design values
+    * \param xval    vector of size nVar. On entry, this holds the
+    *                value of the design variables where the objective,
+    *                constraints, and their gradients were evaluated.
+    *                On exit, this holds the result of the MMA iteration,
+    *                the next design variable value to use.
+    *
+    * \details
+    * The caller returns ownership of all Vectors passed into this method.
+    * This should be used when the number of inequality constraints is zero.
+    */
    void Update( const Vector& dfdx,
                 const Vector& xmin, const Vector& xmax,
                 Vector& xval);
 
+   /**
+    * \brief Change the iteration number
+    * \param iterationNumber    the new iteration number
+    */
    void SetIteration( int iterationNumber ) { iter = iterationNumber; };
-   int GetIteration() { return iter; };
 
+   /// Return the current iteration number
+   int GetIteration() const { return iter; };
+
+   /**
+    * \brief change the print level
+    * \param print_lvl    the new print level
+    */
    void SetPrintLevel(int print_lvl) { print_level = print_lvl; }
 
 protected:

--- a/linalg/mma.hpp
+++ b/linalg/mma.hpp
@@ -34,7 +34,7 @@ class Vector;
  *  program:
  *   \f{eqnarray*}{
  *    \min_{{\bf x} \in R^n} & & F({\bf x})\\
- *     \textrm{subject to}&&C({\bf x})_i \leq 0,\quad \textrm{for all} i =
+ *     \textrm{subject to}&&C({\bf x})_i \leq 0,\quad \textrm{for all}\quad i =
  *      1,\ldots m\\
  *   & & {\bf x}_{\textrm{lo}} \leq {\bf x} \leq {\bf x}_{\textrm{hi}}.
  *   \f}


### PR DESCRIPTION
Provide more details about the meaning of the parameters particularly in the MPI-parallel situation. Format the comments for better rendering in doxygen rather than plain text.

There are minor changes to the API; however, I believe any existing code should work unmodified.