### PR TITLE
Fix parallel anisotropic refinement conflicts in nonconforming meshes

### DIFF
--- a/mesh/ncmesh.cpp
+++ b/mesh/ncmesh.cpp
@@ -827,7 +827,8 @@ void NCMesh::ForceRefinement(int vn1, int vn2, int vn3, int vn4)
    Face* face = faces.Find(vn1, vn2, vn3, vn4);
    if (!face) { return; }
 
-   MFEM_VERIFY(!IsParallel(), "ForceRefinement is supported only in serial");
+   MFEM_VERIFY(!IsParallel() || allow_parallel_forced_refinements,
+               "Forced parallel refinement is not synchronized");
 
    const int elem = face->GetSingleElement();
    Element &el = elements[elem];

--- a/mesh/ncmesh.hpp
+++ b/mesh/ncmesh.hpp
@@ -852,6 +852,8 @@ protected:
 
    // refinement/derefinement
 
+   /// Allow ParNCMesh to collect forced refinements during synchronized rounds.
+   bool allow_parallel_forced_refinements = false;
    Array<Refinement> ref_stack; ///< stack of scheduled refinements (temporary)
    HashTable<Node> shadow; ///< temporary storage for reparented nodes
    Array<Triple<int, int, int> > reparents; ///< scheduled node reparents (tmp)

--- a/mesh/pncmesh.cpp
+++ b/mesh/pncmesh.cpp
@@ -41,6 +41,106 @@ static bool SameSplitScale(real_t a, real_t b)
           std::max(real_t(1.0), std::max(std::abs(a), std::abs(b)));
 }
 
+using ElementPath = std::vector<int>;
+using RefinementKey = std::pair<ElementPath, char>;
+using PendingRefinements = std::map<RefinementKey, Refinement>;
+
+struct PathRefinement
+{
+   ElementPath path;
+   int type;
+   real_t scale[3];
+};
+
+static bool GatherRefinements(MPI_Comm comm, int nranks,
+                              const PendingRefinements &local,
+                              std::vector<PathRefinement> &gathered)
+{
+   gathered.clear();
+   const int local_count = static_cast<int>(local.size());
+   std::vector<int> ref_counts(nranks);
+   MPI_Allgather(&local_count, 1, MPI_INT, ref_counts.data(), 1, MPI_INT,
+                 comm);
+
+   std::vector<int> ref_displs(nranks);
+   int total_refs = 0;
+   for (int i = 0; i < nranks; i++)
+   {
+      ref_displs[i] = total_refs;
+      total_refs += ref_counts[i];
+   }
+   if (!total_refs) { return false; }
+
+   std::vector<int> local_paths;
+   std::vector<real_t> local_scales;
+   local_scales.reserve(3*local_count);
+   for (const auto &entry : local)
+   {
+      const ElementPath &path = entry.first.first;
+      const Refinement &ref = entry.second;
+      local_paths.push_back(static_cast<int>(path.size()));
+      local_paths.insert(local_paths.end(), path.begin(), path.end());
+      local_paths.push_back(ref.GetType());
+      local_scales.insert(local_scales.end(), ref.s, ref.s + 3);
+   }
+
+   const int local_path_size = static_cast<int>(local_paths.size());
+   std::vector<int> path_sizes(nranks), path_displs(nranks);
+   MPI_Allgather(&local_path_size, 1, MPI_INT, path_sizes.data(), 1, MPI_INT,
+                 comm);
+
+   int total_path_size = 0;
+   for (int i = 0; i < nranks; i++)
+   {
+      path_displs[i] = total_path_size;
+      total_path_size += path_sizes[i];
+   }
+
+   std::vector<int> paths(total_path_size);
+   MPI_Allgatherv(local_paths.data(), local_path_size, MPI_INT,
+                  paths.data(), path_sizes.data(), path_displs.data(), MPI_INT,
+                  comm);
+
+   std::vector<int> scale_counts(nranks), scale_displs(nranks);
+   for (int i = 0; i < nranks; i++)
+   {
+      scale_counts[i] = 3*ref_counts[i];
+      scale_displs[i] = 3*ref_displs[i];
+   }
+   std::vector<real_t> scales(3*total_refs);
+   MPI_Allgatherv(local_scales.data(), 3*local_count, MFEM_MPI_REAL_T,
+                  scales.data(), scale_counts.data(), scale_displs.data(),
+                  MFEM_MPI_REAL_T, comm);
+
+   gathered.reserve(total_refs);
+   for (int rank = 0; rank < nranks; rank++)
+   {
+      int path_pos = path_displs[rank];
+      for (int i = 0; i < ref_counts[rank]; i++)
+      {
+         const int path_size = paths[path_pos++];
+         MFEM_ASSERT(path_size > 0 &&
+                     path_pos + path_size <
+                     path_displs[rank] + path_sizes[rank],
+                     "Invalid refinement path");
+
+         PathRefinement ref;
+         ref.path.assign(paths.begin() + path_pos,
+                         paths.begin() + path_pos + path_size);
+         path_pos += path_size;
+         ref.type = paths[path_pos++];
+         for (int d = 0; d < 3; d++)
+         {
+            ref.scale[d] = scales[3*(ref_displs[rank] + i) + d];
+         }
+         gathered.push_back(std::move(ref));
+      }
+      MFEM_ASSERT(path_pos == path_displs[rank] + path_sizes[rank],
+                  "Invalid refinement path data");
+   }
+   return true;
+}
+
 static real_t DirectedHexEdgeScale(const int* nodes, const Refinement &ref,
                                    int v0, int v1)
 {
@@ -2088,16 +2188,42 @@ void ParNCMesh::Refine(const Array<Refinement> &refinements)
 
    for (int i = 0; i < refinements.Size() && Iso; i++)
    {
-      const Refinement &ref = refinements[i];
-      if (ref.GetType() != Refinement::XYZ)
+      if (refinements[i].GetType() != Refinement::XYZ)
       {
          Iso = false;
       }
    }
 
-   NeighborRefinementMessage::Map send_ref;
+   if (NeedsGlobalRefinementSync(refinements))
+   {
+      RefineWithGlobalSync(refinements);
+   }
+   else
+   {
+      RefineWithNeighbors(refinements);
+   }
+}
 
