### PR TITLE
[WIP] `MultiVector`

### DIFF
--- a/fem/fespace.cpp
+++ b/fem/fespace.cpp
@@ -27,37 +27,6 @@ using namespace std;
 
 namespace mfem
 {
-template <>
-void Ordering::DofsToVDofs<Ordering::byNODES>(int ndofs, int vdim,
-                                              Array<int> &dofs)
-{
-   // static method
-   int size = dofs.Size();
-   dofs.SetSize(size*vdim);
-   for (int vd = 1; vd < vdim; vd++)
-   {
-      for (int i = 0; i < size; i++)
-      {
-         dofs[i+size*vd] = Map<byNODES>(ndofs, vdim, dofs[i], vd);
-      }
-   }
-}
-
-template <>
-void Ordering::DofsToVDofs<Ordering::byVDIM>(int ndofs, int vdim,
-                                             Array<int> &dofs)
-{
-   // static method
-   int size = dofs.Size();
-   dofs.SetSize(size*vdim);
-   for (int vd = vdim-1; vd >= 0; vd--)
-   {
-      for (int i = 0; i < size; i++)
-      {
-         dofs[i+size*vd] = Map<byVDIM>(ndofs, vdim, dofs[i], vd);
-      }
-   }
-}
 
 FiniteElementSpace::FiniteElementSpace()
    : mesh(NULL), fec(NULL), vdim(0), ordering(Ordering::byNODES),

--- a/fem/fespace.hpp
+++ b/fem/fespace.hpp
@@ -24,29 +24,6 @@
 namespace mfem
 {
 
-/** @brief The ordering method used when the number of unknowns per mesh node
-    (vector dimension) is bigger than 1. */
-class Ordering
-{
-public:
-   /// %Ordering methods:
-   enum Type
-   {
-      byNODES, /**< loop first over the nodes (inner loop) then over the vector
-                    dimension (outer loop); symbolically it can be represented
-                    as: XXX...,YYY...,ZZZ... */
-      byVDIM   /**< loop first over the vector dimension (inner loop) then over
-                    the nodes (outer loop); symbolically it can be represented
-                    as: XYZ,XYZ,XYZ,... */
-   };
-
-   template <Type Ord>
-   static inline int Map(int ndofs, int vdim, int dof, int vd);
-
-   template <Type Ord>
-   static void DofsToVDofs(int ndofs, int vdim, Array<int> &dofs);
-};
-
 /// @brief Type describing possible layouts for Q-vectors.
 /// @sa QuadratureInterpolator and FaceQuadratureInterpolator.
 enum class QVectorLayout
@@ -63,20 +40,6 @@ enum class QVectorLayout
        - vector RT/ND spaces, values: SDIM x NQPT x NE (vdim = 1). */
    byVDIM
 };
-
-template <> inline int
-Ordering::Map<Ordering::byNODES>(int ndofs, int vdim, int dof, int vd)
-{
-   MFEM_ASSERT(dof < ndofs && -1-dof < ndofs && 0 <= vd && vd < vdim, "");
-   return (dof >= 0) ? dof+ndofs*vd : dof-ndofs*vd;
-}
-
-template <> inline int
-Ordering::Map<Ordering::byVDIM>(int ndofs, int vdim, int dof, int vd)
-{
-   MFEM_ASSERT(dof < ndofs && -1-dof < ndofs && 0 <= vd && vd < vdim, "");
-   return (dof >= 0) ? vd+vdim*dof : -1-(vd+vdim*(-1-dof));
-}
 
 /// Constants describing the possible orderings of the DOFs in one element.
 enum class ElementDofOrdering

--- a/general/array.hpp
+++ b/general/array.hpp
@@ -211,6 +211,9 @@ public:
    /// Delete the first entry with value == 'el'.
    inline void DeleteFirst(const T &el);
 
+   /// Delete entries at @a indices, and resize.
+   inline void DeleteAt(const Array<int> &indices);
+
    /// Delete the whole array.
    inline void DeleteAll();
 
@@ -933,6 +936,30 @@ inline void Array<T>::DeleteFirst(const T &el)
          return;
       }
    }
+}
+
+template <class T>
+inline void Array<T>::DeleteAt(const Array<int> &indices)
+{
+   // Make a copy of the indices, sorted.
+   Array<int> sorted_indices(indices);
+   sorted_indices.Sort();
+
+   int rm_count = 0;
+   for (int i = 0; i < size; i++)
+   {
+      if (rm_count < sorted_indices.Size() && i == sorted_indices[rm_count])
+      {
+         rm_count++;
+      }
+      else
+      {
+         data[i-rm_count] = data[i]; // shift data rm_count
+      }
+   }
+
+   // Resize to remove tail
+   size -= rm_count;
 }
 
 template <class T>

