### PR TITLE
Suggested additions and edits for PR 5361 (Reductions over shared dofs on device)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -94,9 +94,19 @@ Linear and nonlinear solvers
   Operator: MultMV, MultTransposeMV, and GetGradientMV, that use MultiVector
   objects for input and/or output parameters. [PR #5249]
 
+- Added new class MemoryView that enables viewing Vector objects as
+  Array<real_t> objects and vice versa. See the new methods GetArrayView() in
+  class Vector.
+
 GPU computing
 -------------
-- Device support for GroupCommunicator::Reduce() and GroupCommunicator::Bcast().
+- Added device support to class GroupCommunicator. Methods that take the data to
+  be communicated as raw pointers continue to execute on host and expect the
+  raw pointer to be a host pointer. Methods that take the data to be
+  communicated as Array<T>& will perform the operations on the configured
+  mfem::Device and will use GPU-aware MPI, if enabled for the mfem::Device.
+  Not all cases are supported on device; in such cases, execution will fall back
+  to host.
 
 - Improved partial assembly for VectorDivergenceIntegrator with shared-memory
   kernels, kernel registration, and transpose support.

--- a/fem/fespace.cpp
+++ b/fem/fespace.cpp
@@ -4066,8 +4066,6 @@ void FiniteElementSpace::Destroy()
       delete [] bdofs;
    }
    ceed::RemoveBasisAndRestriction(this);
-
-
 }
 
 void FiniteElementSpace::DestroyDoFTransArray()

--- a/fem/gridfunc.cpp
+++ b/fem/gridfunc.cpp
@@ -2354,8 +2354,10 @@ void GridFunction::AccumulateAndCountTraceTangentValues(
    }
 }
 