-   // create refinement messages to all neighbors (NOTE: some may be empty)
+bool ParNCMesh::NeedsGlobalRefinementSync(
+   const Array<Refinement> &refinements)
+{
+   if (Dim != 3) { return false; }
+
+   if (Geoms == (1 << Geometry::CUBE))
+   {
+      std::set<int> conflicts;
+      return AnisotropicConflict(refinements, conflicts);
+   }
+
+   bool global_iso = false;
+   MPI_Allreduce(&Iso, &global_iso, 1, MFEM_MPI_CXX_BOOL, MPI_LAND, MyComm);
+   return !global_iso;
+}
+
+void ParNCMesh::RefineWithNeighbors(
+   const Array<Refinement> &refinements)
+{
+   NeighborRefinementMessage::Map send_ref;
    Array<int> neighbors;
    NeighborProcessors(neighbors);
    for (int i = 0; i < neighbors.Size(); i++)
@@ -2105,15 +2231,12 @@ void ParNCMesh::Refine(const Array<Refinement> &refinements)
       send_ref[neighbors[i]].SetNCMesh(this);
    }
 
-   // populate messages: all refinements that occur next to the processor
-   // boundary need to be sent to the adjoining neighbors so they can keep
-   // their ghost layer up to date
    Array<int> ranks;
    ranks.Reserve(64);
    for (int i = 0; i < refinements.Size(); i++)
    {
       const Refinement &ref = refinements[i];
-      MFEM_ASSERT(ref.index < NElements, "");
+      MFEM_ASSERT(ref.index < NElements, "Invalid local element index");
       const int elem = leaf_elements[ref.index];
       ElementNeighborProcessors(elem, ranks);
       for (int j = 0; j < ranks.Size(); j++)
@@ -2121,19 +2244,15 @@ void ParNCMesh::Refine(const Array<Refinement> &refinements)
          send_ref[ranks[j]].AddRefinement(elem, ref);
       }
    }