--- a/linalg/CMakeLists.txt
+++ b/linalg/CMakeLists.txt
@@ -27,6 +27,7 @@ list(APPEND SRCS
   handle.cpp
   matrix.cpp
   mma.cpp
+  multivector.cpp
   ode.cpp
   operator.cpp
   solvers.cpp
@@ -59,6 +60,7 @@ list(APPEND HDRS
   linalg.hpp
   matrix.hpp
   mma.hpp
+  multivector.hpp
   ode.hpp
   operator.hpp
   solvers.hpp

--- a/linalg/linalg.hpp
+++ b/linalg/linalg.hpp
@@ -37,6 +37,7 @@
 #include "batched/gpu_blas.hpp"
 #include "batched/solver.hpp"
 #include "tensor.hpp"
+#include "multivector.hpp"
 
 #ifdef MFEM_USE_AMGX
 #include "amgxsolver.hpp"

--- a/linalg/multivector.cpp
+++ b/linalg/multivector.cpp
@@ -75,4 +75,201 @@ void Ordering::Reorder(Vector &v, int vdim, Ordering::Type in_ord,
    }
 }
 
+void MultiVector::GrowSize(int min_num_vectors)
+{
+   const int nsize = std::max(min_num_vectors*vdim, 2 * data.Capacity());
+   Memory<real_t> p(nsize, data.GetMemoryType());
+   p.CopyFrom(data, size);
+   p.UseDevice(data.UseDevice());
+   data.Delete();
+   data = p;
+}
+
+MultiVector::MultiVector(int vdim_, Ordering::Type ordering_)
+: MultiVector(vdim_, ordering_, 0)
+{
+
+}
+
+MultiVector::MultiVector(int vdim_, Ordering::Type ordering_, int num_nodes)
+: Vector(num_nodes*vdim_), vdim(vdim_), ordering(ordering_)
+{ 
+   Vector::operator=(0.0);
+}
+
+MultiVector::MultiVector(int vdim_, Ordering::Type ordering_, const Vector &vec)
+: Vector(vec), vdim(vdim_), ordering(ordering_)
+{ 
+   MFEM_ASSERT(vec.Size() % vdim == 0, "Incompatible Vector size of " << vec.Size() << " given vdim " << vdim);
+}
+
+void MultiVector::GetVectorValues(int i, Vector &nvals) const
+{
+   nvals.SetSize(vdim);
+
+   if (ordering == Ordering::byNODES)
+   {
+      int nv = GetNumVectors();
+      for (int c = 0; c < vdim; c++)
+      {
+         nvals[c] = Vector::operator[](i+nv*c);
+      }
+   }
+   else
+   {
+      for (int c = 0; c < vdim; c++)
+      {
+         nvals[c] = Vector::operator[](c+vdim*i);
+      }
+   }
+}
+
+void MultiVector::GetVectorRef(int i, Vector &nref)
+{
+   MFEM_ASSERT(ordering == Ordering::byVDIM, "GetRefVector only valid when ordering byVDIM.");
+
+   nref.MakeRef(*this, i*vdim, vdim);
+}
+
+void MultiVector::SetVectorValues(int i, const Vector &nvals)
+{
+   if (ordering == Ordering::byNODES)
+   {
+      int nv = GetNumVectors();
+      for (int c = 0; c < vdim; c++)
+      {
+         Vector::operator[](i + c*nv) = nvals[c];
+      }
+   }
+   else
+   {
+      for (int c = 0; c < vdim; c++)
+      {
+         Vector::operator[](c + i*vdim) = nvals[c];
+      }
+   }
+}
+
+real_t& MultiVector::operator()(int i, int comp)
+{
+   MFEM_ASSERT(i < GetNumVectors(), "Vector index " << i << " is out-of-range for number of vectors " << GetNumVectors());
+
+   if (ordering == Ordering::byNODES)
+   {
+      return Vector::operator[](i + comp*GetNumVectors());
+   }
+   else
+   {
+      return Vector::operator[](comp + i*vdim);
+   }
+}
+
+const real_t& MultiVector::operator()(int i, int comp) const
+{
+   if (ordering == Ordering::byNODES)
+   {
+      return Vector::operator[](i + comp*GetNumVectors());
+   }
+   else
+   {
+      return Vector::operator[](comp + i*vdim);
+   }
+}
+
+void MultiVector::DeleteVectorsAt(const Array<int> &indices)
+{
+   // Convert list index array of "ldofs" to "vdofs"
+   Array<int> v_list;
+   v_list.Reserve(indices.Size()*vdim);
+   if (ordering == Ordering::byNODES)
+   {
+      for (int l = 0; l < indices.Size(); l++)
+      {
+         for (int vd = 0; vd < vdim; vd++)
+         {
+            v_list.Append(Ordering::Map<Ordering::byNODES>(GetNumVectors(), vdim, indices[l], vd));
+         }
+      }
+   }
+   else
+   {
+      for (int l = 0; l < indices.Size(); l++)
+      {
+         for (int vd = 0; vd < vdim; vd++)
+         {
+            v_list.Append(Ordering::Map<Ordering::byVDIM>(GetNumVectors(), vdim, indices[l], vd));
+         }
+      }
+   }
+
+   Vector::DeleteAt(v_list);
+}
+
+void MultiVector::SetOrdering(Ordering::Type ordering_)
+{
+   Ordering::Reorder(*this, vdim, ordering, ordering_);
+   ordering = ordering_;
+}
+
+void MultiVector::SetNumVectors(int num_vectors)
+{
+   int old_nv = GetNumVectors();
+
+   if (num_vectors == old_nv)
+   {
+      return;
+   }
+   using namespace std;
+
+   // If resizing larger...
+   if (num_vectors > old_nv)
+   {
+      // Increase capacity if needed
+      if (num_vectors*vdim > Vector::Capacity())
+      {
+         GrowSize(num_vectors);
+      }
+
+      // Set larger new size
+      Vector::SetSize(num_vectors*vdim);
+
+      if (ordering == Ordering::byNODES)
+      {
+         // Shift entries for byNODES
+         for (int c = vdim-1; c > 0; c--)
+         {
+            for (int i = old_nv-1; i >= 0; i--)
+            {
+               Vector::operator[](i+c*num_vectors) = Vector::operator[](i+c*old_nv);
+            }
+         }
+
+         // Zero-out data now associated with new Vectors
+         for (int c = 0; c < vdim; c++)
+         {
+            for (int i = old_nv; i < num_vectors; i++)
+            {
+               Vector::operator[](i+c*num_vectors) = 0.0;
+            }
+         }
+      }
+      else // byVDIM
+      {
+         for (int i = old_nv*vdim; i < num_vectors*vdim; i++)
+         {
+            data[i] = 0.0;
+         }
+      }
+   }
+   else // Else just remove the trailing vector data
+   {
+      Array<int> rm_indices(old_nv-num_vectors);
+      for (int i = 0; i < rm_indices.Size(); i++)
+      {
+         rm_indices[i] = old_nv - rm_indices.Size() + i;
+      }
+      DeleteVectorsAt(rm_indices);
+   }
+}
+
 } // namespace mfem

