### PR TITLE
Remove order from NURBS FE Collection

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,6 +7,11 @@
 
                                https://mfem.org
 
+Refactor of NURBS
+
+Remove format 90??
+
+
 
 Version 4.8.1 (development)
 ===========================

--- a/fem/fe/fe_nurbs.cpp
+++ b/fem/fe/fe_nurbs.cpp
@@ -26,6 +26,9 @@ void NURBS1DFiniteElement::SetOrder() const
 
    weights.SetSize(dof);
    shape_x.SetSize(dof);
+#ifndef MFEM_THREAD_SAFE
+   vshape.SetSize(dof, dim);
+#endif
 }
 
 void NURBS1DFiniteElement::CalcShape(const IntegrationPoint &ip,
@@ -101,6 +104,9 @@ void NURBS2DFiniteElement::SetOrder() const
    u.SetSize(dof);
    du.SetSize(dof);
    weights.SetSize(dof);
+#ifndef MFEM_THREAD_SAFE
+   vshape.SetSize(dof, dim);
+#endif
 }
 
 void NURBS2DFiniteElement::CalcShape(const IntegrationPoint &ip,
@@ -238,6 +244,9 @@ void NURBS3DFiniteElement::SetOrder() const
    u.SetSize(dof);
    du.SetSize(dof);
    weights.SetSize(dof);
+#ifndef MFEM_THREAD_SAFE
+   vshape.SetSize(dof, dim);
+#endif
 }
 
 void NURBS3DFiniteElement::CalcShape(const IntegrationPoint &ip,
@@ -437,6 +446,9 @@ void NURBS_HDiv2DFiniteElement::SetOrder() const
    u.SetSize(dof);
    du.SetSize(dof);
    weights.SetSize(dof);
+#ifndef MFEM_THREAD_SAFE
+   vshape.SetSize(dof, dim);
+#endif
 }
 
 void NURBS_HDiv2DFiniteElement::CalcVShape(const IntegrationPoint &ip,
@@ -569,6 +581,9 @@ void NURBS_HDiv3DFiniteElement::SetOrder() const
    u.SetSize(dof);
    du.SetSize(dof);
    weights.SetSize(dof);
+#ifndef MFEM_THREAD_SAFE
+   vshape.SetSize(dof, dim);
+#endif
 }
 
 void NURBS_HDiv3DFiniteElement::CalcVShape(const IntegrationPoint &ip,
@@ -738,6 +753,9 @@ void NURBS_HCurl2DFiniteElement::SetOrder() const
    u.SetSize(dof);
    du.SetSize(dof);
    weights.SetSize(dof);
+#ifndef MFEM_THREAD_SAFE
+   vshape.SetSize(dof, dim);
+#endif
 }
 
 void NURBS_HCurl2DFiniteElement::CalcVShape(const IntegrationPoint &ip,
@@ -869,6 +887,9 @@ void NURBS_HCurl3DFiniteElement::SetOrder() const
    u.SetSize(dof);
    du.SetSize(dof);
    weights.SetSize(dof);
+#ifndef MFEM_THREAD_SAFE
+   vshape.SetSize(dof, dim);
+#endif
 }
 
 void NURBS_HCurl3DFiniteElement::CalcVShape(const IntegrationPoint &ip,

--- a/fem/fe/fe_nurbs.hpp
+++ b/fem/fe/fe_nurbs.hpp
@@ -75,7 +75,7 @@ protected:
 
 public:
    /// Construct the NURBS1DFiniteElement of order @a p
-   NURBS1DFiniteElement(int p)
+   NURBS1DFiniteElement(int p = -1)
       : ScalarFiniteElement(1, Geometry::SEGMENT, p + 1, p, FunctionSpace::Qk),
         NURBSFiniteElement(1),
         shape_x(p + 1) { }
@@ -98,7 +98,7 @@ protected:
 
 public:
    /// Construct the NURBS2DFiniteElement of order @a p
-   NURBS2DFiniteElement(int p)
+   NURBS2DFiniteElement(int p = -1)
       : ScalarFiniteElement(2, Geometry::SQUARE, (p + 1)*(p + 1), p,
                             FunctionSpace::Qk),
         NURBSFiniteElement(2),
@@ -135,7 +135,7 @@ protected:
 
 public:
    /// Construct the NURBS3DFiniteElement of order @a p
-   NURBS3DFiniteElement(int p)
+   NURBS3DFiniteElement(int p = -1)
       : ScalarFiniteElement(3, Geometry::CUBE, (p + 1)*(p + 1)*(p + 1), p,
                             FunctionSpace::Qk),
         NURBSFiniteElement(3),
@@ -187,7 +187,7 @@ protected:
 
 public:
    /// Construct the NURBS_HDiv2DFiniteElement of order @a p
-   NURBS_HDiv2DFiniteElement(int p)
+   NURBS_HDiv2DFiniteElement(int p = -1)
       : VectorFiniteElement(2, Geometry::SQUARE, 2*(p + 1)*(p + 2), p,
                             H_DIV,FunctionSpace::Qk),
         NURBSFiniteElement(2),
@@ -273,7 +273,7 @@ protected:
 
 public:
    /// Construct the NURBS_HDiv3DFiniteElement of order @a p
-   NURBS_HDiv3DFiniteElement(int p)
+   NURBS_HDiv3DFiniteElement(int p = -1)
       : VectorFiniteElement(3, Geometry::CUBE, 3*(p + 1)*(p + 1)*(p + 2),
                             p, H_DIV,FunctionSpace::Qk),
         NURBSFiniteElement(3),
@@ -358,7 +358,7 @@ protected:
 
 public:
    /// Construct the NURBS_HCurl2DFiniteElement of order @a p
-   NURBS_HCurl2DFiniteElement(int p)
+   NURBS_HCurl2DFiniteElement(int p = -1)
       : VectorFiniteElement(2, Geometry::SQUARE, 2*(p + 1)*(p + 2), p,
                             H_CURL,FunctionSpace::Qk),
         NURBSFiniteElement(2),
@@ -441,7 +441,7 @@ protected:
 
 public:
    /// Construct the NURBS_HCurl3DFiniteElement of order @a p
-   NURBS_HCurl3DFiniteElement(int p)
+   NURBS_HCurl3DFiniteElement(int p = -1)
       : VectorFiniteElement(3, Geometry::CUBE, 3*(p + 1)*(p + 2)*(p + 2), p,
                             H_CURL,FunctionSpace::Qk),
         NURBSFiniteElement(3),

--- a/fem/fe_coll.cpp
+++ b/fem/fe_coll.cpp
@@ -3497,27 +3497,12 @@ Local_FECollection::Local_FECollection(const char *fe_name)
 
 NURBSFECollection::NURBSFECollection(int Order)
    : FiniteElementCollection((Order == VariableOrder) ? 1 : Order)
+     //: FiniteElementCollection()
 {
-   const int order = (Order == VariableOrder) ? 1 : Order;
    PointFE          = new PointFiniteElement();
-   SegmentFE        = new NURBS1DFiniteElement(order);
-   QuadrilateralFE  = new NURBS2DFiniteElement(order);
-   ParallelepipedFE = new NURBS3DFiniteElement(order);
-
-   SetOrder(Order);
-}
-
-void NURBSFECollection::SetOrder(int Order) const
-{
-   mOrder = Order;
-   if (Order != VariableOrder)
-   {
-      snprintf(name, 16, "NURBS%i", Order);
-   }
-   else
-   {
-      snprintf(name, 16, "NURBS");
-   }
+   SegmentFE        = new NURBS1DFiniteElement();
+   QuadrilateralFE  = new NURBS2DFiniteElement();
+   ParallelepipedFE = new NURBS3DFiniteElement();
 }
 
 NURBSFECollection::~NURBSFECollection()
@@ -3565,18 +3550,14 @@ FiniteElementCollection *NURBSFECollection::GetTraceCollection() const
 
 
 NURBS_HDivFECollection::NURBS_HDivFECollection(int Order, const int dim)
-   : NURBSFECollection((Order == VariableOrder) ? 1 : Order)
 {
-   const int order = (Order == VariableOrder) ? 1 : Order;
+   SegmentFE       = new NURBS1DFiniteElement();
+   QuadrilateralFE = new NURBS2DFiniteElement();
 
-   SegmentFE       = new NURBS1DFiniteElement(order);
-   QuadrilateralFE = new NURBS2DFiniteElement(order);
-
-   QuadrilateralVFE  = new NURBS_HDiv2DFiniteElement(order);
-   ParallelepipedVFE = new NURBS_HDiv3DFiniteElement(order);
+   QuadrilateralVFE  = new NURBS_HDiv2DFiniteElement();
+   ParallelepipedVFE = new NURBS_HDiv3DFiniteElement();
 
    if (dim != -1) { SetDim(dim); }
-   SetOrder(Order);
 }
 
 void NURBS_HDivFECollection::SetDim(int dim)
@@ -3623,19 +3604,6 @@ NURBS_HDivFECollection::FiniteElementForGeometry(Geometry::Type GeomType) const
    return QuadrilateralFE; // Make some compilers happy
 }
 