-void GridFunction::ComputeMeans(AvgType type, Array<int> &zones_per_vdof)
+void GridFunction::ComputeMeans(AvgType type, const Array<int> &zones_per_vdof)
 {
+   HostReadWrite();
+   zones_per_vdof.HostRead();
    switch (type)
    {
       case ARITHMETIC:

--- a/fem/gridfunc.hpp
+++ b/fem/gridfunc.hpp
@@ -587,7 +587,7 @@ protected:
 
    // Complete the computation of averages; called e.g. after
    // AccumulateAndCountZones().
-   void ComputeMeans(AvgType type, Array<int> &zones_per_vdof);
+   void ComputeMeans(AvgType type, const Array<int> &zones_per_vdof);
 
    /// P-refinement version of Update().
    void UpdatePRef();

--- a/fem/integ/bilininteg_convection_kernels.hpp
+++ b/fem/integ/bilininteg_convection_kernels.hpp
@@ -23,16 +23,11 @@ namespace mfem
 {
 
 // PA Convection Apply 2D kernel
-template<int T_D1D = 0, int T_Q1D = 0> static
-void PAConvectionApply2D(const int ne,
-                         const Array<real_t> &b,
-                         const Array<real_t> &g,
-                         const Array<real_t> &bt,
-                         const Array<real_t> &gt,
-                         const Vector &op_,
-                         const Vector &x_,
-                         Vector &y_,
-                         const int d1d = 0,
+template <int T_D1D = 0, int T_Q1D = 0>
+void PAConvectionApply2D(const int ne, const Array<real_t> &b,
+                         const Array<real_t> &g, const Array<real_t> &bt,
+                         const Array<real_t> &gt, const Vector &op_,
+                         const Vector &x_, Vector &y_, const int d1d = 0,
                          const int q1d = 0)
 {
    const int NE = ne;
@@ -142,16 +137,11 @@ void PAConvectionApply2D(const int ne,
 }
 
 // Optimized PA Convection Apply 2D kernel
-template<int T_D1D = 0, int T_Q1D = 0, int T_NBZ = 0> static
-void SmemPAConvectionApply2D(const int ne,
-                             const Array<real_t> &b,
-                             const Array<real_t> &g,
-                             const Array<real_t> &bt,
-                             const Array<real_t> &gt,
-                             const Vector &op_,
-                             const Vector &x_,
-                             Vector &y_,
-                             const int d1d = 0,
+template <int T_D1D = 0, int T_Q1D = 0, int T_NBZ = 0>
+void SmemPAConvectionApply2D(const int ne, const Array<real_t> &b,
+                             const Array<real_t> &g, const Array<real_t> &bt,
+                             const Array<real_t> &gt, const Vector &op_,
+                             const Vector &x_, Vector &y_, const int d1d = 0,
                              const int q1d = 0)
 {
    const int NE = ne;
@@ -270,16 +260,11 @@ void SmemPAConvectionApply2D(const int ne,
 }
 
 // PA Convection Apply 3D kernel
-template<int T_D1D = 0, int T_Q1D = 0> static
-void PAConvectionApply3D(const int ne,
-                         const Array<real_t> &b,
-                         const Array<real_t> &g,
-                         const Array<real_t> &bt,
-                         const Array<real_t> &gt,
-                         const Vector &op_,
-                         const Vector &x_,
-                         Vector &y_,
-                         const int d1d = 0,
+template <int T_D1D = 0, int T_Q1D = 0>
+void PAConvectionApply3D(const int ne, const Array<real_t> &b,
+                         const Array<real_t> &g, const Array<real_t> &bt,
+                         const Array<real_t> &gt, const Vector &op_,
+                         const Vector &x_, Vector &y_, const int d1d = 0,
                          const int q1d = 0)
 {
    const int NE = ne;
@@ -451,16 +436,11 @@ void PAConvectionApply3D(const int ne,
 }
 
 // Optimized PA Convection Apply 3D kernel
-template<int T_D1D = 0, int T_Q1D = 0> static
-void SmemPAConvectionApply3D(const int ne,
-                             const Array<real_t> &b,
-                             const Array<real_t> &g,
-                             const Array<real_t> &bt,
-                             const Array<real_t> &gt,
-                             const Vector &op_,
-                             const Vector &x_,
-                             Vector &y_,
-                             const int d1d = 0,
+template <int T_D1D = 0, int T_Q1D = 0>
+void SmemPAConvectionApply3D(const int ne, const Array<real_t> &b,
+                             const Array<real_t> &g, const Array<real_t> &bt,
+                             const Array<real_t> &gt, const Vector &op_,
+                             const Vector &x_, Vector &y_, const int d1d = 0,
                              const int q1d = 0)
 {
    const int NE = ne;
@@ -655,16 +635,11 @@ void SmemPAConvectionApply3D(const int ne,
 }
 
 // PA Convection Apply 2D kernel
-template<int T_D1D = 0, int T_Q1D = 0> static
-void PAConvectionApplyT2D(const int ne,
-                          const Array<real_t> &b,
-                          const Array<real_t> &g,
-                          const Array<real_t> &bt,
-                          const Array<real_t> &gt,
-                          const Vector &op_,
-                          const Vector &x_,
-                          Vector &y_,
-                          const int d1d = 0,
+template <int T_D1D = 0, int T_Q1D = 0>
+void PAConvectionApplyT2D(const int ne, const Array<real_t> &b,
+                          const Array<real_t> &g, const Array<real_t> &bt,
+                          const Array<real_t> &gt, const Vector &op_,
+                          const Vector &x_, Vector &y_, const int d1d = 0,
                           const int q1d = 0)
 {
    const int NE = ne;
@@ -770,16 +745,11 @@ void PAConvectionApplyT2D(const int ne,
 }
 
 // Optimized PA Convection Apply 2D kernel
-template<int T_D1D = 0, int T_Q1D = 0, int T_NBZ = 0> static
-void SmemPAConvectionApplyT2D(const int ne,
-                              const Array<real_t> &b,
-                              const Array<real_t> &g,
-                              const Array<real_t> &bt,
-                              const Array<real_t> &gt,
-                              const Vector &op_,
-                              const Vector &x_,
-                              Vector &y_,
-                              const int d1d = 0,
+template <int T_D1D = 0, int T_Q1D = 0, int T_NBZ = 0>
+void SmemPAConvectionApplyT2D(const int ne, const Array<real_t> &b,
+                              const Array<real_t> &g, const Array<real_t> &bt,
+                              const Array<real_t> &gt, const Vector &op_,
+                              const Vector &x_, Vector &y_, const int d1d = 0,
                               const int q1d = 0)
 {
    const int NE = ne;
@@ -893,16 +863,11 @@ void SmemPAConvectionApplyT2D(const int ne,
 }
 
 // PA Convection Apply 3D kernel
-template<int T_D1D = 0, int T_Q1D = 0> static
-void PAConvectionApplyT3D(const int ne,
-                          const Array<real_t> &b,
-                          const Array<real_t> &g,
-                          const Array<real_t> &bt,
-                          const Array<real_t> &gt,
-                          const Vector &op_,
-                          const Vector &x_,
-                          Vector &y_,
-                          const int d1d = 0,
+template <int T_D1D = 0, int T_Q1D = 0>
+void PAConvectionApplyT3D(const int ne, const Array<real_t> &b,
+                          const Array<real_t> &g, const Array<real_t> &bt,
+                          const Array<real_t> &gt, const Vector &op_,
+                          const Vector &x_, Vector &y_, const int d1d = 0,
                           const int q1d = 0)
 {
    const int NE = ne;
@@ -1069,16 +1034,11 @@ void PAConvectionApplyT3D(const int ne,
 }
 
 // Optimized PA Convection Apply 3D kernel
-template<int T_D1D = 0, int T_Q1D = 0> static
-void SmemPAConvectionApplyT3D(const int ne,
-                              const Array<real_t> &b,
-                              const Array<real_t> &g,
-                              const Array<real_t> &bt,
-                              const Array<real_t> &gt,
-                              const Vector &op_,
-                              const Vector &x_,
-                              Vector &y_,
-                              const int d1d = 0,
+template <int T_D1D = 0, int T_Q1D = 0>
+void SmemPAConvectionApplyT3D(const int ne, const Array<real_t> &b,
+                              const Array<real_t> &g, const Array<real_t> &bt,
+                              const Array<real_t> &gt, const Vector &op_,
+                              const Vector &x_, Vector &y_, const int d1d = 0,
                               const int q1d = 0)
 {
    const int NE = ne;

--- a/fem/integ/bilininteg_dgdiffusion_kernels.hpp
+++ b/fem/integ/bilininteg_dgdiffusion_kernels.hpp
@@ -26,13 +26,12 @@ namespace internal
 {
 
 template <int T_D1D = 0, int T_Q1D = 0>
-static void PADGDiffusionApply2D(const int NF, const Array<real_t> &b,
-                                 const Array<real_t> &bt,
-                                 const Array<real_t> &g,
-                                 const Array<real_t> &gt, const real_t sigma,
-                                 const Vector &pa_data, const Vector &x_,
-                                 const Vector &dxdn_, Vector &y_, Vector &dydn_,
-                                 const int d1d = 0, const int q1d = 0)
+void PADGDiffusionApply2D(const int NF, const Array<real_t> &b,
+                          const Array<real_t> &bt, const Array<real_t> &g,
+                          const Array<real_t> &gt, const real_t sigma,
+                          const Vector &pa_data, const Vector &x_,
+                          const Vector &dxdn_, Vector &y_, Vector &dydn_,
+                          const int d1d = 0, const int q1d = 0)
 {
    const int D1D = T_D1D ? T_D1D : d1d;
    const int Q1D = T_Q1D ? T_Q1D : q1d;
@@ -200,13 +199,12 @@ static void PADGDiffusionApply2D(const int NF, const Array<real_t> &b,
 }
 
 template <int T_D1D = 0, int T_Q1D = 0>
-static void PADGDiffusionApply3D(const int NF, const Array<real_t> &b,
-                                 const Array<real_t> &bt,
-                                 const Array<real_t> &g,
-                                 const Array<real_t> &gt, const real_t sigma,
-                                 const Vector &pa_data, const Vector &x_,
-                                 const Vector &dxdn_, Vector &y_, Vector &dydn_,
-                                 const int d1d = 0, const int q1d = 0)
+void PADGDiffusionApply3D(const int NF, const Array<real_t> &b,
+                          const Array<real_t> &bt, const Array<real_t> &g,
+                          const Array<real_t> &gt, const real_t sigma,
+                          const Vector &pa_data, const Vector &x_,
+                          const Vector &dxdn_, Vector &y_, Vector &dydn_,
+                          const int d1d = 0, const int q1d = 0)
 {
    const int D1D = T_D1D ? T_D1D : d1d;
    const int Q1D = T_Q1D ? T_Q1D : q1d;

--- a/fem/integ/bilininteg_dgtrace_kernels.hpp
+++ b/fem/integ/bilininteg_dgtrace_kernels.hpp
@@ -27,10 +27,10 @@ namespace internal
 
 // PA DGTrace Apply 2D kernel for Gauss-Lobatto/Bernstein
 template <int T_D1D = 0, int T_Q1D = 0>
-static void PADGTraceApply2D(const int NF, const Array<real_t> &b,
-                             const Array<real_t> &bt, const Vector &op_,
-                             const Vector &x_, Vector &y_, const int d1d = 0,
-                             const int q1d = 0)
+void PADGTraceApply2D(const int NF, const Array<real_t> &b,
+                      const Array<real_t> &bt, const Vector &op_,
+                      const Vector &x_, Vector &y_, const int d1d = 0,
+                      const int q1d = 0)
 {
    const int VDIM = 1;
    const int D1D = T_D1D ? T_D1D : d1d;
@@ -114,10 +114,10 @@ static void PADGTraceApply2D(const int NF, const Array<real_t> &b,
 
 // PA DGTrace Apply 3D kernel for Gauss-Lobatto/Bernstein
 template <int T_D1D = 0, int T_Q1D = 0>
-static void PADGTraceApply3D(const int NF, const Array<real_t> &b,
-                             const Array<real_t> &bt, const Vector &op_,
-                             const Vector &x_, Vector &y_, const int d1d = 0,
-                             const int q1d = 0)
+void PADGTraceApply3D(const int NF, const Array<real_t> &b,
+                      const Array<real_t> &bt, const Vector &op_,
+                      const Vector &x_, Vector &y_, const int d1d = 0,
+                      const int q1d = 0)
 {
    const int VDIM = 1;
    const int D1D = T_D1D ? T_D1D : d1d;
@@ -255,10 +255,10 @@ static void PADGTraceApply3D(const int NF, const Array<real_t> &b,
 
 // Optimized PA DGTrace Apply 3D kernel for Gauss-Lobatto/Bernstein
 template <int T_D1D = 0, int T_Q1D = 0, int T_NBZ = 0>
-static void SmemPADGTraceApply3D(const int NF, const Array<real_t> &b,
-                                 const Array<real_t> &bt, const Vector &op_,
-                                 const Vector &x_, Vector &y_,
-                                 const int d1d = 0, const int q1d = 0)
+void SmemPADGTraceApply3D(const int NF, const Array<real_t> &b,
+                          const Array<real_t> &bt, const Vector &op_,
+                          const Vector &x_, Vector &y_, const int d1d = 0,
+                          const int q1d = 0)
 {
    const int D1D = T_D1D ? T_D1D : d1d;
    const int Q1D = T_Q1D ? T_Q1D : q1d;
@@ -373,11 +373,10 @@ static void SmemPADGTraceApply3D(const int NF, const Array<real_t> &b,
 
 // PA DGTrace Apply 2D kernel for Gauss-Lobatto/Bernstein
 template <int T_D1D = 0, int T_Q1D = 0>
-static void PADGTraceApplyTranspose2D(const int NF, const Array<real_t> &b,
-                                      const Array<real_t> &bt,
-                                      const Vector &op_, const Vector &x_,
-                                      Vector &y_, const int d1d = 0,
-                                      const int q1d = 0)
+void PADGTraceApplyTranspose2D(const int NF, const Array<real_t> &b,
+                               const Array<real_t> &bt, const Vector &op_,
+                               const Vector &x_, Vector &y_, const int d1d = 0,
+                               const int q1d = 0)
 {
    const int VDIM = 1;
    const int D1D = T_D1D ? T_D1D : d1d;
@@ -468,11 +467,10 @@ static void PADGTraceApplyTranspose2D(const int NF, const Array<real_t> &b,
 
 // PA DGTrace Apply Transpose 3D kernel for Gauss-Lobatto/Bernstein
 template <int T_D1D = 0, int T_Q1D = 0>
-static void PADGTraceApplyTranspose3D(const int NF, const Array<real_t> &b,
-                                      const Array<real_t> &bt,
-                                      const Vector &op_, const Vector &x_,
-                                      Vector &y_, const int d1d = 0,
-                                      const int q1d = 0)
+void PADGTraceApplyTranspose3D(const int NF, const Array<real_t> &b,
+                               const Array<real_t> &bt, const Vector &op_,
+                               const Vector &x_, Vector &y_, const int d1d = 0,
+                               const int q1d = 0)
 {
    const int VDIM = 1;
    const int D1D = T_D1D ? T_D1D : d1d;
@@ -621,11 +619,10 @@ static void PADGTraceApplyTranspose3D(const int NF, const Array<real_t> &b,
 
 // Optimized PA DGTrace Apply Transpose 3D kernel for Gauss-Lobatto/Bernstein
 template <int T_D1D = 0, int T_Q1D = 0, int T_NBZ = 0>
-static void SmemPADGTraceApplyTranspose3D(const int NF, const Array<real_t> &b,
-                                          const Array<real_t> &bt,
-                                          const Vector &op_, const Vector &x_,
-                                          Vector &y_, const int d1d = 0,
-                                          const int q1d = 0)
+void SmemPADGTraceApplyTranspose3D(const int NF, const Array<real_t> &b,
+                                   const Array<real_t> &bt, const Vector &op_,
+                                   const Vector &x_, Vector &y_,
+                                   const int d1d = 0, const int q1d = 0)
 {
    const int D1D = T_D1D ? T_D1D : d1d;
    const int Q1D = T_Q1D ? T_Q1D : q1d;

--- a/fem/integ/bilininteg_gradient_pa.cpp
+++ b/fem/integ/bilininteg_gradient_pa.cpp
@@ -819,6 +819,9 @@ static void PAGradientApplyTranspose3D(const int NE,
    });
 }
 
+#if 0
+// TODO: this is unused, was it supposed to be in some header or did this end up being slower?
+// for now, comment out
 // Shared memory PA Gradient Apply 3D kernel
 template<const int T_TR_D1D = 0, const int T_TE_D1D = 0, const int T_Q1D = 0>
 static void SmemPAGradientApply3D(const int NE,
@@ -1067,6 +1070,7 @@ static void SmemPAGradientApply3D(const int NE,
       }
    });
 }
+#endif
 
 static void PAGradientApply(const int dim,
                             const int TR_D1D,

--- a/fem/integ/bilininteg_mass_kernels.hpp
+++ b/fem/integ/bilininteg_mass_kernels.hpp
@@ -30,12 +30,9 @@ namespace internal
 {
 
 // PA Mass Diagonal 1D kernel
-static void PAMassAssembleDiagonal1D(const int NE,
-                                     const Array<real_t> &b,
-                                     const Vector &d,
-                                     Vector &y,
-                                     const int D1D,
-                                     const int Q1D)
+void PAMassAssembleDiagonal1D(const int NE, const Array<real_t> &b,
+                              const Vector &d, Vector &y, const int D1D,
+                              const int Q1D)
 {
    auto B = Reshape(b.Read(), Q1D, D1D);
    auto D = Reshape(d.Read(), Q1D, NE);
@@ -104,14 +101,9 @@ void PAMassApply1D_Element(const int e,
 }
 
 // PA Mass Apply 1D kernel
-static void PAMassApply1D(const int NE,
-                          const Array<real_t> &b_,
-                          const Array<real_t> &bt_,
-                          const Vector &d_,
-                          const Vector &x_,
-                          Vector &y_,
-                          const int d1d = 0,
-                          const int q1d = 0)
+void PAMassApply1D(const int NE, const Array<real_t> &b_,
+                   const Array<real_t> &bt_, const Vector &d_, const Vector &x_,
+                   Vector &y_, const int d1d = 0, const int q1d = 0)
 {
    MFEM_VERIFY(d1d <= DeviceDofQuadLimits::Get().MAX_D1D, "");
    MFEM_VERIFY(q1d <= DeviceDofQuadLimits::Get().MAX_Q1D, "");

--- a/fem/integ/bilininteg_mass_kernels.hpp
+++ b/fem/integ/bilininteg_mass_kernels.hpp
@@ -30,9 +30,9 @@ namespace internal
 {
 
 // PA Mass Diagonal 1D kernel
-void PAMassAssembleDiagonal1D(const int NE, const Array<real_t> &b,
-                              const Vector &d, Vector &y, const int D1D,
-                              const int Q1D)
+inline void PAMassAssembleDiagonal1D(const int NE, const Array<real_t> &b,
+                                     const Vector &d, Vector &y, const int D1D,
+                                     const int Q1D)
 {
    auto B = Reshape(b.Read(), Q1D, D1D);
    auto D = Reshape(d.Read(), Q1D, NE);
@@ -101,9 +101,10 @@ void PAMassApply1D_Element(const int e,
 }
 
 // PA Mass Apply 1D kernel
-void PAMassApply1D(const int NE, const Array<real_t> &b_,
-                   const Array<real_t> &bt_, const Vector &d_, const Vector &x_,
-                   Vector &y_, const int d1d = 0, const int q1d = 0)
+inline void PAMassApply1D(const int NE, const Array<real_t> &b_,
+                          const Array<real_t> &bt_, const Vector &d_,
+                          const Vector &x_, Vector &y_, const int d1d = 0,
+                          const int q1d = 0)
 {
    MFEM_VERIFY(d1d <= DeviceDofQuadLimits::Get().MAX_D1D, "");
    MFEM_VERIFY(q1d <= DeviceDofQuadLimits::Get().MAX_Q1D, "");

--- a/fem/integ/bilininteg_vecdiffusion_kernels.hpp
+++ b/fem/integ/bilininteg_vecdiffusion_kernels.hpp
@@ -24,12 +24,11 @@ namespace mfem::internal
 
 // PA Diffusion Apply 2D kernel
 template <int T_D1D = 0, int T_Q1D = 0, int T_VDIM = 0>
-static void
-PAVectorDiffusionApply2D(const int NE, const Array<real_t> &b,
-                         const Array<real_t> &g, const Array<real_t> &bt,
-                         const Array<real_t> &gt, const Vector &d_,
-                         const Vector &x_, Vector &y_, const int d1d = 0,
-                         const int q1d = 0, const int vdim = 0)
+void PAVectorDiffusionApply2D(const int NE, const Array<real_t> &b,
+                              const Array<real_t> &g, const Array<real_t> &bt,
+                              const Array<real_t> &gt, const Vector &d_,
+                              const Vector &x_, Vector &y_, const int d1d = 0,
+                              const int q1d = 0, const int vdim = 0)
 {
    const int D1D = T_D1D ? T_D1D : d1d;
    const int Q1D = T_Q1D ? T_Q1D : q1d;
@@ -142,12 +141,11 @@ PAVectorDiffusionApply2D(const int NE, const Array<real_t> &b,
 
 // PA Diffusion Apply 3D kernel
 template <const int T_D1D = 0, const int T_Q1D = 0>
-static void
-PAVectorDiffusionApply3D(const int NE, const Array<real_t> &b,
-                         const Array<real_t> &g, const Array<real_t> &bt,
-                         const Array<real_t> &gt, const Vector &op_,
-                         const Vector &x_, Vector &y_, const int d1d = 0,
-                         const int q1d = 0, const int sdim = 0)
+void PAVectorDiffusionApply3D(const int NE, const Array<real_t> &b,
+                              const Array<real_t> &g, const Array<real_t> &bt,
+                              const Array<real_t> &gt, const Vector &op_,
+                              const Vector &x_, Vector &y_, const int d1d = 0,
+                              const int q1d = 0, const int sdim = 0)
 {
    const int D1D = T_D1D ? T_D1D : d1d;
    const int Q1D = T_Q1D ? T_Q1D : q1d;

--- a/fem/integ/bilininteg_vecmass_pa.hpp
+++ b/fem/integ/bilininteg_vecmass_pa.hpp
@@ -177,12 +177,9 @@ void SmemPAVectorMassApply3D(const int NE,
 }
 
 template <int T_Q1D = 0, int T_MDQ = 16>
-static void SmemPAVectorMassAssembleDiagonal2D(const int ne,
-                                               const int d1d,
-                                               const int q1d,
-                                               const real_t *b_r,
-                                               const real_t *d_r,
-                                               real_t *y_rw)
+void SmemPAVectorMassAssembleDiagonal2D(const int ne, const int d1d,
+                                        const int q1d, const real_t *b_r,
+                                        const real_t *d_r, real_t *y_rw)
 {
    constexpr int VDIM = 2;
 
@@ -234,12 +231,9 @@ static void SmemPAVectorMassAssembleDiagonal2D(const int ne,
 
 // T_MDQ <= 10 so the Q1D^3 thread block stays within the 1024/block GPU limit
 template <int T_Q1D = 0, int T_MDQ = 10>
-static void SmemPAVectorMassAssembleDiagonal3D(const int ne,
-                                               const int d1d,
-                                               const int q1d,
-                                               const real_t *b_r,
-                                               const real_t *d_r,
-                                               real_t *y_rw)
+void SmemPAVectorMassAssembleDiagonal3D(const int ne, const int d1d,
+                                        const int q1d, const real_t *b_r,
+                                        const real_t *d_r, real_t *y_rw)
 {
    constexpr int VDIM = 3;
 

--- a/fem/integ/lininteg_domain_kernels.hpp
+++ b/fem/integ/lininteg_domain_kernels.hpp
@@ -308,11 +308,10 @@ DomainLFIntegrator::AssembleKernels::Kernel()
 }
 
 template <int T_D1D = 0, int T_Q1D = 0>
-static void HdivDLFAssemble2D(const int ne, const Array<int> &markers,
-                              const Vector &jac, const Array<real_t> &weights,
-                              const Array<real_t> &testBO,
-                              const Array<real_t> &testBC, const Vector &coeff,
-                              Vector &y, const int d, const int q)
+void HdivDLFAssemble2D(const int ne, const Array<int> &markers,
+                       const Vector &jac, const Array<real_t> &weights,
+                       const Array<real_t> &testBO, const Array<real_t> &testBC,
+                       const Vector &coeff, Vector &y, const int d, const int q)
 {
    MFEM_VERIFY(T_D1D || d <= DeviceDofQuadLimits::Get().HDIV_MAX_D1D,
                "Problem size too large.");
@@ -412,11 +411,11 @@ static void HdivDLFAssemble2D(const int ne, const Array<int> &markers,
 }
 
 template <int T_D1D = 0, int T_Q1D = 0>
-static void HdivDLFAssemble3D(const int ne, const Array<int> &markers,
-                              const Vector &jac, const Array<real_t> &weights,
-                              const Array<real_t> &testBO,
-                              const Array<real_t> &testBC, const Vector &coeff,
-                              Vector &y, const int d, const int q)
+void HdivDLFAssemble3D(const int ne, const Array<int> &markers,
+                       const Vector &jac, const Array<real_t> &weights,
+                       const Array<real_t> &testBO,
+                       const Array<real_t> &testBC, const Vector &coeff,
+                       Vector &y, const int d, const int q)
 {
    MFEM_VERIFY(T_D1D || d <= DeviceDofQuadLimits::Get().HDIV_MAX_D1D,
                "Problem size too large.");
@@ -581,11 +580,11 @@ static void HdivDLFAssemble3D(const int ne, const Array<int> &markers,
 /// @tparam T_D1D maximum number of dofs along any direction, or 0
 /// @tparam T_Q1D maximum number of quadrature points along any direction, or 0
 template <int T_D1D = 0, int T_Q1D = 0>
-static void HcurlDLFAssemble3D(const int ne, const Array<int> &markers,
-                               const Vector &jac, const Array<real_t> &weights,
-                               const Array<real_t> &testBO,
-                               const Array<real_t> &testBC, const Vector &coeff,
-                               Vector &y, const int d, const int q)
+void HcurlDLFAssemble3D(const int ne, const Array<int> &markers,
+                        const Vector &jac, const Array<real_t> &weights,
+                        const Array<real_t> &testBO,
+                        const Array<real_t> &testBC, const Vector &coeff,
+                        Vector &y, const int d, const int q)
 {
    MFEM_VERIFY(T_D1D || d <= DeviceDofQuadLimits::Get().HCURL_MAX_D1D,
                "Problem size too large.");

--- a/fem/integ/lininteg_domain_kernels.hpp
+++ b/fem/integ/lininteg_domain_kernels.hpp
@@ -22,11 +22,10 @@ namespace mfem
 {
 
 template <int T_D1D = 0, int T_Q1D = 0>
-static void DLFEvalAssemble1D(const int vdim, const int ne, const int d,
-                              const int q, const int map_type,
-                              const int *markers, const real_t *b,
-                              const real_t *detj, const real_t *weights,
-                              const Vector &coeff, real_t *y)
+void DLFEvalAssemble1D(const int vdim, const int ne, const int d, const int q,
+                       const int map_type, const int *markers, const real_t *b,
+                       const real_t *detj, const real_t *weights,
+                       const Vector &coeff, real_t *y)
 {
    {
       constexpr int Q = T_Q1D ? T_Q1D : DofQuadLimits::MAX_Q1D;
@@ -76,11 +75,10 @@ static void DLFEvalAssemble1D(const int vdim, const int ne, const int d,
 }
 
 template <int T_D1D = 0, int T_Q1D = 0>
-static void DLFEvalAssemble2D(const int vdim, const int ne, const int d,
-                              const int q, const int map_type,
-                              const int *markers, const real_t *b,
-                              const real_t *detj, const real_t *weights,
-                              const Vector &coeff, real_t *y)
+void DLFEvalAssemble2D(const int vdim, const int ne, const int d, const int q,
+                       const int map_type, const int *markers, const real_t *b,
+                       const real_t *detj, const real_t *weights,
+                       const Vector &coeff, real_t *y)
 {
    {
       constexpr int Q = T_Q1D ? T_Q1D : DofQuadLimits::MAX_Q1D;
@@ -162,11 +160,10 @@ static void DLFEvalAssemble2D(const int vdim, const int ne, const int d,
 }
 
 template <int T_D1D = 0, int T_Q1D = 0>
-static void DLFEvalAssemble3D(const int vdim, const int ne, const int d,
-                              const int q, const int map_type,
-                              const int* markers, const real_t *b,
-                              const real_t *detj, const real_t *weights,
-                              const Vector &coeff, real_t *y)
+void DLFEvalAssemble3D(const int vdim, const int ne, const int d, const int q,
+                       const int map_type, const int *markers, const real_t *b,
+                       const real_t *detj, const real_t *weights,
+                       const Vector &coeff, real_t *y)
 {
    {
       constexpr int Q = T_Q1D ? T_Q1D : DofQuadLimits::MAX_Q1D;

--- a/fem/kernel_reporter.hpp
+++ b/fem/kernel_reporter.hpp
@@ -29,20 +29,20 @@ namespace internal
 {
 
 template <typename Last>
-static void Stringify_(std::ostream &o, Last &&arg)
+void Stringify_(std::ostream &o, Last &&arg)
 {
    o << arg;
 }
 
 template <typename T1, typename T2, typename... Rest>
-static void Stringify_(std::ostream &o, T1 &&a1, T2 &&a2, Rest&&... rest)
+void Stringify_(std::ostream &o, T1 &&a1, T2 &&a2, Rest&&... rest)
 {
    o << int(a1) << ",";
    Stringify_(o, a2, rest...);
 }
 
 template <typename... Args>
-static std::string Stringify(Args&&... args)
+std::string Stringify(Args&&... args)
 {
    std::stringstream o;
    Stringify_(o, args...);

--- a/fem/lor/lor_batched.hpp
+++ b/fem/lor/lor_batched.hpp
@@ -135,7 +135,7 @@ void EnsureCapacity(Memory<T> &mem, int capacity)
 
 /// Return the first domain integrator in the form @a i of type @a T.
 template <typename T>
-static T *GetIntegrator(Array<BilinearFormIntegrator*> *integs)
+T *GetIntegrator(Array<BilinearFormIntegrator*> *integs)
 {
    if (integs != NULL)
    {
@@ -151,13 +151,13 @@ static T *GetIntegrator(Array<BilinearFormIntegrator*> *integs)
 }
 
 template <typename T>
-static T *GetIntegrator(BilinearForm &a)
+T *GetIntegrator(BilinearForm &a)
 {
    return GetIntegrator<T>(a.GetDBFI());
 }
 
 template <typename T>
-static T *GetInteriorFaceIntegrator(BilinearForm &a)
+T *GetInteriorFaceIntegrator(BilinearForm &a)
 {
    return GetIntegrator<T>(a.GetFBFI());
 }

--- a/fem/pfespace.cpp
+++ b/fem/pfespace.cpp
@@ -1147,9 +1147,8 @@ void ParFiniteElementSpace::Synchronize(Array<int> &ldof_marker) const
    MFEM_VERIFY(ldof_marker.Size() == GetVSize(), "invalid in/out array");
 
    // implement allreduce(|) as reduce(|) + broadcast
-   // (use host communications to avoid an issue when using the debug device)
-   gcomm->Reduce<int>(ldof_marker.HostReadWrite(), GroupCommunicator::BitOR);
-   gcomm->Bcast(ldof_marker.HostReadWrite());
+   gcomm->Reduce<int>(ldof_marker, GroupCommunicator::BitOR);
+   gcomm->Bcast(ldof_marker);
 }
 
 void ParFiniteElementSpace::GetEssentialVDofs(const Array<int> &bdr_attr_is_ess,
@@ -2215,8 +2214,7 @@ void ParFiniteElementSpace::ConstructTrueDofs()
    gcomm->SetLTDofTable(ldof_ltdof);
 
    // have the group masters broadcast their ltdofs to the rest of the group
-   // (use host communication to avoid an issue when using the debug device)
-   gcomm->Bcast(ldof_ltdof.HostReadWrite());
+   gcomm->Bcast(ldof_ltdof);
 }
 
 void ParFiniteElementSpace::ConstructTrueNURBSDofs()

--- a/fem/pfespace.cpp
+++ b/fem/pfespace.cpp
@@ -109,7 +109,6 @@ void ParFiniteElementSpace::ParInit(ParMesh *pm)
    Rconf = nullptr;
    R = nullptr;
    num_face_nbr_dofs = -1;
-   nd_strias = false;
 
    if (NURBSext && !pNURBSext())
    {
@@ -132,11 +131,6 @@ void ParFiniteElementSpace::ParInit(ParMesh *pm)
    {
       ApplyLDofSigns(*elem_dof);
    }
-
-   // Check for shared triangular faces with interior Nedelec DoFs
-   CheckNDSTriaDofs();
-   // Enable the device shared-dof path only for spaces where it is supported.
-   gcomm->SetDeviceSharedDofSupport(Conforming() && !SharedNDTriangleDofs());
 }
 
 void ParFiniteElementSpace::CommunicateGhostOrder()
@@ -287,6 +281,10 @@ void ParFiniteElementSpace::Construct()
       // to overlap its communication with processing between this constructor
       // and the point where the P matrix is actually needed.
    }
+
+   // Check for shared triangular faces with interior Nedelec DoFs:
+   // initializes 'nd_strias'.
+   CheckNDSTriaDofs();
 }
 
 void ParFiniteElementSpace::PrintPartitionStats()
@@ -1149,8 +1147,9 @@ void ParFiniteElementSpace::Synchronize(Array<int> &ldof_marker) const
    MFEM_VERIFY(ldof_marker.Size() == GetVSize(), "invalid in/out array");
 
    // implement allreduce(|) as reduce(|) + broadcast
-   gcomm->Reduce<int>(ldof_marker, GroupCommunicator::BitOR);
-   gcomm->Bcast(ldof_marker);
+   // (use host communications to avoid an issue when using the debug device)
+   gcomm->Reduce<int>(ldof_marker.HostReadWrite(), GroupCommunicator::BitOR);
+   gcomm->Bcast(ldof_marker.HostReadWrite());
 }
 
 void ParFiniteElementSpace::GetEssentialVDofs(const Array<int> &bdr_attr_is_ess,
@@ -2216,7 +2215,8 @@ void ParFiniteElementSpace::ConstructTrueDofs()
    gcomm->SetLTDofTable(ldof_ltdof);
 
    // have the group masters broadcast their ltdofs to the rest of the group
-   gcomm->Bcast(ldof_ltdof);
+   // (use host communication to avoid an issue when using the debug device)
+   gcomm->Bcast(ldof_ltdof.HostReadWrite());
 }
 
 void ParFiniteElementSpace::ConstructTrueNURBSDofs()
@@ -5285,7 +5285,6 @@ void ParFiniteElementSpace::Update(bool want_transform)
 
    Destroy();  // Does not clear elem_order
    FiniteElementSpace::Destroy(); // calls Th.Clear()
-   nd_strias = false;
 
    // In the variable-order case, we call CommunicateGhostOrder whether h-
    // or p-refinement is done.
@@ -5293,9 +5292,6 @@ void ParFiniteElementSpace::Update(bool want_transform)
 
    FiniteElementSpace::Construct();
    Construct();
-   CheckNDSTriaDofs();
-   // Enable the device shared-dof path only for spaces where it is supported.
-   gcomm->SetDeviceSharedDofSupport(Conforming() && !SharedNDTriangleDofs());
 
    BuildElementToDofTable();
 
@@ -5575,7 +5571,7 @@ void ConformingProlongationOperator::Mult(const Vector &x, Vector &y) const
    const int in_layout = 2; // 2 - input is ltdofs array
    if (local)
    {
-      y = 0.0;
+      y.SetSubVector(external_ldofs, 0.0);
    }
    else
    {
@@ -5631,14 +5627,13 @@ void ConformingProlongationOperator::MultTranspose(
 
 DeviceConformingProlongationOperator::DeviceConformingProlongationOperator(
    int lsize, const GroupCommunicator &gc_, bool local_)
-   : ConformingProlongationOperator(lsize, gc_, local_),
-     nbr_comm(new internal::DeviceNeighborDofComm(gc_))
-{
-   shr_buf.SetSize(nbr_comm->SharedLTDof().Size());
-   shr_buf.UseDevice(true);
-   ext_buf.SetSize(nbr_comm->ExternalLDof().Size());
-   ext_buf.UseDevice(true);
-}
+   : ConformingProlongationOperator(lsize, gc_, local_)
+{ }
+
+DeviceConformingProlongationOperator::DeviceConformingProlongationOperator(
+   const GroupCommunicator &gc_, const SparseMatrix *R, bool local_)
+   : ConformingProlongationOperator(R->Width(), gc_, local_)
+{ }
 
 DeviceConformingProlongationOperator::DeviceConformingProlongationOperator(
    const ParFiniteElementSpace &pfes, bool local_)
@@ -5649,110 +5644,31 @@ DeviceConformingProlongationOperator::DeviceConformingProlongationOperator(
    MFEM_ASSERT(pfes.Conforming(), "internal error");
 }
 
-void DeviceConformingProlongationOperator::BcastBeginCopy(
-   const Vector &x) const
-{
-   const auto &shr_ltdof = nbr_comm->SharedLTDof();
-   // shr_buf[i] = src[shr_ltdof[i]]
-   if (shr_ltdof.Size() == 0) { return; }
-   internal::DeviceNeighborDofExtract(shr_ltdof, x, shr_buf);
-   if (nbr_comm->MpiGpuAware()) { MFEM_STREAM_SYNC; }
-}
-
-void DeviceConformingProlongationOperator::BcastLocalCopy(
-   const Vector &x, Vector &y) const
-{
-   const auto &ltdof_ldof = nbr_comm->LocalTDofToLDof();
-   // dst[ltdof_ldof[i]] = src[i]
-   if (ltdof_ldof.Size() == 0) { return; }
-   internal::DeviceNeighborDofSet(ltdof_ldof, x, y);
-}
-
-void DeviceConformingProlongationOperator::BcastEndCopy(
-   Vector &y) const
-{
-   const auto &ext_ldof = nbr_comm->ExternalLDof();
-   // dst[ext_ldof[i]] = ext_buf[i]
-   if (ext_ldof.Size() == 0) { return; }
-   internal::DeviceNeighborDofSet(ext_ldof, ext_buf, y);
-}
-
 void DeviceConformingProlongationOperator::Mult(const Vector &x,
                                                 Vector &y) const
 {
-   int req_counter = 0;
-   // Make sure 'y' is marked as valid on device and for use on device.
-   // This ensures that there is no unnecessary host to device copy when the
-   // input 'y' is valid on host (in 'y.SetSubVector(ext_ldof, 0.0)' when local
-   // is true) or BcastLocalCopy (when local is false).
-   y.Write();
-   if (local)
+   if (!local)
    {
-      // done on device since we've marked ext_ldof for use on device:
-      y.SetSubVector(nbr_comm->ExternalLDof(), 0.0);
+      gc.GetDeviceComm().Prolongate(*x.GetArrayView(), *y.GetArrayView());
    }
    else
    {
-      BcastBeginCopy(x); // copy to 'shr_buf'
-      req_counter = nbr_comm->ExchangeSharedToExternal<real_t>(shr_buf, ext_buf,
-                                                               41822);
+      gc.GetDeviceComm().RestrictTranspose(*x.GetArrayView(),
+                                           *y.GetArrayView());
    }
-   BcastLocalCopy(x, y);
-   if (!local)
-   {
-      nbr_comm->WaitAll(req_counter);
-      BcastEndCopy(y); // copy from 'ext_buf'
-   }
-}
-
-DeviceConformingProlongationOperator::
-~DeviceConformingProlongationOperator() = default;
-
-void DeviceConformingProlongationOperator::ReduceBeginCopy(
-   const Vector &x) const
-{
-   const auto &ext_ldof = nbr_comm->ExternalLDof();
-   // ext_buf[i] = src[ext_ldof[i]]
-   if (ext_ldof.Size() == 0) { return; }
-   internal::DeviceNeighborDofExtract(ext_ldof, x, ext_buf);
-   if (nbr_comm->MpiGpuAware()) { MFEM_STREAM_SYNC; }
-}
-
-void DeviceConformingProlongationOperator::ReduceLocalCopy(
-   const Vector &x, Vector &y) const
-{
-   const auto &ltdof_ldof = nbr_comm->LocalTDofToLDof();
-   // dst[i] = src[ltdof_ldof[i]]
-   if (ltdof_ldof.Size() == 0) { return; }
-   internal::DeviceNeighborDofExtract(ltdof_ldof, x, y);
-}
-
-void DeviceConformingProlongationOperator::ReduceEndAssemble(Vector &y) const
-{
-   const auto &unq_ltdof = nbr_comm->UniqueLTDof();
-   // dst[shr_ltdof[i]] += shr_buf[i]
-   if (unq_ltdof.Size() == 0) { return; }
-   internal::DeviceNeighborDofAdd(unq_ltdof,
-                                  nbr_comm->UniqueSharedOffsets(),
-                                  nbr_comm->UniqueSharedIndices(),
-                                  shr_buf, y);
 }
 
 void DeviceConformingProlongationOperator::MultTranspose(const Vector &x,
                                                          Vector &y) const
 {
-   int req_counter = 0;
    if (!local)
    {
-      ReduceBeginCopy(x); // copy to 'ext_buf'
-      req_counter = nbr_comm->ExchangeExternalToShared<real_t>(ext_buf, shr_buf,
-                                                               41823);
+      gc.GetDeviceComm().ProlongateTranspose(*x.GetArrayView(),
+                                             *y.GetArrayView());
    }
-   ReduceLocalCopy(x, y);
-   if (!local)
+   else
    {
-      nbr_comm->WaitAll(req_counter);
-      ReduceEndAssemble(y); // assemble from 'shr_buf'
+      gc.GetDeviceComm().Restrict(*x.GetArrayView(), *y.GetArrayView());
    }
 }
 

--- a/fem/pfespace.hpp
+++ b/fem/pfespace.hpp
@@ -528,10 +528,10 @@ public:
        that the number of DOFs is @a ndofs. */
    const FiniteElement *GetFaceNbrFE(int i, int ndofs = 0) const;
    const FiniteElement *GetFaceNbrFaceFE(int i) const;
-   const Array<HYPRE_BigInt> &GetFaceNbrGlobalDofMapArray() { return face_nbr_glob_dof_map; }
-   const HYPRE_BigInt *GetFaceNbrGlobalDofMap() { return face_nbr_glob_dof_map; }
    const Array<HYPRE_BigInt> &GetFaceNbrGlobalDofMapArray() const
    { return face_nbr_glob_dof_map; }
+   const HYPRE_BigInt *GetFaceNbrGlobalDofMap() const
+   { return face_nbr_glob_dof_map.HostRead(); }
    ElementTransformation *GetFaceNbrElementTransformation(int i) const
    { return pmesh->GetFaceNbrElementTransformation(i); }
 
@@ -640,45 +640,18 @@ public:
 };
 
 /// Auxiliary device class used by ParFiniteElementSpace.
-class DeviceConformingProlongationOperator: public
-   ConformingProlongationOperator
+class DeviceConformingProlongationOperator
+   : public ConformingProlongationOperator
 {
-protected:
-   mutable Vector shr_buf, ext_buf;
-   std::unique_ptr<internal::DeviceNeighborDofComm> nbr_comm;
-
-   // Kernel: copy ltdofs from 'src' to 'shr_buf' - prepare for send.
-   //         shr_buf[i] = src[shr_ltdof[i]]
-   void BcastBeginCopy(const Vector &src) const;
-
-   // Kernel: copy ltdofs from 'src' to ldofs in 'dst'.
-   //         dst[ltdof_ldof[i]] = src[i]
-   void BcastLocalCopy(const Vector &src, Vector &dst) const;
-
-   // Kernel: copy ext. dofs from 'ext_buf' to 'dst' - after recv.
-   //         dst[ext_ldof[i]] = ext_buf[i]
-   void BcastEndCopy(Vector &dst) const;
-
-   // Kernel: copy ext. dofs from 'src' to 'ext_buf' - prepare for send.
-   //         ext_buf[i] = src[ext_ldof[i]]
-   void ReduceBeginCopy(const Vector &src) const;
-
-   // Kernel: copy owned ldofs from 'src' to ltdofs in 'dst'.
-   //         dst[i] = src[ltdof_ldof[i]]
-   void ReduceLocalCopy(const Vector &src, Vector &dst) const;
-
-   // Kernel: assemble dofs from 'shr_buf' into to 'dst' - after recv.
-   //         dst[shr_ltdof[i]] += shr_buf[i]
-   void ReduceEndAssemble(Vector &dst) const;
-
 public:
    DeviceConformingProlongationOperator(
       int lsize, const GroupCommunicator &gc_, bool local_=false);
 
+   DeviceConformingProlongationOperator(
+      const GroupCommunicator &gc_, const SparseMatrix *R, bool local_=false);
+
    DeviceConformingProlongationOperator(const ParFiniteElementSpace &pfes,
                                         bool local_=false);
-
-   virtual ~DeviceConformingProlongationOperator();
 
    void Mult(const Vector &x, Vector &y) const override;
 

--- a/fem/pgridfunc.cpp
+++ b/fem/pgridfunc.cpp
@@ -511,8 +511,8 @@ void ParGridFunction::CountElementsPerVDof(Array<int> &elem_per_vdof) const
    GridFunction::CountElementsPerVDof(elem_per_vdof);
    // Count the zones globally.
    GroupCommunicator &gcomm = this->ParFESpace()->GroupComm();
-   gcomm.Reduce<int>(elem_per_vdof.HostReadWrite(), GroupCommunicator::Sum);
-   gcomm.Bcast(elem_per_vdof.HostReadWrite());
+   gcomm.Reduce<int>(elem_per_vdof, GroupCommunicator::Sum);
+   gcomm.Bcast(elem_per_vdof);
 }
 
 void ParGridFunction::GetDerivative(int comp, int der_comp,
@@ -523,8 +523,8 @@ void ParGridFunction::GetDerivative(int comp, int der_comp,
 
    // Count the zones globally.
    GroupCommunicator &gcomm = der.ParFESpace()->GroupComm();
-   gcomm.Reduce<int>(overlap.HostReadWrite(), GroupCommunicator::Sum);
-   gcomm.Bcast(overlap.HostReadWrite());
+   gcomm.Reduce<int>(overlap, GroupCommunicator::Sum);
+   gcomm.Bcast(overlap);
 
    // Accumulate for all dofs.
    gcomm.Reduce<real_t>(der.HostReadWrite(), GroupCommunicator::Sum);
@@ -742,9 +742,8 @@ void ParGridFunction::ProjectDiscCoefficient(
    Array<int> gdof_attr;
    ldof_attr.Copy(gdof_attr);
    GroupCommunicator &gcomm = pfes->GroupComm();
-   // use host communications
-   gcomm.Reduce(gdof_attr.HostReadWrite(), GroupCommunicator::Max);
-   gcomm.Bcast(gdof_attr.HostReadWrite());
+   gcomm.Reduce<int>(gdof_attr, GroupCommunicator::Max);
+   gcomm.Bcast(gdof_attr);
 
    // set local value to zero if global maximal element attribute is larger than
    // the local one, and mark (in gdof_attr) if we have the correct value
@@ -763,9 +762,8 @@ void ParGridFunction::ProjectDiscCoefficient(
 
    // parallel averaging plus interpolation to determine final values
    HypreParVector *tv = pfes->NewTrueDofVector();
-   // use host communications
-   gcomm.Reduce(gdof_attr.HostReadWrite(), GroupCommunicator::Sum);
-   gcomm.Bcast(gdof_attr.HostReadWrite());
+   gcomm.Reduce<int>(gdof_attr, GroupCommunicator::Sum);
+   gcomm.Bcast(gdof_attr);
    HostReadWrite();
    for (int i = 0; i < fes->GetVSize(); i++)
    {
@@ -789,12 +787,12 @@ void ParGridFunction::ProjectDiscCoefficient(Coefficient &coeff, AvgType type)
    Array<int> zones_per_vdof;
    AccumulateAndCountZones(coeff, type, zones_per_vdof);
 
-   // Count the zones globally. (host communication)
+   // Count the zones globally.
    GroupCommunicator &gcomm = pfes->GroupComm();
-   gcomm.Reduce(zones_per_vdof.HostReadWrite(), GroupCommunicator::Sum);
-   gcomm.Bcast(zones_per_vdof.HostReadWrite());
+   gcomm.Reduce<int>(zones_per_vdof, GroupCommunicator::Sum);
+   gcomm.Bcast(zones_per_vdof);
 
-   // Accumulate for all vdofs. (host communication)
+   // Accumulate for all vdofs.
    gcomm.Reduce(HostReadWrite(), GroupCommunicator::Sum);
    gcomm.Bcast(HostReadWrite());
 
@@ -813,12 +811,12 @@ void ParGridFunction::ProjectDiscCoefficient(VectorCoefficient &vcoeff,
    Array<int> zones_per_vdof;
    AccumulateAndCountZones(vcoeff, type, zones_per_vdof);
 
-   // Count the zones globally. (host communication)
+   // Count the zones globally.
    GroupCommunicator &gcomm = pfes->GroupComm();
-   gcomm.Reduce(zones_per_vdof.HostReadWrite(), GroupCommunicator::Sum);
-   gcomm.Bcast(zones_per_vdof.HostReadWrite());
+   gcomm.Reduce<int>(zones_per_vdof, GroupCommunicator::Sum);
+   gcomm.Bcast(zones_per_vdof);
 
-   // Accumulate for all vdofs. (host communication)
+   // Accumulate for all vdofs.
    gcomm.Reduce(HostReadWrite(), GroupCommunicator::Sum);
    gcomm.Bcast(HostReadWrite());
 

--- a/fem/pgridfunc.cpp
+++ b/fem/pgridfunc.cpp
@@ -511,8 +511,8 @@ void ParGridFunction::CountElementsPerVDof(Array<int> &elem_per_vdof) const
    GridFunction::CountElementsPerVDof(elem_per_vdof);
    // Count the zones globally.
    GroupCommunicator &gcomm = this->ParFESpace()->GroupComm();
-   gcomm.Reduce<int>(elem_per_vdof, GroupCommunicator::Sum);
-   gcomm.Bcast(elem_per_vdof);
+   gcomm.Reduce<int>(elem_per_vdof.HostReadWrite(), GroupCommunicator::Sum);
+   gcomm.Bcast(elem_per_vdof.HostReadWrite());
 }
 
 void ParGridFunction::GetDerivative(int comp, int der_comp,
@@ -523,8 +523,8 @@ void ParGridFunction::GetDerivative(int comp, int der_comp,
 
    // Count the zones globally.
    GroupCommunicator &gcomm = der.ParFESpace()->GroupComm();
-   gcomm.Reduce<int>(overlap, GroupCommunicator::Sum);
-   gcomm.Bcast(overlap);
+   gcomm.Reduce<int>(overlap.HostReadWrite(), GroupCommunicator::Sum);
+   gcomm.Bcast(overlap.HostReadWrite());
 
    // Accumulate for all dofs.
    gcomm.Reduce<real_t>(der.HostReadWrite(), GroupCommunicator::Sum);
@@ -570,8 +570,8 @@ void ParGridFunction::ProjectCoefficient(Coefficient &coeff, ProjectType type)
       if (pfes->GetNURBSext())
       {
          GroupCommunicator &gcomm = pfes->GroupComm();
-         gcomm.Reduce<real_t>(data, GroupCommunicator::Max);
-         gcomm.Bcast<real_t>(data);
+         gcomm.Reduce<real_t>(HostReadWrite(), GroupCommunicator::Max);
+         gcomm.Bcast<real_t>(HostReadWrite());
       }
    }
    else
@@ -597,8 +597,8 @@ void ParGridFunction::ProjectCoefficient(VectorCoefficient &vcoeff,
    if (pfes->GetNURBSext())
    {
       GroupCommunicator &gcomm = pfes->GroupComm();
-      gcomm.Reduce<real_t>(data, GroupCommunicator::Max);
-      gcomm.Bcast<real_t>(data);
+      gcomm.Reduce<real_t>(HostReadWrite(), GroupCommunicator::Max);
+      gcomm.Bcast<real_t>(HostReadWrite());
    }
 }
 
@@ -639,11 +639,11 @@ void ParGridFunction::ProjectCoefficientElementL2(Coefficient &coeff)
    ProjectCoefficientElementL2_(coeff, *this, Va);
 
    GroupCommunicator &gcomm = pfes->GroupComm();
-   gcomm.Reduce<real_t>(GetData(), GroupCommunicator::Sum);
-   gcomm.Bcast<real_t>(GetData());
+   gcomm.Reduce<real_t>(HostReadWrite(), GroupCommunicator::Sum);
+   gcomm.Bcast<real_t>(HostReadWrite());
 
-   gcomm.Reduce<real_t>(Va.GetData(), GroupCommunicator::Sum);
-   gcomm.Bcast<real_t>(Va.GetData());
+   gcomm.Reduce<real_t>(Va.HostReadWrite(), GroupCommunicator::Sum);
+   gcomm.Bcast<real_t>(Va.HostReadWrite());
    (*this)/=Va;
 }
 
@@ -695,11 +695,11 @@ void ParGridFunction::ProjectCoefficientElementL2(VectorCoefficient &vcoeff)
       ProjectCoefficientElementL2_(vcoeff, *this, Va);
 
       GroupCommunicator &gcomm = pfes->GroupComm();
-      gcomm.Reduce<real_t>(GetData(), GroupCommunicator::Sum);
-      gcomm.Bcast<real_t>(GetData());
+      gcomm.Reduce<real_t>(HostReadWrite(), GroupCommunicator::Sum);
+      gcomm.Bcast<real_t>(HostReadWrite());
 
-      gcomm.Reduce<real_t>(Va.GetData(), GroupCommunicator::Sum);
-      gcomm.Bcast<real_t>(Va.GetData());
+      gcomm.Reduce<real_t>(Va.HostReadWrite(), GroupCommunicator::Sum);
+      gcomm.Bcast<real_t>(Va.HostReadWrite());
       (*this)/=Va;
    }
    else
@@ -719,11 +719,11 @@ void ParGridFunction::ProjectCoefficientElementL2(VectorCoefficient &vcoeff)
       }
 
       GroupCommunicator &gcomm = pfes->GroupComm();
-      gcomm.Reduce<real_t>(GetData(), GroupCommunicator::Sum);
-      gcomm.Bcast<real_t>(GetData());
+      gcomm.Reduce<real_t>(HostReadWrite(), GroupCommunicator::Sum);
+      gcomm.Bcast<real_t>(HostReadWrite());
 
-      gcomm.Reduce<real_t>(gVa.GetData(), GroupCommunicator::Sum);
-      gcomm.Bcast<real_t>(gVa.GetData());
+      gcomm.Reduce<real_t>(gVa.HostReadWrite(), GroupCommunicator::Sum);
+      gcomm.Bcast<real_t>(gVa.HostReadWrite());
       *this /= gVa;
    }
 }
@@ -742,9 +742,9 @@ void ParGridFunction::ProjectDiscCoefficient(
    Array<int> gdof_attr;
    ldof_attr.Copy(gdof_attr);
    GroupCommunicator &gcomm = pfes->GroupComm();
-   gcomm.Reduce<int>(gdof_attr, GroupCommunicator::Max);
-   gcomm.Bcast(gdof_attr);
-   gdof_attr.HostReadWrite();
+   // use host communications
+   gcomm.Reduce(gdof_attr.HostReadWrite(), GroupCommunicator::Max);
+   gcomm.Bcast(gdof_attr.HostReadWrite());
 
    // set local value to zero if global maximal element attribute is larger than
    // the local one, and mark (in gdof_attr) if we have the correct value
@@ -763,9 +763,9 @@ void ParGridFunction::ProjectDiscCoefficient(
 
    // parallel averaging plus interpolation to determine final values
    HypreParVector *tv = pfes->NewTrueDofVector();
-   gcomm.Reduce<int>(gdof_attr, GroupCommunicator::Sum);
-   gcomm.Bcast(gdof_attr);
-   gdof_attr.HostRead();
+   // use host communications
+   gcomm.Reduce(gdof_attr.HostReadWrite(), GroupCommunicator::Sum);
+   gcomm.Bcast(gdof_attr.HostReadWrite());
    HostReadWrite();
    for (int i = 0; i < fes->GetVSize(); i++)
    {
@@ -789,17 +789,14 @@ void ParGridFunction::ProjectDiscCoefficient(Coefficient &coeff, AvgType type)
    Array<int> zones_per_vdof;
    AccumulateAndCountZones(coeff, type, zones_per_vdof);
 
-   // Count the zones globally.
+   // Count the zones globally. (host communication)
    GroupCommunicator &gcomm = pfes->GroupComm();
-   gcomm.Reduce<int>(zones_per_vdof, GroupCommunicator::Sum);
-   gcomm.Bcast(zones_per_vdof);
+   gcomm.Reduce(zones_per_vdof.HostReadWrite(), GroupCommunicator::Sum);
+   gcomm.Bcast(zones_per_vdof.HostReadWrite());
 
-   // Accumulate for all vdofs.
-   real_t *data_ptr = ReadWrite(GetMemory().DeviceIsValid());
-   gcomm.Reduce<real_t>(data_ptr, GroupCommunicator::Sum);
-   gcomm.Bcast<real_t>(data_ptr);
-   zones_per_vdof.HostRead();
-   HostReadWrite();
+   // Accumulate for all vdofs. (host communication)
+   gcomm.Reduce(HostReadWrite(), GroupCommunicator::Sum);
+   gcomm.Bcast(HostReadWrite());
 
    ComputeMeans(type, zones_per_vdof);
 }
@@ -816,17 +813,14 @@ void ParGridFunction::ProjectDiscCoefficient(VectorCoefficient &vcoeff,
    Array<int> zones_per_vdof;
    AccumulateAndCountZones(vcoeff, type, zones_per_vdof);
 
-   // Count the zones globally.
+   // Count the zones globally. (host communication)
    GroupCommunicator &gcomm = pfes->GroupComm();
-   gcomm.Reduce<int>(zones_per_vdof, GroupCommunicator::Sum);
-   gcomm.Bcast(zones_per_vdof);
+   gcomm.Reduce(zones_per_vdof.HostReadWrite(), GroupCommunicator::Sum);
+   gcomm.Bcast(zones_per_vdof.HostReadWrite());
 
-   // Accumulate for all vdofs.
-   real_t *data_ptr = ReadWrite(GetMemory().DeviceIsValid());
-   gcomm.Reduce<real_t>(data_ptr, GroupCommunicator::Sum);
-   gcomm.Bcast<real_t>(data_ptr);
-   zones_per_vdof.HostRead();
-   HostReadWrite();
+   // Accumulate for all vdofs. (host communication)
+   gcomm.Reduce(HostReadWrite(), GroupCommunicator::Sum);
+   gcomm.Bcast(HostReadWrite());
 
    ComputeMeans(type, zones_per_vdof);
 }

--- a/fem/qinterp/eval.hpp
+++ b/fem/qinterp/eval.hpp
@@ -31,9 +31,9 @@ namespace quadrature_interpolator
 {
 
 template <QVectorLayout Q_LAYOUT, bool Integral>
-static void ImplValues1D(const int NE, const real_t *b_, const real_t *detJ_,
-                         const real_t *x_, real_t *y_, const int vdim,
-                         const int d1d, const int q1d)
+void ImplValues1D(const int NE, const real_t *b_, const real_t *detJ_,
+                  const real_t *x_, real_t *y_, const int vdim, const int d1d,
+                  const int q1d)
 {
    mfem::forall(NE, [=] MFEM_HOST_DEVICE(int e)
    {
@@ -69,8 +69,8 @@ static void ImplValues1D(const int NE, const real_t *b_, const real_t *detJ_,
 }
 
 template <QVectorLayout Q_LAYOUT>
-static void Values1D(const int NE, const real_t *b_, const real_t *x_,
-                     real_t *y_, const int vdim, const int d1d, const int q1d)
+void Values1D(const int NE, const real_t *b_, const real_t *x_, real_t *y_,
+              const int vdim, const int d1d, const int q1d)
 {
    ImplValues1D<Q_LAYOUT, false>(NE, b_, nullptr, x_, y_, vdim, d1d, q1d);
 }
@@ -78,9 +78,9 @@ static void Values1D(const int NE, const real_t *b_, const real_t *x_,
 // Template compute kernel for Values in 2D: tensor product version.
 template <QVectorLayout Q_LAYOUT, bool Integral, int T_VDIM = 0, int T_D1D = 0,
           int T_Q1D = 0, int T_NBZ = 1>
-static void ImplValues2D(const int NE, const real_t *b_, const real_t *detJ_,
-                         const real_t *x_, real_t *y_, const int vdim = 0,
-                         const int d1d = 0, const int q1d = 0)
+void ImplValues2D(const int NE, const real_t *b_, const real_t *detJ_,
+                  const real_t *x_, real_t *y_, const int vdim = 0,
+                  const int d1d = 0, const int q1d = 0)
 {
    static constexpr int NBZ = T_NBZ ? T_NBZ : 1;
 
@@ -155,9 +155,8 @@ static void ImplValues2D(const int NE, const real_t *b_, const real_t *detJ_,
 // Template compute kernel for Values in 2D: tensor product version.
 template <QVectorLayout Q_LAYOUT, int T_VDIM = 0, int T_D1D = 0, int T_Q1D = 0,
           int T_NBZ = 1>
-static void Values2D(const int NE, const real_t *b_, const real_t *x_,
-                     real_t *y_, const int vdim = 0, const int d1d = 0,
-                     const int q1d = 0)
+void Values2D(const int NE, const real_t *b_, const real_t *x_, real_t *y_,
+              const int vdim = 0, const int d1d = 0, const int q1d = 0)
 {
    return ImplValues2D<Q_LAYOUT, false, T_VDIM, T_D1D, T_Q1D, T_NBZ>(
              NE, b_, nullptr, x_, y_, vdim, d1d, q1d);
@@ -166,9 +165,9 @@ static void Values2D(const int NE, const real_t *b_, const real_t *x_,
 // Template compute kernel for Values in 3D: tensor product version.
 template <QVectorLayout Q_LAYOUT, bool Integral, int T_VDIM = 0, int T_D1D = 0,
           int T_Q1D = 0>
-static void ImplValues3D(const int NE, const real_t *b_, const real_t *detJ_,
-                         const real_t *x_, real_t *y_, const int vdim = 0,
-                         const int d1d = 0, const int q1d = 0)
+void ImplValues3D(const int NE, const real_t *b_, const real_t *detJ_,
+                  const real_t *x_, real_t *y_, const int vdim = 0,
+                  const int d1d = 0, const int q1d = 0)
 {
    const int D1D = T_D1D ? T_D1D : d1d;
    const int Q1D = T_Q1D ? T_Q1D : q1d;
@@ -247,9 +246,8 @@ static void ImplValues3D(const int NE, const real_t *b_, const real_t *detJ_,
 
 // Template compute kernel for Values in 3D: tensor product version.
 template <QVectorLayout Q_LAYOUT, int T_VDIM = 0, int T_D1D = 0, int T_Q1D = 0>
-static void Values3D(const int NE, const real_t *b_, const real_t *x_,
-                     real_t *y_, const int vdim = 0, const int d1d = 0,
-                     const int q1d = 0)
+void Values3D(const int NE, const real_t *b_, const real_t *x_, real_t *y_,
+              const int vdim = 0, const int d1d = 0, const int q1d = 0)
 {
    return ImplValues3D<Q_LAYOUT, false, T_VDIM, T_D1D, T_Q1D>(
              NE, b_, nullptr, x_, y_, vdim, d1d, q1d);
@@ -275,11 +273,10 @@ inline void Eval1D(const int NE, const int vdim, const QVectorLayout q_layout,
 // * assumes 'e_vec' is using ElementDofOrdering::NATIVE,
 // * assumes 'maps.mode == FULL'.
 template <bool Integral, const int T_VDIM, const int T_ND, const int T_NQ>
-static void ImplEval2D(const int NE, const int vdim,
-                       const QVectorLayout q_layout, const real_t *detJ_,
-                       const GeometricFactors *geom, const DofToQuad &maps,
-                       const Vector &e_vec, Vector &q_val, Vector &q_der,
-                       Vector &q_det, const int eval_flags)
+void ImplEval2D(const int NE, const int vdim, const QVectorLayout q_layout,
+                const real_t *detJ_, const GeometricFactors *geom,
+                const DofToQuad &maps, const Vector &e_vec, Vector &q_val,
+                Vector &q_der, Vector &q_det, const int eval_flags)
 {
    using QI = QuadratureInterpolator;
 
@@ -450,10 +447,10 @@ static void ImplEval2D(const int NE, const int vdim,
 // * assumes 'e_vec' is using ElementDofOrdering::NATIVE,
 // * assumes 'maps.mode == FULL'.
 template <const int T_VDIM, const int T_ND, const int T_NQ>
-static void Eval2D(const int NE, const int vdim, const QVectorLayout q_layout,
-                   const GeometricFactors *geom, const DofToQuad &maps,
-                   const Vector &e_vec, Vector &q_val, Vector &q_der,
-                   Vector &q_det, const int eval_flags)
+void Eval2D(const int NE, const int vdim, const QVectorLayout q_layout,
+            const GeometricFactors *geom, const DofToQuad &maps,
+            const Vector &e_vec, Vector &q_val, Vector &q_der, Vector &q_det,
+            const int eval_flags)
 {
    ImplEval2D<false, T_VDIM, T_ND, T_NQ>(NE, vdim, q_layout, nullptr, geom,
                                          maps, e_vec, q_val, q_der, q_det,
@@ -465,11 +462,10 @@ static void Eval2D(const int NE, const int vdim, const QVectorLayout q_layout,
 // * assumes 'e_vec' is using ElementDofOrdering::NATIVE,
 // * assumes 'maps.mode == FULL'.
 template <bool Integral, const int T_VDIM, const int T_ND, const int T_NQ>
-static void ImplEval3D(const int NE, const int vdim,
-                       const QVectorLayout q_layout, const real_t *detJ_,
-                       const GeometricFactors *geom, const DofToQuad &maps,
-                       const Vector &e_vec, Vector &q_val, Vector &q_der,
-                       Vector &q_det, const int eval_flags)
+void ImplEval3D(const int NE, const int vdim, const QVectorLayout q_layout,
+                const real_t *detJ_, const GeometricFactors *geom,
+                const DofToQuad &maps, const Vector &e_vec, Vector &q_val,
+                Vector &q_der, Vector &q_det, const int eval_flags)
 {
    using QI = QuadratureInterpolator;
 
@@ -643,10 +639,10 @@ static void ImplEval3D(const int NE, const int vdim,
 // * assumes 'e_vec' is using ElementDofOrdering::NATIVE,
 // * assumes 'maps.mode == FULL'.
 template <const int T_VDIM, const int T_ND, const int T_NQ>
-static void Eval3D(const int NE, const int vdim, const QVectorLayout q_layout,
-                   const GeometricFactors *geom, const DofToQuad &maps,
-                   const Vector &e_vec, Vector &q_val, Vector &q_der,
-                   Vector &q_det, const int eval_flags)
+void Eval3D(const int NE, const int vdim, const QVectorLayout q_layout,
+            const GeometricFactors *geom, const DofToQuad &maps,
+            const Vector &e_vec, Vector &q_val, Vector &q_der, Vector &q_det,
+            const int eval_flags)
 {
    ImplEval3D<false, T_VDIM, T_ND, T_NQ>(NE, vdim, q_layout, nullptr, geom,
                                          maps, e_vec, q_val, q_der, q_det,

--- a/fem/qinterp/grad.hpp
+++ b/fem/qinterp/grad.hpp
@@ -30,17 +30,10 @@ namespace internal
 namespace quadrature_interpolator
 {
 
-template<QVectorLayout Q_LAYOUT, bool GRAD_PHYS>
-static void Derivatives1D(const int NE,
-                          const real_t *b_,
-                          const real_t *g_,
-                          const real_t *j_,
-                          const real_t *x_,
-                          real_t *y_,
-                          const int sdim,
-                          const int vdim,
-                          const int d1d,
-                          const int q1d)
+template <QVectorLayout Q_LAYOUT, bool GRAD_PHYS>
+void Derivatives1D(const int NE, const real_t *b_, const real_t *g_,
+                   const real_t *j_, const real_t *x_, real_t *y_,
+                   const int sdim, const int vdim, const int d1d, const int q1d)
 {
    MFEM_CONTRACT_VAR(b_);
    const int SDIM = GRAD_PHYS ? sdim : 1;
@@ -99,19 +92,12 @@ static void Derivatives1D(const int NE,
 }
 
 // Template compute kernel for derivatives in 2D: tensor product version.
-template<QVectorLayout Q_LAYOUT, bool GRAD_PHYS,
-         int T_VDIM = 0, int T_D1D = 0, int T_Q1D = 0,
-         int T_NBZ = 1>
-static void Derivatives2D(const int NE,
-                          const real_t *b_,
-                          const real_t *g_,
-                          const real_t *j_,
-                          const real_t *x_,
-                          real_t *y_,
-                          const int sdim = 2,
-                          const int vdim = 0,
-                          const int d1d = 0,
-                          const int q1d = 0)
+template <QVectorLayout Q_LAYOUT, bool GRAD_PHYS, int T_VDIM = 0, int T_D1D = 0,
+          int T_Q1D = 0, int T_NBZ = 1>
+void Derivatives2D(const int NE, const real_t *b_, const real_t *g_,
+                   const real_t *j_, const real_t *x_, real_t *y_,
+                   const int sdim = 2, const int vdim = 0, const int d1d = 0,
+                   const int q1d = 0)
 {
    const int D1D = T_D1D ? T_D1D : d1d;
    const int Q1D = T_Q1D ? T_Q1D : q1d;
@@ -230,18 +216,12 @@ static void Derivatives2D(const int NE,
 }
 
 // Template compute kernel for derivatives in 3D: tensor product version.
-template<QVectorLayout Q_LAYOUT, bool GRAD_PHYS,
-         int T_VDIM = 0, int T_D1D = 0, int T_Q1D = 0>
-static void Derivatives3D(const int NE,
-                          const real_t *b_,
-                          const real_t *g_,
-                          const real_t *j_,
-                          const real_t *x_,
-                          real_t *y_,
-                          const int sdim = 3,
-                          const int vdim = 0,
-                          const int d1d = 0,
-                          const int q1d = 0)
+template <QVectorLayout Q_LAYOUT, bool GRAD_PHYS, int T_VDIM = 0, int T_D1D = 0,
+          int T_Q1D = 0>
+void Derivatives3D(const int NE, const real_t *b_, const real_t *g_,
+                   const real_t *j_, const real_t *x_, real_t *y_,
+                   const int sdim = 3, const int vdim = 0, const int d1d = 0,
+                   const int q1d = 0)
 {
    const int D1D = T_D1D ? T_D1D : d1d;
    const int Q1D = T_Q1D ? T_Q1D : q1d;
@@ -374,32 +354,21 @@ static void Derivatives3D(const int NE,
    });
 }
 
-template<QVectorLayout Q_LAYOUT, bool GRAD_PHYS>
-static void CollocatedDerivatives1D(const int NE,
-                                    const real_t *g_,
-                                    const real_t *j_,
-                                    const real_t *x_,
-                                    real_t *y_,
-                                    const int sdim,
-                                    const int vdim,
-                                    const int d1d)
+template <QVectorLayout Q_LAYOUT, bool GRAD_PHYS>
+void CollocatedDerivatives1D(const int NE, const real_t *g_, const real_t *j_,
+                             const real_t *x_, real_t *y_, const int sdim,
+                             const int vdim, const int d1d)
 {
    Derivatives1D<Q_LAYOUT, GRAD_PHYS>(
       NE, nullptr, g_, j_, x_, y_, sdim, vdim, d1d, d1d);
 }
 
 // Template compute kernel for derivatives in 2D: tensor product version.
-template<QVectorLayout Q_LAYOUT, bool GRAD_PHYS,
-         int T_VDIM = 0, int T_D1D = 0,
-         int T_NBZ = 1>
-static void CollocatedDerivatives2D(const int NE,
-                                    const real_t *g_,
-                                    const real_t *j_,
-                                    const real_t *x_,
-                                    real_t *y_,
-                                    const int sdim = 2,
-                                    const int vdim = 0,
-                                    const int d1d = 0)
+template <QVectorLayout Q_LAYOUT, bool GRAD_PHYS, int T_VDIM = 0, int T_D1D = 0,
+          int T_NBZ = 1>
+void CollocatedDerivatives2D(const int NE, const real_t *g_, const real_t *j_,
+                             const real_t *x_, real_t *y_, const int sdim = 2,
+                             const int vdim = 0, const int d1d = 0)
 {
    const int D1D = T_D1D ? T_D1D : d1d;
    const int VDIM = T_VDIM ? T_VDIM : vdim;
@@ -494,16 +463,10 @@ static void CollocatedDerivatives2D(const int NE,
 }
 
 // Template compute kernel for derivatives in 3D: tensor product version.
-template<QVectorLayout Q_LAYOUT, bool GRAD_PHYS,
-         int T_VDIM = 0, int T_D1D = 0>
-static void CollocatedDerivatives3D(const int NE,
-                                    const real_t *g_,
-                                    const real_t *j_,
-                                    const real_t *x_,
-                                    real_t *y_,
-                                    const int sdim = 3,
-                                    const int vdim = 0,
-                                    const int d1d = 0)
+template <QVectorLayout Q_LAYOUT, bool GRAD_PHYS, int T_VDIM = 0, int T_D1D = 0>
+void CollocatedDerivatives3D(const int NE, const real_t *g_, const real_t *j_,
+                             const real_t *x_, real_t *y_, const int sdim = 3,
+                             const int vdim = 0, const int d1d = 0)
 {
    MFEM_VERIFY(sdim == 3, "");
 

--- a/general/array.hpp
+++ b/general/array.hpp
@@ -28,6 +28,10 @@
 namespace mfem
 {
 
+// Forward declaration
+template <typename ViewedType> class MemoryView;
+
+
 /** @brief Swap objects of type T. The operation is performed using the most
     specialized `swap` function from the `mfem` namespace (or other visible
     `swap` functions), or using the `std::swap` generic template and its
@@ -55,6 +59,9 @@ protected:
    inline void GrowSize(int minsize);
 
    static_assert(std::is_trivial<T>::value, "type T must be trivial");
+
+   friend class MemoryView<Array<T>>;
+   friend class MemoryView<const Array<T>>;
 
 public:
    using value_type = T; ///< Type alias for stl.

--- a/general/array.hpp
+++ b/general/array.hpp
@@ -279,6 +279,7 @@ public:
 
    /// Make this Array a reference to the given sub-Memory of @a base.
    /// @a offset and @a size_ are in terms of T, i.e. &(*this)[0] == &(base[0]) + offset*sizeof(T)
+   /// U must be one of (T, char, unsigned char, std::byte)
    template <class U>
    inline void MakeRef(Memory<U> &base, int offset, int size_);
 

--- a/general/array.hpp
+++ b/general/array.hpp
@@ -278,10 +278,7 @@ public:
    inline void MakeRef(const Array &master);
 
    /// Make this Array a reference to the given sub-Memory of @a base.
-   /// @a offset and @a size_ are in terms of T, i.e. &(*this)[0] == &(base[0]) + offset*sizeof(T)
-   /// U must be one of (T, char, unsigned char, std::byte)
-   template <class U>
-   inline void MakeRef(Memory<U> &base, int offset, int size_);
+   inline void MakeRef(Memory<T> &base, int offset, int size_);
 
    /// Reset the Array to use the given external Memory @a mem and size @a s.
    /** If @a own_mem is false, the Array will not own any of the pointers of
@@ -1106,8 +1103,7 @@ inline void Array<T>::MakeRef(const Array &master)
 }
 
 template <class T>
-template <class U>
-inline void Array<T>::MakeRef(Memory<U> &base, int offset, int size_)
+inline void Array<T>::MakeRef(Memory<T> &base, int offset, int size_)
 {
    data.Delete();
    size = size_;

--- a/general/array.hpp
+++ b/general/array.hpp
@@ -278,7 +278,9 @@ public:
    inline void MakeRef(const Array &master);
 
    /// Make this Array a reference to the given sub-Memory of @a base.
-   inline void MakeRef(Memory<T> &base, int offset, int size_);
+   /// @a offset and @a size_ are in terms of T, i.e. &(*this)[0] == &(base[0]) + offset*sizeof(T)
+   template <class U>
+   inline void MakeRef(Memory<U> &base, int offset, int size_);
 
    /// Reset the Array to use the given external Memory @a mem and size @a s.
    /** If @a own_mem is false, the Array will not own any of the pointers of
@@ -1103,7 +1105,8 @@ inline void Array<T>::MakeRef(const Array &master)
 }
 
 template <class T>
-inline void Array<T>::MakeRef(Memory<T> &base, int offset, int size_)
+template <class U>
+inline void Array<T>::MakeRef(Memory<U> &base, int offset, int size_)
 {
    data.Delete();
    size = size_;

--- a/general/array.hpp
+++ b/general/array.hpp
@@ -166,6 +166,13 @@ public:
    /// Return a reference to the Memory object used by the Array, const version.
    const Memory<T> &GetMemory() const { return data; }
 
+   /** @brief Set the device flag of the Array, i.e. the device flag of the
+       Memory object used by the Array.
+
+       Setting the device flag to true will inform other MFEM functions and
+       classes to prefer using the Array on device. */
+   void UseDevice(bool use_dev) const { data.UseDevice(use_dev); }
+
    /// Return the device flag of the Memory object used by the Array
    bool UseDevice() const { return data.UseDevice(); }
 

--- a/general/communication.cpp
+++ b/general/communication.cpp
@@ -1950,11 +1950,8 @@ DeviceGroupCommunicator::DeviceGroupCommunicator(const GroupCommunicator &gc_)
       nbr_ldof.LoseData();
    }
 
-   shr_buf.SetSize(shr_ltdof.Size());
-   ext_buf.SetSize(ext_ldof.Size());
-   // Allocate the buffers on device to make sure the reinterpred_cast versions
-   // used by MakeTypedBufferView do not need to allocate on device -- they will
-   // allocate less memory if the type has smaller size.
+   shr_buf.SetSize(shr_ltdof.Size() * sizeof(buffer_max_type));
+   ext_buf.SetSize(ext_ldof.Size() * sizeof(buffer_max_type));
    shr_buf.Write();
    ext_buf.Write();
 
@@ -1974,64 +1971,81 @@ DeviceGroupCommunicator::DeviceGroupCommunicator(const GroupCommunicator &gc_)
    num_requests = 0;
 }
 
-// Returns 'storage' reinterpret_cast as Array<T> &.
-// The returned array should not be resized in a way where new bigger
-// allocations are needed, unless the type T has the same size as BT.
-template <typename T, typename BT>
-static inline Array<T> &MakeTypedBufferView(Array<BT> &storage)
+namespace
 {
-   static_assert(sizeof(BT) >= sizeof(T),
-                 "internal buffer type is too small for this view!");
-   return *reinterpret_cast<Array<T>*>(&storage);
+// MakeTypedBufferView needs to access the protected buffer_max_type
+struct BufferMaxTypeGetter : public DeviceGroupCommunicator
+{
+   using buffer_max_type = DeviceGroupCommunicator::buffer_max_type;
+};
+} // namespace
+
+template <typename T, typename BT>
+static inline Array<T> MakeTypedBufferView(Array<BT> &storage)
+{
+   using buffer_max_type = BufferMaxTypeGetter::buffer_max_type;
+   static_assert(sizeof(T) <= sizeof(buffer_max_type));
+   Array<T> res;
+   res.MakeRef(storage.GetMemory(), 0,
+               storage.Size() / sizeof(buffer_max_type));
+   return res;
 }
 
 template <typename T>
 void DeviceGroupCommunicator::BcastBeginTDofs(Array<T> &x_tdof) const
 {
-   Array<T> &shr_buf_t = MakeTypedBufferView<T>(shr_buf);
-   Array<T> &ext_buf_t = MakeTypedBufferView<T>(ext_buf);
+   Array<T> shr_buf_t = MakeTypedBufferView<T>(shr_buf);
+   Array<T> ext_buf_t = MakeTypedBufferView<T>(ext_buf);
    BcastBeginCopyTDofs(x_tdof, shr_buf_t);
    ExchangeSharedToExternal(shr_buf_t, ext_buf_t);
+   ext_buf.GetMemory().Sync(ext_buf_t.GetMemory());
+   shr_buf.GetMemory().Sync(shr_buf_t.GetMemory());
 }
 
 template <typename T>
 void DeviceGroupCommunicator::BcastBeginLDofs(Array<T> &x_ldof) const
 {
-   Array<T> &shr_buf_t = MakeTypedBufferView<T>(shr_buf);
-   Array<T> &ext_buf_t = MakeTypedBufferView<T>(ext_buf);
+   Array<T> shr_buf_t = MakeTypedBufferView<T>(shr_buf);
+   Array<T> ext_buf_t = MakeTypedBufferView<T>(ext_buf);
    BcastBeginCopyLDofs(x_ldof, shr_buf_t);
    ExchangeSharedToExternal(shr_buf_t, ext_buf_t);
+   ext_buf.GetMemory().Sync(ext_buf_t.GetMemory());
+   shr_buf.GetMemory().Sync(shr_buf_t.GetMemory());
 }
 
 template <typename T>
 void DeviceGroupCommunicator::BcastEndLDofs(Array<T> &x_ldof) const
 {
-   Array<T> &ext_buf_t = MakeTypedBufferView<T>(ext_buf);
+   Array<T> ext_buf_t = MakeTypedBufferView<T>(ext_buf);
    WaitAll();
    BcastEndCopy(ext_buf_t, x_ldof);
+   ext_buf.GetMemory().Sync(ext_buf_t.GetMemory());
 }
 
 template <typename T>
 void DeviceGroupCommunicator::ReduceBeginLDofs(const Array<T> &x_ldof) const
 {
-   Array<T> &ext_buf_t = MakeTypedBufferView<T>(ext_buf);
-   Array<T> &shr_buf_t = MakeTypedBufferView<T>(shr_buf);
+   Array<T> ext_buf_t = MakeTypedBufferView<T>(ext_buf);
+   Array<T> shr_buf_t = MakeTypedBufferView<T>(shr_buf);
    ReduceBeginCopy(x_ldof, ext_buf_t);
    ExchangeExternalToShared(ext_buf_t, shr_buf_t);
+   ext_buf.GetMemory().Sync(ext_buf_t.GetMemory());
+   shr_buf.GetMemory().Sync(shr_buf_t.GetMemory());
 }
 
 template <typename T>
 void DeviceGroupCommunicator::ReduceEndTDofs(Array<T> &x_tdof, Op op) const
 {
-   Array<T> &shr_buf_t = MakeTypedBufferView<T>(shr_buf);
+   Array<T> shr_buf_t = MakeTypedBufferView<T>(shr_buf);
    WaitAll();
    ReduceEndAssembleTDofs(shr_buf_t, x_tdof, op);
+   shr_buf.GetMemory().Sync(shr_buf_t.GetMemory());
 }
 
 template <typename T>
 void DeviceGroupCommunicator::ReduceEndLDofs(Array<T> &x_ldof, Op op) const
 {
-   Array<T> &shr_buf_t = MakeTypedBufferView<T>(shr_buf);
+   Array<T> shr_buf_t = MakeTypedBufferView<T>(shr_buf);
    WaitAll();
    if (unq_ldof.Size() == 0) { return; }
    if (op == Op::Sum)
@@ -2044,6 +2058,7 @@ void DeviceGroupCommunicator::ReduceEndLDofs(Array<T> &x_ldof, Op op) const
       internal::BooleanReduceApply(unq_ldof, unq_shr_i, unq_shr_j,
                                    shr_buf_t, x_ldof, op);
    }
+   shr_buf.GetMemory().Sync(shr_buf_t.GetMemory());
 }
 
 template <typename T>
@@ -2060,13 +2075,15 @@ void DeviceGroupCommunicator::Prolongate(const Array<T> &x_tdof,
 {
    MFEM_ASSERT(x_tdof.Size() == gc.ltdof_ldof.Size(), "incompatible sizes!");
    MFEM_ASSERT(x_ldof.Size() == gc.ldof_size, "incompatible sizes!");
-   Array<T> &ext_buf_t = MakeTypedBufferView<T>(ext_buf);
-   Array<T> &shr_buf_t = MakeTypedBufferView<T>(shr_buf);
+   Array<T> ext_buf_t = MakeTypedBufferView<T>(ext_buf);
+   Array<T> shr_buf_t = MakeTypedBufferView<T>(shr_buf);
    BcastBeginCopyTDofs(x_tdof, shr_buf_t);
    ExchangeSharedToExternal(shr_buf_t, ext_buf_t);
    CopyTDofsToLDofs(x_tdof, x_ldof);
    WaitAll();
    BcastEndCopy(ext_buf_t, x_ldof);
+   ext_buf.GetMemory().Sync(ext_buf_t.GetMemory());
+   shr_buf.GetMemory().Sync(shr_buf_t.GetMemory());
 }
 
 template <typename T>
@@ -2076,13 +2093,15 @@ void DeviceGroupCommunicator::ProlongateTranspose(const Array<T> &x_ldof,
 {
    MFEM_ASSERT(x_ldof.Size() == gc.ldof_size, "incompatible sizes!");
    MFEM_ASSERT(x_tdof.Size() == gc.ltdof_ldof.Size(), "incompatible sizes!");
-   Array<T> &ext_buf_t = MakeTypedBufferView<T>(ext_buf);
-   Array<T> &shr_buf_t = MakeTypedBufferView<T>(shr_buf);
+   Array<T> ext_buf_t = MakeTypedBufferView<T>(ext_buf);
+   Array<T> shr_buf_t = MakeTypedBufferView<T>(shr_buf);
    ReduceBeginCopy(x_ldof, ext_buf_t);
    ExchangeExternalToShared(ext_buf_t, shr_buf_t);
    Restrict(x_ldof, x_tdof);
    WaitAll();
    ReduceEndAssembleTDofs(shr_buf_t, x_tdof, op);
+   ext_buf.GetMemory().Sync(ext_buf_t.GetMemory());
+   shr_buf.GetMemory().Sync(shr_buf_t.GetMemory());
 }
 
 template <typename T>

--- a/general/communication.cpp
+++ b/general/communication.cpp
@@ -911,7 +911,8 @@ void GroupCommunicator::BcastBegin(Array<T> &ldata, int layout) const
    }
 
    // Use 'while' instead of 'if' so that we can break out without using 'goto'.
-   while (Device::Allows(Backend::DEVICE_MASK) &&
+   while (ldata.UseDevice() &&
+          Device::Allows(Backend::DEVICE_MASK) &&
           have_ltdof_ldof &&
           mode == byNeighbor)
    {
@@ -1032,7 +1033,8 @@ void GroupCommunicator::BcastEnd(Array<T> &ldata, int layout) const
       return;
    }
 
-   if (Device::Allows(Backend::DEVICE_MASK) &&
+   if (ldata.UseDevice() &&
+       Device::Allows(Backend::DEVICE_MASK) &&
        have_ltdof_ldof &&
        mode == byNeighbor &&
        layout == 0)  // output is ldofs array
@@ -1192,7 +1194,8 @@ void GroupCommunicator::ReduceBegin(const Array<T> &ldata) const
       return;
    }
 
-   if (Device::Allows(Backend::DEVICE_MASK) &&
+   if (ldata.UseDevice() &&
+       Device::Allows(Backend::DEVICE_MASK) &&
        have_ltdof_ldof &&
        mode == byNeighbor)
    {
@@ -1310,7 +1313,8 @@ void GroupCommunicator::ReduceEnd(Array<T> &ldata, int layout,
       return;
    }
 
-   if (Device::Allows(Backend::DEVICE_MASK) &&
+   if (ldata.UseDevice() &&
+       Device::Allows(Backend::DEVICE_MASK) &&
        have_ltdof_ldof &&
        mode == byNeighbor)
    {

--- a/general/communication.cpp
+++ b/general/communication.cpp
@@ -1918,9 +1918,12 @@ DeviceGroupCommunicator::DeviceGroupCommunicator(const GroupCommunicator &gc_)
    }
 
    shr_buf.SetSize(shr_ltdof.Size());
-   shr_buf.GetMemory().UseDevice(true);
    ext_buf.SetSize(ext_ldof.Size());
-   ext_buf.GetMemory().UseDevice(true);
+   // Allocate the buffers on device to make sure the reinterpred_cast versions
+   // used by MakeTypedBufferView do not need to allocate on device -- they will
+   // allocate less memory if the type has smaller size.
+   shr_buf.Write();
+   ext_buf.Write();
 
    const GroupTopology &gtopo = gc.GetGroupTopology();
    int req_counter = 0;
@@ -1938,29 +1941,22 @@ DeviceGroupCommunicator::DeviceGroupCommunicator(const GroupCommunicator &gc_)
    num_requests = 0;
 }
 
-// Returns an Array<T> 'view' that is valid on device only.
-// This function assumes that if 'storage' contains data that we want to access
-// using the 'view', then 'storage' is valid on device.
-// If 'view' is modified on host and that data needs to be preserved in
-// 'storage', then 'view' must be copied to device using 'view.Read()'.
+// Returns 'storage' reinterpret_cast as Array<T> &.
+// The returned array should not be resized in a way where new bigger
+// allocations are needed, unless the type T has the same size as BT.
 template <typename T, typename BT>
-static inline Array<T> MakeTypedBufferView(Array<BT> &storage)
+static inline Array<T> &MakeTypedBufferView(Array<BT> &storage)
 {
    static_assert(sizeof(BT) >= sizeof(T),
                  "internal buffer type is too small for this view!");
-   Array<T> view;
-   storage.Write();
-   view.NewMemoryAndSize(reinterpret_cast<Memory<T>&>(storage.GetMemory()),
-                         storage.Size(), true);
-   view.GetMemory().ClearOwnerFlags();
-   return view;
+   return *reinterpret_cast<Array<T>*>(&storage);
 }
 
 template <typename T>
 void DeviceGroupCommunicator::BcastBeginTDofs(Array<T> &x_tdof) const
 {
-   Array<T> shr_buf_t = MakeTypedBufferView<T>(shr_buf);
-   Array<T> ext_buf_t = MakeTypedBufferView<T>(ext_buf);
+   Array<T> &shr_buf_t = MakeTypedBufferView<T>(shr_buf);
+   Array<T> &ext_buf_t = MakeTypedBufferView<T>(ext_buf);
    BcastBeginCopyTDofs(x_tdof, shr_buf_t);
    ExchangeSharedToExternal(shr_buf_t, ext_buf_t);
 }
@@ -1968,8 +1964,8 @@ void DeviceGroupCommunicator::BcastBeginTDofs(Array<T> &x_tdof) const
 template <typename T>
 void DeviceGroupCommunicator::BcastBeginLDofs(Array<T> &x_ldof) const
 {
-   Array<T> shr_buf_t = MakeTypedBufferView<T>(shr_buf);
-   Array<T> ext_buf_t = MakeTypedBufferView<T>(ext_buf);
+   Array<T> &shr_buf_t = MakeTypedBufferView<T>(shr_buf);
+   Array<T> &ext_buf_t = MakeTypedBufferView<T>(ext_buf);
    BcastBeginCopyLDofs(x_ldof, shr_buf_t);
    ExchangeSharedToExternal(shr_buf_t, ext_buf_t);
 }
@@ -1977,7 +1973,7 @@ void DeviceGroupCommunicator::BcastBeginLDofs(Array<T> &x_ldof) const
 template <typename T>
 void DeviceGroupCommunicator::BcastEndLDofs(Array<T> &x_ldof) const
 {
-   Array<T> ext_buf_t = MakeTypedBufferView<T>(ext_buf);
+   Array<T> &ext_buf_t = MakeTypedBufferView<T>(ext_buf);
    WaitAll();
    BcastEndCopy(ext_buf_t, x_ldof);
 }
@@ -1985,8 +1981,8 @@ void DeviceGroupCommunicator::BcastEndLDofs(Array<T> &x_ldof) const
 template <typename T>
 void DeviceGroupCommunicator::ReduceBeginLDofs(const Array<T> &x_ldof) const
 {
-   Array<T> ext_buf_t = MakeTypedBufferView<T>(ext_buf);
-   Array<T> shr_buf_t = MakeTypedBufferView<T>(shr_buf);
+   Array<T> &ext_buf_t = MakeTypedBufferView<T>(ext_buf);
+   Array<T> &shr_buf_t = MakeTypedBufferView<T>(shr_buf);
    ReduceBeginCopy(x_ldof, ext_buf_t);
    ExchangeExternalToShared(ext_buf_t, shr_buf_t);
 }
@@ -1994,7 +1990,7 @@ void DeviceGroupCommunicator::ReduceBeginLDofs(const Array<T> &x_ldof) const
 template <typename T>
 void DeviceGroupCommunicator::ReduceEndTDofs(Array<T> &x_tdof, Op op) const
 {
-   Array<T> shr_buf_t = MakeTypedBufferView<T>(shr_buf);
+   Array<T> &shr_buf_t = MakeTypedBufferView<T>(shr_buf);
    WaitAll();
    ReduceEndAssembleTDofs(shr_buf_t, x_tdof, op);
 }
@@ -2002,7 +1998,7 @@ void DeviceGroupCommunicator::ReduceEndTDofs(Array<T> &x_tdof, Op op) const
 template <typename T>
 void DeviceGroupCommunicator::ReduceEndLDofs(Array<T> &x_ldof, Op op) const
 {
-   Array<T> shr_buf_t = MakeTypedBufferView<T>(shr_buf);
+   Array<T> &shr_buf_t = MakeTypedBufferView<T>(shr_buf);
    WaitAll();
    if (unq_ldof.Size() == 0) { return; }
    if (op == Op::Sum)
@@ -2031,8 +2027,8 @@ void DeviceGroupCommunicator::Prolongate(const Array<T> &x_tdof,
 {
    MFEM_ASSERT(x_tdof.Size() == gc.ltdof_ldof.Size(), "incompatible sizes!");
    MFEM_ASSERT(x_ldof.Size() == gc.ldof_size, "incompatible sizes!");
-   Array<T> ext_buf_t = MakeTypedBufferView<T>(ext_buf);
-   Array<T> shr_buf_t = MakeTypedBufferView<T>(shr_buf);
+   Array<T> &ext_buf_t = MakeTypedBufferView<T>(ext_buf);
+   Array<T> &shr_buf_t = MakeTypedBufferView<T>(shr_buf);
    BcastBeginCopyTDofs(x_tdof, shr_buf_t);
    ExchangeSharedToExternal(shr_buf_t, ext_buf_t);
    CopyTDofsToLDofs(x_tdof, x_ldof);
@@ -2047,8 +2043,8 @@ void DeviceGroupCommunicator::ProlongateTranspose(const Array<T> &x_ldof,
 {
    MFEM_ASSERT(x_ldof.Size() == gc.ldof_size, "incompatible sizes!");
    MFEM_ASSERT(x_tdof.Size() == gc.ltdof_ldof.Size(), "incompatible sizes!");
-   Array<T> ext_buf_t = MakeTypedBufferView<T>(ext_buf);
-   Array<T> shr_buf_t = MakeTypedBufferView<T>(shr_buf);
+   Array<T> &ext_buf_t = MakeTypedBufferView<T>(ext_buf);
+   Array<T> &shr_buf_t = MakeTypedBufferView<T>(shr_buf);
    ReduceBeginCopy(x_ldof, ext_buf_t);
    ExchangeExternalToShared(ext_buf_t, shr_buf_t);
    Restrict(x_ldof, x_tdof);

--- a/general/communication.cpp
+++ b/general/communication.cpp
@@ -19,7 +19,6 @@
 #endif
 
 #include "array.hpp"
-#include "../linalg/vector.hpp"
 #include "table.hpp"
 #include "sets.hpp"
 #include "communication.hpp"
@@ -47,259 +46,6 @@ int Mpi::default_thread_required = MPI_THREAD_MULTIPLE;
 #else
 int Mpi::default_thread_required = MPI_THREAD_SINGLE;
 #endif
-
-namespace internal
-{
-
-void BuildNeighborLDofTable(const Table &group_ldof,
-                            const Table &nbr_groups,
-                            Table &nbr_ldof)
-{
-   nbr_ldof.MakeI(nbr_groups.Size());
-   for (int nbr = 1; nbr < nbr_groups.Size(); nbr++)
-   {
-      const int num_groups = nbr_groups.RowSize(nbr);
-      if (num_groups == 0) { continue; }
-      const int *grp_list = nbr_groups.GetRow(nbr);
-      for (int i = 0; i < num_groups; i++)
-      {
-         nbr_ldof.AddColumnsInRow(nbr, group_ldof.RowSize(grp_list[i]));
-      }
-   }
-   nbr_ldof.MakeJ();
-   for (int nbr = 1; nbr < nbr_groups.Size(); nbr++)
-   {
-      const int num_groups = nbr_groups.RowSize(nbr);
-      if (num_groups == 0) { continue; }
-      const int *grp_list = nbr_groups.GetRow(nbr);
-      for (int i = 0; i < num_groups; i++)
-      {
-         const int group = grp_list[i];
-         const int nldofs = group_ldof.RowSize(group);
-         nbr_ldof.AddConnections(nbr, group_ldof.GetRow(group), nldofs);
-      }
-   }
-   nbr_ldof.ShiftUpI();
-}
-
-DeviceNeighborDofComm::DeviceNeighborDofComm(const GroupCommunicator &gc_)
-   : gc(gc_),
-     mpi_gpu_aware(Device::GetGPUAwareMPI())
-{
-   MFEM_VERIFY(gc_.have_ltdof_ldof,
-               "Device shared-dof communication requires SetLTDofTable().");
-   ltdof_ldof = gc_.ltdof_ldof;
-   {
-      Table nbr_ltdof;
-      gc_.GetNeighborLTDofTable(nbr_ltdof);
-      const int nb_connections = nbr_ltdof.Size_of_connections();
-      shr_ltdof.SetSize(nb_connections);
-      if (nb_connections > 0) { shr_ltdof.CopyFrom(nbr_ltdof.GetJ()); }
-      shr_buf_offsets = nbr_ltdof.GetIMemory();
-      {
-         Array<int> shared_ltdof(nbr_ltdof.GetJ(), nb_connections);
-         Array<int> unique_ltdof(shared_ltdof);
-         unique_ltdof.Sort();
-         unique_ltdof.Unique();
-         for (int i = 0; i < shared_ltdof.Size(); i++)
-         {
-            shared_ltdof[i] = unique_ltdof.FindSorted(shared_ltdof[i]);
-            MFEM_ASSERT(shared_ltdof[i] != -1, "internal error");
-         }
-         Table unique_shr;
-         Transpose(shared_ltdof, unique_shr, unique_ltdof.Size());
-         unq_ltdof = unique_ltdof;
-         unq_shr_i.GetMemory() = unique_shr.GetIMemory();
-         unq_shr_i.SetSize(unique_shr.Size()+1);
-         unq_shr_j.GetMemory() = unique_shr.GetJMemory();
-         unq_shr_j.SetSize(unique_shr.Size_of_connections());
-         unique_shr.LoseData();
-      }
-      nbr_ltdof.GetJMemory().Delete();
-      nbr_ltdof.LoseData();
-   }
-   {
-      Table nbr_ldof;
-      gc_.GetNeighborLDofTable(nbr_ldof);
-      const int nb_connections = nbr_ldof.Size_of_connections();
-      ext_ldof.SetSize(nb_connections);
-      if (nb_connections > 0) { ext_ldof.CopyFrom(nbr_ldof.GetJ()); }
-      ext_ldof.GetMemory().UseDevice(true);
-      ext_buf_offsets = nbr_ldof.GetIMemory();
-      nbr_ldof.GetJMemory().Delete();
-      nbr_ldof.LoseData();
-   }
-
-   const GroupTopology &gtopo = gc_.GetGroupTopology();
-   int req_counter = 0;
-   for (int nbr = 1; nbr < gtopo.GetNumNeighbors(); nbr++)
-   {
-      const int send_offset = shr_buf_offsets[nbr];
-      const int send_size = shr_buf_offsets[nbr+1] - send_offset;
-      if (send_size > 0) { req_counter++; }
-
-      const int recv_offset = ext_buf_offsets[nbr];
-      const int recv_size = ext_buf_offsets[nbr+1] - recv_offset;
-      if (recv_size > 0) { req_counter++; }
-   }
-   requests.SetSize(req_counter);
-}
-
-DeviceNeighborDofComm::~DeviceNeighborDofComm()
-{
-   ext_buf_offsets.Delete();
-   shr_buf_offsets.Delete();
-}
-
-template <typename T, typename SendBuffer, typename RecvBuffer>
-int DeviceNeighborDofComm::Exchange(const SendBuffer &send_buf,
-                                    const Memory<int> &send_offsets,
-                                    RecvBuffer &recv_buf,
-                                    const Memory<int> &recv_offsets,
-                                    int tag) const
-{
-   const GroupTopology &gtopo = gc.GetGroupTopology();
-   int req_counter = 0;
-   for (int nbr = 1; nbr < gtopo.GetNumNeighbors(); nbr++)
-   {
-      const int send_offset = send_offsets[nbr];
-      const int send_size = send_offsets[nbr+1] - send_offset;
-      if (send_size > 0)
-      {
-         auto send_ptr = mpi_gpu_aware ? send_buf.Read() : send_buf.HostRead();
-         MPI_Isend(send_ptr + send_offset, send_size, MPITypeMap<T>::mpi_type,
-                   gtopo.GetNeighborRank(nbr), tag, gtopo.GetComm(),
-                   &requests[req_counter++]);
-      }
-      const int recv_offset = recv_offsets[nbr];
-      const int recv_size = recv_offsets[nbr+1] - recv_offset;
-      if (recv_size > 0)
-      {
-         auto recv_ptr = mpi_gpu_aware ? recv_buf.Write() : recv_buf.HostWrite();
-         MPI_Irecv(recv_ptr + recv_offset, recv_size, MPITypeMap<T>::mpi_type,
-                   gtopo.GetNeighborRank(nbr), tag, gtopo.GetComm(),
-                   &requests[req_counter++]);
-      }
-   }
-   return req_counter;
-}
-
-template <typename T, typename SendBuffer, typename RecvBuffer>
-int DeviceNeighborDofComm::ExchangeSharedToExternal(const SendBuffer &shr_buf,
-                                                    RecvBuffer &ext_buf,
-                                                    int tag) const
-{
-   return Exchange<T>(shr_buf, shr_buf_offsets, ext_buf, ext_buf_offsets, tag);
-}
-
-template <typename T, typename SendBuffer, typename RecvBuffer>
-int DeviceNeighborDofComm::ExchangeExternalToShared(const SendBuffer &ext_buf,
-                                                    RecvBuffer &shr_buf,
-                                                    int tag) const
-{
-   return Exchange<T>(ext_buf, ext_buf_offsets, shr_buf, shr_buf_offsets, tag);
-}
-
-void DeviceNeighborDofComm::WaitAll(int req_counter) const
-{
-   MPI_Waitall(req_counter, requests.GetData(), MPI_STATUSES_IGNORE);
-}
-
-template <typename InBuffer, typename OutBuffer>
-void DeviceNeighborDofExtract(const Array<int> &indices,
-                              const InBuffer &xin,
-                              OutBuffer &xout)
-{
-   MFEM_ASSERT(indices.Size() == xout.Size(), "incompatible sizes!");
-   auto y = xout.Write();
-   const auto x = xin.Read();
-   const auto I = indices.Read();
-   mfem::forall(indices.Size(), [=] MFEM_HOST_DEVICE (int i)
-   {
-      y[i] = x[I[i]];
-   });
-}
-
-template <typename InBuffer, typename OutBuffer>
-void DeviceNeighborDofSet(const Array<int> &indices,
-                          const InBuffer &xin,
-                          OutBuffer &xout)
-{
-   MFEM_ASSERT(indices.Size() == xin.Size(), "incompatible sizes!");
-   auto y = xout.ReadWrite();
-   const auto x = xin.Read();
-   const auto I = indices.Read();
-   mfem::forall(indices.Size(), [=] MFEM_HOST_DEVICE (int i)
-   {
-      y[I[i]] = x[i];
-   });
-}
-
-template <typename SrcBuffer, typename DstBuffer>
-void DeviceNeighborDofAdd(const Array<int> &unique_dst_indices,
-                          const Array<int> &unique_to_src_offsets,
-                          const Array<int> &unique_to_src_indices,
-                          const SrcBuffer &src,
-                          DstBuffer &dst)
-{
-   auto y = dst.ReadWrite();
-   const auto x = src.Read();
-   const auto DST_I = unique_dst_indices.Read();
-   const auto SRC_O = unique_to_src_offsets.Read();
-   const auto SRC_I = unique_to_src_indices.Read();
-   mfem::forall(unique_dst_indices.Size(), [=] MFEM_HOST_DEVICE (int i)
-   {
-      const int dst_idx = DST_I[i];
-      real_t sum = y[dst_idx];
-      const int end = SRC_O[i+1];
-      for (int j = SRC_O[i]; j != end; ++j) { sum += x[SRC_I[j]]; }
-      y[dst_idx] = sum;
-   });
-}
-
-template <typename T>
-void DeviceSharedDofApplyReduction(const Array<int> &unique_dst_indices,
-                                   const Array<int> &unique_to_src_offsets,
-                                   const Array<int> &unique_to_src_indices,
-                                   const Array<T> &src,
-                                   Array<T> &dst,
-                                   DeviceSharedDofCommunicator::Op op)
-{
-   auto y = dst.ReadWrite();
-   const auto x = src.Read();
-   const auto DST_I = unique_dst_indices.Read();
-   const auto SRC_O = unique_to_src_offsets.Read();
-   const auto SRC_I = unique_to_src_indices.Read();
-   mfem::forall(unique_dst_indices.Size(), [=] MFEM_HOST_DEVICE (int i)
-   {
-      const int dst_idx = DST_I[i];
-      T val = y[dst_idx];
-      const int end = SRC_O[i+1];
-      switch (op)
-      {
-         case DeviceSharedDofCommunicator::Op::Sum:
-            for (int j = SRC_O[i]; j != end; ++j) { val += x[SRC_I[j]]; }
-            break;
-         case DeviceSharedDofCommunicator::Op::Min:
-            for (int j = SRC_O[i]; j != end; ++j)
-            {
-               const T xj = x[SRC_I[j]];
-               val = (xj < val) ? xj : val;
-            }
-            break;
-         case DeviceSharedDofCommunicator::Op::Max:
-            for (int j = SRC_O[i]; j != end; ++j)
-            {
-               const T xj = x[SRC_I[j]];
-               val = (xj > val) ? xj : val;
-            }
-            break;
-      }
-      y[dst_idx] = val;
-   });
-}
-
-} // namespace internal
 
 
 GroupTopology::GroupTopology(const GroupTopology &gt)
@@ -631,14 +377,16 @@ GroupCommunicator::GroupCommunicator(const GroupTopology &gt, Mode m)
    num_requests = 0;
    request_marker = NULL;
    buf_offsets = NULL;
-   ldof_size = 0;
-   device_shared_dof_comm = NULL;
-   device_shared_dof_comm_enabled = true;
    have_ltdof_ldof = false;
+   ldof_size = -1; // unknown ldof_size
+   device_gc = NULL;
 }
 
 void GroupCommunicator::Create(const Array<int> &ldof_group)
 {
+   MFEM_VERIFY(buf_offsets == nullptr,
+               "the GroupCommunicator is already Finalized!");
+
    group_ldof.MakeI(gtopo.NGroups());
    for (int i = 0; i < ldof_group.Size(); i++)
    {
@@ -665,6 +413,8 @@ void GroupCommunicator::Create(const Array<int> &ldof_group)
 
 void GroupCommunicator::Finalize()
 {
+   if (buf_offsets) { return; } // Finalize() was already called.
+
    int request_counter = 0;
 
    // size buf_offsets = max(number of groups, number of neighbors)
@@ -774,10 +524,8 @@ void GroupCommunicator::Finalize()
 
 void GroupCommunicator::SetLTDofTable(const Array<int> &ldof_ltdof)
 {
-   if (group_ltdof.Size() == group_ldof.Size() && have_ltdof_ldof) { return; }
-
-   delete device_shared_dof_comm;
-   device_shared_dof_comm = NULL;
+   MFEM_VERIFY(!have_ltdof_ldof,
+               "SetLTDofTable() should be called at most once!");
 
    group_ltdof.MakeI(group_ldof.Size());
    for (int gr = 1; gr < group_ldof.Size(); gr++)
@@ -802,445 +550,88 @@ void GroupCommunicator::SetLTDofTable(const Array<int> &ldof_ltdof)
    }
    group_ltdof.ShiftUpI();
 
-   int ltdof_size = 0;
    ldof_size = ldof_ltdof.Size();
-   for (int ldof = 0; ldof < ldof_ltdof.Size(); ldof++)
-   {
-      if (ldof_ltdof[ldof] >= 0)
-      {
-         ltdof_size = max(ltdof_size, ldof_ltdof[ldof] + 1);
-      }
-   }
+   const int ltdof_size = (ldof_size == 0) ? 0 :
+                          std::max(ldof_ltdof.Max() + 1, 0);
    ltdof_ldof.SetSize(ltdof_size);
-   for (int ltdof = 0; ltdof < ltdof_size; ltdof++) { ltdof_ldof[ltdof] = -1; }
+#ifdef MFEM_DEBUG
+   int ltdof_counter = 0;
+   ltdof_ldof = -1;
+#endif
    for (int ldof = 0; ldof < ldof_ltdof.Size(); ldof++)
    {
       const int ltdof = ldof_ltdof[ldof];
-      if (ltdof >= 0) { ltdof_ldof[ltdof] = ldof; }
+      if (ltdof >= 0)
+      {
+#ifdef MFEM_DEBUG
+         ltdof_counter++;
+#endif
+         MFEM_ASSERT(ltdof_ldof[ltdof] == -1, "repeated ltdof indices found!");
+         ltdof_ldof[ltdof] = ldof;
+      }
    }
+   MFEM_ASSERT(ltdof_counter == ltdof_size, "unassigned ltdof indices found!");
    have_ltdof_ldof = true;
 }
 
-void GroupCommunicator::SetDeviceSharedDofSupport(bool enable)
+namespace internal
 {
-   device_shared_dof_comm_enabled = enable;
-   if (!enable)
+
+static void BuildNeighborDofTable(const Table &group_dof,
+                                  const Table &nbr_groups,
+                                  Table &nbr_dof)
+{
+   nbr_dof.MakeI(nbr_groups.Size());
+   for (int nbr = 1; nbr < nbr_groups.Size(); nbr++)
    {
-      delete device_shared_dof_comm;
-      device_shared_dof_comm = NULL;
+      const int num_groups = nbr_groups.RowSize(nbr);
+      if (num_groups == 0) { continue; }
+      const int *grp_list = nbr_groups.GetRow(nbr);
+      for (int i = 0; i < num_groups; i++)
+      {
+         const int group = grp_list[i];
+         const int ndofs = group_dof.RowSize(group);
+         nbr_dof.AddColumnsInRow(nbr, ndofs);
+      }
    }
+   nbr_dof.MakeJ();
+   for (int nbr = 1; nbr < nbr_groups.Size(); nbr++)
+   {
+      const int num_groups = nbr_groups.RowSize(nbr);
+      if (num_groups == 0) { continue; }
+      const int *grp_list = nbr_groups.GetRow(nbr);
+      for (int i = 0; i < num_groups; i++)
+      {
+         const int group = grp_list[i];
+         const int ndofs = group_dof.RowSize(group);
+         const int *dofs = group_dof.GetRow(group);
+         nbr_dof.AddConnections(nbr, dofs, ndofs);
+      }
+   }
+   nbr_dof.ShiftUpI();
 }
 
-const DeviceSharedDofCommunicator *
-GroupCommunicator::GetDeviceSharedDofCommunicator() const
-{
-   MFEM_VERIFY(mode == byNeighbor,
-               "Device shared-dof communicator requires neighbor mode.");
-   MFEM_VERIFY(device_shared_dof_comm_enabled,
-               "Device shared-dof communicator is not enabled.");
-   MFEM_VERIFY(have_ltdof_ldof,
-               "Device shared-dof communicator requires SetLTDofTable().");
-   if (!device_shared_dof_comm)
-   {
-      device_shared_dof_comm = new DeviceSharedDofCommunicator(*this);
-   }
-   return device_shared_dof_comm;
-}
-
-bool GroupCommunicator::UseDeviceSharedDofComm(const void *ptr) const
-{
-   if (!device_shared_dof_comm_enabled || !have_ltdof_ldof || ptr == NULL)
-   {
-      return false;
-   }
-   if (mode != byNeighbor || group_buf_size == 0) { return false; }
-   if (!Device::Allows(Backend::DEVICE_MASK)) { return false; }
-   const MemoryType mt = Device::QueryMemoryType(ptr);
-   return IsDeviceMemory(mt) || mt == MemoryType::MANAGED;
-}
+} // namespace internal
 
 void GroupCommunicator::GetNeighborLTDofTable(Table &nbr_ltdof) const
 {
-   nbr_ltdof.MakeI(nbr_send_groups.Size());
-   for (int nbr = 1; nbr < nbr_send_groups.Size(); nbr++)
-   {
-      const int num_send_groups = nbr_send_groups.RowSize(nbr);
-      if (num_send_groups > 0)
-      {
-         const int *grp_list = nbr_send_groups.GetRow(nbr);
-         for (int i = 0; i < num_send_groups; i++)
-         {
-            const int group = grp_list[i];
-            const int nltdofs = group_ltdof.RowSize(group);
-            nbr_ltdof.AddColumnsInRow(nbr, nltdofs);
-         }
-      }
-   }
-   nbr_ltdof.MakeJ();
-   for (int nbr = 1; nbr < nbr_send_groups.Size(); nbr++)
-   {
-      const int num_send_groups = nbr_send_groups.RowSize(nbr);
-      if (num_send_groups > 0)
-      {
-         const int *grp_list = nbr_send_groups.GetRow(nbr);
-         for (int i = 0; i < num_send_groups; i++)
-         {
-            const int group = grp_list[i];
-            const int nltdofs = group_ltdof.RowSize(group);
-            const int *ltdofs = group_ltdof.GetRow(group);
-            nbr_ltdof.AddConnections(nbr, ltdofs, nltdofs);
-         }
-      }
-   }
-   nbr_ltdof.ShiftUpI();
+   internal::BuildNeighborDofTable(group_ltdof, nbr_send_groups, nbr_ltdof);
 }
 
 void GroupCommunicator::GetNeighborLDofTable(Table &nbr_ldof) const
 {
-   nbr_ldof.MakeI(nbr_recv_groups.Size());
-   for (int nbr = 1; nbr < nbr_recv_groups.Size(); nbr++)
+   internal::BuildNeighborDofTable(group_ldof, nbr_recv_groups, nbr_ldof);
+}
+
+const DeviceGroupCommunicator &GroupCommunicator::GetDeviceComm() const
+{
+   if (!device_gc)
    {
-      const int num_recv_groups = nbr_recv_groups.RowSize(nbr);
-      if (num_recv_groups > 0)
-      {
-         const int *grp_list = nbr_recv_groups.GetRow(nbr);
-         for (int i = 0; i < num_recv_groups; i++)
-         {
-            const int group = grp_list[i];
-            const int nldofs = group_ldof.RowSize(group);
-            nbr_ldof.AddColumnsInRow(nbr, nldofs);
-         }
-      }
+      // The ctor of DeviceGroupCommunicator verifies that the GroupCommunicator
+      // meets all requirements: mode == byNeighbor and have_ltdof_ldof == true.
+      device_gc = new DeviceGroupCommunicator(*this);
    }
-   nbr_ldof.MakeJ();
-   for (int nbr = 1; nbr < nbr_recv_groups.Size(); nbr++)
-   {
-      const int num_recv_groups = nbr_recv_groups.RowSize(nbr);
-      if (num_recv_groups > 0)
-      {
-         const int *grp_list = nbr_recv_groups.GetRow(nbr);
-         for (int i = 0; i < num_recv_groups; i++)
-         {
-            const int group = grp_list[i];
-            const int nldofs = group_ldof.RowSize(group);
-            const int *ldofs = group_ldof.GetRow(group);
-            nbr_ldof.AddConnections(nbr, ldofs, nldofs);
-         }
-      }
-   }
-   nbr_ldof.ShiftUpI();
-}
-
-template <typename T>
-void DeviceSharedDofCommunicator::ReduceBeginCopy(const Array<T> &x_ldof,
-                                                  Array<T> &ext_buf_t) const
-{
-   const auto &ext_ldof = nbr_comm->ExternalLDof();
-   if (ext_ldof.Size() == 0) { return; }
-   internal::DeviceNeighborDofExtract(ext_ldof, x_ldof, ext_buf_t);
-   if (nbr_comm->MpiGpuAware()) { MFEM_STREAM_SYNC; }
-}
-
-template <typename T>
-void DeviceSharedDofCommunicator::ReduceLocalCopy(const Array<T> &x_ldof,
-                                                  Array<T> &x_tdof) const
-{
-   const auto &ltdof_ldof = nbr_comm->LocalTDofToLDof();
-   if (ltdof_ldof.Size() == 0) { return; }
-   internal::DeviceNeighborDofExtract(ltdof_ldof, x_ldof, x_tdof);
-}
-
-template <typename T>
-void DeviceSharedDofCommunicator::ReduceEndAssemble(const Array<T> &shr_buf_t,
-                                                    Array<T> &x_tdof,
-                                                    Op op) const
-{
-   const auto &unq_ltdof = nbr_comm->UniqueLTDof();
-   if (unq_ltdof.Size() == 0) { return; }
-   internal::DeviceSharedDofApplyReduction(unq_ltdof,
-                                           nbr_comm->UniqueSharedOffsets(),
-                                           nbr_comm->UniqueSharedIndices(),
-                                           shr_buf_t, x_tdof, op);
-}
-
-template <typename T>
-void DeviceSharedDofCommunicator::BcastBeginCopy(const Array<T> &x_tdof,
-                                                 Array<T> &shr_buf_t) const
-{
-   const auto &shr_ltdof = nbr_comm->SharedLTDof();
-   if (shr_ltdof.Size() == 0) { return; }
-   internal::DeviceNeighborDofExtract(shr_ltdof, x_tdof, shr_buf_t);
-   if (nbr_comm->MpiGpuAware()) { MFEM_STREAM_SYNC; }
-}
-
-template <typename T>
-void DeviceSharedDofCommunicator::BcastLocalCopy(const Array<T> &x_tdof,
-                                                 Array<T> &x_ldof) const
-{
-   const auto &ltdof_ldof = nbr_comm->LocalTDofToLDof();
-   if (ltdof_ldof.Size() == 0) { return; }
-   internal::DeviceNeighborDofSet(ltdof_ldof, x_tdof, x_ldof);
-}
-
-template <typename T>
-void DeviceSharedDofCommunicator::BcastEndCopy(const Array<T> &ext_buf_t,
-                                               Array<T> &x_ldof) const
-{
-   const auto &ext_ldof = nbr_comm->ExternalLDof();
-   if (ext_ldof.Size() == 0) { return; }
-   internal::DeviceNeighborDofSet(ext_ldof, ext_buf_t, x_ldof);
-}
-
-DeviceSharedDofCommunicator::DeviceSharedDofCommunicator(
-   const GroupCommunicator &gc)
-   : nbr_comm(new internal::DeviceNeighborDofComm(gc))
-{
-   const int tdofs = nbr_comm->LocalTDofToLDof().Size();
-   true_buf.SetSize(tdofs);
-   true_buf.GetMemory().UseDevice(true);
-   shr_buf.SetSize(nbr_comm->SharedLTDof().Size());
-   shr_buf.GetMemory().UseDevice(true);
-   ext_buf.SetSize(nbr_comm->ExternalLDof().Size());
-   ext_buf.GetMemory().UseDevice(true);
-}
-
-DeviceSharedDofCommunicator::~DeviceSharedDofCommunicator()
-{
-   delete nbr_comm;
-}
-
-template <typename T>
-void MakeTypedBufferView(Array<real_t> &storage, int size, Array<T> &view)
-{
-   MFEM_ASSERT(sizeof(real_t) >= sizeof(T),
-               "internal buffer type is too small for this view");
-   const int capacity = storage.Size() * int(sizeof(real_t) / sizeof(T));
-   MFEM_VERIFY(size <= capacity, "internal buffer view exceeds capacity");
-   real_t *ptr = storage.ReadWrite();
-   view.MakeRef(reinterpret_cast<T*>(ptr), size, Device::QueryMemoryType(ptr),
-                false);
-}
-
-template <typename T>
-void DeviceSharedDofCommunicator::Reduce(const Array<T> &x_ldof,
-                                         Array<T> &x_tdof,
-                                         Op op) const
-{
-   MFEM_ASSERT(x_tdof.Size() == nbr_comm->LocalTDofToLDof().Size(),
-               "incompatible sizes!");
-   Array<T> ext_buf_t, shr_buf_t;
-   MakeTypedBufferView(ext_buf, nbr_comm->ExternalLDof().Size(), ext_buf_t);
-   MakeTypedBufferView(shr_buf, nbr_comm->SharedLTDof().Size(), shr_buf_t);
-   ReduceBeginCopy(x_ldof, ext_buf_t);
-   const int req_counter =
-      nbr_comm->ExchangeExternalToShared<T>(ext_buf_t, shr_buf_t, 41827);
-   ReduceLocalCopy(x_ldof, x_tdof);
-   nbr_comm->WaitAll(req_counter);
-   ReduceEndAssemble(shr_buf_t, x_tdof, op);
-}
-
-template <>
-void DeviceSharedDofCommunicator::Reduce<real_t>(const Array<real_t> &x_ldof,
-                                                 Array<real_t> &x_tdof,
-                                                 Op op) const
-{
-   MFEM_ASSERT(x_tdof.Size() == nbr_comm->LocalTDofToLDof().Size(),
-               "incompatible sizes!");
-   ReduceBeginCopy(x_ldof, ext_buf);
-   const int req_counter =
-      nbr_comm->ExchangeExternalToShared<real_t>(ext_buf, shr_buf, 41825);
-   ReduceLocalCopy(x_ldof, x_tdof);
-   nbr_comm->WaitAll(req_counter);
-   ReduceEndAssemble(shr_buf, x_tdof, op);
-}
-
-template <typename T>
-void DeviceSharedDofCommunicator::Reduce(Array<T> &x_ldof, Op op) const
-{
-   Array<T> x_tdof;
-   MakeTypedBufferView(true_buf, nbr_comm->LocalTDofToLDof().Size(), x_tdof);
-   Reduce(x_ldof, x_tdof, op);
-   BcastLocalCopy(x_tdof, x_ldof);
-}
-
-template <>
-void DeviceSharedDofCommunicator::Reduce<real_t>(Array<real_t> &x_ldof,
-                                                 Op op) const
-{
-   Reduce(x_ldof, true_buf, op);
-   BcastLocalCopy(true_buf, x_ldof);
-}
-
-template <typename T>
-void DeviceSharedDofCommunicator::Bcast(const Array<T> &x_tdof,
-                                        Array<T> &x_ldof) const
-{
-   MFEM_ASSERT(x_tdof.Size() == nbr_comm->LocalTDofToLDof().Size(),
-               "incompatible sizes!");
-   Array<T> ext_buf_t, shr_buf_t;
-   MakeTypedBufferView(ext_buf, nbr_comm->ExternalLDof().Size(), ext_buf_t);
-   MakeTypedBufferView(shr_buf, nbr_comm->SharedLTDof().Size(), shr_buf_t);
-   x_ldof.Write();
-   BcastBeginCopy(x_tdof, shr_buf_t);
-   const int req_counter =
-      nbr_comm->ExchangeSharedToExternal<T>(shr_buf_t, ext_buf_t, 41826);
-   BcastLocalCopy(x_tdof, x_ldof);
-   nbr_comm->WaitAll(req_counter);
-   BcastEndCopy(ext_buf_t, x_ldof);
-}
-
-template <>
-void DeviceSharedDofCommunicator::Bcast<real_t>(const Array<real_t> &x_tdof,
-                                                Array<real_t> &x_ldof) const
-{
-   MFEM_ASSERT(x_tdof.Size() == nbr_comm->LocalTDofToLDof().Size(),
-               "incompatible sizes!");
-   x_ldof.Write();
-   BcastBeginCopy(x_tdof, shr_buf);
-   const int req_counter =
-      nbr_comm->ExchangeSharedToExternal<real_t>(shr_buf, ext_buf, 41824);
-   BcastLocalCopy(x_tdof, x_ldof);
-   nbr_comm->WaitAll(req_counter);
-   BcastEndCopy(ext_buf, x_ldof);
-}
-
-template <typename T>
-void DeviceSharedDofCommunicator::Bcast(Array<T> &x_ldof) const
-{
-   Array<T> x_tdof;
-   MakeTypedBufferView(true_buf, nbr_comm->LocalTDofToLDof().Size(), x_tdof);
-   ReduceLocalCopy(x_ldof, x_tdof);
-   Bcast(x_tdof, x_ldof);
-}
-
-template <>
-void DeviceSharedDofCommunicator::Bcast<real_t>(Array<real_t> &x_ldof) const
-{
-   ReduceLocalCopy(x_ldof, true_buf);
-   Bcast(true_buf, x_ldof);
-}
-
-template <class T>
-void GroupCommunicator::Bcast(T *ldata, int layout) const
-{
-   BcastBegin(ldata, layout);
-   BcastEnd(ldata, layout);
-}
-
-template <class T>
-void GroupCommunicator::Bcast(T *ldata) const
-{
-   if (ldata == NULL)
-   {
-      Bcast<T>(ldata, 0);
-      return;
-   }
-   const MemoryType mt = Device::QueryMemoryType(ldata);
-
-   // Use the shared-dof device path when it is available.
-   if (UseDeviceSharedDofComm(ldata))
-   {
-      Array<T> ldata_view;
-      ldata_view.MakeRef(ldata, ldof_size, mt, false);
-      GetDeviceSharedDofCommunicator()->Bcast(ldata_view);
-      return;
-   }
-
-   // Go back to host when the shared-dof device path is not available.
-   if (IsDeviceMemory(mt))
-   {
-      Array<T> device_view, host_data(ldof_size);
-      device_view.MakeRef(ldata, ldof_size, mt, false);
-      host_data = device_view;
-      Bcast<T>(host_data.HostReadWrite(), 0);
-      device_view = host_data;
-      return;
-   }
-
-   Bcast<T>(ldata, 0);
-}
-
-template <class T>
-void GroupCommunicator::Bcast(Array<T> &ldata) const
-{
-   const bool on_dev =
-      ldata.GetMemory().DeviceIsValid() && device_shared_dof_comm_enabled;
-   Bcast<T>(ldata.ReadWrite(on_dev));
-}
-
-template <class T>
-void GroupCommunicator::Reduce(T *ldata, void (*Op)(OpData<T>)) const
-{
-   if (ldata == NULL)
-   {
-      ReduceBegin(ldata);
-      ReduceEnd(ldata, 0, Op);
-      return;
-   }
-   const MemoryType mt = Device::QueryMemoryType(ldata);
-
-   // Use the shared-dof device path when it is available.
-   if (UseDeviceSharedDofComm(ldata))
-   {
-      // Materialize typed function pointers before comparison so stricter GPU
-      // toolchains do not have to resolve overloaded template names here.
-      using OpFunc = void (*)(OpData<T>);
-      const OpFunc sum_op = &GroupCommunicator::template Sum<T>;
-      const OpFunc min_op = &GroupCommunicator::template Min<T>;
-      const OpFunc max_op = &GroupCommunicator::template Max<T>;
-      DeviceSharedDofCommunicator::Op device_op;
-      if (Op == sum_op)
-      {
-         device_op = DeviceSharedDofCommunicator::Op::Sum;
-      }
-      else if (Op == min_op)
-      {
-         device_op = DeviceSharedDofCommunicator::Op::Min;
-      }
-      else if (Op == max_op)
-      {
-         device_op = DeviceSharedDofCommunicator::Op::Max;
-      }
-      else
-      {
-         // Just a placeholder - this case won't be executed on GPU.
-         device_op = DeviceSharedDofCommunicator::Op::Sum;
-      }
-
-      // Only the operations with a direct DeviceSharedDofCommunicator mapping
-      // can stay on the device; the rest fall back to the legacy host path.
-      if (Op == sum_op || Op == min_op || Op == max_op)
-      {
-         Array<T> ldata_view;
-         ldata_view.MakeRef(ldata, ldof_size, mt, false);
-         GetDeviceSharedDofCommunicator()->Reduce(ldata_view, device_op);
-         return;
-      }
-   }
-
-   // Go back to host when the shared-dof device path is not available.
-   if (IsDeviceMemory(mt))
-   {
-      Array<T> device_view, host_data(ldof_size);
-      device_view.MakeRef(ldata, ldof_size, mt, false);
-      host_data = device_view;
-      ReduceBegin(host_data.HostRead());
-      ReduceEnd(host_data.HostReadWrite(), 0, Op);
-      device_view = host_data;
-      return;
-   }
-
-   ReduceBegin(ldata);
-   ReduceEnd(ldata, 0, Op);
-}
-
-template <class T>
-void GroupCommunicator::Reduce(Array<T> &ldata,
-                               void (*Op)(OpData<T>)) const
-{
-   const bool on_dev =
-      ldata.GetMemory().DeviceIsValid() && device_shared_dof_comm_enabled;
-   Reduce<T>(ldata.ReadWrite(on_dev), Op);
+   return *device_gc;
 }
 
 template <class T>
@@ -1355,8 +746,13 @@ template <class T>
 void GroupCommunicator::BcastBegin(T *ldata, int layout) const
 {
    MFEM_VERIFY(comm_lock == 0, "object is already in use");
+   MFEM_ASSERT(0 <= layout && layout <= 2, "invalid layout: " << layout);
 
-   if (group_buf_size == 0) { return; }
+   if (group_buf_size == 0)
+   {
+      comm_lock = 1; // 1 - locked for Bcast
+      return;
+   }
 
    int request_counter = 0;
    switch (mode)
@@ -1489,11 +885,72 @@ void GroupCommunicator::BcastBegin(T *ldata, int layout) const
 }
 
 template <class T>
+void GroupCommunicator::BcastBegin(Array<T> &ldata, int layout) const
+{
+   MFEM_VERIFY(comm_lock == 0, "object is already in use");
+   MFEM_ASSERT(0 <= layout && layout <= 2, "invalid layout: " << layout);
+#ifdef MFEM_DEBUG
+   // for layouts 0 and 2, ldata_size is known only when have_ltdof_ldof is true
+   if (layout == 1 || have_ltdof_ldof)
+   {
+      // FIXME: Currently, this check causes a failure in the unit test
+      //          "Parallel Variable Order FiniteElementSpace" "Quad mesh"
+      //        Re-enable this check when the issue is fixed.
+
+      // const int ldata_size = layout == 0 ? ldof_size :
+      //                        layout == 1 ? group_ldof.Size_of_connections() :
+      //                        ltdof_ldof.Size();
+      // MFEM_ASSERT(ldata.Size() == ldata_size, "invalid 'ldata' size");
+   }
+#endif
+
+   if (group_buf_size == 0)
+   {
+      comm_lock = 1; // 1 - locked for Bcast
+      return;
+   }
+
+   // Use 'while' instead of 'if' so that we can break out without using 'goto'.
+   while (Device::Allows(Backend::DEVICE_MASK) &&
+          have_ltdof_ldof &&
+          mode == byNeighbor)
+   {
+      if (layout == 0)  // input is ldofs array
+      {
+         GetDeviceComm().BcastBeginLDofs(ldata);
+      }
+      else if (layout == 2)  // input is ltdofs array
+      {
+         GetDeviceComm().BcastBeginTDofs(ldata);
+      }
+      else
+      {
+         break;
+      }
+      comm_lock = 1; // 1 - locked for Bcast
+      return;
+   }
+
+   // Call the host version of this method with the data moved to host
+   BcastBegin(ldata.HostReadWrite(), layout);
+   // comm_lock is set by the above call
+}
+
+template <class T>
 void GroupCommunicator::BcastEnd(T *ldata, int layout) const
 {
-   if (comm_lock == 0) { return; }
-   // The above also handles the case (group_buf_size == 0).
+   // Is there a real case where we want to allow BcastEnd without corresponding
+   // BcastBegin?
+   // if (comm_lock == 0) { return; }
+
    MFEM_VERIFY(comm_lock == 1, "object is NOT locked for Bcast");
+   MFEM_ASSERT(layout == 0 || layout == 1, "invalid layout: " << layout);
+
+   if (group_buf_size == 0)
+   {
+      comm_lock = 0; // 0 - no lock
+      return;
+   }
 
    switch (mode)
    {
@@ -1551,11 +1008,55 @@ void GroupCommunicator::BcastEnd(T *ldata, int layout) const
 }
 
 template <class T>
+void GroupCommunicator::BcastEnd(Array<T> &ldata, int layout) const
+{
+   MFEM_VERIFY(comm_lock == 1, "object is NOT locked for Bcast");
+   MFEM_ASSERT(layout == 0 || layout == 1, "invalid layout: " << layout);
+#ifdef MFEM_DEBUG
+   // for layouts 0 and 2, ldata_size is known only when have_ltdof_ldof is true
+   if (layout == 1 || have_ltdof_ldof)
+   {
+      // FIXME: Currently, this check causes a failure in the unit test
+      //          "Parallel Variable Order FiniteElementSpace" "Quad mesh"
+      //        Re-enable this check when the issue is fixed.
+
+      // const int ldata_size = layout == 0 ? ldof_size :
+      //                        group_ldof.Size_of_connections();
+      // MFEM_ASSERT(ldata.Size() == ldata_size, "invalid 'ldata' size");
+   }
+#endif
+
+   if (group_buf_size == 0)
+   {
+      comm_lock = 0; // 0 - no lock
+      return;
+   }
+
+   if (Device::Allows(Backend::DEVICE_MASK) &&
+       have_ltdof_ldof &&
+       mode == byNeighbor &&
+       layout == 0)  // output is ldofs array
+   {
+      GetDeviceComm().BcastEndLDofs(ldata);
+      comm_lock = 0; // 0 - no lock
+      return;
+   }
+
+   // call the host version of this method with the data moved to host
+   BcastEnd(ldata.HostReadWrite(), layout);
+   // comm_lock is set by the above call
+}
+
+template <class T>
 void GroupCommunicator::ReduceBegin(const T *ldata) const
 {
    MFEM_VERIFY(comm_lock == 0, "object is already in use");
 
-   if (group_buf_size == 0) { return; }
+   if (group_buf_size == 0)
+   {
+      comm_lock = 2; // 2 - locked for Reduce
+      return;
+   }
 
    int request_counter = 0;
    group_buf.SetSize(group_buf_size*sizeof(T));
@@ -1665,17 +1166,62 @@ void GroupCommunicator::ReduceBegin(const T *ldata) const
       }
    }
 
-   comm_lock = 2;
+   comm_lock = 2; // 2 - locked for Reduce
    num_requests = request_counter;
+}
+
+template <class T>
+void GroupCommunicator::ReduceBegin(const Array<T> &ldata) const
+{
+   MFEM_VERIFY(comm_lock == 0, "object is already in use");
+   // layout is 0
+#ifdef MFEM_DEBUG
+   if (ldof_size >= 0) // ldof_size is -1 when it is unknown
+   {
+      // FIXME: Currently, this check causes a failure in the unit test
+      //          "Parallel Variable Order FiniteElementSpace" "Quad mesh"
+      //        Re-enable this check when the issue is fixed.
+
+      // MFEM_ASSERT(ldata.Size() == ldof_size, "invalid 'ldata' size");
+   }
+#endif
+
+   if (group_buf_size == 0)
+   {
+      comm_lock = 2; // 2 - locked for Reduce
+      return;
+   }
+
+   if (Device::Allows(Backend::DEVICE_MASK) &&
+       have_ltdof_ldof &&
+       mode == byNeighbor)
+   {
+      GetDeviceComm().ReduceBeginLDofs(ldata);
+      comm_lock = 2; // 2 - locked for Reduce
+      return;
+   }
+
+   // call the host version of this method with the data copied to host
+   ReduceBegin(ldata.HostRead());
+   // comm_lock is set by the above call
 }
 
 template <class T>
 void GroupCommunicator::ReduceEnd(T *ldata, int layout,
                                   void (*Op)(OpData<T>)) const
 {
-   if (comm_lock == 0) { return; }
-   // The above also handles the case (group_buf_size == 0).
+   // Is there a real case where we want to allow ReduceEnd without
+   // corresponding ReduceBegin?
+   // if (comm_lock == 0) { return; }
+
    MFEM_VERIFY(comm_lock == 2, "object is NOT locked for Reduce");
+   MFEM_ASSERT(layout == 0 || layout == 2, "invalid layout: " << layout);
+
+   if (group_buf_size == 0)
+   {
+      comm_lock = 0; // 0 - no lock
+      return;
+   }
 
    switch (mode)
    {
@@ -1737,6 +1283,83 @@ void GroupCommunicator::ReduceEnd(T *ldata, int layout,
 
    comm_lock = 0; // 0 - no lock
    num_requests = 0;
+}
+
+template <class T>
+void GroupCommunicator::ReduceEnd(Array<T> &ldata, int layout,
+                                  void (*Op)(OpData<T>)) const
+{
+   MFEM_VERIFY(comm_lock == 2, "object is NOT locked for Reduce");
+   MFEM_ASSERT(layout == 0 || layout == 2, "invalid layout: " << layout);
+#ifdef MFEM_DEBUG
+   // for layouts 0 and 2, ldata_size is known only when have_ltdof_ldof is true
+   if (have_ltdof_ldof)
+   {
+      // FIXME: Currently, this check causes a failure in the unit test
+      //          "Parallel Variable Order FiniteElementSpace" "Quad mesh"
+      //        Re-enable this check when the issue is fixed.
+
+      // const int ldata_size = layout == 0 ? ldof_size : ltdof_ldof.Size();
+      // MFEM_ASSERT(ldata.Size() == ldata_size, "invalid 'ldata' size");
+   }
+#endif
+
+   if (group_buf_size == 0)
+   {
+      comm_lock = 0; // 0 - no lock
+      return;
+   }
+
+   if (Device::Allows(Backend::DEVICE_MASK) &&
+       have_ltdof_ldof &&
+       mode == byNeighbor)
+   {
+      DeviceGroupCommunicator::Op device_op{};
+      auto op_is_supported_device_op = [&]() -> bool
+      {
+         // Materialize typed function pointers before comparison so stricter
+         // GPU toolchains do not have to resolve overloaded template names
+         // here.
+         using OpFunc = void (*)(OpData<T>);
+         const OpFunc sum_op = &GroupCommunicator::template Sum<T>;
+         const OpFunc min_op = &GroupCommunicator::template Min<T>;
+         const OpFunc max_op = &GroupCommunicator::template Max<T>;
+         if (Op == sum_op)
+         {
+            device_op = DeviceGroupCommunicator::Op::Sum;
+         }
+         else if (Op == min_op)
+         {
+            device_op = DeviceGroupCommunicator::Op::Min;
+         }
+         else if (Op == max_op)
+         {
+            device_op = DeviceGroupCommunicator::Op::Max;
+         }
+         else
+         {
+            return false; // Op is not supported on device
+         }
+         return true; // Op is supported on device
+      };
+      if (op_is_supported_device_op())
+      {
+         if (layout == 0)  // output is ldofs array
+         {
+            GetDeviceComm().ReduceEndLDofs(ldata, device_op);
+         }
+         else // layout == 2 -- output is ltdofs array
+         {
+            GetDeviceComm().ReduceEndTDofs(ldata, device_op);
+         }
+         comm_lock = 0; // 0 - no lock
+         return;
+      }
+   }
+
+   // call the host version of this method with the data moved to host
+   ReduceEnd(ldata.HostReadWrite(), layout, Op);
+   // comm_lock is set by the above call
 }
 
 template <class T>
@@ -2084,132 +1707,519 @@ void GroupCommunicator::PrintInfo(std::ostream &os) const
 
 GroupCommunicator::~GroupCommunicator()
 {
-   delete device_shared_dof_comm;
+   delete device_gc;
    delete [] buf_offsets;
    delete [] request_marker;
    // delete [] statuses;
    delete [] requests;
 }
 
-// @cond DOXYGEN_SKIP
 
-// instantiate GroupCommunicator::Bcast and Reduce for int and double
-template void GroupCommunicator::Bcast<int>(int *, int) const;
-template void GroupCommunicator::Bcast<int>(int *) const;
-template void GroupCommunicator::Bcast<int>(Array<int> &) const;
+namespace internal
+{
+
+/** @brief Extract a sub-array: xout[i] = xin[indices[i]].
+    Note that the 'indices' can contain repeated integers. */
+template <typename T>
+static void ExtractSubArray(const Array<int> &indices,
+                            const Array<T> &xin,
+                            Array<T> &xout)
+{
+   MFEM_ASSERT(indices.Size() == xout.Size(), "incompatible sizes!");
+   auto y = xout.Write();
+   const auto x = xin.Read();
+   const auto I = indices.Read();
+   mfem::forall(indices.Size(), [=] MFEM_HOST_DEVICE (int i)
+   {
+      y[i] = x[I[i]];
+   });
+}
+
+/** @brief Set a sub-array: xout[indices[i]] = xin[i].
+    Note that the 'indices' can NOT contain repeated integers because that will
+    create a race condition during parallel execution. */
+template <typename T>
+static void SetSubArray(const Array<int> &indices,
+                        const Array<T> &xin,
+                        Array<T> &xout)
+{
+   MFEM_ASSERT(indices.Size() == xin.Size(), "incompatible sizes!");
+   // Use ReadWrite() since we modify only a subset of the indices:
+   auto y = xout.ReadWrite();
+   const auto x = xin.Read();
+   const auto I = indices.Read();
+   mfem::forall(indices.Size(), [=] MFEM_HOST_DEVICE (int i)
+   {
+      y[I[i]] = x[i];
+   });
+}
+
+/** @brief Set a sub-array: xout[indices[i]] = val.
+    Note that the 'indices' can contain repeated integers. Since the same value
+    is assigned to all given entries, there no real race condition during
+    parallel execution. */
+template <typename T>
+static void SetSubArray(const Array<int> &indices, Array<T> &xout, T val)
+{
+   // Use ReadWrite() since we modify only a subset of the indices:
+   auto y = xout.ReadWrite();
+   const auto I = indices.Read();
+   mfem::forall(indices.Size(), [=] MFEM_HOST_DEVICE (int i)
+   {
+      y[I[i]] = val;
+   });
+}
+
+/** @brief Perform the operation: dst += A src, where:
+    - A is a Boolean matrix
+    - unique_dst_indices are the nonzeros rows of A
+    - unique_to_src_offsets and unique_to_src_indices are the I and J arrays of
+      the csr format of A restricted to its nonzero rows. */
+template <typename T>
+static void BooleanAddMult(const Array<int> &unique_dst_indices,
+                           const Array<int> &unique_to_src_offsets,
+                           const Array<int> &unique_to_src_indices,
+                           const Array<T> &src,
+                           Array<T> &dst)
+{
+   auto y = dst.ReadWrite();
+   const auto x = src.Read();
+   const auto DST_I = unique_dst_indices.Read();
+   const auto SRC_O = unique_to_src_offsets.Read();
+   const auto SRC_I = unique_to_src_indices.Read();
+   mfem::forall(unique_dst_indices.Size(), [=] MFEM_HOST_DEVICE (int i)
+   {
+      const int dst_idx = DST_I[i];
+      T sum = y[dst_idx];
+      const int end = SRC_O[i+1];
+      for (int j = SRC_O[i]; j != end; ++j) { sum += x[SRC_I[j]]; }
+      y[dst_idx] = sum;
+   });
+}
+
+/** @brief Operation similar to BooleanAddMult(): dst += A src, where:
+    - the addition operations are replaced by the reduction operation op
+    - only nonzero entries of A participate in the reduction operation
+    - A is a Boolean matrix
+    - unique_dst_indices are the nonzeros rows of A
+    - unique_to_src_offsets and unique_to_src_indices are the I and J arrays of
+      the csr format of A restricted to its nonzero rows. */
+template <typename T>
+static void BooleanReduceApply(const Array<int> &unique_dst_indices,
+                               const Array<int> &unique_to_src_offsets,
+                               const Array<int> &unique_to_src_indices,
+                               const Array<T> &src,
+                               Array<T> &dst,
+                               DeviceGroupCommunicator::Op op)
+{
+   auto y = dst.ReadWrite();
+   const auto x = src.Read();
+   const auto DST_I = unique_dst_indices.Read();
+   const auto SRC_O = unique_to_src_offsets.Read();
+   const auto SRC_I = unique_to_src_indices.Read();
+   mfem::forall(unique_dst_indices.Size(), [=] MFEM_HOST_DEVICE (int i)
+   {
+      const int dst_idx = DST_I[i];
+      T val = y[dst_idx];
+      const int end = SRC_O[i+1];
+      switch (op)
+      {
+         case DeviceGroupCommunicator::Op::Sum:
+            for (int j = SRC_O[i]; j != end; ++j) { val += x[SRC_I[j]]; }
+            break;
+         case DeviceGroupCommunicator::Op::Min:
+            for (int j = SRC_O[i]; j != end; ++j)
+            {
+               const T xj = x[SRC_I[j]];
+               val = (xj < val) ? xj : val;
+            }
+            break;
+         case DeviceGroupCommunicator::Op::Max:
+            for (int j = SRC_O[i]; j != end; ++j)
+            {
+               const T xj = x[SRC_I[j]];
+               val = (xj > val) ? xj : val;
+            }
+            break;
+      }
+      y[dst_idx] = val;
+   });
+}
+
+} // namespace internal
+
+
+DeviceGroupCommunicator::DeviceGroupCommunicator(const GroupCommunicator &gc_)
+   : gc(gc_)
+{
+   MFEM_VERIFY(gc.mode == gc.byNeighbor,
+               "Device group-communicator requires neighbor mode.");
+   MFEM_VERIFY(gc.have_ltdof_ldof,
+               "The GroupCommunicator method SetLTDofTable() must be called "
+               "before constructing the DeviceGroupCommunicator!");
+   {
+      Table nbr_ltdof;
+      gc.GetNeighborLTDofTable(nbr_ltdof);
+      // Transfer the I and J arrays of nbr_ltdof to shr_buf_offsets and
+      // shr_ltdof, respectively:
+      shr_buf_offsets.NewMemoryAndSize(nbr_ltdof.GetIMemory(),
+                                       nbr_ltdof.Size()+1, true);
+      shr_ltdof.NewMemoryAndSize(nbr_ltdof.GetJMemory(),
+                                 nbr_ltdof.Size_of_connections(), true);
+      nbr_ltdof.LoseData();
+   }
+   shr_ldof.SetSize(shr_ltdof.Size());
+   // shr_ldof[i] = gc.ltdof_ldof[shr_ltdof[i]]:
+   internal::ExtractSubArray(shr_ltdof, gc.ltdof_ldof, shr_ldof);
+   {
+      // Sort() is a host method, so initialize 'unique_ltdof' on host:
+      Array<int> unique_ltdof(shr_ltdof.Size());
+      unique_ltdof.CopyFrom(shr_ltdof.HostRead());
+      unique_ltdof.Sort();
+      unique_ltdof.Unique();
+      unq_ltdof = unique_ltdof;
+   }
+   {
+      Array<int> shr_unique(shr_ltdof.Size());
+      for (int i = 0; i < shr_unique.Size(); i++)
+      {
+         shr_unique[i] = unq_ltdof.FindSorted(std::as_const(shr_ltdof)[i]);
+         MFEM_ASSERT(shr_unique[i] != -1, "internal error");
+      }
+      Table unique_shr;
+      Transpose(shr_unique, unique_shr, unq_ltdof.Size());
+      // Transfer the I and J arrays of unique_shr to unq_shr_i and unq_shr_j,
+      // respectively:
+      unq_shr_i.NewMemoryAndSize(unique_shr.GetIMemory(),
+                                 unique_shr.Size()+1, true);
+      unq_shr_j.NewMemoryAndSize(unique_shr.GetJMemory(),
+                                 unique_shr.Size_of_connections(), true);
+      unique_shr.LoseData();
+   }
+   unq_ldof.SetSize(unq_ltdof.Size());
+   // unq_ldof[i] = gc.ltdof_ldof[unq_ltdof[i]]:
+   internal::ExtractSubArray(unq_ltdof, gc.ltdof_ldof, unq_ldof);
+   {
+      Table nbr_ldof;
+      gc.GetNeighborLDofTable(nbr_ldof);
+      // Transfer the I and J arrays of nbr_ldof to ext_buf_offsets and
+      // ext_ldof, respectively:
+      ext_buf_offsets.NewMemoryAndSize(nbr_ldof.GetIMemory(),
+                                       nbr_ldof.Size()+1, true);
+      ext_ldof.NewMemoryAndSize(nbr_ldof.GetJMemory(),
+                                nbr_ldof.Size_of_connections(), true);
+      ext_ldof.GetMemory().UseDevice(true);
+      nbr_ldof.LoseData();
+   }
+
+   shr_buf.SetSize(shr_ltdof.Size());
+   shr_buf.GetMemory().UseDevice(true);
+   ext_buf.SetSize(ext_ldof.Size());
+   ext_buf.GetMemory().UseDevice(true);
+
+   const GroupTopology &gtopo = gc.GetGroupTopology();
+   int req_counter = 0;
+   for (int nbr = 1; nbr < gtopo.GetNumNeighbors(); nbr++)
+   {
+      const int send_offset = shr_buf_offsets[nbr];
+      const int send_size = shr_buf_offsets[nbr+1] - send_offset;
+      if (send_size > 0) { req_counter++; }
+
+      const int recv_offset = ext_buf_offsets[nbr];
+      const int recv_size = ext_buf_offsets[nbr+1] - recv_offset;
+      if (recv_size > 0) { req_counter++; }
+   }
+   requests.SetSize(req_counter);
+   num_requests = 0;
+}
+
+// Returns an Array<T> 'view' that is valid on device only.
+// This function assumes that if 'storage' contains data that we want to access
+// using the 'view', then 'storage' is valid on device.
+// If 'view' is modified on host and that data needs to be preserved in
+// 'storage', then 'view' must be copied to device using 'view.Read()'.
+template <typename T, typename BT>
+static inline Array<T> MakeTypedBufferView(Array<BT> &storage)
+{
+   static_assert(sizeof(BT) >= sizeof(T),
+                 "internal buffer type is too small for this view!");
+   Array<T> view;
+   storage.Write();
+   view.NewMemoryAndSize(reinterpret_cast<Memory<T>&>(storage.GetMemory()),
+                         storage.Size(), true);
+   view.GetMemory().ClearOwnerFlags();
+   return view;
+}
+
+template <typename T>
+void DeviceGroupCommunicator::BcastBeginTDofs(Array<T> &x_tdof) const
+{
+   Array<T> shr_buf_t = MakeTypedBufferView<T>(shr_buf);
+   Array<T> ext_buf_t = MakeTypedBufferView<T>(ext_buf);
+   BcastBeginCopyTDofs(x_tdof, shr_buf_t);
+   ExchangeSharedToExternal(shr_buf_t, ext_buf_t);
+}
+
+template <typename T>
+void DeviceGroupCommunicator::BcastBeginLDofs(Array<T> &x_ldof) const
+{
+   Array<T> shr_buf_t = MakeTypedBufferView<T>(shr_buf);
+   Array<T> ext_buf_t = MakeTypedBufferView<T>(ext_buf);
+   BcastBeginCopyLDofs(x_ldof, shr_buf_t);
+   ExchangeSharedToExternal(shr_buf_t, ext_buf_t);
+}
+
+template <typename T>
+void DeviceGroupCommunicator::BcastEndLDofs(Array<T> &x_ldof) const
+{
+   Array<T> ext_buf_t = MakeTypedBufferView<T>(ext_buf);
+   WaitAll();
+   BcastEndCopy(ext_buf_t, x_ldof);
+}
+
+template <typename T>
+void DeviceGroupCommunicator::ReduceBeginLDofs(const Array<T> &x_ldof) const
+{
+   Array<T> ext_buf_t = MakeTypedBufferView<T>(ext_buf);
+   Array<T> shr_buf_t = MakeTypedBufferView<T>(shr_buf);
+   ReduceBeginCopy(x_ldof, ext_buf_t);
+   ExchangeExternalToShared(ext_buf_t, shr_buf_t);
+}
+
+template <typename T>
+void DeviceGroupCommunicator::ReduceEndTDofs(Array<T> &x_tdof, Op op) const
+{
+   Array<T> shr_buf_t = MakeTypedBufferView<T>(shr_buf);
+   WaitAll();
+   ReduceEndAssembleTDofs(shr_buf_t, x_tdof, op);
+}
+
+template <typename T>
+void DeviceGroupCommunicator::ReduceEndLDofs(Array<T> &x_ldof, Op op) const
+{
+   Array<T> shr_buf_t = MakeTypedBufferView<T>(shr_buf);
+   WaitAll();
+   if (unq_ldof.Size() == 0) { return; }
+   if (op == Op::Sum)
+   {
+      internal::BooleanAddMult(unq_ldof, unq_shr_i, unq_shr_j,
+                               shr_buf_t, x_ldof);
+   }
+   else
+   {
+      internal::BooleanReduceApply(unq_ldof, unq_shr_i, unq_shr_j,
+                                   shr_buf_t, x_ldof, op);
+   }
+}
+
+template <typename T>
+void DeviceGroupCommunicator::CopyTDofsToLDofs(const Array<T> &x_tdof,
+                                               Array<T> &x_ldof) const
+{
+   if (gc.ltdof_ldof.Size() == 0) { return; }
+   internal::SetSubArray(gc.ltdof_ldof, x_tdof, x_ldof);
+}
+
+template <typename T>
+void DeviceGroupCommunicator::Prolongate(const Array<T> &x_tdof,
+                                         Array<T> &x_ldof) const
+{
+   MFEM_ASSERT(x_tdof.Size() == gc.ltdof_ldof.Size(), "incompatible sizes!");
+   MFEM_ASSERT(x_ldof.Size() == gc.ldof_size, "incompatible sizes!");
+   Array<T> ext_buf_t = MakeTypedBufferView<T>(ext_buf);
+   Array<T> shr_buf_t = MakeTypedBufferView<T>(shr_buf);
+   BcastBeginCopyTDofs(x_tdof, shr_buf_t);
+   ExchangeSharedToExternal(shr_buf_t, ext_buf_t);
+   CopyTDofsToLDofs(x_tdof, x_ldof);
+   WaitAll();
+   BcastEndCopy(ext_buf_t, x_ldof);
+}
+
+template <typename T>
+void DeviceGroupCommunicator::ProlongateTranspose(const Array<T> &x_ldof,
+                                                  Array<T> &x_tdof,
+                                                  Op op) const
+{
+   MFEM_ASSERT(x_ldof.Size() == gc.ldof_size, "incompatible sizes!");
+   MFEM_ASSERT(x_tdof.Size() == gc.ltdof_ldof.Size(), "incompatible sizes!");
+   Array<T> ext_buf_t = MakeTypedBufferView<T>(ext_buf);
+   Array<T> shr_buf_t = MakeTypedBufferView<T>(shr_buf);
+   ReduceBeginCopy(x_ldof, ext_buf_t);
+   ExchangeExternalToShared(ext_buf_t, shr_buf_t);
+   Restrict(x_ldof, x_tdof);
+   WaitAll();
+   ReduceEndAssembleTDofs(shr_buf_t, x_tdof, op);
+}
+
+template <typename T>
+void DeviceGroupCommunicator::Restrict(const Array<T> &x_ldof,
+                                       Array<T> &x_tdof) const
+{
+   if (gc.ltdof_ldof.Size() == 0) { return; }
+   internal::ExtractSubArray(gc.ltdof_ldof, x_ldof, x_tdof);
+}
+
+template <typename T>
+void DeviceGroupCommunicator::RestrictTranspose(const Array<T> &x_tdof,
+                                                Array<T> &x_ldof) const
+{
+   CopyTDofsToLDofs(x_tdof, x_ldof);
+   internal::SetSubArray(ext_ldof, x_ldof, T(0));
+}
+
+template <typename T>
+void DeviceGroupCommunicator::Exchange(const Array<T> &send_buf,
+                                       const Array<int> &send_offsets,
+                                       Array<T> &recv_buf,
+                                       const Array<int> &recv_offsets,
+                                       int tag) const
+{
+   const GroupTopology &gtopo = gc.GetGroupTopology();
+   const bool mpi_gpu_aware = Device::GetGPUAwareMPI();
+   auto send_ptr = mpi_gpu_aware ? send_buf.Read() : send_buf.HostRead();
+   auto recv_ptr = mpi_gpu_aware ? recv_buf.Write() : recv_buf.HostWrite();
+   num_requests = 0;
+   for (int nbr = 1; nbr < gtopo.GetNumNeighbors(); nbr++)
+   {
+      const int send_offset = send_offsets[nbr];
+      const int send_size = send_offsets[nbr+1] - send_offset;
+      if (send_size > 0)
+      {
+         MPI_Isend(send_ptr + send_offset, send_size, MPITypeMap<T>::mpi_type,
+                   gtopo.GetNeighborRank(nbr), tag, gtopo.GetComm(),
+                   &requests[num_requests++]);
+      }
+      const int recv_offset = recv_offsets[nbr];
+      const int recv_size = recv_offsets[nbr+1] - recv_offset;
+      if (recv_size > 0)
+      {
+         MPI_Irecv(recv_ptr + recv_offset, recv_size, MPITypeMap<T>::mpi_type,
+                   gtopo.GetNeighborRank(nbr), tag, gtopo.GetComm(),
+                   &requests[num_requests++]);
+      }
+   }
+}
+
+template <typename T>
+void DeviceGroupCommunicator::ExchangeSharedToExternal(
+   const Array<T> &shr_buf_t, Array<T> &ext_buf_t) const
+{
+   const int tag = 41822;
+   Exchange(shr_buf_t, shr_buf_offsets, ext_buf_t, ext_buf_offsets, tag);
+}
+
+template <typename T>
+void DeviceGroupCommunicator::ExchangeExternalToShared(
+   const Array<T> &ext_buf_t, Array<T> &shr_buf_t) const
+{
+   const int tag = 41823;
+   Exchange(ext_buf_t, ext_buf_offsets, shr_buf_t, shr_buf_offsets, tag);
+}
+
+template <typename T>
+void DeviceGroupCommunicator::ReduceBeginCopy(const Array<T> &x_ldof,
+                                              Array<T> &ext_buf_t) const
+{
+   if (ext_ldof.Size() == 0) { return; }
+   internal::ExtractSubArray(ext_ldof, x_ldof, ext_buf_t);
+   if (Device::GetGPUAwareMPI()) { MFEM_STREAM_SYNC; }
+}
+
+template <typename T>
+void DeviceGroupCommunicator::ReduceEndAssembleTDofs(const Array<T> &shr_buf_t,
+                                                     Array<T> &x_tdof,
+                                                     Op op) const
+{
+   if (unq_ltdof.Size() == 0) { return; }
+   if (op == Op::Sum)
+   {
+      internal::BooleanAddMult(unq_ltdof, unq_shr_i, unq_shr_j,
+                               shr_buf_t, x_tdof);
+   }
+   else
+   {
+      internal::BooleanReduceApply(unq_ltdof, unq_shr_i, unq_shr_j,
+                                   shr_buf_t, x_tdof, op);
+   }
+}
+
+template <typename T>
+void DeviceGroupCommunicator::BcastBeginCopyTDofs(const Array<T> &x_tdof,
+                                                  Array<T> &shr_buf_t) const
+{
+   if (shr_ltdof.Size() == 0) { return; }
+   internal::ExtractSubArray(shr_ltdof, x_tdof, shr_buf_t);
+   if (Device::GetGPUAwareMPI()) { MFEM_STREAM_SYNC; }
+}
+
+template <typename T>
+void DeviceGroupCommunicator::BcastBeginCopyLDofs(const Array<T> &x_ldof,
+                                                  Array<T> &shr_buf_t) const
+{
+   if (shr_ldof.Size() == 0) { return; }
+   internal::ExtractSubArray(shr_ldof, x_ldof, shr_buf_t);
+   if (Device::GetGPUAwareMPI()) { MFEM_STREAM_SYNC; }
+}
+
+template <typename T>
+void DeviceGroupCommunicator::BcastEndCopy(const Array<T> &ext_buf_t,
+                                           Array<T> &x_ldof) const
+{
+   if (ext_ldof.Size() == 0) { return; }
+   internal::SetSubArray(ext_ldof, ext_buf_t, x_ldof);
+}
+
+void DeviceGroupCommunicator::WaitAll() const
+{
+   MPI_Waitall(num_requests, requests.GetData(), MPI_STATUSES_IGNORE);
+}
+
+/// @cond DOXYGEN_SKIP
+
+// instantiate GroupCommunicator::Bcast and Reduce for int, double, and float
 template void GroupCommunicator::BcastBegin<int>(int *, int) const;
+template void GroupCommunicator::BcastBegin<int>(Array<int> &, int) const;
 template void GroupCommunicator::BcastEnd<int>(int *, int) const;
-template void GroupCommunicator::Reduce<int>(
-   int *, void (*)(OpData<int>)) const;
-template void GroupCommunicator::Reduce<int>(
-   Array<int> &, void (*)(OpData<int>)) const;
+template void GroupCommunicator::BcastEnd<int>(Array<int> &, int) const;
 template void GroupCommunicator::ReduceBegin<int>(const int *) const;
+template void GroupCommunicator::ReduceBegin<int>(const Array<int> &) const;
 template void GroupCommunicator::ReduceEnd<int>(
    int *, int, void (*)(OpData<int>)) const;
+template void GroupCommunicator::ReduceEnd<int>(
+   Array<int> &, int, void (*)(OpData<int>)) const;
 template void GroupCommunicator::ReduceMarked<int>(
    int*, const Array<int>&, int, void (*)(OpData<int>)) const;
 
-template void GroupCommunicator::Bcast<double>(double *, int) const;
-template void GroupCommunicator::Bcast<double>(double *) const;
-template void GroupCommunicator::Bcast<double>(Array<double> &) const;
 template void GroupCommunicator::BcastBegin<double>(double *, int) const;
+template void GroupCommunicator::BcastBegin<double>(Array<double> &, int) const;
 template void GroupCommunicator::BcastEnd<double>(double *, int) const;
-template void GroupCommunicator::Reduce<double>(
-   double *, void (*)(OpData<double>)) const;
-template void GroupCommunicator::Reduce<double>(
-   Array<double> &, void (*)(OpData<double>)) const;
+template void GroupCommunicator::BcastEnd<double>(Array<double> &, int) const;
 template void GroupCommunicator::ReduceBegin<double>(const double *) const;
+template void GroupCommunicator::ReduceBegin<double>(
+   const Array<double> &) const;
 template void GroupCommunicator::ReduceEnd<double>(
    double *, int, void (*)(OpData<double>)) const;
+template void GroupCommunicator::ReduceEnd<double>(
+   Array<double> &, int, void (*)(OpData<double>)) const;
 template void GroupCommunicator::ReduceMarked<double>(
    double*, const Array<int>&, int, void (*)(OpData<double>)) const;
 
-template void GroupCommunicator::Bcast<float>(float *, int) const;
-template void GroupCommunicator::Bcast<float>(float *) const;
-template void GroupCommunicator::Bcast<float>(Array<float> &) const;
 template void GroupCommunicator::BcastBegin<float>(float *, int) const;
+template void GroupCommunicator::BcastBegin<float>(Array<float> &, int) const;
 template void GroupCommunicator::BcastEnd<float>(float *, int) const;
-template void GroupCommunicator::Reduce<float>(
-   float *, void (*)(OpData<float>)) const;
-template void GroupCommunicator::Reduce<float>(
-   Array<float> &, void (*)(OpData<float>)) const;
+template void GroupCommunicator::BcastEnd<float>(Array<float> &, int) const;
 template void GroupCommunicator::ReduceBegin<float>(const float *) const;
+template void GroupCommunicator::ReduceBegin<float>(const Array<float> &) const;
 template void GroupCommunicator::ReduceEnd<float>(
    float *, int, void (*)(OpData<float>)) const;
+template void GroupCommunicator::ReduceEnd<float>(
+   Array<float> &, int, void (*)(OpData<float>)) const;
 template void GroupCommunicator::ReduceMarked<float>(
    float*, const Array<int>&, int, void (*)(OpData<float>)) const;
 
-template int internal::DeviceNeighborDofComm::
-ExchangeSharedToExternal<int,Array<int>, Array<int>>(
-   const Array<int> &, Array<int> &, int) const;
-template int internal::DeviceNeighborDofComm::
-ExchangeExternalToShared<int,Array<int>, Array<int>>(
-   const Array<int> &, Array<int> &, int) const;
-template int internal::DeviceNeighborDofComm::
-ExchangeSharedToExternal<real_t,Array<real_t>, Array<real_t>>(
-   const Array<real_t> &,Array<real_t> &, int) const;
-template int internal::DeviceNeighborDofComm::
-ExchangeExternalToShared<real_t,Array<real_t>, Array<real_t>>(
-   const Array<real_t> &,Array<real_t> &, int) const;
-template int internal::DeviceNeighborDofComm::
-ExchangeSharedToExternal<real_t, Vector, Vector>(
-   const Vector &, Vector &, int) const;
-template int internal::DeviceNeighborDofComm::
-ExchangeExternalToShared<real_t,Vector, Vector>(
-   const Vector &, Vector &, int) const;
+/// @endcond
 
-template void internal::DeviceNeighborDofExtract<Array<int>, Array<int>>(
-   const Array<int> &, const Array<int> &, Array<int> &);
-template void internal::DeviceNeighborDofExtract<Array<real_t>, Array<real_t>>(
-   const Array<int> &, const Array<real_t> &, Array<real_t> &);
-template void internal::DeviceNeighborDofExtract<Vector, Vector>(
-   const Array<int> &, const Vector &, Vector &);
-template void internal::DeviceNeighborDofSet<Array<int>, Array<int>>(
-   const Array<int> &, const Array<int> &, Array<int> &);
-template void internal::DeviceNeighborDofSet<Array<real_t>, Array<real_t>>(
-   const Array<int> &, const Array<real_t> &, Array<real_t> &);
-template void internal::DeviceNeighborDofSet<Vector, Vector>(
-   const Array<int> &, const Vector &, Vector &);
-template void internal::DeviceNeighborDofAdd<Vector, Vector>(
-   const Array<int> &, const Array<int> &, const Array<int> &,
-   const Vector &, Vector &);
-
-template void DeviceSharedDofCommunicator::ReduceBeginCopy<int>(
-   const Array<int> &, Array<int> &) const;
-template void DeviceSharedDofCommunicator::ReduceLocalCopy<int>(
-   const Array<int> &, Array<int> &) const;
-template void DeviceSharedDofCommunicator::ReduceEndAssemble<int>(
-   const Array<int> &, Array<int> &, Op) const;
-template void DeviceSharedDofCommunicator::BcastBeginCopy<int>(
-   const Array<int> &, Array<int> &) const;
-template void DeviceSharedDofCommunicator::BcastLocalCopy<int>(
-   const Array<int> &, Array<int> &) const;
-template void DeviceSharedDofCommunicator::BcastEndCopy<int>(
-   const Array<int> &, Array<int> &) const;
-template void DeviceSharedDofCommunicator::Reduce<int>(
-   const Array<int> &, Array<int> &, Op) const;
-template void DeviceSharedDofCommunicator::Reduce<int>(
-   Array<int> &, Op) const;
-template void DeviceSharedDofCommunicator::Bcast<int>(
-   const Array<int> &, Array<int> &) const;
-template void DeviceSharedDofCommunicator::Bcast<int>(
-   Array<int> &) const;
-template void DeviceSharedDofCommunicator::ReduceBeginCopy<real_t>(
-   const Array<real_t> &, Array<real_t> &) const;
-template void DeviceSharedDofCommunicator::ReduceLocalCopy<real_t>(
-   const Array<real_t> &, Array<real_t> &) const;
-template void DeviceSharedDofCommunicator::ReduceEndAssemble<real_t>(
-   const Array<real_t> &, Array<real_t> &, Op) const;
-template void DeviceSharedDofCommunicator::BcastBeginCopy<real_t>(
-   const Array<real_t> &, Array<real_t> &) const;
-template void DeviceSharedDofCommunicator::BcastLocalCopy<real_t>(
-   const Array<real_t> &, Array<real_t> &) const;
-template void DeviceSharedDofCommunicator::BcastEndCopy<real_t>(
-   const Array<real_t> &, Array<real_t> &) const;
-
-// @endcond
-
-// instantiate reduce operators for int and double
+// instantiate reduce operators for int, double, and float
 template void GroupCommunicator::Sum<int>(OpData<int>);
 template void GroupCommunicator::Min<int>(OpData<int>);
 template void GroupCommunicator::Max<int>(OpData<int>);
@@ -2225,6 +2235,29 @@ template void GroupCommunicator::Sum<float>(OpData<float>);
 template void GroupCommunicator::Min<float>(OpData<float>);
 template void GroupCommunicator::Max<float>(OpData<float>);
 template void GroupCommunicator::MaxAbs<float>(OpData<float>);
+
+
+/// @cond DOXYGEN_SKIP
+
+template void DeviceGroupCommunicator::Prolongate<int>(
+   const Array<int> &, Array<int> &) const;
+template void DeviceGroupCommunicator::ProlongateTranspose<int>(
+   const Array<int> &, Array<int> &, Op) const;
+template void DeviceGroupCommunicator::Restrict<int>(
+   const Array<int> &, Array<int> &) const;
+template void DeviceGroupCommunicator::RestrictTranspose<int>(
+   const Array<int> &, Array<int> &) const;
+
+template void DeviceGroupCommunicator::Prolongate<real_t>(
+   const Array<real_t> &, Array<real_t> &) const;
+template void DeviceGroupCommunicator::ProlongateTranspose<real_t>(
+   const Array<real_t> &, Array<real_t> &, Op) const;
+template void DeviceGroupCommunicator::Restrict<real_t>(
+   const Array<real_t> &, Array<real_t> &) const;
+template void DeviceGroupCommunicator::RestrictTranspose<real_t>(
+   const Array<real_t> &, Array<real_t> &) const;
+
+/// @endcond
 
 
 #ifdef __bgq__

--- a/general/communication.cpp
+++ b/general/communication.cpp
@@ -1983,7 +1983,7 @@ template <class T, class BT> struct TypedBufferView
 {
    Array<BT> &storage;
    Array<T> view;
-   TypedBufferView(Array<BT> &storage_) : storage(storage)
+   TypedBufferView(Array<BT> &storage_) : storage(storage_)
    {
       using buffer_max_type = BufferMaxTypeGetter::buffer_max_type;
       static_assert(sizeof(T) <= sizeof(buffer_max_type));

--- a/general/communication.cpp
+++ b/general/communication.cpp
@@ -1061,6 +1061,9 @@ void GroupCommunicator::ReduceBegin(const T *ldata) const
       return;
    }
 
+   // Set the reduce_op to nullptr -- unknown reduce operation
+   reduce_op = nullptr;
+
    int request_counter = 0;
    group_buf.SetSize(group_buf_size*sizeof(T));
    T *buf = (T *)group_buf.GetData();
@@ -1173,8 +1176,40 @@ void GroupCommunicator::ReduceBegin(const T *ldata) const
    num_requests = request_counter;
 }
 
+template <typename T>
+static inline bool OpIsSupportedDeviceOp(
+   void (*Op)(GroupCommunicator::OpData<T>),
+   DeviceGroupCommunicator::Op &device_op)
+{
+   // Materialize typed function pointers before comparison so stricter
+   // GPU toolchains do not have to resolve overloaded template names
+   // here.
+   using OpFunc = void (*)(GroupCommunicator::OpData<T>);
+   const OpFunc sum_op = &GroupCommunicator::template Sum<T>;
+   const OpFunc min_op = &GroupCommunicator::template Min<T>;
+   const OpFunc max_op = &GroupCommunicator::template Max<T>;
+   if (Op == sum_op)
+   {
+      device_op = DeviceGroupCommunicator::Op::Sum;
+   }
+   else if (Op == min_op)
+   {
+      device_op = DeviceGroupCommunicator::Op::Min;
+   }
+   else if (Op == max_op)
+   {
+      device_op = DeviceGroupCommunicator::Op::Max;
+   }
+   else
+   {
+      return false; // Op is not supported on device
+   }
+   return true; // Op is supported on device
+}
+
 template <class T>
-void GroupCommunicator::ReduceBegin(const Array<T> &ldata) const
+void GroupCommunicator::ReduceBegin(const Array<T> &ldata,
+                                    void (*Op)(OpData<T>)) const
 {
    MFEM_VERIFY(comm_lock == 0, "object is already in use");
    // layout is 0
@@ -1189,6 +1224,9 @@ void GroupCommunicator::ReduceBegin(const Array<T> &ldata) const
    }
 #endif
 
+   // Store the provided Op for inspection in ReduceEnd().
+   reduce_op = reinterpret_cast<decltype(reduce_op)>(Op);
+
    if (group_buf_size == 0)
    {
       comm_lock = 2; // 2 - locked for Reduce
@@ -1200,14 +1238,20 @@ void GroupCommunicator::ReduceBegin(const Array<T> &ldata) const
        have_ltdof_ldof &&
        mode == byNeighbor)
    {
-      GetDeviceComm().ReduceBeginLDofs(ldata);
-      comm_lock = 2; // 2 - locked for Reduce
-      return;
+      DeviceGroupCommunicator::Op device_op{};
+      if (Op == nullptr || OpIsSupportedDeviceOp(Op, device_op))
+      {
+         GetDeviceComm().ReduceBeginLDofs(ldata);
+         comm_lock = 2; // 2 - locked for Reduce
+         return;
+      }
    }
 
    // call the host version of this method with the data copied to host
    ReduceBegin(ldata.HostRead());
    // comm_lock is set by the above call
+   // reduce_op is set to nullptr by the above call -- restore its value:
+   reduce_op = reinterpret_cast<decltype(reduce_op)>(Op);
 }
 
 template <class T>
@@ -1319,36 +1363,25 @@ void GroupCommunicator::ReduceEnd(Array<T> &ldata, int layout,
        have_ltdof_ldof &&
        mode == byNeighbor)
    {
+      auto BeginOp = reinterpret_cast<void(*)(OpData<T>)>(reduce_op);
+      MFEM_VERIFY(BeginOp == nullptr || BeginOp == Op,
+                  "the reduction operations given to ReduceBegin() and "
+                  "ReduceEnd() do not match!");
       DeviceGroupCommunicator::Op device_op{};
-      auto op_is_supported_device_op = [&]() -> bool
+      const bool op_is_supported_device_op =
+         OpIsSupportedDeviceOp(Op, device_op);
+      // The primal definition of 'reduce_began_on_device' is:
+      //    (BeginOp == nullptr) || OpIsSupportedDeviceOp(BeginOp, device_op)
+      // However, due to the above MFEM_VERIFY, this is equivalent to the
+      // expression used below.
+      const bool reduce_began_on_device =
+         (BeginOp == nullptr) || op_is_supported_device_op;
+      if (reduce_began_on_device)
       {
-         // Materialize typed function pointers before comparison so stricter
-         // GPU toolchains do not have to resolve overloaded template names
-         // here.
-         using OpFunc = void (*)(OpData<T>);
-         const OpFunc sum_op = &GroupCommunicator::template Sum<T>;
-         const OpFunc min_op = &GroupCommunicator::template Min<T>;
-         const OpFunc max_op = &GroupCommunicator::template Max<T>;
-         if (Op == sum_op)
-         {
-            device_op = DeviceGroupCommunicator::Op::Sum;
-         }
-         else if (Op == min_op)
-         {
-            device_op = DeviceGroupCommunicator::Op::Min;
-         }
-         else if (Op == max_op)
-         {
-            device_op = DeviceGroupCommunicator::Op::Max;
-         }
-         else
-         {
-            return false; // Op is not supported on device
-         }
-         return true; // Op is supported on device
-      };
-      if (op_is_supported_device_op())
-      {
+         MFEM_VERIFY(op_is_supported_device_op,
+                     "the reduce operation 'Op' is not supported on device!"
+                     "\n\tTo resolve this error, provide 'Op' to ReduceBegin() "
+                     "in the second argument.");
          if (layout == 0)  // output is ldofs array
          {
             GetDeviceComm().ReduceEndLDofs(ldata, device_op);
@@ -2183,7 +2216,8 @@ template void GroupCommunicator::BcastBegin<int>(Array<int> &, int) const;
 template void GroupCommunicator::BcastEnd<int>(int *, int) const;
 template void GroupCommunicator::BcastEnd<int>(Array<int> &, int) const;
 template void GroupCommunicator::ReduceBegin<int>(const int *) const;
-template void GroupCommunicator::ReduceBegin<int>(const Array<int> &) const;
+template void GroupCommunicator::ReduceBegin<int>(
+   const Array<int> &, void (*)(OpData<int>)) const;
 template void GroupCommunicator::ReduceEnd<int>(
    int *, int, void (*)(OpData<int>)) const;
 template void GroupCommunicator::ReduceEnd<int>(
@@ -2197,7 +2231,7 @@ template void GroupCommunicator::BcastEnd<double>(double *, int) const;
 template void GroupCommunicator::BcastEnd<double>(Array<double> &, int) const;
 template void GroupCommunicator::ReduceBegin<double>(const double *) const;
 template void GroupCommunicator::ReduceBegin<double>(
-   const Array<double> &) const;
+   const Array<double> &, void (*)(OpData<double>)) const;
 template void GroupCommunicator::ReduceEnd<double>(
    double *, int, void (*)(OpData<double>)) const;
 template void GroupCommunicator::ReduceEnd<double>(
@@ -2210,7 +2244,8 @@ template void GroupCommunicator::BcastBegin<float>(Array<float> &, int) const;
 template void GroupCommunicator::BcastEnd<float>(float *, int) const;
 template void GroupCommunicator::BcastEnd<float>(Array<float> &, int) const;
 template void GroupCommunicator::ReduceBegin<float>(const float *) const;
-template void GroupCommunicator::ReduceBegin<float>(const Array<float> &) const;
+template void GroupCommunicator::ReduceBegin<float>(
+   const Array<float> &, void (*)(OpData<float>)) const;
 template void GroupCommunicator::ReduceEnd<float>(
    float *, int, void (*)(OpData<float>)) const;
 template void GroupCommunicator::ReduceEnd<float>(

--- a/general/communication.cpp
+++ b/general/communication.cpp
@@ -1973,92 +1973,92 @@ DeviceGroupCommunicator::DeviceGroupCommunicator(const GroupCommunicator &gc_)
 
 namespace
 {
-// MakeTypedBufferView needs to access the protected buffer_max_type
+// TypedBufferView needs to access the protected buffer_max_type
 struct BufferMaxTypeGetter : public DeviceGroupCommunicator
 {
    using buffer_max_type = DeviceGroupCommunicator::buffer_max_type;
 };
-} // namespace
 
-template <typename T, typename BT>
-static inline Array<T> MakeTypedBufferView(Array<BT> &storage)
+template <class T, class BT> struct TypedBufferView
 {
-   using buffer_max_type = BufferMaxTypeGetter::buffer_max_type;
-   static_assert(sizeof(T) <= sizeof(buffer_max_type));
-   Array<T> res;
-   res.MakeRef(storage.GetMemory(), 0,
-               storage.Size() / sizeof(buffer_max_type));
-   return res;
-}
+   Array<BT> &storage;
+   Array<T> view;
+   TypedBufferView(Array<BT> &storage_) : storage(storage)
+   {
+      using buffer_max_type = BufferMaxTypeGetter::buffer_max_type;
+      static_assert(sizeof(T) <= sizeof(buffer_max_type));
+      view.MakeRef(storage.GetMemory(), 0,
+                   storage.Size() / sizeof(buffer_max_type));
+   }
+
+   ~TypedBufferView()
+   {
+      // Use Sync instead of SyncAlias so storage copies the validity flags from
+      // view
+      storage.GetMemory().Sync(view.GetMemory());
+   }
+};
+} // namespace
 
 template <typename T>
 void DeviceGroupCommunicator::BcastBeginTDofs(Array<T> &x_tdof) const
 {
-   Array<T> shr_buf_t = MakeTypedBufferView<T>(shr_buf);
-   Array<T> ext_buf_t = MakeTypedBufferView<T>(ext_buf);
-   BcastBeginCopyTDofs(x_tdof, shr_buf_t);
-   ExchangeSharedToExternal(shr_buf_t, ext_buf_t);
-   ext_buf.GetMemory().Sync(ext_buf_t.GetMemory());
-   shr_buf.GetMemory().Sync(shr_buf_t.GetMemory());
+   TypedBufferView<T, char> shr_buf_t(shr_buf);
+   TypedBufferView<T, char> ext_buf_t(ext_buf);
+   BcastBeginCopyTDofs(x_tdof, shr_buf_t.view);
+   ExchangeSharedToExternal(shr_buf_t.view, ext_buf_t.view);
 }
 
 template <typename T>
 void DeviceGroupCommunicator::BcastBeginLDofs(Array<T> &x_ldof) const
 {
-   Array<T> shr_buf_t = MakeTypedBufferView<T>(shr_buf);
-   Array<T> ext_buf_t = MakeTypedBufferView<T>(ext_buf);
-   BcastBeginCopyLDofs(x_ldof, shr_buf_t);
-   ExchangeSharedToExternal(shr_buf_t, ext_buf_t);
-   ext_buf.GetMemory().Sync(ext_buf_t.GetMemory());
-   shr_buf.GetMemory().Sync(shr_buf_t.GetMemory());
+   TypedBufferView<T, char> shr_buf_t(shr_buf);
+   TypedBufferView<T, char> ext_buf_t(ext_buf);
+   BcastBeginCopyLDofs(x_ldof, shr_buf_t.view);
+   ExchangeSharedToExternal(shr_buf_t.view, ext_buf_t.view);
 }
 
 template <typename T>
 void DeviceGroupCommunicator::BcastEndLDofs(Array<T> &x_ldof) const
 {
-   Array<T> ext_buf_t = MakeTypedBufferView<T>(ext_buf);
+   TypedBufferView<T, char> ext_buf_t(ext_buf);
    WaitAll();
-   BcastEndCopy(ext_buf_t, x_ldof);
-   ext_buf.GetMemory().Sync(ext_buf_t.GetMemory());
+   BcastEndCopy(ext_buf_t.view, x_ldof);
 }
 
 template <typename T>
 void DeviceGroupCommunicator::ReduceBeginLDofs(const Array<T> &x_ldof) const
 {
-   Array<T> ext_buf_t = MakeTypedBufferView<T>(ext_buf);
-   Array<T> shr_buf_t = MakeTypedBufferView<T>(shr_buf);
-   ReduceBeginCopy(x_ldof, ext_buf_t);
-   ExchangeExternalToShared(ext_buf_t, shr_buf_t);
-   ext_buf.GetMemory().Sync(ext_buf_t.GetMemory());
-   shr_buf.GetMemory().Sync(shr_buf_t.GetMemory());
+   TypedBufferView<T, char> shr_buf_t(shr_buf);
+   TypedBufferView<T, char> ext_buf_t(ext_buf);
+   ReduceBeginCopy(x_ldof, ext_buf_t.view);
+   ExchangeExternalToShared(ext_buf_t.view, shr_buf_t.view);
 }
 
 template <typename T>
 void DeviceGroupCommunicator::ReduceEndTDofs(Array<T> &x_tdof, Op op) const
 {
-   Array<T> shr_buf_t = MakeTypedBufferView<T>(shr_buf);
+   TypedBufferView<T, char> shr_buf_t(shr_buf);
    WaitAll();
-   ReduceEndAssembleTDofs(shr_buf_t, x_tdof, op);
-   shr_buf.GetMemory().Sync(shr_buf_t.GetMemory());
+   ReduceEndAssembleTDofs(shr_buf_t.view, x_tdof, op);
 }
 
 template <typename T>
 void DeviceGroupCommunicator::ReduceEndLDofs(Array<T> &x_ldof, Op op) const
 {
-   Array<T> shr_buf_t = MakeTypedBufferView<T>(shr_buf);
+   TypedBufferView<T, char> shr_buf_t(shr_buf);
    WaitAll();
    if (unq_ldof.Size() == 0) { return; }
    if (op == Op::Sum)
    {
       internal::BooleanAddMult(unq_ldof, unq_shr_i, unq_shr_j,
-                               shr_buf_t, x_ldof);
+                               shr_buf_t.view, x_ldof);
    }
    else
    {
       internal::BooleanReduceApply(unq_ldof, unq_shr_i, unq_shr_j,
-                                   shr_buf_t, x_ldof, op);
+                                   shr_buf_t.view, x_ldof, op);
    }
-   shr_buf.GetMemory().Sync(shr_buf_t.GetMemory());
 }
 
 template <typename T>
@@ -2075,15 +2075,13 @@ void DeviceGroupCommunicator::Prolongate(const Array<T> &x_tdof,
 {
    MFEM_ASSERT(x_tdof.Size() == gc.ltdof_ldof.Size(), "incompatible sizes!");
    MFEM_ASSERT(x_ldof.Size() == gc.ldof_size, "incompatible sizes!");
-   Array<T> ext_buf_t = MakeTypedBufferView<T>(ext_buf);
-   Array<T> shr_buf_t = MakeTypedBufferView<T>(shr_buf);
-   BcastBeginCopyTDofs(x_tdof, shr_buf_t);
-   ExchangeSharedToExternal(shr_buf_t, ext_buf_t);
+   TypedBufferView<T, char> shr_buf_t(shr_buf);
+   TypedBufferView<T, char> ext_buf_t(ext_buf);
+   BcastBeginCopyTDofs(x_tdof, shr_buf_t.view);
+   ExchangeSharedToExternal(shr_buf_t.view, ext_buf_t.view);
    CopyTDofsToLDofs(x_tdof, x_ldof);
    WaitAll();
-   BcastEndCopy(ext_buf_t, x_ldof);
-   ext_buf.GetMemory().Sync(ext_buf_t.GetMemory());
-   shr_buf.GetMemory().Sync(shr_buf_t.GetMemory());
+   BcastEndCopy(ext_buf_t.view, x_ldof);
 }
 
 template <typename T>
@@ -2093,15 +2091,13 @@ void DeviceGroupCommunicator::ProlongateTranspose(const Array<T> &x_ldof,
 {
    MFEM_ASSERT(x_ldof.Size() == gc.ldof_size, "incompatible sizes!");
    MFEM_ASSERT(x_tdof.Size() == gc.ltdof_ldof.Size(), "incompatible sizes!");
-   Array<T> ext_buf_t = MakeTypedBufferView<T>(ext_buf);
-   Array<T> shr_buf_t = MakeTypedBufferView<T>(shr_buf);
-   ReduceBeginCopy(x_ldof, ext_buf_t);
-   ExchangeExternalToShared(ext_buf_t, shr_buf_t);
+   TypedBufferView<T, char> shr_buf_t(shr_buf);
+   TypedBufferView<T, char> ext_buf_t(ext_buf);
+   ReduceBeginCopy(x_ldof, ext_buf_t.view);
+   ExchangeExternalToShared(ext_buf_t.view, shr_buf_t.view);
    Restrict(x_ldof, x_tdof);
    WaitAll();
-   ReduceEndAssembleTDofs(shr_buf_t, x_tdof, op);
-   ext_buf.GetMemory().Sync(ext_buf_t.GetMemory());
-   shr_buf.GetMemory().Sync(shr_buf_t.GetMemory());
+   ReduceEndAssembleTDofs(shr_buf_t.view, x_tdof, op);
 }
 
 template <typename T>

--- a/general/communication.cpp
+++ b/general/communication.cpp
@@ -34,6 +34,7 @@
 
 #include <iostream>
 #include <map>
+#include <utility> // std::as_const
 
 using namespace std;
 
@@ -2243,6 +2244,17 @@ template void GroupCommunicator::MaxAbs<float>(OpData<float>);
 
 /// @cond DOXYGEN_SKIP
 
+template void DeviceGroupCommunicator::BcastBeginTDofs<int>(Array<int> &) const;
+template void DeviceGroupCommunicator::BcastBeginLDofs<int>(Array<int> &) const;
+template void DeviceGroupCommunicator::BcastEndLDofs<int>(Array<int> &) const;
+template void DeviceGroupCommunicator::ReduceBeginLDofs<int>(
+   const Array<int> &) const;
+template void DeviceGroupCommunicator::ReduceEndTDofs<int>(
+   Array<int> &, Op) const;
+template void DeviceGroupCommunicator::ReduceEndLDofs<int>(
+   Array<int> &, Op) const;
+template void DeviceGroupCommunicator::CopyTDofsToLDofs<int>(
+   const Array<int> &, Array<int> &) const;
 template void DeviceGroupCommunicator::Prolongate<int>(
    const Array<int> &, Array<int> &) const;
 template void DeviceGroupCommunicator::ProlongateTranspose<int>(
@@ -2252,6 +2264,20 @@ template void DeviceGroupCommunicator::Restrict<int>(
 template void DeviceGroupCommunicator::RestrictTranspose<int>(
    const Array<int> &, Array<int> &) const;
 
+template void DeviceGroupCommunicator::BcastBeginTDofs<real_t>(
+   Array<real_t> &) const;
+template void DeviceGroupCommunicator::BcastBeginLDofs<real_t>(
+   Array<real_t> &) const;
+template void DeviceGroupCommunicator::BcastEndLDofs<real_t>(
+   Array<real_t> &) const;
+template void DeviceGroupCommunicator::ReduceBeginLDofs<real_t>(
+   const Array<real_t> &) const;
+template void DeviceGroupCommunicator::ReduceEndTDofs<real_t>(
+   Array<real_t> &, Op) const;
+template void DeviceGroupCommunicator::ReduceEndLDofs<real_t>(
+   Array<real_t> &, Op) const;
+template void DeviceGroupCommunicator::CopyTDofsToLDofs<real_t>(
+   const Array<real_t> &, Array<real_t> &) const;
 template void DeviceGroupCommunicator::Prolongate<real_t>(
    const Array<real_t> &, Array<real_t> &) const;
 template void DeviceGroupCommunicator::ProlongateTranspose<real_t>(

--- a/general/communication.cpp
+++ b/general/communication.cpp
@@ -1950,8 +1950,8 @@ DeviceGroupCommunicator::DeviceGroupCommunicator(const GroupCommunicator &gc_)
       nbr_ldof.LoseData();
    }
 
-   shr_buf.SetSize(shr_ltdof.Size() * sizeof(buffer_max_type));
-   ext_buf.SetSize(ext_ldof.Size() * sizeof(buffer_max_type));
+   shr_buf.SetSize(shr_ltdof.Size());
+   ext_buf.SetSize(ext_ldof.Size());
    shr_buf.Write();
    ext_buf.Write();
 
@@ -1971,40 +1971,11 @@ DeviceGroupCommunicator::DeviceGroupCommunicator(const GroupCommunicator &gc_)
    num_requests = 0;
 }
 
-namespace
-{
-// TypedBufferView needs to access the protected buffer_max_type
-struct BufferMaxTypeGetter : public DeviceGroupCommunicator
-{
-   using buffer_max_type = DeviceGroupCommunicator::buffer_max_type;
-};
-
-template <class T, class BT> struct TypedBufferView
-{
-   Array<BT> &storage;
-   Array<T> view;
-   TypedBufferView(Array<BT> &storage_) : storage(storage_)
-   {
-      using buffer_max_type = BufferMaxTypeGetter::buffer_max_type;
-      static_assert(sizeof(T) <= sizeof(buffer_max_type));
-      view.MakeRef(storage.GetMemory(), 0,
-                   storage.Size() / sizeof(buffer_max_type));
-   }
-
-   ~TypedBufferView()
-   {
-      // Use Sync instead of SyncAlias so storage copies the validity flags from
-      // view
-      storage.GetMemory().Sync(view.GetMemory());
-   }
-};
-} // namespace
-
 template <typename T>
 void DeviceGroupCommunicator::BcastBeginTDofs(Array<T> &x_tdof) const
 {
-   TypedBufferView<T, char> shr_buf_t(shr_buf);
-   TypedBufferView<T, char> ext_buf_t(ext_buf);
+   TypedBufferView<T> shr_buf_t(shr_buf);
+   TypedBufferView<T> ext_buf_t(ext_buf);
    BcastBeginCopyTDofs(x_tdof, shr_buf_t.view);
    ExchangeSharedToExternal(shr_buf_t.view, ext_buf_t.view);
 }
@@ -2012,8 +1983,8 @@ void DeviceGroupCommunicator::BcastBeginTDofs(Array<T> &x_tdof) const
 template <typename T>
 void DeviceGroupCommunicator::BcastBeginLDofs(Array<T> &x_ldof) const
 {
-   TypedBufferView<T, char> shr_buf_t(shr_buf);
-   TypedBufferView<T, char> ext_buf_t(ext_buf);
+   TypedBufferView<T> shr_buf_t(shr_buf);
+   TypedBufferView<T> ext_buf_t(ext_buf);
    BcastBeginCopyLDofs(x_ldof, shr_buf_t.view);
    ExchangeSharedToExternal(shr_buf_t.view, ext_buf_t.view);
 }
@@ -2021,7 +1992,7 @@ void DeviceGroupCommunicator::BcastBeginLDofs(Array<T> &x_ldof) const
 template <typename T>
 void DeviceGroupCommunicator::BcastEndLDofs(Array<T> &x_ldof) const
 {
-   TypedBufferView<T, char> ext_buf_t(ext_buf);
+   TypedBufferView<T> ext_buf_t(ext_buf);
    WaitAll();
    BcastEndCopy(ext_buf_t.view, x_ldof);
 }
@@ -2029,8 +2000,8 @@ void DeviceGroupCommunicator::BcastEndLDofs(Array<T> &x_ldof) const
 template <typename T>
 void DeviceGroupCommunicator::ReduceBeginLDofs(const Array<T> &x_ldof) const
 {
-   TypedBufferView<T, char> shr_buf_t(shr_buf);
-   TypedBufferView<T, char> ext_buf_t(ext_buf);
+   TypedBufferView<T> shr_buf_t(shr_buf);
+   TypedBufferView<T> ext_buf_t(ext_buf);
    ReduceBeginCopy(x_ldof, ext_buf_t.view);
    ExchangeExternalToShared(ext_buf_t.view, shr_buf_t.view);
 }
@@ -2038,7 +2009,7 @@ void DeviceGroupCommunicator::ReduceBeginLDofs(const Array<T> &x_ldof) const
 template <typename T>
 void DeviceGroupCommunicator::ReduceEndTDofs(Array<T> &x_tdof, Op op) const
 {
-   TypedBufferView<T, char> shr_buf_t(shr_buf);
+   TypedBufferView<T> shr_buf_t(shr_buf);
    WaitAll();
    ReduceEndAssembleTDofs(shr_buf_t.view, x_tdof, op);
 }
@@ -2046,7 +2017,7 @@ void DeviceGroupCommunicator::ReduceEndTDofs(Array<T> &x_tdof, Op op) const
 template <typename T>
 void DeviceGroupCommunicator::ReduceEndLDofs(Array<T> &x_ldof, Op op) const
 {
-   TypedBufferView<T, char> shr_buf_t(shr_buf);
+   TypedBufferView<T> shr_buf_t(shr_buf);
    WaitAll();
    if (unq_ldof.Size() == 0) { return; }
    if (op == Op::Sum)
@@ -2075,8 +2046,8 @@ void DeviceGroupCommunicator::Prolongate(const Array<T> &x_tdof,
 {
    MFEM_ASSERT(x_tdof.Size() == gc.ltdof_ldof.Size(), "incompatible sizes!");
    MFEM_ASSERT(x_ldof.Size() == gc.ldof_size, "incompatible sizes!");
-   TypedBufferView<T, char> shr_buf_t(shr_buf);
-   TypedBufferView<T, char> ext_buf_t(ext_buf);
+   TypedBufferView<T> shr_buf_t(shr_buf);
+   TypedBufferView<T> ext_buf_t(ext_buf);
    BcastBeginCopyTDofs(x_tdof, shr_buf_t.view);
    ExchangeSharedToExternal(shr_buf_t.view, ext_buf_t.view);
    CopyTDofsToLDofs(x_tdof, x_ldof);
@@ -2091,8 +2062,8 @@ void DeviceGroupCommunicator::ProlongateTranspose(const Array<T> &x_ldof,
 {
    MFEM_ASSERT(x_ldof.Size() == gc.ldof_size, "incompatible sizes!");
    MFEM_ASSERT(x_tdof.Size() == gc.ltdof_ldof.Size(), "incompatible sizes!");
-   TypedBufferView<T, char> shr_buf_t(shr_buf);
-   TypedBufferView<T, char> ext_buf_t(ext_buf);
+   TypedBufferView<T> shr_buf_t(shr_buf);
+   TypedBufferView<T> ext_buf_t(ext_buf);
    ReduceBeginCopy(x_ldof, ext_buf_t.view);
    ExchangeExternalToShared(ext_buf_t.view, shr_buf_t.view);
    Restrict(x_ldof, x_tdof);

--- a/general/communication.hpp
+++ b/general/communication.hpp
@@ -377,7 +377,7 @@ public:
        BcastBegin().
 
        @param[out] ldata  Output L-vector data. It must be a host pointer.
-       @param[in] layout  Ouput data layout; one of:
+       @param[in] layout  Output data layout; one of:
                           - 0: @a ldata is an array on all ldofs; the input
                                layout should be either 0 or 2,
                           - 1: @a ldata is the same array as given to
@@ -393,7 +393,7 @@ public:
        BcastBegin().
 
        @param[out] ldata  Output L-vector data.
-       @param[in] layout  Ouput data layout; one of:
+       @param[in] layout  Output data layout; one of:
                           - 0: @a ldata is an array on all ldofs; the input
                                layout should be either 0 or 2,
                           - 1: @a ldata is the same array as given to
@@ -598,7 +598,7 @@ public:
    void BcastBeginTDofs(Array<T> &x_tdof) const;
 
    template <typename T>
-   void BcastBeginLDofs(Array<T> &x_tdof) const;
+   void BcastBeginLDofs(Array<T> &x_ldof) const;
 
    template <typename T>
    void BcastEndLDofs(Array<T> &x_ldof) const;
@@ -652,7 +652,7 @@ protected:
    void ReduceBeginCopy(const Array<T> &x_ldof, Array<T> &ext_buf_t) const;
 
    // Kernel: assemble dofs from 'shr_buf_t' into to 'x_tdof' - after recv.
-   //         x_tdof[shr_ltdof[i]] Op= shr_buf_i[i]
+   //         x_tdof[shr_ltdof[i]] Op= shr_buf_t[i]
    template <typename T>
    void ReduceEndAssembleTDofs(const Array<T> &shr_buf_t,
                                Array<T> &x_tdof, Op op) const;

--- a/general/communication.hpp
+++ b/general/communication.hpp
@@ -693,9 +693,26 @@ protected:
    Array<int> unq_ltdof, unq_ldof;
    Array<int> unq_shr_i, unq_shr_j;
    using buffer_max_type = int64_t;
-   mutable Array<char> shr_buf, ext_buf;
+   mutable Array<buffer_max_type> shr_buf, ext_buf;
    mutable Array<MPI_Request> requests;
    mutable int num_requests;
+
+   template <class T> struct TypedBufferView
+   {
+      Array<buffer_max_type> &storage;
+      Array<T> view;
+      TypedBufferView(Array<buffer_max_type> &storage_) : storage(storage_)
+      {
+         view.GetMemory().CopyConvertPtr(storage.GetMemory());
+         view.SetSize(storage.Size());
+      }
+
+      ~TypedBufferView()
+      {
+         storage.GetMemory().CopyConvertPtr(view.GetMemory());
+         view.LoseData();
+      }
+   };
 };
 
 

--- a/general/communication.hpp
+++ b/general/communication.hpp
@@ -693,7 +693,7 @@ protected:
    Array<int> unq_ltdof, unq_ldof;
    Array<int> unq_shr_i, unq_shr_j;
    using buffer_max_type = int64_t;
-   mutable Array<buffer_max_type> shr_buf, ext_buf;
+   mutable Array<char> shr_buf, ext_buf;
    mutable Array<MPI_Request> requests;
    mutable int num_requests;
 };

--- a/general/communication.hpp
+++ b/general/communication.hpp
@@ -35,13 +35,6 @@
 namespace mfem
 {
 
-class DeviceSharedDofCommunicator;
-
-namespace internal
-{
-class DeviceNeighborDofComm;
-}
-
 /** @brief A simple singleton class that calls MPI_Init() at construction and
     MPI_Finalize() at destruction. It also provides easy access to
     MPI_COMM_WORLD's rank and size. */
@@ -235,11 +228,16 @@ public:
    virtual ~GroupTopology() {}
 };
 
+
+// Forward declaration
+class DeviceGroupCommunicator;
+
+
 /** @brief Communicator performing operations within groups defined by a
     GroupTopology with arbitrary-size data associated with each group. */
 class GroupCommunicator
 {
-   friend class internal::DeviceNeighborDofComm;
+   friend class DeviceGroupCommunicator;
 
 public:
    /// Communication mode.
@@ -265,13 +263,10 @@ protected:
    int *request_marker;
    int *buf_offsets; // size = max(number of groups, number of neighbors)
    Table nbr_send_groups, nbr_recv_groups; // nbr 0 = me
+   bool have_ltdof_ldof;
    Array<int> ltdof_ldof;
    int ldof_size;
-   mutable DeviceSharedDofCommunicator *device_shared_dof_comm;
-   bool device_shared_dof_comm_enabled;
-   bool have_ltdof_ldof;
-
-   bool UseDeviceSharedDofComm(const void *ptr) const;
+   mutable DeviceGroupCommunicator *device_gc;
 
 public:
    /// Construct a GroupCommunicator object.
@@ -302,23 +297,18 @@ public:
        data layout 2, see CopyGroupToBuffer() for layout descriptions. */
    void SetLTDofTable(const Array<int> &ldof_ltdof);
 
-   /// Enable or disable the device shared-dof communicator path.
-   void SetDeviceSharedDofSupport(bool enable);
-
-   /// Return a cached device-friendly communicator for shared dof reductions.
-   const DeviceSharedDofCommunicator *GetDeviceSharedDofCommunicator() const;
-
-   /// Get a reference to the associated GroupTopology object
-   const GroupTopology &GetGroupTopology() { return gtopo; }
-
    /// Get a const reference to the associated GroupTopology object
    const GroupTopology &GetGroupTopology() const { return gtopo; }
 
-   /// Dofs to be sent to communication neighbors
+   /// Dofs to be sent (during Bcast) to communication neighbors
    void GetNeighborLTDofTable(Table &nbr_ltdof) const;
 
-   /// Dofs to be received from communication neighbors
+   /// Dofs to be received (during Bcast) from communication neighbors
    void GetNeighborLDofTable(Table &nbr_ldof) const;
+
+   /** @brief Return the device communicator, 'device_gc', constructing it if
+       it was not already constructed. */
+   const DeviceGroupCommunicator &GetDeviceComm() const;
 
    /** @brief Data structure on which we define reduce operations.
        The data is associated with (and the operation is performed on) one
@@ -360,49 +350,134 @@ public:
    const T *ReduceGroupFromBuffer(const T *buf, T *ldata, int group,
                                   int layout, void (*Op)(OpData<T>)) const;
 
-   /// Begin a broadcast within each group where the master is the root.
-   /** For a description of @a layout, see CopyGroupToBuffer(). */
+   /** @brief Begin a broadcast within each group where the master is the root,
+       host version.
+
+       @param[in,out] ldata  Input L-vector data; in some cases it is used as a
+                             receive buffer, so its type is not const. It must
+                             be a host pointer.
+       @param[in]    layout  For a description, see CopyGroupToBuffer().
+
+       This method performs the operation on host. */
    template <class T> void BcastBegin(T *ldata, int layout) const;
 
-   /** @brief Finalize a broadcast started with BcastBegin().
+   /** @brief Begin a broadcast within each group where the master is the root,
+       device version.
 
-       The output data @a layout can be:
-       - 0 - @a ldata is an array on all ldofs; the input layout should be
-             either 0 or 2
-       - 1 - @a ldata is the same array as given to BcastBegin(); the input
-             layout should be 1.
+       @param[in,out] ldata  Input L-vector data; in some cases it is used as a
+                             receive buffer, so its type is not const.
+       @param[in]    layout  For a description, see CopyGroupToBuffer().
 
-       For more details about @a layout, see CopyGroupToBuffer(). */
+       This method performs the operation on device. However, not all
+       communication modes and layouts are supported on device yet. In such
+       cases, the operation is performed on host. */
+   template <class T> void BcastBegin(Array<T> &ldata, int layout) const;
+
+   /** @brief Finalize a broadcast started with the host version of
+       BcastBegin().
+
+       @param[out] ldata  Output L-vector data. It must be a host pointer.
+       @param[in] layout  Ouput data layout; one of:
+                          - 0: @a ldata is an array on all ldofs; the input
+                               layout should be either 0 or 2,
+                          - 1: @a ldata is the same array as given to
+                               BcastBegin(); the input layout should be 1.
+                          .
+                          For a description of the layouts, see
+                          CopyGroupToBuffer().
+
+       This method performs the operation on host. */
    template <class T> void BcastEnd(T *ldata, int layout) const;
+
+   /** @brief Finalize a broadcast started with the device version of
+       BcastBegin().
+
+       @param[out] ldata  Output L-vector data.
+       @param[in] layout  Ouput data layout; one of:
+                          - 0: @a ldata is an array on all ldofs; the input
+                               layout should be either 0 or 2,
+                          - 1: @a ldata is the same array as given to
+                               BcastBegin(); the input layout should be 1.
+                          .
+                          For a description of the layouts, see
+                          CopyGroupToBuffer().
+
+       This method performs the operation on device. However, not all
+       communication modes and layouts are supported on device yet. In such
+       cases, the operation is performed on host. */
+   template <class T> void BcastEnd(Array<T> &ldata, int layout) const;
 
    /** @brief Broadcast within each group where the master is the root.
 
        The data @a layout can be either 0 or 1.
 
-       For a description of @a layout, see CopyGroupToBuffer(). */
-   template <class T> void Bcast(T *ldata, int layout) const;
+       For a description of @a layout, see CopyGroupToBuffer().
 
-   /// Broadcast within each group where the master is the root.
-   template <class T> void Bcast(T *ldata) const;
-   /// Broadcast within each group where the master is the root.
-   template <class T> void Bcast(Array<T> &ldata) const;
+       This method performs the operation on host and expects @a ldata to be a
+       host pointer. */
+   template <class T> void Bcast(T *ldata, int layout) const
+   {
+      BcastBegin(ldata, layout);
+      BcastEnd(ldata, layout);
+   }
+
+   /// Broadcast within each group where the master is the root, host version.
+   /** The implicit data layout is 0, i.e. the @a ldata array is an L-dof array.
+
+       This method performs the operation on host and expects @a ldata to be a
+       host pointer. */
+   template <class T> void Bcast(T *ldata) const { Bcast(ldata, 0); }
+
+   /// Broadcast within each group where the master is the root, device version.
+   /** The implicit data layout is 0, i.e. the @a ldata array is an L-dof array.
+
+       This method performs the operation on device. However, not all
+       communication modes are supported on device yet. In such cases, the
+       operation is performed on host. */
+   template <class T> void Bcast(Array<T> &ldata) const
+   {
+      BcastBegin(ldata, 0);
+      BcastEnd(ldata, 0);
+   }
 
    /** @brief Begin reduction operation within each group where the master is
-       the root. */
-   /** The input data layout is an array on all ldofs, i.e. layout 0, see
+       the root, host version.
+
+       The input data layout is an array on all ldofs, i.e. layout 0, see
        CopyGroupToBuffer().
 
        The reduce operation will be specified when calling ReduceEnd(). This
-       method is instantiated for int and double. */
+       method is instantiated for int, double, and float.
+
+       This method performs the operation on host and expects @a ldata to be a
+       host pointer. */
    template <class T> void ReduceBegin(const T *ldata) const;
 
-   /** @brief Finalize reduction operation started with ReduceBegin().
+   /** @brief Begin reduction operation within each group where the master is
+       the root, device version.
+
+       The input data layout is an array on all ldofs, i.e. layout 0, see
+       CopyGroupToBuffer().
+
+       The reduce operation will be specified when calling ReduceEnd(). This
+       method is instantiated for int, double, and float.
+
+       This method performs the operation on device. However, not all
+       communication modes are supported on device yet. In such cases, the
+       operation is performed on host. */
+   template <class T> void ReduceBegin(const Array<T> &ldata) const;
+
+   /** @brief Finalize reduction operation started with the host version of
+       ReduceBegin().
 
        The output data @a layout can be either 0 or 2, see CopyGroupToBuffer().
 
        The reduce operation is given by the third argument (see below for list
-       of the supported operations.) This method is instantiated for int and
-       double.
+       of the supported operations.) This method is instantiated for int,
+       double, and float.
+
+       This method performs the operation on host and expects @a ldata to be a
+       host pointer.
 
        @note If the output data layout is 2, then the data from the @a ldata
        array passed to this call is used in the reduction operation, instead of
@@ -412,14 +487,59 @@ public:
    template <class T> void ReduceEnd(T *ldata, int layout,
                                      void (*Op)(OpData<T>)) const;
 
-   /** @brief Reduce within each group where the master is the root.
+   /** @brief Finalize reduction operation started with the device version of
+       ReduceBegin().
+
+       The output data @a layout can be either 0 or 2, see CopyGroupToBuffer().
+
+       The reduce operation is given by the third argument (see below for list
+       of the supported operations.) This method is instantiated for int,
+       double, and float.
+
+       This method performs the operation on device. However, not all
+       communication modes and layouts are supported on device yet. In such
+       cases, the operation is performed on host.
+
+       @note If the output data layout is 2, then the data from the @a ldata
+       array passed to this call is used in the reduction operation, instead of
+       the data from the @a ldata array passed to ReduceBegin(). Therefore, the
+       data for master-groups has to be identical in both arrays.
+   */
+   template <class T> void ReduceEnd(Array<T> &ldata, int layout,
+                                     void (*Op)(OpData<T>)) const;
+
+   /** @brief Reduce within each group where the master is the root, host
+       version.
+
+       The implicit data layout is 0, i.e. the @a ldata array is an L-dof array.
 
        The reduce operation is given by the second argument (see below for list
-       of the supported operations.) */
-   template <class T> void Reduce(T *ldata, void (*Op)(OpData<T>)) const;
+       of the supported operations.)
 
-   /// Reduce within each group where the master is the root.
-   template <class T> void Reduce(Array<T> &ldata, void (*Op)(OpData<T>)) const;
+       This method performs the operation on host and expects @a ldata to be a
+       host pointer. */
+   template <class T> void Reduce(T *ldata, void (*Op)(OpData<T>)) const
+   {
+      ReduceBegin(ldata);
+      ReduceEnd(ldata, 0, Op);
+   }
+
+   /** @brief Reduce within each group where the master is the root, device
+       version.
+
+       The implicit data layout is 0, i.e. the @a ldata array is an L-dof array.
+
+       The reduce operation is given by the second argument (see below for list
+       of the supported operations.)
+
+       This method performs the operation on device. However, not all
+       communication modes are supported on device yet. In such cases, the
+       operation is performed on host. */
+   template <class T> void Reduce(Array<T> &ldata, void (*Op)(OpData<T>)) const
+   {
+      ReduceBegin(ldata);
+      ReduceEnd(ldata, 0, Op);
+   }
 
    /// Reduce operation Sum, instantiated for int, double and float
    template <class T> static void Sum(OpData<T>);
@@ -436,8 +556,8 @@ public:
    /// ties resolve to the positive one regardless of accumulation order.
    template <class T> static void MaxAbs(OpData<T>);
 
-   /** @brief Finalize reduction operation started with ReduceBegin(), but only apply
-       the reduction to DOFs marked in the marker array.
+   /** @brief Finalize reduction operation started with ReduceBegin(), but only
+       apply the reduction to DOFs marked in the marker array.
 
        @note The reduction is carried out in the signed type @a T, so the result
        is signed even for bitwise operations.
@@ -446,7 +566,8 @@ public:
    void ReduceMarked(T *ldata, const Array<int> &marker, int layout,
                      void (*Op)(OpData<T>)) const;
 
-   /** @brief Reduce within each group where the master is the root, but only for marked DOFs. */
+   /** @brief Reduce within each group where the master is the root, but only
+       for marked DOFs. */
    template <class T>
    void Reduce(T *ldata, const Array<int> &marker, void (*Op)(OpData<T>)) const
    {
@@ -462,109 +583,108 @@ public:
    ~GroupCommunicator();
 };
 
-namespace internal
-{
 
-class DeviceNeighborDofComm
-{
-public:
-   explicit DeviceNeighborDofComm(const GroupCommunicator &gc_);
-   ~DeviceNeighborDofComm();
-
-   bool MpiGpuAware() const { return mpi_gpu_aware; }
-
-   const Array<int> &SharedLTDof() const { return shr_ltdof; }
-   const Array<int> &ExternalLDof() const { return ext_ldof; }
-   const Array<int> &LocalTDofToLDof() const { return ltdof_ldof; }
-   const Array<int> &UniqueLTDof() const { return unq_ltdof; }
-   const Array<int> &UniqueSharedOffsets() const { return unq_shr_i; }
-   const Array<int> &UniqueSharedIndices() const { return unq_shr_j; }
-
-   template <typename T, typename SendBuffer, typename RecvBuffer>
-   int ExchangeSharedToExternal(const SendBuffer &shr_buf,
-                                RecvBuffer &ext_buf,
-                                int tag) const;
-
-   template <typename T, typename SendBuffer, typename RecvBuffer>
-   int ExchangeExternalToShared(const SendBuffer &ext_buf,
-                                RecvBuffer &shr_buf,
-                                int tag) const;
-
-   void WaitAll(int req_counter) const;
-
-private:
-   template <typename T, typename SendBuffer, typename RecvBuffer>
-   int Exchange(const SendBuffer &send_buf, const Memory<int> &send_offsets,
-                RecvBuffer &recv_buf, const Memory<int> &recv_offsets,
-                int tag) const;
-
-   const GroupCommunicator &gc;
-   bool mpi_gpu_aware;
-   Array<int> shr_ltdof, ext_ldof;
-   Memory<int> shr_buf_offsets, ext_buf_offsets;
-   Array<int> ltdof_ldof, unq_ltdof;
-   Array<int> unq_shr_i, unq_shr_j;
-   mutable Array<MPI_Request> requests;
-};
-
-template <typename InBuffer, typename OutBuffer>
-void DeviceNeighborDofExtract(const Array<int> &indices,
-                              const InBuffer &xin,
-                              OutBuffer &xout);
-
-template <typename InBuffer, typename OutBuffer>
-void DeviceNeighborDofSet(const Array<int> &indices,
-                          const InBuffer &xin,
-                          OutBuffer &xout);
-
-template <typename SrcBuffer, typename DstBuffer>
-void DeviceNeighborDofAdd(const Array<int> &unique_dst_indices,
-                          const Array<int> &unique_to_src_offsets,
-                          const Array<int> &unique_to_src_indices,
-                          const SrcBuffer &src,
-                          DstBuffer &dst);
-
-} // namespace internal
-
-class DeviceSharedDofCommunicator
+/// Auxiliary class used by class GroupCommunicator
+class DeviceGroupCommunicator
 {
 public:
+   friend class GroupCommunicator;
+
    enum class Op { Sum, Min, Max };
 
-   explicit DeviceSharedDofCommunicator(const GroupCommunicator &gc);
-   ~DeviceSharedDofCommunicator();
+   explicit DeviceGroupCommunicator(const GroupCommunicator &gc_);
 
    template <typename T>
-   void Reduce(Array<T> &x_ldof, Op op) const;
+   void BcastBeginTDofs(Array<T> &x_tdof) const;
 
    template <typename T>
-   void Bcast(Array<T> &x_ldof) const;
+   void BcastBeginLDofs(Array<T> &x_tdof) const;
 
-private:
-   mutable Array<real_t> shr_buf, ext_buf, true_buf;
-   internal::DeviceNeighborDofComm *nbr_comm;
+   template <typename T>
+   void BcastEndLDofs(Array<T> &x_ldof) const;
 
+   template <typename T>
+   void ReduceBeginLDofs(const Array<T> &x_ldof) const;
+
+   template <typename T>
+   void ReduceEndTDofs(Array<T> &x_tdof, Op op) const;
+
+   template <typename T>
+   void ReduceEndLDofs(Array<T> &x_ldof, Op op) const;
+
+   // Kernel: copy ltdofs from 'x_tdof' to ldofs in 'x_ldof'.
+   //         x_ldof[ltdof_ldof[i]] = x_tdof[i]
+   template <typename T>
+   void CopyTDofsToLDofs(const Array<T> &x_tdof, Array<T> &x_ldof) const;
+
+   template <typename T>
+   void Prolongate(const Array<T> &x_tdof, Array<T> &x_ldof) const;
+
+   template <typename T>
+   void ProlongateTranspose(const Array<T> &x_ldof,
+                            Array<T> &x_tdof, Op op = Op::Sum) const;
+
+   // Kernel: copy owned ldofs from 'x_ldof' to ltdofs in 'x_tdof'.
+   //         x_tdof[i] = x_ldof[ltdof_ldof[i]]
+   template <typename T>
+   void Restrict(const Array<T> &x_ldof, Array<T> &x_tdof) const;
+
+   template <typename T>
+   void RestrictTranspose(const Array<T> &x_tdof, Array<T> &x_ldof) const;
+
+protected:
+   template <typename T>
+   void Exchange(const Array<T> &send_buf, const Array<int> &send_offsets,
+                 Array<T> &recv_buf, const Array<int> &recv_offsets,
+                 int tag) const;
+
+   template <typename T>
+   void ExchangeSharedToExternal(const Array<T> &shr_buf,
+                                 Array<T> &ext_buf) const;
+
+   template <typename T>
+   void ExchangeExternalToShared(const Array<T> &ext_buf,
+                                 Array<T> &shr_buf) const;
+
+   // Kernel: copy ext. dofs from 'x_ldof' to 'ext_buf_t' - prepare for send.
+   //         ext_buf_t[i] = x_ldof[ext_ldof[i]]
    template <typename T>
    void ReduceBeginCopy(const Array<T> &x_ldof, Array<T> &ext_buf_t) const;
-   template <typename T>
-   void ReduceLocalCopy(const Array<T> &x_ldof, Array<T> &x_tdof) const;
-   template <typename T>
-   void ReduceEndAssemble(const Array<T> &shr_buf_t,
-                          Array<T> &x_tdof, Op op) const;
 
+   // Kernel: assemble dofs from 'shr_buf_t' into to 'x_tdof' - after recv.
+   //         x_tdof[shr_ltdof[i]] Op= shr_buf_i[i]
    template <typename T>
-   void BcastBeginCopy(const Array<T> &x_tdof, Array<T> &shr_buf_t) const;
+   void ReduceEndAssembleTDofs(const Array<T> &shr_buf_t,
+                               Array<T> &x_tdof, Op op) const;
+
+   // Kernel: copy ltdofs from 'x_tdof' to 'shr_buf_t' - prepare for send.
+   //         shr_buf_t[i] = x_tdof[shr_ltdof[i]]
    template <typename T>
-   void BcastLocalCopy(const Array<T> &x_tdof, Array<T> &x_ldof) const;
+   void BcastBeginCopyTDofs(const Array<T> &x_tdof, Array<T> &shr_buf_t) const;
+
+   // Kernel: copy ldofs from 'x_ldof' to 'shr_buf_t' - prepare for send.
+   //         shr_buf_t[i] = x_ldof[shr_ldof[i]]
+   template <typename T>
+   void BcastBeginCopyLDofs(const Array<T> &x_ldof, Array<T> &shr_buf_t) const;
+
+   // Kernel: copy ext. dofs from 'ext_buf_t' to 'x_ldof' - after recv.
+   //         x_ldof[ext_ldof[i]] = ext_buf_t[i]
    template <typename T>
    void BcastEndCopy(const Array<T> &ext_buf_t, Array<T> &x_ldof) const;
 
-   template <typename T>
-   void Reduce(const Array<T> &x_ldof, Array<T> &x_tdof, Op op) const;
+   void WaitAll() const;
 
-   template <typename T>
-   void Bcast(const Array<T> &x_tdof, Array<T> &x_ldof) const;
+   const GroupCommunicator &gc;
+   Array<int> shr_ltdof, shr_ldof, ext_ldof;
+   Array<int> shr_buf_offsets, ext_buf_offsets;
+   Array<int> unq_ltdof, unq_ldof;
+   Array<int> unq_shr_i, unq_shr_j;
+   using buffer_max_type = int64_t;
+   mutable Array<buffer_max_type> shr_buf, ext_buf;
+   mutable Array<MPI_Request> requests;
+   mutable int num_requests;
 };
+
 
 /// General MPI message tags used by MFEM
 enum MessageTag

--- a/general/communication.hpp
+++ b/general/communication.hpp
@@ -368,9 +368,10 @@ public:
                              receive buffer, so its type is not const.
        @param[in]    layout  For a description, see CopyGroupToBuffer().
 
-       This method performs the operation on device. However, not all
-       communication modes and layouts are supported on device yet. In such
-       cases, the operation is performed on host. */
+       This method performs the operation on device if the device flag of
+       @a ldata is set. However, not all communication modes and layouts are
+       supported on device yet. In such cases, the operation is performed on
+       host. */
    template <class T> void BcastBegin(Array<T> &ldata, int layout) const;
 
    /** @brief Finalize a broadcast started with the host version of
@@ -402,9 +403,10 @@ public:
                           For a description of the layouts, see
                           CopyGroupToBuffer().
 
-       This method performs the operation on device. However, not all
-       communication modes and layouts are supported on device yet. In such
-       cases, the operation is performed on host. */
+       This method performs the operation on device if the device flag of
+       @a ldata is set. However, not all communication modes and layouts are
+       supported on device yet. In such cases, the operation is performed on
+       host. */
    template <class T> void BcastEnd(Array<T> &ldata, int layout) const;
 
    /** @brief Broadcast within each group where the master is the root.
@@ -462,9 +464,9 @@ public:
        The reduce operation will be specified when calling ReduceEnd(). This
        method is instantiated for int, double, and float.
 
-       This method performs the operation on device. However, not all
-       communication modes are supported on device yet. In such cases, the
-       operation is performed on host. */
+       This method performs the operation on device if the device flag of
+       @a ldata is set. However, not all communication modes are supported on
+       device yet. In such cases, the operation is performed on host. */
    template <class T> void ReduceBegin(const Array<T> &ldata) const;
 
    /** @brief Finalize reduction operation started with the host version of
@@ -496,9 +498,10 @@ public:
        of the supported operations.) This method is instantiated for int,
        double, and float.
 
-       This method performs the operation on device. However, not all
-       communication modes and layouts are supported on device yet. In such
-       cases, the operation is performed on host.
+       This method performs the operation on device if the device flag of
+       @a ldata is set. However, not all communication modes and layouts are
+       supported on device yet. In such cases, the operation is performed on
+       host.
 
        @note If the output data layout is 2, then the data from the @a ldata
        array passed to this call is used in the reduction operation, instead of

--- a/general/communication.hpp
+++ b/general/communication.hpp
@@ -260,6 +260,7 @@ protected:
    // comm_lock: 0 - no lock, 1 - locked for Bcast, 2 - locked for Reduce
    mutable int comm_lock;
    mutable int num_requests;
+   mutable void (*reduce_op)(); // used when 'comm_lock' is 2
    int *request_marker;
    int *buf_offsets; // size = max(number of groups, number of neighbors)
    Table nbr_send_groups, nbr_recv_groups; // nbr 0 = me
@@ -406,7 +407,10 @@ public:
        This method performs the operation on device if the device flag of
        @a ldata is set. However, not all communication modes and layouts are
        supported on device yet. In such cases, the operation is performed on
-       host. */
+       host.
+
+       It is expected that the device flag of @a ldata is the same as the device
+       flag of the data array provided to BcastBegin(). */
    template <class T> void BcastEnd(Array<T> &ldata, int layout) const;
 
    /** @brief Broadcast within each group where the master is the root.
@@ -461,13 +465,16 @@ public:
        The input data layout is an array on all ldofs, i.e. layout 0, see
        CopyGroupToBuffer().
 
-       The reduce operation will be specified when calling ReduceEnd(). This
-       method is instantiated for int, double, and float.
+       Generally, the reduce operation will be specified when calling
+       ReduceEnd(), however, if the reduction operation is not supported on
+       device, it must be given to this call as the optional second argument
+       @a Op. This method is instantiated for int, double, and float.
 
        This method performs the operation on device if the device flag of
        @a ldata is set. However, not all communication modes are supported on
        device yet. In such cases, the operation is performed on host. */
-   template <class T> void ReduceBegin(const Array<T> &ldata) const;
+   template <class T> void ReduceBegin(const Array<T> &ldata,
+                                       void (*Op)(OpData<T>) = nullptr) const;
 
    /** @brief Finalize reduction operation started with the host version of
        ReduceBegin().
@@ -502,6 +509,9 @@ public:
        @a ldata is set. However, not all communication modes and layouts are
        supported on device yet. In such cases, the operation is performed on
        host.
+
+       It is expected that the device flag of @a ldata is the same as the device
+       flag of the data array provided to ReduceBegin().
 
        @note If the output data layout is 2, then the data from the @a ldata
        array passed to this call is used in the reduction operation, instead of

--- a/general/hash_util.hpp
+++ b/general/hash_util.hpp
@@ -18,6 +18,7 @@
 #include <functional>
 #include <utility>
 #include <cstdint>
+#include <type_traits>
 
 namespace mfem
 {

--- a/general/mem_manager.hpp
+++ b/general/mem_manager.hpp
@@ -227,7 +227,7 @@ public:
                 !std::is_same_v<std::decay_t<U>, std::decay_t<T>> &&
                 (std::is_same_v<std::decay_t<U>, char> ||
                  std::is_same_v<std::decay_t<U>, unsigned char> ||
-                 std::is_same_v<std::decay_t<U>, std::byte>)>>
+                 std::is_same_v<std::decay_t<U>, std::byte>)> >
    Memory(const Memory<U> &base)
    {
       MakeAlias(base, 0, 0);
@@ -236,7 +236,7 @@ public:
                 !std::is_same_v<std::decay_t<U>, std::decay_t<T>> &&
                 (std::is_same_v<std::decay_t<U>, char> ||
                  std::is_same_v<std::decay_t<U>, unsigned char> ||
-                 std::is_same_v<std::decay_t<U>, std::byte>)>>
+                 std::is_same_v<std::decay_t<U>, std::byte>)> >
    Memory(const Memory<U> &base, int offset, int size)
    {
       MakeAlias(base, offset, size);
@@ -443,7 +443,7 @@ public:
                 !std::is_same_v<std::decay_t<U>, std::decay_t<T>> &&
                 (std::is_same_v<std::decay_t<U>, char> ||
                  std::is_same_v<std::decay_t<U>, unsigned char> ||
-                 std::is_same_v<std::decay_t<U>, std::byte>)>>
+                 std::is_same_v<std::decay_t<U>, std::byte>)> >
    inline void MakeAlias(const Memory<U> &base, int offset, int size);
 
    /// Set the device MemoryType to be used by the Memory object.
@@ -551,24 +551,24 @@ public:
                 std::is_same_v<std::decay_t<U>, std::decay_t<T>> ||
                 std::is_same_v<std::decay_t<T>, char> ||
                 std::is_same_v<std::decay_t<T>, unsigned char> ||
-                std::is_same_v<std::decay_t<T>, std::byte>>>
-                inline void Sync(const Memory<U> &other) const;
+                std::is_same_v<std::decay_t<T>, std::byte> > >
+   inline void Sync(const Memory<U> &other) const;
 
-             /** @brief Update the alias Memory @a *this to match the memory location (all
-                 valid locations) of its base Memory, @a base. */
-             /** This method is useful when alias Memory is moved and manipulated in a
-                 different memory space. Such operations render the pointer validity flags
-                 of the base incorrect. Calling this method will ensure that @a base is
-                 up-to-date. Note that this is achieved by moving/copying @a *this (if
-                 necessary), and not @a base. */
-             inline void SyncAlias(const Memory &base, int alias_size) const;
+   /** @brief Update the alias Memory @a *this to match the memory location (all
+       valid locations) of its base Memory, @a base. */
+   /** This method is useful when alias Memory is moved and manipulated in a
+       different memory space. Such operations render the pointer validity flags
+       of the base incorrect. Calling this method will ensure that @a base is
+       up-to-date. Note that this is achieved by moving/copying @a *this (if
+       necessary), and not @a base. */
+   inline void SyncAlias(const Memory &base, int alias_size) const;
 
-             /** @brief Return a MemoryType that is currently valid. If both the host and
-                 the device pointers are currently valid, then the device memory type is
-                 returned. */
-             inline MemoryType GetMemoryType() const;
+   /** @brief Return a MemoryType that is currently valid. If both the host and
+       the device pointers are currently valid, then the device memory type is
+       returned. */
+   inline MemoryType GetMemoryType() const;
 
-             /// Return the host MemoryType of the Memory object.
+   /// Return the host MemoryType of the Memory object.
    inline MemoryType GetHostMemoryType() const { return h_mt; }
 
    /** @brief Return the device MemoryType of the Memory object. If the device
@@ -1163,14 +1163,14 @@ template <typename T>
 inline void Memory<T>::MakeAlias(const Memory &base, int offset, int size)
 {
    MFEM_ASSERT(0 <= offset, "invalid offset = " << offset);
-               MFEM_ASSERT(0 <= size, "invalid size = " << size);
-               MFEM_ASSERT(offset + size <= base.capacity,
-                           "invalid offset + size = " << offset + size
-                           << " > base capacity = " << base.capacity);
-               capacity = size;
-               h_mt = base.h_mt;
-               h_ptr = base.h_ptr + offset;
-               if (!(base.flags & Registered))
+   MFEM_ASSERT(0 <= size, "invalid size = " << size);
+   MFEM_ASSERT(offset + size <= base.capacity,
+               "invalid offset + size = " << offset + size
+               << " > base capacity = " << base.capacity);
+   capacity = size;
+   h_mt = base.h_mt;
+   h_ptr = base.h_ptr + offset;
+   if (!(base.flags & Registered))
    {
       if (
 #if !defined(HYPRE_USING_GPU)

--- a/general/mem_manager.hpp
+++ b/general/mem_manager.hpp
@@ -221,27 +221,6 @@ public:
       other.Reset();
    }
 
-   /// Makes an Alias from one of Memory<char>, Memory<unsigned char>, or
-   /// Memory<std::byte>
-   template <class U, class = std::enable_if_t<
-                !std::is_same_v<std::decay_t<U>, std::decay_t<T>> &&
-                (std::is_same_v<std::decay_t<U>, char> ||
-                 std::is_same_v<std::decay_t<U>, unsigned char> ||
-                 std::is_same_v<std::decay_t<U>, std::byte>)> >
-   Memory(const Memory<U> &base)
-   {
-      MakeAlias(base, 0, 0);
-   }
-   template <class U, class = std::enable_if_t<
-                !std::is_same_v<std::decay_t<U>, std::decay_t<T>> &&
-                (std::is_same_v<std::decay_t<U>, char> ||
-                 std::is_same_v<std::decay_t<U>, unsigned char> ||
-                 std::is_same_v<std::decay_t<U>, std::byte>)> >
-   Memory(const Memory<U> &base, int offset, int size)
-   {
-      MakeAlias(base, offset, size);
-   }
-
    /// Copy-assignment operator: default.
    Memory &operator=(const Memory &) = default;
 
@@ -538,10 +517,7 @@ public:
        that use the same host/device pointers, or when @a *this is an alias
        (sub-Memory) of @a other. Typically, this method should be called after
        @a other is manipulated in a way that changes its pointer validity flags
-       (e.g. it was moved from device to host memory).
-       @tparam U musst either be the same type as T, or T must be one of (char,
-      unsigned char, std::byte)
-   */
+       (e.g. it was moved from device to host memory). */
    inline void Sync(const Memory &other) const;
 
    /** @brief Update the alias Memory @a *this to match the memory location (all
@@ -1199,7 +1175,7 @@ template <typename T>
 template <class U>
 inline void Memory<T>::CopyConvertPtr(const Memory<U> &base)
 {
-   h_ptr = reinterpret_cast<T*>(base.h_ptr);
+   h_ptr = reinterpret_cast<T*>(base.h_ptr); // can also use (T*)base
    capacity = base.capacity;
    h_mt = base.h_mt;
    flags = base.flags;

--- a/general/mem_manager.hpp
+++ b/general/mem_manager.hpp
@@ -168,6 +168,7 @@ class Memory
 {
 protected:
    friend class MemoryManager;
+   template <class U> friend class Memory;
    friend void MemoryPrintFlags(unsigned flags);
    template <typename VT> friend class MemoryView;
 
@@ -218,6 +219,27 @@ public:
    {
       *this = other;
       other.Reset();
+   }
+
+   /// Makes an Alias from one of Memory<char>, Memory<unsigned char>, or
+   /// Memory<std::byte>
+   template <class U, class = std::enable_if_t<
+                !std::is_same_v<std::decay_t<U>, std::decay_t<T>> &&
+                (std::is_same_v<std::decay_t<U>, char> ||
+                 std::is_same_v<std::decay_t<U>, unsigned char> ||
+                 std::is_same_v<std::decay_t<U>, std::byte>)>>
+   Memory(const Memory<U> &base)
+   {
+      MakeAlias(base, 0, 0);
+   }
+   template <class U, class = std::enable_if_t<
+                !std::is_same_v<std::decay_t<U>, std::decay_t<T>> &&
+                (std::is_same_v<std::decay_t<U>, char> ||
+                 std::is_same_v<std::decay_t<U>, unsigned char> ||
+                 std::is_same_v<std::decay_t<U>, std::byte>)>>
+   Memory(const Memory<U> &base, int offset, int size)
+   {
+      MakeAlias(base, offset, size);
    }
 
    /// Copy-assignment operator: default.
@@ -414,6 +436,16 @@ public:
        @note The current memory is NOT deleted by this method. */
    inline void MakeAlias(const Memory &base, int offset, int size);
 
+   /// Make this an Alias of a Memory<char>, Memory<unsigned char>, or
+   /// Memory<std::byte>.
+   /// @a size and @a offset are in terms of type T, i.e. &(*this)[0] == &(base[0]) + offset*sizeof(T)
+   template <class U, class = std::enable_if_t<
+                !std::is_same_v<std::decay_t<U>, std::decay_t<T>> &&
+                (std::is_same_v<std::decay_t<U>, char> ||
+                 std::is_same_v<std::decay_t<U>, unsigned char> ||
+                 std::is_same_v<std::decay_t<U>, std::byte>)>>
+   inline void MakeAlias(const Memory<U> &base, int offset, int size);
+
    /// Set the device MemoryType to be used by the Memory object.
    /** If the specified @a d_mt is not a device MemoryType, i.e. not one of the
        types in MemoryClass::DEVICE, then this method will return immediately.
@@ -511,24 +543,32 @@ public:
        that use the same host/device pointers, or when @a *this is an alias
        (sub-Memory) of @a other. Typically, this method should be called after
        @a other is manipulated in a way that changes its pointer validity flags
-       (e.g. it was moved from device to host memory). */
-   inline void Sync(const Memory &other) const;
+       (e.g. it was moved from device to host memory).
+       @tparam U musst either be the same type as T, or T must be one of (char,
+      unsigned char, std::byte)
+   */
+   template <class U, class = std::enable_if_t<
+                std::is_same_v<std::decay_t<U>, std::decay_t<T>> ||
+                std::is_same_v<std::decay_t<T>, char> ||
+                std::is_same_v<std::decay_t<T>, unsigned char> ||
+                std::is_same_v<std::decay_t<T>, std::byte>>>
+                inline void Sync(const Memory<U> &other) const;
 
-   /** @brief Update the alias Memory @a *this to match the memory location (all
-       valid locations) of its base Memory, @a base. */
-   /** This method is useful when alias Memory is moved and manipulated in a
-       different memory space. Such operations render the pointer validity flags
-       of the base incorrect. Calling this method will ensure that @a base is
-       up-to-date. Note that this is achieved by moving/copying @a *this (if
-       necessary), and not @a base. */
-   inline void SyncAlias(const Memory &base, int alias_size) const;
+             /** @brief Update the alias Memory @a *this to match the memory location (all
+                 valid locations) of its base Memory, @a base. */
+             /** This method is useful when alias Memory is moved and manipulated in a
+                 different memory space. Such operations render the pointer validity flags
+                 of the base incorrect. Calling this method will ensure that @a base is
+                 up-to-date. Note that this is achieved by moving/copying @a *this (if
+                 necessary), and not @a base. */
+             inline void SyncAlias(const Memory &base, int alias_size) const;
 
-   /** @brief Return a MemoryType that is currently valid. If both the host and
-       the device pointers are currently valid, then the device memory type is
-       returned. */
-   inline MemoryType GetMemoryType() const;
+             /** @brief Return a MemoryType that is currently valid. If both the host and
+                 the device pointers are currently valid, then the device memory type is
+                 returned. */
+             inline MemoryType GetMemoryType() const;
 
-   /// Return the host MemoryType of the Memory object.
+             /// Return the host MemoryType of the Memory object.
    inline MemoryType GetHostMemoryType() const { return h_mt; }
 
    /** @brief Return the device MemoryType of the Memory object. If the device
@@ -1123,14 +1163,14 @@ template <typename T>
 inline void Memory<T>::MakeAlias(const Memory &base, int offset, int size)
 {
    MFEM_ASSERT(0 <= offset, "invalid offset = " << offset);
-   MFEM_ASSERT(0 <= size, "invalid size = " << size);
-   MFEM_ASSERT(offset + size <= base.capacity,
-               "invalid offset + size = " << offset + size
-               << " > base capacity = " << base.capacity);
-   capacity = size;
-   h_mt = base.h_mt;
-   h_ptr = base.h_ptr + offset;
-   if (!(base.flags & Registered))
+               MFEM_ASSERT(0 <= size, "invalid size = " << size);
+               MFEM_ASSERT(offset + size <= base.capacity,
+                           "invalid offset + size = " << offset + size
+                           << " > base capacity = " << base.capacity);
+               capacity = size;
+               h_mt = base.h_mt;
+               h_ptr = base.h_ptr + offset;
+               if (!(base.flags & Registered))
    {
       if (
 #if !defined(HYPRE_USING_GPU)
@@ -1149,6 +1189,55 @@ inline void Memory<T>::MakeAlias(const Memory &base, int offset, int size)
       {
          // Register 'base':
          MemoryManager::Register_(base.h_ptr, nullptr, base.capacity*sizeof(T),
+                                  base.h_mt, base.flags & OWNS_HOST,
+                                  base.flags & ALIAS, base.flags);
+      }
+      else
+      {
+         // Copy the flags from 'base', setting the ALIAS flag to true, and
+         // setting both OWNS_HOST and OWNS_DEVICE to false:
+         flags = (base.flags | ALIAS) & ~(OWNS_HOST | OWNS_DEVICE);
+         return;
+      }
+   }
+   const size_t s_bytes = size*sizeof(T);
+   const size_t o_bytes = offset*sizeof(T);
+   MemoryManager::Alias_(base.h_ptr, o_bytes, s_bytes, base.flags, flags);
+}
+
+template <typename T>
+template <class U, class>
+inline void Memory<T>::MakeAlias(const Memory<U> &base, int offset, int size)
+{
+   static_assert(sizeof(U) == 1);
+   MFEM_ASSERT(0 <= offset, "invalid offset = " << offset);
+   MFEM_ASSERT(0 <= size, "invalid size = " << size);
+   MFEM_ASSERT((offset + size) * sizeof(T) <= base.capacity,
+               "invalid offset + size = " << (offset + size) * sizeof(T)
+               << " > base capacity = "
+               << base.capacity);
+   capacity = size;
+   h_mt = base.h_mt;
+   h_ptr = reinterpret_cast<T*>(base.h_ptr) + offset;
+   if (!(base.flags & Registered))
+   {
+      if (
+#if !defined(HYPRE_USING_GPU)
+         // If the following condition is true then MemoryManager::Exists()
+         // should also be true:
+         IsDeviceMemory(MemoryManager::GetDeviceMemoryType())
+#elif MFEM_HYPRE_VERSION < 23100
+         // When HYPRE_USING_GPU is defined and HYPRE < 2.31.0, we always
+         // register the 'base' if the MemoryManager::Exists():
+         MemoryManager::Exists()
+#else // HYPRE_USING_GPU is defined and MFEM_HYPRE_VERSION >= 23100
+         IsDeviceMemory(MemoryManager::GetDeviceMemoryType()) ||
+         (MemoryManager::Exists() && HypreUsingGPU())
+#endif
+      )
+      {
+         // Register 'base':
+         MemoryManager::Register_(base.h_ptr, nullptr, base.capacity,
                                   base.h_mt, base.flags & OWNS_HOST,
                                   base.flags & ALIAS, base.flags);
       }
@@ -1295,11 +1384,12 @@ inline T *Memory<T>::Write(MemoryClass mc, int size)
 }
 
 template <typename T>
-inline void Memory<T>::Sync(const Memory &other) const
+template <class U, class>
+inline void Memory<T>::Sync(const Memory<U> &other) const
 {
    if (!(flags & Registered) && (other.flags & Registered))
    {
-      MFEM_ASSERT(h_ptr == other.h_ptr &&
+      MFEM_ASSERT(reinterpret_cast<T *>(h_ptr) == other.h_ptr &&
                   (flags & ALIAS) == (other.flags & ALIAS),
                   "invalid input");
       flags = (flags | Registered) & ~(OWNS_DEVICE | OWNS_INTERNAL);
@@ -1307,6 +1397,19 @@ inline void Memory<T>::Sync(const Memory &other) const
    flags = (flags & ~(VALID_HOST | VALID_DEVICE)) |
            (other.flags & (VALID_HOST | VALID_DEVICE));
 }
+
+// template <typename T>
+// inline void Memory<T>::SyncBuffer(const Memory<U> &other) const
+// {
+//    if (!(flags & Registered) && (other.flags & Registered))
+//    {
+//       MFEM_ASSERT((flags & ALIAS) == (other.flags & ALIAS),
+//                   "invalid input");
+//       flags = (flags | Registered) & ~(OWNS_DEVICE | OWNS_INTERNAL);
+//    }
+//    flags = (flags & ~(VALID_HOST | VALID_DEVICE)) |
+//            (other.flags & (VALID_HOST | VALID_DEVICE));
+// }
 
 template <typename T>
 inline void Memory<T>::SyncAlias(const Memory &base, int alias_size) const

--- a/general/mem_manager.hpp
+++ b/general/mem_manager.hpp
@@ -332,8 +332,7 @@ public:
    void Reset(MemoryType host_mt);
 
    /// Return true if the Memory object is empty, see Reset().
-   /** Default-constructed objects are uninitialized, so they are not guaranteed
-       to be empty. */
+   /** Default-constructed objects are guaranteed to be empty. */
    bool Empty() const { return h_ptr == NULL; }
 
    /** @brief Allocate host memory for @a size entries with the current host
@@ -523,6 +522,10 @@ public:
        necessary), and not @a base. */
    inline void SyncAlias(const Memory &base, int alias_size) const;
 
+   /** @brief Copy all flags from @a other to *this. */
+   /** @warning Use this method with caution! */
+   inline void CopyFlagsFrom(const Memory &other) const { flags = other.flags; }
+
    /** @brief Return a MemoryType that is currently valid. If both the host and
        the device pointers are currently valid, then the device memory type is
        returned. */
@@ -606,6 +609,70 @@ private:
    {
       return Alloc<new_align_bytes>::New(size);
    }
+};
+
+
+/** @brief Type that enables viewing Vector objects as Array<real_t> objects and
+    vice versa. For example, see Vector::GetArrayView(). */
+template <typename ViewedType>
+class MemoryView
+{
+protected:
+   static constexpr bool is_const_view = std::is_const_v<ViewedType>;
+   using T =
+      std::remove_reference_t<decltype((std::remove_cv_t<ViewedType> {})[0])>;
+   using MemoryType =
+      std::conditional_t<is_const_view, const Memory<T>, Memory<T>>;
+   using SizeType =
+      std::conditional_t<is_const_view, const int, int>;
+
+   std::remove_cv_t<ViewedType> view;
+   MemoryType &base_mem;
+   SizeType &base_size;  // if is_const_view, this is initialized by not used
+
+public:
+   inline MemoryView(MemoryType &mem, SizeType &size)
+      : base_mem(mem), base_size(size)
+   {
+      // keep for debugging
+      // mfem::out << _MFEM_FUNC_NAME << std::endl;
+      view.data = mem;
+      view.size = size;
+   }
+
+   MemoryView(const MemoryView &) = delete;
+   MemoryView(MemoryView &&) = delete;
+   MemoryView &operator=(const MemoryView &) = delete;
+   MemoryView &operator=(MemoryView &&) = delete;
+
+   inline ~MemoryView()
+   {
+      // keep for debugging
+      // mfem::out << _MFEM_FUNC_NAME << std::endl;
+      if constexpr (!is_const_view)
+      {
+         base_mem = view.data;
+         base_size = view.size;
+      }
+      else
+      {
+         base_mem.CopyFlagsFrom(view.data);
+      }
+      view.data.Reset();
+   }
+
+   /** @brief Implicit conversion function to `ViewedType &`.
+
+       Implicit conversion may not work automatically when the returned type is
+       used for template parameter deduction. In such cases, use the prefix
+       operator*() to explicitly perform the conversion to `ViewedType &`. */
+   inline operator ViewedType &() { return view; }
+
+   /** @brief Return the view object by reference, `ViewedType &`.
+
+       This is an explicit way to return the view object, alternative to the
+       implicit conversion function to `ViewedType &`. */
+   inline ViewedType &operator*() { return view; }
 };
 
 

--- a/general/mem_manager.hpp
+++ b/general/mem_manager.hpp
@@ -614,6 +614,8 @@ private:
 template <typename ViewedType>
 class MemoryView
 {
+   friend class Vector;
+
 protected:
    static constexpr bool is_const_view = std::is_const_v<ViewedType>;
    using T =
@@ -627,7 +629,7 @@ protected:
    MemoryType &base_mem;
    SizeType &base_size;  // if is_const_view, this is initialized but not used
 
-public:
+   // Keep the constructor private, for now.
    inline MemoryView(MemoryType &mem, SizeType &size)
       : base_mem(mem), base_size(size)
    {
@@ -637,6 +639,7 @@ public:
       view.size = size;
    }
 
+public:
    MemoryView(const MemoryView &) = delete;
    MemoryView(MemoryView &&) = delete;
    MemoryView &operator=(const MemoryView &) = delete;

--- a/general/mem_manager.hpp
+++ b/general/mem_manager.hpp
@@ -628,7 +628,7 @@ protected:
 
    std::remove_cv_t<ViewedType> view;
    MemoryType &base_mem;
-   SizeType &base_size;  // if is_const_view, this is initialized by not used
+   SizeType &base_size;  // if is_const_view, this is initialized but not used
 
 public:
    inline MemoryView(MemoryType &mem, SizeType &size)

--- a/general/mem_manager.hpp
+++ b/general/mem_manager.hpp
@@ -169,6 +169,7 @@ class Memory
 protected:
    friend class MemoryManager;
    friend void MemoryPrintFlags(unsigned flags);
+   template <typename VT> friend class MemoryView;
 
    enum FlagMask: unsigned
    {
@@ -522,10 +523,6 @@ public:
        necessary), and not @a base. */
    inline void SyncAlias(const Memory &base, int alias_size) const;
 
-   /** @brief Copy all flags from @a other to *this. */
-   /** @warning Use this method with caution! */
-   inline void CopyFlagsFrom(const Memory &other) const { flags = other.flags; }
-
    /** @brief Return a MemoryType that is currently valid. If both the host and
        the device pointers are currently valid, then the device memory type is
        returned. */
@@ -656,7 +653,7 @@ public:
       }
       else
       {
-         base_mem.CopyFlagsFrom(view.data);
+         base_mem.flags = view.data.flags;
       }
       view.data.Reset();
    }

--- a/general/mem_manager.hpp
+++ b/general/mem_manager.hpp
@@ -1398,19 +1398,6 @@ inline void Memory<T>::Sync(const Memory<U> &other) const
            (other.flags & (VALID_HOST | VALID_DEVICE));
 }
 
-// template <typename T>
-// inline void Memory<T>::SyncBuffer(const Memory<U> &other) const
-// {
-//    if (!(flags & Registered) && (other.flags & Registered))
-//    {
-//       MFEM_ASSERT((flags & ALIAS) == (other.flags & ALIAS),
-//                   "invalid input");
-//       flags = (flags | Registered) & ~(OWNS_DEVICE | OWNS_INTERNAL);
-//    }
-//    flags = (flags & ~(VALID_HOST | VALID_DEVICE)) |
-//            (other.flags & (VALID_HOST | VALID_DEVICE));
-// }
-
 template <typename T>
 inline void Memory<T>::SyncAlias(const Memory &base, int alias_size) const
 {

--- a/general/mem_manager.hpp
+++ b/general/mem_manager.hpp
@@ -1389,7 +1389,7 @@ inline void Memory<T>::Sync(const Memory<U> &other) const
 {
    if (!(flags & Registered) && (other.flags & Registered))
    {
-      MFEM_ASSERT(reinterpret_cast<T *>(h_ptr) == other.h_ptr &&
+      MFEM_ASSERT(reinterpret_cast<U *>(h_ptr) == other.h_ptr &&
                   (flags & ALIAS) == (other.flags & ALIAS),
                   "invalid input");
       flags = (flags | Registered) & ~(OWNS_DEVICE | OWNS_INTERNAL);

--- a/general/mem_manager.hpp
+++ b/general/mem_manager.hpp
@@ -1212,7 +1212,7 @@ inline void Memory<T>::MakeAlias(const Memory<U> &base, int offset, int size)
    static_assert(sizeof(U) == 1);
    MFEM_ASSERT(0 <= offset, "invalid offset = " << offset);
    MFEM_ASSERT(0 <= size, "invalid size = " << size);
-   MFEM_ASSERT((offset + size) * sizeof(T) <= base.capacity,
+   MFEM_ASSERT((offset + size) * sizeof(T) <= static_cast<size_t>(base.capacity),
                "invalid offset + size = " << (offset + size) * sizeof(T)
                << " > base capacity = "
                << base.capacity);

--- a/general/mem_manager.hpp
+++ b/general/mem_manager.hpp
@@ -436,15 +436,10 @@ public:
        @note The current memory is NOT deleted by this method. */
    inline void MakeAlias(const Memory &base, int offset, int size);
 
-   /// Make this an Alias of a Memory<char>, Memory<unsigned char>, or
-   /// Memory<std::byte>.
-   /// @a size and @a offset are in terms of type T, i.e. &(*this)[0] == &(base[0]) + offset*sizeof(T)
-   template <class U, class = std::enable_if_t<
-                !std::is_same_v<std::decay_t<U>, std::decay_t<T>> &&
-                (std::is_same_v<std::decay_t<U>, char> ||
-                 std::is_same_v<std::decay_t<U>, unsigned char> ||
-                 std::is_same_v<std::decay_t<U>, std::byte>)> >
-   inline void MakeAlias(const Memory<U> &base, int offset, int size);
+   /// For internal use only.
+   /// U* must be reinterpret_cast-able to T*
+   template <class U>
+   inline void CopyConvertPtr(const Memory<U> &base);
 
    /// Set the device MemoryType to be used by the Memory object.
    /** If the specified @a d_mt is not a device MemoryType, i.e. not one of the
@@ -547,12 +542,7 @@ public:
        @tparam U musst either be the same type as T, or T must be one of (char,
       unsigned char, std::byte)
    */
-   template <class U, class = std::enable_if_t<
-                std::is_same_v<std::decay_t<U>, std::decay_t<T>> ||
-                std::is_same_v<std::decay_t<T>, char> ||
-                std::is_same_v<std::decay_t<T>, unsigned char> ||
-                std::is_same_v<std::decay_t<T>, std::byte> > >
-   inline void Sync(const Memory<U> &other) const;
+   inline void Sync(const Memory &other) const;
 
    /** @brief Update the alias Memory @a *this to match the memory location (all
        valid locations) of its base Memory, @a base. */
@@ -1206,52 +1196,13 @@ inline void Memory<T>::MakeAlias(const Memory &base, int offset, int size)
 }
 
 template <typename T>
-template <class U, class>
-inline void Memory<T>::MakeAlias(const Memory<U> &base, int offset, int size)
+template <class U>
+inline void Memory<T>::CopyConvertPtr(const Memory<U> &base)
 {
-   static_assert(sizeof(U) == 1);
-   MFEM_ASSERT(0 <= offset, "invalid offset = " << offset);
-   MFEM_ASSERT(0 <= size, "invalid size = " << size);
-   MFEM_ASSERT((offset + size) * sizeof(T) <= static_cast<size_t>(base.capacity),
-               "invalid offset + size = " << (offset + size) * sizeof(T)
-               << " > base capacity = "
-               << base.capacity);
-   capacity = size;
+   h_ptr = reinterpret_cast<T*>(base.h_ptr);
+   capacity = base.capacity;
    h_mt = base.h_mt;
-   h_ptr = reinterpret_cast<T*>(base.h_ptr) + offset;
-   if (!(base.flags & Registered))
-   {
-      if (
-#if !defined(HYPRE_USING_GPU)
-         // If the following condition is true then MemoryManager::Exists()
-         // should also be true:
-         IsDeviceMemory(MemoryManager::GetDeviceMemoryType())
-#elif MFEM_HYPRE_VERSION < 23100
-         // When HYPRE_USING_GPU is defined and HYPRE < 2.31.0, we always
-         // register the 'base' if the MemoryManager::Exists():
-         MemoryManager::Exists()
-#else // HYPRE_USING_GPU is defined and MFEM_HYPRE_VERSION >= 23100
-         IsDeviceMemory(MemoryManager::GetDeviceMemoryType()) ||
-         (MemoryManager::Exists() && HypreUsingGPU())
-#endif
-      )
-      {
-         // Register 'base':
-         MemoryManager::Register_(base.h_ptr, nullptr, base.capacity,
-                                  base.h_mt, base.flags & OWNS_HOST,
-                                  base.flags & ALIAS, base.flags);
-      }
-      else
-      {
-         // Copy the flags from 'base', setting the ALIAS flag to true, and
-         // setting both OWNS_HOST and OWNS_DEVICE to false:
-         flags = (base.flags | ALIAS) & ~(OWNS_HOST | OWNS_DEVICE);
-         return;
-      }
-   }
-   const size_t s_bytes = size*sizeof(T);
-   const size_t o_bytes = offset*sizeof(T);
-   MemoryManager::Alias_(base.h_ptr, o_bytes, s_bytes, base.flags, flags);
+   flags = base.flags;
 }
 
 template <typename T>
@@ -1384,12 +1335,11 @@ inline T *Memory<T>::Write(MemoryClass mc, int size)
 }
 
 template <typename T>
-template <class U, class>
-inline void Memory<T>::Sync(const Memory<U> &other) const
+inline void Memory<T>::Sync(const Memory &other) const
 {
    if (!(flags & Registered) && (other.flags & Registered))
    {
-      MFEM_ASSERT(reinterpret_cast<U *>(h_ptr) == other.h_ptr &&
+      MFEM_ASSERT(h_ptr == other.h_ptr &&
                   (flags & ALIAS) == (other.flags & ALIAS),
                   "invalid input");
       flags = (flags | Registered) & ~(OWNS_DEVICE | OWNS_INTERNAL);

--- a/linalg/vector.hpp
+++ b/linalg/vector.hpp
@@ -547,6 +547,19 @@ public:
        The returned MemoryView object is implicitly and explicitly convertible
        to `Array<real_t> &`, see class MemoryView.
 
+       The simplest way to use this method is:
+       @code
+       func(*v.GetArrayView());
+       @endcode
+       where `func` has an `Array<real_t>&` argument and `v` is a Vector. In
+       this examples, the returned MemoryView object is temporary, created just
+       before the call to `func` and destroyed automatically right after that
+       call.
+
+       Note that when the MemoryView is destroyed, the state of the underlying
+       Array<real_t> object is copied back to this Vector to reflect any changes
+       made to the Array.
+
        Creating multiple views, of the same Vector object, that have overlapping
        life spans is not supported. */
    MemoryView<Array<real_t>> GetArrayView()
@@ -557,6 +570,20 @@ public:
 
        The returned MemoryView object is implicitly and explicitly convertible
        to `const Array<real_t> &`, see class MemoryView.
+
+       The simplest way to use this method is:
+       @code
+       func(*v.GetArrayView());
+       @endcode
+       where `func` has a `const Array<real_t>&` argument and `v` is a const
+       Vector. In this examples, the returned MemoryView object is temporary,
+       created just before the call to `func` and destroyed automatically right
+       after that call.
+
+       Note that when the MemoryView is destroyed, the mutable part of the state
+       of the underlying const Array<real_t> object is copied back to this
+       Vector to reflect any changes made to the Array, e.g. if the data was
+       moved from host to device.
 
        Creating multiple views, of the same Vector object, that have overlapping
        life spans is not supported. */

--- a/linalg/vector.hpp
+++ b/linalg/vector.hpp
@@ -540,6 +540,28 @@ public:
    virtual real_t *HostReadWrite()
    { return mfem::ReadWrite(data, size, false); }
 
+   /** @brief Create a mutable (non-const) view of the Vector as Array<real_t>
+       that can be used to pass Vector objects to functions that take Array
+       arguments.
+
+       The returned MemoryView object is implicitly and explicitly convertible
+       to `Array<real_t> &`, see class MemoryView.
+
+       Creating multiple views, of the same Vector object, that have overlapping
+       life spans is not supported. */
+   MemoryView<Array<real_t>> GetArrayView()
+   { return MemoryView<Array<real_t>>(data, size); }
+
+   /** @brief Create a const view of the Vector as const Array<real_t> that can
+       be used to pass Vector objects to functions that take Array arguments.
+
+       The returned MemoryView object is implicitly and explicitly convertible
+       to `const Array<real_t> &`, see class MemoryView.
+
+       Creating multiple views, of the same Vector object, that have overlapping
+       life spans is not supported. */
+   MemoryView<const Array<real_t>> GetArrayView() const
+   { return MemoryView<const Array<real_t>>(data, size); }
 };
 
 // Inline methods

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -43,6 +43,7 @@ set(UNIT_TESTS_SRCS
   general/test_array.cpp
   general/test_scan.cpp
   general/test_arrays_by_name.cpp
+  general/test_communication.cpp
   general/test_error.cpp
   general/test_mem.cpp
   general/test_ordering.cpp

--- a/tests/unit/catch.hpp
+++ b/tests/unit/catch.hpp
@@ -12,6 +12,8 @@
 #define TWOBLUECUBES_SINGLE_INCLUDE_CATCH_HPP_INCLUDED
 // start catch.hpp
 
+#include <new>
+
 
 #define CATCH_VERSION_MAJOR 2
 #define CATCH_VERSION_MINOR 13

--- a/tests/unit/fem/test_dof_communicator.cpp
+++ b/tests/unit/fem/test_dof_communicator.cpp
@@ -47,17 +47,17 @@ void MakeRowPartitioning(const Mesh &mesh, int ntasks, Array<int> &partitioning)
 
 // Shared values differ only on the lower and upper local vertex rows.
 real_t ExpectedReductionValue(int rank, int ntasks, bool top,
-                              DeviceSharedDofCommunicator::Op op)
+                              DeviceGroupCommunicator::Op op)
 {
    const bool first_rank = (rank == 0);
    const bool last_rank = (rank == ntasks - 1);
 
-   if (op == DeviceSharedDofCommunicator::Op::Min)
+   if (op == DeviceGroupCommunicator::Op::Min)
    {
       if (top) { return rank; }
       return first_rank ? rank : rank - 1;
    }
-   if (op == DeviceSharedDofCommunicator::Op::Max)
+   if (op == DeviceGroupCommunicator::Op::Max)
    {
       if (!top) { return rank; }
       return last_rank ? rank : rank + 1;
@@ -98,27 +98,25 @@ TEST_CASE("GroupCommunicator Shared Dof Reduction", "[Parallel][GPU]")
    const real_t y_top = real_t(rank + 1) / ntasks;
    const real_t tol = 1.0e-12;
 
-   auto check_reduction = [&](DeviceSharedDofCommunicator::Op op)
+   auto check_reduction = [&](DeviceGroupCommunicator::Op op)
    {
       // Start with the row number on every local dof copy.
-      Vector x(pfes.GetVSize());
-      x.UseDevice(true);
+      Array<real_t> x(pfes.GetVSize());
       x = real_t(rank);
 
-      real_t *x_ptr = x.ReadWrite();
       switch (op)
       {
-         case DeviceSharedDofCommunicator::Op::Min:
-            pfes.GroupComm().Reduce<real_t>(x_ptr, GroupCommunicator::Min);
+         case DeviceGroupCommunicator::Op::Min:
+            pfes.GroupComm().Reduce(x, GroupCommunicator::Min);
             break;
-         case DeviceSharedDofCommunicator::Op::Max:
-            pfes.GroupComm().Reduce<real_t>(x_ptr, GroupCommunicator::Max);
+         case DeviceGroupCommunicator::Op::Max:
+            pfes.GroupComm().Reduce(x, GroupCommunicator::Max);
             break;
-         case DeviceSharedDofCommunicator::Op::Sum:
-            pfes.GroupComm().Reduce<real_t>(x_ptr, GroupCommunicator::Sum);
+         case DeviceGroupCommunicator::Op::Sum:
+            pfes.GroupComm().Reduce(x, GroupCommunicator::Sum);
             break;
       }
-      pfes.GroupComm().Bcast<real_t>(x_ptr);
+      pfes.GroupComm().Bcast(x);
       x.HostRead();
 
       // Order 1 H1 scalar dofs coincide with mesh vertices.
@@ -131,24 +129,24 @@ TEST_CASE("GroupCommunicator Shared Dof Reduction", "[Parallel][GPU]")
 
          REQUIRE((top || bottom));
          pfes.GetVertexVDofs(i, vdofs);
-         REQUIRE(x(vdofs[0]) == MFEM_Approx(
+         REQUIRE(std::as_const(x)[vdofs[0]] == MFEM_Approx(
                     ExpectedReductionValue(rank, ntasks, top, op)));
       }
    };
 
    SECTION("Min")
    {
-      check_reduction(DeviceSharedDofCommunicator::Op::Min);
+      check_reduction(DeviceGroupCommunicator::Op::Min);
    }
 
    SECTION("Max")
    {
-      check_reduction(DeviceSharedDofCommunicator::Op::Max);
+      check_reduction(DeviceGroupCommunicator::Op::Max);
    }
 
    SECTION("Sum")
    {
-      check_reduction(DeviceSharedDofCommunicator::Op::Sum);
+      check_reduction(DeviceGroupCommunicator::Op::Sum);
    }
 }
 
@@ -171,6 +169,7 @@ TEST_CASE("ProjectDiscCoefficient Row Partition", "[Parallel][GPU]")
 
    ConstantCoefficient coeff(rank);
    gf.ProjectDiscCoefficient(coeff);
+   gf.HostRead();
 
    const real_t y_bottom = real_t(rank) / ntasks;
    const real_t y_top = real_t(rank + 1) / ntasks;
@@ -186,7 +185,7 @@ TEST_CASE("ProjectDiscCoefficient Row Partition", "[Parallel][GPU]")
 
       REQUIRE((top || bottom));
       pfes.GetVertexVDofs(i, vdofs);
-      REQUIRE(gf(vdofs[0]) == MFEM_Approx(
+      REQUIRE(std::as_const(gf)(vdofs[0]) == MFEM_Approx(
                  ExpectedProjectedValue(rank, ntasks, top)));
    }
 }

--- a/tests/unit/general/test_communication.cpp
+++ b/tests/unit/general/test_communication.cpp
@@ -1,0 +1,93 @@
+// Copyright (c) 2010-2025, Lawrence Livermore National Security, LLC. Produced
+// at the Lawrence Livermore National Laboratory. All Rights reserved. See files
+// LICENSE and NOTICE for details. LLNL-CODE-806117.
+//
+// This file is part of the MFEM library. For more information and source code
+// availability visit https://mfem.org.
+//
+// MFEM is free software; you can redistribute it and/or modify it under the
+// terms of the BSD-3 license. We welcome feedback and contributions, see file
+// CONTRIBUTING.md for details.
+
+#include "mfem.hpp"
+#include "unit_tests.hpp"
+
+using namespace mfem;
+
+TEST_CASE("DeviceGroupCommunicator", "[Parallel][GPU]")
+{
+   const int nx = 6, ny = 6;
+   Mesh mesh = Mesh::MakeCartesian2D(nx, ny, Element::QUADRILATERAL);
+   ParMesh pmesh(MPI_COMM_WORLD, mesh);
+   mesh.Clear();
+   pmesh.UniformRefinement();
+
+   const int p = 2;
+   H1_FECollection fec(p, pmesh.Dimension());
+   ParFiniteElementSpace pfes(&pmesh, &fec);
+   GroupCommunicator &gc = pfes.GroupComm();
+
+   ParGridFunction x(&pfes), y_h(&pfes), y_d(&pfes);
+
+   x = Mpi::WorldRank();
+
+   SECTION("Bcast")
+   {
+      y_h = x;
+      gc.Bcast(y_h.HostReadWrite());
+      y_d = x;
+      if (!Device::Allows(Backend::DEVICE_MASK))
+      {
+         // When not running on device, using 'gc' will not use the
+         // DeviceGroupCommunicator, so to test it, we explicitly create it.
+         gc.GetDeviceComm().BcastBeginLDofs(*y_d.GetArrayView());
+         gc.GetDeviceComm().BcastEndLDofs(*y_d.GetArrayView());
+      }
+      else
+      {
+         gc.Bcast(*y_d.GetArrayView());
+         CHECK(y_d.GetMemory().DeviceIsValid());
+      }
+      y_d -= y_h;
+      const real_t error = ParNormlp(y_d, infinity(), pmesh.GetComm());
+      CHECK(error == 0_r); // numbers should match exactly!
+   }
+
+   auto reduce_check = [&](void (*Op)(GroupCommunicator::OpData<real_t>),
+                           DeviceGroupCommunicator::Op op) -> void
+   {
+      y_h = x;
+      gc.Reduce(y_h.HostReadWrite(), Op);
+      y_d = x;
+      if (!Device::Allows(Backend::DEVICE_MASK))
+      {
+         // When not running on device, using 'gc' will not use the
+         // DeviceGroupCommunicator, so to test it, we explicitly create it.
+         gc.GetDeviceComm().ReduceBeginLDofs(*y_d.GetArrayView());
+         gc.GetDeviceComm().ReduceEndLDofs(*y_d.GetArrayView(), op);
+      }
+      else
+      {
+         gc.Reduce(*y_d.GetArrayView(), Op);
+         CHECK(y_d.GetMemory().DeviceIsValid());
+      }
+      y_d -= y_h;
+      const real_t error = ParNormlp(y_d, infinity(), pmesh.GetComm());
+      CHECK(error == 0_r); // numbers should match exactly! (reducing integers)
+   };
+
+   SECTION("Reduce Sum")
+   {
+      reduce_check(GroupCommunicator::Sum, DeviceGroupCommunicator::Op::Sum);
+   }
+
+   SECTION("Reduce Min")
+   {
+      reduce_check(GroupCommunicator::Min, DeviceGroupCommunicator::Op::Min);
+   }
+
+   SECTION("Reduce Max")
+   {
+      reduce_check(GroupCommunicator::Max, DeviceGroupCommunicator::Op::Max);
+   }
+}

--- a/tests/unit/general/test_communication.cpp
+++ b/tests/unit/general/test_communication.cpp
@@ -14,6 +14,8 @@
 
 using namespace mfem;
 
+#ifdef MFEM_USE_MPI
+
 TEST_CASE("DeviceGroupCommunicator", "[Parallel][GPU]")
 {
    const int nx = 6, ny = 6;
@@ -91,3 +93,5 @@ TEST_CASE("DeviceGroupCommunicator", "[Parallel][GPU]")
       reduce_check(GroupCommunicator::Max, DeviceGroupCommunicator::Op::Max);
    }
 }
+
+#endif

--- a/tests/unit/linalg/test_vector.cpp
+++ b/tests/unit/linalg/test_vector.cpp
@@ -268,3 +268,46 @@ TEST_CASE("Vector delete at indices", "[Vector],[GPU]")
       }
    }
 }
+
+TEST_CASE("Vector GetArrayView", "[Vector]")
+{
+   volatile int n = 5;
+   {
+      Vector x(n);
+      Vector y(n);
+      const Vector &xc = x;
+
+      auto op_on_arrays = [](const Array<real_t> &a, Array<real_t> &b) -> void
+      {
+         if (verbose_tests)
+         {
+            mfem::out << "op_on_arrays(const Array<real_t> &, Array<real_t> &)"
+                      << std::endl;
+         }
+         b = a;
+         b.SetSize(2*b.Size(), 3_r);
+      };
+
+      x = 1_r;
+
+      // The commented out code in the MemoryView ctor + dtor can be uncommented
+      // to show the creation + destruction of the temporary objects returned by
+      // GetArrayView().
+      op_on_arrays(xc.GetArrayView(), y.GetArrayView());
+
+      CHECK(y.Size() == 2*n);
+      if (verbose_tests)
+      {
+         mfem::out << "after call to op_on_arrays()" << std::endl;
+         mfem::out << "x: ";
+         x.Print(mfem::out, x.Size());
+         mfem::out << "y: ";
+         y.Print(mfem::out, y.Size());
+         mfem::out << "before x, y dtor" << std::endl;
+      }
+   }
+   if (verbose_tests)
+   {
+      mfem::out << "after x, y dtor" << std::endl;
+   }
+}

--- a/tests/unit/linalg/test_vector.cpp
+++ b/tests/unit/linalg/test_vector.cpp
@@ -271,6 +271,8 @@ TEST_CASE("Vector delete at indices", "[Vector],[GPU]")
 
 TEST_CASE("Vector GetArrayView", "[Vector]")
 {
+   // Use 'volatile' to prevent the compiler from optimizing for the specific
+   // value of 'n' set here.
    volatile int n = 5;
    {
       Vector x(n);


### PR DESCRIPTION
Re-worked and extended the device support in class `GroupCommunicator`.

Combined and re-worked the classes `DeviceSharedDofCommunicator` and `internal::DeviceNeighborDofComm` into one class -- `DeviceGroupCommunicator`.

Added new methods, `GetArrayView()`, in class `Vector` that enable viewing/using `Vector` objects as `Array<real_t>` objects.