--- a/linalg/multivector.cpp
+++ b/linalg/multivector.cpp
@@ -86,21 +86,22 @@ void MultiVector::GrowSize(int min_num_vectors)
 }
 
 MultiVector::MultiVector(int vdim_, Ordering::Type ordering_)
-: MultiVector(vdim_, ordering_, 0)
+   : MultiVector(vdim_, ordering_, 0)
 {
 
 }
 
 MultiVector::MultiVector(int vdim_, Ordering::Type ordering_, int num_nodes)
-: Vector(num_nodes*vdim_), vdim(vdim_), ordering(ordering_)
-{ 
+   : Vector(num_nodes*vdim_), vdim(vdim_), ordering(ordering_)
+{
    Vector::operator=(0.0);
 }
 
 MultiVector::MultiVector(int vdim_, Ordering::Type ordering_, const Vector &vec)
-: Vector(vec), vdim(vdim_), ordering(ordering_)
-{ 
-   MFEM_ASSERT(vec.Size() % vdim == 0, "Incompatible Vector size of " << vec.Size() << " given vdim " << vdim);
+   : Vector(vec), vdim(vdim_), ordering(ordering_)
+{
+   MFEM_ASSERT(vec.Size() % vdim == 0,
+               "Incompatible Vector size of " << vec.Size() << " given vdim " << vdim);
 }
 
 void MultiVector::GetVectorValues(int i, Vector &nvals) const
@@ -126,7 +127,8 @@ void MultiVector::GetVectorValues(int i, Vector &nvals) const
 
 void MultiVector::GetVectorRef(int i, Vector &nref)
 {
-   MFEM_ASSERT(ordering == Ordering::byVDIM, "GetRefVector only valid when ordering byVDIM.");
+   MFEM_ASSERT(ordering == Ordering::byVDIM,
+               "GetRefVector only valid when ordering byVDIM.");
 
    nref.MakeRef(*this, i*vdim, vdim);
 }
@@ -152,7 +154,9 @@ void MultiVector::SetVectorValues(int i, const Vector &nvals)
 
 real_t& MultiVector::operator()(int i, int comp)
 {
-   MFEM_ASSERT(i < GetNumVectors(), "Vector index " << i << " is out-of-range for number of vectors " << GetNumVectors());
+   MFEM_ASSERT(i < GetNumVectors(),
+               "Vector index " << i << " is out-of-range for number of vectors " <<
+               GetNumVectors());
 
    if (ordering == Ordering::byNODES)
    {
@@ -187,7 +191,8 @@ void MultiVector::DeleteVectorsAt(const Array<int> &indices)
       {
          for (int vd = 0; vd < vdim; vd++)
          {
-            v_list.Append(Ordering::Map<Ordering::byNODES>(GetNumVectors(), vdim, indices[l], vd));
+            v_list.Append(Ordering::Map<Ordering::byNODES>(GetNumVectors(), vdim,
+                                                           indices[l], vd));
          }
       }
    }
@@ -197,7 +202,8 @@ void MultiVector::DeleteVectorsAt(const Array<int> &indices)
       {
          for (int vd = 0; vd < vdim; vd++)
          {
-            v_list.Append(Ordering::Map<Ordering::byVDIM>(GetNumVectors(), vdim, indices[l], vd));
+            v_list.Append(Ordering::Map<Ordering::byVDIM>(GetNumVectors(), vdim, indices[l],
+                                                          vd));
          }
       }
    }

--- a/linalg/multivector.cpp
+++ b/linalg/multivector.cpp
@@ -46,4 +46,33 @@ void Ordering::DofsToVDofs<Ordering::byVDIM>(int ndofs, int vdim,
    }
 }
 
+void Ordering::Reorder(Vector &v, int vdim, Ordering::Type in_ord,
+                       Ordering::Type out_ord)
+{
+   if (in_ord == out_ord)
+   {
+      return;
+   }
+
+   int nvdofs = v.Size();
+   int nldofs = nvdofs/vdim;
+
+   if (out_ord == Ordering::byNODES) // byVDIM -> byNODES
+   {
+      Vector temp = v;
+      for (int i = 0; i < nvdofs; i++)
+      {
+         v[i] = temp[Map<byVDIM>(nldofs,vdim,i%nldofs,i/nldofs)];
+      }
+   }
+   else // byNODES -> byVDIM
+   {
+      Vector temp = v;
+      for (int i = 0; i < nvdofs; i++)
+      {
+         v[i] = temp[Map<byNODES>(nldofs,vdim,i/vdim,i%vdim)];
+      }
+   }
+}
+
 } // namespace mfem

