### PR TITLE
NURBS HO to Linear  interpolation

### DIFF
--- a/fem/fespace.cpp
+++ b/fem/fespace.cpp
@@ -2378,6 +2378,45 @@ void FiniteElementSpace::DerefinementOperator::Mult(const Vector &x,
    }
 }
 
+FiniteElementSpace::GlobalDerefinementOperator::GlobalDerefinementOperator(
+   FiniteElementSpace *f_fes, FiniteElementSpace *c_fes,
+   BilinearFormIntegrator *m_integ, const Operator *ForwardOperator)
+   : Operator(c_fes->GetVSize(), f_fes->GetVSize()),
+     fine_fes(f_fes), F(ForwardOperator)
+{
+   MFEM_VERIFY(F->Width() <= F->Height(),
+               "Forward operator needs full column rank.");
+   MFEM_ASSERT(F->Width() == c_fes->GetVSize(),
+               "Forward operator width does not match input space.");
+   MFEM_ASSERT(F->Height() == f_fes->GetVSize(),
+               "Forward operator height.does not match input space.");
+
+   // Fine scale mass matrix
+   a_f = new BilinearForm(fine_fes);
+   a_f->AddDomainIntegrator(m_integ);
+   a_f->Assemble();
+   a_f->Finalize();
+
+   // Galerkin projection of fine scale mass matrix
+   FTM = new ProductOperator(new TransposeOperator(F), &a_f->SpMat(), true, false);
+   FTMF = new ProductOperator(FTM, F, false, false);
+   b.SetSize(c_fes->GetVSize());
+}
+
+FiniteElementSpace::GlobalDerefinementOperator::~GlobalDerefinementOperator()
+{
+   delete a_f;
+   delete FTM;
+   delete FTMF;
+}
+
+void FiniteElementSpace::GlobalDerefinementOperator::Mult(const Vector &x,
+                                                          Vector &y) const
+{
+   FTM->Mult(x, b);
+   CG(*FTMF, b, y, 2, 1400, 1e-24, 0.0);
+}
+
 void FiniteElementSpace::GetLocalDerefinementMatrices(Geometry::Type geom,
                                                       DenseTensor &localR) const
 {
@@ -2499,6 +2538,66 @@ SparseMatrix* FiniteElementSpace::DerefinementMatrix(int old_ndofs,
 
    R->Finalize(); // no-op if fixed width
    return R;
+}
+
+
+SparseMatrix* FiniteElementSpace::NURBSInterpolationMatrix(
+   FiniteElementSpace *lo, NURBSPointSet pSet)
+{
+   NURBSExtension *ho_ext = NURBSext;
+   NURBSExtension *lo_ext = lo->NURBSext;
+
+   MFEM_VERIFY(ho_ext, "First argument must be a NURBS mesh.")
+   MFEM_VERIFY(lo_ext, "Second argument must be a NURBS mesh.")
+   MFEM_VERIFY(lo_ext->GetNP() == ho_ext->GetNP(), "Patch count must match.")
+
+   int NP = lo_ext->GetNP();
+
+   SparseMatrix *Pi = new SparseMatrix(lo_ext->GetNDof(), ho_ext->GetNDof());
+
+   Array<NURBSPatch*> ho_patches(NP);
+   Array<NURBSPatch*> lo_patches(NP);
+
+   ho_ext->CreatePatches();
+   lo_ext->CreatePatches();
+
+   ho_ext->GetPatches(ho_patches);
+   lo_ext->GetPatches(lo_patches);
+
+   ho_ext->DeletePatches();
+   lo_ext->DeletePatches();
+
+   Array<int> ho_dofs;
+   Array<int> lo_dofs;
+   for (int p = 0; p < NP; p++)
+   {
+      int ho_NCP = ho_patches[p]->GetNCP();
+      int lo_NCP = lo_patches[p]->GetNCP();
+
+      SparseMatrix smat(lo_NCP, ho_NCP);
+      SparseMatrix imat(lo_NCP, lo_NCP);
+
+      Array<Vector *> uknot(lo_patches[p]->GetNKV());
+      lo_patches[p]->GetPoints(uknot, pSet);
+
+      ho_patches[p]->GetInterpolationMatrix(uknot, smat);
+      // For now assume the lo space is linear
+      //lo_patches[p]->GetInterpolationMatrix(uknot, imat);
+      //lo_patches[p]->GetInverseInterpolationMatrix(uknot, imat);
+
+      ho_ext->GetPatchDofs(p, ho_dofs);
+      lo_ext->GetPatchDofs(p, lo_dofs);
+
+      // Set contributions in the global matrix - apply dof ordering
+      Pi->SetSubMatrix(lo_dofs, ho_dofs, smat);
+
+      for (int d = 0; d < uknot.Size(); d++) { delete uknot[d]; }
+      delete lo_patches[p];
+      delete ho_patches[p];
+   }
+
+   Pi->Finalize();
+   return Pi;
 }
 
 void FiniteElementSpace::GetLocalRefinementMatrices(

--- a/fem/fespace.hpp
+++ b/fem/fespace.hpp
@@ -532,6 +532,30 @@ protected:
       virtual ~DerefinementOperator();
    };
 
+   /// Derefinement operator, used by the friend class InterpolationGridTransfer.
+   class GlobalDerefinementOperator : public Operator
+   {
+      // Not owned.
+      FiniteElementSpace *fine_fes;
+      // FiniteElementSpace *coarse_fes;
+      // const BilinearFormIntegrator *mass_integ;
+      const Operator *F;
+
+      // Owned
+      BilinearForm *a_f;
+      Operator *FTM, *FTMF;
+
+      // Temp
+      mutable Vector b;
+   public:
+      GlobalDerefinementOperator(FiniteElementSpace *f_fes,
+                                 FiniteElementSpace *c_fes,
+                                 BilinearFormIntegrator *mass_integ,
+                                 const Operator *ForwardOperator);
+      void Mult(const Vector &x, Vector &y) const override;
+      virtual ~GlobalDerefinementOperator();
+   };
+
    /** This method makes the same assumptions as the method:
        void GetLocalRefinementMatrices(
            const FiniteElementSpace &coarse_fes, Geometry::Type geom,
@@ -562,6 +586,9 @@ protected:
    /// Calculate GridFunction restriction matrix after mesh derefinement.
    SparseMatrix* DerefinementMatrix(int old_ndofs, const Table* old_elem_dof,
                                     const Table* old_elem_fos);
+
+   virtual SparseMatrix* NURBSInterpolationMatrix(FiniteElementSpace *lo,
+                                                  NURBSPointSet pSet);
 
    /** @brief Return in @a localP the local refinement matrices that map
        between fespaces after mesh refinement. */

--- a/fem/lor/lor.cpp
+++ b/fem/lor/lor.cpp
@@ -77,6 +77,7 @@ LORBase::FESpaceType LORBase::GetFESpaceType() const
    else if (dynamic_cast<const ND_FECollection*>(fec_ho)) { return ND; }
    else if (dynamic_cast<const RT_FECollection*>(fec_ho)) { return RT; }
    else if (dynamic_cast<const L2_FECollection*>(fec_ho)) { return L2; }
+   else if (dynamic_cast<const NURBSFECollection*>(fec_ho)) { return NURBS; }
    else { MFEM_ABORT("Bad LOR space type."); }
    return INVALID;
 }
