### PR TITLE
Proposed addtions and changes to PR #4028 (branch table-array)

### DIFF
--- a/fem/fe_coll.cpp
+++ b/fem/fe_coll.cpp
@@ -488,7 +488,7 @@ GetFace(int &nv, v_t &v, int &ne, e_t &e, eo_t &eo,
       int v0 = v[f_consts::Edges[i][0]];
       int v1 = v[f_consts::Edges[i][1]];
       int eor = 0;
-      if (v0 > v1) { swap(v0, v1); eor = 1; }
+      if (v0 > v1) { std::swap(v0, v1); eor = 1; }
       for (int j = g_consts::VertToVert::I[v0]; true; j++)
       {
          MFEM_ASSERT(j < g_consts::VertToVert::I[v0+1],

--- a/general/mem_manager.hpp
+++ b/general/mem_manager.hpp
@@ -280,6 +280,10 @@ public:
    /** @note The destructor will NOT delete the current memory. */
    ~Memory() = default;
 
+   /// Swap without using move assignment, avoiding Reset() calls.
+   void Swap(Memory &other)
+   { Memory tmp(*this); *this = other; other = tmp; }
+
    /** @brief Return true if the host pointer is owned. Ownership indicates
        whether the pointer will be deleted by the method Delete(). */
    bool OwnsHostPtr() const { return flags & OWNS_HOST; }
@@ -599,6 +603,15 @@ private:
       return Alloc<new_align_bytes>::New(size);
    }
 };
+
+
+/** @brief Swap of Memory<T> objects for use with standard library algorithms.
+    Also, used by mfem::Swap(). */
+template <typename T>
+void swap(Memory<T> &a, Memory<T> &b)
+{
+   a.Swap(b);
+}
 
 
 /** The MFEM memory manager class. Host-side pointers are inserted into this

--- a/general/mem_manager.hpp
+++ b/general/mem_manager.hpp
@@ -282,7 +282,11 @@ public:
 
    /// Swap without using move assignment, avoiding Reset() calls.
    void Swap(Memory &other)
-   { Memory tmp(*this); *this = other; other = tmp; }
+   {
+      Memory tmp(*this);
+      *this = other;
+      other = tmp;
+   }
 
    /** @brief Return true if the host pointer is owned. Ownership indicates
        whether the pointer will be deleted by the method Delete(). */

--- a/general/table.cpp
+++ b/general/table.cpp
@@ -256,10 +256,8 @@ void Table::SetIJ(int *newI, int *newJ, int newsize)
    {
       size = newsize;
    }
-   I.MakeRef(newI, size + 1);
-   I.MakeDataOwner();
-   J.MakeRef(newJ, I[size]);
-   J.MakeDataOwner();
+   I.MakeRef(newI, size + 1, true);
+   J.MakeRef(newJ, I[size], true);
 }
 
 int Table::Push(int i, int j)

--- a/general/table.hpp
+++ b/general/table.hpp
@@ -105,8 +105,8 @@ public:
    ///
    /// If Finalize() is not called, it returns the number of possible
    /// connections established by the used constructor. Otherwise, it is exactly
-   /// the number of established connections before calling Finalize(). */
-   inline int Size_of_connections() const { HostReadI(); return I[size]; }
+   /// the number of established connections after calling Finalize(). */
+   inline int Size_of_connections() const { return J.Size(); }
 
    /// @brief Returns index of the connection between element i of TYPE I and
    /// element j of TYPE II.
@@ -133,14 +133,14 @@ public:
    const Memory<int> &GetIMemory() const { return I.GetMemory(); }
    const Memory<int> &GetJMemory() const { return J.GetMemory(); }
 
-   const int *ReadI(bool on_dev = true) const { return I.Read(); }
+   const int *ReadI(bool on_dev = true) const { return I.Read(on_dev); }
    int *WriteI(bool on_dev = true) { return I.Write(on_dev); }
    int *ReadWriteI(bool on_dev = true) { return I.ReadWrite(on_dev); }
    const int *HostReadI() const { return I.HostRead(); }
    int *HostWriteI() { return I.HostWrite(); }
    int *HostReadWriteI() { return I.HostReadWrite(); }
 
-   const int *ReadJ(bool on_dev = true) const { return J.Read(); }
+   const int *ReadJ(bool on_dev = true) const { return J.Read(on_dev); }
    int *WriteJ(bool on_dev = true) { return J.Write(on_dev); }
    int *ReadWriteJ(bool on_dev = true) { return J.ReadWrite(on_dev); }
    const int *HostReadJ() const { return J.HostRead(); }

--- a/linalg/densemat.cpp
+++ b/linalg/densemat.cpp
@@ -92,12 +92,7 @@ void DenseMatrix::SetSize(int h, int w)
    }
    height = h;
    width = w;
