### PR TITLE
Fix tetrahedron leak in ParNCMesh::GetFaceNeighbors

### DIFF
--- a/mesh/ncmesh.cpp
+++ b/mesh/ncmesh.cpp
@@ -2717,21 +2717,6 @@ void NCMesh::InitRootState(int root_count)
    }
 }
 
-mfem::Element* NCMesh::NewMeshElement(int geom) const
-{
-   switch (geom)
-   {
-      case Geometry::CUBE: return new mfem::Hexahedron;
-      case Geometry::PRISM: return new mfem::Wedge;
-      case Geometry::PYRAMID: return new mfem::Pyramid;
-      case Geometry::TETRAHEDRON: return new mfem::Tetrahedron;
-      case Geometry::SQUARE: return new mfem::Quadrilateral;
-      case Geometry::TRIANGLE: return new mfem::Triangle;
-   }
-   MFEM_ABORT("invalid geometry");
-   return NULL;
-}
-
 const real_t* NCMesh::CalcVertexPos(int node) const
 {
    const Node &nd = nodes[node];

--- a/mesh/ncmesh.hpp
+++ b/mesh/ncmesh.hpp
@@ -919,8 +919,6 @@ protected:
 
    int NewSegment(int n0, int n1, int attr, int vattr1, int vattr2);
 
-   mfem::Element* NewMeshElement(int geom) const;
-
    /**
     * @brief Given a quad face defined by four vertices, establish which edges
     * of this face have been split, and if so optionally return the mid points

--- a/mesh/pncmesh.cpp
+++ b/mesh/pncmesh.cpp
@@ -1110,7 +1110,10 @@ void ParNCMesh::GetFaceNeighbors(ParMesh &pmesh)
    for (int i = 0; i < fnbr.Size(); i++)
    {
       NCMesh::Element* elem = fnbr[i];
-      mfem::Element* fne = NewMeshElement(elem->geom);
+      // Allocate through the mesh so tetrahedra come from its MemAlloc pool:
+      // these elements are freed by Mesh::FreeElement (DeleteFaceNbrData),
+      // which returns tetrahedra to the pool and would leak plain new'd ones.
+      mfem::Element* fne = pmesh.NewElement(elem->geom);
       fne->SetAttribute(elem->attribute);
       pmesh.face_nbr_elements.Append(fne);
 


### PR DESCRIPTION
The face neighbor elements were allocated with plain new through `NCMesh::NewMeshElement`, but `ParMesh::DeleteFaceNbrData` releases them with `Mesh::FreeElement`, which returns tetrahedra to the mesh's `MemAlloc` pool. The plain new'd tetrahedra never reach the pool's slabs, so every `ExchangeFaceNbrData` on a nonconforming tetrahedral or mixed mesh leaked the ghost layer. Allocate through `Mesh::NewElement` instead, matching the documented `FreeElement` contract, and remove the now unused `NewMeshElement`.
<!--GHEX{"author":"hughcars","assignment":"2026-07-28T16:47:19","editor":"tzanio","id":5366,"reviewers":["mlstowell","dylan-copeland"],"merge":"2026-08-18T16:47:19","approval":"2026-08-11T16:47:19"}XEHG-->
<!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge|
 | --- | --- | --- | --- | --- | --- | --- |
| [#5366](https://github.com/mfem/mfem/pull/5366) | @hughcars | @tzanio | @mlstowell + @dylan-copeland | 7/28/26 | ⌛due 8/11/26 | ⌛due 8/18/26 | |
<!--ELBATXEHG-->
<details>
<summary>PR Checklist</summary>
    
- [ ] Code builds.
- [ ] Code passes `make style`.
- [ ] Update `CHANGELOG`:
    - [ ] Is this a new feature users need to be aware of? New or updated example or miniapp?
    - [ ] Does it make sense to create a new section in the `CHANGELOG` to group with other related features?
- [ ] Update `INSTALL`:
    - [ ] Had a new optional library been added? If so, what range of versions of this library are required? (*Make sure the external library is compatible with our BSD license, e.g. it is not licensed under GPL!*)
    - [ ] Have the version ranges for any required or optional libraries changed?
    - [ ] Does `make` or `cmake` have a new target?
    - [ ] Did the requirements or the installation process change? *(rare)*
- [ ] Update continuous integration server configurations if necessary (e.g. with new version requirements for each of MFEM's dependencies)
    - [ ] `.github`
    - [ ] `.appveyor.yml`
- [ ] Update `.gitignore`:
    - [ ] Check if `make distclean; git status` shows any files that were generated from the source by the project (not an IDE) but we don't want to track in the repository.
    - [ ] Add new patterns (just for the new files above) and re-run the above test.
- [ ] New examples:
    - [ ] All sample runs at the top of the example source file work.
    - [ ] Update `examples/makefile`:
      - [ ] Add the example code to the appropriate `SEQ_EXAMPLES` and `PAR_EXAMPLES` variables.
      - [ ] Add any files generated by it to the `clean` target.
      - [ ] Add the example binary and any files generated by it to the top-level `.gitignore` file.
    - [ ] Update `examples/CMakeLists.txt`:
      - [ ] Add the example code to the `ALL_EXE_SRCS` variable.
      - [ ] Make sure `THIS_TEST_OPTIONS` is set correctly for the new example.
   - [ ] List the new example in `doc/CodeDocumentation.dox`.
   - [ ] If new examples directory (e.g.`examples/pumi`), list it in `doc/CodeDocumentation.conf.in`
   - [ ] Companion pull request for documentation in [mfem/web](https://github.com/mfem/web) repo:
      - [ ] Update or add example-specific documentation, see e.g. the `src/examples.md`.
      - [ ] Add the description, labels and screenshots in `src/examples.md` and `src/img`.
      - [ ] In `examples.md`, list the example under the appropriate categories, add new categories if necessary.
      - [ ] Add a short description of the example in the "Extensive Examples" section of `features.md`.
- [ ] New miniapps:
   - [ ] All sample runs at the top of the miniapp source file work.
   - [ ] Update top-level `makefile` and `makefile` in corresponding miniapp directory.
   - [ ] Add the miniapp binary and any files generated by it to the top-level `.gitignore` file.
   - [ ] Update CMake build system:
      - [ ] Update the `CMakeLists.txt` file in the `miniapps` directory, if the new miniapp is in a new directory.
      - [ ] Add/update the `CMakeLists.txt` file in the new miniapp directory.
      - [ ] Consider adding a new test for the new miniapp.
   - [ ] List the new miniapp in `doc/CodeDocumentation.dox`
   - [ ] If new miniapps directory (e.g.`miniapps/nurbs`), add it to `MINIAPP_SUBDIRS` in the `makefile`.
   - [ ] If new miniapps directory (e.g.`miniapps/nurbs`), list it in `doc/CodeDocumentation.conf.in`
   - [ ] Companion pull request for documentation in [mfem/web](https://github.com/mfem/web) repo:
     - [ ] Update or add miniapp-specific documentation, see e.g. the `src/meshing.md` and `src/electromagnetics.md` files.
     - [ ] Add the description, labels and screenshots in `src/examples.md` and `src/img`.
     - [ ] The miniapps go at the end of the page, and are usually listed only under a specific "Application (PDE)" category.
     - [ ] Add a short description of the miniapp in the "Extensive Examples" section of `features.md`.
- [ ] New capability:
   - [ ] All new public, protected, and private classes, methods, data members, and functions have full Doxygen-style documentation in source comments. Documentation should include descriptions of member data, function arguments and return values, template parameters, and prerequisites for calling new functions.
   - [ ] Pointer arguments and return values must specify whether ownership is being transferred or lent with the call.
   - [ ] Any new functions should include descriptions of their intended use e.g. for internal use only, user-facing, etc., along with references to example code whenever possible/appropriate.
   - [ ] Consider adding new sample runs in existing examples to highlight the new capability.
   - [ ] Consider saving cool simulation pictures with the new capability in the Confluence gallery (LLNL only) or submitting them, via pull request, to the gallery section of the `mfem/web` repo.
   - [ ] If this is a major new feature, consider mentioning it in the short summary inside `README` *(rare)*.
   - [ ] List major new classes in `doc/CodeDocumentation.dox` *(rare)*.
- [ ] Update this checklist, if the new pull request affects it.
- [ ] Run `make unittest` to make sure all unit tests pass.
- [ ] Run the tests in `tests/scripts`.
- [ ] (LLNL only) After merging:
   - [ ] Update internal tests to include the new features.
</details>
