### PR TITLE
Fix OpenMP race in AtomicAdd using atomic capture

### DIFF
--- a/general/backends.hpp
+++ b/general/backends.hpp
@@ -119,11 +119,14 @@ MFEM_HOST_DEVICE T AtomicAdd(T &add, const T val)
      (defined(MFEM_USE_HIP) && defined(__HIP_DEVICE_COMPILE__)))
    return atomicAdd(&add,val);
 #else
-   T old = add;
+   T old;
 #ifdef MFEM_USE_OPENMP
-   #pragma omp atomic
+   #pragma omp atomic capture
 #endif
-   add += val;
+   {
+      old = add;
+      add += val;
+   }
    return old;
 #endif
 }

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -41,6 +41,7 @@ set(UNIT_TESTS_SRCS
   dfem/test_mass.cpp
   dfem/test_tuple.cpp
   general/test_array.cpp
+  general/test_backends.cpp
   general/test_scan.cpp
   general/test_arrays_by_name.cpp
   general/test_error.cpp

--- a/tests/unit/general/test_backends.cpp
+++ b/tests/unit/general/test_backends.cpp
@@ -1,0 +1,68 @@
+// Copyright (c) 2010-2025, Lawrence Livermore National Security, LLC. Produced
+// at the Lawrence Livermore National Laboratory. All Rights reserved. See files
+// LICENSE and NOTICE for details. LLNL-CODE-806117.
+//
+// This file is part of the MFEM library. For more information and source code
+// availability visit https://mfem.org.
+//
+// MFEM is free software; you can redistribute it and/or modify it under the
+// terms of the BSD-3 license. We welcome feedback and contributions, see file
+// CONTRIBUTING.md for details.
+
+#include <algorithm>
+#include <vector>
+
+#include "mfem.hpp"
+#include "unit_tests.hpp"
+
+#ifdef MFEM_USE_OPENMP
+#include <omp.h>
+#endif
+
+using namespace mfem;
+
+#ifdef MFEM_USE_OPENMP
+template <typename T>
+void TestAtomicAddCapture()
+{
+   constexpr int num_values = 100000;
+   constexpr int requested_threads = 4;
+
+   std::vector<T> old_values(num_values);
+   T value = 0;
+   int actual_threads = 0;
+
+   #pragma omp parallel num_threads(requested_threads)
+   {
+      #pragma omp single
+      actual_threads = omp_get_num_threads();
+
+      #pragma omp for
+      for (int i = 0; i < num_values; i++)
+      {
+         old_values[i] = AtomicAdd(value, T {1});
+      }
+   }
+
+   CAPTURE(actual_threads);
+   REQUIRE(actual_threads > 1);
+   REQUIRE(value == T {num_values});
+
+   std::sort(old_values.begin(), old_values.end());
+   for (int i = 0; i < num_values; i++)
+   {
+      const T expected = static_cast<T>(i);
+      if (old_values[i] != expected)
+      {
+         CAPTURE(i, old_values[i], expected);
+         REQUIRE(old_values[i] == expected);
+      }
+   }
+}
+
+TEST_CASE("AtomicAdd captures old values atomically", "[AtomicAdd][OpenMP]")
+{
+   TestAtomicAddCapture<int>();
+   TestAtomicAddCapture<real_t>();
+}
+#endif


### PR DESCRIPTION
Fix an OpenMP race in `AtomicAdd` by using `atomic capture` for both reading the old value and updating it.

The previous implementation could return duplicate old values, corrupting PA/LOR restriction data.

Added a four-thread regression test for `int` and `real_t`. The focused test and full unit-test suite pass.

This PR was developed with AI assistance.
<!--GHEX{"author":"adamqc","assignment":"2026-09-09T07:34:17","editor":"tzanio","id":5459,"reviewers":["camierjs","helloworld922"],"merge":"2026-09-30T07:34:17","approval":"2026-09-23T07:34:17"}XEHG-->
<!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge|
 | --- | --- | --- | --- | --- | --- | --- |
| [#5459](https://github.com/mfem/mfem/pull/5459) | @adamqc | @tzanio | @camierjs + @helloworld922 | 9/9/26 | ⌛due 9/23/26 | ⌛due 9/30/26 | |
<!--ELBATXEHG-->
<details>
<summary>PR Checklist</summary>
    
- [ ] Code builds.
- [ ] Code passes `make style`.
- [ ] Update `CHANGELOG`:
    - [ ] Is this a new feature users need to be aware of? New or updated example or miniapp?
    - [ ] Does it make sense to create a new section in the `CHANGELOG` to group with other related features?
- [ ] Update `INSTALL`:
    - [ ] Had a new optional library been added? If so, what range of versions of this library are required? (*Make sure the external library is compatible with our BSD license, e.g. it is not licensed under GPL!*)
    - [ ] Have the version ranges for any required or optional libraries changed?
    - [ ] Does `make` or `cmake` have a new target?
    - [ ] Did the requirements or the installation process change? *(rare)*
- [ ] Update continuous integration server configurations if necessary (e.g. with new version requirements for each of MFEM's dependencies)
    - [ ] `.github`
    - [ ] `.appveyor.yml`
- [ ] Update `.gitignore`:
    - [ ] Check if `make distclean; git status` shows any files that were generated from the source by the project (not an IDE) but we don't want to track in the repository.
    - [ ] Add new patterns (just for the new files above) and re-run the above test.
- [ ] New examples:
    - [ ] All sample runs at the top of the example source file work.
    - [ ] Update `examples/makefile`:
      - [ ] Add the example code to the appropriate `SEQ_EXAMPLES` and `PAR_EXAMPLES` variables.
      - [ ] Add any files generated by it to the `clean` target.
      - [ ] Add the example binary and any files generated by it to the top-level `.gitignore` file.
    - [ ] Update `examples/CMakeLists.txt`:
      - [ ] Add the example code to the `ALL_EXE_SRCS` variable.
      - [ ] Make sure `THIS_TEST_OPTIONS` is set correctly for the new example.
   - [ ] List the new example in `doc/CodeDocumentation.dox`.
   - [ ] If new examples directory (e.g.`examples/pumi`), list it in `doc/CodeDocumentation.conf.in`
   - [ ] Companion pull request for documentation in [mfem/web](https://github.com/mfem/web) repo:
      - [ ] Update or add example-specific documentation, see e.g. the `src/examples.md`.
      - [ ] Add the description, labels and screenshots in `src/examples.md` and `src/img`.
      - [ ] In `examples.md`, list the example under the appropriate categories, add new categories if necessary.
      - [ ] Add a short description of the example in the "Extensive Examples" section of `features.md`.
- [ ] New miniapps:
   - [ ] All sample runs at the top of the miniapp source file work.
   - [ ] Update top-level `makefile` and `makefile` in corresponding miniapp directory.
   - [ ] Add the miniapp binary and any files generated by it to the top-level `.gitignore` file.
   - [ ] Update CMake build system:
      - [ ] Update the `CMakeLists.txt` file in the `miniapps` directory, if the new miniapp is in a new directory.
      - [ ] Add/update the `CMakeLists.txt` file in the new miniapp directory.
      - [ ] Consider adding a new test for the new miniapp.
   - [ ] List the new miniapp in `doc/CodeDocumentation.dox`
   - [ ] If new miniapps directory (e.g.`miniapps/nurbs`), add it to `MINIAPP_SUBDIRS` in the `makefile`.
   - [ ] If new miniapps directory (e.g.`miniapps/nurbs`), list it in `doc/CodeDocumentation.conf.in`
   - [ ] Companion pull request for documentation in [mfem/web](https://github.com/mfem/web) repo:
     - [ ] Update or add miniapp-specific documentation, see e.g. the `src/meshing.md` and `src/electromagnetics.md` files.
     - [ ] Add the description, labels and screenshots in `src/examples.md` and `src/img`.
     - [ ] The miniapps go at the end of the page, and are usually listed only under a specific "Application (PDE)" category.
     - [ ] Add a short description of the miniapp in the "Extensive Examples" section of `features.md`.
- [ ] New capability:
   - [ ] All new public, protected, and private classes, methods, data members, and functions have full Doxygen-style documentation in source comments. Documentation should include descriptions of member data, function arguments and return values, template parameters, and prerequisites for calling new functions.
   - [ ] Pointer arguments and return values must specify whether ownership is being transferred or lent with the call.
   - [ ] Any new functions should include descriptions of their intended use e.g. for internal use only, user-facing, etc., along with references to example code whenever possible/appropriate.
   - [ ] Consider adding new sample runs in existing examples to highlight the new capability.
   - [ ] Consider saving cool simulation pictures with the new capability in the Confluence gallery (LLNL only) or submitting them, via pull request, to the gallery section of the `mfem/web` repo.
   - [ ] If this is a major new feature, consider mentioning it in the short summary inside `README` *(rare)*.
   - [ ] List major new classes in `doc/CodeDocumentation.dox` *(rare)*.
- [ ] Update this checklist, if the new pull request affects it.
- [ ] Run `make unittest` to make sure all unit tests pass.
- [ ] Run the tests in `tests/scripts`.
- [ ] (LLNL only) After merging:
   - [ ] Update internal tests to include the new features.
</details>