@@ -210,7 +211,7 @@ void LORBase::ConstructLocalDofPermutation(Array<int> &perm_) const
 void LORBase::ConstructDofPermutation() const
 {
    FESpaceType type = GetFESpaceType();
-   if (type == H1 || type == L2)
+   if (type == H1 || type == L2 || type == NURBS)
    {
       // H1 and L2: no permutation necessary, return identity
       perm.SetSize(fes_ho.GetTrueVSize());
@@ -259,7 +260,7 @@ const Array<int> &LORBase::GetDofPermutation() const
 bool LORBase::HasSameDofNumbering() const
 {
    FESpaceType type = GetFESpaceType();
-   return type == H1 || type == L2;
+   return type == H1 || type == L2 || type == NURBS;
 }
 
 OperatorHandle &LORBase::GetAssembledSystem()
@@ -272,6 +273,16 @@ const OperatorHandle &LORBase::GetAssembledSystem() const
 {
    MFEM_VERIFY(A.Ptr() != NULL, "No LOR system assembled");
    return A;
+}
+
+const GridTransfer *LORBase::GetGridTransfer() const
+{
+   return gt;
+}
+
+GridTransfer *LORBase::GetGridTransfer()
+{
+   return gt;
 }
 
 void LORBase::SetupProlongationAndRestriction()
@@ -457,20 +468,49 @@ LORDiscretization::LORDiscretization(FiniteElementSpace &fes_ho,
 void LORDiscretization::FormLORSpace()
 {
    Mesh &mesh_ho = *fes_ho.GetMesh();
-   // For H1, ND and RT spaces, use refinement = element order, for DG spaces,
-   // use refinement = element order + 1 (since LOR is p = 0 in this case).
-   int increment = (GetFESpaceType() == L2) ? 1 : 0;
-   Array<int> refinements(mesh_ho.GetNE());
-   for (int i=0; i<refinements.Size(); ++i)
-   {
-      refinements[i] = fes_ho.GetOrder(i) + increment;
-   }
-   mesh = new Mesh(Mesh::MakeRefined(mesh_ho, refinements, ref_type));
-
-   fec = fes_ho.FEColl()->Clone(GetLOROrder());
    const int vdim = fes_ho.GetVDim();
    const Ordering::Type ordering = fes_ho.GetOrdering();
-   fes = new FiniteElementSpace(mesh, fec, vdim, ordering);
+   if (!mesh_ho.NURBSext)
+   {
+      // For H1, ND and RT spaces, use refinement = element order, for DG spaces,
+      // use refinement = element order + 1 (since LOR is p = 0 in this case).
+      int increment = (GetFESpaceType() == L2) ? 1 : 0;
+      Array<int> refinements(mesh_ho.GetNE());
+      for (int i=0; i<refinements.Size(); ++i)
+      {
+         refinements[i] = fes_ho.GetOrder(i) + increment;
+      }
+      mesh = new Mesh(Mesh::MakeRefined(mesh_ho, refinements, ref_type));
+
+      fec = fes_ho.FEColl()->Clone(GetLOROrder());
+      fes = new FiniteElementSpace(mesh, fec, vdim, ordering);
+   }
+   else
+   {
+      Array<Vector *> points;
+      fes_ho.GetNURBSext()->GetPointsCompr(points,
+                                           NURBSPointSet::DEMKO); // use ref_type instead hardwire demko?
+      mesh = new Mesh(mesh_ho.GetLinearNURBSMesh(points));
+      for (int i=0; i<points.Size(); ++i)
+      {
+         delete points[i];
+      }
+
+      fec = new NURBSFECollection(1);
+      NURBSExtension *ext = new NURBSExtension(mesh->NURBSext, 1);
+      ext->ConnectBoundaries(fes_ho.GetNURBSext()->GetMaster(),
+                             fes_ho.GetNURBSext()->GetSlave());
+
+      fes = new FiniteElementSpace(mesh, ext, fec);//, vdim, ordering);
+
+      fes_ho.GetNURBSext()->CreatePatches();
+      fes->GetNURBSext()->CreatePatches();
+
+      gt = new InterpolationGridTransfer(fes_ho, *fes);
+
+      fes_ho.GetNURBSext()->DeletePatches();
+      fes->GetNURBSext()->DeletePatches();
+   }
    SetupProlongationAndRestriction();
 }
 

--- a/fem/lor/lor.hpp
+++ b/fem/lor/lor.hpp
@@ -13,6 +13,7 @@
 #define MFEM_LOR
 
 #include "../bilinearform.hpp"
+#include "../transfer.hpp"
 
 namespace mfem
 {
@@ -58,7 +59,7 @@ private:
    void ResetIntegrationRules(GetIntegratorsFn get_integrators);
 
 protected:
-   enum FESpaceType { H1, ND, RT, L2, INVALID };
+   enum FESpaceType { H1, ND, RT, L2, NURBS, INVALID };
 
    int ref_type;
    FiniteElementSpace &fes_ho;
@@ -68,6 +69,7 @@ protected:
    BilinearForm *a = nullptr;
    class BatchedLORAssembly *batched_lor = nullptr;
    OperatorHandle A;
+   GridTransfer *gt = nullptr;
    mutable Array<int> perm;
 
    /// Constructs the local DOF (ldof) permutation. In parallel this is used as
@@ -105,6 +107,12 @@ public:
 
    /// Returns the assembled LOR system (non-const version).
    OperatorHandle &GetAssembledSystem();
+
+   /// Returns the lo-2-ho transfer (const version).
+   const GridTransfer *GetGridTransfer() const;
+
+   /// Returns the lo-2-ho transfer (non-const version).
+   GridTransfer *GetGridTransfer();
 
    /// Assembles the LOR system corresponding to @a a_ho.
    void AssembleSystem(BilinearForm &a_ho, const Array<int> &ess_dofs);
@@ -155,6 +163,7 @@ public:
 
    /// Return the assembled LOR operator as a SparseMatrix.
    SparseMatrix &GetAssembledMatrix() const;
+
 };
 
 #ifdef MFEM_USE_MPI
@@ -204,6 +213,7 @@ protected:
    LORBase *lor;
    bool own_lor = true;
    SolverType solver;
+   Operator *RAP_solver = nullptr;
 public:
    /// @brief Create a solver of type @a SolverType, formed using the assembled
    /// SparseMatrix of the LOR version of @a a_ho. @see LORDiscretization
@@ -248,9 +258,27 @@ public:
       solver.SetOperator(op);
       width = solver.Width();
       height = solver.Height();
+
+      GridTransfer *gt = lor->GetGridTransfer();
+      if (gt)
+      {
+         delete RAP_solver;
+         const Operator &lo_2_ho = gt->BackwardOperator();
+         RAP_solver = new RAPOperator(lo_2_ho, solver, lo_2_ho);
+      }
    }
 
-   void Mult(const Vector &x, Vector &y) const { solver.Mult(x, y); }
+   void Mult(const Vector &x, Vector &y) const
+   {
+      if (RAP_solver)
+      {
+         RAP_solver->Mult(x, y);
+      }
+      else
+      {
+         solver.Mult(x, y);
+      }
+   }
 
    /// Access the underlying solver.
    SolverType &GetSolver() { return solver; }
@@ -261,7 +289,11 @@ public:
    /// Access the LOR discretization object.
    const LORBase &GetLOR() const { return *lor; }
 
-   ~LORSolver() { if (own_lor) { delete lor; } }
+   ~LORSolver()
+   {
+      if (own_lor) { delete lor; }
+      delete RAP_solver;
+   }
 };
 
 #ifdef MFEM_USE_MPI

--- a/fem/transfer.cpp
+++ b/fem/transfer.cpp
@@ -142,6 +142,7 @@ const Operator &GridTransfer::MakeTrueOperator(
 InterpolationGridTransfer::~InterpolationGridTransfer()
 {
    if (own_mass_integ) { delete mass_integ; }
+   if (own_prec) { delete prec; }
 }
 
 void InterpolationGridTransfer::SetMassIntegrator(
@@ -161,7 +162,11 @@ const Operator &InterpolationGridTransfer::ForwardOperator()
    }
 
    // Construct F
-   if (oper_type == Operator::ANY_TYPE)
+   if (ran_fes.GetNURBSext())
+   {
+      F.Reset(dom_fes.NURBSInterpolationMatrix(&ran_fes, NURBSPointSet::DEMKO));
+   }
+   else if (oper_type == Operator::ANY_TYPE)
    {
       F.Reset(new FiniteElementSpace::RefinementOperator(&ran_fes, &dom_fes));
    }
@@ -215,7 +220,33 @@ const Operator &InterpolationGridTransfer::BackwardOperator()
       }
       own_mass_integ = true;
    }