--- a/linalg/multivector.cpp
+++ b/linalg/multivector.cpp
@@ -14,4 +14,36 @@
 namespace mfem
 {
 
+template <>
+void Ordering::DofsToVDofs<Ordering::byNODES>(int ndofs, int vdim,
+                                              Array<int> &dofs)
+{
+   // static method
+   int size = dofs.Size();
+   dofs.SetSize(size*vdim);
+   for (int vd = 1; vd < vdim; vd++)
+   {
+      for (int i = 0; i < size; i++)
+      {
+         dofs[i+size*vd] = Map<byNODES>(ndofs, vdim, dofs[i], vd);
+      }
+   }
+}
+
+template <>
+void Ordering::DofsToVDofs<Ordering::byVDIM>(int ndofs, int vdim,
+                                             Array<int> &dofs)
+{
+   // static method
+   int size = dofs.Size();
+   dofs.SetSize(size*vdim);
+   for (int vd = vdim-1; vd >= 0; vd--)
+   {
+      for (int i = 0; i < size; i++)
+      {
+         dofs[i+size*vd] = Map<byVDIM>(ndofs, vdim, dofs[i], vd);
+      }
+   }
+}
+
 } // namespace mfem

--- a/linalg/multivector.cpp
+++ b/linalg/multivector.cpp
@@ -1,0 +1,17 @@
+// Copyright (c) 2010-2025, Lawrence Livermore National Security, LLC. Produced
+// at the Lawrence Livermore National Laboratory. All Rights reserved. See files
+// LICENSE and NOTICE for details. LLNL-CODE-806117.
+//
+// This file is part of the MFEM library. For more information and source code
+// availability visit https://mfem.org.
+//
+// MFEM is free software; you can redistribute it and/or modify it under the
+// terms of the BSD-3 license. We welcome feedback and contributions, see file
+// CONTRIBUTING.md for details.
+
+#include "multivector.hpp"
+
+namespace mfem
+{
+
+} // namespace mfem

--- a/linalg/multivector.hpp
+++ b/linalg/multivector.hpp
@@ -38,6 +38,9 @@ public:
 
    template <Type Ord>
    static void DofsToVDofs(int ndofs, int vdim, Array<int> &dofs);
+
+   /// Reorder Vector \p v from its current ordering \p in_ord to \p out_ord
+   static void Reorder(Vector &v, int vdim, Type in_ord, Type out_ord);
 };
 
 template <> inline int

--- a/linalg/multivector.hpp
+++ b/linalg/multivector.hpp
@@ -17,6 +17,43 @@
 namespace mfem
 {
 
+/** @brief The ordering method used when the number of unknowns per mesh node
+    (vector dimension) is bigger than 1. */
+class Ordering
+{
+public:
+   /// %Ordering methods:
+   enum Type
+   {
+      byNODES, /**< loop first over the nodes (inner loop) then over the vector
+                    dimension (outer loop); symbolically it can be represented
+                    as: XXX...,YYY...,ZZZ... */
+      byVDIM   /**< loop first over the vector dimension (inner loop) then over
+                    the nodes (outer loop); symbolically it can be represented
+                    as: XYZ,XYZ,XYZ,... */
+   };
+
+   template <Type Ord>
+   static inline int Map(int ndofs, int vdim, int dof, int vd);
+
+   template <Type Ord>
+   static void DofsToVDofs(int ndofs, int vdim, Array<int> &dofs);
+};
+
+template <> inline int
+Ordering::Map<Ordering::byNODES>(int ndofs, int vdim, int dof, int vd)
+{
+   MFEM_ASSERT(dof < ndofs && -1-dof < ndofs && 0 <= vd && vd < vdim, "");
+   return (dof >= 0) ? dof+ndofs*vd : dof-ndofs*vd;
+}
+
+template <> inline int
+Ordering::Map<Ordering::byVDIM>(int ndofs, int vdim, int dof, int vd)
+{
+   MFEM_ASSERT(dof < ndofs && -1-dof < ndofs && 0 <= vd && vd < vdim, "");
+   return (dof >= 0) ? vd+vdim*dof : -1-(vd+vdim*(-1-dof));
+}
+
 } // namespace mfem
 
 

--- a/linalg/multivector.hpp
+++ b/linalg/multivector.hpp
@@ -1,0 +1,23 @@
+// Copyright (c) 2010-2025, Lawrence Livermore National Security, LLC. Produced
+// at the Lawrence Livermore National Laboratory. All Rights reserved. See files
+// LICENSE and NOTICE for details. LLNL-CODE-806117.
+//
+// This file is part of the MFEM library. For more information and source code
+// availability visit https://mfem.org.
+//
+// MFEM is free software; you can redistribute it and/or modify it under the
+// terms of the BSD-3 license. We welcome feedback and contributions, see file
+// CONTRIBUTING.md for details.
+
+#ifndef MFEM_MULTIVECTOR
+#define MFEM_MULTIVECTOR
+
+#include "vector.hpp"
+
+namespace mfem
+{
+
+} // namespace mfem
+
+
+#endif // MFEM_MULTIVECTOR

