### PR TITLE
Move move operators

### DIFF
--- a/general/array.hpp
+++ b/general/array.hpp
@@ -102,18 +102,21 @@ public:
                 std::is_convertible<CT,T>::value,bool>::type = true>
    explicit inline Array(std::initializer_list<CT> values);
 
-   /// Move constructor ("steals" data from 'src')
-   inline Array(Array<T> &&src) : Array() { Swap(src, *this); }
+   /// Move constructor ("steals" data from @a src)
+   inline Array(Array<T> &&src) : Array() { *this = std::move(src); }
 
    /// Destructor
    inline ~Array() { data.Delete(); }
 
-   /// Assignment operator: deep copy from 'src'.
+   /// Copy assignment operator: deep copy from @a src.
    Array<T> &operator=(const Array<T> &src) { src.Copy(*this); return *this; }
 
-   /// Assignment operator (deep copy) from @a src, an Array of convertible type.
+   /// Copy assignment operator (deep copy) from @a src, an Array of convertible type.
    template <typename CT>
    inline Array &operator=(const Array<CT> &src);
+
+   /// Move assignment operator: "steal" from @a src.
+   Array<T> &operator=(Array<T> &&src) { Swap(src, *this); return *this; }
 
    /// Return the data as 'T *'
    inline operator T *() { return data; }

--- a/linalg/densemat.cpp
+++ b/linalg/densemat.cpp
@@ -52,6 +52,11 @@ DenseMatrix::DenseMatrix(const DenseMatrix &m) : Matrix(m.height, m.width)
    }
 }
 
+DenseMatrix::DenseMatrix(DenseMatrix &&m)
+{
+   *this = std::move(m);
+}
+
 DenseMatrix::DenseMatrix(int s) : Matrix(s)
 {
    MFEM_ASSERT(s >= 0, "invalid DenseMatrix size: " << s);
@@ -653,6 +658,12 @@ DenseMatrix &DenseMatrix::operator=(const DenseMatrix &m)
       data[i] = m.data[i];
    }
 
+   return *this;
+}
+
+DenseMatrix &DenseMatrix::operator=(DenseMatrix &&m)
+{
+   Swap(*this, m);
    return *this;
 }
 
@@ -4392,6 +4403,12 @@ DenseTensor &DenseTensor::operator=(const DenseTensor &other)
 {
    DenseTensor new_tensor(other);
    Swap(new_tensor);
+   return *this;
+}
+
+DenseTensor &DenseTensor::operator=(DenseTensor &&other)
+{
+   Swap(other);
    return *this;
 }
 

--- a/linalg/densemat.hpp
+++ b/linalg/densemat.hpp
@@ -43,6 +43,9 @@ public:
    /// Copy constructor
    DenseMatrix(const DenseMatrix &);
 
+   /// Move constructor
+   DenseMatrix(DenseMatrix &&);
+
    /// Creates square matrix of size s.
    explicit DenseMatrix(int s);
 
@@ -249,8 +252,11 @@ public:
    /// Copy the matrix entries from the given array
    DenseMatrix &operator=(const real_t *d);
 
-   /// Sets the matrix size and elements equal to those of m
+   /// Copy assignment operator: sets the matrix size and elements equal to those of @a m
    DenseMatrix &operator=(const DenseMatrix &m);
+
+   /// Move assignment operator: "steals" data from @a m
+   DenseMatrix &operator=(const DenseMatrix &&m);
 
    DenseMatrix &operator+=(const real_t *m);
    DenseMatrix &operator+=(const DenseMatrix &m);
@@ -1160,6 +1166,12 @@ public:
       }
    }
 
+   /// Move constructor: "steals" data from @a other
+   DenseTensor(DenseTensor &&other)
+   {
+      *this = std::move(other);
+   }
+
    int SizeI() const { return Mk.Height(); }
    int SizeJ() const { return Mk.Width(); }
    int SizeK() const { return nk; }
@@ -1213,6 +1225,9 @@ public:
 
    /// Copy assignment operator (performs a deep copy)
    DenseTensor &operator=(const DenseTensor &other);
+
+   /// Move assignment operator ("steals" data from @a other)
+   DenseTensor &operator=(DenseTensor &&other);
 
    DenseMatrix &operator()(int k)
    {


### PR DESCRIPTION
Adds move operators for `DenseMatrix` and `DenseTensor` and finishes `Array`'s implementation