### PR TITLE
Allow Ownership of Individual Blocks in Block Operators

### DIFF
--- a/examples/ex22.cpp
+++ b/examples/ex22.cpp
@@ -419,7 +419,7 @@ int main(int argc, char *argv[])
 
       BDP.SetDiagonalBlock(0, pc_r);
       BDP.SetDiagonalBlock(1, pc_i);
-      BDP.owns_blocks = 1;
+      BDP.SetBlockOwnership(1);
 
       GMRESSolver gmres;
       gmres.SetPreconditioner(BDP);

--- a/examples/ex22p.cpp
+++ b/examples/ex22p.cpp
@@ -465,7 +465,7 @@ int main(int argc, char *argv[])
 
       BDP.SetDiagonalBlock(0, pc_r);
       BDP.SetDiagonalBlock(1, pc_i);
-      BDP.owns_blocks = 1;
+      BDP.SetBlockOwnership(1);
 
       FGMRESSolver fgmres(MPI_COMM_WORLD);
       fgmres.SetPreconditioner(BDP);

--- a/examples/ex35p.cpp
+++ b/examples/ex35p.cpp
@@ -494,7 +494,7 @@ int main(int argc, char *argv[])
 
       BDP.SetDiagonalBlock(0, pc_r);
       BDP.SetDiagonalBlock(1, pc_i);
-      BDP.owns_blocks = 1;
+      BDP.SetBlockOwnership(1);
 
       FGMRESSolver fgmres(MPI_COMM_WORLD);
       fgmres.SetPreconditioner(BDP);

--- a/examples/ex36.cpp
+++ b/examples/ex36.cpp
@@ -292,7 +292,7 @@ int main(int argc, char *argv[])
          BlockDiagonalPreconditioner prec(offsets);
          prec.SetDiagonalBlock(0,new GSSmoother(A00));
          prec.SetDiagonalBlock(1,new GSSmoother(A11));
-         prec.owns_blocks = 1;
+         prec.SetBlockOwnership(1);
 
          GMRES(A,prec,rhs,x,0,10000,500,1e-12,0.0);
 

--- a/examples/ex40.cpp
+++ b/examples/ex40.cpp
@@ -266,7 +266,7 @@ int main(int argc, char *argv[])
 #else
          prec.SetDiagonalBlock(1,new UMFPackSolver(*S));
 #endif
-         prec.owns_blocks = 1;
+         prec.SetBlockOwnership(1);
 
          BlockOperator A(offsets);
          A.SetBlock(0,0,&A00);

--- a/linalg/blockmatrix.cpp
+++ b/linalg/blockmatrix.cpp
@@ -22,27 +22,31 @@ namespace mfem
 
 BlockMatrix::BlockMatrix(const Array<int> & offsets):
    AbstractSparseMatrix(offsets.Last()),
-   owns_blocks(false),
    nRowBlocks(offsets.Size()-1),
    nColBlocks(offsets.Size()-1),
-   Aij(nRowBlocks, nColBlocks)
+   Aij(nRowBlocks, nColBlocks),
+   own_block(nRowBlocks, nColBlocks),
+   owns_blocks(false)
 {
    row_offsets.MakeRef(const_cast< Array<int>& >(offsets));
    col_offsets.MakeRef(const_cast< Array<int>& >(offsets));
    Aij = (SparseMatrix *)NULL;
+   own_block = owns_blocks;
 }
 
 BlockMatrix::BlockMatrix(const Array<int> & row_offsets_,
                          const Array<int> & col_offsets_):
    AbstractSparseMatrix(row_offsets_.Last(), col_offsets_.Last()),
-   owns_blocks(false),
    nRowBlocks(row_offsets_.Size()-1),
    nColBlocks(col_offsets_.Size()-1),
-   Aij(nRowBlocks, nColBlocks)
+   Aij(nRowBlocks, nColBlocks),
+   own_block(nRowBlocks, nColBlocks),
+   owns_blocks(false)
 {
    row_offsets.MakeRef(const_cast< Array<int>& >(row_offsets_));
    col_offsets.MakeRef(const_cast< Array<int>& >(col_offsets_));
    Aij = (SparseMatrix *)NULL;
+   own_block = owns_blocks;
 }
 
 
@@ -50,10 +54,15 @@ BlockMatrix::~BlockMatrix()
 {
    if (owns_blocks)
    {
-      for (SparseMatrix ** it = Aij.GetRow(0);
-           it != Aij.GetRow(0)+(Aij.NumRows()*Aij.NumCols()); ++it)
+      for (int jcol = 0; jcol != nColBlocks; ++jcol)
       {
-         delete *it;
+         for (int irow = 0; irow != nRowBlocks; ++irow)
+         {
+            if (IsBlockOwned(irow,jcol) && Aij(irow,jcol))
+            {
+               delete Aij(irow,jcol);
+            }
+         }
       }
    }
 }
@@ -76,6 +85,10 @@ void BlockMatrix::SetBlock(int i, int j, SparseMatrix * mat)
       mfem_error("BlockMatrix::SetBlock #2");
    }
 #endif
+   if (IsBlockOwned(i,j) && Aij(i,j))
+   {
+      delete Aij(i,j);
+   }
    Aij(i,j) = mat;
 }
 
