### PR TITLE
Do not make ref of offsets in Block Preconditioners.

### DIFF
--- a/linalg/blockoperator.cpp
+++ b/linalg/blockoperator.cpp
@@ -148,11 +148,10 @@ BlockDiagonalPreconditioner::BlockDiagonalPreconditioner(
    Solver(offsets_.Last()),
    owns_blocks(0),
    nBlocks(offsets_.Size() - 1),
-   offsets(0),
+   offsets(offsets_),
    ops(nBlocks)
 {
    ops = nullptr;
-   offsets.MakeRef(offsets_);
 }
 
 void BlockDiagonalPreconditioner::SetDiagonalBlock(int iblock, Operator *op)
@@ -247,11 +246,10 @@ BlockLowerTriangularPreconditioner::BlockLowerTriangularPreconditioner(
    : Solver(offsets_.Last()),
      owns_blocks(0),
      nBlocks(offsets_.Size() - 1),
-     offsets(0),
+     offsets(offsets_),
      ops(nBlocks, nBlocks)
 {
    ops = nullptr;
-   offsets.MakeRef(offsets_);
 }
 
 void BlockLowerTriangularPreconditioner::SetDiagonalBlock(int iblock,


### PR DESCRIPTION
In the constructors of `BlockDiagonalPreconditioner` and `BlockLowerTriangularPreconditioner`, this change avoids using `MakeRef` on the `offsets` array. Since `offsets` is typically not large, there is no significant performance benefit to making it a reference, and it can lead to complications regarding data ownership and lifetime management. These types of errors are difficult to track down. In fact, it took me a while to realize that the issue I encountered was due to the `MakeRef` usage in this context. Therefore, I suggest directly copying the data to maintain consistency with other classes like `BlockOperator`.