-   if (oper_type == Operator::ANY_TYPE)
+   if (ran_fes.GetNURBSext())
+   {
+      MFEM_VERIFY(dom_fes.GetNURBSext(),
+                  "Can only transfer one NURBS GF to another NURBS GF");
+      if (ran_fes.GetVSize() == dom_fes.GetVSize())
+      {
+         prec = new GSSmoother((SparseMatrix&)(ForwardOperator()));
+         own_prec = true;
+         GMRESSolver *gmres = new GMRESSolver();
+         gmres->SetOperator(ForwardOperator());
+         gmres->SetAbsTol(0.0);
+         gmres->SetRelTol(1e-12);
+         gmres->SetMaxIter(1250);
+         gmres->SetKDim(250);
+         gmres->SetPrintLevel(0);
+         gmres->SetPreconditioner(*prec);
+         gmres->iterative_mode = false;
+         B.Reset(gmres);
+      }
+      else
+      {
+         B.Reset(new FiniteElementSpace::GlobalDerefinementOperator(
+                    &ran_fes, &dom_fes, mass_integ, &ForwardOperator()));
+         own_mass_integ = false;
+      }
+   }
+   else if (oper_type == Operator::ANY_TYPE)
    {
       B.Reset(new FiniteElementSpace::DerefinementOperator(
                  &ran_fes, &dom_fes, mass_integ));

--- a/fem/transfer.hpp
+++ b/fem/transfer.hpp
@@ -14,6 +14,7 @@
 
 #include "../linalg/linalg.hpp"
 #include "fespace.hpp"
+#include "../mesh/nurbs.hpp"
 
 #ifdef MFEM_USE_MPI
 #include "pfespace.hpp"

--- a/fem/transfer.hpp
+++ b/fem/transfer.hpp
@@ -142,6 +142,8 @@ protected:
    OperatorHandle F; ///< Forward, coarse-to-fine, operator
    OperatorHandle B; ///< Backward, fine-to-coarse, operator
 
+   Solver *prec = nullptr;
+   bool own_prec = false;
 public:
    InterpolationGridTransfer(FiniteElementSpace &coarse_fes,
                              FiniteElementSpace &fine_fes)

--- a/linalg/solvers.cpp
+++ b/linalg/solvers.cpp
@@ -1133,6 +1133,42 @@ inline void Update(Vector &x, int k, DenseMatrix &h, Vector &s,
 
 void GMRESSolver::Mult(const Vector &b, Vector &x) const
 {
+   Solve<false>(b, x);
+}
+
+void GMRESSolver::MultTranspose(const Vector &b, Vector &x) const
+{
+   Solve<true>(b, x);
+}
+
+template<bool trans>
+void GMRESSolver::Solve(const Vector &b, Vector &x) const
+{
+   // Select which operators tu use.
+   auto oMult = [this](const Vector &x, Vector &y)
+   {
+      if constexpr(trans)
+      {
+         oper->MultTranspose(x, y);
+      }
+      else
+      {
+         oper->Mult(x, y);
+      }
+   };
+
+   auto pMult = [this](const Vector &x, Vector &y)
+   {
+      if constexpr(trans)
+      {
+         prec->MultTranspose(x, y);
+      }
+      else
+      {
+         prec->Mult(x, y);
+      }
+   };
+
    // Generalized Minimum Residual method following the algorithm
    // on p. 20 of the SIAM Templates book.
 
@@ -1162,7 +1198,7 @@ void GMRESSolver::Mult(const Vector &b, Vector &x) const
 
    if (iterative_mode)
    {
-      oper->Mult(x, r);
+      oMult(x, r);
    }
    else
    {
@@ -1174,11 +1210,11 @@ void GMRESSolver::Mult(const Vector &b, Vector &x) const
       if (iterative_mode)
       {
          subtract(b, r, w);
-         prec->Mult(w, r);    // r = M (b - A x)
+         pMult(w, r);    // r = M (b - A x)
       }
       else
       {
-         prec->Mult(b, r);
+         pMult(b, r);
       }
    }
    else
@@ -1230,12 +1266,12 @@ void GMRESSolver::Mult(const Vector &b, Vector &x) const
       {
          if (prec)
          {
-            oper->Mult(*v[i], r);
-            prec->Mult(r, w);        // w = M A v[i]
+            oMult(*v[i], r);
+            pMult(r, w);        // w = M A v[i]
          }
          else
          {
-            oper->Mult(*v[i], w);
+            oMult(*v[i], w);
          }
 
          for (k = 0; k <= i; k++)
@@ -1291,11 +1327,11 @@ void GMRESSolver::Mult(const Vector &b, Vector &x) const
 
       Update(x, i-1, H, s, v);
 
-      oper->Mult(x, r);
+      oMult(x, r);
       if (prec)
       {
          subtract(b, r, w);
-         prec->Mult(w, r);    // r = M (b - A x)
+         pMult(w, r);    // r = M (b - A x)
       }
       else
       {

--- a/linalg/solvers.hpp
+++ b/linalg/solvers.hpp
@@ -662,6 +662,12 @@ class GMRESSolver : public IterativeSolver
 protected:
    int m; // see SetKDim()
 
+   /// Iterative solution  or using the GMRES method
+   /// Dpending on the template argument of the original or its transposed
+   /// linear system is solved.
+   template<bool trans>
+   void Solve(const Vector &b, Vector &x) const;
+
 public:
    GMRESSolver() { m = 50; }
 
@@ -674,6 +680,9 @@ public:
 
    /// Iterative solution of the linear system using the GMRES method
    void Mult(const Vector &b, Vector &x) const override;
+
+   /// Iterative solution of the transposed linear system using the GMRES method
+   void MultTranspose(const Vector &b, Vector &x) const override;
 };
 
 /// FGMRES method

--- a/linalg/sparsemat.cpp
+++ b/linalg/sparsemat.cpp
@@ -2928,6 +2928,91 @@ void SparseMatrix::GetSubMatrix(const Array<int> &rows, const Array<int> &cols,
    }
 }
 
+void SparseMatrix::SetSubMatrix(const Array<int> &rows,
+                                const Array<int> &cols,
+                                const SparseMatrix &subm)
+{
+   MFEM_ASSERT(subm.Height() >= rows.Max()+1,
+               "SparseMatrix::SetSubMatrix row index does not match size");
+   MFEM_ASSERT(subm.Width() >= cols.Max()+1,
+               "SparseMatrix::SetSubMatrix col index does not match size");
+
+   Array<int> lcols;
+   Vector rval;
+   for (int r=0; r<rows.Size(); ++r)
+   {
+      subm.GetRow(r, lcols, rval);
+
+      for (int i=0; i<lcols.Size(); ++i)
+      {
+         lcols[i] = cols[lcols[i]];
+      }
+      SetRow(rows[r], lcols, rval);
+   }
+}
+
+void SparseMatrix::GetSubMatrix(const Array<int> &rows,
+                                const Array<int> &cols,
+                                SparseMatrix &subm) const
+{
+   MFEM_ASSERT(subm.Height() >= rows.Max()+1,
+               "SparseMatrix::GetSubMatrix row index does not match size");
+   MFEM_ASSERT(subm.Width() >= cols.Max()+1,
+               "SparseMatrix::GetSubMatrix col index does not match size");
+
+   Array<int> lcols, scols;
+   Vector rval, sval;
+   for (int r=0; r<rows.Size(); ++r)
+   {
+      GetRow(rows[r], lcols, rval);
+
+      int size = 0;
+      for (int i=0; i<lcols.Size(); ++i)
+      {
+         if (cols.Find(lcols[i])>=0) { size++; }
+      }
+      sval.SetSize(size);
+      scols.SetSize(size);
+      size = 0;
+      for (int i=0; i<lcols.Size(); ++i)
+      {
+         if (cols.Find(lcols[i])>=0)
+         {
+            sval[size] = rval[i];
+            scols[size] = cols.Find(lcols[i]);// lcols[i];
+            size++;
+         }
+      }
+      subm.SetRow(r, scols, sval);
+   }
+   subm.Finalize();
+}
+
+
+void SparseMatrix::AddSubMatrix(const Array<int> &rows,
+                                const Array<int> &cols,
+                                const SparseMatrix &subm)
+{
+   MFEM_ASSERT(subm.Height() == rows.Size(),
+               "SparseMatrix::SetSubMatrix row index does not match size");
+   MFEM_ASSERT(subm.Width() == cols.Size(),
+               "SparseMatrix::SetSubMatrix col index does not match size");
+
+   Array<int> lcols;
+   Vector rval;
+   for (int r=0; r<rows.Size(); ++r)
+   {
+      subm.GetRow(r, lcols, rval);
+
+      for (int i=0; i<lcols.Size(); ++i)
+      {
+         lcols[i] = cols[lcols[i]];
+      }
+
+      AddRow(rows[r], lcols, rval);
+   }
+}
+
 bool SparseMatrix::RowIsEmpty(const int row) const
 {
    int gi;

--- a/linalg/sparsemat.cpp
+++ b/linalg/sparsemat.cpp
@@ -2932,9 +2932,9 @@ void SparseMatrix::SetSubMatrix(const Array<int> &rows,
                                 const Array<int> &cols,
                                 const SparseMatrix &subm)
 {
-   MFEM_ASSERT(subm.Height() >= rows.Max()+1,
+   MFEM_ASSERT(Height() >= rows.Max()+1,
                "SparseMatrix::SetSubMatrix row index does not match size");
-   MFEM_ASSERT(subm.Width() >= cols.Max()+1,
+   MFEM_ASSERT(Width() >= cols.Max()+1,
                "SparseMatrix::SetSubMatrix col index does not match size");
 
    Array<int> lcols;

--- a/linalg/sparsemat.hpp
+++ b/linalg/sparsemat.hpp
@@ -574,6 +574,10 @@ public:
    void GetSubMatrix(const Array<int> &rows, const Array<int> &cols,
                      DenseMatrix &subm) const;
 
+   void GetSubMatrix(const Array<int> &rows, const Array<int> &cols,
+                     SparseMatrix &subm) const;
+
+
    /** @brief Initialize the SparseMatrix for fast access to the entries of the
        given @a row which becomes the "current row". */
    /** Fast access to the entries of the "current row" can be performed using
@@ -621,6 +625,12 @@ public:
        unless it would break the symmetric structure of the SparseMatrix. */
    void AddSubMatrix(const Array<int> &rows, const Array<int> &cols,
                      const DenseMatrix &subm, int skip_zeros = 1);
+
+   void SetSubMatrix(const Array<int> &rows, const Array<int> &cols,
+                     const SparseMatrix &subm);
+
+   void AddSubMatrix(const Array<int> &rows, const Array<int> &cols,
+                     const SparseMatrix &subm);
 
    bool RowIsEmpty(const int row) const;
 

--- a/mesh/mesh.cpp
+++ b/mesh/mesh.cpp
@@ -6079,6 +6079,25 @@ Mesh Mesh::MakePeriodic(const Mesh &orig_mesh, const std::vector<int> &v2v)
    return periodic_mesh;
 }
 
+Mesh Mesh::MakeNURBSInterpolation(const Mesh &orig_mesh, int pSet)
+{
+   NURBSExtension *orig_ext = orig_mesh.NURBSext;
+   MFEM_VERIFY(orig_ext,"Mesh::MakeNURBSInterpolation: Not a NURBS mesh!");
+   orig_ext->ConvertToPatches(*orig_mesh.Nodes);
+
+   int npatch = orig_ext->GetNP();
+   Array<NURBSPatch*> orig_patches(npatch);
+   Array<const NURBSPatch*> new_patches(npatch);
+
+   orig_ext->GetPatches(orig_patches);
+   for (int p = 0; p < npatch; p++)
+   {
+      new_patches[p] = MakeInterpolation(orig_patches[p],static_cast<NURBSPointSet>(pSet));
+   }
+
+   return Mesh(NURBSExtension(orig_ext->GetPatchTopo(), new_patches));
+}
+
 std::vector<int> Mesh::CreatePeriodicVertexMapping(
    const std::vector<Vector> &translations, real_t tol) const
 {

--- a/mesh/mesh.cpp
+++ b/mesh/mesh.cpp
@@ -6079,23 +6079,53 @@ Mesh Mesh::MakePeriodic(const Mesh &orig_mesh, const std::vector<int> &v2v)
    return periodic_mesh;
 }
 
-Mesh Mesh::MakeNURBSInterpolation(const Mesh &orig_mesh, int pSet)
+Mesh Mesh::GetLinearNURBSMesh(Array<Vector *> points)
 {
-   NURBSExtension *orig_ext = orig_mesh.NURBSext;
-   MFEM_VERIFY(orig_ext,"Mesh::MakeNURBSInterpolation: Not a NURBS mesh!");
-   orig_ext->ConvertToPatches(*orig_mesh.Nodes);
+   MFEM_VERIFY(NURBSext,"Mesh::MakeNURBSInterpolation: Not a NURBS mesh!");
+   NURBSext->ConvertToPatches2(*Nodes);
 
-   int npatch = orig_ext->GetNP();
+   int npatch = NURBSext->GetNP();
    Array<NURBSPatch*> orig_patches(npatch);
    Array<const NURBSPatch*> new_patches(npatch);
 
-   orig_ext->GetPatches(orig_patches);
+   NURBSext->GetPatches(orig_patches);
    for (int p = 0; p < npatch; p++)
    {
-      new_patches[p] = MakeInterpolation(orig_patches[p],static_cast<NURBSPointSet>(pSet));
+      Array<Vector *> pts(Dimension());
+      for (int d = 0; d < Dimension(); d++)
+      {
+         pts[d] = points[Dimension()*p + d];
+      }
+      new_patches[p] = orig_patches[p]->MakeInterpolation(pts);
+   }
+   Mesh imesh(NURBSExtension(NURBSext->GetPatchTopo(), new_patches));
+
+   for (int p = 0; p < npatch; p++)
+   {
+      delete orig_patches[p];
+      delete new_patches[p];
    }
 
-   return Mesh(NURBSExtension(orig_ext->GetPatchTopo(), new_patches));
+   return imesh;
+}
+
+Mesh Mesh::GetLinearNURBSMesh(NURBSPointSet pSet)
+{
+   Array<Vector *> points;
+   Nodes->FESpace()->GetNURBSext()->GetPointsCompr(points, pSet);
+
+   Mesh imesh  = GetLinearNURBSMesh(points);
+   for (int i=0; i<points.Size(); ++i)
+   {
+      delete points[i];
+   }
+
+   return imesh;
+}
+
+Mesh Mesh::GetLinearNURBSMesh()
+{
+   return GetLinearNURBSMesh(NURBSPointSet::DEMKO);
 }
 
 std::vector<int> Mesh::CreatePeriodicVertexMapping(

--- a/mesh/mesh.hpp
+++ b/mesh/mesh.hpp
@@ -41,6 +41,7 @@ class FaceGeometricFactors;
 class KnotVector;
 class NURBSPatch;
 class NURBSExtension;
+enum class NURBSPointSet;
 class FiniteElementSpace;
 class GridFunction;
 struct Refinement;
@@ -988,8 +989,15 @@ public:
        SetCurvature() for further details. */
    static Mesh MakePeriodic(const Mesh &orig_mesh, const std::vector<int> &v2v);
 
-   /// Create a linear mesh with nodes at the specified points of @a orig_mesh.
-   static Mesh MakeNURBSInterpolation(const Mesh &orig_mesh, int pSet = 0);
+   /// Create a linear mesh with nodes at the specified @a points in the
+   /// parametric domain.
+   Mesh GetLinearNURBSMesh(Array<Vector *> points);
+
+   /// Create a linear mesh with nodes at the requested pointset
+   Mesh GetLinearNURBSMesh(NURBSPointSet pSet);
+
+   /// Create a linear mesh with nodes at the demko points.
+   Mesh GetLinearNURBSMesh();
 
    ///@}
 

--- a/mesh/mesh.hpp
+++ b/mesh/mesh.hpp
@@ -988,6 +988,9 @@ public:
        SetCurvature() for further details. */
    static Mesh MakePeriodic(const Mesh &orig_mesh, const std::vector<int> &v2v);
 
+   /// Create a linear mesh with nodes at the specified points of @a orig_mesh.
+   static Mesh MakeNURBSInterpolation(const Mesh &orig_mesh, int pSet = 0);
+
    ///@}
 
    /// Construct a Mesh from a NURBSExtension, which is deep-copied.

--- a/mesh/nurbs.cpp
+++ b/mesh/nurbs.cpp
@@ -1592,6 +1592,22 @@ int NURBSPatch::SetLoopDirection(int dir)
    return -1;
 }
 
+int NURBSPatch::GetNCP() const
+{
+   int ncp = 1;
+   for (int d = 0; d < kv.Size(); d++) { ncp *= kv[d]->GetNCP();}
+   return ncp;
+}
+
+void NURBSPatch::GetPoints(Array<Vector *> &uknot, NURBSPointSet pSet) const
+{
+   for (int d = 0; d < kv.Size(); d++)
+   {
+      uknot[d] = new Vector();
+      kv[d]->GetPoints(*uknot[d], pSet);
+   }
+}
+
 void NURBSPatch::UniformRefinement(Array<int> const& rf, int multiplicity)
 {
    Vector new_knots;

--- a/mesh/nurbs.cpp
+++ b/mesh/nurbs.cpp
@@ -28,11 +28,6 @@
 namespace mfem
 {
 
-Mesh MakeNURBSInterpolation(const Mesh &orig_mesh, NURBSPointSet pSet)
-{
-   return Mesh::MakeNURBSInterpolation(orig_mesh, static_cast<int>(pSet));
-}
-
 using namespace std;
 
 const int KnotVector::MaxOrder = 10;
@@ -1296,8 +1291,8 @@ KnotVector* KnotVector::FullyCoarsen()
 
 void NURBSPatch::init(int dim)
 {
-   MFEM_ASSERT(dim > 1, "NURBS patch dimension (including weight) must be "
-               "greater than 1.");
+   MFEM_ASSERT(dim >= 0, "NURBS patch dimension (including weight) must be "
+               "greater than 0.");
    Dim = dim;
    sd = nd = -1;
 
@@ -2641,22 +2636,18 @@ NURBSPatch *Revolve3D(NURBSPatch &patch, real_t n[], real_t ang, int times)
    return newpatch;
 }
 
-
-NURBSPatch *MakeInterpolation(NURBSPatch *parent, NURBSPointSet pSet)
+NURBSPatch *NURBSPatch::MakeInterpolation(Array<Vector *>  &points)
 {
+   MFEM_VERIFY(points.Size() == GetNKV(),"Mismatch");
 
-   Array<const KnotVector *> new_kv(parent->GetNKV());
-   for (int i = 0; i < parent->GetNKV() ; i++)
+   Array<const KnotVector *> new_kv(GetNKV());
+   for (int i = 0; i < GetNKV() ; i++)
    {
-      Vector k;
-      parent->kv[i]->GetPoints(k, pSet);
-      new_kv[i] = new KnotVector(1, k);
-      new_kv[i]->Print(std::cout);
+      new_kv[i] = new KnotVector(1, *points[i]);
    }
 
-   int dim = parent->Dim;
-   NURBSPatch *new_patch = new NURBSPatch(new_kv, dim);
-   Vector val(dim);
+   NURBSPatch *new_patch = new NURBSPatch(new_kv, Dim);
+   Vector val(Dim);
 
    if (new_kv.Size() == 1)
    {
@@ -2665,10 +2656,10 @@ NURBSPatch *MakeInterpolation(NURBSPatch *parent, NURBSPointSet pSet)
       for (int i = 0; i < kv0.GetNCP() ; i++)
       {
          int ii = i;
-         parent->eval(kv0[i+1], val);
-         for (int d = 0; d < dim; d++)
+         eval(kv0[i+1], val);
+         for (int d = 0; d < Dim; d++)
          {
-            new_patch->data[dim*ii + d] = val[d];
+            new_patch->data[Dim*ii + d] = val[d];
          }
       }
    }
@@ -2683,10 +2674,10 @@ NURBSPatch *MakeInterpolation(NURBSPatch *parent, NURBSPointSet pSet)
          for (int j = 0; j < kv1.GetNCP(); j++)
          {
             int jj = ii + j*kv0.GetNCP();
-            parent->eval(kv0[i+1], kv1[j+1], val);
-            for (int d = 0; d < dim; d++)
+            eval(kv0[i+1], kv1[j+1], val);
+            for (int d = 0; d < Dim; d++)
             {
-               new_patch->data[dim*jj + d] = val[d];
+               new_patch->data[Dim*jj + d] = val[d];
             }
          }
       }
@@ -2706,10 +2697,10 @@ NURBSPatch *MakeInterpolation(NURBSPatch *parent, NURBSPointSet pSet)
             for (int k = 0; k < kv2.GetNCP(); k++)
             {
                int kk = jj + k*kv0.GetNCP()*kv1.GetNCP();
-               parent->eval(kv0[i+1], kv1[j+1], kv2[k+1], val);
-               for (int d = 0; d < dim; d++)
+               eval(kv0[i+1], kv1[j+1], kv2[k+1], val);
+               for (int d = 0; d < Dim; d++)
                {
-                  new_patch->data[dim*kk  + d] = val[d];
+                  new_patch->data[Dim*kk  + d] = val[d];
                }
             }
          }
@@ -2720,8 +2711,109 @@ NURBSPatch *MakeInterpolation(NURBSPatch *parent, NURBSPointSet pSet)
       mfem_error("MakeInterpolation wrong dimension");
    }
 
+   for (int i = 0; i < GetNKV() ; i++)
+   {
+      delete new_kv[i];
+   }
    return new_patch;
 }
+
+void NURBSPatch::GetInterpolationMatrix(Array<Vector *> kvs,
+                                        SparseMatrix &smat)
+{
+   // Check inputs
+   const int dim = kvs.Size();  // Topological dimension
+   constexpr int maxdim = 3;
+   MFEM_VERIFY(dim == kv.Size(), "dim != number of knot vectors.");
+
+   // Setup
+   Array<int> sizes(maxdim); // Number of knots (per dim) to interpolate to
+   Array<int> ndofs(maxdim); // Number of dofs in this patch (per dim)
+   Array<int> nnzs(maxdim);  // Maximum non-zero shape functions (per dim)
+   sizes = 1;                // Initialize to 1
+   ndofs = 1;
+   nnzs = 1;
+
+   Array<DenseMatrix *> shape(maxdim);
+   Array<Array<int> *> loc(maxdim);
+   for (int d = 0; d < dim; d++)
+   {
+      sizes[d] = kvs[d]->Size();
+      ndofs[d] = kv[d]->GetNCP();
+      nnzs[d] = kv[d]->GetOrder() + 1;
+      // Check that the output knots are contained within the patch
+      MFEM_VERIFY(kvs[d]->Min() >= (*kv[d])[0] &&
+                  kvs[d]->Max() <= (*kv[d])[kv[d]->Size()-1],
+                  "NURBSPatch::GetInterpolationMatrix : "
+                  "Output knots must be contained within the patch.");
+   }
+
+   for (int d = 0; d < maxdim; d++)
+   {
+      loc[d] = new Array<int>(sizes[d]);
+      shape[d] = new DenseMatrix(nnzs[d], sizes[d]);
+      Array<int>  &rloc = *(loc[d]);
+      DenseMatrix &rsh = *(shape[d]);
+
+      rloc  = 0;
+      rsh = 1.0;
+
+      if (d<dim)
+      {
+         Vector sh(nnzs[d]);
+         for (int i = 0; i < sizes[d]; i++)
+         {
+            real_t u0 =  kvs[d]->Elem(i);
+            int n0 = kv[d]->GetSpan(u0);
+            real_t x0 = kv[d]->GetRefPoint(u0, n0);
+            n0 -= kv[d]->GetOrder();
+            kv[d]->CalcShape  (sh, n0, x0);
+            rsh.SetCol(i, sh);
+            rloc[i] = n0;
+         }
+      }
+   }
+
+   Array<int>  &rloc0 = *(loc[0]);
+   Array<int>  &rloc1 = *(loc[1]);
+   Array<int>  &rloc2 = *(loc[2]);
+
+   for (int k = 0; k < sizes[2]; k++)
+   {
+      for (int j = 0; j < sizes[1]; j++)
+      {
+         for (int i = 0; i < sizes[0]; i++)
+         {
+            int row = i + j*sizes[0] + k*sizes[0]*sizes[1];
+            int dof = rloc0 [i] + rloc1[j]*ndofs[0] + rloc2[k]*ndofs[0]*ndofs[1];
+
+            for (int dk = 0; dk < nnzs[2]; dk++)
+            {
+               real_t shz = shape[2]->Elem(dk,k);
+               for (int dj = 0; dj < nnzs[1]; dj++)
+               {
+                  real_t shzy = shz*shape[1]->Elem(dj,j);
+                  for (int di = 0; di < nnzs[0]; di++)
+                  {
+                     real_t shzyx = shzy*shape[0]->Elem(di,i);
+                     int col = dof + di + dj*ndofs[0] + dk*ndofs[0]*ndofs[1];
+
+                     // Assign
+                     smat.Set(row, col, shzyx);
+                  }
+               }
+            }
+         }
+      }
+   }
+
+   for (int d = 0; d < maxdim; d++)
+   {
+      delete loc[d];
+      delete shape[d];
+   }
+}
+
 
 void NURBSPatch::eval(Vector &u, Vector &val)
 {
@@ -5239,8 +5331,11 @@ void NURBSExtension::LoadBE(int i, const FiniteElement *BE) const
 
 void NURBSExtension::ConvertToPatches(const Vector &Nodes)
 {
-   delete el_dof;
-   delete bel_dof;
+   if (el_dof) { delete el_dof; }
+   if (bel_dof) { delete bel_dof; }
+
+   el_dof = NULL;
+   bel_dof = NULL;
 
    if (patches.Size() == 0)
    {
@@ -5255,6 +5350,57 @@ void NURBSExtension::ConvertToPatches(const Vector &Nodes)
       GetPatchNets(Nodes, phys_vdim);
    }
 }
+
+void NURBSExtension::ConvertToPatches2(const Vector &Nodes)
+{
+   if (patches.Size() == 0)
+   {
+      // Determine the physical vector dimension from the coordinate vector and
+      // the number of DOFs. This is needed in particular for curves/surfaces
+      // embedded in higher-dimensional physical spaces.
+      MFEM_VERIFY(GetNDof() > 0,
+                  "NURBSExtension::ConvertToPatches: invalid number of DOFs.");
+      MFEM_VERIFY(Nodes.Size() % GetNDof() == 0,
+                  "NURBSExtension::ConvertToPatches: coordinate size not divisible by DOFs.");
+      const int phys_vdim = Nodes.Size() / GetNDof();
+      GetPatchNets(Nodes, phys_vdim);
+   }
+}
+
+void NURBSExtension::CreatePatches()
+{
+   if (patches.Size() == 0)
+   {
+      // Determine the physical vector dimension from the coordinate vector and
+      // the number of DOFs. This is needed in particular for curves/surfaces
+      // embedded in higher-dimensional physical spaces.
+      MFEM_VERIFY(GetNDof() > 0,
+                  "NURBSExtension::ConvertToPatches: invalid number of DOFs.");
+
+      Array<const KnotVector *> kv(Dimension());
+      NURBSPatchMap p2g(this);
+
+      patches.SetSize(GetNP());
+      for (int p = 0; p < GetNP(); p++)
+      {
+         p2g.SetPatchDofMap(p, kv);
+         patches[p] = new NURBSPatch(kv, 0);
+      }
+   }
+}
+
+void NURBSExtension::DeletePatches()
+{
+   if (patches.Size() != 0)
+   {
+      for (int p = 0; p < GetNP(); p++)
+      {
+         delete patches[p];
+      }
+      patches.SetSize(0);
+   }
+}
+
 
 void NURBSExtension::SetCoordsFromPatches(Vector &Nodes, int vdim)
 {

--- a/mesh/nurbs.cpp
+++ b/mesh/nurbs.cpp
@@ -28,6 +28,11 @@
 namespace mfem
 {
 
+Mesh MakeNURBSInterpolation(const Mesh &orig_mesh, NURBSPointSet pSet)
+{
+   return Mesh::MakeNURBSInterpolation(orig_mesh, static_cast<int>(pSet));
+}
+
 using namespace std;
 
 const int KnotVector::MaxOrder = 10;
@@ -397,6 +402,24 @@ void KnotVector::ComputeDemko() const
    {
       mfem::out<<"Demko: Remez iteration not converged"<<endl;
       mfem::out<<"|a - anew| = "<<a.Norml2()<<endl;
+   }
+}
+
+void KnotVector::GetPoints(Vector &xi, NURBSPointSet pSet) const
+{
+   switch ( pSet )
+   {
+      case NURBSPointSet::GREVILLE:
+         GetGreville(xi);
+         break;
+      case NURBSPointSet::BOTELLA:
+         GetBotella(xi);
+         break;
+      case NURBSPointSet::DEMKO:
+         GetDemko(xi);
+         break;
+      case NURBSPointSet::DEFAULT:
+         mfem_error("Unknown pointSet defined.");
    }
 }
 
@@ -2618,6 +2641,204 @@ NURBSPatch *Revolve3D(NURBSPatch &patch, real_t n[], real_t ang, int times)
    return newpatch;
 }
 
+
+NURBSPatch *MakeInterpolation(NURBSPatch *parent, NURBSPointSet pSet)
+{
+
+   Array<const KnotVector *> new_kv(parent->GetNKV());
+   for (int i = 0; i < parent->GetNKV() ; i++)
+   {
+      Vector k;
+      parent->kv[i]->GetPoints(k, pSet);
+      new_kv[i] = new KnotVector(1, k);
+      new_kv[i]->Print(std::cout);
+   }
+
+   int dim = parent->Dim;
+   NURBSPatch *new_patch = new NURBSPatch(new_kv, dim);
+   Vector val(dim);
+
+   if (new_kv.Size() == 1)
+   {
+      const KnotVector &kv0 = *new_kv[0];
+
+      for (int i = 0; i < kv0.GetNCP() ; i++)
+      {
+         int ii = i;
+         parent->eval(kv0[i+1], val);
+         for (int d = 0; d < dim; d++)
+         {
+            new_patch->data[dim*ii + d] = val[d];
+         }
+      }
+   }
+   else if (new_kv.Size() == 2)
+   {
+      const KnotVector &kv0 = *new_kv[0];
+      const KnotVector &kv1 = *new_kv[1];
+
+      for (int i = 0; i < kv0.GetNCP() ; i++)
+      {
+         int ii = i;
+         for (int j = 0; j < kv1.GetNCP(); j++)
+         {
+            int jj = ii + j*kv0.GetNCP();
+            parent->eval(kv0[i+1], kv1[j+1], val);
+            for (int d = 0; d < dim; d++)
+            {
+               new_patch->data[dim*jj + d] = val[d];
+            }
+         }
+      }
+   }
+   else if (new_kv.Size() == 3)
+   {
+      const KnotVector &kv0 = *new_kv[0];
+      const KnotVector &kv1 = *new_kv[1];
+      const KnotVector &kv2 = *new_kv[2];
+
+      for (int i = 0; i < kv0.GetNCP() ; i++)
+      {
+         int ii = i;
+         for (int j = 0; j < kv1.GetNCP(); j++)
+         {
+            int jj = ii + j*kv0.GetNCP();
+            for (int k = 0; k < kv2.GetNCP(); k++)
+            {
+               int kk = jj + k*kv0.GetNCP()*kv1.GetNCP();
+               parent->eval(kv0[i+1], kv1[j+1], kv2[k+1], val);
+               for (int d = 0; d < dim; d++)
+               {
+                  new_patch->data[dim*kk  + d] = val[d];
+               }
+            }
+         }
+      }
+   }
+   else
+   {
+      mfem_error("MakeInterpolation wrong dimension");
+   }
+
+   return new_patch;
+}
+
+void NURBSPatch::eval(Vector &u, Vector &val)
+{
+   if (u.Size() == 1)
+   {
+      eval(u[0], val);
+   }
+   else if (u.Size() == 2)
+   {
+      eval(u[0], u[1], val);
+   }
+   else if (u.Size() == 3)
+   {
+      eval(u[0], u[1], u[2], val);
+   }
+   else
+   {
+      mfem_error("NURBSPatch::evalwrong dimension of knot");
+   }
+}
+
+void NURBSPatch::eval(real_t u0, Vector &val)
+{
+   // Get x-dir shape
+   int n0 = kv[0]->GetSpan(u0);
+   real_t x0 = kv[0]->GetRefPoint(u0, n0);
+   n0 -= kv[0]->GetOrder();
+   Vector shx(kv[0]->GetOrder() + 1);
+   kv[0]->CalcShape  (shx, n0, x0);
+
+   // Interpolate value
+   val = 0.0;
+   for (int i = 0; i < kv[0]->GetOrder()+1 ; i++)
+   {
+      int ii = i + n0;
+      for (int d = 0; d < Dim; d++)
+      {
+         val[d] += data[Dim*ii + d]*shx[i];
+      }
+   }
+}
+
+
+void NURBSPatch::eval(real_t u0, real_t u1, Vector &val)
+{
+   // Get x-dir shape
+   int n0 = kv[0]->GetSpan(u0);
+   real_t x0 = kv[0]->GetRefPoint(u0, n0);
+   n0 -= kv[0]->GetOrder();
+   Vector shx(kv[0]->GetOrder() + 1);
+   kv[0]->CalcShape  (shx, n0, x0);
+
+   // Get y-dir shape
+   int n1 = kv[1]->GetSpan(u1);
+   real_t x1 = kv[1]->GetRefPoint(u1, n1);
+   Vector shy(kv[1]->GetOrder() + 1);
+   n1 -= kv[1]->GetOrder();
+   kv[1]->CalcShape  (shy, n1, x1);
+
+   // Interpolate value
+   val = 0.0;
+   for (int i = 0; i < kv[0]->GetOrder()+1 ; i++)
+   {
+      int ii = i + n0;
+      for (int j = 0; j < kv[1]->GetOrder()+1; j++)
+      {
+         int jj = ii + (j + n1)*kv[0]->GetNCP();
+         for (int d = 0; d < Dim; d++)
+         {
+            val[d] += data[Dim*jj + d]*shx[i]*shy[j];
+         }
+      }
+   }
+}
+
+void NURBSPatch::eval(real_t u0, real_t u1, real_t u2, Vector &val)
+{
+   // Get x-dir shape
+   int n0 = kv[0]->GetSpan(u0);
+   real_t x0 = kv[0]->GetRefPoint(u0, n0);
+   n0 -= kv[0]->GetOrder();
+   Vector shx(kv[0]->GetOrder() + 1);
+   kv[0]->CalcShape  (shx, n0, x0);
+
+   // Get y-dir shape
+   int n1 = kv[1]->GetSpan(u1);
+   real_t x1 = kv[1]->GetRefPoint(u1, n1);
+   Vector shy(kv[1]->GetOrder() + 1);
+   n1 -= kv[1]->GetOrder();
+   kv[1]->CalcShape  (shy, n1, x1);
+
+   // Get z-dir shape
+   int n2 = kv[2]->GetSpan(u2);
+   real_t x2 = kv[2]->GetRefPoint(u2, n2);
+   Vector shz(kv[2]->GetOrder() + 1);
+   n2 -= kv[2]->GetOrder();
+   kv[2]->CalcShape  (shz, n2, x2);
+
+   // Interpolate value
+   val = 0.0;
+   for (int i = 0; i < kv[0]->GetOrder()+1 ; i++)
+   {
+      int ii = i + n0;
+      for (int j = 0; j < kv[1]->GetOrder()+1; j++)
+      {
+         int jj = ii + (j + n1)*kv[0]->GetNCP();
+         for (int k = 0; k < kv[2]->GetOrder()+1; k++)
+         {
+            int kk = jj + (k + n2)*kv[0]->GetNCP()*kv[1]->GetNCP();
+            for (int d = 0; d < Dim; d++)
+            {
+               val[d] += data[Dim*kk + d]*shx[i]*shy[j]*shy[k];
+            }
+         }
+      }
+   }
+}
 void NURBSPatch::SetKnotVectorsCoarse(bool c)
 {
    for (int i=0; i<kv.Size(); ++i) { kv[i]->coarse = c; }

--- a/mesh/nurbs.hpp
+++ b/mesh/nurbs.hpp
@@ -503,12 +503,7 @@ public:
    int GetNKV() const { return kv.Size(); }
 
    /// Get number of control points for the entire patch
-   int GetNCP() const
-   {
-      int ncp = 1;
-      for (int d = 0; d < kv.Size(); d++) { ncp *= kv[d]->GetNCP();}
-      return ncp;
-   }
+   int GetNCP() const;
 
    /// Return a pointer to the KnotVector in direction @a dir.
    /// @note The returned object should NOT be deleted by the caller.
@@ -516,15 +511,7 @@ public:
 
    /// Uniform interface for obtaining Greville/Botella/Demko points
    /// Caller needs to delete the vectors.
-   void GetPoints(Array<Vector *> &uknot, NURBSPointSet pSet) const
-   {
-      for (int d = 0; d < kv.Size(); d++)
-      {
-         uknot[d] = new Vector();
-         kv[d]->GetPoints(*uknot[d], pSet);
-      }
-   }
-
+   void GetPoints(Array<Vector *> &uknot, NURBSPointSet pSet) const;
 
    // Standard B-NET access functions
 

--- a/mesh/nurbs.hpp
+++ b/mesh/nurbs.hpp
@@ -28,6 +28,10 @@ namespace mfem
 
 class GridFunction;
 
+/** This enumerated type describes the point set to use for NURBS*/
+enum class NURBSPointSet { DEFAULT = 0, GREVILLE, BOTELLA, DEMKO };
+
+
 /** @brief A vector of knots in one dimension, with B-spline basis functions of
     a prescribed order.
 
@@ -191,6 +195,9 @@ public:
    real_t GetDemko(int i) const;
 
    void GetDemko(Vector &xi) const;
+
+   /// Uniform interface for obtaining Greville/Botella/Demko points
+   void GetPoints(Vector &xi, NURBSPointSet) const;
 
    // The following functions evaluate shape functions, which are B-spline basis
    // functions.
@@ -556,7 +563,20 @@ public:
    /// @note The returned object should be deleted by the caller.
    friend NURBSPatch *Revolve3D(NURBSPatch &patch, real_t n[], real_t ang,
                                 int times);
+
+
+   friend NURBSPatch *MakeInterpolation(NURBSPatch *parent,
+                                        NURBSPointSet pSet);// = NURBSPointSet::DEFAULT);
+
+
+   void eval(Vector &u, Vector &val);
+   void eval(real_t u0, Vector & val);
+   void eval(real_t u0, real_t u1, Vector & val);
+   void eval(real_t u0, real_t u1, real_t u2, Vector &val);
 };
+
+Mesh MakeNURBSInterpolation(const Mesh &orig_mesh, NURBSPointSet pSet);
+
 
 
 #ifdef MFEM_USE_MPI
@@ -1110,6 +1130,9 @@ public:
 
    /// Returns a deep copy of the patch topology mesh
    Mesh GetPatchTopology() const { return Mesh(*patchTopo); }
+
+   /// Returns a pointer of the patch topology mesh
+   Mesh *GetPatchTopo() const { return patchTopo; }
 
    /** Returns a deep copy of all instantiated patches. To ensure that patches
        are instantiated, use Mesh::GetNURBSPatches() instead. Caller gets

--- a/mesh/nurbs.hpp
+++ b/mesh/nurbs.hpp
@@ -502,9 +502,29 @@ public:
    /// Return the number of KnotVectors, which is the patch dimension.
    int GetNKV() const { return kv.Size(); }
 
+   /// Get number of control points for the entire patch
+   int GetNCP() const
+   {
+      int ncp = 1;
+      for (int d = 0; d < kv.Size(); d++) { ncp *= kv[d]->GetNCP();}
+      return ncp;
+   }
+
    /// Return a pointer to the KnotVector in direction @a dir.
    /// @note The returned object should NOT be deleted by the caller.
    KnotVector *GetKV(int dir) { return kv[dir]; }
+
+   /// Uniform interface for obtaining Greville/Botella/Demko points
+   /// Caller needs to delete the vectors.
+   void GetPoints(Array<Vector *> &uknot, NURBSPointSet pSet) const
+   {
+      for (int d = 0; d < kv.Size(); d++)
+      {
+         uknot[d] = new Vector();
+         kv[d]->GetPoints(*uknot[d], pSet);
+      }
+   }
+
 
    // Standard B-NET access functions
 
@@ -564,10 +584,9 @@ public:
    friend NURBSPatch *Revolve3D(NURBSPatch &patch, real_t n[], real_t ang,
                                 int times);
 
+   NURBSPatch *MakeInterpolation(Array<Vector *>  &points);
 
-   friend NURBSPatch *MakeInterpolation(NURBSPatch *parent,
-                                        NURBSPointSet pSet);// = NURBSPointSet::DEFAULT);
-
+   void GetInterpolationMatrix(Array<Vector *> uknot, SparseMatrix &smat);
 
    void eval(Vector &u, Vector &val);
    void eval(real_t u0, Vector & val);
@@ -1045,6 +1064,28 @@ public:
    /// Return the number of knotvector elements for edge @a edge.
    inline int KnotVecNE(int edge) const;
 
+   /// Uniform interface for obtaining Greville/Botella/Demko points
+   /// Caller needs to delete the vectors.
+   void GetPoints(Array<Vector *> &uknot, NURBSPointSet pSet) const
+   {
+      uknot.SetSize(knotVectors.Size());
+      for (int d = 0; d < knotVectors.Size(); d++)
+      {
+         uknot[d] = new Vector();
+         knotVectors[d]->GetPoints(*uknot[d], pSet);
+      }
+   }
+
+   void GetPointsCompr(Array<Vector *> &uknot, NURBSPointSet pSet) const
+   {
+      uknot.SetSize(knotVectorsCompr.Size());
+      for (int d = 0; d < knotVectorsCompr.Size(); d++)
+      {
+         uknot[d] = new Vector();
+         knotVectorsCompr[d]->GetPoints(*uknot[d], pSet);
+      }
+   }
+
    // Load functions
 
    /// Load element @a i into @a FE.
@@ -1060,6 +1101,15 @@ public:
 
    /// Define patches in IKJ (B-net) format, using FE coordinates in @a Nodes.
    void ConvertToPatches(const Vector &Nodes);
+   void ConvertToPatches2(const Vector
+                          &Nodes); // --> No deletion of tables (crazy side effect!!)
+
+   /// Create empty patches
+   void CreatePatches();
+
+   /// Delete patches
+   void DeletePatches();
+
    /// Set KnotVectors from @a patches and construct mesh and space data.
    void SetKnotsFromPatches();
    /** @brief Set FE coordinates in @a Nodes, using data from @a patches,

--- a/miniapps/nurbs/nurbs_ex1.cpp
+++ b/miniapps/nurbs/nurbs_ex1.cpp
@@ -439,10 +439,6 @@ int main(int argc, char *argv[])
    //    this will give a projection without any over and undershoots.
    GridFunction x(fespace);
 
-   VisItDataCollection visit_dc22("Test", mesh);
-   visit_dc22.RegisterField("solution", &x);
-   visit_dc22.Save();
-
    if (homogenousBC)
    {
       x = 0.0;

--- a/miniapps/nurbs/nurbs_ex1.cpp
+++ b/miniapps/nurbs/nurbs_ex1.cpp
@@ -160,12 +160,6 @@ real_t sol(const Vector & x)
 int main(int argc, char *argv[])
 {
 
-   // 0. Initialize MPI and HYPRE.
-  // Mpi::Init(argc, argv);
-   // int num_procs = Mpi::WorldSize();
-   // int myid = Mpi::WorldRank();
-  // Hypre::Init();
-
    // 1. Parse command-line options.
    const char *mesh_file = "../../data/square-nurbs.mesh";
    const char *per_file  = "none";
@@ -444,6 +438,11 @@ int main(int argc, char *argv[])
    //    projection type, also in the case of a NURBS spaces. For a NURBS space
    //    this will give a projection without any over and undershoots.
    GridFunction x(fespace);
+
+   VisItDataCollection visit_dc22("Test", mesh);
+   visit_dc22.RegisterField("solution", &x);
+   visit_dc22.Save();
+
    if (homogenousBC)
    {
       x = 0.0;
@@ -584,49 +583,6 @@ int main(int argc, char *argv[])
       visit_dc.RegisterField("solution", &x);
       visit_dc.Save();
    }
-
-   // 15. Save data in the VisIt format -- on projected mesh!!
-   /*{
-      // Create interpolation mesh
-      Array<Vector *> points;
-      fespace->GetNURBSext()->GetPointsCompr(points, NURBSPointSet::DEMKO);
-      Mesh imesh = mesh->GetLinearNURBSMesh(points);
-      for (int i = 0; i < points.Size(); i++) { delete points[i]; }
-
-      // Create interpolation space
-      NURBSFECollection ifec(1);
-      FiniteElementSpace ifespace(&imesh, new NURBSExtension(imesh.NURBSext, 1),
-                                  &ifec);
-
-      // Create transfer operations
-      fespace->GetNURBSext()->CreatePatches();
-      ifespace.GetNURBSext()->CreatePatches();
-
-      GridTransfer *gt = new InterpolationGridTransfer(*fespace, ifespace);
-      const Operator &ho_2_lo = gt->ForwardOperator();
-      const Operator &lo_2_ho = gt->BackwardOperator();
-
-      fespace->GetNURBSext()->DeletePatches();
-      ifespace.GetNURBSext()->DeletePatches();
-
-      // Project on nodal solution
-      GridFunction ix(&ifespace);
-      ho_2_lo.Mult(x, ix);
-
-      VisItDataCollection visit_dc1("Example1_linear", &imesh);
-      visit_dc1.RegisterField("solution",   &ix);
-      visit_dc1.Save();
-
-      // Project on nodal solution on original
-      x = 0.0;
-      lo_2_ho.Mult(ix, x);
-
-      VisItDataCollection visit_dc2("Example1_orig", mesh);
-      visit_dc2.RegisterField("solution",   &x);
-      visit_dc2.Save();
-
-      delete gt;
-   }*/
 
    // 15. Free the used memory.
    delete a;

--- a/miniapps/nurbs/nurbs_ex1.cpp
+++ b/miniapps/nurbs/nurbs_ex1.cpp
@@ -159,6 +159,13 @@ real_t sol(const Vector & x)
 
 int main(int argc, char *argv[])
 {
+
+   // 0. Initialize MPI and HYPRE.
+  // Mpi::Init(argc, argv);
+   // int num_procs = Mpi::WorldSize();
+   // int myid = Mpi::WorldRank();
+  // Hypre::Init();
+
    // 1. Parse command-line options.
    const char *mesh_file = "../../data/square-nurbs.mesh";
    const char *per_file  = "none";
@@ -168,6 +175,7 @@ int main(int argc, char *argv[])
    Array<int> slave(0);
    Array<int> neu(0);
    bool static_cond = false;
+   bool use_lor = false;
    bool visualization = 1;
    int lod = 0;
    bool ibp = 1;
@@ -210,6 +218,8 @@ int main(int argc, char *argv[])
                   " Negative values are replaced with (order+1)^2.");
    args.AddOption(&static_cond, "-sc", "--static-condensation", "-no-sc",
                   "--no-static-condensation", "Enable static condensation.");
+   args.AddOption(&use_lor, "-lor", "--use-lor", "-no-lor",
+                  "--no-lor", "Enable LOR preconditioning.");
    args.AddOption(&visualization, "-vis", "--visualization", "-no-vis",
                   "--no-visualization",
                   "Enable or disable GLVis visualization.");
@@ -412,7 +422,6 @@ int main(int argc, char *argv[])
    cout <<" - Essential : "; ess_bdr.Print();
    cout <<" - Neumann   : "; neu_bdr.Print();
 
-
    // 6. Set up the linear form b(.) which corresponds to the right-hand side of
    //    the FEM linear system, which in this case is (1,phi_i) where phi_i are
    //    the basis functions in the finite element fespace.
@@ -482,18 +491,24 @@ int main(int argc, char *argv[])
 
    cout << "Size of linear system: " << A.Height() << endl;
 
-#ifndef MFEM_USE_SUITESPARSE
    // 10. Define a simple Jacobi preconditioner and use it to
    //     solve the system A X = B with PCG.
-   GSSmoother M(A);
-   PCG(A, M, B, X, 1, 200, 1e-12, 0.0);
+   Solver *P;
+   if (use_lor)
+   {
+#ifndef MFEM_USE_SUITESPARSE
+      P = new LORSolver<GSSmoother>(*a, ess_tdof_list);
 #else
-   // 10. If MFEM was compiled with SuiteSparse, use UMFPACK to solve the system.
-   UMFPackSolver umf_solver;
-   umf_solver.Control[UMFPACK_ORDERING] = UMFPACK_ORDERING_METIS;
-   umf_solver.SetOperator(A);
-   umf_solver.Mult(B, X);
+      std::cout<<"UMF"<<std::endl;
+      P = new LORSolver<UMFPackSolver>(*a, ess_tdof_list);
 #endif
+   }
+   else
+   {
+      P = new GSSmoother(A);
+   }
+
+   PCG(A, *P, B, X, 1, 200, 1e-12, 0.0);
 
    // 11. Recover the solution as a finite element grid function.
    a->RecoverFEMSolution(X, *b, x);
@@ -570,12 +585,56 @@ int main(int argc, char *argv[])
       visit_dc.Save();
    }
 
+   // 15. Save data in the VisIt format -- on projected mesh!!
+   /*{
+      // Create interpolation mesh
+      Array<Vector *> points;
+      fespace->GetNURBSext()->GetPointsCompr(points, NURBSPointSet::DEMKO);
+      Mesh imesh = mesh->GetLinearNURBSMesh(points);
+      for (int i = 0; i < points.Size(); i++) { delete points[i]; }
+
+      // Create interpolation space
+      NURBSFECollection ifec(1);
+      FiniteElementSpace ifespace(&imesh, new NURBSExtension(imesh.NURBSext, 1),
+                                  &ifec);
+
+      // Create transfer operations
+      fespace->GetNURBSext()->CreatePatches();
+      ifespace.GetNURBSext()->CreatePatches();
+
+      GridTransfer *gt = new InterpolationGridTransfer(*fespace, ifespace);
+      const Operator &ho_2_lo = gt->ForwardOperator();
+      const Operator &lo_2_ho = gt->BackwardOperator();
+
+      fespace->GetNURBSext()->DeletePatches();
+      ifespace.GetNURBSext()->DeletePatches();
+
+      // Project on nodal solution
+      GridFunction ix(&ifespace);
+      ho_2_lo.Mult(x, ix);
+
+      VisItDataCollection visit_dc1("Example1_linear", &imesh);
+      visit_dc1.RegisterField("solution",   &ix);
+      visit_dc1.Save();
+
+      // Project on nodal solution on original
+      x = 0.0;
+      lo_2_ho.Mult(ix, x);
+
+      VisItDataCollection visit_dc2("Example1_orig", mesh);
+      visit_dc2.RegisterField("solution",   &x);
+      visit_dc2.Save();
+
+      delete gt;
+   }*/
+
    // 15. Free the used memory.
    delete a;
    delete b;
    delete fespace;
    if (own_fec) { delete fec; }
    delete mesh;
+   delete P;
 
    return 0;
 }

--- a/miniapps/tools/lor-transfer.cpp
+++ b/miniapps/tools/lor-transfer.cpp
@@ -70,6 +70,7 @@ int main(int argc, char *argv[])
    // Parse command-line options.
    const char *mesh_file = "../../data/star.mesh";
    int order = 3;
+   int ref = 0;
    int lref = order+1;
    int lorder = 0;
    bool vis = true;
@@ -87,6 +88,8 @@ int main(int argc, char *argv[])
    args.AddOption(&order, "-o", "--order",
                   "Finite element order (polynomial degree) or -1 for"
                   " isoparametric space.");
+   args.AddOption(&ref, "-r", "--refine",
+                  "Number of times to refine the mesh uniformly, -1 for auto.");
    args.AddOption(&lref, "-lref", "--lor-ref-level", "LOR refinement level.");
    args.AddOption(&lorder, "-lo", "--lor-order",
                   "LOR space order (polynomial degree, zero by default).");
@@ -110,33 +113,99 @@ int main(int argc, char *argv[])
    // Read the mesh from the given mesh file.
    Mesh mesh(mesh_file, 1, 1);
    int dim = mesh.Dimension();
+   for (int l = 0; l < ref; l++)
+   {
+      mesh.UniformRefinement();
+   }
+   cout << "------------------------------------\n";
+   cout << " Original HO mesh                   \n";
+   cout << "------------------------------------\n";
+   mesh.PrintInfo();
 
-   // Create the low-order refined mesh
-   int basis_lor = BasisType::GaussLobatto; // BasisType::ClosedUniform;
-   Mesh mesh_lor = Mesh::MakeRefined(mesh, lref, basis_lor);
-
-   // Create spaces
-   FiniteElementCollection *fec, *fec_lor;
+   // Create HO spaces
+   FiniteElementCollection *fec;
+   NURBSExtension *ext = nullptr;
    if (useH1)
    {
       space = "H1";
+      if (mesh.NURBSext)
+      {
+         fec = new NURBSFECollection(order);
+         ext = new NURBSExtension(mesh.NURBSext, order);
+      }
+      else
+      {
+         fec = new H1_FECollection(order, dim);
+      }
+   }
+   else
+   {
+      if (mesh.NURBSext)
+      {
+         cerr << "NURBS mesh but making standard L2 FE space\n";
+      }
+      space = "L2";
+      fec = new L2_FECollection(order, dim);
+   }
+   FiniteElementSpace fespace(&mesh, ext, fec);
+   cout<<"degrees of freedom : "<<fespace.GetNDofs() <<std::endl<<std::endl;
+
+
+   // Create the low-order refined mesh
+   Mesh mesh_lor;
+   if (fespace.GetNURBSext())
+   {
+      Array<Vector *> points;
+      NURBSPointSet points_lor = NURBSPointSet::DEMKO;
+      fespace.GetNURBSext()->GetPointsCompr(points, points_lor);
+
+      mesh_lor = mesh.GetLinearNURBSMesh(points);
+      for (int l = 0; l < lref; l++)
+      {
+         mesh_lor.UniformRefinement();
+      }
+      for (int i=0; i<points.Size(); ++i)
+      {
+         delete points[i];
+      }
+   }
+   else
+   {
+      int basis_lor = BasisType::GaussLobatto; // BasisType::ClosedUniform;
+      mesh_lor = Mesh::MakeRefined(mesh, lref, basis_lor);
+   }
+   cout << "------------------------------------\n";
+   cout << " Refined LOR mesh                   \n";
+   cout << "------------------------------------\n";
+   mesh_lor.PrintInfo();
+
+   // Create LOR spaces
+   FiniteElementCollection *fec_lor;
+   NURBSExtension *ext_lor = nullptr;
+   if (useH1)
+   {
       if (lorder == 0)
       {
          lorder = 1;
          cerr << "Switching the H1 LOR space order from 0 to 1\n";
       }
-      fec = new H1_FECollection(order, dim);
-      fec_lor = new H1_FECollection(lorder, dim);
+
+      if (mesh_lor.NURBSext)
+      {
+         fec_lor = new NURBSFECollection(lorder);
+         ext_lor = new NURBSExtension(mesh_lor.NURBSext, lorder);
+      }
+      else
+      {
+         fec_lor = new H1_FECollection(lorder, dim);
+      }
    }
    else
    {
-      space = "L2";
-      fec = new L2_FECollection(order, dim);
       fec_lor = new L2_FECollection(lorder, dim);
    }
-
-   FiniteElementSpace fespace(&mesh, fec);
-   FiniteElementSpace fespace_lor(&mesh_lor, fec_lor);
+   FiniteElementSpace fespace_lor(&mesh_lor, ext_lor, fec_lor);
+   cout<<"degrees of freedom : "<<fespace_lor.GetNDofs() <<std::endl<<std::endl;
 
    GridFunction rho(&fespace);
    GridFunction rho_lor(&fespace_lor);
@@ -175,6 +244,7 @@ int main(int argc, char *argv[])
    }
    else
    {
+      MFEM_VERIFY(!ext_lor, "L2 GridTransfer not implemented for NURBS.");
       gt = new L2ProjectionGridTransfer(fespace, fespace_lor);
    }
 


### PR DESCRIPTION
This PR adds the capability to create Linear NURBS meshes and spaces, based on higher-order equivalents. The global number of dofs remain the same. Different point sets can be chosen, but Demko points are expected to have the best performance and are therefor chosen as default (in most cases). The LOR classes have been extended to use this capability. 

This is more a proof of concept and a stepping stone. There are a couple of important caveats:
 - It is only a serial implementation. Parallel implementation will be far from trivial and might require a new way of determining the partition. This to make the LO & HO spaces partitions compatible.
 - Performance was not considered. The interpolation matrix can be accelerated by exploiting the tensor product nature (using the Kronecker product) and BandMatrices (defined in separate PR).
 - There are issues in the multi patch case. I do not think this is related to this PR, but something more problematic deeper down, reveled by this PR.   This is related to orientations of knot vectors.