### PR TITLE
Direct threadblock loops

### DIFF
--- a/fem/integ/bilininteg_diffusion_kernels.hpp
+++ b/fem/integ/bilininteg_diffusion_kernels.hpp
@@ -1051,11 +1051,11 @@ inline void SmemPADiffusionApply3D(const int NE,
       real_t (*QDD0)[MD1][MD1] = (real_t (*)[MD1][MD1]) (sm0+0);
       real_t (*QDD1)[MD1][MD1] = (real_t (*)[MD1][MD1]) (sm0+1);
       real_t (*QDD2)[MD1][MD1] = (real_t (*)[MD1][MD1]) (sm0+2);
-      MFEM_FOREACH_THREAD(dz,z,D1D)
+      MFEM_FOREACH_THREAD_DIRECT(dz,z,D1D)
       {
-         MFEM_FOREACH_THREAD(dy,y,D1D)
+         MFEM_FOREACH_THREAD_DIRECT(dy,y,D1D)
          {
-            MFEM_FOREACH_THREAD(dx,x,D1D)
+            MFEM_FOREACH_THREAD_DIRECT(dx,x,D1D)
             {
                X[dz][dy][dx] = x(dx,dy,dz,e);
             }
@@ -1063,9 +1063,9 @@ inline void SmemPADiffusionApply3D(const int NE,
       }
       if (MFEM_THREAD_ID(z) == 0)
       {
-         MFEM_FOREACH_THREAD(dy,y,D1D)
+         MFEM_FOREACH_THREAD_DIRECT(dy,y,D1D)
          {
-            MFEM_FOREACH_THREAD(qx,x,Q1D)
+            MFEM_FOREACH_THREAD_DIRECT(qx,x,Q1D)
             {
                B[qx][dy] = b(qx,dy);
                G[qx][dy] = g(qx,dy);
@@ -1073,11 +1073,11 @@ inline void SmemPADiffusionApply3D(const int NE,
          }
       }
       MFEM_SYNC_THREAD;
-      MFEM_FOREACH_THREAD(dz,z,D1D)
+      MFEM_FOREACH_THREAD_DIRECT(dz,z,D1D)
       {
-         MFEM_FOREACH_THREAD(dy,y,D1D)
+         MFEM_FOREACH_THREAD_DIRECT(dy,y,D1D)
          {
-            MFEM_FOREACH_THREAD(qx,x,Q1D)
+            MFEM_FOREACH_THREAD_DIRECT(qx,x,Q1D)
             {
                real_t u = 0.0, v = 0.0;
                MFEM_UNROLL(MD1)
@@ -1093,11 +1093,11 @@ inline void SmemPADiffusionApply3D(const int NE,
          }
       }
       MFEM_SYNC_THREAD;
-      MFEM_FOREACH_THREAD(dz,z,D1D)
+      MFEM_FOREACH_THREAD_DIRECT(dz,z,D1D)
       {
-         MFEM_FOREACH_THREAD(qy,y,Q1D)
+         MFEM_FOREACH_THREAD_DIRECT(qy,y,Q1D)
          {
-            MFEM_FOREACH_THREAD(qx,x,Q1D)
+            MFEM_FOREACH_THREAD_DIRECT(qx,x,Q1D)
             {
                real_t u = 0.0, v = 0.0, w = 0.0;
                MFEM_UNROLL(MD1)
@@ -1114,11 +1114,11 @@ inline void SmemPADiffusionApply3D(const int NE,
          }
       }
       MFEM_SYNC_THREAD;
-      MFEM_FOREACH_THREAD(qz,z,Q1D)
+      MFEM_FOREACH_THREAD_DIRECT(qz,z,Q1D)
       {
-         MFEM_FOREACH_THREAD(qy,y,Q1D)
+         MFEM_FOREACH_THREAD_DIRECT(qy,y,Q1D)
          {
-            MFEM_FOREACH_THREAD(qx,x,Q1D)
+            MFEM_FOREACH_THREAD_DIRECT(qx,x,Q1D)
             {
                real_t u = 0.0, v = 0.0, w = 0.0;
                MFEM_UNROLL(MD1)
@@ -1149,9 +1149,9 @@ inline void SmemPADiffusionApply3D(const int NE,
       MFEM_SYNC_THREAD;
       if (MFEM_THREAD_ID(z) == 0)
       {
-         MFEM_FOREACH_THREAD(dy,y,D1D)
+         MFEM_FOREACH_THREAD_DIRECT(dy,y,D1D)
          {
-            MFEM_FOREACH_THREAD(qx,x,Q1D)
+            MFEM_FOREACH_THREAD_DIRECT(qx,x,Q1D)
             {
                Bt[dy][qx] = b(qx,dy);
                Gt[dy][qx] = g(qx,dy);
@@ -1159,11 +1159,11 @@ inline void SmemPADiffusionApply3D(const int NE,
          }
       }
       MFEM_SYNC_THREAD;
-      MFEM_FOREACH_THREAD(qz,z,Q1D)
+      MFEM_FOREACH_THREAD_DIRECT(qz,z,Q1D)
       {
-         MFEM_FOREACH_THREAD(qy,y,Q1D)
+         MFEM_FOREACH_THREAD_DIRECT(qy,y,Q1D)
          {
-            MFEM_FOREACH_THREAD(dx,x,D1D)
+            MFEM_FOREACH_THREAD_DIRECT(dx,x,D1D)
             {
                real_t u = 0.0, v = 0.0, w = 0.0;
                MFEM_UNROLL(MQ1)
@@ -1180,11 +1180,11 @@ inline void SmemPADiffusionApply3D(const int NE,
          }
       }
       MFEM_SYNC_THREAD;
-      MFEM_FOREACH_THREAD(qz,z,Q1D)
+      MFEM_FOREACH_THREAD_DIRECT(qz,z,Q1D)
       {
-         MFEM_FOREACH_THREAD(dy,y,D1D)
+         MFEM_FOREACH_THREAD_DIRECT(dy,y,D1D)
          {
-            MFEM_FOREACH_THREAD(dx,x,D1D)
+            MFEM_FOREACH_THREAD_DIRECT(dx,x,D1D)
             {
                real_t u = 0.0, v = 0.0, w = 0.0;
                MFEM_UNROLL(Q1D)
@@ -1201,11 +1201,11 @@ inline void SmemPADiffusionApply3D(const int NE,
          }
       }
       MFEM_SYNC_THREAD;
-      MFEM_FOREACH_THREAD(dz,z,D1D)
+      MFEM_FOREACH_THREAD_DIRECT(dz,z,D1D)
       {
-         MFEM_FOREACH_THREAD(dy,y,D1D)
+         MFEM_FOREACH_THREAD_DIRECT(dy,y,D1D)
          {
-            MFEM_FOREACH_THREAD(dx,x,D1D)
+            MFEM_FOREACH_THREAD_DIRECT(dx,x,D1D)
             {
                real_t u = 0.0, v = 0.0, w = 0.0;
                MFEM_UNROLL(MQ1)

--- a/general/backends.hpp
+++ b/general/backends.hpp
@@ -62,6 +62,7 @@
 #define MFEM_THREAD_ID(k) 0
 #define MFEM_THREAD_SIZE(k) 1
 #define MFEM_FOREACH_THREAD(i,k,N) for(int i=0; i<N; i++)
+#define MFEM_FOREACH_THREAD_DIRECT(i,k,N) MFEM_FOREACH_THREAD(i,k,N)
 #endif
 
 // 'double' and 'float' atomicAdd implementation for previous versions of CUDA

--- a/general/cuda.hpp
+++ b/general/cuda.hpp
@@ -47,6 +47,13 @@
 #define MFEM_THREAD_ID(k) threadIdx.k
 #define MFEM_THREAD_SIZE(k) blockDim.k
 #define MFEM_FOREACH_THREAD(i,k,N) for(int i=threadIdx.k; i<N; i+=blockDim.k)
+#if __cplusplus >= 201703L
+#define MFEM_FOREACH_THREAD_DIRECT(i,k,N) \
+    if(const int i=threadIdx.k; i<N)
+#else
+#define MFEM_FOREACH_THREAD_DIRECT(i,k,N) MFEM_FOREACH_THREAD(i,k,N)
+#error "no c++17"
+#endif
 #endif
 
 namespace mfem

--- a/general/hip.hpp
+++ b/general/hip.hpp
@@ -48,6 +48,13 @@
 #define MFEM_THREAD_SIZE(k) hipBlockDim_ ##k
 #define MFEM_FOREACH_THREAD(i,k,N) \
     for(int i=hipThreadIdx_ ##k; i<N; i+=hipBlockDim_ ##k)
+#if __cplusplus >= 201703L
+#define MFEM_FOREACH_THREAD_DIRECT(i,k,N) \
+    if(const int i=hipThreadIdx_ ##k; i<N)
+#else
+#define MFEM_FOREACH_THREAD_DIRECT(i,k,N) MFEM_FOREACH_THREAD(i,k,N)
+#error "no c++17"
+#endif
 #endif
 
 namespace mfem


### PR DESCRIPTION
Adds `MFEM_FOREACH_THREAD_DIRECT` which uses a conditional instead of loop for faster GPU kernels when the thread loop bound is less-than-or-equal-to the corresponding block size; these are called direct threading policies in RAJA but I'm fine with a different name