-
-   // send the messages (overlap with local refinements)
    NeighborRefinementMessage::IsendAll(send_ref, MyComm);
 
-   // do local refinements
    for (int i = 0; i < refinements.Size(); i++)
    {
-      Refinement ref_i = refinements[i];
-      ref_i.index = leaf_elements[refinements[i].index];
-      NCMesh::RefineElement(ref_i);
+      Refinement ref = refinements[i];
+      ref.index = leaf_elements[ref.index];
+      NCMesh::RefineElement(ref);
    }
 
-   // receive (ghost layer) refinements from all neighbors
    for (int j = 0; j < neighbors.Size(); j++)
    {
       int rank, size;
@@ -2143,7 +2262,6 @@ void ParNCMesh::Refine(const Array<Refinement> &refinements)
       msg.SetNCMesh(this);
       msg.Recv(rank, size, MyComm);
 
-      // do the ghost refinements
       for (int i = 0; i < msg.Size(); i++)
       {
          Refinement ghost_ref(msg.elements[i], msg.values[i].ref_type);
@@ -2152,10 +2270,169 @@ void ParNCMesh::Refine(const Array<Refinement> &refinements)
       }
    }
 
+   MFEM_VERIFY(ref_stack.Size() == 0,
+               "Unexpected forced parallel refinement");
    Update();
-
-   // make sure we can delete the send buffers
    NeighborRefinementMessage::WaitAllSent(send_ref);
+}
+
+void ParNCMesh::RefineWithGlobalSync(
+   const Array<Refinement> &refinements)
+{
+   // A forced refinement can propagate beyond the original processor
+   // neighborhood. Synchronize processor-independent root-to-child paths in
+   // global rounds until no rank schedules another refinement.
+   auto GetElementPath = [this](int elem)
+   {
+      ElementPath path;
+      int parent;
+      while ((parent = elements[elem].parent) >= 0)
+      {
+         const Element &parent_el = elements[parent];
+         int child = -1;
+         for (int i = 0; i < MaxElemChildren; i++)
+         {
+            if (parent_el.child[i] == elem)
+            {
+               child = i;
+               break;
+            }
+         }
+         MFEM_ASSERT(child >= 0, "Element is not a child of its parent");
+         path.push_back(child);
+         elem = parent;
+      }
+      path.push_back(elem);
+      std::reverse(path.begin(), path.end());
+      return path;
+   };
+
+   auto AddPending = [&](PendingRefinements &pending,
+                         const Refinement &ref)
+   {
+      for (int d = 0; d < 3; d++)
+      {
+         MFEM_VERIFY(ref.s[d] <= 0.0 || SameSplitScale(ref.s[d], 0.5),
+                     "Parallel anisotropic refinement conflicts currently "
+                     "require midpoint splits");
+      }
+      const ElementPath path = GetElementPath(ref.index);
+      const RefinementKey key(path, ref.GetType());
+      auto inserted = pending.emplace(key, ref);
+      if (inserted.second) { return; }
+
+      Refinement &combined = inserted.first->second;
+      MFEM_ASSERT(combined.index == ref.index,
+                  "Inconsistent local refinement paths");
+      for (int d = 0; d < 3; d++)
+      {
+         if (ref.s[d] <= 0.0) { continue; }
+         MFEM_VERIFY(combined.s[d] <= 0.0 ||
+                     SameSplitScale(combined.s[d], ref.s[d]),
+                     "Conflicting refinement scales are not supported");
+         combined.s[d] = ref.s[d];
+      }
+   };
+
+   auto FindElementPath = [this](const ElementPath &path)
+   {
+      if (path.empty() || path[0] < 0 || path[0] >= root_state.Size())
+      {
+         return -1;
+      }
+
+      int elem = path[0];
+      for (std::size_t i = 1; i < path.size(); i++)
+      {
+         const int child = path[i];
+         if (!elements[elem].ref_type || child < 0 ||
+             child >= MaxElemChildren || elements[elem].child[child] < 0)
+         {
+            return -1;
+         }
+         elem = elements[elem].child[child];
+      }
+      return elem;
+   };
+
+   auto GetIndexedAncestor = [this](int elem)
+   {
+      while (elem >= 0 && elements[elem].index < 0)
+      {
+         elem = elements[elem].parent;
+      }
+      return elem;
+   };
+
+   auto ApplyPending = [&](const PendingRefinements &pending,
+                           PendingRefinements &forced)
+   {
+      allow_parallel_forced_refinements = true;
+      for (const auto &entry : pending)
+      {
+         NCMesh::RefineElement(entry.second);
+         for (int i = 0; i < ref_stack.Size(); i++)
+         {
+            // A forced refinement outside the current ghost layer is also
+            // generated by a rank that stores the affected interface. Let
+            // that rank propagate it to avoid acting on an incomplete tree.
+            if (GetIndexedAncestor(ref_stack[i].index) >= 0)
+            {
+               AddPending(forced, ref_stack[i]);
+            }
+         }
+         ref_stack.DeleteAll();
+      }
+      allow_parallel_forced_refinements = false;
+   };
+
+   auto SynchronizeRefinements = [&](const PendingRefinements &local,
+                                     PendingRefinements &synchronized)
+   {
+      std::vector<PathRefinement> gathered;
+      if (!GatherRefinements(MyComm, NRanks, local, gathered))
+      {
+         synchronized.clear();
+         return false;
+      }
+
+      synchronized.clear();
+      for (const PathRefinement &path_ref : gathered)
+      {
+         const int elem = FindElementPath(path_ref.path);
+         if (elem >= 0 && GetIndexedAncestor(elem) >= 0)
+         {
+            Refinement ref(elem, path_ref.type);
+            ref.SetScaleForType(path_ref.scale);
+            AddPending(synchronized, ref);
+         }
+      }
+      return true;
+   };
+
+   PendingRefinements pending;
+   for (int i = 0; i < refinements.Size(); i++)
+   {
+      const Refinement &ref = refinements[i];
+      MFEM_ASSERT(ref.index < NElements, "Invalid local element index");
+      Refinement local_ref = ref;
+      local_ref.index = leaf_elements[ref.index];
+      AddPending(pending, local_ref);
+   }
+
+   ref_stack.DeleteAll();
+   shadow.DeleteAll();
+
+   PendingRefinements synchronized;
+   while (SynchronizeRefinements(pending, synchronized))
+   {
+      pending.clear();
+      ApplyPending(synchronized, pending);
+   }
+
+   ref_stack.DeleteAll();
+   shadow.DeleteAll();
+   Update();
 }
 
 

