### PR TITLE
Dgdiffusion face coefficient

### DIFF
--- a/fem/coefficient.cpp
+++ b/fem/coefficient.cpp
@@ -2195,6 +2195,8 @@ void CoefficientVector::SetConstant(const DenseSymmetricMatrix &constant)
 
 int CoefficientVector::GetVDim() const { return vdim; }
 
+void CoefficientVector::SetVDim(int vdim_) { vdim = vdim_; }
+
 CoefficientVector::~CoefficientVector()
 {
    delete qf;

--- a/fem/coefficient.hpp
+++ b/fem/coefficient.hpp
@@ -2606,6 +2606,9 @@ public:
    /// Return the number of values per quadrature point.
    int GetVDim() const;
 
+   /// Override the vector dimension (number of values per quadrature point).
+   void SetVDim(int vdim_);
+
    ~CoefficientVector();
 };
 

--- a/fem/integ/bilininteg_dgdiffusion_kernels.hpp
+++ b/fem/integ/bilininteg_dgdiffusion_kernels.hpp
@@ -43,7 +43,7 @@ static void PADGDiffusionApply2D(const int NF, const Array<real_t> &b,
    auto G_ = Reshape(g.Read(), Q1D, D1D);
 
    auto pa =
-      Reshape(pa_data.Read(), 6, Q1D, NF); // (q, 1/h, J00, J01, J10, J11)
+      Reshape(pa_data.Read(), 5, Q1D, NF); // (J00, J01, J10, J11, q/h)
 
    auto x = Reshape(x_.Read(), D1D, 2, NF);
    auto y = Reshape(y_.ReadWrite(), D1D, 2, NF);
@@ -109,8 +109,8 @@ static void PADGDiffusionApply2D(const int NF, const Array<real_t> &b,
 
          MFEM_FOREACH_THREAD(p, x, Q1D)
          {
-            const real_t Je_side[] = {pa(2 + 2 * side, p, f),
-                                      pa(2 + 2 * side + 1, p, f)
+            const real_t Je_side[] = {pa(2 * side + 0, p, f),
+                                      pa(2 * side + 1, p, f)
                                      };
 
             Bu[p] = 0.0;
@@ -133,11 +133,10 @@ static void PADGDiffusionApply2D(const int NF, const Array<real_t> &b,
       {
          MFEM_FOREACH_THREAD(p, x, Q1D)
          {
-            const real_t q = pa(0, p, f);
-            const real_t hi = pa(1, p, f);
+            const real_t q = pa(4, p, f);
             const real_t jump = Bu0[p] - Bu1[p];
             const real_t avg = Bdu0[p] + Bdu1[p]; // = {Q du/dn} * w * det(J)
-            r[p] = -avg + hi * q * jump;
+            r[p] = -avg + q * jump;
          }
       }
       MFEM_SYNC_THREAD;
@@ -173,8 +172,8 @@ static void PADGDiffusionApply2D(const int NF, const Array<real_t> &b,
          {
             for (int p = 0; p < Q1D; ++p)
             {
-               const real_t Je[] = {pa(2 + 2 * side, p, f),
-                                    pa(2 + 2 * side + 1, p, f)
+               const real_t Je[] = {pa(2 * side + 0, p, f),
+                                    pa(2 * side + 1, p, f)
                                    };
                const real_t jump = Bu0[p] - Bu1[p];
                const real_t r_p = Je[0] * jump; // normal

--- a/fem/integ/bilininteg_dgdiffusion_pa.cpp
+++ b/fem/integ/bilininteg_dgdiffusion_pa.cpp
@@ -42,8 +42,8 @@ static void PADGDiffusionSetup2D(const int Q1D, const int NE, const int NF,
    const auto n = Reshape(face_geom.normal.Read(), Q1D, 2, NF);
 
    const bool const_q = (q.Size() == coeff_dim);
-   const auto Q = const_q ? Reshape(q.Read(), 2, coeff_dim, 1, 1)
-                  : Reshape(q.Read(), 2, coeff_dim, Q1D, NF);
+   const auto Q = const_q ? Reshape(q.Read(), coeff_dim, 1, 1, 1)
+                  : Reshape(q.Read(), coeff_dim, Q1D, 2, NF);
 
    const auto W = w.Read();
 
@@ -161,8 +161,8 @@ static void PADGDiffusionSetup3D(const int Q1D, const int NE, const int NF,
    const auto n = Reshape(face_geom.normal.Read(), Q1D, Q1D, 3, NF);
 
    const bool const_q = (q.Size() == coeff_dim);
-   const auto Q = const_q ? Reshape(q.Read(), coeff_dim, 1, 1, 1)
-                  : Reshape(q.Read(), coeff_dim, Q1D, Q1D, NF);
+   const auto Q = const_q ? Reshape(q.Read(), coeff_dim, 1, 1, 1, 1)
+                  : Reshape(q.Read(), coeff_dim, Q1D, Q1D, 2, NF);
 
    const auto W = Reshape(w.Read(), Q1D, Q1D);
 
@@ -179,7 +179,7 @@ static void PADGDiffusionSetup3D(const int Q1D, const int NE, const int NF,
    {
       auto get_coeff = [&] (int i, int qx, int qy, int side, int e)
       {
-         return const_q ? Q(i, 0, 0, 0) : Q(i, qx, qy, e);
+         return const_q ? Q(i, 0, 0, 0, 0) : Q(i, qx, qy, side, e);
       };
 
       MFEM_SHARED int perm[2][3];

--- a/tests/unit/fem/test_pa_kernels.cpp
+++ b/tests/unit/fem/test_pa_kernels.cpp
@@ -946,6 +946,11 @@ TEST_CASE("Parallel PA DG Diffusion", "[PartialAssembly][Parallel][GPU]")
    CAPTURE(order, mesh_fname);
 
    Mesh serial_mesh = Mesh::LoadFromFile(mesh_fname.c_str());
+   for (int i = 0; i < serial_mesh.GetNE(); ++i)
+   {
+      serial_mesh.SetAttribute(i, 1 + (i % 2));
+   }
+
    ParMesh mesh(MPI_COMM_WORLD, serial_mesh);
    serial_mesh.Clear();
 
@@ -956,6 +961,8 @@ TEST_CASE("Parallel PA DG Diffusion", "[PartialAssembly][Parallel][GPU]")
 
    test_dg_diffusion<ConstantCoefficient>(fes);
    test_dg_diffusion<MatrixConstantCoefficient>(fes);
+   test_dg_diffusion<SymmetricMatrixConstantCoefficient>(fes);
+   test_dg_diffusion<PWConstCoefficient>(fes);
 }
 
 #endif

--- a/tests/unit/fem/test_pa_kernels.cpp
+++ b/tests/unit/fem/test_pa_kernels.cpp
@@ -841,6 +841,13 @@ MakeCoeff<SymmetricMatrixConstantCoefficient>(int dim)
    return std::make_unique<SymmetricMatrixConstantCoefficient>(A);
 }
 
+template <> std::unique_ptr<PWConstCoefficient>
+MakeCoeff<PWConstCoefficient>(int)
+{
+   Vector c({1.0, 2.0});
+   return std::make_unique<PWConstCoefficient>(c);
+}
+
 template <typename CoeffType = ConstantCoefficient,
           typename FES = FiniteElementSpace>
 void test_dg_diffusion(FES &fes)
@@ -916,12 +923,18 @@ TEST_CASE("PA DG Diffusion", "[PartialAssembly], [GPU]")
    Mesh mesh = Mesh::LoadFromFile(mesh_fname.c_str());
    const int dim = mesh.Dimension();
 
+   for (int i = 0; i < mesh.GetNE(); ++i)
+   {
+      mesh.SetAttribute(i, 1 + (i % 2));
+   }
+
    DG_FECollection fec(order, dim, BasisType::GaussLobatto);
    FiniteElementSpace fes(&mesh, &fec);
 
    test_dg_diffusion<ConstantCoefficient>(fes);
    test_dg_diffusion<MatrixConstantCoefficient>(fes);
    test_dg_diffusion<SymmetricMatrixConstantCoefficient>(fes);
+   test_dg_diffusion<PWConstCoefficient>(fes);
 }
 
 #ifdef MFEM_USE_MPI


### PR DESCRIPTION
# DG Diffusion Now Correctly Evaluates Piecewise Coefficients.

**Previous Error:** DG Diffusion was evaluating coefficients using FaceQuadratureSpace. This lead to an error when attempting to evaluate piecewise coefficients because interior faces are not labeled with attributes.

**Fix:** The coefficients are now evaluated via the element quadrature points from the left and right elements on the face. This correctly handles piecewise coefficients.