@@ -667,7 +680,7 @@ void BlockMatrix::PrintMatlab(std::ostream & os) const
 BlockMatrix * Transpose(const BlockMatrix & A)
 {
    BlockMatrix * At = new BlockMatrix(A.ColOffsets(), A.RowOffsets());
-   At->owns_blocks = 1;
+   At->SetBlockOwnership(1);
 
    for (int irowAt = 0; irowAt < At->NumRowBlocks(); ++irowAt)
    {
@@ -685,7 +698,7 @@ BlockMatrix * Transpose(const BlockMatrix & A)
 BlockMatrix * Mult(const BlockMatrix & A, const BlockMatrix & B)
 {
    BlockMatrix * C= new BlockMatrix(A.RowOffsets(), B.ColOffsets());
-   C->owns_blocks = 1;
+   C->SetBlockOwnership(1);
    Array<SparseMatrix *> CijPieces(A.NumColBlocks());
 
    for (int irowC = 0; irowC < A.NumRowBlocks(); ++irowC)

--- a/linalg/blockmatrix.hpp
+++ b/linalg/blockmatrix.hpp
@@ -53,6 +53,15 @@ public:
    const SparseMatrix & GetBlock(int i, int j) const;
    //! Check if block (i,j) is a zero block.
    int IsZeroBlock(int i, int j) const {return (Aij(i,j)==NULL) ? 1 : 0; }
+   //! Set the ownership of block (i,j)
+   void SetBlockOwnership(int i, int j, int own)
+   { own_block(i,j) = own; if (own) { owns_blocks = 1; } }
+   //! Set the ownership of all blocks
+   void SetBlockOwnership(int own)
+   { own_block = own; owns_blocks = own; }
+   //! Check if non-NULL block (i,j) is owned by the BlockMatrix
+   int IsBlockOwned(int i, int j) const
+   { return (own_block(i,j) && Aij(i,j)) ? 1 : 0; }
    //! Return the row offsets for block starts
    Array<int> & RowOffsets() { return row_offsets; }
    //! Return the columns offsets for block starts
@@ -151,8 +160,6 @@ public:
 
    //! Destructor
    virtual ~BlockMatrix();
-   //! If owns_blocks the SparseMatrix objects Aij will be deallocated.
-   int owns_blocks;
 
    virtual Type GetType() const { return MFEM_Block_Matrix; }
 
@@ -173,6 +180,12 @@ private:
    //! 2D array that stores each block of the BlockMatrix. Aij(iblock, jblock)
    //! == NULL if block (iblock, jblock) is all zeros.
    Array2D<SparseMatrix *> Aij;
+   //! 2D array that stores the ownership of each block of the operator.
+   //! if nonzero, BlockMatrix will delete all blocks that are set (non-NULL);
+   //! the default value is zero.
+   Array2D<int> own_block;
+   //! Nonzero if at least one block is owned by the BlockMatrix.
+   int owns_blocks;
 };
 
 //! Transpose a BlockMatrix: result = A'

--- a/linalg/blockoperator.cpp
+++ b/linalg/blockoperator.cpp
@@ -19,29 +19,33 @@ namespace mfem
 
 BlockOperator::BlockOperator(const Array<int> &offsets)
    : Operator(offsets.Last()),
-     owns_blocks(0),
      nRowBlocks(offsets.Size() - 1),
      nColBlocks(offsets.Size() - 1),
      row_offsets(offsets),
      col_offsets(offsets),
      op(nRowBlocks, nRowBlocks),
-     coef(nRowBlocks, nColBlocks)
+     coef(nRowBlocks, nColBlocks),
+     own_block(nRowBlocks, nColBlocks),
+     owns_blocks(0)
 {
    op = nullptr;
+   own_block = owns_blocks;
 }
 
 BlockOperator::BlockOperator(const Array<int> &row_offsets_,
                              const Array<int> &col_offsets_)
    : Operator(row_offsets_.Last(), col_offsets_.Last()),
-     owns_blocks(0),
      nRowBlocks(row_offsets_.Size()-1),
      nColBlocks(col_offsets_.Size()-1),
      row_offsets(row_offsets_),
      col_offsets(col_offsets_),
      op(nRowBlocks, nColBlocks),
-     coef(nRowBlocks, nColBlocks)
+     coef(nRowBlocks, nColBlocks),
+     own_block(nRowBlocks, nColBlocks),
+     owns_blocks(0)
 {
    op = nullptr;
+   own_block = owns_blocks;
 }
 
 void BlockOperator::SetDiagonalBlock(int iblock, Operator *opt, real_t c)
@@ -51,7 +55,7 @@ void BlockOperator::SetDiagonalBlock(int iblock, Operator *opt, real_t c)
 
 void BlockOperator::SetBlock(int iRow, int iCol, Operator *opt, real_t c)
 {
-   if (owns_blocks && op(iRow, iCol))
+   if (own_block(iRow, iCol) && op(iRow, iCol))
    {
       delete op(iRow, iCol);
    }
@@ -137,7 +141,10 @@ BlockOperator::~BlockOperator()
       {
          for (int jCol=0; jCol < nColBlocks; ++jCol)
          {
-            delete op(iRow, jCol);
+            if (own_block(iRow, jCol) && op(iRow, jCol))
+            {
+               delete op(iRow, jCol);
+            }
          }
       }
    }
@@ -146,13 +153,14 @@ BlockOperator::~BlockOperator()
 BlockDiagonalPreconditioner::BlockDiagonalPreconditioner(
    const Array<int> & offsets_):
    Solver(offsets_.Last()),
-   owns_blocks(0),
    nBlocks(offsets_.Size() - 1),
    offsets(0),
-   ops(nBlocks)
+   ops(nBlocks),
+   own_block(nBlocks)
 {
    ops = nullptr;
    offsets.MakeRef(offsets_);
+   own_block = 0;
 }
 
 void BlockDiagonalPreconditioner::SetDiagonalBlock(int iblock, Operator *op)
@@ -161,7 +169,7 @@ void BlockDiagonalPreconditioner::SetDiagonalBlock(int iblock, Operator *op)
                offsets[iblock+1] - offsets[iblock] == op->Width(),
                "incompatible Operator dimensions");
 
-   if (owns_blocks && ops[iblock])
+   if (own_block[iblock] && ops[iblock])
    {
       delete ops[iblock];
    }
@@ -233,9 +241,9 @@ void BlockDiagonalPreconditioner::MultTranspose(const Vector & x,
 
 BlockDiagonalPreconditioner::~BlockDiagonalPreconditioner()
 {
-   if (owns_blocks)
+   for (int i=0; i<nBlocks; ++i)
    {
-      for (int i=0; i<nBlocks; ++i)
+      if (own_block[i] && ops[i])
       {
          delete ops[i];
       }
@@ -245,13 +253,15 @@ BlockDiagonalPreconditioner::~BlockDiagonalPreconditioner()
 BlockLowerTriangularPreconditioner::BlockLowerTriangularPreconditioner(
    const Array<int> & offsets_)
    : Solver(offsets_.Last()),
-     owns_blocks(0),
      nBlocks(offsets_.Size() - 1),
      offsets(0),
-     ops(nBlocks, nBlocks)
+     ops(nBlocks, nBlocks),
+     own_block(nBlocks, nBlocks),
+     owns_blocks(0)
 {
    ops = nullptr;
    offsets.MakeRef(offsets_);
+   own_block = owns_blocks;
 }
 
 void BlockLowerTriangularPreconditioner::SetDiagonalBlock(int iblock,
@@ -272,6 +282,10 @@ void BlockLowerTriangularPreconditioner::SetBlock(int iRow, int iCol,
                offsets[iCol+1] - offsets[iCol] == op->NumCols(),
                "incompatible Operator dimensions");
 
+   if (own_block(iRow, iCol) && ops(iRow, iCol))
+   {
+      delete ops(iRow, iCol);
+   }
    ops(iRow, iCol) = op;
 }
 
@@ -375,7 +389,10 @@ BlockLowerTriangularPreconditioner::~BlockLowerTriangularPreconditioner()
       {
          for (int jCol=0; jCol < nBlocks; ++jCol)
          {
-            delete ops(jCol,iRow);
+            if (own_block(iRow, jCol) && ops(iRow, jCol))
+            {
+               delete ops(iRow, jCol);
+            }
          }
       }
    }

--- a/linalg/blockoperator.hpp
+++ b/linalg/blockoperator.hpp
@@ -89,6 +89,15 @@ public:
    //! Set the coefficient for block i,j
    void SetBlockCoef(int i, int j, real_t c)
    { MFEM_VERIFY(op(i,j), ""); coef(i,j) = c; }
+   //! Set the ownership of block (i,j)
+   void SetBlockOwnership(int i, int j, int own)
+   { MFEM_VERIFY(op(i,j), ""); own_block(i,j) = own; if (own) { owns_blocks = 1; } }
+   //! Set the ownership of all blocks
+   void SetBlockOwnership(int own)
+   { own_block = own; owns_blocks = own; }
+   //! Check if block (i,j) is owned by the BlockOperator
+   int IsBlockOwned(int i, int j) const
+   { MFEM_VERIFY(op(i,j), ""); return own_block(i,j) ? 1 : 0; }
 
    //! Return the row offsets for block starts
    Array<int> & RowOffsets() { return row_offsets; }
@@ -107,10 +116,6 @@ public:
 
    ~BlockOperator();
 
-   //! Controls the ownership of the blocks: if nonzero, BlockOperator will
-   //! delete all blocks that are set (non-NULL); the default value is zero.
-   int owns_blocks;
-
    virtual Type GetType() const { return MFEM_Block_Operator; }
 
 private:
@@ -126,6 +131,12 @@ private:
    Array2D<Operator *> op;
    //! 2D array that stores a coefficient for each block of the operator.
    Array2D<real_t> coef;
+   //! 2D array that stores the ownership of each block of the operator.
+   //! if nonzero, BlockOperator will delete all blocks that are set (non-NULL);
+   //! the default value is zero.
+   Array2D<int> own_block;
+   //! Nonzero if at least one block is owned by the BlockOperator.
+   int owns_blocks;
 
    //! Temporary Vectors used to efficiently apply the Mult and MultTranspose methods.
    mutable BlockVector xblock;
@@ -170,6 +181,18 @@ public:
    const Operator & GetDiagonalBlock(int iblock) const
    { MFEM_VERIFY(ops[iblock], ""); return *ops[iblock]; }
 
+   //! Set the ownership of block (i,i)
+   void SetBlockOwnership(int iblock, int own)
+   { MFEM_VERIFY(ops[iblock], ""); own_block[iblock] = own; }
+
+   //! Set the ownership of all blocks
+   void SetBlockOwnership(int own) { own_block = own; }
+
+   //! Check if block (i,i) is owned by the BlockOperator
+   int IsBlockOwned(int iblock) const
+   { MFEM_VERIFY(ops[iblock], ""); return own_block[iblock] ? 1 : 0; }
+
+
    //! Return the offsets for block starts
    Array<int> & Offsets() { return offsets; }
 
@@ -184,11 +207,6 @@ public:
 
    ~BlockDiagonalPreconditioner();
 
-   //! Controls the ownership of the blocks: if nonzero,
-   //! BlockDiagonalPreconditioner will delete all blocks that are set
-   //! (non-NULL); the default value is zero.
-   int owns_blocks;
-
 private:
    //! Number of Blocks
    int nBlocks;
@@ -196,6 +214,10 @@ private:
    Array<int> offsets;
    //! 1D array that stores each block of the operator.
    Array<Operator *> ops;
+   //! 1D array that stores the ownership of each block of the operator.
+   //! if nonzero, BlockDiagonalPreconditioner will delete all blocks
+   //! that are set (non-NULL); the default value is zero.
+   Array<int> own_block;
    //! Temporary Vectors used to efficiently apply the Mult and MultTranspose
    //! methods.
    mutable BlockVector xblock;
@@ -256,6 +278,18 @@ public:
    Operator & GetBlock(int iblock, int jblock)
    { MFEM_VERIFY(ops(iblock,jblock), ""); return *ops(iblock,jblock); }
 
+   //! Set the ownership of block (i,j)
+   void SetBlockOwnership(int i, int j, int own)
+   { MFEM_VERIFY(ops(i,j), ""); own_block(i,j) = own; if (own) { owns_blocks = 1; } }
+
+   //! Set the ownership of all blocks
+   void SetBlockOwnership(int own)
+   { own_block = own; owns_blocks = own; }
+
+   //! Check if block (i,j) is owned by the BlockLowerTriangularPreconditioner
+   int IsBlockOwned(int i, int j) const
+   { MFEM_VERIFY(ops(i,j), ""); return own_block(i,j) ? 1 : 0; }
+
    //! Return the offsets for block starts
    Array<int> & Offsets() { return offsets; }
 
@@ -267,11 +301,6 @@ public:
 
    ~BlockLowerTriangularPreconditioner();
 
-   //! Controls the ownership of the blocks: if nonzero,
-   //! BlockLowerTriangularPreconditioner will delete all blocks that are set
-   //! (non-NULL); the default value is zero.
-   int owns_blocks;
-
 private:
    //! Number of block rows/columns
    int nBlocks;
@@ -279,6 +308,12 @@ private:
    Array<int> offsets;
    //! 2D array that stores each block of the operator.
    Array2D<Operator *> ops;
+   //! 2D array that stores the ownership of each block of the operator.
+   //! if nonzero, BlockLowerTriangularPreconditioner will delete all
+   //! blocks that are set (non-NULL); the default value is zero.
+   Array2D<int> own_block;
+   //! Nonzero if at least one block is owned by the BlockLowerTriangularPreconditioner.
+   int owns_blocks;
 
    //! Temporary Vectors used to efficiently apply the Mult and MultTranspose
    //! methods.

--- a/miniapps/dpg/acoustics.cpp
+++ b/miniapps/dpg/acoustics.cpp
@@ -365,7 +365,7 @@ int main(int argc, char *argv[])
       }
 
       BlockDiagonalPreconditioner M(tdof_offsets);
-      M.owns_blocks = 1;
+      M.SetBlockOwnership(1);
       for (int i = 0; i<num_blocks; i++)
       {
          M.SetDiagonalBlock(i, new GSSmoother((SparseMatrix&)A_r->GetBlock(i,i)));

--- a/miniapps/dpg/convection-diffusion.cpp
+++ b/miniapps/dpg/convection-diffusion.cpp
@@ -361,7 +361,7 @@ int main(int argc, char *argv[])
       BlockMatrix * A = Ah.As<BlockMatrix>();
 
       BlockDiagonalPreconditioner M(A->RowOffsets());
-      M.owns_blocks = 1;
+      M.SetBlockOwnership(1);
       for (int i = 0 ; i < A->NumRowBlocks(); i++)
       {
          M.SetDiagonalBlock(i,new DSmoother(A->GetBlock(i,i)));

--- a/miniapps/dpg/diffusion.cpp
+++ b/miniapps/dpg/diffusion.cpp
@@ -297,7 +297,7 @@ int main(int argc, char *argv[])
       BlockMatrix * A = Ah.As<BlockMatrix>();
 
       BlockDiagonalPreconditioner M(A->RowOffsets());
-      M.owns_blocks = 1;
+      M.SetBlockOwnership(1);
       for (int i=0; i<A->NumRowBlocks(); i++)
       {
          M.SetDiagonalBlock(i,new GSSmoother(A->GetBlock(i,i)));

--- a/miniapps/dpg/maxwell.cpp
+++ b/miniapps/dpg/maxwell.cpp
@@ -445,7 +445,7 @@ int main(int argc, char *argv[])
       }
 
       BlockDiagonalPreconditioner M(tdof_offsets);
-      M.owns_blocks = 1;
+      M.SetBlockOwnership(1);
       for (int i = 0; i<num_blocks; i++)
       {
          M.SetDiagonalBlock(i, new GSSmoother((SparseMatrix&)A_r->GetBlock(i,i)));

--- a/miniapps/dpg/pacoustics.cpp
+++ b/miniapps/dpg/pacoustics.cpp
@@ -648,7 +648,7 @@ int main(int argc, char *argv[])
 
       X = 0.;
       BlockDiagonalPreconditioner M(tdof_offsets);
-      M.owns_blocks=0;
+      M.SetBlockOwnership(0);
 
       if (!static_cond)
       {

--- a/miniapps/dpg/pconvection-diffusion.cpp
+++ b/miniapps/dpg/pconvection-diffusion.cpp
@@ -454,7 +454,7 @@ int main(int argc, char *argv[])
       BlockOperator * A = Ah.As<BlockOperator>();
 
       BlockDiagonalPreconditioner M(A->RowOffsets());
-      M.owns_blocks = 1;
+      M.SetBlockOwnership(1);
       int skip = 0;
       if (!static_cond)
       {

--- a/miniapps/dpg/pdiffusion.cpp
+++ b/miniapps/dpg/pdiffusion.cpp
@@ -379,7 +379,7 @@ int main(int argc, char *argv[])
       BlockOperator * A = Ah.As<BlockOperator>();
 
       BlockDiagonalPreconditioner M(A->RowOffsets());
-      M.owns_blocks = 1;
+      M.SetBlockOwnership(1);
       int skip = 0;
       if (!static_cond)
       {

--- a/miniapps/dpg/util/blockstaticcond.cpp
+++ b/miniapps/dpg/util/blockstaticcond.cpp
@@ -160,7 +160,7 @@ void BlockStaticCondensation::Init()
    ComputeOffsets();
 
    S = new BlockMatrix(rdof_offsets);
-   S->owns_blocks = 1;
+   S->SetBlockOwnership(1);
 
    for (int i = 0; i<S->NumRowBlocks(); i++)
    {
@@ -520,8 +520,8 @@ void BlockStaticCondensation::BuildProlongation()
 {
    P = new BlockMatrix(rdof_offsets, rtdof_offsets);
    R = new BlockMatrix(rtdof_offsets, rdof_offsets);
-   P->owns_blocks = 0;
-   R->owns_blocks = 0;
+   P->SetBlockOwnership(0);
+   R->SetBlockOwnership(0);
    int skip = 0;
    for (int i = 0; i<nblocks; i++)
    {
@@ -543,8 +543,8 @@ void BlockStaticCondensation::BuildParallelProlongation()
    MFEM_VERIFY(parallel, "BuildParallelProlongation: wrong code path");
    pP = new BlockOperator(rdof_offsets, rtdof_offsets);
    R = new BlockMatrix(rtdof_offsets, rdof_offsets);
-   pP->owns_blocks = 0;
-   R->owns_blocks = 0;
+   pP->SetBlockOwnership(0);
+   R->SetBlockOwnership(0);
    int skip = 0;
    for (int i = 0; i<nblocks; i++)
    {
@@ -567,8 +567,8 @@ void BlockStaticCondensation::ParallelAssemble(BlockMatrix *m)
 
    pS = new BlockOperator(rtdof_offsets);
    pS_e = new BlockOperator(rtdof_offsets);
-   pS->owns_blocks = 1;
-   pS_e->owns_blocks = 1;
+   pS->SetBlockOwnership(1);
+   pS_e->SetBlockOwnership(1);
    HypreParMatrix * A = nullptr;
    HypreParMatrix * PtAP = nullptr;
    int skip_i=0;
@@ -784,7 +784,7 @@ void BlockStaticCondensation::EliminateReducedTrueDofs(const Array<int>
       offsets.MakeRef( (P) ? rtdof_offsets : rdof_offsets);
 
       S_e = new BlockMatrix(offsets);
-      S_e->owns_blocks = 1;
+      S_e->SetBlockOwnership(1);
       for (int i = 0; i<S_e->NumRowBlocks(); i++)
       {
          int h = offsets[i+1] - offsets[i];

--- a/miniapps/dpg/util/complexstaticcond.cpp
+++ b/miniapps/dpg/util/complexstaticcond.cpp
@@ -161,9 +161,9 @@ void ComplexBlockStaticCondensation::Init()
    ComputeOffsets();
 
    S_r = new BlockMatrix(rdof_offsets);
-   S_r->owns_blocks = 1;
+   S_r->SetBlockOwnership(1);
    S_i = new BlockMatrix(rdof_offsets);
-   S_i->owns_blocks = 1;
+   S_i->SetBlockOwnership(1);
 
    for (int i = 0; i<S_r->NumRowBlocks(); i++)
    {
@@ -564,8 +564,8 @@ void ComplexBlockStaticCondensation::BuildProlongation()
 {
    P = new BlockMatrix(rdof_offsets, rtdof_offsets);
    R = new BlockMatrix(rtdof_offsets, rdof_offsets);
-   P->owns_blocks = 0;
-   R->owns_blocks = 0;
+   P->SetBlockOwnership(0);
+   R->SetBlockOwnership(0);
    int skip = 0;
    for (int i = 0; i<nblocks; i++)
    {
@@ -587,8 +587,8 @@ void ComplexBlockStaticCondensation::BuildParallelProlongation()
    MFEM_VERIFY(parallel, "BuildParallelProlongation: wrong code path");
    pP = new BlockOperator(rdof_offsets, rtdof_offsets);
    R = new BlockMatrix(rtdof_offsets, rdof_offsets);
-   pP->owns_blocks = 0;
-   R->owns_blocks = 0;
+   pP->SetBlockOwnership(0);
+   R->SetBlockOwnership(0);
    int skip = 0;
    for (int i = 0; i<nblocks; i++)
    {
@@ -615,10 +615,10 @@ void ComplexBlockStaticCondensation::ParallelAssemble(BlockMatrix *m_r,
    pS_e_r = new BlockOperator(rtdof_offsets);
    pS_i = new BlockOperator(rtdof_offsets);
    pS_e_i = new BlockOperator(rtdof_offsets);
-   pS_r->owns_blocks = 1;
-   pS_i->owns_blocks = 1;
-   pS_e_r->owns_blocks = 1;
-   pS_e_i->owns_blocks = 1;
+   pS_r->SetBlockOwnership(1);
+   pS_i->SetBlockOwnership(1);
+   pS_e_r->SetBlockOwnership(1);
+   pS_e_i->SetBlockOwnership(1);
    HypreParMatrix * A_r = nullptr;
    HypreParMatrix * A_i = nullptr;
    HypreParMatrix * PtAP_r = nullptr;
@@ -877,8 +877,8 @@ void ComplexBlockStaticCondensation::EliminateReducedTrueDofs(const Array<int>
 
       S_e_r = new BlockMatrix(offsets);
       S_e_i = new BlockMatrix(offsets);
-      S_e_r->owns_blocks = 1;
-      S_e_i->owns_blocks = 1;
+      S_e_r->SetBlockOwnership(1);
+      S_e_i->SetBlockOwnership(1);
       for (int i = 0; i<S_e_r->NumRowBlocks(); i++)
       {
          int h = offsets[i+1] - offsets[i];

--- a/miniapps/dpg/util/complexweakform.cpp
+++ b/miniapps/dpg/util/complexweakform.cpp
@@ -85,9 +85,9 @@ void ComplexDPGWeakForm::AllocMat()
    if (static_cond) { return; }
 
    mat_r = new BlockMatrix(dof_offsets);
-   mat_r->owns_blocks = 1;
+   mat_r->SetBlockOwnership(1);
    mat_i = new BlockMatrix(dof_offsets);
-   mat_i->owns_blocks = 1;
+   mat_i->SetBlockOwnership(1);
 
    for (int i = 0; i < mat_r->NumRowBlocks(); i++)
    {
@@ -179,8 +179,8 @@ void ComplexDPGWeakForm::BuildProlongation()
 {
    P = new BlockMatrix(dof_offsets, tdof_offsets);
    R = new BlockMatrix(tdof_offsets, dof_offsets);
-   P->owns_blocks = 0;
-   R->owns_blocks = 0;
+   P->SetBlockOwnership(0);
+   R->SetBlockOwnership(0);
    for (int i = 0; i<nblocks; i++)
    {
       const SparseMatrix *P_ = trial_fes[i]->GetConformingProlongation();
@@ -201,8 +201,8 @@ void ComplexDPGWeakForm::ConformingAssemble()
    BlockMatrix * Pt = Transpose(*P);
    BlockMatrix * PtA_r = mfem::Mult(*Pt, *mat_r);
    BlockMatrix * PtA_i = mfem::Mult(*Pt, *mat_i);
-   mat_r->owns_blocks = 0;
-   mat_i->owns_blocks = 0;
+   mat_r->SetBlockOwnership(0);
+   mat_i->SetBlockOwnership(0);
    for (int i = 0; i < nblocks; i++)
    {
       for (int j = 0; j < nblocks; j++)
@@ -227,8 +227,8 @@ void ComplexDPGWeakForm::ConformingAssemble()
    {
       BlockMatrix *PtAe_r = mfem::Mult(*Pt, *mat_e_r);
       BlockMatrix *PtAe_i = mfem::Mult(*Pt, *mat_e_i);
-      mat_e_r->owns_blocks = 0;
-      mat_e_i->owns_blocks = 0;
+      mat_e_r->SetBlockOwnership(0);
+      mat_e_i->SetBlockOwnership(0);
       for (int i = 0; i<nblocks; i++)
       {
          for (int j = 0; j<nblocks; j++)
@@ -257,8 +257,8 @@ void ComplexDPGWeakForm::ConformingAssemble()
    mat_r = mfem::Mult(*PtA_r, *P);
    mat_i = mfem::Mult(*PtA_i, *P);
 
-   PtA_r->owns_blocks = 0;
-   PtA_i->owns_blocks = 0;
+   PtA_r->SetBlockOwnership(0);
+   PtA_i->SetBlockOwnership(0);
    for (int i = 0; i < nblocks; i++)
    {
       for (int j = 0; j < nblocks; j++)
@@ -284,8 +284,8 @@ void ComplexDPGWeakForm::ConformingAssemble()
    {
       BlockMatrix *PtAeP_r = mfem::Mult(*mat_e_r, *P);
       BlockMatrix *PtAeP_i = mfem::Mult(*mat_e_i, *P);
-      mat_e_r->owns_blocks = 0;
-      mat_e_i->owns_blocks = 0;
+      mat_e_r->SetBlockOwnership(0);
+      mat_e_i->SetBlockOwnership(0);
       for (int i = 0; i < nblocks; i++)
       {
          for (int j = 0; j < nblocks; j++)
@@ -742,9 +742,9 @@ void ComplexDPGWeakForm::EliminateVDofs(const Array<int> &vdofs,
       offsets.MakeRef( (P) ? tdof_offsets : dof_offsets);
 
       mat_e_r = new BlockMatrix(offsets);
-      mat_e_r->owns_blocks = 1;
+      mat_e_r->SetBlockOwnership(1);
       mat_e_i = new BlockMatrix(offsets);
-      mat_e_i->owns_blocks = 1;
+      mat_e_i->SetBlockOwnership(1);
       for (int i = 0; i < mat_e_r->NumRowBlocks(); i++)
       {
          int h = offsets[i+1] - offsets[i];

--- a/miniapps/dpg/util/pcomplexweakform.cpp
+++ b/miniapps/dpg/util/pcomplexweakform.cpp
@@ -45,10 +45,10 @@ void ParComplexDPGWeakForm::ParallelAssemble(BlockMatrix *m_r,
    p_mat_i = new BlockOperator(tdof_offsets);
    p_mat_e_r = new BlockOperator(tdof_offsets);
    p_mat_e_i = new BlockOperator(tdof_offsets);
-   p_mat_r->owns_blocks = 1;
-   p_mat_i->owns_blocks = 1;
-   p_mat_e_r->owns_blocks = 1;
-   p_mat_e_i->owns_blocks = 1;
+   p_mat_r->SetBlockOwnership(1);
+   p_mat_i->SetBlockOwnership(1);
+   p_mat_e_r->SetBlockOwnership(1);
+   p_mat_e_i->SetBlockOwnership(1);
    HypreParMatrix * A_r = nullptr;
    HypreParMatrix * A_i = nullptr;
    HypreParMatrix * PtAP_r = nullptr;
@@ -106,8 +106,8 @@ void ParComplexDPGWeakForm::BuildProlongation()
 {
    P = new BlockOperator(dof_offsets, tdof_offsets);
    R = new BlockMatrix(tdof_offsets, dof_offsets);
-   P->owns_blocks = 0;
-   R->owns_blocks = 0;
+   P->SetBlockOwnership(0);
+   R->SetBlockOwnership(0);
 
    for (int i = 0; i < nblocks; i++)
    {

--- a/miniapps/dpg/util/pweakform.cpp
+++ b/miniapps/dpg/util/pweakform.cpp
@@ -41,8 +41,8 @@ void ParDPGWeakForm::ParallelAssemble(BlockMatrix *m)
 
    p_mat = new BlockOperator(tdof_offsets);
    p_mat_e = new BlockOperator(tdof_offsets);
-   p_mat->owns_blocks = 1;
-   p_mat_e->owns_blocks = 1;
+   p_mat->SetBlockOwnership(1);
+   p_mat_e->SetBlockOwnership(1);
    HypreParMatrix * A = nullptr;
    HypreParMatrix * PtAP = nullptr;
    for (int i = 0; i<nblocks; i++)
@@ -85,8 +85,8 @@ void ParDPGWeakForm::BuildProlongation()
 {
    P = new BlockOperator(dof_offsets, tdof_offsets);
    R = new BlockMatrix(tdof_offsets, dof_offsets);
-   P->owns_blocks = 0;
-   R->owns_blocks = 0;
+   P->SetBlockOwnership(0);
+   R->SetBlockOwnership(0);
 
    for (int i = 0; i<nblocks; i++)
    {

--- a/miniapps/dpg/util/weakform.cpp
+++ b/miniapps/dpg/util/weakform.cpp
@@ -79,7 +79,7 @@ void DPGWeakForm::AllocMat()
    if (static_cond) { return; }
 
    mat = new BlockMatrix(dof_offsets);
-   mat->owns_blocks = 1;
+   mat->SetBlockOwnership(1);
 
    for (int i = 0; i<mat->NumRowBlocks(); i++)
    {
@@ -134,8 +134,8 @@ void DPGWeakForm::BuildProlongation()
 {
    P = new BlockMatrix(dof_offsets, tdof_offsets);
    R = new BlockMatrix(tdof_offsets, dof_offsets);
-   P->owns_blocks = 0;
-   R->owns_blocks = 0;
+   P->SetBlockOwnership(0);
+   R->SetBlockOwnership(0);
    for (int i = 0; i<nblocks; i++)
    {
       const SparseMatrix *P_ = trial_fes[i]->GetConformingProlongation();
@@ -155,7 +155,7 @@ void DPGWeakForm::ConformingAssemble()
 
    BlockMatrix * Pt = Transpose(*P);
    BlockMatrix * PtA = mfem::Mult(*Pt, *mat);
-   mat->owns_blocks = 0;
+   mat->SetBlockOwnership(0);
    for (int i = 0; i<nblocks; i++)
    {
       for (int j = 0; j<nblocks; j++)
@@ -175,7 +175,7 @@ void DPGWeakForm::ConformingAssemble()
    if (mat_e)
    {
       BlockMatrix *PtAe = mfem::Mult(*Pt, *mat_e);
-      mat_e->owns_blocks = 0;
+      mat_e->SetBlockOwnership(0);
       for (int i = 0; i<nblocks; i++)
       {
          for (int j = 0; j<nblocks; j++)
@@ -198,7 +198,7 @@ void DPGWeakForm::ConformingAssemble()
 
    mat = mfem::Mult(*PtA, *P);
 
-   PtA->owns_blocks = 0;
+   PtA->SetBlockOwnership(0);
    for (int i = 0; i<nblocks; i++)
    {
       for (int j = 0; j<nblocks; j++)
@@ -219,7 +219,7 @@ void DPGWeakForm::ConformingAssemble()
    if (mat_e)
    {
       BlockMatrix *PtAeP = mfem::Mult(*mat_e, *P);
-      mat_e->owns_blocks = 0;
+      mat_e->SetBlockOwnership(0);
       for (int i = 0; i<nblocks; i++)
       {
          for (int j = 0; j<nblocks; j++)
@@ -575,7 +575,7 @@ void DPGWeakForm::EliminateVDofs(const Array<int> &vdofs,
       offsets.MakeRef( (P) ? tdof_offsets : dof_offsets);
 
       mat_e = new BlockMatrix(offsets);
-      mat_e->owns_blocks = 1;
+      mat_e->SetBlockOwnership(1);
       for (int i = 0; i<mat_e->NumRowBlocks(); i++)
       {
          int h = offsets[i+1] - offsets[i];

--- a/miniapps/solvers/bramble_pasciak.cpp
+++ b/miniapps/solvers/bramble_pasciak.cpp
@@ -79,13 +79,13 @@ void BramblePasciakSolver::Init(HypreParMatrix &M,
       temp_tri->SetBlock(0, 0, id_m);
       temp_tri->SetBlock(1, 1, id_b, -1.0);
       temp_tri->SetBlock(1, 0, BinvQ);
-      temp_tri->owns_blocks = 1;
+      temp_tri->SetBlockOwnership(1);
 
       ppc_ = std::make_unique<ProductOperator>(temp_cpc, temp_tri, true, true);
 
       ipc_ = std::make_unique<BlockOperator>(offsets_);
       ipc_->SetDiagonalBlock(0, invQ);
-      ipc_->owns_blocks = 1;
+      ipc_->SetBlockOwnership(1);
 
       // bpcg
       solver_ = std::make_unique<BPCGSolver>(M.GetComm(), ipc_.get(), ppc_.get());
@@ -102,7 +102,7 @@ void BramblePasciakSolver::Init(HypreParMatrix &M,
       // ipc_ unused in cg
       auto temp_ipc = new BlockOperator(offsets_);
       temp_ipc->SetDiagonalBlock(0, invQ);
-      temp_ipc->owns_blocks = 1;
+      temp_ipc->SetBlockOwnership(1);
 
       // temp_AN = temp_oop * temp_ipc
       auto temp_AN = new ProductOperator(temp_oop, temp_ipc, true, true);

--- a/miniapps/solvers/darcy_solver.cpp
+++ b/miniapps/solvers/darcy_solver.cpp
@@ -48,7 +48,7 @@ BDPMinresSolver::BDPMinresSolver(const HypreParMatrix& M,
    prec_.SetDiagonalBlock(0, new HypreDiagScale(M));
    prec_.SetDiagonalBlock(1, new HypreBoomerAMG(*S_.As<HypreParMatrix>()));
    static_cast<HypreBoomerAMG&>(prec_.GetDiagonalBlock(1)).SetPrintLevel(0);
-   prec_.owns_blocks = 1;
+   prec_.SetBlockOwnership(1);
 
    SetOptions(solver_, param);
    solver_.SetOperator(op_);

--- a/miniapps/solvers/div_free_solver.cpp
+++ b/miniapps/solvers/div_free_solver.cpp
@@ -373,7 +373,7 @@ DivFreeSolver::DivFreeSolver(const HypreParMatrix &M,
       {
          auto S1 = new BlockDiagonalPreconditioner(ops_offsets_[l]);
          S1->SetDiagonalBlock(0, new AuxSpaceSmoother(M_f, C_l));
-         S1->owns_blocks = 1;
+         S1->SetBlockOwnership(1);
          smoothers_[l] =
             std::make_unique<ProductSolver>(ops_[l].get(), S0, S1, false, true, true);
       }
@@ -399,7 +399,7 @@ DivFreeSolver::DivFreeSolver(const HypreParMatrix &M,
       ops_[l-1]->SetBlock(0, 0, M_c);
       ops_[l-1]->SetBlock(1, 0, B_c);
       ops_[l-1]->SetBlock(0, 1, B_c->Transpose());
-      ops_[l-1]->owns_blocks = 1;
+      ops_[l-1]->SetBlockOwnership(1);
    }
 
    if (data_.P_l2.size() == 0) { return; }

--- a/tests/unit/linalg/test_matrix_block.cpp
+++ b/tests/unit/linalg/test_matrix_block.cpp
@@ -328,7 +328,7 @@ TEST_CASE("BlockMatrix", "[BlockMatrix]")
    SECTION("Check EliminateRowCols")
    {
       Array<int> rows{{18,72,1342,951,423,877,1234}};
-      BlockMatrix Ae(offsets); Ae.owns_blocks = 1;
+      BlockMatrix Ae(offsets); Ae.SetBlockOwnership(1);
 
       // Make sure the matrix is symmetric
       BlockMatrix * At = Transpose(*A);


### PR DESCRIPTION
Added capability to specify ownership of individual blocks in the following classes:
1. `BlockOperator`
2. `BlockDiagonalPreconditioner`
3. `BlockLowerTriangularPreconditioner`
4. `BlockMatrix`

Defaults to original implementation (no blocks are owned) for backward compatibility.
Updated examples, unit tests and miniapps.
<!--GHEX{"author":"sohailreddy","assignment":"2026-05-19T23:26:10","editor":"tzanio","id":5336,"reviewers":["jandrej","bslazarov"],"merge":"2026-06-09T23:26:10","approval":"2026-06-02T23:26:10"}XEHG-->
<!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge|
 | --- | --- | --- | --- | --- | --- | --- |
| [#5336](https://github.com/mfem/mfem/pull/5336) | @sohailreddy | @tzanio | @jandrej + @bslazarov | 5/19/26 | ⌛due 6/2/26 | ⌛due 6/9/26 | |
<!--ELBATXEHG-->
<details>
<summary>PR Checklist</summary>
    
- [ ] Code builds.
- [ ] Code passes `make style`.
- [ ] Update `CHANGELOG`:
    - [ ] Is this a new feature users need to be aware of? New or updated example or miniapp?
    - [ ] Does it make sense to create a new section in the `CHANGELOG` to group with other related features?
- [ ] Update `INSTALL`:
    - [ ] Had a new optional library been added? If so, what range of versions of this library are required? (*Make sure the external library is compatible with our BSD license, e.g. it is not licensed under GPL!*)
    - [ ] Have the version ranges for any required or optional libraries changed?
    - [ ] Does `make` or `cmake` have a new target?
    - [ ] Did the requirements or the installation process change? *(rare)*
- [ ] Update continuous integration server configurations if necessary (e.g. with new version requirements for each of MFEM's dependencies)
    - [ ] `.github`
    - [ ] `.appveyor.yml`
- [ ] Update `.gitignore`:
    - [ ] Check if `make distclean; git status` shows any files that were generated from the source by the project (not an IDE) but we don't want to track in the repository.
    - [ ] Add new patterns (just for the new files above) and re-run the above test.
- [ ] New examples:
    - [ ] All sample runs at the top of the example source file work.
    - [ ] Update `examples/makefile`:
      - [ ] Add the example code to the appropriate `SEQ_EXAMPLES` and `PAR_EXAMPLES` variables.
      - [ ] Add any files generated by it to the `clean` target.
      - [ ] Add the example binary and any files generated by it to the top-level `.gitignore` file.
    - [ ] Update `examples/CMakeLists.txt`:
      - [ ] Add the example code to the `ALL_EXE_SRCS` variable.
      - [ ] Make sure `THIS_TEST_OPTIONS` is set correctly for the new example.
   - [ ] List the new example in `doc/CodeDocumentation.dox`.
   - [ ] If new examples directory (e.g.`examples/pumi`), list it in `doc/CodeDocumentation.conf.in`
   - [ ] Companion pull request for documentation in [mfem/web](https://github.com/mfem/web) repo:
      - [ ] Update or add example-specific documentation, see e.g. the `src/examples.md`.
      - [ ] Add the description, labels and screenshots in `src/examples.md` and `src/img`.
      - [ ] In `examples.md`, list the example under the appropriate categories, add new categories if necessary.
      - [ ] Add a short description of the example in the "Extensive Examples" section of `features.md`.
- [ ] New miniapps:
   - [ ] All sample runs at the top of the miniapp source file work.
   - [ ] Update top-level `makefile` and `makefile` in corresponding miniapp directory.
   - [ ] Add the miniapp binary and any files generated by it to the top-level `.gitignore` file.
   - [ ] Update CMake build system:
      - [ ] Update the `CMakeLists.txt` file in the `miniapps` directory, if the new miniapp is in a new directory.
      - [ ] Add/update the `CMakeLists.txt` file in the new miniapp directory.
      - [ ] Consider adding a new test for the new miniapp.
   - [ ] List the new miniapp in `doc/CodeDocumentation.dox`
   - [ ] If new miniapps directory (e.g.`miniapps/nurbs`), add it to `MINIAPP_SUBDIRS` in the `makefile`.
   - [ ] If new miniapps directory (e.g.`miniapps/nurbs`), list it in `doc/CodeDocumentation.conf.in`
   - [ ] Companion pull request for documentation in [mfem/web](https://github.com/mfem/web) repo:
     - [ ] Update or add miniapp-specific documentation, see e.g. the `src/meshing.md` and `src/electromagnetics.md` files.
     - [ ] Add the description, labels and screenshots in `src/examples.md` and `src/img`.
     - [ ] The miniapps go at the end of the page, and are usually listed only under a specific "Application (PDE)" category.
     - [ ] Add a short description of the miniapp in the "Extensive Examples" section of `features.md`.
- [ ] New capability:
   - [ ] All new public, protected, and private classes, methods, data members, and functions have full Doxygen-style documentation in source comments. Documentation should include descriptions of member data, function arguments and return values, template parameters, and prerequisites for calling new functions.
   - [ ] Pointer arguments and return values must specify whether ownership is being transferred or lent with the call.
   - [ ] Any new functions should include descriptions of their intended use e.g. for internal use only, user-facing, etc., along with references to example code whenever possible/appropriate.
   - [ ] Consider adding new sample runs in existing examples to highlight the new capability.
   - [ ] Consider saving cool simulation pictures with the new capability in the Confluence gallery (LLNL only) or submitting them, via pull request, to the gallery section of the `mfem/web` repo.
   - [ ] If this is a major new feature, consider mentioning it in the short summary inside `README` *(rare)*.
   - [ ] List major new classes in `doc/CodeDocumentation.dox` *(rare)*.
- [ ] Update this checklist, if the new pull request affects it.
- [ ] Run `make unittest` to make sure all unit tests pass.
- [ ] Run the tests in `tests/scripts`.
- [ ] (LLNL only) After merging:
   - [ ] Update internal tests to include the new features.
</details>
