### PR TITLE
Batched LOR & Markers filtering

### DIFF
--- a/fem/lor/lor.cpp
+++ b/fem/lor/lor.cpp
@@ -48,7 +48,7 @@ void LORBase::AddIntegratorsAndMarkers(BilinearForm &a_from,
    for (int i=0; i<integrators->Size(); ++i)
    {
       BilinearFormIntegrator *integrator = (*integrators)[i];
-      if (*markers[i])
+      if (markers[i] && (*markers[i]))
       {
          (a_to.*add_integrator_marker)(integrator, *markers[i]);
       }

--- a/fem/lor/lor_batched.cpp
+++ b/fem/lor/lor_batched.cpp
@@ -58,7 +58,7 @@ bool BatchedLORAssembly::FormIsSupported(BilinearForm &a)
    // Batched LOR requires all elements to be similar
    const auto *mesh = fes->GetMesh();
    if (fes->IsVariableOrder() || mesh->Nonconforming() ||
-       mesh->GetNumGeometries(mesh->Dimension())) { return false; }
+       mesh->GetNumGeometries(mesh->Dimension()) > 1) { return false; }
 
    if (dynamic_cast<const H1_FECollection*>(fec))
    {

--- a/fem/lor/lor_batched.cpp
+++ b/fem/lor/lor_batched.cpp
@@ -48,11 +48,17 @@ bool HasIntegrators(BilinearForm &a)
 
 bool BatchedLORAssembly::FormIsSupported(BilinearForm &a)
 {
-   const FiniteElementCollection *fec = a.FESpace()->FEColl();
+   const FiniteElementSpace *fes = a.FESpace();
+   const FiniteElementCollection *fec = fes->FEColl();
    // TODO: check for maximum supported orders
 
    // Batched LOR requires all tensor elements
    if (!UsesTensorBasis(*a.FESpace())) { return false; }
+
+   // Batched LOR requires all elements to be similar
+   const auto *mesh = fes->GetMesh();
+   if (fes->IsVariableOrder() || mesh->Nonconforming() ||
+       mesh->GetNumGeometries(mesh->Dimension())) { return false; }
 
    if (dynamic_cast<const H1_FECollection*>(fec))
    {

--- a/miniapps/solvers/CMakeLists.txt
+++ b/miniapps/solvers/CMakeLists.txt
@@ -76,5 +76,7 @@ add_mfem_miniapp(lor_solvers
   LIBRARIES mfem)
 
 if (MFEM_ENABLE_TESTING)
-  add_test(NAME lor_solvers_ser COMMAND lor_solvers -fe n -no-vis)
+  add_test(NAME lor_solvers_nd_ser COMMAND lor_solvers -fe n -no-vis)
+  add_test(NAME lor_solvers_l2_ser COMMAND lor_solvers -fe l -no-vis)
+  add_test(NAME lor_solvers_h1_amr_ser COMMAND lor_solvers -fe h -m ../../data/amr-quad.mesh -no-vis)
 endif()


### PR DESCRIPTION
Adds filtering for Batched LOR Assembly and a `markers` test in `AddIntegratorsAndMarkers`, which enables all `lor_solvers` tests to pass:
 - `lor_solvers -m ../../data/amr-quad.mesh -fe [h,n,r]`
 - `lor_solvers -fe l`