--- a/linalg/multivector.hpp
+++ b/linalg/multivector.hpp
@@ -85,7 +85,7 @@ public:
    /// Initialize a MultiVector with \p num_vectors vectors each of size \p vdim_ ordered \p ordering_.
    MultiVector(int vdim_, Ordering::Type ordering_, int num_vectors);
 
-   /// Initialize a MultiVector of vdim \p vdim_ with ordering \p ordering_ , initialized with copy of data in \p vec . 
+   /// Initialize a MultiVector of vdim \p vdim_ with ordering \p ordering_ , initialized with copy of data in \p vec .
    MultiVector(int vdim_, Ordering::Type ordering_, const Vector &vec);
 
    /// Get the Vector dimension of the MultiVector.
@@ -101,7 +101,7 @@ public:
    void GetVectorValues(int i, Vector &nvals) const;
 
    /** @brief For `GetOrdering` == Ordering::byVDIM, set \p \nref to refer to Vector \p i 's data.
-    * 
+    *
     *  @warning This method only works when ordering is Ordering::byVDIM, where an individual Vector's data is stored contiguously in memory.
     */
    void GetVectorRef(int i, Vector &nref);
@@ -116,7 +116,7 @@ public:
    const real_t& operator()(int i, int comp) const;
 
    /** @brief Remove Vector s at \p indices.
-    * 
+    *
     *  @details The MultiVector is resized appropriately.
     */
    void DeleteVectorsAt(const Array<int> &indices);
@@ -125,13 +125,13 @@ public:
    void SetVDim(int vdim_) { vdim = vdim_; }
 
    /** @brief Set the ordering of the Vector data in MultiVector.
-    *  
+    *
     *  @details For \p ordering != \ref GetOrdering , Vector data in the MultiVector is reordered.
     */
    void SetOrdering(Ordering::Type ordering_);
 
    /** @brief Set the number of vectors held by the MultiVector, keeping existing Vectors.
-    * 
+    *
     * @details If \p num_vectors * \ref GetVDim > \p Vector::Capacity , memory is re-allocated.
     */
    void SetNumVectors(int num_vectors);

--- a/linalg/multivector.hpp
+++ b/linalg/multivector.hpp
@@ -57,6 +57,88 @@ Ordering::Map<Ordering::byVDIM>(int ndofs, int vdim, int dof, int vd)
    return (dof >= 0) ? vd+vdim*dof : -1-(vd+vdim*(-1-dof));
 }
 
+
+/// MultiVector carries data for an arbitrary number of Vectors of a given size/vdim.
+class MultiVector : public Vector
+{
+protected:
+
+   /// Vector dimension.
+   int vdim;
+
+   /// Ordering of Vector data in MultiVector.
+   Ordering::Type ordering;
+
+   /// Re-allocate + copy memory. See Array::GrowSize.
+   void GrowSize(int min_num_vectors);
+
+public:
+
+   using Vector::operator=;
+   using Vector::operator();
+
+   MultiVector() : vdim(0), ordering(Ordering::byNODES) {};
+
+   /// Initialize an empty MultiVector of vdim \p vdim_ with ordering \p ordering_.
+   MultiVector(int vdim_, Ordering::Type ordering_);
+
+   /// Initialize a MultiVector with \p num_vectors vectors each of size \p vdim_ ordered \p ordering_.
+   MultiVector(int vdim_, Ordering::Type ordering_, int num_vectors);
+
+   /// Initialize a MultiVector of vdim \p vdim_ with ordering \p ordering_ , initialized with copy of data in \p vec . 
+   MultiVector(int vdim_, Ordering::Type ordering_, const Vector &vec);
+
+   /// Get the Vector dimension of the MultiVector.
+   int GetVDim() const { return vdim; }
+
+   /// Get the ordering of data in the MultiVector.
+   Ordering::Type GetOrdering() const { return ordering; }
+
+   /// Get the number of Vectors in the MultiVector.
+   int GetNumVectors() const { return Size()/vdim; }
+
+   /// Get a copy of Vector \p i 's data.
+   void GetVectorValues(int i, Vector &nvals) const;
+
+   /** @brief For `GetOrdering` == Ordering::byVDIM, set \p \nref to refer to Vector \p i 's data.
+    * 
+    *  @warning This method only works when ordering is Ordering::byVDIM, where an individual Vector's data is stored contiguously in memory.
+    */
+   void GetVectorRef(int i, Vector &nref);
+
+   /// Set Vector \p i 's data to \p nvals .
+   void SetVectorValues(int i, const Vector &nvals);
+
+   /// Reference to Vector \p i component \p comp value.
+   real_t& operator()(int i, int comp);
+
+   /// Const reference to Vector \p i component \p comp value.
+   const real_t& operator()(int i, int comp) const;
+
+   /** @brief Remove Vector s at \p indices.
+    * 
+    *  @details The MultiVector is resized appropriately.
+    */
+   void DeleteVectorsAt(const Array<int> &indices);
+
+   /// Set the vector dimension of the MultiVector.
+   void SetVDim(int vdim_) { vdim = vdim_; }
+
+   /** @brief Set the ordering of the Vector data in MultiVector.
+    *  
+    *  @details For \p ordering != \ref GetOrdering , Vector data in the MultiVector is reordered.
+    */
+   void SetOrdering(Ordering::Type ordering_);
+
+   /** @brief Set the number of vectors held by the MultiVector, keeping existing Vectors.
+    * 
+    * @details If \p num_vectors * \ref GetVDim > \p Vector::Capacity , memory is re-allocated.
+    */
+   void SetNumVectors(int num_vectors);
+
+};
+
+
 } // namespace mfem
 
 

