### PR TITLE
bilininteg: eliminate usage of modulus to avoid llvm backend bug

### DIFF
--- a/fem/integ/bilininteg_hdiv_ea.cpp
+++ b/fem/integ/bilininteg_hdiv_ea.cpp
@@ -198,21 +198,20 @@ static void EAHdivAssemble3D(const int NE,
       MFEM_FOREACH_THREAD(idx_i, x, NDOF)
       {
          // NOTE: due to an llvm backend bug, usage of the modulus operator
-         // has been removed from this foreach section. Example of previous
-         // modulus usage: idx_ii = idx_i % NDOF_C;
+         // has been removed from this foreach section.
          const int ic = idx_i / NDOF_C;
-         const int idx_ii = idx_i - ic * NDOF_C;
+         const int idx_ii = idx_i - ic * NDOF_C; // idx_i % NDOF_C
 
          const int nx_i = (ic == 0) ? D1D : D1D-1;
          const int ny_i = (ic == 1) ? D1D : D1D-1;
 
          const int qx_i = idx_ii / nx_i;
-         const int ix = idx_ii - qx_i * nx_i;
+         const int ix = idx_ii - qx_i * nx_i; // idx_ii % nx_i
 
          const int qy_i = qx_i / ny_i;
-         const int iy = qx_i - qy_i * ny_i;
+         const int iy = qx_i - qy_i * ny_i; // (idx_ii / nx_i) % ny_i
 
-         const int iz = qy_i;
+         const int iz = qy_i; // (idx_ii / nx_i) / ny_i
 
          const real_t (&Bi1)[MQ1][MD1] = (ic == 0) ? r_Bc : r_Bo;
          const real_t (&Bi2)[MQ1][MD1] = (ic == 1) ? r_Bc : r_Bo;
@@ -221,18 +220,18 @@ static void EAHdivAssemble3D(const int NE,
          for (int idx_j = 0; idx_j < NDOF; ++idx_j)
          {
             const int jc = idx_j / NDOF_C;
-            const int idx_jj = idx_j - jc * NDOF_C;
+            const int idx_jj = idx_j - jc * NDOF_C; // idx_j % NDOF_C
 
             const int nx_j = (jc == 0) ? D1D : D1D-1;
             const int ny_j = (jc == 1) ? D1D : D1D-1;
 
             const int qx_j = idx_jj / nx_j;
-            const int jx = idx_jj - qx_j * nx_j;
+            const int jx = idx_jj - qx_j * nx_j; // idx_jj % nx_j
 
             const int qy_j = qx_j / ny_j;
-            const int jy = qx_j - qy_j * ny_j;
+            const int jy = qx_j - qy_j * ny_j; // (idx_jj / nx_j) % ny_j
 
-            const int jz = qy_j;
+            const int jz = qy_j; // (idx_jj / nx_j) / ny_j
 
             const real_t (&Bj1)[MQ1][MD1] = (jc == 0) ? r_Bc : r_Bo;
             const real_t (&Bj2)[MQ1][MD1] = (jc == 1) ? r_Bc : r_Bo;


### PR DESCRIPTION
This PR is a bugfix. It seems to only occur when building MFEM with CMAKE_BUILD_TYPE=Debug, using clang 19, rocm-6.4.2.

Error (shortened):

```
error: fatal error: error in backend: Cannot select: 0xf859be0: i16,i16 = sdivrem 0xf85a510,0xa74aeb0,mfem/fem/integ/bilininteg_hdiv_ea.cpp:224:44

...

              0xe064460: i16 = Constant<11>
          0xe0650a0: i32 = Constant<244>
        0xaab8160: i32,ch = CopyFromReg 0xe3d52f8, Register:i32 %73, mfem/fem/integ/bilininteg_hdiv_ea.cpp:216:34
          0xe064930: i32 = Register %73
  0xe3e9e70: i16 = select 0xf85a660, Constant:i16<3>, Constant:i16<2>, mfem/fem/integ/bilininteg_hdiv_ea.cpp:222:35
    0xf85a660: i1 = setcc 0xaab8160, Constant:i32<12>, setult:ch, mfem/fem/integ/bilininteg_hdiv_ea.cpp:219:34
      0xaab8160: i32,ch = CopyFromReg 0xe3d52f8, Register:i32 %73, mfem/fem/integ/bilininteg_hdiv_ea.cpp:216:34
        0xe064930: i32 = Register %73
      0xa747c50: i32 = Constant<12>
    0xe095680: i16 = Constant<3>
    0xa33bc10: i16 = Constant<2>

...

_ZZN4mfemL16EAHdivAssemble3DILi3ELi4EEEviRKNS_5ArrayIdEES4_iRKNS_6VectorERS5_biiENKUliE_clEi clang++: 
error: clang frontend command failed with exit code 70 (use -v to see invocation)

AMD clang version 19.0.0git (https://github.com/RadeonOpenCompute/llvm-project roc-6.4.2 25224 d366fa84f3fdcbd4b10847ebd5db572ae12a34fb)
Target: x86_64-unknown-linux-gnu
Thread model: posix InstalledDir: /opt/rocm-6.4.2/lib/llvm/bin
Configuration file: /opt/rocm-6.4.2/lib/llvm/bin/clang++.cfg clang++: note: diagnostic msg: Error generating preprocessed source(s).
```

Removing usage of modulus in this section appears to resolve the problem.
<!--GHEX{"author":"chapman39","assignment":"2026-03-01T23:37:55","editor":"tzanio","id":5245,"reviewers":["jandrej","dylan-copeland","camierjs","v-dobrev"],"merge":"2026-04-01T18:34:52","approval":"2026-03-22T17:39:05"}XEHG-->
<!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge|
 | --- | --- | --- | --- | --- | --- | --- |
| [#5245](https://github.com/mfem/mfem/pull/5245) | @chapman39 | @tzanio | @jandrej + @dylan-copeland + @camierjs + @v-dobrev | 3/1/26 | 3/22/26 | 4/1/26 | |
<!--ELBATXEHG-->
<details>
<summary>PR Checklist</summary>
    
- [ ] Code builds.
- [ ] Code passes `make style`.
- [ ] Update `CHANGELOG`:
    - [ ] Is this a new feature users need to be aware of? New or updated example or miniapp?
    - [ ] Does it make sense to create a new section in the `CHANGELOG` to group with other related features?
- [ ] Update `INSTALL`:
    - [ ] Had a new optional library been added? If so, what range of versions of this library are required? (*Make sure the external library is compatible with our BSD license, e.g. it is not licensed under GPL!*)
    - [ ] Have the version ranges for any required or optional libraries changed?
    - [ ] Does `make` or `cmake` have a new target?
    - [ ] Did the requirements or the installation process change? *(rare)*
- [ ] Update continuous integration server configurations if necessary (e.g. with new version requirements for each of MFEM's dependencies)
    - [ ] `.github`
    - [ ] `.appveyor.yml`
- [ ] Update `.gitignore`:
    - [ ] Check if `make distclean; git status` shows any files that were generated from the source by the project (not an IDE) but we don't want to track in the repository.
    - [ ] Add new patterns (just for the new files above) and re-run the above test.
- [ ] New examples:
    - [ ] All sample runs at the top of the example source file work.
    - [ ] Update `examples/makefile`:
      - [ ] Add the example code to the appropriate `SEQ_EXAMPLES` and `PAR_EXAMPLES` variables.
      - [ ] Add any files generated by it to the `clean` target.
      - [ ] Add the example binary and any files generated by it to the top-level `.gitignore` file.
    - [ ] Update `examples/CMakeLists.txt`:
      - [ ] Add the example code to the `ALL_EXE_SRCS` variable.
      - [ ] Make sure `THIS_TEST_OPTIONS` is set correctly for the new example.
   - [ ] List the new example in `doc/CodeDocumentation.dox`.
   - [ ] If new examples directory (e.g.`examples/pumi`), list it in `doc/CodeDocumentation.conf.in`
   - [ ] Companion pull request for documentation in [mfem/web](https://github.com/mfem/web) repo:
      - [ ] Update or add example-specific documentation, see e.g. the `src/examples.md`.
      - [ ] Add the description, labels and screenshots in `src/examples.md` and `src/img`.
      - [ ] In `examples.md`, list the example under the appropriate categories, add new categories if necessary.
      - [ ] Add a short description of the example in the "Extensive Examples" section of `features.md`.
- [ ] New miniapps:
   - [ ] All sample runs at the top of the miniapp source file work.
   - [ ] Update top-level `makefile` and `makefile` in corresponding miniapp directory.
   - [ ] Add the miniapp binary and any files generated by it to the top-level `.gitignore` file.
   - [ ] Update CMake build system:
      - [ ] Update the `CMakeLists.txt` file in the `miniapps` directory, if the new miniapp is in a new directory.
      - [ ] Add/update the `CMakeLists.txt` file in the new miniapp directory.
      - [ ] Consider adding a new test for the new miniapp.
   - [ ] List the new miniapp in `doc/CodeDocumentation.dox`
   - [ ] If new miniapps directory (e.g.`miniapps/nurbs`), add it to `MINIAPP_SUBDIRS` in the `makefile`.
   - [ ] If new miniapps directory (e.g.`miniapps/nurbs`), list it in `doc/CodeDocumentation.conf.in`
   - [ ] Companion pull request for documentation in [mfem/web](https://github.com/mfem/web) repo:
     - [ ] Update or add miniapp-specific documentation, see e.g. the `src/meshing.md` and `src/electromagnetics.md` files.
     - [ ] Add the description, labels and screenshots in `src/examples.md` and `src/img`.
     - [ ] The miniapps go at the end of the page, and are usually listed only under a specific "Application (PDE)" category.
     - [ ] Add a short description of the miniapp in the "Extensive Examples" section of `features.md`.
- [ ] New capability:
   - [ ] All new public, protected, and private classes, methods, data members, and functions have full Doxygen-style documentation in source comments. Documentation should include descriptions of member data, function arguments and return values, template parameters, and prerequisites for calling new functions.
   - [ ] Pointer arguments and return values must specify whether ownership is being transferred or lent with the call.
   - [ ] Any new functions should include descriptions of their intended use e.g. for internal use only, user-facing, etc., along with references to example code whenever possible/appropriate.
   - [ ] Consider adding new sample runs in existing examples to highlight the new capability.
   - [ ] Consider saving cool simulation pictures with the new capability in the Confluence gallery (LLNL only) or submitting them, via pull request, to the gallery section of the `mfem/web` repo.
   - [ ] If this is a major new feature, consider mentioning it in the short summary inside `README` *(rare)*.
   - [ ] List major new classes in `doc/CodeDocumentation.dox` *(rare)*.
- [ ] Update this checklist, if the new pull request affects it.
- [ ] Run `make unittest` to make sure all unit tests pass.
- [ ] Run the tests in `tests/scripts`.
- [ ] (LLNL only) After merging:
   - [ ] Update internal tests to include the new features.
</details>
