### PR TITLE
Add `Ordering::Reorder`

### DIFF
--- a/fem/fespace.cpp
+++ b/fem/fespace.cpp
@@ -55,6 +55,35 @@ DofsToVDofs<Ordering::byVDIM>(int ndofs, int vdim, Array<int> &dofs)
    }
 }
 
+void Ordering::Reorder(Vector &v, int vdim, Ordering::Type in_ord,
+                       Ordering::Type out_ord)
+{
+   if (in_ord == out_ord)
+   {
+      return;
+   }
+
+   int nvdofs = v.Size();
+   int nldofs = nvdofs/vdim;
+
+   if (out_ord == Ordering::byNODES) // byVDIM -> byNODES
+   {
+      Vector temp = v;
+      for (int i = 0; i < nvdofs; i++)
+      {
+         v[i] = temp[Map<byVDIM>(nldofs,vdim,i%nldofs,i/nldofs)];
+      }
+   }
+   else // byNODES -> byVDIM
+   {
+      Vector temp = v;
+      for (int i = 0; i < nvdofs; i++)
+      {
+         v[i] = temp[Map<byNODES>(nldofs,vdim,i/vdim,i%vdim)];
+      }
+   }
+}
+
 
 FiniteElementSpace::FiniteElementSpace()
    : mesh(NULL), fec(NULL), vdim(0), ordering(Ordering::byNODES),

--- a/fem/fespace.hpp
+++ b/fem/fespace.hpp
@@ -45,6 +45,9 @@ public:
 
    template <Type Ord>
    static void DofsToVDofs(int ndofs, int vdim, Array<int> &dofs);
+
+   /// Reorder Vector \p v from its current ordering \p in_ord to \p out_ord
+   static void Reorder(Vector &v, int vdim, Type in_ord, Type out_ord);
 };
 
 /// @brief Type describing possible layouts for Q-vectors.

--- a/fem/fespace.hpp
+++ b/fem/fespace.hpp
@@ -40,6 +40,7 @@ public:
                     as: XYZ,XYZ,XYZ,... */
    };
 
+   /// Map ldof \p dof to vdof component \p vd for \p ndof total ldofs
    template <Type Ord>
    static inline int Map(int ndofs, int vdim, int dof, int vd);
 

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -108,6 +108,7 @@ set(UNIT_TESTS_SRCS
   fem/test_lor_batched.cpp
   fem/test_nonlinearform.cpp
   fem/test_operatorjacobismoother.cpp
+  fem/test_ordering.cpp
   fem/test_oscillation.cpp
   fem/test_pa_coeff.cpp
   fem/test_pa_grad.cpp

--- a/tests/unit/fem/test_ordering.cpp
+++ b/tests/unit/fem/test_ordering.cpp
@@ -1,0 +1,36 @@
+// Copyright (c) 2010-2025, Lawrence Livermore National Security, LLC. Produced
+// at the Lawrence Livermore National Laboratory. All Rights reserved. See files
+// LICENSE and NOTICE for details. LLNL-CODE-806117.
+//
+// This file is part of the MFEM library. For more information and source code
+// availability visit https://mfem.org.
+//
+// MFEM is free software; you can redistribute it and/or modify it under the
+// terms of the BSD-3 license. We welcome feedback and contributions, see file
+// CONTRIBUTING.md for details.
+
+#include "mfem.hpp"
+#include "unit_tests.hpp"
+
+using namespace mfem;
+
+TEST_CASE("Reordering Vector (byVDIM/byNODES)",
+          "[Ordering]")
+{
+   const Vector x_byNODES({1.0, 2.0, 3.0, 4.0, 5.0, 6.0});
+   const Vector x_byVDIM ({1.0, 3.0, 5.0, 2.0, 4.0, 6.0});
+   SECTION("byNODES -> byVDIM")
+   {
+      Vector x_test = x_byNODES;
+
+      Ordering::Reorder(x_test, 3, Ordering::byNODES, Ordering::byVDIM);
+      REQUIRE(x_test.DistanceTo(x_byVDIM) == MFEM_Approx(0));
+   }
+
+   SECTION("byVDIM -> byNODES")
+   {
+      Vector x_test = x_byVDIM;
+      Ordering::Reorder(x_test, 3, Ordering::byVDIM, Ordering::byNODES);
+      REQUIRE(x_test.DistanceTo(x_byNODES) == MFEM_Approx(0));
+   }
+};


### PR DESCRIPTION
This PR adds a function to `Ordering` that reorders any given `Vector` from its existing ordering to a different one. There are multiple different places where this kind of functionality is re-written in MFEM repetitively, like `GridFunction::ReorderByNodes` and `FindPointsGSLIB::InterpolateH1`, in addition to users having to currently manually write their own versions of this if they want to reorganize vector data. A unit test is included as well - please let me know if I should move it to an existing file or if it is OK as is in a new one.

A description was also added to Ordering::Map.

I can also go through and try to convert any existing reorderings in MFEM to use this function instead as well in this PR, just let me know!