-void NURBS_HDivFECollection::SetOrder(int Order) const
-{
-   mOrder = Order;
-   if (Order != VariableOrder)
-   {
-      snprintf(name, 16, "NURBS_HDiv%i", Order);
-   }
-   else
-   {
-      snprintf(name, 16, "NURBS_HDiv");
-   }
-}
-
 int NURBS_HDivFECollection::DofForGeometry(Geometry::Type GeomType) const
 {
    mfem_error("NURBS_HDivFECollection::DofForGeometry");
@@ -3657,17 +3625,13 @@ FiniteElementCollection *NURBS_HDivFECollection::GetTraceCollection() const
 }
 
 NURBS_HCurlFECollection::NURBS_HCurlFECollection(int Order, const int dim)
-   : NURBSFECollection((Order == VariableOrder) ? 1 : Order)
 {
-   const int order = (Order == VariableOrder) ? 1 : Order;
+   SegmentFE       = new NURBS1DFiniteElement();
+   QuadrilateralFE = new NURBS2DFiniteElement();
 
-   SegmentFE       = new NURBS1DFiniteElement(order+1);
-   QuadrilateralFE = new NURBS2DFiniteElement(order+1);
-
-   QuadrilateralVFE  = new NURBS_HCurl2DFiniteElement(order);
-   ParallelepipedVFE = new NURBS_HCurl3DFiniteElement(order);
+   QuadrilateralVFE  = new NURBS_HCurl2DFiniteElement();
+   ParallelepipedVFE = new NURBS_HCurl3DFiniteElement();
    if (dim != -1) { SetDim(dim); }
-   SetOrder(Order);
 }
 
 void NURBS_HCurlFECollection::SetDim(int dim)
