### PR TITLE
Add fallback for QuadratureFunction::ProjectGridFunction

### DIFF
--- a/fem/fespace.cpp
+++ b/fem/fespace.cpp
@@ -1582,6 +1582,11 @@ const FaceRestriction *FiniteElementSpace::GetFaceRestriction(
 const QuadratureInterpolator *FiniteElementSpace::GetQuadratureInterpolator(
    const IntegrationRule &ir) const
 {
+   if (!QuadratureInterpolator::SupportsFESpace(*this))
+   {
+      return nullptr;
+   }
+
    for (int i = 0; i < E2Q_array.Size(); i++)
    {
       const QuadratureInterpolator *qi = E2Q_array[i];
@@ -1596,6 +1601,11 @@ const QuadratureInterpolator *FiniteElementSpace::GetQuadratureInterpolator(
 const QuadratureInterpolator *FiniteElementSpace::GetQuadratureInterpolator(
    const QuadratureSpace &qs) const
 {
+   if (!QuadratureInterpolator::SupportsFESpace(*this))
+   {
+      return nullptr;
+   }
+
    for (int i = 0; i < E2Q_array.Size(); i++)
    {
       const QuadratureInterpolator *qi = E2Q_array[i];
@@ -1611,6 +1621,11 @@ const FaceQuadratureInterpolator
 *FiniteElementSpace::GetFaceQuadratureInterpolator(
    const IntegrationRule &ir, FaceType type) const
 {
+   if (!FaceQuadratureInterpolator::SupportsFESpace(*this))
+   {
+      return nullptr;
+   }
+
    if (type==FaceType::Interior)
    {
       for (int i = 0; i < E2IFQ_array.Size(); i++)

--- a/fem/fespace.hpp
+++ b/fem/fespace.hpp
@@ -794,7 +794,10 @@ public:
        @note The returned pointer is shared. A good practice, before using it,
        is to set all its properties to their expected values, as other parts of
        the code may also change them. That is, it's good to call
-       SetOutputLayout() and DisableTensorProducts() before interpolating. */
+       SetOutputLayout() and DisableTensorProducts() before interpolating.
+
+       @note If the space is not supported by QuadratureInterpolator, nullptr is
+       returned. */
    const QuadratureInterpolator *GetQuadratureInterpolator(
       const IntegrationRule &ir) const;
 
@@ -810,7 +813,10 @@ public:
        @note The returned pointer is shared. A good practice, before using it,
        is to set all its properties to their expected values, as other parts of
        the code may also change them. That is, it's good to call
-       SetOutputLayout() and DisableTensorProducts() before interpolating. */
+       SetOutputLayout() and DisableTensorProducts() before interpolating.
+
+       @note If the space is not supported by QuadratureInterpolator, nullptr is
+       returned. */
    const QuadratureInterpolator *GetQuadratureInterpolator(
       const QuadratureSpace &qs) const;
 
@@ -820,7 +826,10 @@ public:
        @note The returned pointer is shared. A good practice, before using it,
        is to set all its properties to their expected values, as other parts of
        the code may also change them. That is, it's good to call
-       SetOutputLayout() and DisableTensorProducts() before interpolating. */
+       SetOutputLayout() and DisableTensorProducts() before interpolating.
+
+       @note If the space is not supported by FaceQuadratureInterpolator,
+       nullptr is returned. */
    const FaceQuadratureInterpolator *GetFaceQuadratureInterpolator(
       const IntegrationRule &ir, FaceType type) const;
 

--- a/fem/qfunction.hpp
+++ b/fem/qfunction.hpp
@@ -27,6 +27,8 @@ protected:
    bool own_qspace; ///< Does this own the associated QuadratureSpaceBase?
    int vdim; ///< Vector dimension.
 
+   void ProjectGridFunctionFallback(const GridFunction &gf);
+
 public:
    /// Default constructor, results in an empty vector.
    QuadratureFunction() : qspace(nullptr), own_qspace(false), vdim(0)

--- a/fem/quadinterpolator.cpp
+++ b/fem/quadinterpolator.cpp
@@ -69,9 +69,7 @@ QuadratureInterpolator::QuadratureInterpolator(const FiniteElementSpace &fes,
 
    d_buffer.UseDevice(true);
    if (fespace->GetNE() == 0) { return; }
-   const FiniteElement *fe = fespace->GetTypicalFE();
-   MFEM_VERIFY(fe->GetMapType() == FiniteElement::MapType::VALUE ||
-               fe->GetMapType() == FiniteElement::MapType::H_DIV,
+   MFEM_VERIFY(SupportsFESpace(fes),
                "Only elements with MapType VALUE and H_DIV are supported!");
 }
 
@@ -86,10 +84,15 @@ QuadratureInterpolator::QuadratureInterpolator(const FiniteElementSpace &fes,
 {
    d_buffer.UseDevice(true);
    if (fespace->GetNE() == 0) { return; }
-   const FiniteElement *fe = fespace->GetTypicalFE();
-   MFEM_VERIFY(fe->GetMapType() == FiniteElement::MapType::VALUE ||
-               fe->GetMapType() == FiniteElement::MapType::H_DIV,
+   MFEM_VERIFY(SupportsFESpace(fes),
                "Only elements with MapType VALUE and H_DIV are supported!");
+}
+
+bool QuadratureInterpolator::SupportsFESpace(const FiniteElementSpace &fespace)
+{
+   const FiniteElement *fe = fespace.GetTypicalFE();
+   return fe->GetMapType() == FiniteElement::MapType::VALUE ||
+          fe->GetMapType() == FiniteElement::MapType::H_DIV;
 }
 
 namespace internal

--- a/fem/quadinterpolator.hpp
+++ b/fem/quadinterpolator.hpp
@@ -151,6 +151,9 @@ public:
    void MultTranspose(unsigned eval_flags, const Vector &q_val,
                       const Vector &q_der, Vector &e_vec) const;
 
+   /// @brief Returns true if the given finite element space is supported by
+   /// QuadratureInterpolator.
+   static bool SupportsFESpace(const FiniteElementSpace &fespace);
 
    using TensorEvalKernelType = void(*)(const int, const real_t *, const real_t *,
                                         real_t *, const int, const int, const int);

--- a/fem/quadinterpolator_face.cpp
+++ b/fem/quadinterpolator_face.cpp
@@ -77,17 +77,17 @@ FaceQuadratureInterpolator::FaceQuadratureInterpolator(
 
    if (fespace->GetNE() == 0) { return; }
    GetSigns(*fespace, type, signs);
-   const FiniteElement *fe = fespace->GetTypicalFE();
-   const ScalarFiniteElement *sfe =
-      dynamic_cast<const ScalarFiniteElement*>(fe);
-   const TensorBasisElement *tfe =
-      dynamic_cast<const TensorBasisElement*>(fe);
-   MFEM_VERIFY(sfe != NULL, "Only scalar finite elements are supported");
-   MFEM_VERIFY(tfe != NULL &&
-               (tfe->GetBasisType()==BasisType::GaussLobatto ||
-                tfe->GetBasisType()==BasisType::Positive),
-               "Only Gauss-Lobatto and Bernstein basis are supported in "
-               "FaceQuadratureInterpolator.");
+   MFEM_VERIFY(SupportsFESpace(fes), "Unsupported finite element space");
+}
+
+bool FaceQuadratureInterpolator::SupportsFESpace(const FiniteElementSpace &fes)
+{
+   const FiniteElement *fe = fes.GetTypicalFE();
+   const auto *sfe = dynamic_cast<const ScalarFiniteElement*>(fe);
+   const auto *tfe = dynamic_cast<const TensorBasisElement*>(fe);
+   return sfe != nullptr && tfe != nullptr && (
+             tfe->GetBasisType() == BasisType::GaussLobatto ||
+             tfe->GetBasisType() == BasisType::Positive);
 }
 
 template<const int T_VDIM, const int T_ND1D, const int T_NQ1D>

--- a/fem/quadinterpolator_face.hpp
+++ b/fem/quadinterpolator_face.hpp
@@ -64,6 +64,10 @@ public:
    FaceQuadratureInterpolator(const FiniteElementSpace &fes,
                               const IntegrationRule &ir, FaceType type);
 
+   /// @brief Returns true if the given finite element space is supported by
+   /// FaceQuadratureInterpolator.
+   static bool SupportsFESpace(const FiniteElementSpace &fes);
+
    /** @brief Disable the use of tensor product evaluations, for tensor-product
        elements, e.g. quads and hexes. */
    /** Currently, tensor product evaluations are not implemented and this method


### PR DESCRIPTION
This PR adds a slower fallback for QuadratureFunction::ProjectGridFunction that will be used when QuadratureInterpolator is not supported for the finite element space.

FiniteElementSpace::GetQuadratureInterpolator and FiniteElementSpace::GetFaceQuadratureInterpolator now may return nullptr if the space isn't supported by QuadratureInterpolator.

Some discussion about the implications of this design might be useful.