### PR TITLE
Fix parallel nurbs miniapps

### DIFF
--- a/miniapps/nurbs/nurbs_ex1.cpp
+++ b/miniapps/nurbs/nurbs_ex1.cpp
@@ -311,14 +311,14 @@ int main(int argc, char *argv[])
       {
          cout << "No integration by parts requires a NURBS mesh, with only 1 patch."<<
               endl;
-         cout << "A C_1 discretisation is required."<< endl;
+         cout << "A C_1 discretization is required."<< endl;
          cout << "Currently only C_0 multipatch coupling implemented."<< endl;
          return 3;
       }
       if (order[0]<2)
       {
          cout << "No integration by parts requires at least quadratic NURBS."<< endl;
-         cout << "A C_1 discretisation is required."<< endl;
+         cout << "A C_1 discretization is required."<< endl;
          return 4;
       }
    }

--- a/miniapps/nurbs/nurbs_ex11p.cpp
+++ b/miniapps/nurbs/nurbs_ex11p.cpp
@@ -57,8 +57,7 @@ int main(int argc, char *argv[])
    const char *mesh_file = "../../data/star.mesh";
    int ser_ref_levels = 2;
    int par_ref_levels = 1;
-   Array<int> order(1);
-   order[0] = 0;
+   int order = 0;
    int nev = 5;
    int seed = 75;
    bool slu_solver  = false;
@@ -148,10 +147,9 @@ int main(int argc, char *argv[])
    //    use continuous Lagrange finite elements of the specified order. If
    //    order < 1, we instead use an isoparametric/isogeometric space.
    FiniteElementCollection *fec;
-   NURBSExtension *NURBSext = NULL;
    int own_fec = 0;
 
-   if (order[0] == 0) // Isoparametric
+   if (order < 0) // Isoparametric
    {
       if (pmesh->GetNodes())
       {
@@ -172,25 +170,19 @@ int main(int argc, char *argv[])
          own_fec = 1;
       }
    }
-   else if (pmesh->NURBSext && (order[0] > 0) )  // Subparametric NURBS
+   else if (pmesh->NURBSext && (order > 0) )  // Subparametric NURBS
    {
-      fec = new H1_FECollection(order[0], dim);
+      fec = new H1_FECollection(order, dim);
       own_fec = 1;
       int nkv = pmesh->NURBSext->GetNKV();
-
-      if (order.Size() == 1)
-      {
-         int tmp = order[0];
-         order.SetSize(nkv);
-         order = tmp;
-      }
-      if (order.Size() != nkv ) { mfem_error("Wrong number of orders set."); }
-      NURBSext = new NURBSExtension(pmesh->NURBSext, order);
    }
    else
    {
-      if (order.Size() > 1) { cout <<"Wrong number of orders set, needs one.\n"; }
-      fec = new H1_FECollection(abs(order[0]), dim);
+      if (myid == 0)
+      {
+         cout << "Invalid order, setting to one." << endl;
+      }
+      fec = new H1_FECollection(1, dim);
       own_fec = 1;
    }
    ParFiniteElementSpace *fespace = new ParFiniteElementSpace(pmesh,fec);

--- a/miniapps/nurbs/nurbs_ex11p.cpp
+++ b/miniapps/nurbs/nurbs_ex11p.cpp
@@ -174,7 +174,6 @@ int main(int argc, char *argv[])
    {
       fec = new H1_FECollection(order, dim);
       own_fec = 1;
-      int nkv = pmesh->NURBSext->GetNKV();
    }
    else
    {

--- a/miniapps/nurbs/nurbs_ex11p.cpp
+++ b/miniapps/nurbs/nurbs_ex11p.cpp
@@ -174,7 +174,7 @@ int main(int argc, char *argv[])
    }
    else if (pmesh->NURBSext && (order[0] > 0) )  // Subparametric NURBS
    {
-      fec = new NURBSFECollection(order[0]);
+      fec = new H1_FECollection(order[0], dim);
       own_fec = 1;
       int nkv = pmesh->NURBSext->GetNKV();
 
@@ -193,7 +193,7 @@ int main(int argc, char *argv[])
       fec = new H1_FECollection(abs(order[0]), dim);
       own_fec = 1;
    }
-   ParFiniteElementSpace *fespace = new ParFiniteElementSpace(pmesh,NURBSext,fec);
+   ParFiniteElementSpace *fespace = new ParFiniteElementSpace(pmesh,fec);
    HYPRE_BigInt size = fespace->GlobalTrueVSize();
    if (myid == 0)
    {

--- a/miniapps/nurbs/nurbs_ex1p.cpp
+++ b/miniapps/nurbs/nurbs_ex1p.cpp
@@ -360,9 +360,9 @@ int main(int argc, char *argv[])
          const int p = fec->GetOrder();
          kappa = 4*(p+1)*(p+1);
       }
-      if (myid == 0) { cout << "Enforcing BC weakly, kappa = " << kappa << endl; }
-      b->AddBdrFaceIntegrator(
-         new DGDirichletLFIntegrator(zero, one, -1.0, kappa));
+   if (myid == 0) { cout << "Enforcing BC weakly, kappa = " << kappa << endl; }
+   b->AddBdrFaceIntegrator(
+      new DGDirichletLFIntegrator(zero, one, -1.0, kappa));
    b->Assemble();
 
    // 9. Define the solution vector x as a parallel finite element grid function

