### PR TITLE
Fix cuDSS build for mpich

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -86,6 +86,11 @@ Miscellaneous
   using the new method ApplyDofSigns() in class ParFiniteElementSpace: the
   method will return immediately if no sign flips are needed.
 
+- Fixed the cuDSS build to select the communication layer matching the linked
+  MPI implementation instead of always using the Open MPI layer. MPICH builds
+  previously failed at CuDSSSolver construction with cudssSetCommLayer returning
+  CUDSS_STATUS_INVALID_VALUE.
+
 
 Version 4.9, released on Dec 11, 2025
 =====================================

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -320,6 +320,37 @@ endif()
 if (MFEM_USE_MPI)
   find_package(MPI REQUIRED)
   set(MPI_CXX_INCLUDE_DIRS ${MPI_CXX_INCLUDE_PATH})
+  # Detect the MPI implementation (vendor) once, for downstream code that needs
+  # implementation-specific handling (e.g. cuDSS ships a prebuilt communication
+  # layer for Open MPI only). Open MPI defines OMPI_MAJOR_VERSION and the MPICH
+  # family (MPICH, Intel MPI, MVAPICH, Cray MPICH) defines MPICH_VERSION in
+  # mpi.h. Results are cached in MFEM_MPI_IS_OPENMPI and MFEM_MPI_IS_MPICH for
+  # reuse by any Find module or feature below.
+  include(CheckCXXSourceCompiles)
+  set(_mfem_mpi_req_incl_save "${CMAKE_REQUIRED_INCLUDES}")
+  list(APPEND CMAKE_REQUIRED_INCLUDES ${MPI_CXX_INCLUDE_DIRS})
+  check_cxx_source_compiles("
+#include <mpi.h>
+#ifndef OMPI_MAJOR_VERSION
+#error MPI implementation is not Open MPI.
+#endif
+int main() { return 0; }
+" MFEM_MPI_IS_OPENMPI)
+  check_cxx_source_compiles("
+#include <mpi.h>
+#ifndef MPICH_VERSION
+#error MPI implementation is not MPICH.
+#endif
+int main() { return 0; }
+" MFEM_MPI_IS_MPICH)
+  set(CMAKE_REQUIRED_INCLUDES "${_mfem_mpi_req_incl_save}")
+  if (MFEM_MPI_IS_OPENMPI)
+    message(STATUS "MPI implementation: Open MPI")
+  elseif (MFEM_MPI_IS_MPICH)
+    message(STATUS "MPI implementation: MPICH-family")
+  else()
+    message(STATUS "MPI implementation: unrecognized")
+  endif()
   if (MFEM_MPIEXEC)
     string(REPLACE " " ";" MPIEXEC ${MFEM_MPIEXEC})
   endif()

--- a/config/cmake/modules/FindCUDSS.cmake
+++ b/config/cmake/modules/FindCUDSS.cmake
@@ -49,20 +49,53 @@ if (MFEM_USE_OPENMP)
   message(STATUS "CUDSS threading layer library: ${MFEM_CUDSS_THREADING_LIB}")
 endif()
 
-# Set the full name of the cuDSS communication library if MFEM use OpenMPI.
-# The communication layer library (libcudss_commlayer_mpi.so) is located under the
-# cuDSS library directory by default.
-# The communication layer library is used pre-built communication layers for OpenMPI 
-# by default.
+# Set the full name of the cuDSS communication layer library when MFEM is built
+# with MPI. cuDSS requires a communication layer that matches the MPI
+# implementation MFEM is linked against, so we must not bake in a layer for the
+# wrong implementation. NVIDIA ships a prebuilt layer for Open MPI
+# (libcudss_commlayer_openmpi.so), which we locate automatically. For other
+# implementations (e.g. MPICH) no prebuilt layer is shipped: a matching layer
+# must be built (see cuDSS's cudss_build_commlayer.sh) and its path supplied via
+# the CUDSS_COMM_LIB environment variable at runtime. These layers live under
+# the cuDSS library directory by default.
 if (MFEM_USE_MPI)
-  find_file(
-    CUDSS_COMM_LIB
-    NAMES libcudss_commlayer_openmpi.so
-    PATHS ${CUDSS_LIBRARY_DIR}
-    NO_DEFAULT_PATH
-  )
+  # cuDSS requires a communication layer matching the MPI implementation. Use
+  # the vendor detected during MPI setup (MFEM_MPI_IS_MPICH). We only deviate
+  # from the prebuilt Open MPI layer when the MPI is positively identified as
+  # MPICH-family, so the previous behavior is preserved when the vendor cannot
+  # be determined.
+  if (MFEM_MPI_IS_MPICH)
+    # MPICH-family MPI: NVIDIA does not ship a prebuilt layer. Use a user-built
+    # layer if one has been installed alongside cuDSS; otherwise leave
+    # MFEM_CUDSS_COMM_LIB unset and rely on the CUDSS_COMM_LIB environment
+    # variable at runtime.
+    find_file(
+      CUDSS_COMM_LIB
+      NAMES libcudss_commlayer_mpich.so libcudss_commlayer_mpi.so
+      PATHS ${CUDSS_LIBRARY_DIR}
+      NO_DEFAULT_PATH
+    )
+  else()
+    # Open MPI (or an undetermined implementation): use the prebuilt Open MPI
+    # communication layer shipped with cuDSS.
+    find_file(
+      CUDSS_COMM_LIB
+      NAMES libcudss_commlayer_openmpi.so
+      PATHS ${CUDSS_LIBRARY_DIR}
+      NO_DEFAULT_PATH
+    )
+  endif()
+
   if (NOT DEFINED MFEM_CUDSS_COMM_LIB AND CUDSS_COMM_LIB)
     set(MFEM_CUDSS_COMM_LIB "${CUDSS_COMM_LIB}")
   endif()
-  message(STATUS "CUDSS communication layer library: ${MFEM_CUDSS_COMM_LIB}")
+
+  if (MFEM_CUDSS_COMM_LIB)
+    message(STATUS "CUDSS communication layer library: ${MFEM_CUDSS_COMM_LIB}")
+  else()
+    message(STATUS
+      "CUDSS communication layer library not found for the detected MPI "
+      "implementation; set the CUDSS_COMM_LIB environment variable at runtime to "
+      "a layer matching your MPI (see cuDSS's cudss_build_commlayer.sh).")
+  endif()
 endif()

--- a/config/defaults.mk
+++ b/config/defaults.mk
@@ -376,9 +376,18 @@ CUDSS_LIBRARY_DIR = $(CUDSS_DIR)/lib
 CUDSS_OPT         = -I$(CUDSS_INCLUDE_DIR)
 CUDSS_LIB         = \
  $(XLINKER)-rpath,$(CUDSS_LIBRARY_DIR) -L$(CUDSS_LIBRARY_DIR) -lcudss
-# The cuDSS communication and threading libraries. 
+# The cuDSS communication and threading libraries.
+# NVIDIA ships a prebuilt cuDSS communication layer for Open MPI only, and cuDSS
+# requires a layer matching the MPI implementation. Detect MPICH-family MPI
+# (MPICH, Intel MPI, MVAPICH, Cray MPICH all define MPICH_VERSION in mpi.h) so
+# we do not bake in the Open MPI layer for a non-Open MPI build. This mirrors
+# the CMake MFEM_MPI_IS_MPICH detection and is evaluated lazily, i.e. only when
+# MFEM_CUDSS_COMM_LIB is expanded (cuDSS builds). For MPICH-family MPI, build a
+# matching layer (see cuDSS's cudss_build_commlayer.sh) and set CUDSS_COMM_LIB.
+MFEM_MPI_IS_MPICH = $(shell $(MPICXX) -E -dM -include mpi.h -x c++ /dev/null 2>/dev/null | grep -c 'define MPICH_VERSION')
 MFEM_CUDSS_COMM_LIB = $(abspath $(wildcard $(or $(CUDSS_COMM_LIB),\
-   $(subst @MFEM_DIR@,$(MFEM_DIR), $(CUDSS_LIBRARY_DIR)/libcudss_commlayer_openmpi.so))))
+   $(if $(filter-out 0,$(MFEM_MPI_IS_MPICH)),,\
+   $(subst @MFEM_DIR@,$(MFEM_DIR), $(CUDSS_LIBRARY_DIR)/libcudss_commlayer_openmpi.so)))))
 MFEM_CUDSS_THREADING_LIB = $(abspath $(wildcard $(or $(CUDSS_THREADING_LIB),\
    $(subst @MFEM_DIR@,$(MFEM_DIR),$(CUDSS_LIBRARY_DIR)/libcudss_mtlayer_gomp.so))))
 


