### PR TITLE
Skips comments when parsing nurbs patch controlpoints sections

### DIFF
--- a/mesh/nurbs.cpp
+++ b/mesh/nurbs.cpp
@@ -1354,22 +1354,27 @@ NURBSPatch::NURBSPatch(std::istream &input)
    int pdim, dim, size = 1;
    string ident;
 
+   skip_comment_lines(input, '#');
    input >> ws >> ident >> pdim; // knotvectors
    kv.SetSize(pdim);
    for (int i = 0; i < pdim; i++)
    {
+      skip_comment_lines(input, '#');
       kv[i] = new KnotVector(input);
       size *= kv[i]->GetNCP();
    }
 
+   skip_comment_lines(input, '#');
    input >> ws >> ident >> dim; // dimension
    init(dim + 1);
 
+   skip_comment_lines(input, '#');
    input >> ws >> ident; // controlpoints (homogeneous coordinates)
    if (ident == "controlpoints" || ident == "controlpoints_homogeneous")
    {
       for (int j = 0, i = 0; i < size; i++)
       {
+         skip_comment_lines(input, '#');
          for (int d = 0; d <= dim; d++, j++)
          {
             input >> data[j];
@@ -1380,6 +1385,7 @@ NURBSPatch::NURBSPatch(std::istream &input)
    {
       for (int j = 0, i = 0; i < size; i++)
       {
+         skip_comment_lines(input, '#');
          for (int d = 0; d <= dim; d++)
          {
             input >> data[j+d];

--- a/tests/unit/mesh/test_nurbs.cpp
+++ b/tests/unit/mesh/test_nurbs.cpp
@@ -13,6 +13,7 @@
 using namespace mfem;
 
 #include "unit_tests.hpp"
+#include <sstream>
 
 TEST_CASE("NURBS knot insertion and removal", "[NURBS]")
 {
@@ -130,6 +131,77 @@ TEST_CASE("NURBS mesh reconstruction", "[NURBS]")
 
    // Cleanup
    for (auto *p : patches) { delete p; }
+}
+
+TEST_CASE("NURBSPatch skips comments while loading", "[NURBS]")
+{
+   SECTION("Homogeneous control points")
+   {
+      std::stringstream input(R"(
+# before knotvectors
+knotvectors
+1
+# before first knotvector
+1 2 0 0 1 1
+
+# before dimension
+dimension
+2
+
+# before controlpoints
+controlpoints
+# before first control point
+0.0 0.0 1.0
+# before second control point
+1.0 0.0 1.0
+)");
+
+      NURBSPatch patch(input);
+      REQUIRE(patch.GetNKV() == 1);
+      REQUIRE(patch.GetNC() == 3);
+      REQUIRE(patch.GetKV(0)->GetOrder() == 1);
+      REQUIRE(patch.GetKV(0)->GetNCP() == 2);
+      REQUIRE(patch(0, 0) == MFEM_Approx(0.0));
+      REQUIRE(patch(0, 1) == MFEM_Approx(0.0));
+      REQUIRE(patch(0, 2) == MFEM_Approx(1.0));
+      REQUIRE(patch(1, 0) == MFEM_Approx(1.0));
+      REQUIRE(patch(1, 1) == MFEM_Approx(0.0));
+      REQUIRE(patch(1, 2) == MFEM_Approx(1.0));
+   }
+
+   SECTION("Cartesian control points")
+   {
+      std::stringstream input(R"(
+# before knotvectors
+knotvectors
+1
+# before first knotvector
+1 2 0 0 1 1
+
+# before dimension
+dimension
+2
+
+# before controlpoints
+controlpoints_cartesian
+# before first control point
+0.0 0.0 1.0
+# before second control point
+2.0 4.0 0.5
+)");
+
+      NURBSPatch patch(input);
+      REQUIRE(patch.GetNKV() == 1);
+      REQUIRE(patch.GetNC() == 3);
+      REQUIRE(patch.GetKV(0)->GetOrder() == 1);
+      REQUIRE(patch.GetKV(0)->GetNCP() == 2);
+      REQUIRE(patch(0, 0) == MFEM_Approx(0.0));
+      REQUIRE(patch(0, 1) == MFEM_Approx(0.0));
+      REQUIRE(patch(0, 2) == MFEM_Approx(1.0));
+      REQUIRE(patch(1, 0) == MFEM_Approx(1.0));
+      REQUIRE(patch(1, 1) == MFEM_Approx(2.0));
+      REQUIRE(patch(1, 2) == MFEM_Approx(0.5));
+   }
 }
 
 TEST_CASE("Location conversion check", "[NURBS]")


### PR DESCRIPTION
This PR adds some `skip_comment_lines` to the nurbs patch parser.

Resolves #5428 
<!--GHEX{"author":"kennyweiss","assignment":"2026-07-29T15:23:59","editor":"tzanio","id":5429,"reviewers":["dylan-copeland","tzanio","v-dobrev"],"merge":"2026-07-31T17:02:04","approval":"2026-07-30T23:03:47"}XEHG-->
<!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge|
 | --- | --- | --- | --- | --- | --- | --- |
| [#5429](https://github.com/mfem/mfem/pull/5429) | @kennyweiss | @tzanio | @dylan-copeland + @tzanio + @v-dobrev | 7/29/26 | 7/30/26 | 7/31/26 | |
<!--ELBATXEHG-->
<details>
<summary>PR Checklist</summary>
    
- [ ] Code builds.
- [ ] Code passes `make style`.
- [ ] Update `CHANGELOG`:
    - [ ] Is this a new feature users need to be aware of? New or updated example or miniapp?
    - [ ] Does it make sense to create a new section in the `CHANGELOG` to group with other related features?
- [ ] Update `INSTALL`:
    - [ ] Had a new optional library been added? If so, what range of versions of this library are required? (*Make sure the external library is compatible with our BSD license, e.g. it is not licensed under GPL!*)
    - [ ] Have the version ranges for any required or optional libraries changed?
    - [ ] Does `make` or `cmake` have a new target?
    - [ ] Did the requirements or the installation process change? *(rare)*
- [ ] Update continuous integration server configurations if necessary (e.g. with new version requirements for each of MFEM's dependencies)
    - [ ] `.github`
    - [ ] `.appveyor.yml`
- [ ] Update `.gitignore`:
    - [ ] Check if `make distclean; git status` shows any files that were generated from the source by the project (not an IDE) but we don't want to track in the repository.
    - [ ] Add new patterns (just for the new files above) and re-run the above test.
- [ ] New examples:
    - [ ] All sample runs at the top of the example source file work.
    - [ ] Update `examples/makefile`:
      - [ ] Add the example code to the appropriate `SEQ_EXAMPLES` and `PAR_EXAMPLES` variables.
      - [ ] Add any files generated by it to the `clean` target.
      - [ ] Add the example binary and any files generated by it to the top-level `.gitignore` file.
    - [ ] Update `examples/CMakeLists.txt`:
      - [ ] Add the example code to the `ALL_EXE_SRCS` variable.
      - [ ] Make sure `THIS_TEST_OPTIONS` is set correctly for the new example.
   - [ ] List the new example in `doc/CodeDocumentation.dox`.
   - [ ] If new examples directory (e.g.`examples/pumi`), list it in `doc/CodeDocumentation.conf.in`
   - [ ] Companion pull request for documentation in [mfem/web](https://github.com/mfem/web) repo:
      - [ ] Update or add example-specific documentation, see e.g. the `src/examples.md`.
      - [ ] Add the description, labels and screenshots in `src/examples.md` and `src/img`.
      - [ ] In `examples.md`, list the example under the appropriate categories, add new categories if necessary.
      - [ ] Add a short description of the example in the "Extensive Examples" section of `features.md`.
- [ ] New miniapps:
   - [ ] All sample runs at the top of the miniapp source file work.
   - [ ] Update top-level `makefile` and `makefile` in corresponding miniapp directory.
   - [ ] Add the miniapp binary and any files generated by it to the top-level `.gitignore` file.
   - [ ] Update CMake build system:
      - [ ] Update the `CMakeLists.txt` file in the `miniapps` directory, if the new miniapp is in a new directory.
      - [ ] Add/update the `CMakeLists.txt` file in the new miniapp directory.
      - [ ] Consider adding a new test for the new miniapp.
   - [ ] List the new miniapp in `doc/CodeDocumentation.dox`
   - [ ] If new miniapps directory (e.g.`miniapps/nurbs`), add it to `MINIAPP_SUBDIRS` in the `makefile`.
   - [ ] If new miniapps directory (e.g.`miniapps/nurbs`), list it in `doc/CodeDocumentation.conf.in`
   - [ ] Companion pull request for documentation in [mfem/web](https://github.com/mfem/web) repo:
     - [ ] Update or add miniapp-specific documentation, see e.g. the `src/meshing.md` and `src/electromagnetics.md` files.
     - [ ] Add the description, labels and screenshots in `src/examples.md` and `src/img`.
     - [ ] The miniapps go at the end of the page, and are usually listed only under a specific "Application (PDE)" category.
     - [ ] Add a short description of the miniapp in the "Extensive Examples" section of `features.md`.
- [ ] New capability:
   - [ ] All new public, protected, and private classes, methods, data members, and functions have full Doxygen-style documentation in source comments. Documentation should include descriptions of member data, function arguments and return values, template parameters, and prerequisites for calling new functions.
   - [ ] Pointer arguments and return values must specify whether ownership is being transferred or lent with the call.
   - [ ] Any new functions should include descriptions of their intended use e.g. for internal use only, user-facing, etc., along with references to example code whenever possible/appropriate.
   - [ ] Consider adding new sample runs in existing examples to highlight the new capability.
   - [ ] Consider saving cool simulation pictures with the new capability in the Confluence gallery (LLNL only) or submitting them, via pull request, to the gallery section of the `mfem/web` repo.
   - [ ] If this is a major new feature, consider mentioning it in the short summary inside `README` *(rare)*.
   - [ ] List major new classes in `doc/CodeDocumentation.dox` *(rare)*.
- [ ] Update this checklist, if the new pull request affects it.
- [ ] Run `make unittest` to make sure all unit tests pass.
- [ ] Run the tests in `tests/scripts`.
- [ ] (LLNL only) After merging:
   - [ ] Update internal tests to include the new features.
</details>
