### PR TITLE
GlobalVector bug fix

### DIFF
--- a/linalg/hypre.cpp
+++ b/linalg/hypre.cpp
@@ -317,7 +317,7 @@ void HypreParVector::WrapHypreParVector(hypre_ParVector *y, bool owner)
 
 Vector * HypreParVector::GlobalVector() const
 {
-   MFEM_ASSERT(size > 0,
+   MFEM_VERIFY(size > 0,
                "GlobalVector method can only be called on vectors wherein each process owns one or more elements");
    hypre_Vector *hv = hypre_ParVectorToVectorAll(*this);
    Vector *v = new Vector(hv->data, internal::to_int(hv->size));

--- a/linalg/hypre.cpp
+++ b/linalg/hypre.cpp
@@ -317,6 +317,8 @@ void HypreParVector::WrapHypreParVector(hypre_ParVector *y, bool owner)
 
 Vector * HypreParVector::GlobalVector() const
 {
+   MFEM_ASSERT(size > 0, "GlobalVector method cannot be called on a vector that has one or more processes that don't own any
+		  elements of the global vector");
    hypre_Vector *hv = hypre_ParVectorToVectorAll(*this);
    Vector *v = new Vector(hv->data, internal::to_int(hv->size));
    v->MakeDataOwner();

--- a/linalg/hypre.cpp
+++ b/linalg/hypre.cpp
@@ -317,8 +317,8 @@ void HypreParVector::WrapHypreParVector(hypre_ParVector *y, bool owner)
 
 Vector * HypreParVector::GlobalVector() const
 {
-   MFEM_ASSERT(size > 0, "GlobalVector method cannot be called on a vector that has one or more processes that don't own any
-		  elements of the global vector");
+   MFEM_ASSERT(size > 0,
+               "GlobalVector method can only be called on vectors wherein each process owns one or more elements");
    hypre_Vector *hv = hypre_ParVectorToVectorAll(*this);
    Vector *v = new Vector(hv->data, internal::to_int(hv->size));
    v->MakeDataOwner();


### PR DESCRIPTION
The local `size` of the `HypreParVector` is checked in the `HypreParVector::GlobalVector` method. If one or more processes has size equal to 0 then `hv` as given by `hypre_ParVectorToVectorAll` is a null pointer and `hv->data` and `hv->size` then lead to seg faults.

This PR attempts to address the issue raised in #4940. 