### PR DESCRIPTION
The cuDSS build always baked in the prebuilt Open MPI communication layer (`libcudss_commlayer_openmpi.so`) whenever MPI was enabled, regardless of the linked MPI. cuDSS needs a layer matching the MPI, so MPICH builds pick up the Open MPI layer and abort in `CuDSSSolver::CuDSSSolver(MPI_Comm)` with `cudssSetCommLayer` returning `CUDSS_STATUS_INVALID_VALUE`.

Detect the MPI at configure time (`MFEM_MPI_IS_OPENMPI` / `MFEM_MPI_IS_MPICH`, from the `OMPI_MAJOR_VERSION` / `MPICH_VERSION` macros, same `check_cxx_source_compiles` pattern as `FindHYPRE`) and only use the Open MPI layer when the MPI isn't MPICH-family. NVIDIA ships a prebuilt layer for Open MPI only, so for MPICH we look for a user-built one and otherwise leave `MFEM_CUDSS_COMM_LIB` unset, deferring to the `CUDSS_COMM_LIB` env var (buildable via cuDSS's `cudss_build_commlayer.sh`). We only deviate from the Open MPI default on a positive MPICH match, so Open MPI builds are unchanged, and an explicit `CUDSS_COMM_LIB` still wins. `config/defaults.mk` mirrors this for the Make build.

Validation: configured/built with CUDA 13.1 + cuDSS 0.7.1 against Open MPI 5.0 and MPICH 5.0, both CMake and Make. Open MPI bakes the layer as before; MPICH leaves it unset (or honors `CUDSS_COMM_LIB`). `CuDSSSolver` constructs and solves under MPICH with a matching layer, where it previously aborted.
