### PR TITLE
Bug fixes for anisotropic refinement conflict checks

### DIFF
--- a/mesh/pncmesh.cpp
+++ b/mesh/pncmesh.cpp
@@ -1708,7 +1708,16 @@ bool ParNCMesh::CheckRefAnisoFaceSplits(int vn1, int vn2, int vn3, int vn4,
       }
    }
 
-   if (level > 0) { return true; }
+   return (level > 0);
+}
+
+bool ParNCMesh::CheckRefIsoFaceSplits(int vn1, int vn2, int vn3, int vn4,
+                                      int en1, int en2, int en3, int en4)
+{
+   if (CheckRefAnisoFaceSplits(vn1, vn2, en2, en4)) { return true; }
+   if (CheckRefAnisoFaceSplits(en4, en2, vn3, vn4)) { return true; }
+   if (CheckRefAnisoFaceSplits(vn4, vn1, en1, en3)) { return true; }
+   if (CheckRefAnisoFaceSplits(en3, en1, vn2, vn3)) { return true; }
 
    return false;
 }
@@ -1742,7 +1751,7 @@ void ParNCMesh::CheckRefinementMaster(const Array<Refinement> &refinements,
                     Geometry::Constants<Geometry::CUBE>::FaceVert[mf.local][i]];
       }
 
-      if (faceRefType != 2) // X or XY split w.r.t. the face.
+      if (faceRefType == 1) // X split w.r.t. the face.
       {
          // Check X face split
          if (CheckRefAnisoFaceSplits(fv[0], fv[1], fv[2], fv[3]))
@@ -1750,11 +1759,23 @@ void ParNCMesh::CheckRefinementMaster(const Array<Refinement> &refinements,
             conflicts.insert(refIndex);
          }
       }
-
-      if (faceRefType != 1) // Y or XY split w.r.t. the face.
+      else if (faceRefType == 2) // Y split w.r.t. the face.
       {
          // Check Y face split
          if (CheckRefAnisoFaceSplits(fv[1], fv[2], fv[3], fv[0]))
+         {
+            conflicts.insert(refIndex);
+         }
+      }
+      else // XY split w.r.t. the face.
+      {
+         const int mid01 = GetMidEdgeNode(fv[0], fv[1]);
+         const int mid12 = GetMidEdgeNode(fv[1], fv[2]);
+         const int mid23 = GetMidEdgeNode(fv[2], fv[3]);
+         const int mid30 = GetMidEdgeNode(fv[3], fv[0]);
+
+         if (CheckRefIsoFaceSplits(fv[0], fv[1], fv[2], fv[3], mid01,
+                                   mid12, mid23, mid30))
          {
             conflicts.insert(refIndex);
          }
@@ -1828,7 +1849,8 @@ void ParNCMesh::CheckRefAnisoFace(const Refinement &ref, int elem,
                                   int vn1, int vn2, int vn3, int vn4,
                                   const Array<Refinement> &refinements,
                                   const std::map<int, int> &elemToRef,
-                                  std::set<int> &conflicts)
+                                  std::set<int> &conflicts,
+                                  real_t elem_scale)
 {
    Face* face = faces.Find(vn1, vn2, vn3, vn4);
    if (!face) { return; }
@@ -1885,11 +1907,12 @@ void ParNCMesh::CheckRefAnisoFace(const Refinement &ref, int elem,
          }
          else
          {
-            const real_t elem_scale =
+            const real_t scale =
+               elem_scale >= 0.0 ? elem_scale :
                DirectedHexEdgeScale(elements[elem].node, ref, vn1, vn2);
             const real_t nghb_scale =
                DirectedHexEdgeScale(nghb.node, nghb_ref, vn1, vn2);
-            if (!SameSplitScale(elem_scale, nghb_scale))
+            if (!SameSplitScale(scale, nghb_scale))
             {
                conflicts.insert(refIndex);
             }
@@ -1907,14 +1930,21 @@ void ParNCMesh::CheckRefIsoFace(const Refinement &ref, int elem,
                                 const std::map<int, int> &elemToRef,
                                 std::set<int> &conflicts)
 {
+   // Calls 2 and 4 start on face midlines. Preserve their direction using
+   // the parallel, actual edge of elem.
+   const real_t scale12 =
+      DirectedHexEdgeScale(elements[elem].node, ref, vn1, vn2);
+   const real_t scale41 =
+      DirectedHexEdgeScale(elements[elem].node, ref, vn4, vn1);
+
    CheckRefAnisoFace(ref, elem, vn1, vn2, en2, en4, refinements, elemToRef,
-                     conflicts);
+                     conflicts, scale12);
    CheckRefAnisoFace(ref, elem, en4, en2, vn3, vn4, refinements, elemToRef,
-                     conflicts);
+                     conflicts, scale12);
    CheckRefAnisoFace(ref, elem, vn4, vn1, en1, en3, refinements, elemToRef,
-                     conflicts);
+                     conflicts, scale41);
    CheckRefAnisoFace(ref, elem, en3, en1, vn2, vn3, refinements, elemToRef,
-                     conflicts);
+                     conflicts, scale41);
 }
 
 void ParNCMesh::CheckRefinement(int elem, const Refinement &ref,

--- a/mesh/pncmesh.hpp
+++ b/mesh/pncmesh.hpp
@@ -632,7 +632,8 @@ protected: // implementation
                           int vn1, int vn2, int vn3, int vn4,
                           const Array<Refinement> &refinements,
                           const std::map<int, int> &elemToRef,
-                          std::set<int> &conflicts);
+                          std::set<int> &conflicts,
+                          real_t elem_scale = -1.0);
 
    /** For the face with ordered vertices vn*, edge midpoints en*, and
        neighboring element @a elem, check whether the other neighboring element
@@ -661,6 +662,12 @@ protected: // implementation
        slave faces. */
    bool CheckRefAnisoFaceSplits(int vn1, int vn2, int vn3, int vn4,
                                 int level = 0);
