### PR TITLE
Add vector and matrix component coefficient

### DIFF
--- a/fem/coefficient.cpp
+++ b/fem/coefficient.cpp
@@ -1131,6 +1131,73 @@ real_t TraceCoefficient::Eval(ElementTransformation &T,
    return ma.Trace();
 }
 
+VectorComponentCoefficient::VectorComponentCoefficient(VectorCoefficient &A,
+                                                       int I)
+   : a(&A), va(A.GetVDim())
+{
+   SetIndex(I);
+}
+
+void VectorComponentCoefficient::SetIndex(int I)
+{
+   MFEM_ASSERT(I < a->GetVDim() && I >= 0,
+               "VectorComponentCoefficient:  "
+               "Index not in range.");
+
+   i = I;
+}
+
+void VectorComponentCoefficient::SetTime(real_t t)
+{
+   if (a) { a->SetTime(t); }
+   this->Coefficient::SetTime(t);
+}
+
+real_t VectorComponentCoefficient::Eval(ElementTransformation &T,
+                                        const IntegrationPoint &ip)
+{
+   a->Eval(va, T, ip);
+   return va[i];
+}
+
+MatrixComponentCoefficient::MatrixComponentCoefficient(MatrixCoefficient &A,
+                                                       int I, int J)
+   : a(&A), ma(A.GetHeight(), A.GetWidth())
+{
+   SetRowIndex(I);
+   SetColumnIndex(J);
+}
+
+void MatrixComponentCoefficient::SetRowIndex(int I)
+{
+   MFEM_ASSERT(I < a->GetHeight() && I >= 0,
+               "MatrixComponentCoefficient:  "
+               "Row index not in range.");
+
+   i = I;
+}
+
+void MatrixComponentCoefficient::SetColumnIndex(int J)
+{
+   MFEM_ASSERT(J < a->GetWidth() && J >= 0,
+               "MatrixComponentCoefficient:  "
+               "Column index not in range.");
+   j = J;
+}
+
+void MatrixComponentCoefficient::SetTime(real_t t)
+{
+   if (a) { a->SetTime(t); }
+   this->Coefficient::SetTime(t);
+}
+
+real_t MatrixComponentCoefficient::Eval(ElementTransformation &T,
+                                        const IntegrationPoint &ip)
+{
+   a->Eval(ma, T, ip);
+   return ma(i,j);
+}
+
 VectorSumCoefficient::VectorSumCoefficient(int dim)
    : VectorCoefficient(dim),
      ACoef(NULL), BCoef(NULL),

--- a/fem/coefficient.hpp
+++ b/fem/coefficient.hpp
@@ -1855,6 +1855,85 @@ public:
                const IntegrationPoint &ip) override;
 };
 
+/// Scalar coefficient defined as component of a vector coefficient
+class VectorComponentCoefficient : public Coefficient
+{
+private:
+   VectorCoefficient *a;// = nullptr;
+
+   mutable Vector va;
+   int i;
+
+public:
+   /// Construct with a vector coefficient.
+   VectorComponentCoefficient(VectorCoefficient &A)
+      : a(&A), va(A.GetVDim()), i(0) {};
+
+   VectorComponentCoefficient(VectorCoefficient &A, int I);
+
+   /// Set the time for internally stored coefficients
+   void SetTime(real_t t) override;
+
+   /// Reset the vector coefficient
+   void SetACoef(VectorCoefficient &A) { a = &A; }
+
+   /// Return the vector coefficient
+   VectorCoefficient * GetACoef() const { return a; }
+
+   /// Reset the index
+   void SetIndex(int I);
+
+   /// Return the index
+   int GetIndex() const { return i; }
+
+   /// Evaluate the trace coefficient at @a ip.
+   real_t Eval(ElementTransformation &T,
+               const IntegrationPoint &ip) override;
+};
+
+/// Scalar coefficient defined as component of a matrix coefficient
+class MatrixComponentCoefficient : public Coefficient
+{
+private:
+   MatrixCoefficient *a = nullptr;
+
+   mutable DenseMatrix ma;
+   int i,j;
+
+public:
+   MatrixComponentCoefficient(MatrixCoefficient &A)
+      : a(&A), ma(A.GetHeight(), A.GetWidth()), i(0), j(0) {};
+
+   /// Construct with the matrix coefficient.
+   MatrixComponentCoefficient(MatrixCoefficient &A, int I, int J);
+
+   /// Set the time for internally stored coefficients
+   void SetTime(real_t t) override;
+
+   /// Reset the matrix coefficient
+   void SetACoef(MatrixCoefficient &A) { a = &A; }
+
+   /// Return the matrix coefficient
+   MatrixCoefficient * GetACoef() const { return a; }
+
+   /// Reset the index
+   void SetRowIndex(int I);
+
+   /// Return the index
+   int GetRowIndex() const { return i; }
+
+   /// Reset the index
+   void SetColumnIndex(int J);
+
+   /// Return the index
+   int GetColumnIndex() const { return j; }
+
+
+   /// Evaluate the trace coefficient at @a ip.
+   real_t Eval(ElementTransformation &T,
+               const IntegrationPoint &ip) override;
+};
+
 /// Vector coefficient defined as the linear combination of two vectors
 class VectorSumCoefficient : public VectorCoefficient
 {


### PR DESCRIPTION
This small PR allows the definition of a Coefficient based on a component of a VectorCoefficient or MatrixCoefficient.

This allows for code reuse, for instance by projecting a VectorCoefficient on a Array of Scalar FEs. See #4326.