### PR TITLE
Chain asan sigaction

### DIFF
--- a/general/mem_manager.cpp
+++ b/general/mem_manager.cpp
@@ -324,15 +324,17 @@ static void MmuError(int sig, siginfo_t *si, void* context)
    const void *ptr = si->si_addr;
    snprintf(str, buf_size, "Error while accessing address %p!", ptr);
    mfem::out << std::endl << "An illegal memory access was made!";
-   mfem::out << std::endl << "Caught signal " << sig << ", code " << si->si_code << " at " << ptr << std::endl;
+   mfem::out << std::endl << "Caught signal " << sig << ", code " << si->si_code <<
+             " at " << ptr << std::endl;
    // chain to previous handler
-   struct sigaction *old_action = (sig == SIGSEGV) ? &old_segv_action : &old_bus_action;
-   if(old_action->sa_flags & SA_SIGINFO && old_action->sa_sigaction)
+   struct sigaction *old_action = (sig == SIGSEGV) ? &old_segv_action :
+                                  &old_bus_action;
+   if (old_action->sa_flags & SA_SIGINFO && old_action->sa_sigaction)
    {
       // old action uses three argument handler.
       old_action->sa_sigaction(sig, si, context);
    }
-   else if(old_action->sa_handler == SIG_DFL)
+   else if (old_action->sa_handler == SIG_DFL)
    {
       // reinstall and raise the default handler.
       sigaction(sig, old_action, NULL);

--- a/general/mem_manager.cpp
+++ b/general/mem_manager.cpp
@@ -340,11 +340,7 @@ static void MmuError(int sig, siginfo_t *si, void* context)
       sigaction(sig, old_action, NULL);
       raise(sig);
    }
-   else
-   {
-      MFEM_ABORT(str);
-   }
-
+   MFEM_ABORT(str);
 }
 
 /// MMU initialization, setting SIGBUS & SIGSEGV signals to MmuError


### PR DESCRIPTION
Chain the mfem signal handlers so that previously installed signal handlers can still be called, like if asan is being used.

Includes the signal and code in the error message for illegal memory access. I didn't realize before that I was running into an access permission error specifically, which asan can't help much with, so this extra information can be helpful.

I tested this with and without asan on this MWE I posted in this #4825  

Without asan, it falls through to calling the original `MFEM_ABORT`.

With asan, there is a partial error message from mfem, and then it goes to the asan signal handler and prints the stack trace. It does not print the `MFEM_ABORT` stuff in that case, which I hope is ok.