-   const int hw = h*w;
-   if (hw > data.Size())
-   {
-      data.SetSize(hw);
-      *this = 0.0; // init with zeroes
-   }
+   data.SetSize(h*w, 0.0);
 }
 
 real_t &DenseMatrix::Elem(int i, int j)

--- a/linalg/densemat.hpp
+++ b/linalg/densemat.hpp
@@ -95,7 +95,6 @@ public:
    /** The DenseMatrix does not assume ownership of the data array, i.e. it will
        not delete the new array @a d. This method will delete the current data
        array, if owned. */
-
    void Reset(real_t *d, int h, int w)
    { UseExternalData(d, h, w); }
 
@@ -110,7 +109,7 @@ public:
    /// For backward compatibility define Size to be synonym of Width()
    int Size() const { return Width(); }
 
-   // Total size = width*height
+   /// Total size = width*height
    int TotalSize() const { return width*height; }
 
    /// Change the size of the DenseMatrix to s x s.
@@ -119,11 +118,11 @@ public:
    /// Change the size of the DenseMatrix to h x w.
    void SetSize(int h, int w);
 
-   /// Returns the matrix data array.
+   /// Returns the matrix data array. Warning: this method casts away constness.
    inline real_t *Data() const
    { return const_cast<real_t*>((const real_t*)data);}
 
-   /// Returns the matrix data array.
+   /// Returns the matrix data array. Warning: this method casts away constness.
    inline real_t *GetData() const { return Data(); }
 
    Memory<real_t> &GetMemory() { return data.GetMemory(); }

--- a/linalg/vector.cpp
+++ b/linalg/vector.cpp
@@ -118,8 +118,9 @@ Vector::Vector(const Vector &v)
 }
 
 Vector::Vector(Vector &&v)
+   : data(std::move(v.data)), size(v.size)
 {
-   *this = std::move(v);
+   v.size = 0;
 }
 
 void Vector::Load(std::istream **in, int np, int *dim)
@@ -208,19 +209,22 @@ Vector &Vector::operator=(const Vector &v)
    SetSize(v.Size());
    const bool vuse = v.UseDevice();
    const bool use_dev = UseDevice() || vuse;
-   v.UseDevice(use_dev);
+   if (use_dev != vuse) { v.UseDevice(use_dev); }
    // keep 'data' where it is, unless 'use_dev' is true
    if (use_dev) { Write(); }
    data.CopyFrom(v.data, v.Size());
-   v.UseDevice(vuse);
+   if (use_dev != vuse) { v.UseDevice(vuse); }
 #endif
    return *this;
 }
 
 Vector &Vector::operator=(Vector &&v)
 {
-   v.Swap(*this);
-   if (this != &v) { v.Destroy(); }
+   if (this != &v)
+   {
+      v.Swap(*this);
+      v.Destroy();
+   }
    return *this;
 }
 

--- a/linalg/vector.hpp
+++ b/linalg/vector.hpp
@@ -367,6 +367,7 @@ public:
    void Pow(const real_t p);
 
    /// Swap the contents of two Vectors
+   /** Implemented without using move assignment, avoiding Destroy() calls. */
    inline void Swap(Vector &other);
 
    /// Set v = v1 + v2.
@@ -652,9 +653,8 @@ inline void Vector::MakeRef(Vector &base, int offset)
 inline void Vector::Destroy()
 {
    const bool use_dev = data.UseDevice();
-   data.Delete();
+   data.Delete();  // calls data.Reset(h_mt) as well
    size = 0;
-   data.Reset();
    data.UseDevice(use_dev);
 }
 
@@ -680,8 +680,9 @@ inline void Vector::Swap(Vector &other)
    mfem::Swap(size, other.size);
 }
 
-/// Specialization of the template function Swap<> for class Vector
-template<> inline void Swap<Vector>(Vector &a, Vector &b)
+/** @brief Swap of Vector objects for use with standard library algorithms.
+    Also, used by mfem::Swap(). */
+inline void swap(Vector &a, Vector &b)
 {
    a.Swap(b);
 }


### PR DESCRIPTION
* Add `mfem::swap` for the classes `Memory`, `Array`, `Array2D`, and `Vector`.
* These `mfem::swap` functions are for use by the standard library.
* Re-define `mfem::Swap` to use `mfem::swap`, or, if is not defined, `std::swap`.
* Remove some calls to `Memory::Reset` after `Memory::Delete` since the latter calls the former.
* Update/improve the definitions of the `Vector` move-constructor and move-assignment; in the copy-assignment, skip the virtual calls to `v.UseDevice(bool)` when they are not needed.
* In `DenseMatrix::SetSize`, update the size of the data `Array` to match height x width.
* Propagate the parameter `use_dev` in `Table::{ReadI,ReadJ}` to the respective `Array::Read` calls.
* In `Table::Size_of_connections`, return `J.Size()` instead of `I[size]`.
* Some small Doxygen tweaks.
