### PR TITLE
Initialize `KnotVector::coarse`

### DIFF
--- a/mesh/nurbs.hpp
+++ b/mesh/nurbs.hpp
@@ -202,7 +202,7 @@ public:
 
    /** Flag to indicate whether the KnotVector has been coarsened, which means
        it is ready for non-nested refinement. */
-   bool coarse;
+   bool coarse = false;
 };
 
 


### PR DESCRIPTION
`KnotVector::coarse` is not initialized during construction which is causing undefined behavior [here](https://github.com/mfem/mfem/blob/master/mesh/nurbs.cpp#L97) because a non-valid value for bool is being assigned to another bool.