### PR TITLE
Enable CMake fetching of GSLIB (and renaming of FETCH_TPLS, HYPRE_FETCH, and METIS_FETCH)

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -123,7 +123,7 @@ Parallel build:
 
 Parallel build with fetching of hypre and METIS:
    mkdir <mfem-buil-dir> ; cd <mfem-build-dir>
-   cmake <mfem-source-dir> -DMFEM_USE_MPI=YES -DFETCH_TPLS=YES
+   cmake <mfem-source-dir> -DMFEM_USE_MPI=YES -DMFEM_FETCH_TPLS=YES
    make -j 4
 
 CUDA build:
@@ -1081,9 +1081,10 @@ The following options are CMake specific:
 MFEM_ENABLE_TESTING  - Enable the ctest framework for testing.
 MFEM_ENABLE_EXAMPLES - Build all of the examples by default.
 MFEM_ENABLE_MINIAPPS - Build all of the miniapps by default.
-FETCH_TPLS           - Enable fetching of all supported third-party libraries.
-HYPRE_FETCH          - Enable fetching of hypre.
-METIS_FETCH          - Enable fetching of metis.
+MFEM_FETCH_TPLS      - Enable fetching of all supported third-party libraries.
+MFEM_FETCH_GSLIB     - Enable fetching of gslib.
+MFEM_FETCH_HYPRE     - Enable fetching of hypre.
+MFEM_FETCH_METIS     - Enable fetching of metis.
 
 External libraries (CMake):
 ---------------------------
@@ -1149,6 +1150,7 @@ The MFEM CMake build system also provides fetching (automated building) for the
 packages/libraries listed below. Note that when fetching is enabled, any related
 auto-detection functionality is disabled.
 
+ - GSLIB
  - HYPRE
  - METIS
 

--- a/config/cmake/modules/FindGSLIB.cmake
+++ b/config/cmake/modules/FindGSLIB.cmake
@@ -9,10 +9,38 @@
 # terms of the BSD-3 license. We welcome feedback and contributions, see file
 # CONTRIBUTING.md for details.
 
-# Defines the following variables:
+# Defines the following variables if fetching of TPLs is disabled (default):
 #   - GSLIB_FOUND
 #   - GSLIB_LIBRARIES
 #   - GSLIB_INCLUDE_DIRS