--- a/miniapps/nurbs/nurbs_ex1p.cpp
+++ b/miniapps/nurbs/nurbs_ex1p.cpp
@@ -267,7 +267,7 @@ int main(int argc, char *argv[])
    }
    else if (pmesh->NURBSext && (order[0] > 0) )  // Subparametric NURBS
    {
-      fec = new NURBSFECollection(order[0]);
+      fec = new H1_FECollection(order[0], dim);
       own_fec = 1;
       int nkv = pmesh->NURBSext->GetNKV();
 
@@ -290,7 +290,7 @@ int main(int argc, char *argv[])
             cout<<" - slave  : "; slave.Print();
          }
 
-         NURBSext->ConnectBoundaries(master,slave);
+         pmesh->NURBSext->ConnectBoundaries(master,slave);
       }
    }
    else
@@ -299,7 +299,7 @@ int main(int argc, char *argv[])
       fec = new H1_FECollection(abs(order[0]), dim);
       own_fec = 1;
    }
-   ParFiniteElementSpace *fespace = new ParFiniteElementSpace(pmesh,NURBSext,fec);
+   ParFiniteElementSpace *fespace = new ParFiniteElementSpace(pmesh,fec);
    HYPRE_BigInt size = fespace->GlobalTrueVSize();
    if (myid == 0)
    {

--- a/miniapps/nurbs/nurbs_ex1p.cpp
+++ b/miniapps/nurbs/nurbs_ex1p.cpp
@@ -305,14 +305,14 @@ int main(int argc, char *argv[])
       {
          cout << "No integration by parts requires a NURBS mesh, with only 1 patch."<<
               endl;
-         cout << "A C_1 discretisation is required."<< endl;
+         cout << "A C_1 discretization is required."<< endl;
          cout << "Currently only C_0 multipatch coupling implemented."<< endl;
          return 3;
       }
       if (order<2)
       {
          cout << "No integration by parts requires at least quadratic NURBS."<< endl;
-         cout << "A C_1 discretisation is required."<< endl;
+         cout << "A C_1 discretization is required."<< endl;
          return 4;
       }
    }

--- a/miniapps/nurbs/nurbs_ex1p.cpp
+++ b/miniapps/nurbs/nurbs_ex1p.cpp
@@ -263,7 +263,6 @@ int main(int argc, char *argv[])
    {
       fec = new H1_FECollection(order, dim);
       own_fec = 1;
-      int nkv = pmesh->NURBSext->GetNKV();
 
       // Enforce periodic BC's
       if (master.Size() > 0)
@@ -354,15 +353,17 @@ int main(int argc, char *argv[])
    b->AddDomainIntegrator(new DomainLFIntegrator(one));
 
    if (!strongBC)
+   {
       // Set kappa if needed using fec order
       if (kappa < 0)
       {
          const int p = fec->GetOrder();
          kappa = 4*(p+1)*(p+1);
       }
-   if (myid == 0) { cout << "Enforcing BC weakly, kappa = " << kappa << endl; }
-   b->AddBdrFaceIntegrator(
-      new DGDirichletLFIntegrator(zero, one, -1.0, kappa));
+      if (myid == 0) { cout << "Enforcing BC weakly, kappa = " << kappa << endl; }
+      b->AddBdrFaceIntegrator(
+         new DGDirichletLFIntegrator(zero, one, -1.0, kappa));
+   }
    b->Assemble();
 
    // 9. Define the solution vector x as a parallel finite element grid function


### PR DESCRIPTION
# Main change
A recent issue pointed out some weird looking answers when running `nurbs_ex1p`. I was able to reproduce this even without the `-no-ibp` flag, simply by running `mpirun -np 4 nurbs_ex1p -m ../../data/square-nurbs.mesh -o 3` we get an erroneous looking answer.

<img width="264" height="322" alt="image" src="https://github.com/user-attachments/assets/a84278eb-f607-498f-ab2c-5fd0710e1a34" />

Similarly, running `mpirun -np 4 nurbs_ex11p -m ../../data/square-nurbs.mesh -o 3` will give incorrect answers.

After some investigation this seems to be related to changes in how nurbs `FiniteElementCollection` and `FiniteElementSpace` are constructed. This PR makes appropriate changes which results in correct outputs.

# Other changes
~~Another minor change in this PR - in these examples, `order` is an array but I don't see any way this would be set? I've changed these to scalar values and made changes accordingly.~~ I guess arrays can be set via cli args. I'd still like to get a second opinion on how we are setting up the problem. e.g. this line: `NURBSext = new NURBSExtension(pmesh->NURBSext, order)` - should we be creating a whole new (serial) `NURBSExtension`? The approach of `nurbs_patch_ex1` using `incdeg` instead of `order` (iga is assumed) to change the order of the mesh makes more sense to me. With the current approach, we now have the `NURBSExtension` associated with the mesh, and an independent one associated with the finite element space.

Finally, one last minor change is that the initialization of the default `kappa` value is moved down, because it should rely on the order of the `FiniteElementCollection` (if using IGA where `order=-1` this would result in an incorrect value).
