### PR TITLE
Adding subdirectory knowledge to makefile in miniapps/plasma

### DIFF
--- a/miniapps/plasma/CMakeLists.txt
+++ b/miniapps/plasma/CMakeLists.txt
@@ -23,3 +23,5 @@ if (MFEM_USE_MPI)
       EXTRA_HEADERS ${PLASMA_COMMON_HEADERS})
 
 endif()
+
+add_subdirectory(pic)

--- a/miniapps/plasma/makefile
+++ b/miniapps/plasma/makefile
@@ -14,9 +14,6 @@ MFEM_DIR ?= ../..
 MFEM_BUILD_DIR ?= ../..
 SRC = $(if $(MFEM_DIR:../..=),$(MFEM_DIR)/miniapps/plasma/,)
 CONFIG_MK = $(MFEM_BUILD_DIR)/config/config.mk
-# Use the MFEM install directory
-# MFEM_INSTALL_DIR = ../../mfem
-# CONFIG_MK = $(MFEM_INSTALL_DIR)/share/mfem/config.mk
 
 MFEM_LIB_FILE = mfem_is_not_built
 -include $(CONFIG_MK)
@@ -28,6 +25,8 @@ ifeq ($(MFEM_USE_MPI),NO)
 else
    MINIAPPS = $(PAR_MINIAPPS) $(SEQ_MINIAPPS)
 endif
+
+PLASMA_SUBDIRS = pic
 
 .SUFFIXES:
 .SUFFIXES: .o .cpp .mk
@@ -47,7 +46,12 @@ COMMON_O=
 %: %.cpp
 %.o: %.cpp
 
-all: $(MINIAPPS)
+all: $(MINIAPPS) subdirs
+
+.PHONY: subdirs $(PLASMA_SUBDIRS)
+subdirs: $(PLASMA_SUBDIRS)
+$(PLASMA_SUBDIRS): lib-common
+	$(MAKE) -C $(BLD)$(@)
 
 # Rules for building the miniapps
 %: $(SRC)%.cpp $(COMMON_O) $(MFEM_LIB_FILE) $(CONFIG_MK) | lib-common
@@ -75,9 +79,14 @@ RUN_MPI = $(MFEM_MPIEXEC) $(MFEM_MPIEXEC_NP) $(MFEM_MPI_NP)
 $(MFEM_LIB_FILE):
 	$(error The MFEM library is not built)
 
+ALL_CLEAN_SUBDIRS = $(addsuffix /clean,$(PLASMA_SUBDIRS))
+.PHONY: $(ALL_CLEAN_SUBDIRS)
+$(ALL_CLEAN_SUBDIRS):
+	$(MAKE) -C $(BLD)$(@D) $(@F)
+
 clean: clean-build clean-exec
 
-clean-build:
+clean-build: $(addsuffix /clean,$(PLASMA_SUBDIRS))
 	rm -f *.o *~ $(SEQ_MINIAPPS) $(PAR_MINIAPPS)
 	rm -rf *.dSYM *.TVD.*breakpoints
 


### PR DESCRIPTION
Just a suggestion which will allow the makefile in `miniapps/plasma` to dive into the `pic` subdirectory and build or clean that as well.