### PR TITLE
Fix Mesh::Swap to preserve named attribute sets 

### DIFF
--- a/mesh/mesh.cpp
+++ b/mesh/mesh.cpp
@@ -11332,6 +11332,8 @@ void Mesh::Swap(Mesh& other, bool non_geometry)
 
    mfem::Swap(attributes, other.attributes);
    mfem::Swap(bdr_attributes, other.bdr_attributes);
+   mfem::Swap(attribute_sets.attr_sets, other.attribute_sets.attr_sets);
+   mfem::Swap(bdr_attribute_sets.attr_sets, other.bdr_attribute_sets.attr_sets);
 
    mfem::Swap(geom_factors, other.geom_factors);
    mfem::Swap(face_geom_factors, other.face_geom_factors);

--- a/tests/unit/mesh/test_mesh.cpp
+++ b/tests/unit/mesh/test_mesh.cpp
@@ -512,8 +512,8 @@ TEST_CASE("Mesh::Swap preserves named attribute sets", "[Mesh]")
    REQUIRE(!b.bdr_attribute_sets.AttributeSetExists("bdr_set_b"));
 
    // Verify set contents survived the swap.
-   REQUIRE(a.bdr_attribute_sets.GetAttributeSet("bdr_set_b")[0] == 3);
-   REQUIRE(a.bdr_attribute_sets.GetAttributeSet("bdr_set_b")[1] == 4);
-   REQUIRE(b.bdr_attribute_sets.GetAttributeSet("bdr_set_a")[0] == 1);
-   REQUIRE(b.bdr_attribute_sets.GetAttributeSet("bdr_set_a")[1] == 2);
+   Array<int> a_bdr_result = a.bdr_attribute_sets.GetAttributeSet("bdr_set_b");
+   Array<int> b_bdr_result = b.bdr_attribute_sets.GetAttributeSet("bdr_set_a");
+   REQUIRE(a_bdr_result == b_bdr_attrs);
+   REQUIRE(b_bdr_result == a_bdr_attrs);
 }

--- a/tests/unit/mesh/test_mesh.cpp
+++ b/tests/unit/mesh/test_mesh.cpp
@@ -478,3 +478,42 @@ TEST_CASE("NURBS 1D curve in 2D from patches", "[Mesh]")
       }
    }
 }
+
+TEST_CASE("Mesh::Swap preserves named attribute sets", "[Mesh]")
+{
+   // Regression test for a bug where Mesh::Swap swapped attributes and
+   // bdr_attributes but omitted the attr_sets maps, silently losing all named
+   // element/boundary sets on any move or swap of an mfem::Mesh.
+
+   Mesh a = Mesh::MakeCartesian2D(2, 2, Element::QUADRILATERAL);
+   Mesh b = Mesh::MakeCartesian2D(3, 3, Element::QUADRILATERAL);
+
+   Array<int> a_elem_attrs({1});
+   Array<int> b_elem_attrs({1});
+   Array<int> a_bdr_attrs({1, 2});
+   Array<int> b_bdr_attrs({3, 4});
+
+   a.attribute_sets.SetAttributeSet("elem_set_a", a_elem_attrs);
+   a.bdr_attribute_sets.SetAttributeSet("bdr_set_a", a_bdr_attrs);
+   b.attribute_sets.SetAttributeSet("elem_set_b", b_elem_attrs);
+   b.bdr_attribute_sets.SetAttributeSet("bdr_set_b", b_bdr_attrs);
+
+   a.Swap(b, true);
+
+   // After swap, a should hold b's sets and b should hold a's sets.
+   REQUIRE(a.attribute_sets.AttributeSetExists("elem_set_b"));
+   REQUIRE(!a.attribute_sets.AttributeSetExists("elem_set_a"));
+   REQUIRE(a.bdr_attribute_sets.AttributeSetExists("bdr_set_b"));
+   REQUIRE(!a.bdr_attribute_sets.AttributeSetExists("bdr_set_a"));
+
+   REQUIRE(b.attribute_sets.AttributeSetExists("elem_set_a"));
+   REQUIRE(!b.attribute_sets.AttributeSetExists("elem_set_b"));
+   REQUIRE(b.bdr_attribute_sets.AttributeSetExists("bdr_set_a"));
+   REQUIRE(!b.bdr_attribute_sets.AttributeSetExists("bdr_set_b"));
+
+   // Verify set contents survived the swap.
+   REQUIRE(a.bdr_attribute_sets.GetAttributeSet("bdr_set_b")[0] == 3);
+   REQUIRE(a.bdr_attribute_sets.GetAttributeSet("bdr_set_b")[1] == 4);
+   REQUIRE(b.bdr_attribute_sets.GetAttributeSet("bdr_set_a")[0] == 1);
+   REQUIRE(b.bdr_attribute_sets.GetAttributeSet("bdr_set_a")[1] == 2);
+}


### PR DESCRIPTION
`Mesh::Swap` swapped `attributes` and `bdr_attributes` but omitted the
`attr_sets` maps inside `attribute_sets` and `bdr_attribute_sets`, causing
all named boundary/element sets to be silently lost on any move or
swap of an `mfem::Mesh`.
<!--GHEX{"author":"lindsayad","assignment":"2026-04-24T23:05:29","editor":"v-dobrev","id":5316,"reviewers":["pazner","najlkin","mlstowell"],"merge":"2026-05-19T19:06:39","approval":"2026-05-14T23:17:24"}XEHG-->
<!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge|
 | --- | --- | --- | --- | --- | --- | --- |