@@ -3714,19 +3678,6 @@ NURBS_HCurlFECollection::FiniteElementForGeometry(Geometry::Type GeomType) const
          mfem_error ("NURBS_HCurlFECollection: unknown geometry type.");
    }
    return QuadrilateralFE; // Make some compilers happy
-}
-
-void NURBS_HCurlFECollection::SetOrder(int Order) const
-{
-   mOrder = Order;
-   if (Order != VariableOrder)
-   {
-      snprintf(name, 16, "NURBS_HCurl%i", Order);
-   }
-   else
-   {
-      snprintf(name, 16, "NURBS_HCurl");
-   }
 }
 
 int NURBS_HCurlFECollection::DofForGeometry(Geometry::Type GeomType) const

--- a/fem/fe_coll.hpp
+++ b/fem/fe_coll.hpp
@@ -717,14 +717,6 @@ protected:
    NURBS2DFiniteElement *QuadrilateralFE;
    NURBS3DFiniteElement *ParallelepipedFE;
 
-   mutable int mOrder; // >= 1 or VariableOrder
-   // The 'name' can be:
-   // 1) name = "NURBS" + "number", for fixed order, or
-   // 2) name = "NURBS", for VariableOrder.
-   // The name is updated before writing it to a stream, for example, see
-   // FiniteElementSpace::Save().
-   mutable char name[16];
-
 public:
    enum { VariableOrder = -1 };
 
