### PR TITLE
Consistent mass in HO->LOR transfer forward operator [lor-consistent-mass-dev]

### DIFF
--- a/fem/transfer.cpp
+++ b/fem/transfer.cpp
@@ -1179,19 +1179,14 @@ L2ProjectionGridTransfer::L2ProjectionH1Space::L2ProjectionH1Space(
       return;
    }
 
-   std::unique_ptr<SparseMatrix> R_local_sp, M_LH_local_sp;
-   std::tie(R_local_sp, M_LH_local_sp) =
-      ComputeSparseRAndM_LH(!use_consistent_mass);
-
-   M_LH_local_sp->Finalize(0);
-   if (R_local_sp) { R_local_sp->Finalize(0); }
+   std::tie(R, M_LH) = ComputeSparseRAndM_LH(!use_consistent_mass);
 
    HypreParMatrix M_LH_local = HypreParMatrix(pfes_ho.GetComm(),
                                               pfes_lor_scalar->GlobalVSize(),
                                               pfes_ho_scalar->GlobalVSize(),
                                               pfes_lor_scalar->GetDofOffsets(),
                                               pfes_ho_scalar->GetDofOffsets(),
-                                              M_LH_local_sp.get());
+                                              static_cast<SparseMatrix*>(M_LH.get()));
    HypreParMatrix *M_LH_mat = RAP(pfes_lor_scalar->Dof_TrueDof_Matrix(),
                                   &M_LH_local, pfes_ho_scalar->Dof_TrueDof_Matrix());
 
@@ -1227,7 +1222,7 @@ L2ProjectionGridTransfer::L2ProjectionH1Space::L2ProjectionH1Space(
                                            pfes_ho_scalar->GlobalVSize(),
                                            pfes_lor_scalar->GetDofOffsets(),
                                            pfes_ho_scalar->GetDofOffsets(),
-                                           R_local_sp.get());
+                                           static_cast<SparseMatrix*>(R.get()));
 
    HypreParMatrix *R_mat = RAP(pfes_lor_scalar->Dof_TrueDof_Matrix(),
                                &R_local, pfes_ho_scalar->Dof_TrueDof_Matrix());

--- a/fem/transfer.cpp
+++ b/fem/transfer.cpp
@@ -1629,10 +1629,10 @@ std::unique_ptr<SparseMatrix>>
    // If the local mesh is empty, skip all computations
    if (nel_ho == 0)
    {
-      return std::make_pair(
-                std::unique_ptr<SparseMatrix>(new SparseMatrix),
-                std::unique_ptr<SparseMatrix>(new SparseMatrix)
-             );
+      std::unique_ptr<SparseMatrix> R_empty;
+      if (build_R) { R_empty.reset(new SparseMatrix); }
+      std::unique_ptr<SparseMatrix> M_LH_empty(new SparseMatrix);
+      return std::make_pair(std::move(R_empty), std::move(M_LH_empty));
    }
 
    const CoarseFineTransformations& cf_tr = mesh_lor->GetRefinementTransforms();

--- a/fem/transfer.cpp
+++ b/fem/transfer.cpp
@@ -1030,43 +1030,31 @@ void L2ProjectionGridTransfer::L2ProjectionL2Space::EAProlongateTranspose(
    BatchedLinAlg::MultTranspose(P_dt, x, y);
 }
 
-namespace
+L2ProjectionGridTransfer::L2ProjectionH1Space::H1ConsistentMassOperator::
+H1ConsistentMassOperator(const Operator &M_LH_, const Solver &M_L_solver_)
+   : Operator(M_LH_.Height(), M_LH_.Width()),
+     M_LH(M_LH_),
+     M_L_solver(M_L_solver_)
 {
+   MFEM_VERIFY(M_LH.Height() == M_L_solver.Height() &&
+               M_LH.Height() == M_L_solver.Width(),
+               "incompatible consistent mass operator dimensions");
+}
 
-/// Applies the H1 transfer R = M_L^{-1} M_LH and its transpose, where M_L is
-/// the consistent low-order mass matrix.
-class H1ConsistentMassOperator : public Operator
+void L2ProjectionGridTransfer::L2ProjectionH1Space::H1ConsistentMassOperator::
+Mult(const Vector &x, Vector &y) const
 {
-private:
-   const Operator &M_LH;
-   const Solver &M_L_solver;
+   Vector tmp(M_LH.Height());
+   M_LH.Mult(x, tmp);
+   M_L_solver.Mult(tmp, y);
+}
 