| [#5316](https://github.com/mfem/mfem/pull/5316) | @lindsayad | @v-dobrev | @pazner + @najlkin + @mlstowell | 4/24/26 | 5/14/26 | 5/19/26 | |
<!--ELBATXEHG-->
<details>
<summary>PR Checklist</summary>
    
- [ ] Code builds.
- [ ] Code passes `make style`.
- [ ] Update `CHANGELOG`:
    - [ ] Is this a new feature users need to be aware of? New or updated example or miniapp?
    - [ ] Does it make sense to create a new section in the `CHANGELOG` to group with other related features?
- [ ] Update `INSTALL`:
    - [ ] Had a new optional library been added? If so, what range of versions of this library are required? (*Make sure the external library is compatible with our BSD license, e.g. it is not licensed under GPL!*)
    - [ ] Have the version ranges for any required or optional libraries changed?
    - [ ] Does `make` or `cmake` have a new target?
    - [ ] Did the requirements or the installation process change? *(rare)*
- [ ] Update continuous integration server configurations if necessary (e.g. with new version requirements for each of MFEM's dependencies)
    - [ ] `.github`
    - [ ] `.appveyor.yml`
- [ ] Update `.gitignore`:
    - [ ] Check if `make distclean; git status` shows any files that were generated from the source by the project (not an IDE) but we don't want to track in the repository.
    - [ ] Add new patterns (just for the new files above) and re-run the above test.
- [ ] New examples:
    - [ ] All sample runs at the top of the example source file work.
    - [ ] Update `examples/makefile`:
      - [ ] Add the example code to the appropriate `SEQ_EXAMPLES` and `PAR_EXAMPLES` variables.
      - [ ] Add any files generated by it to the `clean` target.
      - [ ] Add the example binary and any files generated by it to the top-level `.gitignore` file.
    - [ ] Update `examples/CMakeLists.txt`:
      - [ ] Add the example code to the `ALL_EXE_SRCS` variable.
      - [ ] Make sure `THIS_TEST_OPTIONS` is set correctly for the new example.
   - [ ] List the new example in `doc/CodeDocumentation.dox`.
   - [ ] If new examples directory (e.g.`examples/pumi`), list it in `doc/CodeDocumentation.conf.in`
   - [ ] Companion pull request for documentation in [mfem/web](https://github.com/mfem/web) repo:
      - [ ] Update or add example-specific documentation, see e.g. the `src/examples.md`.
      - [ ] Add the description, labels and screenshots in `src/examples.md` and `src/img`.
      - [ ] In `examples.md`, list the example under the appropriate categories, add new categories if necessary.
      - [ ] Add a short description of the example in the "Extensive Examples" section of `features.md`.
- [ ] New miniapps:
   - [ ] All sample runs at the top of the miniapp source file work.
   - [ ] Update top-level `makefile` and `makefile` in corresponding miniapp directory.
   - [ ] Add the miniapp binary and any files generated by it to the top-level `.gitignore` file.
   - [ ] Update CMake build system:
      - [ ] Update the `CMakeLists.txt` file in the `miniapps` directory, if the new miniapp is in a new directory.
      - [ ] Add/update the `CMakeLists.txt` file in the new miniapp directory.
      - [ ] Consider adding a new test for the new miniapp.
   - [ ] List the new miniapp in `doc/CodeDocumentation.dox`
   - [ ] If new miniapps directory (e.g.`miniapps/nurbs`), add it to `MINIAPP_SUBDIRS` in the `makefile`.
   - [ ] If new miniapps directory (e.g.`miniapps/nurbs`), list it in `doc/CodeDocumentation.conf.in`
   - [ ] Companion pull request for documentation in [mfem/web](https://github.com/mfem/web) repo:
     - [ ] Update or add miniapp-specific documentation, see e.g. the `src/meshing.md` and `src/electromagnetics.md` files.
     - [ ] Add the description, labels and screenshots in `src/examples.md` and `src/img`.
     - [ ] The miniapps go at the end of the page, and are usually listed only under a specific "Application (PDE)" category.
     - [ ] Add a short description of the miniapp in the "Extensive Examples" section of `features.md`.
- [ ] New capability:
   - [ ] All new public, protected, and private classes, methods, data members, and functions have full Doxygen-style documentation in source comments. Documentation should include descriptions of member data, function arguments and return values, template parameters, and prerequisites for calling new functions.
   - [ ] Pointer arguments and return values must specify whether ownership is being transferred or lent with the call.
   - [ ] Any new functions should include descriptions of their intended use e.g. for internal use only, user-facing, etc., along with references to example code whenever possible/appropriate.
   - [ ] Consider adding new sample runs in existing examples to highlight the new capability.
   - [ ] Consider saving cool simulation pictures with the new capability in the Confluence gallery (LLNL only) or submitting them, via pull request, to the gallery section of the `mfem/web` repo.
   - [ ] If this is a major new feature, consider mentioning it in the short summary inside `README` *(rare)*.
   - [ ] List major new classes in `doc/CodeDocumentation.dox` *(rare)*.
- [ ] Update this checklist, if the new pull request affects it.
- [ ] Run `make unittest` to make sure all unit tests pass.
- [ ] Run the tests in `tests/scripts`.
- [ ] (LLNL only) After merging:
   - [ ] Update internal tests to include the new features.
</details>