+# otherwise, the following are defined:
+#   - GSLIB (imported library target)
+
+if (MFEM_FETCH_GSLIB OR MFEM_FETCH_TPLS)
+  set(GSLIB_FETCH_VERSION 1.0.9)
+  add_library(GSLIB STATIC IMPORTED)
+  # define external project and create future include directory so it is present
+  # to pass CMake checks at end of MFEM configuration step
+  message(STATUS "Will fetch GSLIB ${GSLIB_FETCH_VERSION} to be built with default options")
+  set(PREFIX ${CMAKE_BINARY_DIR}/fetch/gslib)
+  include(ExternalProject)
+  ExternalProject_Add(gslib
+    GIT_REPOSITORY https://github.com/Nek5000/gslib
+    GIT_TAG v${GSLIB_FETCH_VERSION}
+    GIT_SHALLOW TRUE
+    UPDATE_DISCONNECTED TRUE
+    PREFIX ${PREFIX}
+    CONFIGURE_COMMAND ""
+    BUILD_COMMAND cd ${PREFIX}/src/gslib && make DESTDIR=${PREFIX}
+    INSTALL_COMMAND "")
+  file(MAKE_DIRECTORY ${PREFIX}/include)
+  # set imported library target properties
+  add_dependencies(GSLIB gslib)
+  set_target_properties(GSLIB PROPERTIES
+    IMPORTED_LOCATION ${PREFIX}/lib/libgs.a
+    INTERFACE_INCLUDE_DIRECTORIES ${PREFIX}/include)
+  return()
+endif()
 
 include(MfemCmakeUtilities)
 mfem_find_package(GSLIB GSLIB GSLIB_DIR "include" gslib.h "lib" gs

--- a/config/cmake/modules/FindHYPRE.cmake
+++ b/config/cmake/modules/FindHYPRE.cmake
@@ -36,7 +36,7 @@ if (HYPRE_FOUND OR TARGET HYPRE)
   endif()
 endif()
 
-if (HYPRE_FETCH OR FETCH_TPLS)
+if (MFEM_FETCH_HYPRE OR MFEM_FETCH_TPLS)
   set(HYPRE_FETCH_VERSION 2.33.0)
   add_library(HYPRE STATIC IMPORTED)
   # set options and associated dependencies

--- a/config/cmake/modules/FindMETIS.cmake
+++ b/config/cmake/modules/FindMETIS.cmake
@@ -18,7 +18,7 @@
 #   - METIS (imported library target)
 #   - METIS_VERSION_5 (cache variable)
 
-if (METIS_FETCH OR FETCH_TPLS)
+if (MFEM_FETCH_METIS OR MFEM_FETCH_TPLS)
   set(METIS_FETCH_VERSION 4.0.3)
   add_library(METIS STATIC IMPORTED)
   # define external project

--- a/config/defaults.cmake
+++ b/config/defaults.cmake
@@ -91,9 +91,10 @@ option(MFEM_ENABLE_BENCHMARKS "Build all of the benchmarks" OFF)
 
 # Allow a user to specify fetching of certain third-party libraries instead of
 # searching for existing installations.
-option(FETCH_TPLS "Enable fetching of all supported third-party libraries" OFF)
-option(HYPRE_FETCH "Enable fetching of hypre" OFF)
-option(METIS_FETCH "Enable fetching of METIS" OFF)
+option(MFEM_FETCH_TPLS "Enable fetching of all supported third-party libraries" OFF)
+option(MFEM_GSLIB_FETCH "Enable fetching of GSLIB" OFF)
+option(MFEM_HYPRE_FETCH "Enable fetching of hypre" OFF)
+option(MFEM_METIS_FETCH "Enable fetching of METIS" OFF)
 
 # Setting CXX/MPICXX on the command line or in user.cmake will overwrite the
 # autodetected C++ compiler.

--- a/config/defaults.cmake
+++ b/config/defaults.cmake
@@ -92,9 +92,9 @@ option(MFEM_ENABLE_BENCHMARKS "Build all of the benchmarks" OFF)
 # Allow a user to specify fetching of certain third-party libraries instead of
 # searching for existing installations.
 option(MFEM_FETCH_TPLS "Enable fetching of all supported third-party libraries" OFF)
-option(MFEM_GSLIB_FETCH "Enable fetching of GSLIB" OFF)
-option(MFEM_HYPRE_FETCH "Enable fetching of hypre" OFF)
-option(MFEM_METIS_FETCH "Enable fetching of METIS" OFF)
+option(MFEM_FETCH_GSLIB "Enable fetching of GSLIB" OFF)
+option(MFEM_FETCH_HYPRE "Enable fetching of hypre" OFF)
+option(MFEM_FETCH_METIS "Enable fetching of METIS" OFF)
 
 # Setting CXX/MPICXX on the command line or in user.cmake will overwrite the
 # autodetected C++ compiler.


### PR DESCRIPTION
This PR enables the fetching and building of GSLIB with the use of either `MFEM_FETCH_TPLS` or `MFEM_FETCH_GSLIB` during the CMake configuration.

This PR also renames existing fetching variables:
- adding "MFEM_" prefix to existing `FETCH_TPLS`, `HYPRE_FETCH`, and `METIS_FETCH`
- renamed `MFEM_HYPRE_FETCH` and `MFEM_METIS_FETCH` to `MFEM_FETCH_HYPRE` and `MFEM_FETCH_METIS`, respectively, so all `MFEM_FETCH_*` variables appear together in alphabetically-sorted list