--- a/linalg/vector.hpp
+++ b/linalg/vector.hpp
@@ -171,6 +171,9 @@ public:
    /// Resize the vector to size @a s using the MemoryType of @a v.
    void SetSize(int s, const Vector &v) { SetSize(s, v.GetMemory().GetMemoryType()); }
 
+   /// Update \ref Capacity() to @a res (if less than current), keeping existing entries. 
+   void Reserve(int res);
+
    /// Delete entries at @a indices and resize vector accordingly.
    void DeleteAt(const Array<int> &indices);
 
@@ -622,6 +625,17 @@ inline void Vector::SetSize(int s, MemoryType mt)
       size = 0;
    }
    data.UseDevice(use_dev);
+}
+
+inline void Vector::Reserve(int res)
+{
+   if (res > Capacity())
+   {
+      Vector copy = *this;
+      SetSize(res);
+      SetVector(copy, 0);
+      SetSize(copy.Size());
+   }
 }
 
 inline void Vector::DeleteAt(const Array<int> &indices)

--- a/linalg/vector.hpp
+++ b/linalg/vector.hpp
@@ -171,6 +171,9 @@ public:
    /// Resize the vector to size @a s using the MemoryType of @a v.
    void SetSize(int s, const Vector &v) { SetSize(s, v.GetMemory().GetMemoryType()); }
 
+   /// Delete entries at @a indices and resize vector accordingly.
+   void DeleteAt(const Array<int> &indices);
+
    /// Set the Vector data.
    /// @warning This method should be called only when OwnsData() is false.
    void SetData(real_t *d) { data.Wrap(d, data.Capacity(), false); }
@@ -619,6 +622,29 @@ inline void Vector::SetSize(int s, MemoryType mt)
       size = 0;
    }
    data.UseDevice(use_dev);
+}
+
+inline void Vector::DeleteAt(const Array<int> &indices)
+{
+   // Make copy of the indices, sorted.
+   Array<int> sorted_indices(indices);
+   sorted_indices.Sort();
+
+   int rm_count = 0;
+   for (int i = 0; i < size; i++)
+   {
+      if (rm_count < sorted_indices.Size() && i == sorted_indices[rm_count])
+      {
+         rm_count++;
+      }
+      else
+      {
+         data[i-rm_count] = data[i]; // shift data rm_count
+      }
+   }
+
+   // Resize to remove tail
+   size -= rm_count;
 }
 
 inline void Vector::NewMemoryAndSize(const Memory<real_t> &mem, int s,

--- a/linalg/vector.hpp
+++ b/linalg/vector.hpp
@@ -171,7 +171,7 @@ public:
    /// Resize the vector to size @a s using the MemoryType of @a v.
    void SetSize(int s, const Vector &v) { SetSize(s, v.GetMemory().GetMemoryType()); }
 
-   /// Update \ref Capacity() to @a res (if less than current), keeping existing entries. 
+   /// Update \ref Capacity() to @a res (if less than current), keeping existing entries.
    void Reserve(int res);
 
    /// Delete entries at @a indices and resize vector accordingly.

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -45,6 +45,7 @@ set(UNIT_TESTS_SRCS
   linalg/test_matrix_sparse.cpp
   linalg/test_matrix_square.cpp
   linalg/test_mma.cpp
+  linalg/test_multivector.cpp
   linalg/test_ode.cpp
   linalg/test_ode2.cpp
   linalg/test_operator.cpp

--- a/tests/unit/general/test_array.cpp
+++ b/tests/unit/general/test_array.cpp
@@ -124,3 +124,19 @@ TEST_CASE("Array stl-interactions", "[Array]")
       CHECK(x[i] == y[i]);
    }
 }
+
+TEST_CASE("Array delete at indices", "[Array]")
+{
+   Array<int>       test({0,1,2,3,4,5,6,7,8});
+   Array<int> rm_indices({0,    3,4,  6,  8});
+   Array<int>     result({  1,2,    5,  7  });
+
+   test.DeleteAt(rm_indices);
+
+   REQUIRE(test.Size() == result.Size());
+
+   for (int i = 0; i < test.Size(); i++)
+   {
+      CHECK(test[i] == result[i]);
+   }
+}

--- a/tests/unit/linalg/test_multivector.cpp
+++ b/tests/unit/linalg/test_multivector.cpp
@@ -29,6 +29,12 @@ using namespace mfem;
 #include "unit_tests.hpp"
 
 using namespace mfem;
+using namespace std;
+
+static constexpr int VDIM = 7;
+static constexpr int NV_rm = 12;
+static constexpr int NV = 27;
+static_assert(NV_rm < NV);
 
 TEST_CASE("Reordering Vector (byVDIM/byNODES)",
           "[Ordering]")
@@ -49,4 +55,61 @@ TEST_CASE("Reordering Vector (byVDIM/byNODES)",
       Ordering::Reorder(x_test, 3, Ordering::byVDIM, Ordering::byNODES);
       REQUIRE(x_test.DistanceTo(x_byNODES) == MFEM_Approx(0));
    }
+}
+
+
+void TestResize(Ordering::Type ordering)
+{
+    SECTION((ordering == Ordering::byNODES ? "byNODES" : "byVDIM"))
+    {
+        Vector all_data(NV*VDIM);
+        all_data.Randomize(1234);
+        const MultiVector mv_all(VDIM, ordering, all_data);
+
+        // Start with mv_test = mv_all
+        MultiVector mv_test(VDIM, ordering, NV);
+        mv_test = mv_all;
+        REQUIRE(mv_test.DistanceTo(mv_all) == MFEM_Approx(0.0));
+
+        // Remove N_rm vectors from mv_test + save them into vecs_diff
+        std::vector<Vector> vecs_diff(NV_rm);
+        for (int i = 0; i < NV_rm; i++)
+        {
+            mv_all.GetVectorValues(NV - NV_rm + i, vecs_diff[i]);
+        }
+        mv_test.SetNumVectors(NV-NV_rm);
+        REQUIRE(mv_test.GetNumVectors() == NV - NV_rm);
+
+        // Resize mv_test back
+        mv_test.SetNumVectors(NV);
+        REQUIRE(mv_test.GetNumVectors() == NV);
+
+        // Ensure that vectors post-shrink match those in mv_all
+        int wrong_shrink_vec_count = 0;
+        Vector v1, v2;
+        for (int i = 0; i < NV-NV_rm; i++)
+        {
+            mv_all.GetVectorValues(i, v1);
+            mv_test.GetVectorValues(i, v2);
+            if (!(v1.DistanceTo(v2) == MFEM_Approx(0,0)))
+            {
+                wrong_shrink_vec_count++;
+            }
+        }
+        REQUIRE(wrong_shrink_vec_count == 0);
+
+        // Set vectors back to mv_test, and then check equality
+        mv_test.SetNumVectors(NV);
+        for (int i = 0; i < NV_rm; i++)
+        {
+            mv_test.SetVectorValues(i+(NV-NV_rm), vecs_diff[i]);
+        }
+        REQUIRE(mv_test.DistanceTo(mv_all) == MFEM_Approx(0.0));
+    }
+}
+
+TEST_CASE("MultiVector resize", "[MultiVector]")
+{
+    TestResize(Ordering::byNODES);
+    TestResize(Ordering::byVDIM);
 }