--- a/mesh/pncmesh.hpp
+++ b/mesh/pncmesh.hpp
@@ -339,6 +339,10 @@ protected: // implementation
 
    void Update() override;
 
+   bool NeedsGlobalRefinementSync(const Array<Refinement> &refinements);
+   void RefineWithNeighbors(const Array<Refinement> &refinements);
+   void RefineWithGlobalSync(const Array<Refinement> &refinements);
+
    /// Return the processor number for a global element number.
    int Partition(long index, long total_elements) const
    { return index * NRanks / total_elements; }

--- a/tests/unit/mesh/test_ncmesh.cpp
+++ b/tests/unit/mesh/test_ncmesh.cpp
@@ -13,7 +13,6 @@
 #include "mesh_test_utils.hpp"
 #include "unit_tests.hpp"
 
-#include <array>
 namespace mfem
 {
 
@@ -303,6 +302,269 @@ TEST_CASE("pNCMesh PA diagonal",  "[Parallel], [NCMesh]")
       }
    }
 } // test case
+
+static const char tangential_refinements[3][2] =
+{
+   {Refinement::Y, Refinement::Z},
+   {Refinement::X, Refinement::Z},
+   {Refinement::X, Refinement::Y}
+};
+
+static Mesh MakeHexLine(int normal, int elements)
+{
+   int size[3] = {1, 1, 1};
+   size[normal] = elements;
+   Mesh mesh = Mesh::MakeCartesian3D(
+                  size[0], size[1], size[2], Element::HEXAHEDRON,
+                  1.0, 1.0, 1.0);
+   mesh.EnsureNCMesh();
+   return mesh;
+}
+
+static int ElementSide(Mesh &mesh, int elem, int normal)
+{
+   const IntegrationPoint &center =
+      Geometries.GetCenter(mesh.GetElementBaseGeometry(elem));
+   Vector point(3);
+   mesh.GetElementTransformation(elem)->Transform(center, point);
+   return point[normal] < 0.5 ? 0 : 1;
+}
+
+static void AppendSideRefinements(Mesh &mesh, int normal,
+                                  char lower, char upper,
+                                  Array<Refinement> &refs)
+{
+   const char ref_type[2] = {lower, upper};
+   for (int i = 0; i < mesh.GetNE(); i++)
+   {
+      refs.Append(Refinement(i, ref_type[ElementSide(mesh, i, normal)]));
+   }
+}
+
+static void AppendSideRefinement(Mesh &mesh, int normal, int side,
+                                 char ref_type, Array<Refinement> &refs)
+{
+   for (int i = 0; i < mesh.GetNE(); i++)
+   {
+      if (ElementSide(mesh, i, normal) == side)
+      {
+         refs.Append(Refinement(i, ref_type));
+      }
+   }
+}
+
+static void AppendOppositeFaceRefinements(Mesh &mesh, int normal,
+                                          Array<Refinement> &refs)
+{
+   for (int i = 0; i < mesh.GetNE(); i++)
+   {
+      const IntegrationPoint &center =
+         Geometries.GetCenter(mesh.GetElementBaseGeometry(i));
+      Vector point(3);
+      mesh.GetElementTransformation(i)->Transform(center, point);
+      const bool middle = point[normal] > 1.0/3.0 &&
+                          point[normal] < 2.0/3.0;
+      refs.Append(Refinement(
+                     i, tangential_refinements[normal][middle ? 0 : 1]));
+   }
+}
+
+static real_t MeshVolume(Mesh &mesh)
+{
+   real_t volume = 0.0;
+   for (int i = 0; i < mesh.GetNE(); i++)
+   {
+      volume += mesh.GetElementVolume(i);
+   }
+   return volume;
+}
+
+static real_t GlobalMeshVolume(ParMesh &mesh)
+{
+   const real_t local_volume = MeshVolume(mesh);
+   real_t global_volume = 0.0;
+   MPI_Allreduce(&local_volume, &global_volume, 1, MFEM_MPI_REAL_T,
+                 MPI_SUM, mesh.GetComm());
+   return global_volume;
+}
+
+static void CheckParallelMesh(Mesh &serial, ParMesh &parallel,
+                              bool rebalance = true)
+{
+   const int checks = rebalance ? 2 : 1;
+   for (int pass = 0; pass < checks; pass++)
+   {
+      CHECK(parallel.GetGlobalNE() == serial.GetNE());
+      CHECK(GlobalMeshVolume(parallel) == MFEM_Approx(MeshVolume(serial)));
+
+      H1_FECollection fec(1, 3);
+      FiniteElementSpace serial_fes(&serial, &fec);
+      ParFiniteElementSpace parallel_fes(&parallel, &fec);
+      CHECK(parallel_fes.GlobalTrueVSize() == serial_fes.GetTrueVSize());
+
+      if (pass == 0 && rebalance) { parallel.Rebalance(); }
+   }
+}
+
+static bool HasAnisotropicConflict(ParMesh &mesh,
+                                   const Array<Refinement> &refs)
+{
+   std::set<int> conflicts;
+   return mesh.AnisotropicConflict(refs, conflicts);
+}
+
+static void CheckTwoElementRefinement(int normal, char lower, char upper,
+                                      bool expect_conflict,
+                                      bool same_rank = false)
+{
+   Mesh serial = MakeHexLine(normal, 2);
+   int partition[2] = {0, same_rank ? 0 : 1};
+   ParMesh parallel(MPI_COMM_WORLD, serial, partition);
+
+   Array<Refinement> serial_refs, parallel_refs;
+   AppendSideRefinements(serial, normal, lower, upper, serial_refs);
+   AppendSideRefinements(parallel, normal, lower, upper, parallel_refs);
+   serial.GeneralRefinement(serial_refs);
+
+   CHECK(HasAnisotropicConflict(parallel, parallel_refs) == expect_conflict);
+   parallel.GeneralRefinement(parallel_refs);
+   CheckParallelMesh(serial, parallel);
+}
+
+TEST_CASE("ParNCMesh anisotropic refinement conflicts",
+          "[Parallel], [NCMesh]")
+{
+   const int nranks = Mpi::WorldSize();
+   if (nranks < 2) { return; }
+
+   SECTION("Non-conflicting control")
+   {
+      const int normal = GENERATE(0, 1, 2);
+      const char ref_type = tangential_refinements[normal][0];
+      CheckTwoElementRefinement(normal, ref_type, ref_type, false);
+   }
+
+   SECTION("Simultaneous conflict in every face orientation")
+   {
+      const int normal = GENERATE(0, 1, 2);
+      CheckTwoElementRefinement(
+         normal, tangential_refinements[normal][0],
+         tangential_refinements[normal][1], true);
+   }
+
+   SECTION("Isotropic refinement opposite an anisotropic split is compatible")
+   {
+      const int normal = GENERATE(0, 1, 2);
+      CheckTwoElementRefinement(
+         normal, tangential_refinements[normal][0], Refinement::XYZ,
+         false);
+   }
+
+   SECTION("Conflict with an existing anisotropic interface")
+   {
+      const int normal = GENERATE(0, 1, 2);
+      Mesh serial = MakeHexLine(normal, 2);
+      int partition[2] = {0, 1};
+      ParMesh parallel(MPI_COMM_WORLD, serial, partition);
+
+      Array<Refinement> refs;
+      AppendSideRefinement(serial, normal, 0,
+                           tangential_refinements[normal][0], refs);
+      serial.GeneralRefinement(refs);
+
+      refs.SetSize(0);
+      AppendSideRefinement(parallel, normal, 0,
+                           tangential_refinements[normal][0], refs);
+      parallel.GeneralRefinement(refs);
+
+      refs.SetSize(0);
+      AppendSideRefinement(serial, normal, 1,
+                           tangential_refinements[normal][1], refs);
+      REQUIRE(refs.Size() == 1);
+      serial.GeneralRefinement(refs);
+
+      refs.SetSize(0);
+      AppendSideRefinement(parallel, normal, 1,
+                           tangential_refinements[normal][1], refs);
+
+      // Exercise refinement without requiring a conflict preflight.
+      parallel.GeneralRefinement(refs);
+
+      CheckParallelMesh(serial, parallel);
+   }
+
+   SECTION("Conflict between elements owned by one rank")
+   {
+      const int normal = GENERATE(0, 1, 2);
+      CheckTwoElementRefinement(
+         normal, tangential_refinements[normal][0],
+         tangential_refinements[normal][1], true, true);
+   }
+
+   SECTION("Forced refinement from opposite faces")
+   {
+      const int normal = GENERATE(0, 1, 2);
+      Mesh serial = MakeHexLine(normal, 3);
+      int partition[3] = {0, 1, 0};
+      ParMesh parallel(MPI_COMM_WORLD, serial, partition);
+
+      Array<Refinement> serial_refs, parallel_refs;
+      AppendOppositeFaceRefinements(serial, normal, serial_refs);
+      AppendOppositeFaceRefinements(parallel, normal, parallel_refs);
+      serial.GeneralRefinement(serial_refs);
+
+      CHECK(HasAnisotropicConflict(parallel, parallel_refs));
+      parallel.GeneralRefinement(parallel_refs);
+
+      CheckParallelMesh(serial, parallel);
+   }
+
+   SECTION("Conflicts propagated through multiple refinement generations")
+   {
+      Mesh serial = Mesh::MakeCartesian3D(
+                       2, 2, 2, Element::HEXAHEDRON, 1.0, 1.0, 1.0);
+      serial.EnsureNCMesh();
+
+      Array<int> partition_a(serial.GetNE()), partition_b(serial.GetNE());
+      for (int i = 0; i < serial.GetNE(); i++)
+      {
+         partition_a[i] = i % nranks;
+         partition_b[i] = i*nranks/serial.GetNE();
+      }
+      ParMesh parallel_a(MPI_COMM_WORLD, serial, partition_a);
+      ParMesh parallel_b(MPI_COMM_WORLD, serial, partition_b);
+
+      for (int normal = 0; normal < 3; normal++)
+      {
+         Array<Refinement> serial_refs, parallel_a_refs, parallel_b_refs;
+         const char lower = tangential_refinements[normal][0];
+         const char upper = tangential_refinements[normal][1];
+         AppendSideRefinements(serial, normal, lower, upper, serial_refs);
+         AppendSideRefinements(parallel_a, normal, lower, upper,
+                               parallel_a_refs);
+         AppendSideRefinements(parallel_b, normal, lower, upper,
+                               parallel_b_refs);
+
+         serial.GeneralRefinement(serial_refs);
+
+         CHECK(HasAnisotropicConflict(parallel_a, parallel_a_refs));
+         parallel_a.GeneralRefinement(parallel_a_refs);
+         CHECK(HasAnisotropicConflict(parallel_b, parallel_b_refs));
+         parallel_b.GeneralRefinement(parallel_b_refs);
+
+         const real_t serial_volume = MeshVolume(serial);
+         CHECK(parallel_a.GetGlobalNE() == serial.GetNE());
+         CHECK(parallel_b.GetGlobalNE() == parallel_a.GetGlobalNE());
+         CHECK(GlobalMeshVolume(parallel_a) == MFEM_Approx(serial_volume));
+         CHECK(GlobalMeshVolume(parallel_b) == MFEM_Approx(serial_volume));
+
+         H1_FECollection fec(1, 3);
+         ParFiniteElementSpace fes_a(&parallel_a, &fec);
+         ParFiniteElementSpace fes_b(&parallel_b, &fec);
+         CHECK(fes_a.GlobalTrueVSize() == fes_b.GlobalTrueVSize());
+      }
+   }
+}
 
 TEST_CASE("EdgeFaceConstraint", "[Parallel], [NCMesh]")
 {


### PR DESCRIPTION
This pull request enables parallel nonconforming hexahedral meshes to resolve
conflicting anisotropic refinements. It is a follow-up to #4906.

Previously, a refinement conflict at a processor boundary could schedule a
forced refinement through `NCMesh::ForceRefinement`, which aborted for parallel
meshes. The existing neighbor exchange was also insufficient because a forced
refinement can propagate beyond the original ghost-layer neighborhood.

The new implementation:

- preserves the existing neighbor-only fast path when forced refinement is not
  needed;
- detects when a 3D refinement requires synchronized conflict resolution;
- identifies elements by processor-independent root-to-child paths;
- gathers, deduplicates, and applies refinements in deterministic global rounds
  until no rank generates another forced refinement; and
- ignores forced refinements outside the locally indexed tree, allowing a rank
  that stores the affected interface to propagate them safely.

`ParNCMesh::Refine` is kept as a small dispatcher between the serial,
neighbor-only, and globally synchronized paths. The MPI packing and gathering
logic is separated from the refinement orchestration.

This change supports midpoint anisotropic splits. Arbitrary split locations are
not included: the synchronized conflict path verifies that active refinement
scales are `0.5`.

For all-hexahedral 3D meshes, the global path is selected when
`AnisotropicConflict` detects a conflict. Other 3D element combinations use the
global path conservatively whenever the mesh is anisotropic. Existing behavior
is unchanged for serial meshes and for the 1D, 2D, and non-conflicting
all-hexahedral parallel fast paths.

The new parallel test covers:

- non-conflicting anisotropic refinement as a control;
- simultaneous conflicts across processor boundaries for all three face
  orientations;
- compatible isotropic-versus-anisotropic refinement;
- a conflict with an already anisotropically refined interface, without an
  explicit conflict preflight;
- a conflict where both elements are owned by one rank;
- forced refinement generated from opposite faces; and
- propagation through multiple refinement generations using two different
  mesh partitionings.

Each scenario compares the parallel result with a serial reference using the
global element count and volume. The single-generation cases also compare the
global H1 true-vector size before and after rebalancing. The multi-generation
case verifies that both partitionings produce the same parallel H1 true-vector
size.

This pull request was developed with AI assistance.
