### PR TITLE
Mark the forall dispatch chain always-inline

### DIFF
--- a/general/forall.hpp
+++ b/general/forall.hpp
@@ -13,6 +13,7 @@
 #define MFEM_FORALL_HPP
 
 #include "../config/config.hpp"
+#include "../config/tconfig.hpp"
 #include "annotation.hpp"
 #include "error.hpp"
 #include "backends.hpp"
@@ -422,7 +423,7 @@ template <int MAX_THREADS_PER_BLOCK>
 struct RajaCuWrap<1, MAX_THREADS_PER_BLOCK>
 {
    template <typename DBODY>
-   static void run(const int N, DBODY &&d_body,
+   static MFEM_ALWAYS_INLINE void run(const int N, DBODY &&d_body,
                    const int X, const int Y, const int Z, const int G)
    {
       RajaCuWrap1D(N, d_body);
@@ -433,7 +434,7 @@ template <>
 struct RajaCuWrap<2, 0>
 {
    template <typename DBODY>
-   static void run(const int N, DBODY &&d_body,
+   static MFEM_ALWAYS_INLINE void run(const int N, DBODY &&d_body,
                    const int X, const int Y, const int Z, const int G)
    {
       RajaCuWrap2D(N, d_body, X, Y, Z);
@@ -444,7 +445,7 @@ template <int MAX_THREADS_PER_BLOCK>
 struct RajaCuWrap<2, MAX_THREADS_PER_BLOCK>
 {
    template <typename DBODY>
-   static void run(const int N, DBODY &&d_body,
+   static MFEM_ALWAYS_INLINE void run(const int N, DBODY &&d_body,
                    const int X, const int Y, const int Z, const int G)
    {
       RajaCuWrap2DLaunchBounds<MAX_THREADS_PER_BLOCK>(N, d_body, X, Y, Z);
@@ -455,7 +456,7 @@ template <>
 struct RajaCuWrap<3, 0>
 {
    template <typename DBODY>
-   static void run(const int N, DBODY &&d_body,
+   static MFEM_ALWAYS_INLINE void run(const int N, DBODY &&d_body,
                    const int X, const int Y, const int Z, const int G)
    {
       RajaCuWrap3D(N, d_body, X, Y, Z, G);
@@ -466,7 +467,7 @@ template <int MAX_THREADS_PER_BLOCK>
 struct RajaCuWrap<3, MAX_THREADS_PER_BLOCK>
 {
    template <typename DBODY>
-   static void run(const int N, DBODY &&d_body,
+   static MFEM_ALWAYS_INLINE void run(const int N, DBODY &&d_body,
                    const int X, const int Y, const int Z, const int G)
    {
       RajaCuWrap3DLaunchBounds<MAX_THREADS_PER_BLOCK>(N, d_body, X, Y, Z, G);
@@ -585,7 +586,7 @@ template <int MAX_THREADS_PER_BLOCK>
 struct RajaHipWrap<1, MAX_THREADS_PER_BLOCK>
 {
    template <typename DBODY>
-   static void run(const int N, DBODY &&d_body,
+   static MFEM_ALWAYS_INLINE void run(const int N, DBODY &&d_body,
                    const int X, const int Y, const int Z, const int G)
    {
       RajaHipWrap1D(N, d_body);
@@ -596,7 +597,7 @@ template <>
 struct RajaHipWrap<2, 0>
 {
    template <typename DBODY>
-   static void run(const int N, DBODY &&d_body,
+   static MFEM_ALWAYS_INLINE void run(const int N, DBODY &&d_body,
                    const int X, const int Y, const int Z, const int G)
    {
       RajaHipWrap2D(N, d_body, X, Y, Z);
@@ -607,7 +608,7 @@ template <int MAX_THREADS_PER_BLOCK>
 struct RajaHipWrap<2, MAX_THREADS_PER_BLOCK>
 {
    template <typename DBODY>
-   static void run(const int N, DBODY &&d_body,
+   static MFEM_ALWAYS_INLINE void run(const int N, DBODY &&d_body,
                    const int X, const int Y, const int Z, const int G)
    {
       RajaHipWrap2DLaunchBounds<MAX_THREADS_PER_BLOCK>(N, d_body, X, Y, Z);
@@ -618,7 +619,7 @@ template <>
 struct RajaHipWrap<3, 0>
 {
    template <typename DBODY>
-   static void run(const int N, DBODY &&d_body,
+   static MFEM_ALWAYS_INLINE void run(const int N, DBODY &&d_body,
                    const int X, const int Y, const int Z, const int G)
    {
       RajaHipWrap3D(N, d_body, X, Y, Z, G);
@@ -629,7 +630,7 @@ template <int MAX_THREADS_PER_BLOCK>
 struct RajaHipWrap<3, MAX_THREADS_PER_BLOCK>
 {
    template <typename DBODY>
-   static void run(const int N, DBODY &&d_body,
+   static MFEM_ALWAYS_INLINE void run(const int N, DBODY &&d_body,
                    const int X, const int Y, const int Z, const int G)
    {
       RajaHipWrap3DLaunchBounds<MAX_THREADS_PER_BLOCK>(N, d_body, X, Y, Z, G);
@@ -754,7 +755,7 @@ static void CuKernel3DLaunchBounds(const int N, BODY body)
 }
 
 template <const int BLCK, typename DBODY>
-void CuWrap1D(const int N, DBODY &&d_body)
+MFEM_ALWAYS_INLINE void CuWrap1D(const int N, DBODY &&d_body)
 {
    if (N==0) { return; }
    const int GRID = (N+BLCK-1)/BLCK;
@@ -763,7 +764,7 @@ void CuWrap1D(const int N, DBODY &&d_body)
 }
 
 template <typename DBODY>
-void CuWrap2D(const int N, DBODY &&d_body,
+MFEM_ALWAYS_INLINE void CuWrap2D(const int N, DBODY &&d_body,
               const int X, const int Y, const int BZ)
 {
    if (N==0) { return; }
@@ -777,7 +778,7 @@ void CuWrap2D(const int N, DBODY &&d_body,
 }
 
 template <int MAX_THREADS_PER_BLOCK, typename DBODY>
-void CuWrap2DLaunchBounds(const int N, DBODY &&d_body,
+MFEM_ALWAYS_INLINE void CuWrap2DLaunchBounds(const int N, DBODY &&d_body,
                           const int X, const int Y, const int BZ)
 {
    if (N==0) { return; }
@@ -790,7 +791,7 @@ void CuWrap2DLaunchBounds(const int N, DBODY &&d_body,
 }
 
 template <typename DBODY>
-void CuWrap3D(const int N, DBODY &&d_body,
+MFEM_ALWAYS_INLINE void CuWrap3D(const int N, DBODY &&d_body,
               const int X, const int Y, const int Z, const int G)
 {
    if (N==0) { return; }
@@ -801,7 +802,7 @@ void CuWrap3D(const int N, DBODY &&d_body,
 }
 
 template <int MAX_THREADS_PER_BLOCK, typename DBODY>
-void CuWrap3DLaunchBounds(const int N, DBODY &&d_body,
+MFEM_ALWAYS_INLINE void CuWrap3DLaunchBounds(const int N, DBODY &&d_body,
                           const int X, const int Y, const int Z, const int G)
 {
    if (N==0) { return; }
@@ -826,7 +827,7 @@ template <int MAX_THREADS_PER_BLOCK>
 struct CuWrap<1, MAX_THREADS_PER_BLOCK>
 {
    template <typename DBODY>
-   static void run(const int N, DBODY &&d_body,
+   static MFEM_ALWAYS_INLINE void run(const int N, DBODY &&d_body,
                    const int X, const int Y, const int Z, const int G)
    {
       CuWrap1D<MFEM_CUDA_BLOCKS>(N, d_body);
@@ -837,7 +838,7 @@ template <>
 struct CuWrap<2, 0>
 {
    template <typename DBODY>
-   static void run(const int N, DBODY &&d_body,
+   static MFEM_ALWAYS_INLINE void run(const int N, DBODY &&d_body,
                    const int X, const int Y, const int Z, const int G)
    {
       CuWrap2D(N, d_body, X, Y, Z);
@@ -848,7 +849,7 @@ template <int MAX_THREADS_PER_BLOCK>
 struct CuWrap<2, MAX_THREADS_PER_BLOCK>
 {
    template <typename DBODY>
-   static void run(const int N, DBODY &&d_body,
+   static MFEM_ALWAYS_INLINE void run(const int N, DBODY &&d_body,
                    const int X, const int Y, const int Z, const int G)
    {
       static_assert(MAX_THREADS_PER_BLOCK > 0);
@@ -860,7 +861,7 @@ template <>
 struct CuWrap<3, 0>
 {
    template <typename DBODY>
-   static void run(const int N, DBODY &&d_body,
+   static MFEM_ALWAYS_INLINE void run(const int N, DBODY &&d_body,
                    const int X, const int Y, const int Z, const int G)
    {
       CuWrap3D(N, d_body, X, Y, Z, G);
@@ -871,7 +872,7 @@ template <int MAX_THREADS_PER_BLOCK>
 struct CuWrap<3, MAX_THREADS_PER_BLOCK>
 {
    template <typename DBODY>
-   static void run(const int N, DBODY &&d_body,
+   static MFEM_ALWAYS_INLINE void run(const int N, DBODY &&d_body,
                    const int X, const int Y, const int Z, const int G)
    {
       CuWrap3DLaunchBounds<MAX_THREADS_PER_BLOCK>(N, d_body, X, Y, Z, G);
@@ -1011,7 +1012,7 @@ static void HipKernel3DLaunchBounds(const int N, BODY body)
 }
 
 template <int BLCK = MFEM_HIP_BLOCKS, typename DBODY>
-void HipWrap1D(const int N, DBODY &&d_body)
+MFEM_ALWAYS_INLINE void HipWrap1D(const int N, DBODY &&d_body)
 {
    if (N==0) { return; }
    const int GRID = (N+BLCK-1)/BLCK;
@@ -1020,7 +1021,7 @@ void HipWrap1D(const int N, DBODY &&d_body)
 }
 
 template <typename DBODY>
-void HipWrap2D(const int N, DBODY &&d_body,
+MFEM_ALWAYS_INLINE void HipWrap2D(const int N, DBODY &&d_body,
                const int X, const int Y, const int BZ)
 {
    if (N==0) { return; }
@@ -1032,7 +1033,7 @@ void HipWrap2D(const int N, DBODY &&d_body,
 }
 
 template <int MAX_THREADS_PER_BLOCK, typename DBODY>
-void HipWrap2DLaunchBounds(const int N, DBODY &&d_body,
+MFEM_ALWAYS_INLINE void HipWrap2DLaunchBounds(const int N, DBODY &&d_body,
                            const int X, const int Y, const int BZ)
 {
    if (N==0) { return; }
@@ -1046,7 +1047,7 @@ void HipWrap2DLaunchBounds(const int N, DBODY &&d_body,
 }
 
 template <typename DBODY>
-void HipWrap3D(const int N, DBODY &&d_body,
+MFEM_ALWAYS_INLINE void HipWrap3D(const int N, DBODY &&d_body,
                const int X, const int Y, const int Z, const int G)
 {
    if (N==0) { return; }
@@ -1057,7 +1058,7 @@ void HipWrap3D(const int N, DBODY &&d_body,
 }
 
 template <int MAX_THREADS_PER_BLOCK, typename DBODY>
-void HipWrap3DLaunchBounds(const int N, DBODY &&d_body,
+MFEM_ALWAYS_INLINE void HipWrap3DLaunchBounds(const int N, DBODY &&d_body,
                            const int X, const int Y, const int Z, const int G)
 {
    if (N==0) { return; }
@@ -1075,7 +1076,7 @@ template <int MAX_THREADS_PER_BLOCK>
 struct HipWrap<1, MAX_THREADS_PER_BLOCK>
 {
    template <typename DBODY>
-   static void run(const int N, DBODY &&d_body,
+   static MFEM_ALWAYS_INLINE void run(const int N, DBODY &&d_body,
                    const int X, const int Y, const int Z, const int G)
    {
       HipWrap1D<MFEM_HIP_BLOCKS>(N, d_body);
@@ -1086,7 +1087,7 @@ template <>
 struct HipWrap<2, 0>
 {
    template <typename DBODY>
-   static void run(const int N, DBODY &&d_body,
+   static MFEM_ALWAYS_INLINE void run(const int N, DBODY &&d_body,
                    const int X, const int Y, const int Z, const int G)
    {
       HipWrap2D(N, d_body, X, Y, Z);
@@ -1097,7 +1098,7 @@ template <int MAX_THREADS_PER_BLOCK>
 struct HipWrap<2, MAX_THREADS_PER_BLOCK>
 {
    template <typename DBODY>
-   static void run(const int N, DBODY &&d_body,
+   static MFEM_ALWAYS_INLINE void run(const int N, DBODY &&d_body,
                    const int X, const int Y, const int Z, const int G)
    {
       HipWrap2DLaunchBounds<MAX_THREADS_PER_BLOCK>(N, d_body, X, Y, Z);
@@ -1108,7 +1109,7 @@ template <>
 struct HipWrap<3, 0>
 {
    template <typename DBODY>
-   static void run(const int N, DBODY &&d_body,
+   static MFEM_ALWAYS_INLINE void run(const int N, DBODY &&d_body,
                    const int X, const int Y, const int Z, const int G)
    {
       HipWrap3D(N, d_body, X, Y, Z, G);
@@ -1119,7 +1120,7 @@ template <int MAX_THREADS_PER_BLOCK>
 struct HipWrap<3, MAX_THREADS_PER_BLOCK>
 {
    template <typename DBODY>
-   static void run(const int N, DBODY &&d_body,
+   static MFEM_ALWAYS_INLINE void run(const int N, DBODY &&d_body,
                    const int X, const int Y, const int Z, const int G)
    {
       HipWrap3DLaunchBounds<MAX_THREADS_PER_BLOCK>(N, d_body, X, Y, Z, G);
@@ -1133,7 +1134,7 @@ struct HipWrap<3, MAX_THREADS_PER_BLOCK>
 /// Forall host & device kernel dispatch
 template <int DIM, int MAX_THREADS_PER_BLOCK = 0, bool use_enzyme = false,
           typename d_lambda, typename h_lambda>
-inline void ForallWrap(const bool use_dev, const int N,
+inline MFEM_ALWAYS_INLINE void ForallWrap(const bool use_dev, const int N,
                        d_lambda &&d_body, h_lambda &&h_body,
                        const int X=0, const int Y=0, const int Z=0,
                        const int G=0)
@@ -1220,7 +1221,7 @@ backend_cpu:
 /// Forall host & device kernel wrappers
 template <int DIM, int MAX_THREADS_PER_BLOCK = 0, bool use_enzyme = false,
           typename lambda>
-inline void ForallWrap(const bool use_dev, const int N, lambda &&body,
+inline MFEM_ALWAYS_INLINE void ForallWrap(const bool use_dev, const int N, lambda &&body,
                        const int X=0, const int Y=0, const int Z=0,
                        const int G=0)
 {
@@ -1232,14 +1233,14 @@ inline void ForallWrap(const bool use_dev, const int N, lambda &&body,
 // forall interfaces
 
 template<bool use_enzyme = false, typename lambda>
-inline void forall(int N, lambda &&body)
+inline MFEM_ALWAYS_INLINE void forall(int N, lambda &&body)
 {
    constexpr int MAX_THREADS_PER_BLOCK = 0;
    ForallWrap<1, MAX_THREADS_PER_BLOCK, use_enzyme>(true, N, body);
 }
 
 template<typename lambda>
-inline void forall(int Nx, int Ny, lambda &&body)
+inline MFEM_ALWAYS_INLINE void forall(int Nx, int Ny, lambda &&body)
 {
    if (Device::Allows(Backend::DEVICE_MASK))
    {
@@ -1275,7 +1276,7 @@ inline void forall(int Nx, int Ny, lambda &&body)
 }
 
 template<typename lambda>
-inline void forall(int Nx, int Ny, int Nz, lambda &&body)
+inline MFEM_ALWAYS_INLINE void forall(int Nx, int Ny, int Nz, lambda &&body)
 {
    if (Device::Allows(Backend::DEVICE_MASK))
    {
@@ -1316,49 +1317,49 @@ inline void forall(int Nx, int Ny, int Nz, lambda &&body)
 }
 
 template<typename lambda>
-inline void forall_switch(bool use_dev, int N, lambda &&body)
+inline MFEM_ALWAYS_INLINE void forall_switch(bool use_dev, int N, lambda &&body)
 {
    ForallWrap<1>(use_dev, N, body);
 }
 
 template<typename lambda>
-inline void forall_2D(int N, int X, int Y, lambda &&body)
+inline MFEM_ALWAYS_INLINE void forall_2D(int N, int X, int Y, lambda &&body)
 {
    ForallWrap<2>(true, N, body, X, Y, 1);
 }
 
 template<int MAX_THREADS_PER_BLOCK, typename lambda>
-inline void forall_2D(int N, int X, int Y, lambda &&body)
+inline MFEM_ALWAYS_INLINE void forall_2D(int N, int X, int Y, lambda &&body)
 {
    ForallWrap<2, MAX_THREADS_PER_BLOCK>(true, N, body, X, Y, 1);
 }
 
 template<typename lambda>
-inline void forall_2D_batch(int N, int X, int Y, int BZ, lambda &&body)
+inline MFEM_ALWAYS_INLINE void forall_2D_batch(int N, int X, int Y, int BZ, lambda &&body)
 {
    ForallWrap<2>(true, N, body, X, Y, BZ);
 }
 
 template<int MAX_THREADS_PER_BLOCK, typename lambda>
-inline void forall_2D_batch(int N, int X, int Y, int BZ, lambda &&body)
+inline MFEM_ALWAYS_INLINE void forall_2D_batch(int N, int X, int Y, int BZ, lambda &&body)
 {
    ForallWrap<2, MAX_THREADS_PER_BLOCK>(true, N, body, X, Y, BZ);
 }
 
 template<typename lambda>
-inline void forall_3D(int N, int X, int Y, int Z, lambda &&body)
+inline MFEM_ALWAYS_INLINE void forall_3D(int N, int X, int Y, int Z, lambda &&body)
 {
    ForallWrap<3>(true, N, body, X, Y, Z, 0);
 }
 
 template<int MAX_THREADS_PER_BLOCK, typename lambda>
-inline void forall_3D(int N, int X, int Y, int Z, lambda &&body)
+inline MFEM_ALWAYS_INLINE void forall_3D(int N, int X, int Y, int Z, lambda &&body)
 {
    ForallWrap<3, MAX_THREADS_PER_BLOCK>(true, N, body, X, Y, Z, 0);
 }
 
 template<typename lambda>
-inline void forall_3D_grid(int N, int X, int Y, int Z, int G, lambda &&body)
+inline MFEM_ALWAYS_INLINE void forall_3D_grid(int N, int X, int Y, int Z, int G, lambda &&body)
 {
    ForallWrap<3>(true, N, body, X, Y, Z, G);
 }


### PR DESCRIPTION
Draft for discussion on the `dfem` line of development.

**Problem.** The device launch path is a four-layer dispatch — `forall*` → `ForallWrap` → `{Cu,Hip}Wrap<Dim>::run` → `CuWrapND`/`HipWrapND` — each a linkonce template with exactly one caller per instantiation. The `MFEM_GPU_CHECK` error path gives every layer an exception personality and enough inlined ostream text that LLVM's inliner cost model stops partway up the chain (and MLIR-based tooling refuses personality functions outright). The kernel launch then sits in a helper that receives the grid/block sizes and the lambda capture as *runtime function arguments* — even when the caller passes compile-time constants (e.g. `Q1D` template parameters in specialized kernels).

**Change.** Mark the whole chain `MFEM_ALWAYS_INLINE` (defined in `config/tconfig.hpp`, now included by `forall.hpp`; it is a no-op in `MFEM_DEBUG` builds). Marking only the innermost `CuWrapND` is not enough: each inline step moves the personality-carrying body one level up where the cost model refuses again, so all four layers need the attribute.

**Effect** (measured with an MLIR-based CUDA toolchain on `fem/integ/bilininteg_mass_pa.cpp` / `bilininteg_mass_kernels.cpp`): every `CuWrap*`/`ForallWrap` definition disappears from the optimized host IR; launches land in the kernel wrappers where template-constant block dimensions fold to constants and the by-value capture becomes a local object (visible to scalar replacement instead of crossing a call boundary by reference). For specialized `<D1D,Q1D>` kernels the only remaining runtime launch parameter is the grid size derived from `NE`, which is irreducible. A regular clang CUDA build of the touched TUs is unaffected in output-object size.

**Cost / open question for review:** `ForallWrap`'s backend-dispatch branches (CUDA/HIP/RAJA/OpenMP/CPU) get duplicated at every `forall` call site instead of being shared, so host text grows in multi-backend builds; and `always_inline` on the RAJA-dispatch `run` members is included for uniformity but easy to drop. Happy to trim scope to the CUDA/HIP native wrappers if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD