### PR TITLE
Fix memory leak in `TensorBasisElement::GetTensorDofToQuad`

### DIFF
--- a/fem/fe/fe_base.cpp
+++ b/fem/fe/fe_base.cpp
@@ -2634,7 +2634,11 @@ const DofToQuad &TensorBasisElement::GetTensorDofToQuad(
       for (int i = 0; i < dof2quad_array.Size(); i++)
       {
          auto* d2q_ = dof2quad_array[i];
-         if (d2q_->IntRule == &ir && d2q_->mode == mode) { d2q = d2q_; }
+         if (d2q_->IntRule == &ir && d2q_->mode == mode)
+         {
+            d2q = d2q_;
+            break;
+         }
       }
       if (!d2q)
       {


### PR DESCRIPTION
This PR fixes a slow memory leak that leads to long running simulations running out of memory after several hours. It is not picked up by asan or leak-check because everything is freed at the end of the program. This was found with massif.

It is triggered by using different quadrature rules on the same mesh, so you won't see it if you use the same quadrature rule for everything or have a bounded number of calls to recomputing geometric factors. It's easily fixed by fixing the logic that's supposed to prevent duplicate `DofToQuad` tables from being generated.

Here's a minimal working example that runs partial assembly for the mass integrator on a single element mesh a bunch of times and alternates between the same two integration rules.

```c++
// memory_leak_mwe.cpp
#include "mfem.hpp"
#include <iostream>

using namespace mfem;
using namespace std;

int main()
{   
    Mesh mesh = Mesh::MakeCartesian2D(1, 1, Element::QUADRILATERAL, true, 1.0, 1.0);
    int order = 2;
    H1_FECollection fec(order, mesh.Dimension());
    FiniteElementSpace fespace(&mesh, &fec);
    
    const IntegrationRule *ir1 = &IntRules.Get(fespace.GetFE(0)->GetGeomType(), 2*order - 1);
    const IntegrationRule *ir2 = &IntRules.Get(fespace.GetFE(0)->GetGeomType(), 2*order);
    
    int num_iterations = 10000;
    
    for (int i = 0; i < num_iterations; ++i)
    {
        // Alternate quadrature rules
        const IntegrationRule *current_ir = (i % 2 == 0) ? ir1 : ir2;
        MassIntegrator vmi(current_ir);
        vmi.AssemblePA(fespace);
    }
}
```

Running with massif, `valgrind --tool=massif  ./memory_leak_mwe`, before the fix shows unbounded memory growth.
```
--------------------------------------------------------------------------------
Command:            ./bin/examples/memory_leak_mwe
Massif arguments:   (none)
ms_print arguments: massif.out.286844
--------------------------------------------------------------------------------


    MB
4.634^                                                                       :
     |                                                                 :@@:@#:
     |                                                          ::::::::@@:@#:
     |                                                     :::::::: ::::@@:@#:
     |                                                 :::::::::::: ::::@@:@#:
     |                                          :::::::::: :::::::: ::::@@:@#:
     |                                      :::@: :: : ::: :::::::: ::::@@:@#:
     |                                :::::::: @: :: : ::: :::::::: ::::@@:@#:
     |                           :::::: ::: :: @: :: : ::: :::::::: ::::@@:@#:
     |                       :::::: ::: ::: :: @: :: : ::: :::::::: ::::@@:@#:
     |                    :::: :::: ::: ::: :: @: :: : ::: :::::::: ::::@@:@#:
     |                 ::::: : :::: ::: ::: :: @: :: : ::: :::::::: ::::@@:@#:
     |              @:::: :: : :::: ::: ::: :: @: :: : ::: :::::::: ::::@@:@#:
     |           :::@: :: :: : :::: ::: ::: :: @: :: : ::: :::::::: ::::@@:@#:
     |        ::@:: @: :: :: : :::: ::: ::: :: @: :: : ::: :::::::: ::::@@:@#:
     |       :: @:: @: :: :: : :::: ::: ::: :: @: :: : ::: :::::::: ::::@@:@#:
     |     :::: @:: @: :: :: : :::: ::: ::: :: @: :: : ::: :::::::: ::::@@:@#:
     |     : :: @:: @: :: :: : :::: ::: ::: :: @: :: : ::: :::::::: ::::@@:@#:
     |   ::: :: @:: @: :: :: : :::: ::: ::: :: @: :: : ::: :::::::: ::::@@:@#:
     |   : : :: @:: @: :: :: : :::: ::: ::: :: @: :: : ::: :::::::: ::::@@:@#:
   0 +----------------------------------------------------------------------->Gi
     0                                                                   1.125
```
and then after the fix
```
--------------------------------------------------------------------------------
Command:            ./bin/examples/memory_leak_mwe
Massif arguments:   (none)
ms_print arguments: massif.out.305808
--------------------------------------------------------------------------------


    KB
196.6^                                                 ::::::::::::::::::@  : 
     |                          ##:::::::::::::::@::::@::::: ::::::::::::@::::
     |                         :# ::::::: :: :: :@::::@::::: ::::::::::::@::::
     |                         :# ::::::: :: :: :@::::@::::: ::::::::::::@::::
     |                         :# ::::::: :: :: :@::::@::::: ::::::::::::@::::
     |                        ::# ::::::: :: :: :@::::@::::: ::::::::::::@::::
     |                      ::::# ::::::: :: :: :@::::@::::: ::::::::::::@::::
     |                      : ::# ::::::: :: :: :@::::@::::: ::::::::::::@::::
     |                      : ::# ::::::: :: :: :@::::@::::: ::::::::::::@::::
     |                     :: ::# ::::::: :: :: :@::::@::::: ::::::::::::@::::
     |                    ::: ::# ::::::: :: :: :@::::@::::: ::::::::::::@::::
     |                    ::: ::# ::::::: :: :: :@::::@::::: ::::::::::::@::::
     |                    ::: ::# ::::::: :: :: :@::::@::::: ::::::::::::@::::
     |                    ::: ::# ::::::: :: :: :@::::@::::: ::::::::::::@::::
     |                    ::: ::# ::::::: :: :: :@::::@::::: ::::::::::::@::::
     |                    ::: ::# ::::::: :: :: :@::::@::::: ::::::::::::@::::
     |                    ::: ::# ::::::: :: :: :@::::@::::: ::::::::::::@::::
     |                    ::: ::# ::::::: :: :: :@::::@::::: ::::::::::::@::::
     |                    ::: ::# ::::::: :: :: :@::::@::::: ::::::::::::@::::
     |                    ::: ::# ::::::: :: :: :@::::@::::: ::::::::::::@::::
   0 +----------------------------------------------------------------------->Mi
     0                                                                   95.38
```
<!--GHEX{"author":"victor-decaria-nnl","assignment":"2025-11-13T21:34:20","editor":"tzanio","id":5114,"reviewers":["v-dobrev","jandrej"],"merge":"2025-11-15T18:02:19","approval":"2025-11-14T00:23:34"}XEHG-->
<!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge|
 | --- | --- | --- | --- | --- | --- | --- |
| [#5114](https://github.com/mfem/mfem/pull/5114) | @victor-decaria-nnl | @tzanio | @v-dobrev + @jandrej | 11/13/25 | 11/13/25 | 11/15/25 | |
<!--ELBATXEHG-->
<details>
<summary>PR Checklist</summary>
    
- [ ] Code builds.
- [ ] Code passes `make style`.
- [ ] Update `CHANGELOG`:
    - [ ] Is this a new feature users need to be aware of? New or updated example or miniapp?
    - [ ] Does it make sense to create a new section in the `CHANGELOG` to group with other related features?
- [ ] Update `INSTALL`:
    - [ ] Had a new optional library been added? If so, what range of versions of this library are required? (*Make sure the external library is compatible with our BSD license, e.g. it is not licensed under GPL!*)
    - [ ] Have the version ranges for any required or optional libraries changed?
    - [ ] Does `make` or `cmake` have a new target?
    - [ ] Did the requirements or the installation process change? *(rare)*
- [ ] Update continuous integration server configurations if necessary (e.g. with new version requirements for each of MFEM's dependencies)
    - [ ] `.github`
    - [ ] `.appveyor.yml`
- [ ] Update `.gitignore`:
    - [ ] Check if `make distclean; git status` shows any files that were generated from the source by the project (not an IDE) but we don't want to track in the repository.
    - [ ] Add new patterns (just for the new files above) and re-run the above test.
- [ ] New examples:
    - [ ] All sample runs at the top of the example source file work.
    - [ ] Update `examples/makefile`:
      - [ ] Add the example code to the appropriate `SEQ_EXAMPLES` and `PAR_EXAMPLES` variables.
      - [ ] Add any files generated by it to the `clean` target.
      - [ ] Add the example binary and any files generated by it to the top-level `.gitignore` file.
    - [ ] Update `examples/CMakeLists.txt`:
      - [ ] Add the example code to the `ALL_EXE_SRCS` variable.
      - [ ] Make sure `THIS_TEST_OPTIONS` is set correctly for the new example.
   - [ ] List the new example in `doc/CodeDocumentation.dox`.
   - [ ] If new examples directory (e.g.`examples/pumi`), list it in `doc/CodeDocumentation.conf.in`
   - [ ] Companion pull request for documentation in [mfem/web](https://github.com/mfem/web) repo:
      - [ ] Update or add example-specific documentation, see e.g. the `src/examples.md`.
      - [ ] Add the description, labels and screenshots in `src/examples.md` and `src/img`.
      - [ ] In `examples.md`, list the example under the appropriate categories, add new categories if necessary.
      - [ ] Add a short description of the example in the "Extensive Examples" section of `features.md`.
- [ ] New miniapps:
   - [ ] All sample runs at the top of the miniapp source file work.
   - [ ] Update top-level `makefile` and `makefile` in corresponding miniapp directory.
   - [ ] Add the miniapp binary and any files generated by it to the top-level `.gitignore` file.
   - [ ] Update CMake build system:
      - [ ] Update the `CMakeLists.txt` file in the `miniapps` directory, if the new miniapp is in a new directory.
      - [ ] Add/update the `CMakeLists.txt` file in the new miniapp directory.
      - [ ] Consider adding a new test for the new miniapp.
   - [ ] List the new miniapp in `doc/CodeDocumentation.dox`
   - [ ] If new miniapps directory (e.g.`miniapps/nurbs`), add it to `MINIAPP_SUBDIRS` in the `makefile`.
   - [ ] If new miniapps directory (e.g.`miniapps/nurbs`), list it in `doc/CodeDocumentation.conf.in`
   - [ ] Companion pull request for documentation in [mfem/web](https://github.com/mfem/web) repo:
     - [ ] Update or add miniapp-specific documentation, see e.g. the `src/meshing.md` and `src/electromagnetics.md` files.
     - [ ] Add the description, labels and screenshots in `src/examples.md` and `src/img`.
     - [ ] The miniapps go at the end of the page, and are usually listed only under a specific "Application (PDE)" category.
     - [ ] Add a short description of the miniapp in the "Extensive Examples" section of `features.md`.
- [ ] New capability:
   - [ ] All new public, protected, and private classes, methods, data members, and functions have full Doxygen-style documentation in source comments. Documentation should include descriptions of member data, function arguments and return values, template parameters, and prerequisites for calling new functions.
   - [ ] Pointer arguments and return values must specify whether ownership is being transferred or lent with the call.
   - [ ] Any new functions should include descriptions of their intended use e.g. for internal use only, user-facing, etc., along with references to example code whenever possible/appropriate.
   - [ ] Consider adding new sample runs in existing examples to highlight the new capability.
   - [ ] Consider saving cool simulation pictures with the new capability in the Confluence gallery (LLNL only) or submitting them, via pull request, to the gallery section of the `mfem/web` repo.
   - [ ] If this is a major new feature, consider mentioning it in the short summary inside `README` *(rare)*.
   - [ ] List major new classes in `doc/CodeDocumentation.dox` *(rare)*.
- [ ] Update this checklist, if the new pull request affects it.
- [ ] Run `make unittest` to make sure all unit tests pass.
- [ ] Run the tests in `tests/scripts`.
- [ ] (LLNL only) After merging:
   - [ ] Update internal tests to include the new features.
</details>
