### PR TITLE
Don't copy over host/device interface from invalid side

### DIFF
--- a/general/mem_manager.cpp
+++ b/general/mem_manager.cpp
@@ -1159,9 +1159,14 @@ void MemoryManager::SyncAlias_(const void *base_h_ptr, void *alias_h_ptr,
    // This is called only when (base_flags & Mem::Registered) is true.
    // Note that (alias_flags & Registered) may not be true.
    MFEM_ASSERT(alias_flags & Mem::ALIAS, "not an alias");
+   // The alias shares the base host and device buffers, so syncing only needs to
+   // establish/register the alias pointers and copy the base's validity flags
+   // below. Any host<->device copy must source from the side that is actually
+   // valid: copying from a stale side would clobber the valid data in the shared
+   // buffer (e.g. an HtoD from a stale host overwriting a valid device buffer).
    if ((base_flags & Mem::VALID_HOST) && !(alias_flags & Mem::VALID_HOST))
    {
-      mm.GetAliasHostPtr(alias_h_ptr, alias_bytes, true);
+      mm.GetAliasHostPtr(alias_h_ptr, alias_bytes, base_flags & Mem::VALID_DEVICE);
    }
    if ((base_flags & Mem::VALID_DEVICE) && !(alias_flags & Mem::VALID_DEVICE))
    {
@@ -1171,7 +1176,7 @@ void MemoryManager::SyncAlias_(const void *base_h_ptr, void *alias_h_ptr,
          alias_flags = (alias_flags | Mem::Registered | Mem::OWNS_INTERNAL) &
                        ~(Mem::OWNS_HOST | Mem::OWNS_DEVICE);
       }
-      mm.GetAliasDevicePtr(alias_h_ptr, alias_bytes, true);
+      mm.GetAliasDevicePtr(alias_h_ptr, alias_bytes, base_flags & Mem::VALID_HOST);
    }
    alias_flags = (alias_flags & ~(Mem::VALID_HOST | Mem::VALID_DEVICE)) |
                  (base_flags & (Mem::VALID_HOST | Mem::VALID_DEVICE));

--- a/tests/unit/general/test_mem.cpp
+++ b/tests/unit/general/test_mem.cpp
@@ -67,3 +67,52 @@ TEST_CASE("MemoryManager/Scopes",
       REQUIRE((x_data == x.HostRead()));
    }
 }
+
+TEST_CASE("MemoryManager/SyncAliasDeviceValidBase",
+          "[MemoryManager]"
+          "[GPU]")
+{
+   // Regression test for SyncAlias on a base that is valid on the device with a
+   // stale host buffer (flags = VALID_DEVICE only), with an alias that was
+   // created earlier while the base was host-valid (as BlockVector blocks are).
+   // The alias shares the base buffers, so SyncAlias only needs to update the
+   // alias flags: it must copy across the host/device boundary only from the
+   // side that is actually valid. Copying the stale host buffer onto the valid
+   // device data corrupts the base data in place.
+   constexpr int n = 8;
+   constexpr real_t stale_host = 1.0;
+   constexpr real_t valid_device = 2.0;
+
+   Vector base(n);
+   base.UseDevice(true);
+
+   // Put stale values in the host buffer.
+   {
+      real_t *hp = base.HostWrite();
+      for (int i = 0; i < n; i++) { hp[i] = stale_host; }
+   }
+
+   // The block alias is created while the base is host-valid, mirroring
+   // BlockVector::SetBlocks() which builds the block aliases at construction.
+   Vector alias;
+   alias.MakeRef(base, 0, n);
+
+   // Write the correct values on the device only. The base is now VALID_DEVICE
+   // only, with the host buffer left holding the stale values.
+   {
+      real_t *dp = base.Write();
+      mfem::forall(n, [=] MFEM_HOST_DEVICE (int i) { dp[i] = valid_device; });
+   }
+
+   // Sync the alias's flags with the base.
+   alias.SyncAliasMemory(base);
+
+   // The valid device data must survive: SyncAlias must not have copied the
+   // stale host buffer over it. On a host-only build the data lives on the host,
+   // so the expected value is the same either way.
+   const real_t *hp = base.HostRead();
+   for (int i = 0; i < n; i++)
+   {
+      REQUIRE(hp[i] == valid_device);
+   }
+}


### PR DESCRIPTION
I'm a little bit surprised that the code was this way without it being intentional, so it's fully possible I'm missing something. But it seems like before this patch we were explicitly testing what side of the base device/host interface was valid and then copying data from the untested side over to the valid side. This bug only triggers when one side is valid and the other is not so maybe users are generally not calling `SyncAlias_` when there is this asymmetry