+
+   /** For an isotropic split of the master face with ordered vertices vn* and
+       edge midpoints en*, check the resulting subfaces for conflicts. */
+   bool CheckRefIsoFaceSplits(int vn1, int vn2, int vn3, int vn4,
+                              int en1, int en2, int en3, int en4);
+
    friend class NeighborRowMessage;
    friend class NeighborOrderMessage;
 };


### PR DESCRIPTION
This PR fixes some bugs in the anisotropic refinement conflict checking introduced by PR 4906, see `ParMesh::AnisotropicConflict` used in `miniapps/meshing/phpref.cpp`. There are differences in results for the miniapp sample run `mpirun -np 8 phpref -dim 3 -n 20 --anisotropic --fixed-order` which show far fewer retries for random refinements without conflicts. The reason for this is that false positives for conflicts were previously determined, which are fixed now.

- In `ParNCMesh::CheckRefAnisoFace`, the scale is taken from an element edge instead of a line connecting edge midpoints, since the latter may fail in some cases. This is related to changes in PR 5297 introducing refinement scale in `ParNCMesh`.
- The logic in `ParNCMesh::CheckRefinementMaster` is fixed, to call the new function `ParNCMesh::CheckRefIsoFaceSplits` in the XY face-split case. This eliminates some false positives for conflicts.
- No new unit test, since `phpref` serves as a regression test (output has changed).
<!--GHEX{"author":"dylan-copeland","assignment":"2026-09-09T07:31:18","editor":"tzanio","id":5464,"reviewers":["tzanio","hughcars","v-dobrev","rw-anderson"],"merge":"2026-09-30T07:31:18","approval":"2026-09-23T07:31:18"}XEHG-->
<!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge|
 | --- | --- | --- | --- | --- | --- | --- |