@@ -741,15 +733,6 @@ public:
 
    virtual void SetDim(const int dim) {};
 
-   /** @brief Get the order of the NURBS collection: either a positive number,
-       when using fixed order, or VariableOrder. */
-   /** @note Not to be confused with FiniteElementCollection::GetOrder(). */
-   int GetOrder() const { return mOrder; }
-
-   /** @brief Set the order and the name, based on the given @a Order: either a
-       positive number for fixed order, or VariableOrder. */
-   virtual void SetOrder(int Order) const;
-
    const FiniteElement *
    FiniteElementForGeometry(Geometry::Type GeomType) const override;
 
@@ -758,7 +741,7 @@ public:
    const int *DofOrderForOrientation(Geometry::Type GeomType,
                                      int Or) const override;
 
-   const char *Name() const override { return name; }
+   const char *Name() const override { return "NURBS"; }
 
    int GetContType() const override { return CONTINUOUS; }
 
@@ -798,10 +781,6 @@ public:
 
    void SetDim(const int dim) override;
 
-   /** @brief Set the order and the name, based on the given @a Order: either a
-       positive number for fixed order, or VariableOrder. */
-   void SetOrder(int Order) const override;
-
    const FiniteElement *
    FiniteElementForGeometry(Geometry::Type GeomType) const override;
 
@@ -810,7 +789,7 @@ public:
    const int *DofOrderForOrientation(Geometry::Type GeomType,
                                      int Or) const override;
 
-   const char *Name() const override { return name; }
+   const char *Name() const override { return "NURBS_HDiv"; }
 
    int GetContType() const override { return CONTINUOUS; }
 
@@ -849,10 +828,6 @@ public:
 
    void SetDim(const int dim) override;
 
-   /** @brief Set the order and the name, based on the given @a Order: either a
-       positive number for fixed order, or VariableOrder. */
-   void SetOrder(int Order) const override;
-
    const FiniteElement *
    FiniteElementForGeometry(Geometry::Type GeomType) const override;
 
@@ -861,7 +836,7 @@ public:
    const int *DofOrderForOrientation(Geometry::Type GeomType,
                                      int Or) const override;
 
-   const char *Name() const override { return name; }
+   const char *Name() const override { return "NURBS_HCurl"; }
 
    int GetContType() const override { return CONTINUOUS; }
 

--- a/fem/fespace.cpp
+++ b/fem/fespace.cpp
@@ -4391,7 +4391,6 @@ void FiniteElementSpace::Save(std::ostream &os) const
       const NURBSFECollection *nurbs_fec =
          dynamic_cast<const NURBSFECollection *>(fec);
       MFEM_VERIFY(nurbs_fec, "invalid FE collection");
-      nurbs_fec->SetOrder(NURBSext->GetOrder());
       const real_t eps = 5e-14;
       nurbs_unit_weights = (NURBSext->GetWeights().Min() >= 1.0-eps &&
                             NURBSext->GetWeights().Max() <= 1.0+eps);


### PR DESCRIPTION
Remove largely unused order memberfunction from  NURBS FE Collections.

Problems will arise in reading a mesh in format 90. Perhaps this format should be removed.