-public:
-   H1ConsistentMassOperator(const Operator &M_LH_, const Solver &M_L_solver_)
-      : Operator(M_LH_.Height(), M_LH_.Width()),
-        M_LH(M_LH_),
-        M_L_solver(M_L_solver_)
-   {
-      MFEM_VERIFY(M_LH.Height() == M_L_solver.Height() &&
-                  M_LH.Height() == M_L_solver.Width(),
-                  "incompatible consistent mass operator dimensions");
-   }
-
-   void Mult(const Vector &x, Vector &y) const override
-   {
-      Vector tmp(M_LH.Height());
-      M_LH.Mult(x, tmp);
-      M_L_solver.Mult(tmp, y);
-   }
-
-   void MultTranspose(const Vector &x, Vector &y) const override
-   {
-      Vector tmp(M_LH.Height());
-      M_L_solver.Mult(x, tmp);
-      M_LH.MultTranspose(tmp, y);
-   }
-};
-
+void L2ProjectionGridTransfer::L2ProjectionH1Space::H1ConsistentMassOperator::
+MultTranspose(const Vector &x, Vector &y) const
+{
+   Vector tmp(M_LH.Height());
+   M_L_solver.Mult(x, tmp);
+   M_LH.MultTranspose(tmp, y);
 }
 
 L2ProjectionGridTransfer::L2ProjectionH1Space::L2ProjectionH1Space(

--- a/fem/transfer.cpp
+++ b/fem/transfer.cpp
@@ -1630,8 +1630,8 @@ void L2ProjectionGridTransfer::L2ProjectionH1Space::SetAbsTol(real_t p_atol_)
 std::pair<
 std::unique_ptr<SparseMatrix>,
 std::unique_ptr<SparseMatrix>>
-L2ProjectionGridTransfer::L2ProjectionH1Space::ComputeSparseRAndM_LH(
-   bool build_R)
+                            L2ProjectionGridTransfer::L2ProjectionH1Space::ComputeSparseRAndM_LH(
+                               bool build_R)
 {
    std::pair<std::unique_ptr<SparseMatrix>,
        std::unique_ptr<SparseMatrix>> r_and_mlh;

--- a/fem/transfer.cpp
+++ b/fem/transfer.cpp
@@ -1113,7 +1113,7 @@ L2ProjectionGridTransfer::L2ProjectionH1Space::L2ProjectionH1Space(
       M_lor.AddDomainIntegrator(new MassIntegrator);
       M_lor.Assemble();
       M_lor.Finalize();
-      SparseMatrix *M_L_mat = new SparseMatrix(M_lor.SpMat());
+      SparseMatrix *M_L_mat = M_lor.LoseMat();
 
       ML_precon.reset(new DSmoother(*M_L_mat));
       ML_pcg.SetPrintLevel(0);
@@ -1149,8 +1149,8 @@ L2ProjectionGridTransfer::L2ProjectionH1Space::L2ProjectionH1Space(
    : L2Projection(pfes_ho, pfes_lor, d_mt_),
      use_ea(use_ea_),
      use_consistent_mass(use_consistent_mass_),
-     pcg(pfes_ho.GetComm()),
-     ML_pcg(pfes_ho.GetComm())
+     ML_pcg(pfes_ho.GetComm()),
+     pcg(pfes_ho.GetComm())
 {
    MFEM_VERIFY(!(use_ea && use_consistent_mass),
                "consistent mass is not supported with element assembly");

--- a/fem/transfer.cpp
+++ b/fem/transfer.cpp
@@ -1033,6 +1033,8 @@ void L2ProjectionGridTransfer::L2ProjectionL2Space::EAProlongateTranspose(
 namespace
 {
 
+/// Applies the H1 transfer R = M_L^{-1} M_LH and its transpose, where M_L is
+/// the consistent low-order mass matrix.
 class H1ConsistentMassOperator : public Operator
 {
 private:
@@ -1198,12 +1200,6 @@ L2ProjectionGridTransfer::L2ProjectionH1Space::L2ProjectionH1Space(
       M_lor.Finalize(0);
       HypreParMatrix *M_L_mat = M_lor.ParallelAssemble();
 
-      ML_pcg.SetPrintLevel(0);
-      ML_pcg.SetMaxIter(1000);
-      ML_pcg.SetRelTol(1e-13);
-      ML_pcg.SetAbsTol(1e-13);
-      ML_pcg.SetOperator(*M_L_mat);
-
       M_L.reset(M_L_mat);
       M_LH.reset(M_LH_mat);
       HyprePCG *ML_hypre_pcg = new HyprePCG(*M_L_mat);
@@ -1211,6 +1207,8 @@ L2ProjectionGridTransfer::L2ProjectionH1Space::L2ProjectionH1Space(
       ML_hypre_pcg->SetMaxIter(1000);
       ML_hypre_pcg->SetTol(1e-13);
       ML_hypre_pcg->SetAbsTol(1e-13);
+      // Start each solve from zero so repeated Operator::Mult() calls do not
+      // depend on the output vector contents supplied by the caller.
       ML_hypre_pcg->SetZeroInitialIterate();
       ML_solver.reset(ML_hypre_pcg);
       R.reset(new H1ConsistentMassOperator(*M_LH, *ML_solver));
@@ -2139,9 +2137,7 @@ const Operator &L2ProjectionGridTransfer::ForwardOperator()
 
 const Operator &L2ProjectionGridTransfer::BackwardOperator()
 {
-   MFEM_VERIFY(!(use_consistent_mass && !force_l2_space &&
-                 dom_fes.FEColl()->GetContType() ==
-                 FiniteElementCollection::CONTINUOUS),
+   MFEM_VERIFY(!UsesH1ConsistentMass(),
                "BackwardOperator is not supported with consistent mass");
    if (!B)
    {
@@ -2158,13 +2154,19 @@ void L2ProjectionGridTransfer::UseConsistentMass(bool use_consistent_mass_)
    use_consistent_mass = use_consistent_mass_;
 }
 
+bool L2ProjectionGridTransfer::UsesH1ConsistentMass() const
+{
+   return use_consistent_mass && !force_l2_space &&
+          dom_fes.FEColl()->GetContType() == FiniteElementCollection::CONTINUOUS;
+}
+
 void L2ProjectionGridTransfer::BuildF()
 {
-   MFEM_VERIFY(!(use_ea && use_consistent_mass),
-               "consistent mass is not supported with element assembly");
    if (!force_l2_space &&
        dom_fes.FEColl()->GetContType() == FiniteElementCollection::CONTINUOUS)
    {
+      MFEM_VERIFY(!(use_ea && use_consistent_mass),
+                  "consistent mass is not supported with element assembly");
       if (!Parallel())
       {
          F = new L2ProjectionH1Space(dom_fes, ran_fes,
@@ -2191,11 +2193,7 @@ void L2ProjectionGridTransfer::BuildF()
 
 bool L2ProjectionGridTransfer::SupportsBackwardsOperator() const
 {
-   if (use_consistent_mass && !force_l2_space &&
-       dom_fes.FEColl()->GetContType() == FiniteElementCollection::CONTINUOUS)
-   {
-      return false;
-   }
+   if (UsesH1ConsistentMass()) { return false; }
    return ran_fes.GetTrueVSize() >= dom_fes.GetTrueVSize();
 }
 

--- a/fem/transfer.cpp
+++ b/fem/transfer.cpp
@@ -1030,12 +1030,52 @@ void L2ProjectionGridTransfer::L2ProjectionL2Space::EAProlongateTranspose(
    BatchedLinAlg::MultTranspose(P_dt, x, y);
 }
 
+namespace
+{
+
+class H1ConsistentMassOperator : public Operator
+{
+private:
+   const Operator &M_LH;
+   const Solver &M_L_solver;
+
+public:
+   H1ConsistentMassOperator(const Operator &M_LH_, const Solver &M_L_solver_)
+      : Operator(M_LH_.Height(), M_LH_.Width()),
+        M_LH(M_LH_),
+        M_L_solver(M_L_solver_)
+   {
+      MFEM_VERIFY(M_LH.Height() == M_L_solver.Height() &&
+                  M_LH.Height() == M_L_solver.Width(),
+                  "incompatible consistent mass operator dimensions");
+   }
+
+   void Mult(const Vector &x, Vector &y) const override
+   {
+      Vector tmp(M_LH.Height());
+      M_LH.Mult(x, tmp);
+      M_L_solver.Mult(tmp, y);
+   }
+
+   void MultTranspose(const Vector &x, Vector &y) const override
+   {
+      Vector tmp(M_LH.Height());
+      M_L_solver.Mult(x, tmp);
+      M_LH.MultTranspose(tmp, y);
+   }
+};
+
+}
+
 L2ProjectionGridTransfer::L2ProjectionH1Space::L2ProjectionH1Space(
    const FiniteElementSpace& fes_ho_, const FiniteElementSpace& fes_lor_,
-   const bool use_ea_, MemoryType d_mt_)
+   const bool use_ea_, const bool use_consistent_mass_, MemoryType d_mt_)
    : L2Projection(fes_ho_, fes_lor_, d_mt_),
-     use_ea(use_ea_)
+     use_ea(use_ea_),
+     use_consistent_mass(use_consistent_mass_)
 {
+   MFEM_VERIFY(!(use_ea && use_consistent_mass),
+               "consistent mass is not supported with element assembly");
 
    // need scalar to keep dimensions matching (operators are built to apply
    // individually on each vdim)
@@ -1053,7 +1093,7 @@ L2ProjectionGridTransfer::L2ProjectionH1Space::L2ProjectionH1Space(
 
    std::unique_ptr<SparseMatrix> R_mat, M_LH_mat;
 
-   std::tie(R_mat, M_LH_mat) = ComputeSparseRAndM_LH();
+   std::tie(R_mat, M_LH_mat) = ComputeSparseRAndM_LH(!use_consistent_mass);
 
    const SparseMatrix *P_ho = fes_ho_scalar->GetConformingProlongation();
    const SparseMatrix *P_lor = fes_lor_scalar->GetConformingProlongation();
@@ -1062,40 +1102,68 @@ L2ProjectionGridTransfer::L2ProjectionH1Space::L2ProjectionH1Space(
    {
       if (P_ho && P_lor)
       {
-         R_mat.reset(RAP(*P_lor, *R_mat, *P_ho));
+         if (R_mat) { R_mat.reset(RAP(*P_lor, *R_mat, *P_ho)); }
          M_LH_mat.reset(RAP(*P_lor, *M_LH_mat, *P_ho));
       }
       else if (P_ho)
       {
-         R_mat.reset(mfem::Mult(*R_mat, *P_ho));
+         if (R_mat) { R_mat.reset(mfem::Mult(*R_mat, *P_ho)); }
          M_LH_mat.reset(mfem::Mult(*M_LH_mat, *P_ho));
       }
       else // P_lor != nullptr
       {
-         R_mat.reset(mfem::Mult(*P_lor, *R_mat));
+         if (R_mat) { R_mat.reset(mfem::Mult(*P_lor, *R_mat)); }
          M_LH_mat.reset(mfem::Mult(*P_lor, *M_LH_mat));
       }
    }
 
-   SparseMatrix *RTxM_LH_mat = TransposeMult(*R_mat, *M_LH_mat);
-   precon.reset(new DSmoother(*RTxM_LH_mat));
+   if (use_consistent_mass)
+   {
+      BilinearForm M_lor(fes_lor_scalar.get());
+      M_lor.AddDomainIntegrator(new MassIntegrator);
+      M_lor.Assemble();
+      M_lor.Finalize(0);
+      SparseMatrix *M_L_mat = new SparseMatrix(M_lor.SpMat());
 
-   // Set ownership
-   RTxM_LH.reset(RTxM_LH_mat);
-   R = std::move(R_mat);
-   M_LH = std::move(M_LH_mat);
+      ML_precon.reset(new DSmoother(*M_L_mat));
+      ML_pcg.SetPrintLevel(0);
+      ML_pcg.SetMaxIter(1000);
+      ML_pcg.SetRelTol(1e-13);
+      ML_pcg.SetAbsTol(1e-13);
+      ML_pcg.SetPreconditioner(*ML_precon);
+      ML_pcg.SetOperator(*M_L_mat);
 
-   SetupPCG();
+      M_L.reset(M_L_mat);
+      M_LH = std::move(M_LH_mat);
+      R.reset(new H1ConsistentMassOperator(*M_LH, ML_pcg));
+   }
+   else
+   {
+      SparseMatrix *RTxM_LH_mat = TransposeMult(*R_mat, *M_LH_mat);
+      precon.reset(new DSmoother(*RTxM_LH_mat));
+
+      // Set ownership
+      RTxM_LH.reset(RTxM_LH_mat);
+      R = std::move(R_mat);
+      M_LH = std::move(M_LH_mat);
+
+      SetupPCG();
+   }
 }
 
 #ifdef MFEM_USE_MPI
 
 L2ProjectionGridTransfer::L2ProjectionH1Space::L2ProjectionH1Space(
    const ParFiniteElementSpace& pfes_ho, const ParFiniteElementSpace& pfes_lor,
-   const bool use_ea_, MemoryType d_mt_)
+   const bool use_ea_, const bool use_consistent_mass_, MemoryType d_mt_)
    : L2Projection(pfes_ho, pfes_lor, d_mt_),
-     use_ea(use_ea_), pcg(pfes_ho.GetComm())
+     use_ea(use_ea_),
+     use_consistent_mass(use_consistent_mass_),
+     pcg(pfes_ho.GetComm()),
+     ML_pcg(pfes_ho.GetComm())
 {
+   MFEM_VERIFY(!(use_ea && use_consistent_mass),
+               "consistent mass is not supported with element assembly");
 
    // need scalar to keep dimensions matching (operators are built to apply
    // individually on each vdim)
@@ -1111,26 +1179,58 @@ L2ProjectionGridTransfer::L2ProjectionH1Space::L2ProjectionH1Space(
       return;
    }
 
-   std::tie(R, M_LH) = ComputeSparseRAndM_LH();
+   std::unique_ptr<SparseMatrix> R_local_sp, M_LH_local_sp;
+   std::tie(R_local_sp, M_LH_local_sp) =
+      ComputeSparseRAndM_LH(!use_consistent_mass);
 
+   M_LH_local_sp->Finalize(0);
+   if (R_local_sp) { R_local_sp->Finalize(0); }
+
+   HypreParMatrix M_LH_local = HypreParMatrix(pfes_ho.GetComm(),
+                                              pfes_lor_scalar->GlobalVSize(),
+                                              pfes_ho_scalar->GlobalVSize(),
+                                              pfes_lor_scalar->GetDofOffsets(),
+                                              pfes_ho_scalar->GetDofOffsets(),
+                                              M_LH_local_sp.get());
+   HypreParMatrix *M_LH_mat = RAP(pfes_lor_scalar->Dof_TrueDof_Matrix(),
+                                  &M_LH_local, pfes_ho_scalar->Dof_TrueDof_Matrix());
+
+   if (use_consistent_mass)
+   {
+      ParBilinearForm M_lor(pfes_lor_scalar.get());
+      M_lor.AddDomainIntegrator(new MassIntegrator);
+      M_lor.Assemble();
+      M_lor.Finalize(0);
+      HypreParMatrix *M_L_mat = M_lor.ParallelAssemble();
+
+      ML_pcg.SetPrintLevel(0);
+      ML_pcg.SetMaxIter(1000);
+      ML_pcg.SetRelTol(1e-13);
+      ML_pcg.SetAbsTol(1e-13);
+      ML_pcg.SetOperator(*M_L_mat);
+
+      M_L.reset(M_L_mat);
+      M_LH.reset(M_LH_mat);
+      HyprePCG *ML_hypre_pcg = new HyprePCG(*M_L_mat);
+      ML_hypre_pcg->SetPrintLevel(0);
+      ML_hypre_pcg->SetMaxIter(1000);
+      ML_hypre_pcg->SetTol(1e-13);
+      ML_hypre_pcg->SetAbsTol(1e-13);
+      ML_hypre_pcg->SetZeroInitialIterate();
+      ML_solver.reset(ML_hypre_pcg);
+      R.reset(new H1ConsistentMassOperator(*M_LH, *ML_solver));
+      return;
+   }
 
    HypreParMatrix R_local = HypreParMatrix(pfes_ho.GetComm(),
                                            pfes_lor_scalar->GlobalVSize(),
                                            pfes_ho_scalar->GlobalVSize(),
                                            pfes_lor_scalar->GetDofOffsets(),
                                            pfes_ho_scalar->GetDofOffsets(),
-                                           static_cast<SparseMatrix*>(R.get()));
-   HypreParMatrix M_LH_local = HypreParMatrix(pfes_ho.GetComm(),
-                                              pfes_lor_scalar->GlobalVSize(),
-                                              pfes_ho_scalar->GlobalVSize(),
-                                              pfes_lor_scalar->GetDofOffsets(),
-                                              pfes_ho_scalar->GetDofOffsets(),
-                                              static_cast<SparseMatrix*>(M_LH.get()));
+                                           R_local_sp.get());
 
    HypreParMatrix *R_mat = RAP(pfes_lor_scalar->Dof_TrueDof_Matrix(),
                                &R_local, pfes_ho_scalar->Dof_TrueDof_Matrix());
-   HypreParMatrix *M_LH_mat = RAP(pfes_lor_scalar->Dof_TrueDof_Matrix(),
-                                  &M_LH_local, pfes_ho_scalar->Dof_TrueDof_Matrix());
 
    std::unique_ptr<HypreParMatrix> R_T(R_mat->Transpose());
    HypreParMatrix *RTxM_LH_mat = ParMult(R_T.get(), M_LH_mat, true);
@@ -1438,6 +1538,8 @@ void L2ProjectionGridTransfer::L2ProjectionH1Space::MultTranspose(
 void L2ProjectionGridTransfer::L2ProjectionH1Space::Prolongate(
    const Vector& x, Vector& y) const
 {
+   MFEM_VERIFY(!use_consistent_mass,
+               "BackwardOperator is not supported with consistent mass");
 
    Vector X(fes_lor.GetTrueVSize());
    Vector X_dim(M_LH->Height());
@@ -1469,6 +1571,9 @@ void L2ProjectionGridTransfer::L2ProjectionH1Space::Prolongate(
 void L2ProjectionGridTransfer::L2ProjectionH1Space::ProlongateTranspose(
    const Vector& x, Vector& y) const
 {
+   MFEM_VERIFY(!use_consistent_mass,
+               "BackwardOperator is not supported with consistent mass");
+
    Vector X(fes_ho.GetTrueVSize());
    Vector X_dim(pcg.Width());
    Vector Xbar(pcg.Height());
@@ -1499,17 +1604,34 @@ void L2ProjectionGridTransfer::L2ProjectionH1Space::ProlongateTranspose(
 void L2ProjectionGridTransfer::L2ProjectionH1Space::SetRelTol(real_t p_rtol_)
 {
    pcg.SetRelTol(p_rtol_);
+   ML_pcg.SetRelTol(p_rtol_);
+#ifdef MFEM_USE_MPI
+   if (ML_solver)
+   {
+      HyprePCG *hypre_pcg = dynamic_cast<HyprePCG*>(ML_solver.get());
+      if (hypre_pcg) { hypre_pcg->SetTol(p_rtol_); }
+   }
+#endif
 }
 
 void L2ProjectionGridTransfer::L2ProjectionH1Space::SetAbsTol(real_t p_atol_)
 {
    pcg.SetAbsTol(p_atol_);
+   ML_pcg.SetAbsTol(p_atol_);
+#ifdef MFEM_USE_MPI
+   if (ML_solver)
+   {
+      HyprePCG *hypre_pcg = dynamic_cast<HyprePCG*>(ML_solver.get());
+      if (hypre_pcg) { hypre_pcg->SetAbsTol(p_atol_); }
+   }
+#endif
 }
 
 std::pair<
 std::unique_ptr<SparseMatrix>,
 std::unique_ptr<SparseMatrix>>
-                            L2ProjectionGridTransfer::L2ProjectionH1Space::ComputeSparseRAndM_LH()
+L2ProjectionGridTransfer::L2ProjectionH1Space::ComputeSparseRAndM_LH(
+   bool build_R)
 {
    std::pair<std::unique_ptr<SparseMatrix>,
        std::unique_ptr<SparseMatrix>> r_and_mlh;
@@ -1542,69 +1664,76 @@ std::unique_ptr<SparseMatrix>>
 
    BuildHo2Lor(nel_ho, nel_lor, cf_tr);
 
-   // ML_inv contains the inverse lumped (row sum) mass matrix. Note that the
-   // method will also work with a full (consistent) mass matrix, though this is
-   // not implemented here. L refers to the low-order refined mesh
    Vector ML_inv(ndof_lor);
-   ML_inv = 0.0;
-
-   // Compute ML_inv
-   for (int iho = 0; iho < nel_ho; ++iho)
+   if (build_R)
    {
-      Array<int> lor_els;
-      ho2lor.GetRow(iho, lor_els);
-      int nref = ho2lor.RowSize(iho);
+      // ML_inv contains the inverse lumped (row sum) mass matrix. L refers to
+      // the low-order refined mesh.
+      ML_inv = 0.0;
 
-      Geometry::Type geom = mesh_ho->GetElementBaseGeometry(iho);
-      const FiniteElement& fe_lor = *fes_lor.GetFE(lor_els[0]);
-      int nedof_lor = fe_lor.GetDof();
-
-      // Instead of using a MassIntegrator, manually loop over integration
-      // points so we can row sum and store the diagonal as a Vector.
-      Vector ML_el(nedof_lor);
-      Vector shape_lor(nedof_lor);
-      Array<int> dofs_lor(nedof_lor);
-
-      for (int iref = 0; iref < nref; ++iref)
+      // Compute ML_inv
+      for (int iho = 0; iho < nel_ho; ++iho)
       {
-         int ilor = lor_els[iref];
-         ElementTransformation* el_tr = fes_lor.GetElementTransformation(ilor);
+         Array<int> lor_els;
+         ho2lor.GetRow(iho, lor_els);
+         int nref = ho2lor.RowSize(iho);
 
-         int order = 2 * fe_lor.GetOrder() + el_tr->OrderW();
-         const IntegrationRule* ir = &IntRules.Get(geom, order);
-         ML_el = 0.0;
-         for (int i = 0; i < ir->GetNPoints(); ++i)
+         Geometry::Type geom = mesh_ho->GetElementBaseGeometry(iho);
+         const FiniteElement& fe_lor = *fes_lor.GetFE(lor_els[0]);
+         int nedof_lor = fe_lor.GetDof();
+
+         // Instead of using a MassIntegrator, manually loop over integration
+         // points so we can row sum and store the diagonal as a Vector.
+         Vector ML_el(nedof_lor);
+         Vector shape_lor(nedof_lor);
+         Array<int> dofs_lor(nedof_lor);
+
+         for (int iref = 0; iref < nref; ++iref)
          {
-            const IntegrationPoint& ip_lor = ir->IntPoint(i);
-            fe_lor.CalcShape(ip_lor, shape_lor);
-            el_tr->SetIntPoint(&ip_lor);
-            ML_el += (shape_lor *= (el_tr->Weight() * ip_lor.weight));
+            int ilor = lor_els[iref];
+            ElementTransformation* el_tr = fes_lor.GetElementTransformation(ilor);
+
+            int order = 2 * fe_lor.GetOrder() + el_tr->OrderW();
+            const IntegrationRule* ir = &IntRules.Get(geom, order);
+            ML_el = 0.0;
+            for (int i = 0; i < ir->GetNPoints(); ++i)
+            {
+               const IntegrationPoint& ip_lor = ir->IntPoint(i);
+               fe_lor.CalcShape(ip_lor, shape_lor);
+               el_tr->SetIntPoint(&ip_lor);
+               ML_el += (shape_lor *= (el_tr->Weight() * ip_lor.weight));
+            }
+            fes_lor.GetElementDofs(ilor, dofs_lor);
+            ML_inv.AddElementVector(dofs_lor, ML_el);
          }
-         fes_lor.GetElementDofs(ilor, dofs_lor);
-         ML_inv.AddElementVector(dofs_lor, ML_el);
       }
+      // DOF by DOF inverse of non-zero entries
+      LumpedMassInverse(ML_inv);
    }
-   // DOF by DOF inverse of non-zero entries
-   LumpedMassInverse(ML_inv);
 
    // Compute sparsity pattern for R = M_L^(-1) M_LH and allocate
-   r_and_mlh.first = AllocR();
+   std::unique_ptr<SparseMatrix> pattern = AllocR();
+   if (build_R)
+   {
+      r_and_mlh.first = std::move(pattern);
+   }
    // Allocate M_LH (same sparsity pattern as R)
    // L refers to the low-order refined mesh (DOFs correspond to rows)
    // H refers to the higher-order mesh (DOFs correspond to columns)
-   Memory<int> I(r_and_mlh.first->Height() + 1);
-   for (int icol = 0; icol < r_and_mlh.first->Height() + 1; ++icol)
+   SparseMatrix &pattern_mat = build_R ? *r_and_mlh.first : *pattern;
+   Memory<int> I(pattern_mat.Height() + 1);
+   for (int icol = 0; icol < pattern_mat.Height() + 1; ++icol)
    {
-      I[icol] = r_and_mlh.first->GetI()[icol];
+      I[icol] = pattern_mat.GetI()[icol];
    }
-   Memory<int> J(r_and_mlh.first->NumNonZeroElems());
-   for (int jcol = 0; jcol < r_and_mlh.first->NumNonZeroElems(); ++jcol)
+   Memory<int> J(pattern_mat.NumNonZeroElems());
+   for (int jcol = 0; jcol < pattern_mat.NumNonZeroElems(); ++jcol)
    {
-      J[jcol] = r_and_mlh.first->GetJ()[jcol];
+      J[jcol] = pattern_mat.GetJ()[jcol];
    }
    r_and_mlh.second = std::unique_ptr<SparseMatrix>(
-                         new SparseMatrix(I, J, NULL, r_and_mlh.first->Height(),
-                                          r_and_mlh.first->Width(), true, true, true));
+                         new SparseMatrix(I, J, NULL, pattern_mat.Height(),
+                                          pattern_mat.Width(), true, true, true));
 
    IntegrationPointTransformation ip_tr;
    IsoparametricTransformation& emb_tr = ip_tr.Transf;
@@ -1647,15 +1776,21 @@ std::unique_ptr<SparseMatrix>>
          Array<int> dofs_lor(nedof_lor);
          fes_lor.GetElementDofs(ilor, dofs_lor);
          Vector R_row;
-         for (int i = 0; i < nedof_lor; ++i)
+         if (build_R)
          {
-            M_LH_el.GetRow(i, R_row);
-            R_el.SetRow(i, R_row.Set(ML_inv[dofs_lor[i]], R_row));
+            for (int i = 0; i < nedof_lor; ++i)
+            {
+               M_LH_el.GetRow(i, R_row);
+               R_el.SetRow(i, R_row.Set(ML_inv[dofs_lor[i]], R_row));
+            }
          }
          Array<int> dofs_ho(nedof_ho);
          fes_ho.GetElementDofs(iho, dofs_ho);
          r_and_mlh.second->AddSubMatrix(dofs_lor, dofs_ho, M_LH_el);
-         r_and_mlh.first->AddSubMatrix(dofs_lor, dofs_ho, R_el);
+         if (build_R)
+         {
+            r_and_mlh.first->AddSubMatrix(dofs_lor, dofs_ho, R_el);
+         }
 
       }
    }
@@ -2009,6 +2144,10 @@ const Operator &L2ProjectionGridTransfer::ForwardOperator()
 
 const Operator &L2ProjectionGridTransfer::BackwardOperator()
 {
+   MFEM_VERIFY(!(use_consistent_mass && !force_l2_space &&
+                 dom_fes.FEColl()->GetContType() ==
+                 FiniteElementCollection::CONTINUOUS),
+               "BackwardOperator is not supported with consistent mass");
    if (!B)
    {
       if (!F) { BuildF(); }
@@ -2017,15 +2156,24 @@ const Operator &L2ProjectionGridTransfer::BackwardOperator()
    return *B;
 }
 
+void L2ProjectionGridTransfer::UseConsistentMass(bool use_consistent_mass_)
+{
+   MFEM_VERIFY(!F && !B,
+               "UseConsistentMass must be called before constructing operators");
+   use_consistent_mass = use_consistent_mass_;
+}
+
 void L2ProjectionGridTransfer::BuildF()
 {
+   MFEM_VERIFY(!(use_ea && use_consistent_mass),
+               "consistent mass is not supported with element assembly");
    if (!force_l2_space &&
        dom_fes.FEColl()->GetContType() == FiniteElementCollection::CONTINUOUS)
    {
       if (!Parallel())
       {
          F = new L2ProjectionH1Space(dom_fes, ran_fes,
-                                     use_ea, d_mt);
+                                     use_ea, use_consistent_mass, d_mt);
       }
       else
       {
@@ -2035,7 +2183,7 @@ void L2ProjectionGridTransfer::BuildF()
          const mfem::ParFiniteElementSpace& ran_pfes =
             static_cast<mfem::ParFiniteElementSpace&>(ran_fes);
          F = new L2ProjectionH1Space(dom_pfes, ran_pfes,
-                                     use_ea, d_mt);
+                                     use_ea, use_consistent_mass, d_mt);
 #endif
       }
    }
@@ -2048,6 +2196,11 @@ void L2ProjectionGridTransfer::BuildF()
 
 bool L2ProjectionGridTransfer::SupportsBackwardsOperator() const
 {
+   if (use_consistent_mass && !force_l2_space &&
+       dom_fes.FEColl()->GetContType() == FiniteElementCollection::CONTINUOUS)
+   {
+      return false;
+   }
    return ran_fes.GetTrueVSize() >= dom_fes.GetTrueVSize();
 }
 

--- a/fem/transfer.cpp
+++ b/fem/transfer.cpp
@@ -1124,7 +1124,7 @@ L2ProjectionGridTransfer::L2ProjectionH1Space::L2ProjectionH1Space(
       BilinearForm M_lor(fes_lor_scalar.get());
       M_lor.AddDomainIntegrator(new MassIntegrator);
       M_lor.Assemble();
-      M_lor.Finalize(0);
+      M_lor.Finalize();
       SparseMatrix *M_L_mat = new SparseMatrix(M_lor.SpMat());
 
       ML_precon.reset(new DSmoother(*M_L_mat));
@@ -1197,19 +1197,22 @@ L2ProjectionGridTransfer::L2ProjectionH1Space::L2ProjectionH1Space(
       ParBilinearForm M_lor(pfes_lor_scalar.get());
       M_lor.AddDomainIntegrator(new MassIntegrator);
       M_lor.Assemble();
-      M_lor.Finalize(0);
+      M_lor.Finalize();
       HypreParMatrix *M_L_mat = M_lor.ParallelAssemble();
 
       M_L.reset(M_L_mat);
       M_LH.reset(M_LH_mat);
+      HypreDiagScale *ML_hypre_precon = new HypreDiagScale(*M_L_mat);
       HyprePCG *ML_hypre_pcg = new HyprePCG(*M_L_mat);
       ML_hypre_pcg->SetPrintLevel(0);
       ML_hypre_pcg->SetMaxIter(1000);
       ML_hypre_pcg->SetTol(1e-13);
       ML_hypre_pcg->SetAbsTol(1e-13);
+      ML_hypre_pcg->SetPreconditioner(*ML_hypre_precon);
       // Start each solve from zero so repeated Operator::Mult() calls do not
       // depend on the output vector contents supplied by the caller.
       ML_hypre_pcg->SetZeroInitialIterate();
+      ML_precon.reset(ML_hypre_precon);
       ML_solver.reset(ML_hypre_pcg);
       R.reset(new H1ConsistentMassOperator(*M_LH, *ML_solver));
       return;

--- a/fem/transfer.cpp
+++ b/fem/transfer.cpp
@@ -1122,6 +1122,9 @@ L2ProjectionGridTransfer::L2ProjectionH1Space::L2ProjectionH1Space(
       ML_pcg.SetAbsTol(1e-13);
       ML_pcg.SetPreconditioner(*ML_precon);
       ML_pcg.SetOperator(*M_L_mat);
+      // Start each solve from zero so repeated Operator::Mult() calls do not
+      // depend on the output vector contents supplied by the caller.
+      ML_pcg.iterative_mode = false;
 
       M_L.reset(M_L_mat);
       M_LH = std::move(M_LH_mat);

--- a/fem/transfer.hpp
+++ b/fem/transfer.hpp
@@ -480,30 +480,30 @@ public:
       /// elements and refined LOR elements.
       std::unique_ptr<SparseMatrix> AllocR();
 
-      CGSolver pcg;
-      /// Serial PCG solver for applying the inverse consistent low-order mass
-      /// matrix in H1 Mult() and MultTranspose().
-      CGSolver ML_pcg;
-      std::unique_ptr<Solver> precon;
+      /// Consistent low-order mass matrix used when use_consistent_mass is true.
+      std::unique_ptr<Operator> M_L;
+      // Used to compute P = (RT*M_LH)^(-1) M_LH^T
+      std::unique_ptr<Operator> M_LH;
+      // Lumped M_L inverse operator built via EA. Wrapped with restriction maps
+      // to multiply with scalar TDof LOR vectors.
+      std::unique_ptr<Operator> ML_inv_vea;
       /// Preconditioner for applying the inverse consistent low-order mass
       /// matrix.
       std::unique_ptr<Solver> ML_precon;
+      /// Serial PCG solver for applying the inverse consistent low-order mass
+      /// matrix in H1 Mult() and MultTranspose().
+      CGSolver ML_pcg;
       /// Solver used by H1ConsistentMassOperator to apply M_L^{-1}.
       std::unique_ptr<Solver> ML_solver;
-      /// Consistent low-order mass matrix used when use_consistent_mass is true.
-      std::unique_ptr<Operator> M_L;
       // The restriction operator is represented as an Operator R. The
       // prolongation operator is a dense matrix computed as the inverse of (R^T
       // M_L R), and hence, is not stored.
       // If element assembly is enabled
       std::unique_ptr<Operator> R;
-      // Used to compute P = (RT*M_LH)^(-1) M_LH^T
-      std::unique_ptr<Operator> M_LH;
       // Inverted operator in P = (RT*M_LH)^(-1) M_LH^T. Used to compute P via PCG.
       std::unique_ptr<Operator> RTxM_LH;
-      // Lumped M_L inverse operator built via EA. Wrapped with restriction maps
-      // to multiply with scalar TDof LOR vectors.
-      std::unique_ptr<Operator> ML_inv_vea;
+      std::unique_ptr<Solver> precon;
+      CGSolver pcg;
       // LDof Mixed mass operator built via EA. Wrapped with restriction maps to send
       // scalar LDof HO vectors to LDof LOR vectors.
       Operator *M_LH_local_op;

--- a/fem/transfer.hpp
+++ b/fem/transfer.hpp
@@ -169,8 +169,10 @@ public:
     is the forward transfer matrix, and M_f is the mass matrix on the coarse
     element. For L2 spaces, M_f is the mass matrix on the union of all fine
     elements comprising the coarse element. For H1 spaces, M_f is a diagonal
-    (lumped) mass matrix computed through row-summation. Note that the backward
-    transfer operator, B, is a left inverse of the forward transfer operator, F,
+    (lumped) mass matrix computed through row-summation, unless
+    UseConsistentMass() is enabled for the forward H1 operator. Note that the
+    backward transfer operator, B, is a left inverse of the forward transfer
+    operator, F,
     i.e. B F = I. Both F and B are defined in physical space and, generally for
     L2 spaces, vary between different mesh elements.
 
@@ -352,16 +354,19 @@ public:
    class L2ProjectionH1Space : public L2Projection
    {
       const bool use_ea;
+      const bool use_consistent_mass;
 
    public:
       L2ProjectionH1Space(const FiniteElementSpace &fes_ho_,
                           const FiniteElementSpace &fes_lor_,
                           const bool use_ea_,
+                          const bool use_consistent_mass_,
                           MemoryType d_mt_ = Device::GetHostMemoryType());
 #ifdef MFEM_USE_MPI
       L2ProjectionH1Space(const ParFiniteElementSpace &pfes_ho_,
                           const ParFiniteElementSpace &pfes_lor_,
                           const bool use_ea_,
+                          const bool use_consistent_mass_,
                           MemoryType d_mt_ = Device::GetHostMemoryType());
 #endif
       /// Same as above but assembles action of R through 4 parts:
@@ -423,7 +428,8 @@ public:
       /// @brief Computes on-rank R and M_LH matrices. If true, computes mixed mass and/or
       /// inverse lumped mass matrix error when compared to device implementation.
       std::pair<std::unique_ptr<SparseMatrix>,
-          std::unique_ptr<SparseMatrix>> ComputeSparseRAndM_LH();
+          std::unique_ptr<SparseMatrix>> ComputeSparseRAndM_LH(
+             bool build_R = true);
 
       /// @brief Recovers vector of tdofs given a vector of dofs and a finite
       /// element space
@@ -454,7 +460,11 @@ public:
       std::unique_ptr<SparseMatrix> AllocR();
 
       CGSolver pcg;
+      CGSolver ML_pcg;
       std::unique_ptr<Solver> precon;
+      std::unique_ptr<Solver> ML_precon;
+      std::unique_ptr<Solver> ML_solver;
+      std::unique_ptr<Operator> M_L;
       // The restriction operator is represented as an Operator R. The
       // prolongation operator is a dense matrix computed as the inverse of (R^T
       // M_L R), and hence, is not stored.
@@ -478,7 +488,6 @@ public:
       Vector M_LH_ea;
       // Element Assembled lumped M_L inverse built via EA. Stores diagonal as a Ldof vector.
       Vector ML_inv_ea;
-
 #ifdef MFEM_USE_MPI
       std::unique_ptr<ParFiniteElementSpace> pfes_ho_scalar;
       std::unique_ptr<ParFiniteElementSpace> pfes_lor_scalar;
@@ -511,6 +520,7 @@ public:
    L2Projection   *F; ///< Forward, coarse-to-fine, operator
    L2Prolongation *B; ///< Backward, fine-to-coarse, operator
    bool force_l2_space;
+   bool use_consistent_mass;
 
 public:
    L2ProjectionGridTransfer(FiniteElementSpace &coarse_fes_,
@@ -518,9 +528,14 @@ public:
                             bool force_l2_space_ = false,
                             MemoryType d_mt_ = Device::GetHostMemoryType()) // move to method
       : GridTransfer(coarse_fes_, fine_fes_),
-        F(NULL), B(NULL), force_l2_space(force_l2_space_)
+        F(NULL), B(NULL), force_l2_space(force_l2_space_),
+        use_consistent_mass(false)
    { }
    virtual ~L2ProjectionGridTransfer();
+
+   /** Use the consistent low-order mass matrix in H1 non-EA Mult() and
+       MultTranspose(). This option does not support BackwardOperator(). */
+   void UseConsistentMass(bool use_consistent_mass_ = true);
 
    const Operator &ForwardOperator() override;
 

--- a/fem/transfer.hpp
+++ b/fem/transfer.hpp
@@ -424,6 +424,23 @@ public:
       void SetAbsTol(real_t p_atol_) override;
 
    protected:
+      /// Applies the H1 transfer R = M_L^{-1} M_LH and its transpose, where
+      /// M_L is the consistent low-order mass matrix.
+      class H1ConsistentMassOperator : public Operator
+      {
+      private:
+         const Operator &M_LH;
+         const Solver &M_L_solver;
+
+      public:
+         H1ConsistentMassOperator(const Operator &M_LH_,
+                                  const Solver &M_L_solver_);
+
+         void Mult(const Vector &x, Vector &y) const override;
+
+         void MultTranspose(const Vector &x, Vector &y) const override;
+      };
+
       /// Sets up the PCG solver (sets parameters, operator, and preconditioner)
       void SetupPCG();
 

--- a/fem/transfer.hpp
+++ b/fem/transfer.hpp
@@ -170,11 +170,11 @@ public:
     element. For L2 spaces, M_f is the mass matrix on the union of all fine
     elements comprising the coarse element. For H1 spaces, M_f is a diagonal
     (lumped) mass matrix computed through row-summation, unless
-    UseConsistentMass() is enabled for the forward H1 operator. Note that the
-    backward transfer operator, B, is a left inverse of the forward transfer
-    operator, F,
-    i.e. B F = I. Both F and B are defined in physical space and, generally for
-    L2 spaces, vary between different mesh elements.
+    UseConsistentMass() is enabled for the forward H1 operator. When the
+    backward transfer operator, B, is supported, it is a left inverse of the
+    forward transfer operator, F, i.e. B F = I. Both F and B are defined in
+    physical space and, generally for L2 spaces, vary between different mesh
+    elements.
 
     This class supports H1 and L2 finite element spaces. Fine meshes are a
     uniform refinement of the coarse mesh, usually created through
@@ -354,6 +354,8 @@ public:
    class L2ProjectionH1Space : public L2Projection
    {
       const bool use_ea;
+      /// Use the consistent low-order mass matrix in non-EA H1 Mult() and
+      /// MultTranspose().
       const bool use_consistent_mass;
 
    public:
@@ -425,8 +427,10 @@ public:
       /// Sets up the PCG solver (sets parameters, operator, and preconditioner)
       void SetupPCG();
 
-      /// @brief Computes on-rank R and M_LH matrices. If true, computes mixed mass and/or
-      /// inverse lumped mass matrix error when compared to device implementation.
+      /** @brief Computes on-rank R and M_LH matrices.
+
+          If build_R is true, the returned pair contains both R and M_LH. If
+          build_R is false, the first pointer is null and only M_LH is built. */
       std::pair<std::unique_ptr<SparseMatrix>,
           std::unique_ptr<SparseMatrix>> ComputeSparseRAndM_LH(
              bool build_R = true);
@@ -460,10 +464,15 @@ public:
       std::unique_ptr<SparseMatrix> AllocR();
 
       CGSolver pcg;
+      /// Serial PCG solver for applying the inverse consistent low-order mass
+      /// matrix in H1 Mult() and MultTranspose().
       CGSolver ML_pcg;
       std::unique_ptr<Solver> precon;
+      /// Serial preconditioner for ML_pcg.
       std::unique_ptr<Solver> ML_precon;
+      /// Solver used by H1ConsistentMassOperator to apply M_L^{-1}.
       std::unique_ptr<Solver> ML_solver;
+      /// Consistent low-order mass matrix used when use_consistent_mass is true.
       std::unique_ptr<Operator> M_L;
       // The restriction operator is represented as an Operator R. The
       // prolongation operator is a dense matrix computed as the inverse of (R^T
@@ -520,6 +529,8 @@ public:
    L2Projection   *F; ///< Forward, coarse-to-fine, operator
    L2Prolongation *B; ///< Backward, fine-to-coarse, operator
    bool force_l2_space;
+   /// Use the consistent low-order mass matrix for non-EA H1 Mult() and
+   /// MultTranspose().
    bool use_consistent_mass;
 
 public:
@@ -533,8 +544,12 @@ public:
    { }
    virtual ~L2ProjectionGridTransfer();
 
-   /** Use the consistent low-order mass matrix in H1 non-EA Mult() and
-       MultTranspose(). This option does not support BackwardOperator(). */
+   /** @brief Use the consistent low-order mass matrix in H1 non-EA Mult() and
+       MultTranspose().
+
+       This option must be set before constructing the transfer operators. It
+       only affects H1 transfer, is not supported with element assembly, and
+       disables BackwardOperator(). */
    void UseConsistentMass(bool use_consistent_mass_ = true);
 
    const Operator &ForwardOperator() override;
@@ -543,6 +558,7 @@ public:
 
    bool SupportsBackwardsOperator() const override;
 private:
+   bool UsesH1ConsistentMass() const;
    void BuildF();
 };
 

--- a/fem/transfer.hpp
+++ b/fem/transfer.hpp
@@ -468,7 +468,8 @@ public:
       /// matrix in H1 Mult() and MultTranspose().
       CGSolver ML_pcg;
       std::unique_ptr<Solver> precon;
-      /// Serial preconditioner for ML_pcg.
+      /// Preconditioner for applying the inverse consistent low-order mass
+      /// matrix.
       std::unique_ptr<Solver> ML_precon;
       /// Solver used by H1ConsistentMassOperator to apply M_L^{-1}.
       std::unique_ptr<Solver> ML_solver;

--- a/tests/unit/fem/test_transfer.cpp
+++ b/tests/unit/fem/test_transfer.cpp
@@ -16,557 +16,619 @@
 
 using namespace mfem;
 
-int RandomPRefinement(FiniteElementSpace &fes) {
-  Mesh *mesh = fes.GetMesh();
-  int maxorder = 0;
-  for (int i = 0; i < mesh->GetNE(); i++) {
-    const int order = fes.GetElementOrder(i);
-    maxorder = std::max(maxorder, order);
-    if ((double)rand() / RAND_MAX < 0.5) {
-      fes.SetElementOrder(i, order + 1);
-      maxorder = std::max(maxorder, order + 1);
-    }
-  }
-  fes.Update(false);
-  return maxorder;
+int RandomPRefinement(FiniteElementSpace &fes)
+{
+   Mesh *mesh = fes.GetMesh();
+   int maxorder = 0;
+   for (int i = 0; i < mesh->GetNE(); i++)
+   {
+      const int order = fes.GetElementOrder(i);
+      maxorder = std::max(maxorder, order);
+      if ((double)rand() / RAND_MAX < 0.5)
+      {
+         fes.SetElementOrder(i, order + 1);
+         maxorder = std::max(maxorder, order + 1);
+      }
+   }
+   fes.Update(false);
+   return maxorder;
 }
 
 int dimension;
 int coeff_order;
-double coeff(const Vector &X) {
-  double x = X[0];
-  double y = X[1];
-  double z = 0.;
-  if (dimension == 2) {
-    if (coeff_order == 1) {
-      return 1.1 * x + 2.0 * y;
-    } else {
-      return (1. - x) * x * (1. - y) * y;
-    }
-  } else {
-    z = X[2];
-    if (coeff_order == 1) {
-      return 1.1 * x + 2.0 * y + 3.0 * z;
-    } else {
-      return (1. - x) * x * (1. - y) * y * (1. - z) * z;
-    }
-  }
+double coeff(const Vector &X)
+{
+   double x = X[0];
+   double y = X[1];
+   double z = 0.;
+   if (dimension == 2)
+   {
+      if (coeff_order == 1)
+      {
+         return 1.1 * x + 2.0 * y;
+      }
+      else
+      {
+         return (1. - x) * x * (1. - y) * y;
+      }
+   }
+   else
+   {
+      z = X[2];
+      if (coeff_order == 1)
+      {
+         return 1.1 * x + 2.0 * y + 3.0 * z;
+      }
+      else
+      {
+         return (1. - x) * x * (1. - y) * y * (1. - z) * z;
+      }
+   }
 }
 
-void vectorcoeff(const Vector &x, Vector &y) {
-  y(0) = coeff(x);
-  y(1) = -coeff(x);
-  if (dimension == 3) {
-    y(2) = 2.0 * coeff(x);
-  }
+void vectorcoeff(const Vector &x, Vector &y)
+{
+   y(0) = coeff(x);
+   y(1) = -coeff(x);
+   if (dimension == 3)
+   {
+      y(2) = 2.0 * coeff(x);
+   }
 }
 
 enum class VecSpace { H1, VectorH1nodes, VectorH1vdim, ND, RT };
 
-std::string VecSpaceName(VecSpace vectorspace) {
-  switch (vectorspace) {
-    case VecSpace::H1:
-      return "H1";
-    case VecSpace::VectorH1nodes:
-      return "Vector H1 by nodes";
-    case VecSpace::VectorH1vdim:
-      return "Vector H1 by vdim";
-    case VecSpace::ND:
-      return "Nedelec";
-    case VecSpace::RT:
-      return "Raviart-Thomas";
-  }
-  return "";
+std::string VecSpaceName(VecSpace vectorspace)
+{
+   switch (vectorspace)
+   {
+      case VecSpace::H1:
+         return "H1";
+      case VecSpace::VectorH1nodes:
+         return "Vector H1 by nodes";
+      case VecSpace::VectorH1vdim:
+         return "Vector H1 by vdim";
+      case VecSpace::ND:
+         return "Nedelec";
+      case VecSpace::RT:
+         return "Raviart-Thomas";
+   }
+   return "";
 }
 
-TEST_CASE("Transfer", "[Transfer]") {
-  auto vectorspace =
+TEST_CASE("Transfer", "[Transfer]")
+{
+   auto vectorspace =
       GENERATE(VecSpace::H1, VecSpace::VectorH1nodes, VecSpace::VectorH1vdim,
                VecSpace::ND, VecSpace::RT);
-  auto geometric = GENERATE(true, false);
-  auto simplex = GENERATE(true, false);
-  dimension = GENERATE(2, 3);
+   auto geometric = GENERATE(true, false);
+   auto simplex = GENERATE(true, false);
+   dimension = GENERATE(2, 3);
 
-  int order = 2;
-  int ne = 2;
+   int order = 2;
+   int ne = 2;
 
-  int fineOrder = geometric ? order : 2 * order;
+   int fineOrder = geometric ? order : 2 * order;
 
-  // Log test case information
-  int total_ne = static_cast<int>(std::pow(ne, dimension));
-  CAPTURE(VecSpaceName(vectorspace), dimension, simplex, total_ne, order,
-          fineOrder, geometric);
+   // Log test case information
+   int total_ne = static_cast<int>(std::pow(ne, dimension));
+   CAPTURE(VecSpaceName(vectorspace), dimension, simplex, total_ne, order,
+           fineOrder, geometric);
 
-  Mesh mesh;
-  if (dimension == 2) {
-    Element::Type type = simplex ? Element::TRIANGLE : Element::QUADRILATERAL;
-    mesh = Mesh::MakeCartesian2D(ne, ne, type, 1, 1.0, 1.0);
-  } else {
-    Element::Type type = simplex ? Element::TETRAHEDRON : Element::HEXAHEDRON;
-    mesh = Mesh::MakeCartesian3D(ne, ne, ne, type, 1.0, 1.0, 1.0);
-  }
-  FiniteElementCollection *c_fec = nullptr;
-  FiniteElementCollection *f_fec = nullptr;
+   Mesh mesh;
+   if (dimension == 2)
+   {
+      Element::Type type = simplex ? Element::TRIANGLE : Element::QUADRILATERAL;
+      mesh = Mesh::MakeCartesian2D(ne, ne, type, 1, 1.0, 1.0);
+   }
+   else
+   {
+      Element::Type type = simplex ? Element::TETRAHEDRON : Element::HEXAHEDRON;
+      mesh = Mesh::MakeCartesian3D(ne, ne, ne, type, 1.0, 1.0, 1.0);
+   }
+   FiniteElementCollection *c_fec = nullptr;
+   FiniteElementCollection *f_fec = nullptr;
 
-  switch (vectorspace) {
-    case VecSpace::H1:
-    case VecSpace::VectorH1nodes:
-    case VecSpace::VectorH1vdim:
-      c_fec = new H1_FECollection(order, dimension);
-      f_fec = geometric ? c_fec : new H1_FECollection(fineOrder, dimension);
-      break;
-    case VecSpace::ND:
-      c_fec = new ND_FECollection(order + 1, dimension);
-      f_fec = geometric ? c_fec : new ND_FECollection(fineOrder, dimension);
-      break;
-    case VecSpace::RT:
-      c_fec = new RT_FECollection(order, dimension);
-      f_fec = geometric ? c_fec : new RT_FECollection(fineOrder, dimension);
-      break;
-  }
+   switch (vectorspace)
+   {
+      case VecSpace::H1:
+      case VecSpace::VectorH1nodes:
+      case VecSpace::VectorH1vdim:
+         c_fec = new H1_FECollection(order, dimension);
+         f_fec = geometric ? c_fec : new H1_FECollection(fineOrder, dimension);
+         break;
+      case VecSpace::ND:
+         c_fec = new ND_FECollection(order + 1, dimension);
+         f_fec = geometric ? c_fec : new ND_FECollection(fineOrder, dimension);
+         break;
+      case VecSpace::RT:
+         c_fec = new RT_FECollection(order, dimension);
+         f_fec = geometric ? c_fec : new RT_FECollection(fineOrder, dimension);
+         break;
+   }
 
-  Mesh fineMesh(mesh);
-  if (geometric) {
-    fineMesh.UniformRefinement();
-  }
+   Mesh fineMesh(mesh);
+   if (geometric)
+   {
+      fineMesh.UniformRefinement();
+   }
 
-  const int vdim = (vectorspace == VecSpace::VectorH1nodes ||
-                    vectorspace == VecSpace::VectorH1vdim)
-                       ? dimension
-                       : 1;
-  Ordering::Type ordering = (vectorspace == VecSpace::VectorH1vdim)
-                                ? Ordering::byVDIM
-                                : Ordering::byNODES;
-  FiniteElementSpace *c_fespace =
+   const int vdim = (vectorspace == VecSpace::VectorH1nodes ||
+                     vectorspace == VecSpace::VectorH1vdim)
+                    ? dimension
+                    : 1;
+   Ordering::Type ordering = (vectorspace == VecSpace::VectorH1vdim)
+                             ? Ordering::byVDIM
+                             : Ordering::byNODES;
+   FiniteElementSpace *c_fespace =
       new FiniteElementSpace(&mesh, c_fec, vdim, ordering);
-  FiniteElementSpace *f_fespace =
+   FiniteElementSpace *f_fespace =
       new FiniteElementSpace(&fineMesh, f_fec, vdim, ordering);
 
-  Operator *referenceOperator = nullptr;
+   Operator *referenceOperator = nullptr;
 
-  if (!geometric) {
-    referenceOperator = new PRefinementTransferOperator(*c_fespace, *f_fespace);
-  } else {
-    OperatorPtr P(Operator::ANY_TYPE);
-    f_fespace->GetTransferOperator(*c_fespace, P);
-    P.SetOperatorOwner(false);
-    referenceOperator = P.Ptr();
-  }
+   if (!geometric)
+   {
+      referenceOperator = new PRefinementTransferOperator(*c_fespace, *f_fespace);
+   }
+   else
+   {
+      OperatorPtr P(Operator::ANY_TYPE);
+      f_fespace->GetTransferOperator(*c_fespace, P);
+      P.SetOperatorOwner(false);
+      referenceOperator = P.Ptr();
+   }
 
-  TransferOperator testTransferOperator(*c_fespace, *f_fespace);
-  GridFunction X(c_fespace);
-  GridFunction X_cmp(c_fespace);
-  GridFunction Y_exact(f_fespace);
-  GridFunction Y_std(f_fespace);
-  GridFunction Y_test(f_fespace);
-  coeff_order = 1;
-  if (vectorspace == VecSpace::H1) {
-    FunctionCoefficient funcCoeff(&coeff);
-    X.ProjectCoefficient(funcCoeff);
-    Y_exact.ProjectCoefficient(funcCoeff);
-  } else {
-    VectorFunctionCoefficient funcCoeff(dimension, &vectorcoeff);
-    X.ProjectCoefficient(funcCoeff);
-    Y_exact.ProjectCoefficient(funcCoeff);
-  }
+   TransferOperator testTransferOperator(*c_fespace, *f_fespace);
+   GridFunction X(c_fespace);
+   GridFunction X_cmp(c_fespace);
+   GridFunction Y_exact(f_fespace);
+   GridFunction Y_std(f_fespace);
+   GridFunction Y_test(f_fespace);
+   coeff_order = 1;
+   if (vectorspace == VecSpace::H1)
+   {
+      FunctionCoefficient funcCoeff(&coeff);
+      X.ProjectCoefficient(funcCoeff);
+      Y_exact.ProjectCoefficient(funcCoeff);
+   }
+   else
+   {
+      VectorFunctionCoefficient funcCoeff(dimension, &vectorcoeff);
+      X.ProjectCoefficient(funcCoeff);
+      Y_exact.ProjectCoefficient(funcCoeff);
+   }
 
-  Y_std = 0.0;
-  Y_test = 0.0;
+   Y_std = 0.0;
+   Y_test = 0.0;
 
-  referenceOperator->Mult(X, Y_std);
+   referenceOperator->Mult(X, Y_std);
 
-  Y_std -= Y_exact;
-  REQUIRE(Y_std.Norml2() < 1e-12 * Y_exact.Norml2());
+   Y_std -= Y_exact;
+   REQUIRE(Y_std.Norml2() < 1e-12 * Y_exact.Norml2());
 
-  testTransferOperator.Mult(X, Y_test);
+   testTransferOperator.Mult(X, Y_test);
 
-  Y_test -= Y_exact;
-  REQUIRE(Y_test.Norml2() < 1e-12 * Y_exact.Norml2());
+   Y_test -= Y_exact;
+   REQUIRE(Y_test.Norml2() < 1e-12 * Y_exact.Norml2());
 
-  referenceOperator->MultTranspose(Y_exact, X);
-  testTransferOperator.MultTranspose(Y_exact, X_cmp);
+   referenceOperator->MultTranspose(Y_exact, X);
+   testTransferOperator.MultTranspose(Y_exact, X_cmp);
 
-  X -= X_cmp;
-  REQUIRE(X.Norml2() < 1e-12 * X_cmp.Norml2());
+   X -= X_cmp;
+   REQUIRE(X.Norml2() < 1e-12 * X_cmp.Norml2());
 
-  delete referenceOperator;
-  delete f_fespace;
-  delete c_fespace;
-  if (geometric == 0) {
-    delete f_fec;
-  }
-  delete c_fec;
+   delete referenceOperator;
+   delete f_fespace;
+   delete c_fespace;
+   if (geometric == 0)
+   {
+      delete f_fec;
+   }
+   delete c_fec;
 }
 
-TEST_CASE("Variable Order Transfer", "[Transfer][VariableOrder]") {
-  auto vectorspace =
+TEST_CASE("Variable Order Transfer", "[Transfer][VariableOrder]")
+{
+   auto vectorspace =
       GENERATE(VecSpace::H1, VecSpace::VectorH1nodes, VecSpace::VectorH1vdim,
                VecSpace::ND, VecSpace::RT);
-  dimension = GENERATE(2, 3);
+   dimension = GENERATE(2, 3);
 
-  int ne = 2;
-  int order = 2;
+   int ne = 2;
+   int order = 2;
 
-  // Log test case information
-  int total_ne = static_cast<int>(pow(ne, dimension));
-  CAPTURE(VecSpaceName(vectorspace), dimension, total_ne, order);
+   // Log test case information
+   int total_ne = static_cast<int>(pow(ne, dimension));
+   CAPTURE(VecSpaceName(vectorspace), dimension, total_ne, order);
 
-  Mesh mesh;
-  if (dimension == 2) {
-    Element::Type type = Element::QUADRILATERAL;
-    mesh = Mesh::MakeCartesian2D(ne, ne, type, 1, 1.0, 1.0);
-  } else {
-    Element::Type type = Element::HEXAHEDRON;
-    mesh = Mesh::MakeCartesian3D(ne, ne, ne, type, 1.0, 1.0, 1.0);
-  }
-  FiniteElementCollection *c_fec = nullptr;
-  FiniteElementCollection *f_fec = nullptr;
-  switch (vectorspace) {
-    case VecSpace::H1:
-    case VecSpace::VectorH1nodes:
-    case VecSpace::VectorH1vdim:
-      c_fec = new H1_FECollection(order, dimension);
-      f_fec = new H1_FECollection(order, dimension);
-      break;
-    case VecSpace::ND:
-      c_fec = new ND_FECollection(order + 1, dimension);
-      f_fec = new ND_FECollection(order + 1, dimension);
-      break;
-    case VecSpace::RT:
-      c_fec = new RT_FECollection(order, dimension);
-      f_fec = new RT_FECollection(order, dimension);
-      break;
-  }
+   Mesh mesh;
+   if (dimension == 2)
+   {
+      Element::Type type = Element::QUADRILATERAL;
+      mesh = Mesh::MakeCartesian2D(ne, ne, type, 1, 1.0, 1.0);
+   }
+   else
+   {
+      Element::Type type = Element::HEXAHEDRON;
+      mesh = Mesh::MakeCartesian3D(ne, ne, ne, type, 1.0, 1.0, 1.0);
+   }
+   FiniteElementCollection *c_fec = nullptr;
+   FiniteElementCollection *f_fec = nullptr;
+   switch (vectorspace)
+   {
+      case VecSpace::H1:
+      case VecSpace::VectorH1nodes:
+      case VecSpace::VectorH1vdim:
+         c_fec = new H1_FECollection(order, dimension);
+         f_fec = new H1_FECollection(order, dimension);
+         break;
+      case VecSpace::ND:
+         c_fec = new ND_FECollection(order + 1, dimension);
+         f_fec = new ND_FECollection(order + 1, dimension);
+         break;
+      case VecSpace::RT:
+         c_fec = new RT_FECollection(order, dimension);
+         f_fec = new RT_FECollection(order, dimension);
+         break;
+   }
 
-  mesh.EnsureNCMesh();
-  mesh.RandomRefinement(0.5);
+   mesh.EnsureNCMesh();
+   mesh.RandomRefinement(0.5);
 
-  const int vdim = (vectorspace == VecSpace::VectorH1nodes ||
-                    vectorspace == VecSpace::VectorH1vdim)
-                       ? dimension
-                       : 1;
-  Ordering::Type ordering = (vectorspace == VecSpace::VectorH1vdim)
-                                ? Ordering::byVDIM
-                                : Ordering::byNODES;
+   const int vdim = (vectorspace == VecSpace::VectorH1nodes ||
+                     vectorspace == VecSpace::VectorH1vdim)
+                    ? dimension
+                    : 1;
+   Ordering::Type ordering = (vectorspace == VecSpace::VectorH1vdim)
+                             ? Ordering::byVDIM
+                             : Ordering::byNODES;
 
-  FiniteElementSpace *c_fespace =
+   FiniteElementSpace *c_fespace =
       new FiniteElementSpace(&mesh, c_fec, vdim, ordering);
-  FiniteElementSpace *f_fespace =
+   FiniteElementSpace *f_fespace =
       new FiniteElementSpace(&mesh, f_fec, vdim, ordering);
 
-  RandomPRefinement(*f_fespace);
+   RandomPRefinement(*f_fespace);
 
-  Operator *referenceOperator = nullptr;
+   Operator *referenceOperator = nullptr;
 
-  referenceOperator = new PRefinementTransferOperator(*c_fespace, *f_fespace);
+   referenceOperator = new PRefinementTransferOperator(*c_fespace, *f_fespace);
 
-  TransferOperator testTransferOperator(*c_fespace, *f_fespace);
-  GridFunction X(c_fespace);
-  X = 0.;
-  GridFunction X_cmp(c_fespace);
-  X_cmp = 0.;
-  GridFunction Y_exact(f_fespace);
-  Y_exact = 0.;
-  GridFunction Y_std(f_fespace);
-  Y_std = 0.;
-  GridFunction Y_test(f_fespace);
-  Y_test = 0.;
-  coeff_order = std::min(2, order);
-  if (vectorspace == VecSpace::H1) {
-    FunctionCoefficient funcCoeff(&coeff);
-    X.ProjectCoefficient(funcCoeff);
-    Y_exact.ProjectCoefficient(funcCoeff);
-  } else {
-    VectorFunctionCoefficient funcCoeff(dimension, &vectorcoeff);
-    X.ProjectCoefficient(funcCoeff);
-    Y_exact.ProjectCoefficient(funcCoeff);
-  }
+   TransferOperator testTransferOperator(*c_fespace, *f_fespace);
+   GridFunction X(c_fespace);
+   X = 0.;
+   GridFunction X_cmp(c_fespace);
+   X_cmp = 0.;
+   GridFunction Y_exact(f_fespace);
+   Y_exact = 0.;
+   GridFunction Y_std(f_fespace);
+   Y_std = 0.;
+   GridFunction Y_test(f_fespace);
+   Y_test = 0.;
+   coeff_order = std::min(2, order);
+   if (vectorspace == VecSpace::H1)
+   {
+      FunctionCoefficient funcCoeff(&coeff);
+      X.ProjectCoefficient(funcCoeff);
+      Y_exact.ProjectCoefficient(funcCoeff);
+   }
+   else
+   {
+      VectorFunctionCoefficient funcCoeff(dimension, &vectorcoeff);
+      X.ProjectCoefficient(funcCoeff);
+      Y_exact.ProjectCoefficient(funcCoeff);
+   }
 
-  Y_std = 0.0;
-  Y_test = 0.0;
+   Y_std = 0.0;
+   Y_test = 0.0;
 
-  referenceOperator->Mult(X, Y_std);
-  Y_std -= Y_exact;
-  REQUIRE(Y_std.Norml2() < 1e-12 * Y_exact.Norml2());
+   referenceOperator->Mult(X, Y_std);
+   Y_std -= Y_exact;
+   REQUIRE(Y_std.Norml2() < 1e-12 * Y_exact.Norml2());
 
-  testTransferOperator.Mult(X, Y_test);
+   testTransferOperator.Mult(X, Y_test);
 
-  Y_test -= Y_exact;
-  REQUIRE(Y_test.Norml2() < 1e-12 * Y_exact.Norml2());
+   Y_test -= Y_exact;
+   REQUIRE(Y_test.Norml2() < 1e-12 * Y_exact.Norml2());
 
-  referenceOperator->MultTranspose(Y_exact, X);
-  testTransferOperator.MultTranspose(Y_exact, X_cmp);
+   referenceOperator->MultTranspose(Y_exact, X);
+   testTransferOperator.MultTranspose(Y_exact, X_cmp);
 
-  X -= X_cmp;
-  REQUIRE(X.Norml2() < 1e-12 * X_cmp.Norml2());
+   X -= X_cmp;
+   REQUIRE(X.Norml2() < 1e-12 * X_cmp.Norml2());
 
-  delete referenceOperator;
-  delete f_fespace;
-  delete c_fespace;
-  delete f_fec;
-  delete c_fec;
+   delete referenceOperator;
+   delete f_fespace;
+   delete c_fespace;
+   delete f_fec;
+   delete c_fec;
 }
 
-TEST_CASE("Variable Order True Transfer", "[Transfer][VariableOrder]") {
-  auto vectorspace =
+TEST_CASE("Variable Order True Transfer", "[Transfer][VariableOrder]")
+{
+   auto vectorspace =
       GENERATE(VecSpace::H1, VecSpace::VectorH1nodes, VecSpace::VectorH1vdim);
-  dimension = GENERATE(2, 3);
+   dimension = GENERATE(2, 3);
 
-  int ne = 2;
-  int order = 2;
+   int ne = 2;
+   int order = 2;
 
-  // Log test case information
-  CAPTURE(VecSpaceName(vectorspace), dimension, order);
+   // Log test case information
+   CAPTURE(VecSpaceName(vectorspace), dimension, order);
 
-  Mesh mesh;
-  if (dimension == 2) {
-    Element::Type type = Element::QUADRILATERAL;
-    mesh = Mesh::MakeCartesian2D(ne, ne, type, 1, 1.0, 1.0);
-  } else {
-    Element::Type type = Element::HEXAHEDRON;
-    mesh = Mesh::MakeCartesian3D(ne, ne, ne, type, 1.0, 1.0, 1.0);
-  }
-  FiniteElementCollection *c_fec = nullptr;
-  FiniteElementCollection *f_fec = nullptr;
-  c_fec = new H1_FECollection(order, dimension);
-  f_fec = new H1_FECollection(order, dimension);
-  mesh.EnsureNCMesh();
-  mesh.RandomRefinement(0.5);
-  const int vdim = (vectorspace == VecSpace::VectorH1nodes ||
-                    vectorspace == VecSpace::VectorH1vdim)
-                       ? dimension
-                       : 1;
-  Ordering::Type ordering = (vectorspace == VecSpace::VectorH1vdim)
-                                ? Ordering::byVDIM
-                                : Ordering::byNODES;
+   Mesh mesh;
+   if (dimension == 2)
+   {
+      Element::Type type = Element::QUADRILATERAL;
+      mesh = Mesh::MakeCartesian2D(ne, ne, type, 1, 1.0, 1.0);
+   }
+   else
+   {
+      Element::Type type = Element::HEXAHEDRON;
+      mesh = Mesh::MakeCartesian3D(ne, ne, ne, type, 1.0, 1.0, 1.0);
+   }
+   FiniteElementCollection *c_fec = nullptr;
+   FiniteElementCollection *f_fec = nullptr;
+   c_fec = new H1_FECollection(order, dimension);
+   f_fec = new H1_FECollection(order, dimension);
+   mesh.EnsureNCMesh();
+   mesh.RandomRefinement(0.5);
+   const int vdim = (vectorspace == VecSpace::VectorH1nodes ||
+                     vectorspace == VecSpace::VectorH1vdim)
+                    ? dimension
+                    : 1;
+   Ordering::Type ordering = (vectorspace == VecSpace::VectorH1vdim)
+                             ? Ordering::byVDIM
+                             : Ordering::byNODES;
 
-  FiniteElementSpace *c_fespace =
+   FiniteElementSpace *c_fespace =
       new FiniteElementSpace(&mesh, c_fec, vdim, ordering);
-  FiniteElementSpace *f_fespace =
+   FiniteElementSpace *f_fespace =
       new FiniteElementSpace(&mesh, f_fec, vdim, ordering);
 
-  RandomPRefinement(*f_fespace);
+   RandomPRefinement(*f_fespace);
 
-  const SparseMatrix *Rc = c_fespace->GetRestrictionMatrix();
-  TrueTransferOperator T(*c_fespace, *f_fespace);
-  GridFunction xc(c_fespace);
-  Vector Xc(c_fespace->GetTrueVSize());
-  Vector Diff(c_fespace->GetTrueVSize());
-  Vector Yc(c_fespace->GetTrueVSize());
-  Vector Xf(f_fespace->GetTrueVSize());
-  Vector Yf(f_fespace->GetTrueVSize());
+   const SparseMatrix *Rc = c_fespace->GetRestrictionMatrix();
+   TrueTransferOperator T(*c_fespace, *f_fespace);
+   GridFunction xc(c_fespace);
+   Vector Xc(c_fespace->GetTrueVSize());
+   Vector Diff(c_fespace->GetTrueVSize());
+   Vector Yc(c_fespace->GetTrueVSize());
+   Vector Xf(f_fespace->GetTrueVSize());
+   Vector Yf(f_fespace->GetTrueVSize());
 
-  coeff_order = 2;
+   coeff_order = 2;
 
-  BilinearFormIntegrator *massc = nullptr;
-  BilinearFormIntegrator *massf = nullptr;
+   BilinearFormIntegrator *massc = nullptr;
+   BilinearFormIntegrator *massf = nullptr;
 
-  if (vectorspace == VecSpace::H1) {
-    FunctionCoefficient funcCoeff(&coeff);
-    xc.ProjectCoefficient(funcCoeff);
-    massc = new MassIntegrator;
-    massf = new MassIntegrator;
-  } else {
-    VectorFunctionCoefficient funcCoeff(dimension, &vectorcoeff);
-    xc.ProjectCoefficient(funcCoeff);
-    massc = new VectorMassIntegrator;
-    massf = new VectorMassIntegrator;
-  }
-  if (Rc) {
-    Rc->Mult(xc, Xc);
-  } else {
-    Xc.MakeRef(xc, 0);
-  }
-  T.Mult(Xc, Xf);
+   if (vectorspace == VecSpace::H1)
+   {
+      FunctionCoefficient funcCoeff(&coeff);
+      xc.ProjectCoefficient(funcCoeff);
+      massc = new MassIntegrator;
+      massf = new MassIntegrator;
+   }
+   else
+   {
+      VectorFunctionCoefficient funcCoeff(dimension, &vectorcoeff);
+      xc.ProjectCoefficient(funcCoeff);
+      massc = new VectorMassIntegrator;
+      massf = new VectorMassIntegrator;
+   }
+   if (Rc)
+   {
+      Rc->Mult(xc, Xc);
+   }
+   else
+   {
+      Xc.MakeRef(xc, 0);
+   }
+   T.Mult(Xc, Xf);
 
-  BilinearForm mc(c_fespace);
-  mc.AddDomainIntegrator(massc);
-  mc.Assemble();
-  SparseMatrix Mc;
-  Array<int> empty;
-  mc.FormSystemMatrix(empty, Mc);
+   BilinearForm mc(c_fespace);
+   mc.AddDomainIntegrator(massc);
+   mc.Assemble();
+   SparseMatrix Mc;
+   Array<int> empty;
+   mc.FormSystemMatrix(empty, Mc);
 
-  BilinearForm mf(f_fespace);
-  mf.AddDomainIntegrator(massf);
-  mf.Assemble();
-  SparseMatrix Mf;
-  mf.FormSystemMatrix(empty, Mf);
+   BilinearForm mf(f_fespace);
+   mf.AddDomainIntegrator(massf);
+   mf.Assemble();
+   SparseMatrix Mf;
+   mf.FormSystemMatrix(empty, Mf);
 
-  Mf.Mult(Xf, Yf);
+   Mf.Mult(Xf, Yf);
 
-  T.MultTranspose(Yf, Yc);
+   T.MultTranspose(Yf, Yc);
 
-  GSSmoother M(Mc);
-  Diff = 0.0;
-  PCG(Mc, M, Yc, Diff, 0, 500, 1e-24, 0.0);
+   GSSmoother M(Mc);
+   Diff = 0.0;
+   PCG(Mc, M, Yc, Diff, 0, 500, 1e-24, 0.0);
 
-  Diff -= Xc;
-  REQUIRE(Diff.Norml2() < 1e-10);
+   Diff -= Xc;
+   REQUIRE(Diff.Norml2() < 1e-10);
 
-  delete f_fespace;
-  delete c_fespace;
-  delete f_fec;
-  delete c_fec;
+   delete f_fespace;
+   delete c_fespace;
+   delete f_fec;
+   delete c_fec;
 }
 
-TEST_CASE("H1 L2 transfer with consistent mass", "[Transfer]") {
-  auto vectorspace = GENERATE(VecSpace::H1, VecSpace::VectorH1);
-  dimension = GENERATE(2, 3);
+TEST_CASE("H1 L2 transfer with consistent mass", "[Transfer]")
+{
+   auto vectorspace = GENERATE(VecSpace::H1, VecSpace::VectorH1);
+   dimension = GENERATE(2, 3);
 
-  const int order = 2;
-  const int ne = 2;
-  const int vdim = (vectorspace == VecSpace::VectorH1) ? dimension : 1;
+   const int order = 2;
+   const int ne = 2;
+   const int vdim = (vectorspace == VecSpace::VectorH1) ? dimension : 1;
 
-  CAPTURE(VecSpaceName(vectorspace), dimension, order);
+   CAPTURE(VecSpaceName(vectorspace), dimension, order);
 
-  Mesh mesh;
-  if (dimension == 2) {
-    mesh = Mesh::MakeCartesian2D(ne, ne, Element::QUADRILATERAL, 1, 1.0, 1.0);
-  } else {
-    mesh =
-        Mesh::MakeCartesian3D(ne, ne, ne, Element::HEXAHEDRON, 1.0, 1.0, 1.0);
-  }
+   Mesh mesh;
+   if (dimension == 2)
+   {
+      mesh = Mesh::MakeCartesian2D(ne, ne, Element::QUADRILATERAL, 1, 1.0, 1.0);
+   }
+   else
+   {
+      mesh =
+         Mesh::MakeCartesian3D(ne, ne, ne, Element::HEXAHEDRON, 1.0, 1.0, 1.0);
+   }
 
-  Mesh fineMesh(mesh);
-  fineMesh.UniformRefinement();
+   Mesh fineMesh(mesh);
+   fineMesh.UniformRefinement();
 
-  H1_FECollection fec(order, dimension);
-  FiniteElementSpace c_fespace(&mesh, &fec, vdim);
-  FiniteElementSpace f_fespace(&fineMesh, &fec, vdim);
+   H1_FECollection fec(order, dimension);
+   FiniteElementSpace c_fespace(&mesh, &fec, vdim);
+   FiniteElementSpace f_fespace(&fineMesh, &fec, vdim);
 
-  L2ProjectionGridTransfer transfer(c_fespace, f_fespace);
-  transfer.UseConsistentMass();
-  const Operator &R = transfer.ForwardOperator();
+   L2ProjectionGridTransfer transfer(c_fespace, f_fespace);
+   transfer.UseConsistentMass();
+   const Operator &R = transfer.ForwardOperator();
 
-  GridFunction X(&c_fespace);
-  GridFunction Y(&f_fespace);
-  GridFunction Y_ref(&f_fespace);
-  coeff_order = 1;
+   GridFunction X(&c_fespace);
+   GridFunction Y(&f_fespace);
+   GridFunction Y_ref(&f_fespace);
+   coeff_order = 1;
 
-  LinearForm rhs(&f_fespace);
-  BilinearForm mass(&f_fespace);
-  FunctionCoefficient funcCoeff(&coeff);
-  VectorFunctionCoefficient vecCoeff(dimension, &vectorcoeff);
-  if (vectorspace == VecSpace::H1) {
-    X.ProjectCoefficient(funcCoeff);
-    rhs.AddDomainIntegrator(new DomainLFIntegrator(funcCoeff));
-    mass.AddDomainIntegrator(new MassIntegrator);
-  } else {
-    X.ProjectCoefficient(vecCoeff);
-    rhs.AddDomainIntegrator(new VectorDomainLFIntegrator(vecCoeff));
-    mass.AddDomainIntegrator(new VectorMassIntegrator);
-  }
+   LinearForm rhs(&f_fespace);
+   BilinearForm mass(&f_fespace);
+   FunctionCoefficient funcCoeff(&coeff);
+   VectorFunctionCoefficient vecCoeff(dimension, &vectorcoeff);
+   if (vectorspace == VecSpace::H1)
+   {
+      X.ProjectCoefficient(funcCoeff);
+      rhs.AddDomainIntegrator(new DomainLFIntegrator(funcCoeff));
+      mass.AddDomainIntegrator(new MassIntegrator);
+   }
+   else
+   {
+      X.ProjectCoefficient(vecCoeff);
+      rhs.AddDomainIntegrator(new VectorDomainLFIntegrator(vecCoeff));
+      mass.AddDomainIntegrator(new VectorMassIntegrator);
+   }
 
-  rhs.Assemble();
-  mass.Assemble();
-  SparseMatrix M;
-  Array<int> empty;
-  mass.FormSystemMatrix(empty, M);
+   rhs.Assemble();
+   mass.Assemble();
+   SparseMatrix M;
+   Array<int> empty;
+   mass.FormSystemMatrix(empty, M);
 
-  GSSmoother M_prec(M);
-  Y_ref = 0.0;
-  PCG(M, M_prec, rhs, Y_ref, 0, 500, 1e-24, 0.0);
+   GSSmoother M_prec(M);
+   Y_ref = 0.0;
+   PCG(M, M_prec, rhs, Y_ref, 0, 500, 1e-24, 0.0);
 
-  Y = 0.0;
-  R.Mult(X, Y);
-  Y -= Y_ref;
-  REQUIRE(Y.Norml2() < 1e-11 * Y_ref.Norml2());
+   Y = 0.0;
+   R.Mult(X, Y);
+   Y -= Y_ref;
+   REQUIRE(Y.Norml2() < 1e-11 * Y_ref.Norml2());
 
-  Vector x(c_fespace.GetVSize());
-  Vector y(f_fespace.GetVSize());
-  Vector Ry(f_fespace.GetVSize());
-  Vector Rtx(c_fespace.GetVSize());
-  x.Randomize(1);
-  y.Randomize(2);
+   Vector x(c_fespace.GetVSize());
+   Vector y(f_fespace.GetVSize());
+   Vector Ry(f_fespace.GetVSize());
+   Vector Rtx(c_fespace.GetVSize());
+   x.Randomize(1);
+   y.Randomize(2);
 
-  R.Mult(x, Ry);
-  R.MultTranspose(y, Rtx);
+   R.Mult(x, Ry);
+   R.MultTranspose(y, Rtx);
 
-  const real_t ip1 = InnerProduct(Ry, y);
-  const real_t ip2 = InnerProduct(x, Rtx);
-  REQUIRE(std::abs(ip1 - ip2) < 1e-10 * std::max(std::abs(ip1), std::abs(ip2)));
+   const real_t ip1 = InnerProduct(Ry, y);
+   const real_t ip2 = InnerProduct(x, Rtx);
+   REQUIRE(std::abs(ip1 - ip2) < 1e-10 * std::max(std::abs(ip1), std::abs(ip2)));
 
-  REQUIRE_FALSE(transfer.SupportsBackwardsOperator());
+   REQUIRE_FALSE(transfer.SupportsBackwardsOperator());
 }
 
-TEST_CASE("Restriction Transpose Operator") {
-  int order = GENERATE(1, 2);
-  auto mesh_fname =
+TEST_CASE("Restriction Transpose Operator")
+{
+   int order = GENERATE(1, 2);
+   auto mesh_fname =
       GENERATE("../../data/amr-quad.mesh", "../../data/fichera-amr.mesh");
 
-  Mesh mesh = Mesh::LoadFromFile(mesh_fname);
-  H1_FECollection fec(order, mesh.Dimension());
-  FiniteElementSpace fes(&mesh, &fec);
+   Mesh mesh = Mesh::LoadFromFile(mesh_fname);
+   H1_FECollection fec(order, mesh.Dimension());
+   FiniteElementSpace fes(&mesh, &fec);
 
-  BilinearForm a(&fes);
+   BilinearForm a(&fes);
 
-  const Operator *R = fes.GetRestrictionOperator();
-  const Operator *Rt = fes.GetRestrictionTransposeOperator();
-  const Operator *Rt_2 = a.GetOutputRestrictionTranspose();
+   const Operator *R = fes.GetRestrictionOperator();
+   const Operator *Rt = fes.GetRestrictionTransposeOperator();
+   const Operator *Rt_2 = a.GetOutputRestrictionTranspose();
 
-  REQUIRE(R);
-  REQUIRE(Rt);
-  REQUIRE(Rt_2);
+   REQUIRE(R);
+   REQUIRE(Rt);
+   REQUIRE(Rt_2);
 
-  Vector x(R->Height()), y1(R->Width()), y2(Rt->Height()), y3(Rt_2->Height());
+   Vector x(R->Height()), y1(R->Width()), y2(Rt->Height()), y3(Rt_2->Height());
 
-  x.Randomize(1);
+   x.Randomize(1);
 
-  R->MultTranspose(x, y1);
-  Rt->Mult(x, y2);
-  Rt_2->Mult(x, y3);
+   R->MultTranspose(x, y1);
+   Rt->Mult(x, y2);
+   Rt_2->Mult(x, y3);
 
-  y2 -= y1;
-  REQUIRE(y2.Normlinf() == MFEM_Approx(0.0));
+   y2 -= y1;
+   REQUIRE(y2.Normlinf() == MFEM_Approx(0.0));
 
-  y3 -= y1;
-  REQUIRE(y3.Normlinf() == MFEM_Approx(0.0));
+   y3 -= y1;
+   REQUIRE(y3.Normlinf() == MFEM_Approx(0.0));
 }
 
 real_t sin_func(const Vector &x) { return sin(M_PI * x.Sum()); }
 
-void sin_vfunc(const Vector &x, Vector &y) {
-  y.SetSize(x.Size());
-  for (int i = 0; i < y.Size(); i++) {
-    y(i) = sin(M_PI * x[i]);
-  }
+void sin_vfunc(const Vector &x, Vector &y)
+{
+   y.SetSize(x.Size());
+   for (int i = 0; i < y.Size(); i++)
+   {
+      y(i) = sin(M_PI * x[i]);
+   }
 }
 
-namespace {
+namespace
+{
 
-struct TraceCollections {
-  std::unique_ptr<FiniteElementCollection> c_fec;
-  std::unique_ptr<FiniteElementCollection> f_fec;
-  std::unique_ptr<FiniteElementCollection> c_trace_fec;
-  std::unique_ptr<FiniteElementCollection> f_trace_fec;
+struct TraceCollections
+{
+   std::unique_ptr<FiniteElementCollection> c_fec;
+   std::unique_ptr<FiniteElementCollection> f_fec;
+   std::unique_ptr<FiniteElementCollection> c_trace_fec;
+   std::unique_ptr<FiniteElementCollection> f_trace_fec;
 };
 
 TraceCollections MakeTraceCollections(const VecSpace vectorspace,
-                                      const int order, const int dim) {
-  TraceCollections fec;
-  switch (vectorspace) {
-    case VecSpace::H1:
-    case VecSpace::VectorH1nodes:
-    case VecSpace::VectorH1vdim:
-      fec.c_fec = std::make_unique<H1_FECollection>(order, dim);
-      fec.f_fec = std::make_unique<H1_FECollection>(order + 1, dim);
-      fec.c_trace_fec = std::make_unique<H1_Trace_FECollection>(order, dim);
-      fec.f_trace_fec = std::make_unique<H1_Trace_FECollection>(order + 1, dim);
-      break;
-    case VecSpace::ND:
-      fec.c_fec = std::make_unique<ND_FECollection>(order, dim);
-      fec.f_fec = std::make_unique<ND_FECollection>(order + 1, dim);
-      fec.c_trace_fec = std::make_unique<ND_Trace_FECollection>(order, dim);
-      fec.f_trace_fec = std::make_unique<ND_Trace_FECollection>(order + 1, dim);
-      break;
-    case VecSpace::RT:
-      fec.c_fec = std::make_unique<RT_FECollection>(order - 1, dim);
-      fec.f_fec = std::make_unique<RT_FECollection>(order, dim);
-      fec.c_trace_fec = std::make_unique<RT_Trace_FECollection>(order - 1, dim);
-      fec.f_trace_fec = std::make_unique<RT_Trace_FECollection>(order, dim);
-      break;
-  }
-  return fec;
+                                      const int order, const int dim)
+{
+   TraceCollections fec;
+   switch (vectorspace)
+   {
+      case VecSpace::H1:
+      case VecSpace::VectorH1nodes:
+      case VecSpace::VectorH1vdim:
+         fec.c_fec = std::make_unique<H1_FECollection>(order, dim);
+         fec.f_fec = std::make_unique<H1_FECollection>(order + 1, dim);
+         fec.c_trace_fec = std::make_unique<H1_Trace_FECollection>(order, dim);
+         fec.f_trace_fec = std::make_unique<H1_Trace_FECollection>(order + 1, dim);
+         break;
+      case VecSpace::ND:
+         fec.c_fec = std::make_unique<ND_FECollection>(order, dim);
+         fec.f_fec = std::make_unique<ND_FECollection>(order + 1, dim);
+         fec.c_trace_fec = std::make_unique<ND_Trace_FECollection>(order, dim);
+         fec.f_trace_fec = std::make_unique<ND_Trace_FECollection>(order + 1, dim);
+         break;
+      case VecSpace::RT:
+         fec.c_fec = std::make_unique<RT_FECollection>(order - 1, dim);
+         fec.f_fec = std::make_unique<RT_FECollection>(order, dim);
+         fec.c_trace_fec = std::make_unique<RT_Trace_FECollection>(order - 1, dim);
+         fec.f_trace_fec = std::make_unique<RT_Trace_FECollection>(order, dim);
+         break;
+   }
+   return fec;
 }
 
 template <typename MeshT, typename FESpaceT, typename GridFunctionT>
@@ -574,361 +636,390 @@ void CheckTracePRefinementTrueTransfer(MeshT &mesh, FESpaceT &c_fes,
                                        FESpaceT &f_fes, FESpaceT &c_trace_fes,
                                        FESpaceT &f_trace_fes,
                                        const VecSpace vectorspace,
-                                       const int dim, const bool assembleP) {
-  GridFunctionT x_c(&c_fes);
-  x_c = 0.0;
-  GridFunctionT x_f(&f_fes);
-  x_f = 0.0;
-  GridFunctionT x_trace_c(&c_trace_fes);
-  x_trace_c = 0.0;
-  GridFunctionT x_trace_f(&f_trace_fes);
-  x_trace_f = 0.0;
+                                       const int dim, const bool assembleP)
+{
+   GridFunctionT x_c(&c_fes);
+   x_c = 0.0;
+   GridFunctionT x_f(&f_fes);
+   x_f = 0.0;
+   GridFunctionT x_trace_c(&c_trace_fes);
+   x_trace_c = 0.0;
+   GridFunctionT x_trace_f(&f_trace_fes);
+   x_trace_f = 0.0;
 
-  if (vectorspace == VecSpace::H1) {
-    FunctionCoefficient cf(sin_func);
-    x_c.ProjectCoefficient(cf);
-    x_trace_c.ProjectTraceCoefficient(cf);
-  } else {
-    VectorFunctionCoefficient vec_cf(dim, &sin_vfunc);
-    x_c.ProjectCoefficient(vec_cf);
-    switch (vectorspace) {
-      case VecSpace::VectorH1nodes:
-      case VecSpace::VectorH1vdim:
-        x_trace_c.ProjectTraceCoefficient(vec_cf);
-        break;
-      case VecSpace::ND:
-        x_trace_c.ProjectTraceCoefficientTangent(vec_cf);
-        break;
-      case VecSpace::RT:
-        x_trace_c.ProjectTraceCoefficientNormal(vec_cf);
-        break;
-      default:
-        break;
-    }
-  }
+   if (vectorspace == VecSpace::H1)
+   {
+      FunctionCoefficient cf(sin_func);
+      x_c.ProjectCoefficient(cf);
+      x_trace_c.ProjectTraceCoefficient(cf);
+   }
+   else
+   {
+      VectorFunctionCoefficient vec_cf(dim, &sin_vfunc);
+      x_c.ProjectCoefficient(vec_cf);
+      switch (vectorspace)
+      {
+         case VecSpace::VectorH1nodes:
+         case VecSpace::VectorH1vdim:
+            x_trace_c.ProjectTraceCoefficient(vec_cf);
+            break;
+         case VecSpace::ND:
+            x_trace_c.ProjectTraceCoefficientTangent(vec_cf);
+            break;
+         case VecSpace::RT:
+            x_trace_c.ProjectTraceCoefficientNormal(vec_cf);
+            break;
+         default:
+            break;
+      }
+   }
 
-  // Generate transfer operators for field and trace spaces
-  PRefinementTransferOperator P(c_fes, f_fes, assembleP);
-  PRefinementTransferOperator P_trace(c_trace_fes, f_trace_fes, assembleP);
+   // Generate transfer operators for field and trace spaces
+   PRefinementTransferOperator P(c_fes, f_fes, assembleP);
+   PRefinementTransferOperator P_trace(c_trace_fes, f_trace_fes, assembleP);
 
-  Vector x_c_true(c_fes.GetTrueVSize());
-  Vector x_f_true(f_fes.GetTrueVSize());
-  Vector x_trace_c_true(c_trace_fes.GetTrueVSize());
-  Vector x_trace_f_true(f_trace_fes.GetTrueVSize());
-  x_c.GetTrueDofs(x_c_true);
-  x_trace_c.GetTrueDofs(x_trace_c_true);
-  P.GetTrueTransferOperator()->Mult(x_c_true, x_f_true);
-  P_trace.GetTrueTransferOperator()->Mult(x_trace_c_true, x_trace_f_true);
+   Vector x_c_true(c_fes.GetTrueVSize());
+   Vector x_f_true(f_fes.GetTrueVSize());
+   Vector x_trace_c_true(c_trace_fes.GetTrueVSize());
+   Vector x_trace_f_true(f_trace_fes.GetTrueVSize());
+   x_c.GetTrueDofs(x_c_true);
+   x_trace_c.GetTrueDofs(x_trace_c_true);
+   P.GetTrueTransferOperator()->Mult(x_c_true, x_f_true);
+   P_trace.GetTrueTransferOperator()->Mult(x_trace_c_true, x_trace_f_true);
 
-  x_f.SetFromTrueDofs(x_f_true);
-  x_trace_f.SetFromTrueDofs(x_trace_f_true);
+   x_f.SetFromTrueDofs(x_f_true);
+   x_trace_f.SetFromTrueDofs(x_trace_f_true);
 
-  // zero out interior dofs before and after p-ref to compare with trace
-  Array<int> vdofs;
-  for (int i = 0; i < mesh.GetNE(); i++) {
-    c_fes.GetElementInteriorVDofs(i, vdofs);
-    x_c.SetSubVector(vdofs, 0.0);
-    f_fes.GetElementInteriorVDofs(i, vdofs);
-    x_f.SetSubVector(vdofs, 0.0);
-  }
+   // zero out interior dofs before and after p-ref to compare with trace
+   Array<int> vdofs;
+   for (int i = 0; i < mesh.GetNE(); i++)
+   {
+      c_fes.GetElementInteriorVDofs(i, vdofs);
+      x_c.SetSubVector(vdofs, 0.0);
+      f_fes.GetElementInteriorVDofs(i, vdofs);
+      x_f.SetSubVector(vdofs, 0.0);
+   }
 
-  // Embed the trace dofs to a field GridFunction for comparison
-  Array<int> face_vdofs, trace_vdofs;
-  Vector values;
-  GridFunctionT x_embedded_trace_c(&c_fes);
-  x_embedded_trace_c = 0.0;
-  GridFunctionT x_embedded_trace_f(&f_fes);
-  x_embedded_trace_f = 0.0;
-  for (int i = 0; i < mesh.GetNumFaces(); i++) {
-    c_trace_fes.GetFaceVDofs(i, trace_vdofs);
-    x_trace_c.GetSubVector(trace_vdofs, values);
-    c_fes.GetFaceVDofs(i, face_vdofs);
-    x_embedded_trace_c.SetSubVector(face_vdofs, values);
+   // Embed the trace dofs to a field GridFunction for comparison
+   Array<int> face_vdofs, trace_vdofs;
+   Vector values;
+   GridFunctionT x_embedded_trace_c(&c_fes);
+   x_embedded_trace_c = 0.0;
+   GridFunctionT x_embedded_trace_f(&f_fes);
+   x_embedded_trace_f = 0.0;
+   for (int i = 0; i < mesh.GetNumFaces(); i++)
+   {
+      c_trace_fes.GetFaceVDofs(i, trace_vdofs);
+      x_trace_c.GetSubVector(trace_vdofs, values);
+      c_fes.GetFaceVDofs(i, face_vdofs);
+      x_embedded_trace_c.SetSubVector(face_vdofs, values);
 
-    f_trace_fes.GetFaceVDofs(i, trace_vdofs);
-    x_trace_f.GetSubVector(trace_vdofs, values);
-    f_fes.GetFaceVDofs(i, face_vdofs);
-    x_embedded_trace_f.SetSubVector(face_vdofs, values);
-  }
+      f_trace_fes.GetFaceVDofs(i, trace_vdofs);
+      x_trace_f.GetSubVector(trace_vdofs, values);
+      f_fes.GetFaceVDofs(i, face_vdofs);
+      x_embedded_trace_f.SetSubVector(face_vdofs, values);
+   }
 
-  x_embedded_trace_c -= x_c;
-  REQUIRE(x_embedded_trace_c.Norml2() == MFEM_Approx(0.0));
-  x_embedded_trace_f -= x_f;
-  REQUIRE(x_embedded_trace_f.Norml2() == MFEM_Approx(0.0));
+   x_embedded_trace_c -= x_c;
+   REQUIRE(x_embedded_trace_c.Norml2() == MFEM_Approx(0.0));
+   x_embedded_trace_f -= x_f;
+   REQUIRE(x_embedded_trace_f.Norml2() == MFEM_Approx(0.0));
 }
 
 }  // namespace
 
-TEST_CASE("Trace PRefinement Serial TrueTransfer", "[Transfer]") {
-  auto simplex = GENERATE(true, false);
-  dimension = GENERATE(2, 3);
-  constexpr int ne = 4;
-  auto order = GENERATE(1, 2, 3);
-  auto vectorspace =
+TEST_CASE("Trace PRefinement Serial TrueTransfer", "[Transfer]")
+{
+   auto simplex = GENERATE(true, false);
+   dimension = GENERATE(2, 3);
+   constexpr int ne = 4;
+   auto order = GENERATE(1, 2, 3);
+   auto vectorspace =
       GENERATE(VecSpace::H1, VecSpace::VectorH1nodes, VecSpace::VectorH1vdim,
                VecSpace::ND, VecSpace::RT);
-  auto assembleP = GENERATE(false, true);
-  auto amr = GENERATE(false, true);
+   auto assembleP = GENERATE(false, true);
+   auto amr = GENERATE(false, true);
 
-  // Log test case information
-  const int total_ne = static_cast<int>(std::pow(ne, dimension));
-  CAPTURE(VecSpaceName(vectorspace), dimension, simplex, total_ne, order,
-          assembleP);
+   // Log test case information
+   const int total_ne = static_cast<int>(std::pow(ne, dimension));
+   CAPTURE(VecSpaceName(vectorspace), dimension, simplex, total_ne, order,
+           assembleP);
 
-  Mesh mesh;
-  if (dimension == 2) {
-    Element::Type type = simplex ? Element::TRIANGLE : Element::QUADRILATERAL;
-    mesh = Mesh::MakeCartesian2D(ne, ne, type, 1, 1.0, 1.0);
-  } else {
-    Element::Type type = simplex ? Element::TETRAHEDRON : Element::HEXAHEDRON;
-    mesh = Mesh::MakeCartesian3D(ne, ne, ne, type, 1.0, 1.0, 1.0);
-  }
+   Mesh mesh;
+   if (dimension == 2)
+   {
+      Element::Type type = simplex ? Element::TRIANGLE : Element::QUADRILATERAL;
+      mesh = Mesh::MakeCartesian2D(ne, ne, type, 1, 1.0, 1.0);
+   }
+   else
+   {
+      Element::Type type = simplex ? Element::TETRAHEDRON : Element::HEXAHEDRON;
+      mesh = Mesh::MakeCartesian3D(ne, ne, ne, type, 1.0, 1.0, 1.0);
+   }
 
-  if (amr) {
-    mesh.RandomRefinement(0.5);
-  }
+   if (amr)
+   {
+      mesh.RandomRefinement(0.5);
+   }
 
-  auto fec = MakeTraceCollections(vectorspace, order, dimension);
+   auto fec = MakeTraceCollections(vectorspace, order, dimension);
 
-  const int vdim = (vectorspace == VecSpace::VectorH1nodes ||
-                    vectorspace == VecSpace::VectorH1vdim)
-                       ? dimension
-                       : 1;
-  Ordering::Type ordering = (vectorspace == VecSpace::VectorH1vdim)
-                                ? Ordering::byVDIM
-                                : Ordering::byNODES;
+   const int vdim = (vectorspace == VecSpace::VectorH1nodes ||
+                     vectorspace == VecSpace::VectorH1vdim)
+                    ? dimension
+                    : 1;
+   Ordering::Type ordering = (vectorspace == VecSpace::VectorH1vdim)
+                             ? Ordering::byVDIM
+                             : Ordering::byNODES;
 
-  FiniteElementSpace c_fes(&mesh, fec.c_fec.get(), vdim, ordering);
-  FiniteElementSpace f_fes(&mesh, fec.f_fec.get(), vdim, ordering);
-  FiniteElementSpace c_trace_fes(&mesh, fec.c_trace_fec.get(), vdim, ordering);
-  FiniteElementSpace f_trace_fes(&mesh, fec.f_trace_fec.get(), vdim, ordering);
+   FiniteElementSpace c_fes(&mesh, fec.c_fec.get(), vdim, ordering);
+   FiniteElementSpace f_fes(&mesh, fec.f_fec.get(), vdim, ordering);
+   FiniteElementSpace c_trace_fes(&mesh, fec.c_trace_fec.get(), vdim, ordering);
+   FiniteElementSpace f_trace_fes(&mesh, fec.f_trace_fec.get(), vdim, ordering);
 
-  CheckTracePRefinementTrueTransfer<Mesh, FiniteElementSpace, GridFunction>(
+   CheckTracePRefinementTrueTransfer<Mesh, FiniteElementSpace, GridFunction>(
       mesh, c_fes, f_fes, c_trace_fes, f_trace_fes, vectorspace, dimension,
       assembleP);
 }
 
 #ifdef MFEM_USE_MPI
 
-TEST_CASE("Parallel Transfer", "[Transfer][Parallel]") {
-  auto simplex = GENERATE(true, false);
-  auto geometric = GENERATE(true, false);
-  dimension = GENERATE(2, 3);
-  int ne = 4;
-  int order = 2;
+TEST_CASE("Parallel Transfer", "[Transfer][Parallel]")
+{
+   auto simplex = GENERATE(true, false);
+   auto geometric = GENERATE(true, false);
+   dimension = GENERATE(2, 3);
+   int ne = 4;
+   int order = 2;
 
-  int fineOrder = geometric ? order : 2 * order;
-  int num_procs, myid;
-  MPI_Comm_size(MPI_COMM_WORLD, &num_procs);
-  MPI_Comm_rank(MPI_COMM_WORLD, &myid);
+   int fineOrder = geometric ? order : 2 * order;
+   int num_procs, myid;
+   MPI_Comm_size(MPI_COMM_WORLD, &num_procs);
+   MPI_Comm_rank(MPI_COMM_WORLD, &myid);
 
-  // Log test case information
-  int total_ne = static_cast<int>(std::pow(ne, dimension));
-  CAPTURE(dimension, simplex, total_ne, order, fineOrder, geometric);
+   // Log test case information
+   int total_ne = static_cast<int>(std::pow(ne, dimension));
+   CAPTURE(dimension, simplex, total_ne, order, fineOrder, geometric);
 
-  coeff_order = 1;
+   coeff_order = 1;
 
-  Mesh mesh;
-  if (dimension == 2) {
-    Element::Type type = simplex ? Element::TRIANGLE : Element::QUADRILATERAL;
-    mesh = Mesh::MakeCartesian2D(ne, ne, type, 1, 1.0, 1.0);
-  } else {
-    Element::Type type = simplex ? Element::TETRAHEDRON : Element::HEXAHEDRON;
-    mesh = Mesh::MakeCartesian3D(ne, ne, ne, type, 1.0, 1.0, 1.0);
-  }
+   Mesh mesh;
+   if (dimension == 2)
+   {
+      Element::Type type = simplex ? Element::TRIANGLE : Element::QUADRILATERAL;
+      mesh = Mesh::MakeCartesian2D(ne, ne, type, 1, 1.0, 1.0);
+   }
+   else
+   {
+      Element::Type type = simplex ? Element::TETRAHEDRON : Element::HEXAHEDRON;
+      mesh = Mesh::MakeCartesian3D(ne, ne, ne, type, 1.0, 1.0, 1.0);
+   }
 
-  Mesh fineMesh(mesh);
-  if (geometric) {
-    fineMesh.UniformRefinement();
-  }
+   Mesh fineMesh(mesh);
+   if (geometric)
+   {
+      fineMesh.UniformRefinement();
+   }
 
-  ParMesh *pmesh = new ParMesh(MPI_COMM_WORLD, mesh);
-  ParMesh pfineMesh(MPI_COMM_WORLD, mesh);
-  if (geometric) {
-    pfineMesh.UniformRefinement();
-  }
+   ParMesh *pmesh = new ParMesh(MPI_COMM_WORLD, mesh);
+   ParMesh pfineMesh(MPI_COMM_WORLD, mesh);
+   if (geometric)
+   {
+      pfineMesh.UniformRefinement();
+   }
 
-  FiniteElementCollection *c_h1_fec = new H1_FECollection(order, dimension);
-  FiniteElementCollection *f_h1_fec =
+   FiniteElementCollection *c_h1_fec = new H1_FECollection(order, dimension);
+   FiniteElementCollection *f_h1_fec =
       geometric ? c_h1_fec : new H1_FECollection(fineOrder, dimension);
 
-  constexpr int vdim = 1;
+   constexpr int vdim = 1;
 
-  double referenceRestrictionValue = 0.0;
+   double referenceRestrictionValue = 0.0;
 
-  // Compute reference values in serial
-  {
-    FiniteElementSpace *c_h1_fespace =
-        new FiniteElementSpace(&mesh, c_h1_fec, vdim);
-    FiniteElementSpace *f_h1_fespace =
-        new FiniteElementSpace(&fineMesh, f_h1_fec, vdim);
+   // Compute reference values in serial
+   {
+      FiniteElementSpace *c_h1_fespace =
+         new FiniteElementSpace(&mesh, c_h1_fec, vdim);
+      FiniteElementSpace *f_h1_fespace =
+         new FiniteElementSpace(&fineMesh, f_h1_fec, vdim);
 
-    Operator *transferOperator =
-        new TransferOperator(*c_h1_fespace, *f_h1_fespace);
-    GridFunction X(c_h1_fespace);
-    GridFunction Y(f_h1_fespace);
+      Operator *transferOperator =
+         new TransferOperator(*c_h1_fespace, *f_h1_fespace);
+      GridFunction X(c_h1_fespace);
+      GridFunction Y(f_h1_fespace);
 
-    FunctionCoefficient funcCoeff(&coeff);
-    Y.ProjectCoefficient(funcCoeff);
-    X = 0.0;
+      FunctionCoefficient funcCoeff(&coeff);
+      Y.ProjectCoefficient(funcCoeff);
+      X = 0.0;
 
-    transferOperator->MultTranspose(Y, X);
+      transferOperator->MultTranspose(Y, X);
 
-    referenceRestrictionValue = std::sqrt(InnerProduct(X, X));
+      referenceRestrictionValue = std::sqrt(InnerProduct(X, X));
 
-    delete transferOperator;
-    delete f_h1_fespace;
-    delete c_h1_fespace;
-  }
+      delete transferOperator;
+      delete f_h1_fespace;
+      delete c_h1_fespace;
+   }
 
-  ParFiniteElementSpace *c_h1_fespace =
+   ParFiniteElementSpace *c_h1_fespace =
       new ParFiniteElementSpace(pmesh, c_h1_fec, vdim);
-  ParFiniteElementSpace *f_h1_fespace =
+   ParFiniteElementSpace *f_h1_fespace =
       new ParFiniteElementSpace(&pfineMesh, f_h1_fec, vdim);
 
-  Operator *transferOperator =
+   Operator *transferOperator =
       new TrueTransferOperator(*c_h1_fespace, *f_h1_fespace);
-  ParGridFunction X(c_h1_fespace);
-  ParGridFunction Y_exact(f_h1_fespace);
-  ParGridFunction Y(f_h1_fespace);
-  FunctionCoefficient funcCoeff(&coeff);
-  X.ProjectCoefficient(funcCoeff);
-  Y_exact.ProjectCoefficient(funcCoeff);
+   ParGridFunction X(c_h1_fespace);
+   ParGridFunction Y_exact(f_h1_fespace);
+   ParGridFunction Y(f_h1_fespace);
+   FunctionCoefficient funcCoeff(&coeff);
+   X.ProjectCoefficient(funcCoeff);
+   Y_exact.ProjectCoefficient(funcCoeff);
 
-  Y = 0.0;
+   Y = 0.0;
 
-  Vector X_true(c_h1_fespace->GetTrueVSize());
-  Vector Y_true(f_h1_fespace->GetTrueVSize());
+   Vector X_true(c_h1_fespace->GetTrueVSize());
+   Vector Y_true(f_h1_fespace->GetTrueVSize());
 
-  c_h1_fespace->GetRestrictionMatrix()->Mult(X, X_true);
-  transferOperator->Mult(X_true, Y_true);
-  f_h1_fespace->GetProlongationMatrix()->Mult(Y_true, Y);
+   c_h1_fespace->GetRestrictionMatrix()->Mult(X, X_true);
+   transferOperator->Mult(X_true, Y_true);
+   f_h1_fespace->GetProlongationMatrix()->Mult(Y_true, Y);
 
-  Y -= Y_exact;
-  REQUIRE(Y.Norml2() < 1e-12 * Y_exact.Norml2());
+   Y -= Y_exact;
+   REQUIRE(Y.Norml2() < 1e-12 * Y_exact.Norml2());
 
-  f_h1_fespace->GetRestrictionMatrix()->Mult(Y_exact, Y_true);
-  transferOperator->MultTranspose(Y_true, X_true);
+   f_h1_fespace->GetRestrictionMatrix()->Mult(Y_exact, Y_true);
+   transferOperator->MultTranspose(Y_true, X_true);
 
-  double restrictionValue =
+   double restrictionValue =
       std::sqrt(InnerProduct(MPI_COMM_WORLD, X_true, X_true));
-  REQUIRE(std::abs(restrictionValue - referenceRestrictionValue) <
-          1e-12 * std::abs(referenceRestrictionValue));
+   REQUIRE(std::abs(restrictionValue - referenceRestrictionValue) <
+           1e-12 * std::abs(referenceRestrictionValue));
 
-  delete transferOperator;
-  delete f_h1_fespace;
-  delete c_h1_fespace;
-  if (!geometric) {
-    delete f_h1_fec;
-  }
-  delete c_h1_fec;
-  delete pmesh;
+   delete transferOperator;
+   delete f_h1_fespace;
+   delete c_h1_fespace;
+   if (!geometric)
+   {
+      delete f_h1_fec;
+   }
+   delete c_h1_fec;
+   delete pmesh;
 }
 
-TEST_CASE("Trace PRefinement Parallel TrueTransfer", "[Transfer][Parallel]") {
-  auto simplex = GENERATE(true, false);
-  dimension = GENERATE(2, 3);
-  constexpr int ne = 4;
-  auto order = GENERATE(1, 2, 3);
-  auto vectorspace =
+TEST_CASE("Trace PRefinement Parallel TrueTransfer", "[Transfer][Parallel]")
+{
+   auto simplex = GENERATE(true, false);
+   dimension = GENERATE(2, 3);
+   constexpr int ne = 4;
+   auto order = GENERATE(1, 2, 3);
+   auto vectorspace =
       GENERATE(VecSpace::H1, VecSpace::VectorH1nodes, VecSpace::VectorH1vdim,
                VecSpace::ND, VecSpace::RT);
-  auto assembleP = GENERATE(true, false);
+   auto assembleP = GENERATE(true, false);
 
-  auto amr = GENERATE(true, false);
+   auto amr = GENERATE(true, false);
 
-  // Log test case information
-  const int total_ne = static_cast<int>(std::pow(ne, dimension));
-  CAPTURE(VecSpaceName(vectorspace), dimension, simplex, total_ne, order,
-          assembleP);
+   // Log test case information
+   const int total_ne = static_cast<int>(std::pow(ne, dimension));
+   CAPTURE(VecSpaceName(vectorspace), dimension, simplex, total_ne, order,
+           assembleP);
 
-  Mesh mesh;
-  if (dimension == 2) {
-    Element::Type type = simplex ? Element::TRIANGLE : Element::QUADRILATERAL;
-    mesh = Mesh::MakeCartesian2D(ne, ne, type, 1, 1.0, 1.0);
-  } else {
-    Element::Type type = simplex ? Element::TETRAHEDRON : Element::HEXAHEDRON;
-    mesh = Mesh::MakeCartesian3D(ne, ne, ne, type, 1.0, 1.0, 1.0);
-  }
+   Mesh mesh;
+   if (dimension == 2)
+   {
+      Element::Type type = simplex ? Element::TRIANGLE : Element::QUADRILATERAL;
+      mesh = Mesh::MakeCartesian2D(ne, ne, type, 1, 1.0, 1.0);
+   }
+   else
+   {
+      Element::Type type = simplex ? Element::TETRAHEDRON : Element::HEXAHEDRON;
+      mesh = Mesh::MakeCartesian3D(ne, ne, ne, type, 1.0, 1.0, 1.0);
+   }
 
-  if (amr) {
-    mesh.EnsureNCMesh(true);
-  }
+   if (amr)
+   {
+      mesh.EnsureNCMesh(true);
+   }
 
-  ParMesh pmesh(MPI_COMM_WORLD, mesh);
+   ParMesh pmesh(MPI_COMM_WORLD, mesh);
 
-  if (amr) {
-    pmesh.RandomRefinement(0.5);
-  }
+   if (amr)
+   {
+      pmesh.RandomRefinement(0.5);
+   }
 
-  auto fec = MakeTraceCollections(vectorspace, order, dimension);
+   auto fec = MakeTraceCollections(vectorspace, order, dimension);
 
-  const int vdim = (vectorspace == VecSpace::VectorH1nodes ||
-                    vectorspace == VecSpace::VectorH1vdim)
-                       ? dimension
-                       : 1;
-  Ordering::Type ordering = (vectorspace == VecSpace::VectorH1vdim)
-                                ? Ordering::byVDIM
-                                : Ordering::byNODES;
+   const int vdim = (vectorspace == VecSpace::VectorH1nodes ||
+                     vectorspace == VecSpace::VectorH1vdim)
+                    ? dimension
+                    : 1;
+   Ordering::Type ordering = (vectorspace == VecSpace::VectorH1vdim)
+                             ? Ordering::byVDIM
+                             : Ordering::byNODES;
 
-  ParFiniteElementSpace c_fes(&pmesh, fec.c_fec.get(), vdim, ordering);
-  ParFiniteElementSpace f_fes(&pmesh, fec.f_fec.get(), vdim, ordering);
-  ParFiniteElementSpace c_trace_fes(&pmesh, fec.c_trace_fec.get(), vdim,
-                                    ordering);
-  ParFiniteElementSpace f_trace_fes(&pmesh, fec.f_trace_fec.get(), vdim,
-                                    ordering);
+   ParFiniteElementSpace c_fes(&pmesh, fec.c_fec.get(), vdim, ordering);
+   ParFiniteElementSpace f_fes(&pmesh, fec.f_fec.get(), vdim, ordering);
+   ParFiniteElementSpace c_trace_fes(&pmesh, fec.c_trace_fec.get(), vdim,
+                                     ordering);
+   ParFiniteElementSpace f_trace_fes(&pmesh, fec.f_trace_fec.get(), vdim,
+                                     ordering);
 
-  CheckTracePRefinementTrueTransfer<ParMesh, ParFiniteElementSpace,
-                                    ParGridFunction>(
-      pmesh, c_fes, f_fes, c_trace_fes, f_trace_fes, vectorspace, dimension,
-      assembleP);
+   CheckTracePRefinementTrueTransfer<ParMesh, ParFiniteElementSpace,
+                                     ParGridFunction>(
+                                        pmesh, c_fes, f_fes, c_trace_fes, f_trace_fes, vectorspace, dimension,
+                                        assembleP);
 }
 
 TEST_CASE("Parallel H1 L2 transfer with consistent mass",
-          "[Transfer][Parallel]") {
-  dimension = GENERATE(2, 3);
+          "[Transfer][Parallel]")
+{
+   dimension = GENERATE(2, 3);
 
-  const int order = 2;
-  const int ne = 2;
-  const int vdim = 1;
+   const int order = 2;
+   const int ne = 2;
+   const int vdim = 1;
 
-  CAPTURE(dimension, order);
+   CAPTURE(dimension, order);
 
-  Mesh mesh;
-  if (dimension == 2) {
-    mesh = Mesh::MakeCartesian2D(ne, ne, Element::QUADRILATERAL, 1, 1.0, 1.0);
-  } else {
-    mesh =
-        Mesh::MakeCartesian3D(ne, ne, ne, Element::HEXAHEDRON, 1.0, 1.0, 1.0);
-  }
+   Mesh mesh;
+   if (dimension == 2)
+   {
+      mesh = Mesh::MakeCartesian2D(ne, ne, Element::QUADRILATERAL, 1, 1.0, 1.0);
+   }
+   else
+   {
+      mesh =
+         Mesh::MakeCartesian3D(ne, ne, ne, Element::HEXAHEDRON, 1.0, 1.0, 1.0);
+   }
 
-  ParMesh pmesh(MPI_COMM_WORLD, mesh);
-  ParMesh pfineMesh(MPI_COMM_WORLD, mesh);
-  pfineMesh.UniformRefinement();
+   ParMesh pmesh(MPI_COMM_WORLD, mesh);
+   ParMesh pfineMesh(MPI_COMM_WORLD, mesh);
+   pfineMesh.UniformRefinement();
 
-  H1_FECollection fec(order, dimension);
-  ParFiniteElementSpace c_fespace(&pmesh, &fec, vdim);
-  ParFiniteElementSpace f_fespace(&pfineMesh, &fec, vdim);
+   H1_FECollection fec(order, dimension);
+   ParFiniteElementSpace c_fespace(&pmesh, &fec, vdim);
+   ParFiniteElementSpace f_fespace(&pfineMesh, &fec, vdim);
 
-  L2ProjectionGridTransfer transfer(c_fespace, f_fespace);
-  transfer.UseConsistentMass();
-  const Operator &R = transfer.TrueForwardOperator();
+   L2ProjectionGridTransfer transfer(c_fespace, f_fespace);
+   transfer.UseConsistentMass();
+   const Operator &R = transfer.TrueForwardOperator();
 
-  Vector x(c_fespace.GetTrueVSize());
-  Vector y(f_fespace.GetTrueVSize());
-  Vector Rx(f_fespace.GetTrueVSize());
-  Vector Rty(c_fespace.GetTrueVSize());
-  x.Randomize(1);
-  y.Randomize(2);
+   Vector x(c_fespace.GetTrueVSize());
+   Vector y(f_fespace.GetTrueVSize());
+   Vector Rx(f_fespace.GetTrueVSize());
+   Vector Rty(c_fespace.GetTrueVSize());
+   x.Randomize(1);
+   y.Randomize(2);
 
-  R.Mult(x, Rx);
-  R.MultTranspose(y, Rty);
+   R.Mult(x, Rx);
+   R.MultTranspose(y, Rty);
 
-  const real_t ip1 = InnerProduct(MPI_COMM_WORLD, Rx, y);
-  const real_t ip2 = InnerProduct(MPI_COMM_WORLD, x, Rty);
-  REQUIRE(std::abs(ip1 - ip2) < 1e-10 * std::max(std::abs(ip1), std::abs(ip2)));
+   const real_t ip1 = InnerProduct(MPI_COMM_WORLD, Rx, y);
+   const real_t ip2 = InnerProduct(MPI_COMM_WORLD, x, Rty);
+   REQUIRE(std::abs(ip1 - ip2) < 1e-10 * std::max(std::abs(ip1), std::abs(ip2)));
 
-  REQUIRE_FALSE(transfer.SupportsBackwardsOperator());
+   REQUIRE_FALSE(transfer.SupportsBackwardsOperator());
 }
 
 #endif

--- a/tests/unit/fem/test_transfer.cpp
+++ b/tests/unit/fem/test_transfer.cpp
@@ -425,6 +425,95 @@ TEST_CASE("Variable Order True Transfer", "[Transfer][VariableOrder]")
    delete c_fec;
 }
 
+TEST_CASE("H1 L2 transfer with consistent mass", "[Transfer]")
+{
+   auto vectorspace = GENERATE(VecSpace::H1, VecSpace::VectorH1);
+   dimension = GENERATE(2, 3);
+
+   const int order = 2;
+   const int ne = 2;
+   const int vdim = (vectorspace == VecSpace::VectorH1) ? dimension : 1;
+
+   CAPTURE(VecSpaceName(vectorspace), dimension, order);
+
+   Mesh mesh;
+   if (dimension == 2)
+   {
+      mesh = Mesh::MakeCartesian2D(ne, ne, Element::QUADRILATERAL,
+                                   1, 1.0, 1.0);
+   }
+   else
+   {
+      mesh = Mesh::MakeCartesian3D(ne, ne, ne, Element::HEXAHEDRON,
+                                   1.0, 1.0, 1.0);
+   }
+
+   Mesh fineMesh(mesh);
+   fineMesh.UniformRefinement();
+
+   H1_FECollection fec(order, dimension);
+   FiniteElementSpace c_fespace(&mesh, &fec, vdim);
+   FiniteElementSpace f_fespace(&fineMesh, &fec, vdim);
+
+   L2ProjectionGridTransfer transfer(c_fespace, f_fespace);
+   transfer.UseConsistentMass();
+   const Operator &R = transfer.ForwardOperator();
+
+   GridFunction X(&c_fespace);
+   GridFunction Y(&f_fespace);
+   GridFunction Y_ref(&f_fespace);
+   coeff_order = 1;
+
+   LinearForm rhs(&f_fespace);
+   BilinearForm mass(&f_fespace);
+   FunctionCoefficient funcCoeff(&coeff);
+   VectorFunctionCoefficient vecCoeff(dimension, &vectorcoeff);
+   if (vectorspace == VecSpace::H1)
+   {
+      X.ProjectCoefficient(funcCoeff);
+      rhs.AddDomainIntegrator(new DomainLFIntegrator(funcCoeff));
+      mass.AddDomainIntegrator(new MassIntegrator);
+   }
+   else
+   {
+      X.ProjectCoefficient(vecCoeff);
+      rhs.AddDomainIntegrator(new VectorDomainLFIntegrator(vecCoeff));
+      mass.AddDomainIntegrator(new VectorMassIntegrator);
+   }
+
+   rhs.Assemble();
+   mass.Assemble();
+   SparseMatrix M;
+   Array<int> empty;
+   mass.FormSystemMatrix(empty, M);
+
+   GSSmoother M_prec(M);
+   Y_ref = 0.0;
+   PCG(M, M_prec, rhs, Y_ref, 0, 500, 1e-24, 0.0);
+
+   Y = 0.0;
+   R.Mult(X, Y);
+   Y -= Y_ref;
+   REQUIRE(Y.Norml2() < 1e-11 * Y_ref.Norml2());
+
+   Vector x(c_fespace.GetVSize());
+   Vector y(f_fespace.GetVSize());
+   Vector Ry(f_fespace.GetVSize());
+   Vector Rtx(c_fespace.GetVSize());
+   x.Randomize(1);
+   y.Randomize(2);
+
+   R.Mult(x, Ry);
+   R.MultTranspose(y, Rtx);
+
+   const real_t ip1 = InnerProduct(Ry, y);
+   const real_t ip2 = InnerProduct(x, Rtx);
+   REQUIRE(std::abs(ip1 - ip2) <
+           1e-10 * std::max(std::abs(ip1), std::abs(ip2)));
+
+   REQUIRE_FALSE(transfer.SupportsBackwardsOperator());
+}
+
 TEST_CASE("Restriction Transpose Operator")
 {
    int order = GENERATE(1, 2);
@@ -582,6 +671,59 @@ TEST_CASE("Parallel Transfer", "[Transfer][Parallel]")
    if (!geometric) { delete f_h1_fec; }
    delete c_h1_fec;
    delete pmesh;
+}
+
+TEST_CASE("Parallel H1 L2 transfer with consistent mass",
+          "[Transfer][Parallel]")
+{
+   dimension = GENERATE(2, 3);
+
+   const int order = 2;
+   const int ne = 2;
+   const int vdim = 1;
+
+   CAPTURE(dimension, order);
+
+   Mesh mesh;
+   if (dimension == 2)
+   {
+      mesh = Mesh::MakeCartesian2D(ne, ne, Element::QUADRILATERAL,
+                                   1, 1.0, 1.0);
+   }
+   else
+   {
+      mesh = Mesh::MakeCartesian3D(ne, ne, ne, Element::HEXAHEDRON,
+                                   1.0, 1.0, 1.0);
+   }
+
+   ParMesh pmesh(MPI_COMM_WORLD, mesh);
+   ParMesh pfineMesh(MPI_COMM_WORLD, mesh);
+   pfineMesh.UniformRefinement();
+
+   H1_FECollection fec(order, dimension);
+   ParFiniteElementSpace c_fespace(&pmesh, &fec, vdim);
+   ParFiniteElementSpace f_fespace(&pfineMesh, &fec, vdim);
+
+   L2ProjectionGridTransfer transfer(c_fespace, f_fespace);
+   transfer.UseConsistentMass();
+   const Operator &R = transfer.TrueForwardOperator();
+
+   Vector x(c_fespace.GetTrueVSize());
+   Vector y(f_fespace.GetTrueVSize());
+   Vector Rx(f_fespace.GetTrueVSize());
+   Vector Rty(c_fespace.GetTrueVSize());
+   x.Randomize(1);
+   y.Randomize(2);
+
+   R.Mult(x, Rx);
+   R.MultTranspose(y, Rty);
+
+   const real_t ip1 = InnerProduct(MPI_COMM_WORLD, Rx, y);
+   const real_t ip2 = InnerProduct(MPI_COMM_WORLD, x, Rty);
+   REQUIRE(std::abs(ip1 - ip2) <
+           1e-10 * std::max(std::abs(ip1), std::abs(ip2)));
+
+   REQUIRE_FALSE(transfer.SupportsBackwardsOperator());
 }
 
 #endif

--- a/tests/unit/fem/test_transfer.cpp
+++ b/tests/unit/fem/test_transfer.cpp
@@ -9,34 +9,35 @@
 // terms of the BSD-3 license. We welcome feedback and contributions, see file
 // CONTRIBUTING.md for details.
 
-#include <memory>
-
 #include "mfem.hpp"
 #include "unit_tests.hpp"
 
+#include <memory>
+
 using namespace mfem;
 
-int RandomPRefinement(FiniteElementSpace &fes)
+int RandomPRefinement(FiniteElementSpace & fes)
 {
    Mesh *mesh = fes.GetMesh();
    int maxorder = 0;
    for (int i = 0; i < mesh->GetNE(); i++)
    {
       const int order = fes.GetElementOrder(i);
-      maxorder = std::max(maxorder, order);
-      if ((double)rand() / RAND_MAX < 0.5)
+      maxorder = std::max(maxorder,order);
+      if ((double) rand() / RAND_MAX < 0.5)
       {
-         fes.SetElementOrder(i, order + 1);
-         maxorder = std::max(maxorder, order + 1);
+         fes.SetElementOrder(i,order+1);
+         maxorder = std::max(maxorder,order+1);
       }
    }
    fes.Update(false);
    return maxorder;
 }
 
+
 int dimension;
 int coeff_order;
-double coeff(const Vector &X)
+double coeff(const Vector& X)
 {
    double x = X[0];
    double y = X[1];
@@ -49,7 +50,7 @@ double coeff(const Vector &X)
       }
       else
       {
-         return (1. - x) * x * (1. - y) * y;
+         return (1.-x)*x*(1.-y)*y;
       }
    }
    else
@@ -61,12 +62,12 @@ double coeff(const Vector &X)
       }
       else
       {
-         return (1. - x) * x * (1. - y) * y * (1. - z) * z;
+         return (1.-x)*x*(1.-y)*y*(1.-z)*z;
       }
    }
 }
 
-void vectorcoeff(const Vector &x, Vector &y)
+void vectorcoeff(const Vector& x, Vector& y)
 {
    y(0) = coeff(x);
    y(1) = -coeff(x);
@@ -82,25 +83,19 @@ std::string VecSpaceName(VecSpace vectorspace)
 {
    switch (vectorspace)
    {
-      case VecSpace::H1:
-         return "H1";
-      case VecSpace::VectorH1nodes:
-         return "Vector H1 by nodes";
-      case VecSpace::VectorH1vdim:
-         return "Vector H1 by vdim";
-      case VecSpace::ND:
-         return "Nedelec";
-      case VecSpace::RT:
-         return "Raviart-Thomas";
+      case VecSpace::H1: return "H1";
+      case VecSpace::VectorH1nodes: return "Vector H1 by nodes";
+      case VecSpace::VectorH1vdim: return "Vector H1 by vdim";
+      case VecSpace::ND: return "Nedelec";
+      case VecSpace::RT: return "Raviart-Thomas";
    }
    return "";
 }
 
 TEST_CASE("Transfer", "[Transfer]")
 {
-   auto vectorspace =
-      GENERATE(VecSpace::H1, VecSpace::VectorH1nodes, VecSpace::VectorH1vdim,
-               VecSpace::ND, VecSpace::RT);
+   auto vectorspace = GENERATE(VecSpace::H1, VecSpace::VectorH1nodes,
+                               VecSpace::VectorH1vdim, VecSpace::ND, VecSpace::RT);
    auto geometric = GENERATE(true, false);
    auto simplex = GENERATE(true, false);
    dimension = GENERATE(2, 3);
@@ -108,7 +103,7 @@ TEST_CASE("Transfer", "[Transfer]")
    int order = 2;
    int ne = 2;
 
-   int fineOrder = geometric ? order : 2 * order;
+   int fineOrder = geometric ? order : 2*order;
 
    // Log test case information
    int total_ne = static_cast<int>(std::pow(ne, dimension));
@@ -138,7 +133,7 @@ TEST_CASE("Transfer", "[Transfer]")
          f_fec = geometric ? c_fec : new H1_FECollection(fineOrder, dimension);
          break;
       case VecSpace::ND:
-         c_fec = new ND_FECollection(order + 1, dimension);
+         c_fec = new ND_FECollection(order+1, dimension);
          f_fec = geometric ? c_fec : new ND_FECollection(fineOrder, dimension);
          break;
       case VecSpace::RT:
@@ -153,23 +148,21 @@ TEST_CASE("Transfer", "[Transfer]")
       fineMesh.UniformRefinement();
    }
 
-   const int vdim = (vectorspace == VecSpace::VectorH1nodes ||
-                     vectorspace == VecSpace::VectorH1vdim)
-                    ? dimension
-                    : 1;
+   const int vdim = (vectorspace == VecSpace::VectorH1nodes
+                     || vectorspace == VecSpace::VectorH1vdim) ? dimension : 1;
    Ordering::Type ordering = (vectorspace == VecSpace::VectorH1vdim)
-                             ? Ordering::byVDIM
-                             : Ordering::byNODES;
+                             ? Ordering::byVDIM : Ordering::byNODES;
    FiniteElementSpace *c_fespace =
       new FiniteElementSpace(&mesh, c_fec, vdim, ordering);
    FiniteElementSpace *f_fespace =
       new FiniteElementSpace(&fineMesh, f_fec, vdim, ordering);
 
-   Operator *referenceOperator = nullptr;
+   Operator* referenceOperator = nullptr;
 
    if (!geometric)
    {
-      referenceOperator = new PRefinementTransferOperator(*c_fespace, *f_fespace);
+      referenceOperator = new PRefinementTransferOperator(*c_fespace,
+                                                          *f_fespace);
    }
    else
    {
@@ -230,9 +223,9 @@ TEST_CASE("Transfer", "[Transfer]")
 
 TEST_CASE("Variable Order Transfer", "[Transfer][VariableOrder]")
 {
-   auto vectorspace =
-      GENERATE(VecSpace::H1, VecSpace::VectorH1nodes, VecSpace::VectorH1vdim,
-               VecSpace::ND, VecSpace::RT);
+   auto vectorspace = GENERATE(VecSpace::H1, VecSpace::VectorH1nodes,
+                               VecSpace::VectorH1vdim, VecSpace::ND,
+                               VecSpace::RT);
    dimension = GENERATE(2, 3);
 
    int ne = 2;
@@ -253,8 +246,8 @@ TEST_CASE("Variable Order Transfer", "[Transfer][VariableOrder]")
       Element::Type type = Element::HEXAHEDRON;
       mesh = Mesh::MakeCartesian3D(ne, ne, ne, type, 1.0, 1.0, 1.0);
    }
-   FiniteElementCollection *c_fec = nullptr;
-   FiniteElementCollection *f_fec = nullptr;
+   FiniteElementCollection* c_fec = nullptr;
+   FiniteElementCollection* f_fec = nullptr;
    switch (vectorspace)
    {
       case VecSpace::H1:
@@ -264,8 +257,8 @@ TEST_CASE("Variable Order Transfer", "[Transfer][VariableOrder]")
          f_fec = new H1_FECollection(order, dimension);
          break;
       case VecSpace::ND:
-         c_fec = new ND_FECollection(order + 1, dimension);
-         f_fec = new ND_FECollection(order + 1, dimension);
+         c_fec = new ND_FECollection(order+1, dimension);
+         f_fec = new ND_FECollection(order+1, dimension);
          break;
       case VecSpace::RT:
          c_fec = new RT_FECollection(order, dimension);
@@ -276,13 +269,10 @@ TEST_CASE("Variable Order Transfer", "[Transfer][VariableOrder]")
    mesh.EnsureNCMesh();
    mesh.RandomRefinement(0.5);
 
-   const int vdim = (vectorspace == VecSpace::VectorH1nodes ||
-                     vectorspace == VecSpace::VectorH1vdim)
-                    ? dimension
-                    : 1;
+   const int vdim = (vectorspace == VecSpace::VectorH1nodes
+                     || vectorspace == VecSpace::VectorH1vdim) ? dimension : 1;
    Ordering::Type ordering = (vectorspace == VecSpace::VectorH1vdim)
-                             ? Ordering::byVDIM
-                             : Ordering::byNODES;
+                             ? Ordering::byVDIM : Ordering::byNODES;
 
    FiniteElementSpace *c_fespace =
       new FiniteElementSpace(&mesh, c_fec, vdim, ordering);
@@ -291,22 +281,18 @@ TEST_CASE("Variable Order Transfer", "[Transfer][VariableOrder]")
 
    RandomPRefinement(*f_fespace);
 
-   Operator *referenceOperator = nullptr;
+   Operator* referenceOperator = nullptr;
 
-   referenceOperator = new PRefinementTransferOperator(*c_fespace, *f_fespace);
+   referenceOperator = new PRefinementTransferOperator(*c_fespace,
+                                                       *f_fespace);
 
    TransferOperator testTransferOperator(*c_fespace, *f_fespace);
-   GridFunction X(c_fespace);
-   X = 0.;
-   GridFunction X_cmp(c_fespace);
-   X_cmp = 0.;
-   GridFunction Y_exact(f_fespace);
-   Y_exact = 0.;
-   GridFunction Y_std(f_fespace);
-   Y_std = 0.;
-   GridFunction Y_test(f_fespace);
-   Y_test = 0.;
-   coeff_order = std::min(2, order);
+   GridFunction X(c_fespace); X = 0.;
+   GridFunction X_cmp(c_fespace); X_cmp = 0.;
+   GridFunction Y_exact(f_fespace); Y_exact = 0.;
+   GridFunction Y_std(f_fespace); Y_std = 0.;
+   GridFunction Y_test(f_fespace); Y_test = 0.;
+   coeff_order = std::min(2,order);
    if (vectorspace == VecSpace::H1)
    {
       FunctionCoefficient funcCoeff(&coeff);
@@ -347,8 +333,8 @@ TEST_CASE("Variable Order Transfer", "[Transfer][VariableOrder]")
 
 TEST_CASE("Variable Order True Transfer", "[Transfer][VariableOrder]")
 {
-   auto vectorspace =
-      GENERATE(VecSpace::H1, VecSpace::VectorH1nodes, VecSpace::VectorH1vdim);
+   auto vectorspace = GENERATE(VecSpace::H1, VecSpace::VectorH1nodes,
+                               VecSpace::VectorH1vdim);
    dimension = GENERATE(2, 3);
 
    int ne = 2;
@@ -374,13 +360,10 @@ TEST_CASE("Variable Order True Transfer", "[Transfer][VariableOrder]")
    f_fec = new H1_FECollection(order, dimension);
    mesh.EnsureNCMesh();
    mesh.RandomRefinement(0.5);
-   const int vdim = (vectorspace == VecSpace::VectorH1nodes ||
-                     vectorspace == VecSpace::VectorH1vdim)
-                    ? dimension
-                    : 1;
+   const int vdim = (vectorspace == VecSpace::VectorH1nodes
+                     || vectorspace == VecSpace::VectorH1vdim) ? dimension : 1;
    Ordering::Type ordering = (vectorspace == VecSpace::VectorH1vdim)
-                             ? Ordering::byVDIM
-                             : Ordering::byNODES;
+                             ? Ordering::byVDIM : Ordering::byNODES;
 
    FiniteElementSpace *c_fespace =
       new FiniteElementSpace(&mesh, c_fec, vdim, ordering);
@@ -419,11 +402,11 @@ TEST_CASE("Variable Order True Transfer", "[Transfer][VariableOrder]")
    }
    if (Rc)
    {
-      Rc->Mult(xc, Xc);
+      Rc->Mult(xc,Xc);
    }
    else
    {
-      Xc.MakeRef(xc, 0);
+      Xc.MakeRef(xc,0);
    }
    T.Mult(Xc, Xf);
 
@@ -440,9 +423,9 @@ TEST_CASE("Variable Order True Transfer", "[Transfer][VariableOrder]")
    SparseMatrix Mf;
    mf.FormSystemMatrix(empty, Mf);
 
-   Mf.Mult(Xf, Yf);
+   Mf.Mult(Xf,Yf);
 
-   T.MultTranspose(Yf, Yc);
+   T.MultTranspose(Yf,Yc);
 
    GSSmoother M(Mc);
    Diff = 0.0;
@@ -459,32 +442,37 @@ TEST_CASE("Variable Order True Transfer", "[Transfer][VariableOrder]")
 
 TEST_CASE("H1 L2 transfer with consistent mass", "[Transfer]")
 {
-   auto vectorspace = GENERATE(VecSpace::H1, VecSpace::VectorH1);
+   auto vectorspace = GENERATE(VecSpace::H1, VecSpace::VectorH1nodes,
+                               VecSpace::VectorH1vdim);
    dimension = GENERATE(2, 3);
 
    const int order = 2;
    const int ne = 2;
-   const int vdim = (vectorspace == VecSpace::VectorH1) ? dimension : 1;
+   const int vdim = (vectorspace == VecSpace::VectorH1nodes
+                     || vectorspace == VecSpace::VectorH1vdim) ? dimension : 1;
+   Ordering::Type ordering = (vectorspace == VecSpace::VectorH1vdim)
+                             ? Ordering::byVDIM : Ordering::byNODES;
 
    CAPTURE(VecSpaceName(vectorspace), dimension, order);
 
    Mesh mesh;
    if (dimension == 2)
    {
-      mesh = Mesh::MakeCartesian2D(ne, ne, Element::QUADRILATERAL, 1, 1.0, 1.0);
+      mesh = Mesh::MakeCartesian2D(ne, ne, Element::QUADRILATERAL,
+                                   1, 1.0, 1.0);
    }
    else
    {
-      mesh =
-         Mesh::MakeCartesian3D(ne, ne, ne, Element::HEXAHEDRON, 1.0, 1.0, 1.0);
+      mesh = Mesh::MakeCartesian3D(ne, ne, ne, Element::HEXAHEDRON,
+                                   1.0, 1.0, 1.0);
    }
 
    Mesh fineMesh(mesh);
    fineMesh.UniformRefinement();
 
    H1_FECollection fec(order, dimension);
-   FiniteElementSpace c_fespace(&mesh, &fec, vdim);
-   FiniteElementSpace f_fespace(&fineMesh, &fec, vdim);
+   FiniteElementSpace c_fespace(&mesh, &fec, vdim, ordering);
+   FiniteElementSpace f_fespace(&fineMesh, &fec, vdim, ordering);
 
    L2ProjectionGridTransfer transfer(c_fespace, f_fespace);
    transfer.UseConsistentMass();
@@ -539,7 +527,8 @@ TEST_CASE("H1 L2 transfer with consistent mass", "[Transfer]")
 
    const real_t ip1 = InnerProduct(Ry, y);
    const real_t ip2 = InnerProduct(x, Rtx);
-   REQUIRE(std::abs(ip1 - ip2) < 1e-10 * std::max(std::abs(ip1), std::abs(ip2)));
+   REQUIRE(std::abs(ip1 - ip2) <
+           1e-10 * std::max(std::abs(ip1), std::abs(ip2)));
 
    REQUIRE_FALSE(transfer.SupportsBackwardsOperator());
 }
@@ -547,8 +536,8 @@ TEST_CASE("H1 L2 transfer with consistent mass", "[Transfer]")
 TEST_CASE("Restriction Transpose Operator")
 {
    int order = GENERATE(1, 2);
-   auto mesh_fname =
-      GENERATE("../../data/amr-quad.mesh", "../../data/fichera-amr.mesh");
+   auto mesh_fname = GENERATE("../../data/amr-quad.mesh",
+                              "../../data/fichera-amr.mesh");
 
    Mesh mesh = Mesh::LoadFromFile(mesh_fname);
    H1_FECollection fec(order, mesh.Dimension());
@@ -579,7 +568,11 @@ TEST_CASE("Restriction Transpose Operator")
    REQUIRE(y3.Normlinf() == MFEM_Approx(0.0));
 }
 
-real_t sin_func(const Vector &x) { return sin(M_PI * x.Sum()); }
+
+real_t sin_func(const Vector &x)
+{
+   return sin(M_PI * x.Sum());
+}
 
 void sin_vfunc(const Vector &x, Vector &y)
 {
@@ -611,20 +604,20 @@ TraceCollections MakeTraceCollections(const VecSpace vectorspace,
       case VecSpace::VectorH1nodes:
       case VecSpace::VectorH1vdim:
          fec.c_fec = std::make_unique<H1_FECollection>(order, dim);
-         fec.f_fec = std::make_unique<H1_FECollection>(order + 1, dim);
+         fec.f_fec = std::make_unique<H1_FECollection>(order+1, dim);
          fec.c_trace_fec = std::make_unique<H1_Trace_FECollection>(order, dim);
-         fec.f_trace_fec = std::make_unique<H1_Trace_FECollection>(order + 1, dim);
+         fec.f_trace_fec = std::make_unique<H1_Trace_FECollection>(order+1, dim);
          break;
       case VecSpace::ND:
          fec.c_fec = std::make_unique<ND_FECollection>(order, dim);
-         fec.f_fec = std::make_unique<ND_FECollection>(order + 1, dim);
+         fec.f_fec = std::make_unique<ND_FECollection>(order+1, dim);
          fec.c_trace_fec = std::make_unique<ND_Trace_FECollection>(order, dim);
-         fec.f_trace_fec = std::make_unique<ND_Trace_FECollection>(order + 1, dim);
+         fec.f_trace_fec = std::make_unique<ND_Trace_FECollection>(order+1, dim);
          break;
       case VecSpace::RT:
-         fec.c_fec = std::make_unique<RT_FECollection>(order - 1, dim);
+         fec.c_fec = std::make_unique<RT_FECollection>(order-1, dim);
          fec.f_fec = std::make_unique<RT_FECollection>(order, dim);
-         fec.c_trace_fec = std::make_unique<RT_Trace_FECollection>(order - 1, dim);
+         fec.c_trace_fec = std::make_unique<RT_Trace_FECollection>(order-1, dim);
          fec.f_trace_fec = std::make_unique<RT_Trace_FECollection>(order, dim);
          break;
    }
@@ -632,20 +625,17 @@ TraceCollections MakeTraceCollections(const VecSpace vectorspace,
 }
 
 template <typename MeshT, typename FESpaceT, typename GridFunctionT>
-void CheckTracePRefinementTrueTransfer(MeshT &mesh, FESpaceT &c_fes,
-                                       FESpaceT &f_fes, FESpaceT &c_trace_fes,
-                                       FESpaceT &f_trace_fes,
+void CheckTracePRefinementTrueTransfer(MeshT &mesh,
+                                       FESpaceT &c_fes, FESpaceT &f_fes,
+                                       FESpaceT &c_trace_fes, FESpaceT &f_trace_fes,
                                        const VecSpace vectorspace,
-                                       const int dim, const bool assembleP)
+                                       const int dim,
+                                       const bool assembleP)
 {
-   GridFunctionT x_c(&c_fes);
-   x_c = 0.0;
-   GridFunctionT x_f(&f_fes);
-   x_f = 0.0;
-   GridFunctionT x_trace_c(&c_trace_fes);
-   x_trace_c = 0.0;
-   GridFunctionT x_trace_f(&f_trace_fes);
-   x_trace_f = 0.0;
+   GridFunctionT x_c(&c_fes); x_c = 0.0;
+   GridFunctionT x_f(&f_fes); x_f = 0.0;
+   GridFunctionT x_trace_c(&c_trace_fes); x_trace_c = 0.0;
+   GridFunctionT x_trace_f(&f_trace_fes); x_trace_f = 0.0;
 
    if (vectorspace == VecSpace::H1)
    {
@@ -703,10 +693,8 @@ void CheckTracePRefinementTrueTransfer(MeshT &mesh, FESpaceT &c_fes,
    // Embed the trace dofs to a field GridFunction for comparison
    Array<int> face_vdofs, trace_vdofs;
    Vector values;
-   GridFunctionT x_embedded_trace_c(&c_fes);
-   x_embedded_trace_c = 0.0;
-   GridFunctionT x_embedded_trace_f(&f_fes);
-   x_embedded_trace_f = 0.0;
+   GridFunctionT x_embedded_trace_c(&c_fes); x_embedded_trace_c = 0.0;
+   GridFunctionT x_embedded_trace_f(&f_fes); x_embedded_trace_f = 0.0;
    for (int i = 0; i < mesh.GetNumFaces(); i++)
    {
       c_trace_fes.GetFaceVDofs(i, trace_vdofs);
@@ -726,23 +714,24 @@ void CheckTracePRefinementTrueTransfer(MeshT &mesh, FESpaceT &c_fes,
    REQUIRE(x_embedded_trace_f.Norml2() == MFEM_Approx(0.0));
 }
 
-}  // namespace
+} // namespace
+
 
 TEST_CASE("Trace PRefinement Serial TrueTransfer", "[Transfer]")
 {
    auto simplex = GENERATE(true, false);
    dimension = GENERATE(2, 3);
    constexpr int ne = 4;
-   auto order = GENERATE(1, 2, 3);
-   auto vectorspace =
-      GENERATE(VecSpace::H1, VecSpace::VectorH1nodes, VecSpace::VectorH1vdim,
-               VecSpace::ND, VecSpace::RT);
+   auto order = GENERATE(1,2,3);
+   auto vectorspace = GENERATE(VecSpace::H1, VecSpace::VectorH1nodes,
+                               VecSpace::VectorH1vdim,
+                               VecSpace::ND,VecSpace::RT);
    auto assembleP = GENERATE(false, true);
    auto amr = GENERATE(false, true);
 
    // Log test case information
    const int total_ne = static_cast<int>(std::pow(ne, dimension));
-   CAPTURE(VecSpaceName(vectorspace), dimension, simplex, total_ne, order,
+   CAPTURE(VecSpaceName(vectorspace),dimension, simplex, total_ne, order,
            assembleP);
 
    Mesh mesh;
@@ -757,20 +746,14 @@ TEST_CASE("Trace PRefinement Serial TrueTransfer", "[Transfer]")
       mesh = Mesh::MakeCartesian3D(ne, ne, ne, type, 1.0, 1.0, 1.0);
    }
 
-   if (amr)
-   {
-      mesh.RandomRefinement(0.5);
-   }
+   if (amr) { mesh.RandomRefinement(0.5); }
 
    auto fec = MakeTraceCollections(vectorspace, order, dimension);
 
-   const int vdim = (vectorspace == VecSpace::VectorH1nodes ||
-                     vectorspace == VecSpace::VectorH1vdim)
-                    ? dimension
-                    : 1;
+   const int vdim = (vectorspace == VecSpace::VectorH1nodes
+                     || vectorspace == VecSpace::VectorH1vdim) ? dimension : 1;
    Ordering::Type ordering = (vectorspace == VecSpace::VectorH1vdim)
-                             ? Ordering::byVDIM
-                             : Ordering::byNODES;
+                             ? Ordering::byVDIM : Ordering::byNODES;
 
    FiniteElementSpace c_fes(&mesh, fec.c_fec.get(), vdim, ordering);
    FiniteElementSpace f_fes(&mesh, fec.f_fec.get(), vdim, ordering);
@@ -781,6 +764,7 @@ TEST_CASE("Trace PRefinement Serial TrueTransfer", "[Transfer]")
       mesh, c_fes, f_fes, c_trace_fes, f_trace_fes, vectorspace, dimension,
       assembleP);
 }
+
 
 #ifdef MFEM_USE_MPI
 
@@ -828,9 +812,10 @@ TEST_CASE("Parallel Transfer", "[Transfer][Parallel]")
       pfineMesh.UniformRefinement();
    }
 
-   FiniteElementCollection *c_h1_fec = new H1_FECollection(order, dimension);
-   FiniteElementCollection *f_h1_fec =
-      geometric ? c_h1_fec : new H1_FECollection(fineOrder, dimension);
+   FiniteElementCollection *c_h1_fec =
+      new H1_FECollection(order, dimension);
+   FiniteElementCollection *f_h1_fec = geometric ? c_h1_fec : new
+                                       H1_FECollection(fineOrder, dimension);
 
    constexpr int vdim = 1;
 
@@ -838,13 +823,13 @@ TEST_CASE("Parallel Transfer", "[Transfer][Parallel]")
 
    // Compute reference values in serial
    {
-      FiniteElementSpace *c_h1_fespace =
-         new FiniteElementSpace(&mesh, c_h1_fec, vdim);
-      FiniteElementSpace *f_h1_fespace =
-         new FiniteElementSpace(&fineMesh, f_h1_fec, vdim);
+      FiniteElementSpace* c_h1_fespace = new FiniteElementSpace(&mesh, c_h1_fec,
+                                                                vdim);
+      FiniteElementSpace* f_h1_fespace = new FiniteElementSpace(&fineMesh,
+                                                                f_h1_fec, vdim);
 
-      Operator *transferOperator =
-         new TransferOperator(*c_h1_fespace, *f_h1_fespace);
+      Operator* transferOperator = new TransferOperator(*c_h1_fespace,
+                                                        *f_h1_fespace);
       GridFunction X(c_h1_fespace);
       GridFunction Y(f_h1_fespace);
 
@@ -861,13 +846,15 @@ TEST_CASE("Parallel Transfer", "[Transfer][Parallel]")
       delete c_h1_fespace;
    }
 
-   ParFiniteElementSpace *c_h1_fespace =
-      new ParFiniteElementSpace(pmesh, c_h1_fec, vdim);
-   ParFiniteElementSpace *f_h1_fespace =
-      new ParFiniteElementSpace(&pfineMesh, f_h1_fec, vdim);
+   ParFiniteElementSpace* c_h1_fespace = new ParFiniteElementSpace(pmesh,
+                                                                   c_h1_fec,
+                                                                   vdim);
+   ParFiniteElementSpace* f_h1_fespace = new ParFiniteElementSpace(&pfineMesh,
+                                                                   f_h1_fec,
+                                                                   vdim);
 
-   Operator *transferOperator =
-      new TrueTransferOperator(*c_h1_fespace, *f_h1_fespace);
+   Operator* transferOperator = new TrueTransferOperator(*c_h1_fespace,
+                                                         *f_h1_fespace);
    ParGridFunction X(c_h1_fespace);
    ParGridFunction Y_exact(f_h1_fespace);
    ParGridFunction Y(f_h1_fespace);
@@ -890,85 +877,17 @@ TEST_CASE("Parallel Transfer", "[Transfer][Parallel]")
    f_h1_fespace->GetRestrictionMatrix()->Mult(Y_exact, Y_true);
    transferOperator->MultTranspose(Y_true, X_true);
 
-   double restrictionValue =
-      std::sqrt(InnerProduct(MPI_COMM_WORLD, X_true, X_true));
-   REQUIRE(std::abs(restrictionValue - referenceRestrictionValue) <
-           1e-12 * std::abs(referenceRestrictionValue));
+   double restrictionValue = std::sqrt(InnerProduct(MPI_COMM_WORLD, X_true,
+                                                    X_true));
+   REQUIRE(std::abs(restrictionValue - referenceRestrictionValue) < 1e-12 *
+           std::abs(referenceRestrictionValue));
 
    delete transferOperator;
    delete f_h1_fespace;
    delete c_h1_fespace;
-   if (!geometric)
-   {
-      delete f_h1_fec;
-   }
+   if (!geometric) { delete f_h1_fec; }
    delete c_h1_fec;
    delete pmesh;
-}
-
-TEST_CASE("Trace PRefinement Parallel TrueTransfer", "[Transfer][Parallel]")
-{
-   auto simplex = GENERATE(true, false);
-   dimension = GENERATE(2, 3);
-   constexpr int ne = 4;
-   auto order = GENERATE(1, 2, 3);
-   auto vectorspace =
-      GENERATE(VecSpace::H1, VecSpace::VectorH1nodes, VecSpace::VectorH1vdim,
-               VecSpace::ND, VecSpace::RT);
-   auto assembleP = GENERATE(true, false);
-
-   auto amr = GENERATE(true, false);
-
-   // Log test case information
-   const int total_ne = static_cast<int>(std::pow(ne, dimension));
-   CAPTURE(VecSpaceName(vectorspace), dimension, simplex, total_ne, order,
-           assembleP);
-
-   Mesh mesh;
-   if (dimension == 2)
-   {
-      Element::Type type = simplex ? Element::TRIANGLE : Element::QUADRILATERAL;
-      mesh = Mesh::MakeCartesian2D(ne, ne, type, 1, 1.0, 1.0);
-   }
-   else
-   {
-      Element::Type type = simplex ? Element::TETRAHEDRON : Element::HEXAHEDRON;
-      mesh = Mesh::MakeCartesian3D(ne, ne, ne, type, 1.0, 1.0, 1.0);
-   }
-
-   if (amr)
-   {
-      mesh.EnsureNCMesh(true);
-   }
-
-   ParMesh pmesh(MPI_COMM_WORLD, mesh);
-
-   if (amr)
-   {
-      pmesh.RandomRefinement(0.5);
-   }
-
-   auto fec = MakeTraceCollections(vectorspace, order, dimension);
-
-   const int vdim = (vectorspace == VecSpace::VectorH1nodes ||
-                     vectorspace == VecSpace::VectorH1vdim)
-                    ? dimension
-                    : 1;
-   Ordering::Type ordering = (vectorspace == VecSpace::VectorH1vdim)
-                             ? Ordering::byVDIM
-                             : Ordering::byNODES;
-
-   ParFiniteElementSpace c_fes(&pmesh, fec.c_fec.get(), vdim, ordering);
-   ParFiniteElementSpace f_fes(&pmesh, fec.f_fec.get(), vdim, ordering);
-   ParFiniteElementSpace c_trace_fes(&pmesh, fec.c_trace_fec.get(), vdim,
-                                     ordering);
-   ParFiniteElementSpace f_trace_fes(&pmesh, fec.f_trace_fec.get(), vdim,
-                                     ordering);
-
-   CheckTracePRefinementTrueTransfer<ParMesh, ParFiniteElementSpace,
-                                     ParGridFunction>(
-                                        pmesh, c_fes, f_fes, c_trace_fes, f_trace_fes, vectorspace, dimension,
-                                        assembleP);
 }
 
 TEST_CASE("Parallel H1 L2 transfer with consistent mass",
@@ -985,12 +904,13 @@ TEST_CASE("Parallel H1 L2 transfer with consistent mass",
    Mesh mesh;
    if (dimension == 2)
    {
-      mesh = Mesh::MakeCartesian2D(ne, ne, Element::QUADRILATERAL, 1, 1.0, 1.0);
+      mesh = Mesh::MakeCartesian2D(ne, ne, Element::QUADRILATERAL,
+                                   1, 1.0, 1.0);
    }
    else
    {
-      mesh =
-         Mesh::MakeCartesian3D(ne, ne, ne, Element::HEXAHEDRON, 1.0, 1.0, 1.0);
+      mesh = Mesh::MakeCartesian3D(ne, ne, ne, Element::HEXAHEDRON,
+                                   1.0, 1.0, 1.0);
    }
 
    ParMesh pmesh(MPI_COMM_WORLD, mesh);
@@ -1017,9 +937,68 @@ TEST_CASE("Parallel H1 L2 transfer with consistent mass",
 
    const real_t ip1 = InnerProduct(MPI_COMM_WORLD, Rx, y);
    const real_t ip2 = InnerProduct(MPI_COMM_WORLD, x, Rty);
-   REQUIRE(std::abs(ip1 - ip2) < 1e-10 * std::max(std::abs(ip1), std::abs(ip2)));
+   REQUIRE(std::abs(ip1 - ip2) <
+           1e-10 * std::max(std::abs(ip1), std::abs(ip2)));
 
    REQUIRE_FALSE(transfer.SupportsBackwardsOperator());
 }
+
+TEST_CASE("Trace PRefinement Parallel TrueTransfer", "[Transfer][Parallel]")
+{
+   auto simplex = GENERATE(true, false);
+   dimension = GENERATE(2, 3);
+   constexpr int ne = 4;
+   auto order = GENERATE(1,2,3);
+   auto vectorspace = GENERATE(VecSpace::H1, VecSpace::VectorH1nodes,
+                               VecSpace::VectorH1vdim,
+                               VecSpace::ND,VecSpace::RT);
+   auto assembleP = GENERATE(true, false);
+
+   auto amr = GENERATE(true, false);
+
+   // Log test case information
+   const int total_ne = static_cast<int>(std::pow(ne, dimension));
+   CAPTURE(VecSpaceName(vectorspace),dimension, simplex, total_ne, order,
+           assembleP);
+
+   Mesh mesh;
+   if (dimension == 2)
+   {
+      Element::Type type = simplex ? Element::TRIANGLE : Element::QUADRILATERAL;
+      mesh = Mesh::MakeCartesian2D(ne, ne, type, 1, 1.0, 1.0);
+   }
+   else
+   {
+      Element::Type type = simplex ? Element::TETRAHEDRON : Element::HEXAHEDRON;
+      mesh = Mesh::MakeCartesian3D(ne, ne, ne, type, 1.0, 1.0, 1.0);
+   }
+
+   if (amr) { mesh.EnsureNCMesh(true); }
+
+   ParMesh pmesh(MPI_COMM_WORLD, mesh);
+
+   if (amr) { pmesh.RandomRefinement(0.5); }
+
+   auto fec = MakeTraceCollections(vectorspace, order, dimension);
+
+   const int vdim = (vectorspace == VecSpace::VectorH1nodes
+                     || vectorspace == VecSpace::VectorH1vdim) ? dimension : 1;
+   Ordering::Type ordering = (vectorspace == VecSpace::VectorH1vdim)
+                             ? Ordering::byVDIM : Ordering::byNODES;
+
+   ParFiniteElementSpace c_fes(&pmesh, fec.c_fec.get(), vdim, ordering);
+   ParFiniteElementSpace f_fes(&pmesh, fec.f_fec.get(), vdim, ordering);
+   ParFiniteElementSpace c_trace_fes(&pmesh, fec.c_trace_fec.get(), vdim,
+                                     ordering);
+   ParFiniteElementSpace f_trace_fes(&pmesh, fec.f_trace_fec.get(), vdim,
+                                     ordering);
+
+   CheckTracePRefinementTrueTransfer<ParMesh, ParFiniteElementSpace, ParGridFunction>
+   (
+      pmesh, c_fes, f_fes, c_trace_fes, f_trace_fes, vectorspace, dimension,
+      assembleP);
+}
+
+
 
 #endif


### PR DESCRIPTION
 - Adds `L2ProjectionGridTransfer::UseConsistentMass()` for H1 non-EA transfer, enabling forward `Mult()`/`MultTranspose()` to use the consistent low-order mass matrix instead of the lumped row-sum mass matrix.
 - Implements the consistent-mass forward operator as $M_L^{-1} M_{LH}$, storing $M_L$, $M_{LH}$, and a PCG solve rather than precomputing $R$; serial uses `DSmoother`, and parallel uses `HyprePCG` with hypre diagonal scaling.
 - Keeps `BackwardOperator()` unsupported for the consistent-mass H1 path, with `SupportsBackwardsOperator()` reporting false and `Prolongate()`/`ProlongateTranspose()` guarded accordingly.
 - Updates sparse assembly helper logic so `ComputeSparseRAndM_LH()` can build only $M_{LH}$ when the lumped $R$ matrix is not needed.
 - Adds serial and parallel unit tests for the consistent-mass H1 transfer, including a serial reference mass solve and `Mult()`/`MultTranspose()` adjoint checks.
<!--GHEX{"author":"ebchin","assignment":"2026-06-24T00:16:19","editor":"tzanio","id":5368,"reviewers":["artv3","helloworld922","pazner"],"merge":"2026-07-15T00:16:19","approval":"2026-07-08T00:16:19"}XEHG-->
<!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge|
 | --- | --- | --- | --- | --- | --- | --- |
| [#5368](https://github.com/mfem/mfem/pull/5368) | @ebchin | @tzanio | @artv3 + @helloworld922 + @pazner | 6/23/26 | ⌛due 7/7/26 | ⌛due 7/14/26 | |
<!--ELBATXEHG-->
<details>
<summary>PR Checklist</summary>
    
- [ ] Code builds.
- [ ] Code passes `make style`.
- [ ] Update `CHANGELOG`:
    - [ ] Is this a new feature users need to be aware of? New or updated example or miniapp?
    - [ ] Does it make sense to create a new section in the `CHANGELOG` to group with other related features?
- [ ] Update `INSTALL`:
    - [ ] Had a new optional library been added? If so, what range of versions of this library are required? (*Make sure the external library is compatible with our BSD license, e.g. it is not licensed under GPL!*)
    - [ ] Have the version ranges for any required or optional libraries changed?
    - [ ] Does `make` or `cmake` have a new target?
    - [ ] Did the requirements or the installation process change? *(rare)*
- [ ] Update continuous integration server configurations if necessary (e.g. with new version requirements for each of MFEM's dependencies)
    - [ ] `.github`
    - [ ] `.appveyor.yml`
- [ ] Update `.gitignore`:
    - [ ] Check if `make distclean; git status` shows any files that were generated from the source by the project (not an IDE) but we don't want to track in the repository.
    - [ ] Add new patterns (just for the new files above) and re-run the above test.
- [ ] New examples:
    - [ ] All sample runs at the top of the example source file work.
    - [ ] Update `examples/makefile`:
      - [ ] Add the example code to the appropriate `SEQ_EXAMPLES` and `PAR_EXAMPLES` variables.
      - [ ] Add any files generated by it to the `clean` target.
      - [ ] Add the example binary and any files generated by it to the top-level `.gitignore` file.
    - [ ] Update `examples/CMakeLists.txt`:
      - [ ] Add the example code to the `ALL_EXE_SRCS` variable.
      - [ ] Make sure `THIS_TEST_OPTIONS` is set correctly for the new example.
   - [ ] List the new example in `doc/CodeDocumentation.dox`.
   - [ ] If new examples directory (e.g.`examples/pumi`), list it in `doc/CodeDocumentation.conf.in`
   - [ ] Companion pull request for documentation in [mfem/web](https://github.com/mfem/web) repo:
      - [ ] Update or add example-specific documentation, see e.g. the `src/examples.md`.
      - [ ] Add the description, labels and screenshots in `src/examples.md` and `src/img`.
      - [ ] In `examples.md`, list the example under the appropriate categories, add new categories if necessary.
      - [ ] Add a short description of the example in the "Extensive Examples" section of `features.md`.
- [ ] New miniapps:
   - [ ] All sample runs at the top of the miniapp source file work.
   - [ ] Update top-level `makefile` and `makefile` in corresponding miniapp directory.
   - [ ] Add the miniapp binary and any files generated by it to the top-level `.gitignore` file.
   - [ ] Update CMake build system:
      - [ ] Update the `CMakeLists.txt` file in the `miniapps` directory, if the new miniapp is in a new directory.
      - [ ] Add/update the `CMakeLists.txt` file in the new miniapp directory.
      - [ ] Consider adding a new test for the new miniapp.
   - [ ] List the new miniapp in `doc/CodeDocumentation.dox`
   - [ ] If new miniapps directory (e.g.`miniapps/nurbs`), add it to `MINIAPP_SUBDIRS` in the `makefile`.
   - [ ] If new miniapps directory (e.g.`miniapps/nurbs`), list it in `doc/CodeDocumentation.conf.in`
   - [ ] Companion pull request for documentation in [mfem/web](https://github.com/mfem/web) repo:
     - [ ] Update or add miniapp-specific documentation, see e.g. the `src/meshing.md` and `src/electromagnetics.md` files.
     - [ ] Add the description, labels and screenshots in `src/examples.md` and `src/img`.
     - [ ] The miniapps go at the end of the page, and are usually listed only under a specific "Application (PDE)" category.
     - [ ] Add a short description of the miniapp in the "Extensive Examples" section of `features.md`.
- [ ] New capability:
   - [ ] All new public, protected, and private classes, methods, data members, and functions have full Doxygen-style documentation in source comments. Documentation should include descriptions of member data, function arguments and return values, template parameters, and prerequisites for calling new functions.
   - [ ] Pointer arguments and return values must specify whether ownership is being transferred or lent with the call.
   - [ ] Any new functions should include descriptions of their intended use e.g. for internal use only, user-facing, etc., along with references to example code whenever possible/appropriate.
   - [ ] Consider adding new sample runs in existing examples to highlight the new capability.
   - [ ] Consider saving cool simulation pictures with the new capability in the Confluence gallery (LLNL only) or submitting them, via pull request, to the gallery section of the `mfem/web` repo.
   - [ ] If this is a major new feature, consider mentioning it in the short summary inside `README` *(rare)*.
   - [ ] List major new classes in `doc/CodeDocumentation.dox` *(rare)*.
- [ ] Update this checklist, if the new pull request affects it.
- [ ] Run `make unittest` to make sure all unit tests pass.
- [ ] Run the tests in `tests/scripts`.
- [ ] (LLNL only) After merging:
   - [ ] Update internal tests to include the new features.
</details>