--- a/tests/unit/linalg/test_multivector.cpp
+++ b/tests/unit/linalg/test_multivector.cpp
@@ -60,56 +60,56 @@ TEST_CASE("Reordering Vector (byVDIM/byNODES)",
 
 void TestResize(Ordering::Type ordering)
 {
-    SECTION((ordering == Ordering::byNODES ? "byNODES" : "byVDIM"))
-    {
-        Vector all_data(NV*VDIM);
-        all_data.Randomize(1234);
-        const MultiVector mv_all(VDIM, ordering, all_data);
+   SECTION((ordering == Ordering::byNODES ? "byNODES" : "byVDIM"))
+   {
+      Vector all_data(NV*VDIM);
+      all_data.Randomize(1234);
+      const MultiVector mv_all(VDIM, ordering, all_data);
 
-        // Start with mv_test = mv_all
-        MultiVector mv_test(VDIM, ordering, NV);
-        mv_test = mv_all;
-        REQUIRE(mv_test.DistanceTo(mv_all) == MFEM_Approx(0.0));
+      // Start with mv_test = mv_all
+      MultiVector mv_test(VDIM, ordering, NV);
+      mv_test = mv_all;
+      REQUIRE(mv_test.DistanceTo(mv_all) == MFEM_Approx(0.0));
 
-        // Remove N_rm vectors from mv_test + save them into vecs_diff
-        std::vector<Vector> vecs_diff(NV_rm);
-        for (int i = 0; i < NV_rm; i++)
-        {
-            mv_all.GetVectorValues(NV - NV_rm + i, vecs_diff[i]);
-        }
-        mv_test.SetNumVectors(NV-NV_rm);
-        REQUIRE(mv_test.GetNumVectors() == NV - NV_rm);
+      // Remove N_rm vectors from mv_test + save them into vecs_diff
+      std::vector<Vector> vecs_diff(NV_rm);
+      for (int i = 0; i < NV_rm; i++)
+      {
+         mv_all.GetVectorValues(NV - NV_rm + i, vecs_diff[i]);
+      }
+      mv_test.SetNumVectors(NV-NV_rm);
+      REQUIRE(mv_test.GetNumVectors() == NV - NV_rm);
 
-        // Resize mv_test back
-        mv_test.SetNumVectors(NV);
-        REQUIRE(mv_test.GetNumVectors() == NV);
+      // Resize mv_test back
+      mv_test.SetNumVectors(NV);
+      REQUIRE(mv_test.GetNumVectors() == NV);
 
-        // Ensure that vectors post-shrink match those in mv_all
-        int wrong_shrink_vec_count = 0;
-        Vector v1, v2;
-        for (int i = 0; i < NV-NV_rm; i++)
-        {
-            mv_all.GetVectorValues(i, v1);
-            mv_test.GetVectorValues(i, v2);
-            if (!(v1.DistanceTo(v2) == MFEM_Approx(0,0)))
-            {
-                wrong_shrink_vec_count++;
-            }
-        }
-        REQUIRE(wrong_shrink_vec_count == 0);
+      // Ensure that vectors post-shrink match those in mv_all
+      int wrong_shrink_vec_count = 0;
+      Vector v1, v2;
+      for (int i = 0; i < NV-NV_rm; i++)
+      {
+         mv_all.GetVectorValues(i, v1);
+         mv_test.GetVectorValues(i, v2);
+         if (!(v1.DistanceTo(v2) == MFEM_Approx(0,0)))
+         {
+            wrong_shrink_vec_count++;
+         }
+      }
+      REQUIRE(wrong_shrink_vec_count == 0);
 
-        // Set vectors back to mv_test, and then check equality
-        mv_test.SetNumVectors(NV);
-        for (int i = 0; i < NV_rm; i++)
-        {
-            mv_test.SetVectorValues(i+(NV-NV_rm), vecs_diff[i]);
-        }
-        REQUIRE(mv_test.DistanceTo(mv_all) == MFEM_Approx(0.0));
-    }
+      // Set vectors back to mv_test, and then check equality
+      mv_test.SetNumVectors(NV);
+      for (int i = 0; i < NV_rm; i++)
+      {
+         mv_test.SetVectorValues(i+(NV-NV_rm), vecs_diff[i]);
+      }
+      REQUIRE(mv_test.DistanceTo(mv_all) == MFEM_Approx(0.0));
+   }
 }
 
 TEST_CASE("MultiVector resize", "[MultiVector]")
 {
-    TestResize(Ordering::byNODES);
-    TestResize(Ordering::byVDIM);
+   TestResize(Ordering::byNODES);
+   TestResize(Ordering::byVDIM);
 }

--- a/tests/unit/linalg/test_multivector.cpp
+++ b/tests/unit/linalg/test_multivector.cpp
@@ -29,3 +29,24 @@ using namespace mfem;
 #include "unit_tests.hpp"
 
 using namespace mfem;
+
+TEST_CASE("Reordering Vector (byVDIM/byNODES)",
+          "[Ordering]")
+{
+   const Vector x_byNODES({1.0, 2.0, 3.0, 4.0, 5.0, 6.0});
+   const Vector x_byVDIM ({1.0, 3.0, 5.0, 2.0, 4.0, 6.0});
+   SECTION("byNODES -> byVDIM")
+   {
+      Vector x_test = x_byNODES;
+
+      Ordering::Reorder(x_test, 3, Ordering::byNODES, Ordering::byVDIM);
+      REQUIRE(x_test.DistanceTo(x_byVDIM) == MFEM_Approx(0));
+   }
+
+   SECTION("byVDIM -> byNODES")
+   {
+      Vector x_test = x_byVDIM;
+      Ordering::Reorder(x_test, 3, Ordering::byVDIM, Ordering::byNODES);
+      REQUIRE(x_test.DistanceTo(x_byNODES) == MFEM_Approx(0));
+   }
+}

--- a/tests/unit/linalg/test_multivector.cpp
+++ b/tests/unit/linalg/test_multivector.cpp
@@ -1,0 +1,31 @@
+// Copyright (c) 2010-2025, Lawrence Livermore National Security, LLC. Produced
+// at the Lawrence Livermore National Laboratory. All Rights reserved. See files
+// LICENSE and NOTICE for details. LLNL-CODE-806117.
+//
+// This file is part of the MFEM library. For more information and source code
+// availability visit https://mfem.org.
+//
+// MFEM is free software; you can redistribute it and/or modify it under the
+// terms of the BSD-3 license. We welcome feedback and contributions, see file
+// CONTRIBUTING.md for details.
+
+#include "mfem.hpp"
+#include "unit_tests.hpp"
+
+using namespace mfem;
+
+// Copyright (c) 2010-2025, Lawrence Livermore National Security, LLC. Produced
+// at the Lawrence Livermore National Laboratory. All Rights reserved. See files
+// LICENSE and NOTICE for details. LLNL-CODE-806117.
+//
+// This file is part of the MFEM library. For more information and source code
+// availability visit https://mfem.org.
+//
+// MFEM is free software; you can redistribute it and/or modify it under the
+// terms of the BSD-3 license. We welcome feedback and contributions, see file
+// CONTRIBUTING.md for details.
+
+#include "mfem.hpp"
+#include "unit_tests.hpp"
+
+using namespace mfem;

--- a/tests/unit/linalg/test_vector.cpp
+++ b/tests/unit/linalg/test_vector.cpp
@@ -247,3 +247,19 @@ TEST_CASE("Vector Sum", "[Vector],[GPU]")
 
    REQUIRE(sum_1 == MFEM_Approx(sum_2));
 }
+
+TEST_CASE("Vector delete at indices", "[Vector]")
+{
+   Vector           test({0,1,2,3,4,5,6,7,8});
+   Array<int> rm_indices({0,    3,4,  6,  8});
+   Vector         result({  1,2,    5,  7  });
+
+   test.DeleteAt(rm_indices);
+
+   REQUIRE(test.Size() == result.Size());
+
+   for (int i = 0; i < test.Size(); i++)
+   {
+      CHECK(test[i] == result[i]);
+   }
+}


### PR DESCRIPTION
This PR adds a new class `MultiVector` as a generalization of `GridFunction` for representing a type of `Vector` that holds a number of entries of vector data with a given vdim and `Ordering::Type`.

- Ordering is moved to the file linalg/multivector.cpp/hpp
- A new function `Ordering::Reorder` is added with a unit test
- The new `MultiVector` class is added with unit tests

The long term goal would be to have GridFunction derived from this type.

Note that this PR relies on `Vector::DeleteAt` from #4979 for the function `MultiVector::DeleteVectorsAt`.