| [#5464](https://github.com/mfem/mfem/pull/5464) | @dylan-copeland | @tzanio | @tzanio + @hughcars + @v-dobrev + @rw-anderson | 9/9/26 | ⌛due 9/23/26 | ⌛due 9/30/26 | |
<!--ELBATXEHG-->
<details>
<summary>PR Checklist</summary>
    
- [ ] Code builds.
- [ ] Code passes `make style`.
- [ ] Update `CHANGELOG`:
    - [ ] Is this a new feature users need to be aware of? New or updated example or miniapp?
    - [ ] Does it make sense to create a new section in the `CHANGELOG` to group with other related features?
- [ ] Update `INSTALL`:
    - [ ] Had a new optional library been added? If so, what range of versions of this library are required? (*Make sure the external library is compatible with our BSD license, e.g. it is not licensed under GPL!*)
    - [ ] Have the version ranges for any required or optional libraries changed?
    - [ ] Does `make` or `cmake` have a new target?
    - [ ] Did the requirements or the installation process change? *(rare)*
- [ ] Update continuous integration server configurations if necessary (e.g. with new version requirements for each of MFEM's dependencies)
    - [ ] `.github`
    - [ ] `.appveyor.yml`
- [ ] Update `.gitignore`:
    - [ ] Check if `make distclean; git status` shows any files that were generated from the source by the project (not an IDE) but we don't want to track in the repository.
    - [ ] Add new patterns (just for the new files above) and re-run the above test.
- [ ] New examples:
    - [ ] All sample runs at the top of the example source file work.
    - [ ] Update `examples/makefile`:
      - [ ] Add the example code to the appropriate `SEQ_EXAMPLES` and `PAR_EXAMPLES` variables.
      - [ ] Add any files generated by it to the `clean` target.
      - [ ] Add the example binary and any files generated by it to the top-level `.gitignore` file.
    - [ ] Update `examples/CMakeLists.txt`:
      - [ ] Add the example code to the `ALL_EXE_SRCS` variable.
      - [ ] Make sure `THIS_TEST_OPTIONS` is set correctly for the new example.
   - [ ] List the new example in `doc/CodeDocumentation.dox`.
   - [ ] If new examples directory (e.g.`examples/pumi`), list it in `doc/CodeDocumentation.conf.in`
   - [ ] Companion pull request for documentation in [mfem/web](https://github.com/mfem/web) repo:
      - [ ] Update or add example-specific documentation, see e.g. the `src/examples.md`.
      - [ ] Add the description, labels and screenshots in `src/examples.md` and `src/img`.
      - [ ] In `examples.md`, list the example under the appropriate categories, add new categories if necessary.
      - [ ] Add a short description of the example in the "Extensive Examples" section of `features.md`.
- [ ] New miniapps:
   - [ ] All sample runs at the top of the miniapp source file work.
   - [ ] Update top-level `makefile` and `makefile` in corresponding miniapp directory.
   - [ ] Add the miniapp binary and any files generated by it to the top-level `.gitignore` file.
   - [ ] Update CMake build system:
      - [ ] Update the `CMakeLists.txt` file in the `miniapps` directory, if the new miniapp is in a new directory.
      - [ ] Add/update the `CMakeLists.txt` file in the new miniapp directory.
      - [ ] Consider adding a new test for the new miniapp.
   - [ ] List the new miniapp in `doc/CodeDocumentation.dox`
   - [ ] If new miniapps directory (e.g.`miniapps/nurbs`), add it to `MINIAPP_SUBDIRS` in the `makefile`.
   - [ ] If new miniapps directory (e.g.`miniapps/nurbs`), list it in `doc/CodeDocumentation.conf.in`
   - [ ] Companion pull request for documentation in [mfem/web](https://github.com/mfem/web) repo:
     - [ ] Update or add miniapp-specific documentation, see e.g. the `src/meshing.md` and `src/electromagnetics.md` files.
     - [ ] Add the description, labels and screenshots in `src/examples.md` and `src/img`.
     - [ ] The miniapps go at the end of the page, and are usually listed only under a specific "Application (PDE)" category.
     - [ ] Add a short description of the miniapp in the "Extensive Examples" section of `features.md`.
- [ ] New capability:
   - [ ] All new public, protected, and private classes, methods, data members, and functions have full Doxygen-style documentation in source comments. Documentation should include descriptions of member data, function arguments and return values, template parameters, and prerequisites for calling new functions.
   - [ ] Pointer arguments and return values must specify whether ownership is being transferred or lent with the call.
   - [ ] Any new functions should include descriptions of their intended use e.g. for internal use only, user-facing, etc., along with references to example code whenever possible/appropriate.
   - [ ] Consider adding new sample runs in existing examples to highlight the new capability.
   - [ ] Consider saving cool simulation pictures with the new capability in the Confluence gallery (LLNL only) or submitting them, via pull request, to the gallery section of the `mfem/web` repo.
   - [ ] If this is a major new feature, consider mentioning it in the short summary inside `README` *(rare)*.
   - [ ] List major new classes in `doc/CodeDocumentation.dox` *(rare)*.
- [ ] Update this checklist, if the new pull request affects it.
- [ ] Run `make unittest` to make sure all unit tests pass.
- [ ] Run the tests in `tests/scripts`.
- [ ] (LLNL only) After merging:
   - [ ] Update internal tests to include the new features.
</details>
