### PR TITLE
Direct solver symbolic reuse

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -94,6 +94,15 @@ Linear and nonlinear solvers
   Operator: MultMV, MultTransposeMV, and GetGradientMV, that use MultiVector
   objects for input and/or output parameters. [PR #5249]
 
+- UMFPackSolver and KLUSolver can now retain the symbolic factorization across
+  SetOperator() calls and reuse it whenever the sparsity pattern is unchanged,
+  which saves the analysis -- a fifth to a quarter of the cost of a
+  factorization -- in any loop that refactorizes a matrix of fixed structure: a
+  Newton iteration, an implicit time step, a continuation loop, a parameter
+  sweep. Off by default, enabled with SetReuseSymbolic(), and the pattern is
+  checked rather than taken on trust. KLUSolver::SetReuseNumeric() additionally
+  refactorizes through klu_refactor(), reusing the pivot ordering as well.
+
 GPU computing
 -------------
 - Improved partial assembly for VectorDivergenceIntegrator with shared-memory

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -103,6 +103,15 @@ Linear and nonlinear solvers
   checked rather than taken on trust. KLUSolver::SetReuseNumeric() additionally
   refactorizes through klu_refactor(), reusing the pivot ordering as well.
 
+- The same reuse is now available in ComplexUMFPackSolver, PardisoSolver and
+  CPardisoSolver, each through its own SetReuseSymbolic(): the UMFPACK analysis
+  for the complex solver, and PARDISO's phase 11 for the two MKL ones. The
+  pattern is checked rather than assumed in every case, and CPardisoSolver
+  reduces the decision across its communicator, since cluster_sparse_solver()
+  is collective. PardisoSolver and CPardisoSolver now also release the previous
+  factorization before analysing a new one, which repeated SetOperator() calls
+  did not.
+
 GPU computing
 -------------
 - Improved partial assembly for VectorDivergenceIntegrator with shared-memory

--- a/linalg/CMakeLists.txt
+++ b/linalg/CMakeLists.txt
@@ -72,6 +72,7 @@ list(APPEND HDRS
   solvers.hpp
   sparsemat.hpp
   sparsesmoothers.hpp
+  sparsitypattern.hpp
   symmat.hpp
   tlayout.hpp
   tmatrix.hpp

--- a/linalg/complex_operator.cpp
+++ b/linalg/complex_operator.cpp
@@ -313,6 +313,11 @@ void ComplexUMFPackSolver::Init()
    mat = NULL;
    Numeric = NULL;
    AI = AJ = NULL;
+   Symbolic = NULL;
+   reuse_symbolic = false;
+   pattern.Clear();
+   num_symbolic = 0;
+   num_numeric = 0;
    if (!use_long_ints)
    {
       umfpack_zi_defaults(Control);
@@ -323,22 +328,36 @@ void ComplexUMFPackSolver::Init()
    }
 }
 
-void ComplexUMFPackSolver::SetOperator(const Operator &op)
+void ComplexUMFPackSolver::FreeSymbolic()
 {
-   void *Symbolic;
-
-   if (Numeric)
+   if (Symbolic)
    {
       if (!use_long_ints)
       {
-         umfpack_zi_free_numeric(&Numeric);
+         umfpack_zi_free_symbolic(&Symbolic);
       }
       else
       {
-         umfpack_zl_free_numeric(&Numeric);
+         umfpack_zl_free_symbolic(&Symbolic);
       }
+      Symbolic = NULL;
    }
+   pattern.Clear();
+}
 
+bool ComplexUMFPackSolver::CanReuseSymbolic(const SparseMatrix &A) const
+{
+   return reuse_symbolic && Symbolic && pattern.Matches(A);
+}
+
+void ComplexUMFPackSolver::SetReuseSymbolic(bool reuse)
+{
+   reuse_symbolic = reuse;
+   if (!reuse) { FreeSymbolic(); }
+}
+
+void ComplexUMFPackSolver::SetOperator(const Operator &op)
+{
    mat = const_cast<ComplexSparseMatrix *>
          (dynamic_cast<const ComplexSparseMatrix *>(&op));
    MFEM_VERIFY(mat, "not a ComplexSparseMatrix");
@@ -357,6 +376,25 @@ void ComplexUMFPackSolver::SetOperator(const Operator &op)
    width = mat->real().Width();
    MFEM_VERIFY(width == height, "not a square matrix");
 
+   // Whether the retained symbolic analysis, if there is one, was made for this
+   // pattern. Checked against the pattern itself, never assumed; see
+   // SetReuseSymbolic(). Without reuse there is never one to retain, and this
+   // is false on every call.
+   const bool reuse = CanReuseSymbolic(mat->real());
+   if (!reuse) { FreeSymbolic(); }
+
+   if (Numeric)
+   {
+      if (!use_long_ints)
+      {
+         umfpack_zi_free_numeric(&Numeric);
+      }
+      else
+      {
+         umfpack_zl_free_numeric(&Numeric);
+      }
+   }
+
    const int * Ap =
       mat->real().HostReadI(); // assuming real and imag have the same sparsity
    const int * Ai = mat->real().HostReadJ();
@@ -365,14 +403,20 @@ void ComplexUMFPackSolver::SetOperator(const Operator &op)
 
    if (!use_long_ints)
    {
-      int status = umfpack_zi_symbolic(width,width,Ap,Ai,Ax,Az,&Symbolic,
-                                       Control,Info);
-      if (status < 0)
+      int status;
+      if (!Symbolic)
       {
-         umfpack_zi_report_info(Control, Info);
-         umfpack_zi_report_status(Control, status);
-         mfem_error("ComplexUMFPackSolver::SetOperator :"
-                    " umfpack_zi_symbolic() failed!");
+         status = umfpack_zi_symbolic(width,width,Ap,Ai,Ax,Az,&Symbolic,
+                                      Control,Info);
+         if (status < 0)
+         {
+            umfpack_zi_report_info(Control, Info);
+            umfpack_zi_report_status(Control, status);
+            mfem_error("ComplexUMFPackSolver::SetOperator :"
+                       " umfpack_zi_symbolic() failed!");
+         }
+         num_symbolic++;
+         if (reuse_symbolic) { pattern.Set(mat->real()); }
       }
 
       status = umfpack_zi_numeric(Ap, Ai, Ax, Az, Symbolic, &Numeric,
@@ -384,33 +428,49 @@ void ComplexUMFPackSolver::SetOperator(const Operator &op)
          mfem_error("ComplexUMFPackSolver::SetOperator :"
                     " umfpack_zi_numeric() failed!");
       }
-      umfpack_zi_free_symbolic(&Symbolic);
+      num_numeric++;
+      // Without reuse the analysis is discarded here, as it always has been;
+      // umfpack_zi_free_symbolic() sets Symbolic back to NULL.
+      if (!reuse_symbolic)
+      {
+         umfpack_zi_free_symbolic(&Symbolic);
+      }
    }
    else
    {
       SuiteSparse_long status;
 
-      delete [] AJ;
-      delete [] AI;
-      AI = new SuiteSparse_long[width + 1];
-      AJ = new SuiteSparse_long[Ap[width]];
-      for (int i = 0; i <= width; i++)
+      // The long copies of the pattern are the pattern: when it is unchanged,
+      // so are they, and rebuilding them would only copy it again.
+      if (!reuse)
       {
-         AI[i] = (SuiteSparse_long)(Ap[i]);
-      }
-      for (int i = 0; i < Ap[width]; i++)
-      {
-         AJ[i] = (SuiteSparse_long)(Ai[i]);
+         delete [] AJ;
+         delete [] AI;
+         AI = new SuiteSparse_long[width + 1];
+         AJ = new SuiteSparse_long[Ap[width]];
+         for (int i = 0; i <= width; i++)
+         {
+            AI[i] = (SuiteSparse_long)(Ap[i]);
+         }
+         for (int i = 0; i < Ap[width]; i++)
+         {
+            AJ[i] = (SuiteSparse_long)(Ai[i]);
+         }
       }
 
-      status = umfpack_zl_symbolic(width, width, AI, AJ, Ax, Az, &Symbolic,
-                                   Control, Info);
-      if (status < 0)
+      if (!Symbolic)
       {
-         umfpack_zl_report_info(Control, Info);
-         umfpack_zl_report_status(Control, status);
-         mfem_error("ComplexUMFPackSolver::SetOperator :"
-                    " umfpack_zl_symbolic() failed!");
+         status = umfpack_zl_symbolic(width, width, AI, AJ, Ax, Az, &Symbolic,
+                                      Control, Info);
+         if (status < 0)
+         {
+            umfpack_zl_report_info(Control, Info);
+            umfpack_zl_report_status(Control, status);
+            mfem_error("ComplexUMFPackSolver::SetOperator :"
+                       " umfpack_zl_symbolic() failed!");
+         }
+         num_symbolic++;
+         if (reuse_symbolic) { pattern.Set(mat->real()); }
       }
 
       status = umfpack_zl_numeric(AI, AJ, Ax, Az, Symbolic, &Numeric,
@@ -422,7 +482,11 @@ void ComplexUMFPackSolver::SetOperator(const Operator &op)
          mfem_error("ComplexUMFPackSolver::SetOperator :"
                     " umfpack_zl_numeric() failed!");
       }
-      umfpack_zl_free_symbolic(&Symbolic);
+      num_numeric++;
+      if (!reuse_symbolic)
+      {
+         umfpack_zl_free_symbolic(&Symbolic);
+      }
    }
 }
 
@@ -561,6 +625,7 @@ ComplexUMFPackSolver::~ComplexUMFPackSolver()
          umfpack_zl_free_numeric(&Numeric);
       }
    }
+   FreeSymbolic();
 }
 
 #endif

--- a/linalg/complex_operator.hpp
+++ b/linalg/complex_operator.hpp
@@ -19,6 +19,7 @@
 #endif
 
 #ifdef MFEM_USE_SUITESPARSE
+#include "sparsitypattern.hpp"
 #include <umfpack.h>
 #endif
 
@@ -209,7 +210,26 @@ protected:
    void *Numeric;
    SuiteSparse_long *AI, *AJ;
 
+   /** @brief The symbolic analysis: retained between SetOperator() calls when
+       reuse is enabled, and NULL otherwise. */
+   void *Symbolic;
+   /// Whether #Symbolic may be retained and reused; see SetReuseSymbolic().
+   bool reuse_symbolic;
+   /// The pattern #Symbolic was computed from; empty unless reusing.
+   RetainedSparsityPattern pattern;
+   /// The number of symbolic analyses actually performed.
+   long num_symbolic;
+   /// The number of numeric factorizations actually performed.
+   long num_numeric;
+
    void Init();
+
+   /// Discard the retained symbolic analysis, and the pattern it was made for.
+   void FreeSymbolic();
+
+   /** @brief Whether the retained symbolic analysis applies to @a A, that is,
+       whether @a A has the sparsity pattern it was computed from. */
+   bool CanReuseSymbolic(const SparseMatrix &A) const;
 
 public:
    real_t Control[UMFPACK_CONTROL];
@@ -234,6 +254,40 @@ public:
        for real and imag parts of the ComplexSparseMatrix,
        modifying the matrices if the column indices are not already sorted. */
    void SetOperator(const Operator &op) override;
+
+   /** @brief Retain the symbolic factorization across SetOperator() calls and
+       reuse it whenever the sparsity pattern is unchanged. Off by default.
+
+       This is UMFPackSolver::SetReuseSymbolic() for the complex solver, and it
+       behaves the same way: the analysis is a fifth to a quarter of the cost of
+       a factorization and depends only on the pattern, so any caller that
+       refactorizes a matrix of fixed structure -- a Newton iteration, an
+       implicit time step, a continuation loop, a parameter sweep -- otherwise
+       recomputes it on every call and uses it once.
+
+       The pattern is checked, not assumed, by the exact comparison described in
+       UMFPackSolver::SetReuseSymbolic(), against the real part of the
+       ComplexSparseMatrix, which is the pattern UMFPACK is given. The class
+       already requires the imaginary part to share it.
+
+       @note umfpack_z*_symbolic() reads the values as well as the pattern, so a
+       retained analysis stays correct for any values but may carry a poorer
+       ordering than a fresh analysis of the current ones. A performance caveat,
+       not a correctness one. */
+   void SetReuseSymbolic(bool reuse = true);
+
+   /// Whether symbolic reuse is enabled; see SetReuseSymbolic().
+   bool GetReuseSymbolic() const { return reuse_symbolic; }
+
+   /** @brief The number of symbolic analyses actually performed, that is, of
+       umfpack_z*_symbolic() calls. Without reuse this is the number of
+       SetOperator() calls; with reuse it is the number of times the pattern
+       changed. */
+   long GetNumSymbolicFactorizations() const { return num_symbolic; }
+
+   /** @brief The number of numeric factorizations actually performed, that is,
+       of umfpack_z*_numeric() calls. Reuse never skips one of these. */
+   long GetNumNumericFactorizations() const { return num_numeric; }
 
    // Set the print level field in the #Control data member.
    void SetPrintLevel(int print_lvl) { Control[UMFPACK_PRL] = print_lvl; }

--- a/linalg/cpardiso.cpp
+++ b/linalg/cpardiso.cpp
@@ -61,6 +61,47 @@ CPardisoSolver::CPardisoSolver(MPI_Comm comm)
    nrhs = 1;
 };
 
+void CPardisoSolver::ReleaseFactorization()
+{
+   if (!factored) { return; }
+
+   // Release all internal memory held for the current factorization. Without
+   // this a second analysis on the same handle leaks whatever the first one
+   // allocated inside MKL.
+   phase = -1;
+   cluster_sparse_solver(pt,
+                         &maxfct,
+                         &mnum,
+                         &mtype,
+                         &phase,
+                         &m,
+                         reordered_csr_nzval,
+                         csr_rowptr,
+                         reordered_csr_colind,
+                         &idum,
+                         &nrhs,
+                         iparm,
+                         &msglvl,
+                         &ddum,
+                         &ddum,
+                         &comm_,
+                         &error);
+
+   MFEM_ASSERT(error == 0, "CPardiso free error");
+
+   factored = false;
+}
+
+void CPardisoSolver::SetReuseSymbolic(bool reuse)
+{
+   reuse_symbolic = reuse;
+   if (!reuse)
+   {
+      pattern.Clear();
+      pattern_first_row = -1;
+   }
+}
+
 void CPardisoSolver::SetOperator(const Operator &op)
 {
    auto hypreParMat = dynamic_cast<const HypreParMatrix &>(op);
@@ -88,16 +129,15 @@ void CPardisoSolver::SetOperator(const Operator &op)
    real_t *csr_nzval = csr_op->data;
    int *csr_colind = csr_op->j;
 
-   delete[] csr_rowptr;
-   delete[] reordered_csr_colind;
-   delete[] reordered_csr_nzval;
-   csr_rowptr = new int[m_loc + 1];
-   reordered_csr_colind = new int[nnz_loc];
-   reordered_csr_nzval = new real_t[nnz_loc];
+   // The local CSR has to be built before it can be compared, so what reuse
+   // saves here is the analysis, not the assembly of the copy.
+   int *new_csr_rowptr = new int[m_loc + 1];
+   int *new_csr_colind = new int[nnz_loc];
+   real_t *new_csr_nzval = new real_t[nnz_loc];
 
    for (int i = 0; i <= m_loc; i++)
    {
-      csr_rowptr[i] = (csr_op->i)[i];
+      new_csr_rowptr[i] = (csr_op->i)[i];
    }
 
    // CPardiso expects the column indices to be sorted for each row
@@ -105,8 +145,8 @@ void CPardisoSolver::SetOperator(const Operator &op)
    std::iota(permutation_idx.begin(), permutation_idx.end(), 0);
    for (int i = 0; i < m_loc; i++)
    {
-      std::sort(permutation_idx.begin() + csr_rowptr[i],
-                permutation_idx.begin() + csr_rowptr[i + 1],
+      std::sort(permutation_idx.begin() + new_csr_rowptr[i],
+                permutation_idx.begin() + new_csr_rowptr[i + 1],
                 [csr_colind](int i1, int i2)
       {
          return csr_colind[i1] < csr_colind[i2];
@@ -115,11 +155,35 @@ void CPardisoSolver::SetOperator(const Operator &op)
 
    for (int i = 0; i < nnz_loc; i++)
    {
-      reordered_csr_colind[i] = csr_colind[permutation_idx[i]];
-      reordered_csr_nzval[i] = csr_nzval[permutation_idx[i]];
+      new_csr_colind[i] = csr_colind[permutation_idx[i]];
+      new_csr_nzval[i] = csr_nzval[permutation_idx[i]];
    }
 
    hypre_CSRMatrixDestroy(csr_op);
+
+   // Whether the analysis in hand was made for this pattern. Checked against
+   // the pattern itself, never assumed; see SetReuseSymbolic().
+   int reuse_here = (reuse_symbolic && factored &&
+                     first_row == pattern_first_row &&
+                     pattern.Matches(m_loc, nnz_loc, new_csr_rowptr,
+                                     new_csr_colind)) ? 1 : 0;
+
+   // cluster_sparse_solver() is collective, so the decision has to be. A rank
+   // that skipped phase 11 while another ran it would leave the two of them in
+   // different calls, and the run would hang rather than fail.
+   int reuse_all = reuse_here;
+   MPI_Allreduce(&reuse_here, &reuse_all, 1, MPI_INT, MPI_MIN,
+                 MPI_Comm_f2c(comm_));
+   const bool reuse = (reuse_all == 1);
+
+   if (!reuse) { ReleaseFactorization(); }
+
+   delete[] csr_rowptr;
+   delete[] reordered_csr_colind;
+   delete[] reordered_csr_nzval;
+   csr_rowptr = new_csr_rowptr;
+   reordered_csr_colind = new_csr_colind;
+   reordered_csr_nzval = new_csr_nzval;
 
    // iparm[40], the number of row in global matrix, rhs element and solution vector that
    // begins the input domain belonging to this MPI process
@@ -138,27 +202,37 @@ void CPardisoSolver::SetOperator(const Operator &op)
       iparm[41] = first_row + m_loc - 1;
    }
 
-   // Analyze inputs
-   phase = 11;
-   cluster_sparse_solver(pt,
-                         &maxfct,
-                         &mnum,
-                         &mtype,
-                         &phase,
-                         &m,
-                         reordered_csr_nzval,
-                         csr_rowptr,
-                         reordered_csr_colind,
-                         &idum,
-                         &nrhs,
-                         iparm,
-                         &msglvl,
-                         &ddum,
-                         &ddum,
-                         &comm_,
-                         &error);
+   if (!reuse)
+   {
+      // Analyze inputs
+      phase = 11;
+      cluster_sparse_solver(pt,
+                            &maxfct,
+                            &mnum,
+                            &mtype,
+                            &phase,
+                            &m,
+                            reordered_csr_nzval,
+                            csr_rowptr,
+                            reordered_csr_colind,
+                            &idum,
+                            &nrhs,
+                            iparm,
+                            &msglvl,
+                            &ddum,
+                            &ddum,
+                            &comm_,
+                            &error);
 
-   MFEM_ASSERT(error == 0, "CPardiso analyze input error");
+      MFEM_ASSERT(error == 0, "CPardiso analyze input error");
+
+      num_symbolic++;
+      if (reuse_symbolic)
+      {
+         pattern.Set(m_loc, nnz_loc, csr_rowptr, reordered_csr_colind);
+         pattern_first_row = first_row;
+      }
+   }
 
    // Numerical factorization
    phase = 22;
@@ -181,6 +255,9 @@ void CPardisoSolver::SetOperator(const Operator &op)
                          &error);
 
    MFEM_ASSERT(error == 0, "CPardiso factorization input error");
+
+   num_numeric++;
+   factored = true;
 }
 
 void CPardisoSolver::Mult(const Vector &b, Vector &x) const
@@ -220,27 +297,9 @@ void CPardisoSolver::SetMatrixType(MatType mat_type)
 
 CPardisoSolver::~CPardisoSolver()
 {
-   // Release all internal memory
-   phase = -1;
-   cluster_sparse_solver(pt,
-                         &maxfct,
-                         &mnum,
-                         &mtype,
-                         &phase,
-                         &m,
-                         reordered_csr_nzval,
-                         csr_rowptr,
-                         reordered_csr_colind,
-                         &idum,
-                         &nrhs,
-                         iparm,
-                         &msglvl,
-                         &ddum,
-                         &ddum,
-                         &comm_,
-                         &error);
-
-   MFEM_ASSERT(error == 0, "CPardiso free error");
+   // Release all internal memory. There is none to release, and no matrix to
+   // name in the call, if SetOperator() was never reached.
+   ReleaseFactorization();
 
    delete[] csr_rowptr;
    delete[] reordered_csr_colind;

--- a/linalg/cpardiso.hpp
+++ b/linalg/cpardiso.hpp
@@ -19,6 +19,7 @@
 
 #include "mkl_cluster_sparse_solver.h"
 #include "operator.hpp"
+#include "sparsitypattern.hpp"
 
 namespace mfem
 {
@@ -80,6 +81,45 @@ public:
     */
    void SetMatrixType(MatType mat_type);
 
+   /**
+    * @brief Retain the analysis phase across SetOperator() calls and reuse it
+    * whenever the sparsity pattern is unchanged. Off by default.
+    *
+    * This is PardisoSolver::SetReuseSymbolic() for the cluster solver, and the
+    * saving is the same: phase 11, the reordering and symbolic factorization,
+    * depends only on the pattern, so a caller refactorizing a matrix of fixed
+    * structure otherwise repeats it on every SetOperator() call.
+    *
+    * The pattern compared is that of the local CSR matrix this rank builds
+    * from the HypreParMatrix -- the merged diagonal and off-diagonal blocks,
+    * with global column indices -- together with the index of its first row.
+    *
+    * @note The decision is reduced across the communicator: the analysis is
+    * reused only if every rank finds its own pattern unchanged. It has to be,
+    * because cluster_sparse_solver() is collective, and ranks that disagreed
+    * about whether to call phase 11 would deadlock.
+    *
+    * @param reuse Whether to reuse the analysis
+    */
+   void SetReuseSymbolic(bool reuse = true);
+
+   /// Whether analysis reuse is enabled; see SetReuseSymbolic().
+   bool GetReuseSymbolic() const { return reuse_symbolic; }
+
+   /**
+    * @brief The number of analyses actually performed, that is, of phase 11
+    * calls. Without reuse this is the number of SetOperator() calls; with
+    * reuse it is the number of times the pattern changed. The same on every
+    * rank, since the decision is collective.
+    */
+   long GetNumSymbolicFactorizations() const { return num_symbolic; }
+
+   /**
+    * @brief The number of numeric factorizations actually performed, that is,
+    * of phase 22 calls. Reuse never skips one of these.
+    */
+   long GetNumNumericFactorizations() const { return num_numeric; }
+
    ~CPardisoSolver();
 
 private:
@@ -117,6 +157,24 @@ private:
    // Dummy variables
    mutable int idum;
    mutable real_t ddum;
+
+   // Whether the analysis may be retained and reused; see SetReuseSymbolic()
+   bool reuse_symbolic = false;
+
+   // The pattern of the local CSR matrix the retained analysis was made for,
+   // and the first row index that went with it; empty unless reusing
+   RetainedSparsityPattern pattern;
+   int pattern_first_row = -1;
+
+   // Whether pt holds a factorization, and so has memory to release
+   bool factored = false;
+
+   // The number of phase 11 and phase 22 calls actually made
+   long num_symbolic = 0;
+   long num_numeric = 0;
+
+   // Release the memory held by pt, if there is any
+   void ReleaseFactorization();
 };
 } // namespace mfem
 

--- a/linalg/linalg.hpp
+++ b/linalg/linalg.hpp
@@ -19,6 +19,7 @@
 #include "operator.hpp"
 #include "matrix.hpp"
 #include "sparsemat.hpp"
+#include "sparsitypattern.hpp"
 #include "complex_operator.hpp"
 #include "complex_densemat.hpp"
 #include "blockvector.hpp"

--- a/linalg/pardiso.cpp
+++ b/linalg/pardiso.cpp
@@ -55,6 +55,29 @@ PardisoSolver::PardisoSolver()
    nrhs = 1;
 }
 
+void PardisoSolver::ReleaseFactorization()
+{
+   if (!factored) { return; }
+
+   // Release all internal memory held for the current factorization. Without
+   // this a second analysis on the same handle leaks whatever the first one
+   // allocated inside MKL.
+   phase = -1;
+   PARDISO(pt, &maxfct, &mnum, &mtype, &phase, &m, reordered_csr_nzval, csr_rowptr,
+           reordered_csr_colind, &idum, &nrhs,
+           iparm, &msglvl, &ddum, &ddum, &error);
+
+   MFEM_ASSERT(error == 0, "Pardiso free error");
+
+   factored = false;
+}
+
+void PardisoSolver::SetReuseSymbolic(bool reuse)
+{
+   reuse_symbolic = reuse;
+   if (!reuse) { pattern.Clear(); }
+}
+
 void PardisoSolver::SetOperator(const Operator &op)
 {
    auto mat = const_cast<SparseMatrix *>(dynamic_cast<const SparseMatrix *>(&op));
@@ -69,35 +92,60 @@ void PardisoSolver::SetOperator(const Operator &op)
 
    nnz = mat->NumNonZeroElems();
 
+   // Pardiso expects the column indices to be sorted for each row
+   mat->SortColumnIndices();
+
    const int *Ap = mat->HostReadI();
    const int *Ai = mat->HostReadJ();
    const real_t *Ax = mat->HostReadData();
 
-   csr_rowptr = new int[m + 1];
-   reordered_csr_colind = new int[nnz];
-   reordered_csr_nzval = new real_t[nnz];
+   // Whether the analysis in hand was made for this pattern. Checked against
+   // the pattern itself, never assumed; see SetReuseSymbolic(). Without reuse
+   // there is never one to keep, and this is false on every call.
+   const bool reuse = reuse_symbolic && factored &&
+                      pattern.Matches(m, nnz, Ap, Ai);
 
-   for (int i = 0; i <= m; i++)
+   if (!reuse)
    {
-      csr_rowptr[i] = Ap[i];
+      ReleaseFactorization();
+
+      delete[] csr_rowptr;
+      delete[] reordered_csr_colind;
+      delete[] reordered_csr_nzval;
+      csr_rowptr = new int[m + 1];
+      reordered_csr_colind = new int[nnz];
+      reordered_csr_nzval = new real_t[nnz];
+
+      for (int i = 0; i <= m; i++)
+      {
+         csr_rowptr[i] = Ap[i];
+      }
+
+      for (int i = 0; i < nnz; i++)
+      {
+         reordered_csr_colind[i] = Ai[i];
+      }
    }
 
-   // Pardiso expects the column indices to be sorted for each row
-   mat->SortColumnIndices();
-
+   // The values are the reason for the call, reuse or not.
    for (int i = 0; i < nnz; i++)
    {
-      reordered_csr_colind[i] = Ai[i];
       reordered_csr_nzval[i] = Ax[i];
    }
 
-   // Analyze inputs
-   phase = 11;
-   PARDISO(pt, &maxfct, &mnum, &mtype, &phase, &m, reordered_csr_nzval, csr_rowptr,
-           reordered_csr_colind, &idum, &nrhs,
-           iparm, &msglvl, &ddum, &ddum, &error);
+   if (!reuse)
+   {
+      // Analyze inputs
+      phase = 11;
+      PARDISO(pt, &maxfct, &mnum, &mtype, &phase, &m, reordered_csr_nzval,
+              csr_rowptr, reordered_csr_colind, &idum, &nrhs,
+              iparm, &msglvl, &ddum, &ddum, &error);
 
-   MFEM_ASSERT(error == 0, "Pardiso symbolic factorization error");
+      MFEM_ASSERT(error == 0, "Pardiso symbolic factorization error");
+
+      num_symbolic++;
+      if (reuse_symbolic) { pattern.Set(m, nnz, Ap, Ai); }
+   }
 
    // Numerical factorization
    phase = 22;
@@ -106,6 +154,9 @@ void PardisoSolver::SetOperator(const Operator &op)
            iparm, &msglvl, &ddum, &ddum, &error);
 
    MFEM_ASSERT(error == 0, "Pardiso numerical factorization error");
+
+   num_numeric++;
+   factored = true;
 }
 
 void PardisoSolver::Mult(const Vector &b, Vector &x) const
@@ -131,13 +182,9 @@ void PardisoSolver::SetMatrixType(MatType mat_type)
 
 PardisoSolver::~PardisoSolver()
 {
-   // Release all internal memory
-   phase = -1;
-   PARDISO(pt, &maxfct, &mnum, &mtype, &phase, &m, reordered_csr_nzval, csr_rowptr,
-           reordered_csr_colind, &idum, &nrhs,
-           iparm, &msglvl, &ddum, &ddum, &error);
-
-   MFEM_ASSERT(error == 0, "Pardiso free error");
+   // Release all internal memory. There is none to release, and no m or matrix
+   // to name in the call, if SetOperator() was never reached.
+   ReleaseFactorization();
 
    delete[] csr_rowptr;
    delete[] reordered_csr_colind;

--- a/linalg/pardiso.hpp
+++ b/linalg/pardiso.hpp
@@ -18,6 +18,7 @@
 
 #include "mkl_pardiso.h"
 #include "operator.hpp"
+#include "sparsitypattern.hpp"
 
 namespace mfem
 {
@@ -79,6 +80,41 @@ public:
     */
    void SetMatrixType(MatType mat_type);
 
+   /**
+    * @brief Retain the analysis phase across SetOperator() calls and reuse it
+    * whenever the sparsity pattern is unchanged. Off by default.
+    *
+    * PARDISO's phase 11, the reordering and symbolic factorization, depends
+    * only on the sparsity pattern. A caller that refactorizes a matrix whose
+    * pattern does not change -- a Newton iteration, an implicit time step, a
+    * continuation loop, a parameter sweep -- otherwise repeats it on every
+    * SetOperator() call and uses it once. With reuse, such a call is phase 22
+    * alone.
+    *
+    * The pattern is checked, not assumed, by the exact comparison described in
+    * UMFPackSolver::SetReuseSymbolic(): when it has changed, the factorization
+    * is released and phase 11 is run again.
+    *
+    * @param reuse Whether to reuse the analysis
+    */
+   void SetReuseSymbolic(bool reuse = true);
+
+   /// Whether analysis reuse is enabled; see SetReuseSymbolic().
+   bool GetReuseSymbolic() const { return reuse_symbolic; }
+
+   /**
+    * @brief The number of analyses actually performed, that is, of PARDISO
+    * phase 11 calls. Without reuse this is the number of SetOperator() calls;
+    * with reuse it is the number of times the pattern changed.
+    */
+   long GetNumSymbolicFactorizations() const { return num_symbolic; }
+
+   /**
+    * @brief The number of numeric factorizations actually performed, that is,
+    * of PARDISO phase 22 calls. Reuse never skips one of these.
+    */
+   long GetNumNumericFactorizations() const { return num_numeric; }
+
    ~PardisoSolver();
 
 private:
@@ -108,6 +144,22 @@ private:
    // Dummy variables
    mutable int idum;
    mutable real_t ddum;
+
+   // Whether the analysis may be retained and reused; see SetReuseSymbolic()
+   bool reuse_symbolic = false;
+
+   // The pattern the retained analysis was made for; empty unless reusing
+   RetainedSparsityPattern pattern;
+
+   // Whether pt holds a factorization, and so has memory to release
+   bool factored = false;
+
+   // The number of phase 11 and phase 22 calls actually made
+   long num_symbolic = 0;
+   long num_numeric = 0;
+
+   // Release the memory held by pt, if there is any
+   void ReleaseFactorization();
 };
 } // namespace mfem
 

--- a/linalg/solvers.cpp
+++ b/linalg/solvers.cpp
@@ -3350,11 +3350,86 @@ void ResidualBCMonitor::MonitorResidual(
 
 #ifdef MFEM_USE_SUITESPARSE
 
+/** The sparsity pattern of a SparseMatrix, copied so that a matrix seen later
+    can be tested against it.
+
+    The test is exact: the size and the number of nonzeros first, which rejects
+    most changes at O(1), and then the pattern itself, entry by entry, at O(nnz)
+    integer compares. That is a fraction of a percent of the factorization it
+    guards -- some 1 ms against the 100 ms symbolic analysis of a matrix with a
+    million nonzeros -- and it is the whole safety of reusing an analysis, so it
+    is not worth shortening.
+
+    In particular it is not enough to ask whether this is the same matrix object
+    with the same I and J arrays, tempting though that O(1) test is for a matrix
+    reassembled in place. A matrix destroyed and rebuilt with different
+    structure but the same size and the same number of nonzeros asks the
+    allocator for blocks of exactly the sizes just freed, and readily lands on
+    the same addresses; a SparseMatrix built in a loop can even be the same
+    object every time. Identity would then hold for a pattern that had changed,
+    which is the one failure this check exists to prevent, and it would be
+    silent.
+
+    The pattern is copied rather than pointed at so that the comparison stays
+    valid, and stays safe, after the matrix it was taken from is destroyed. */
+class SuiteSparsePattern
+{
+private:
+   int size, nnz;
+   Array<int> I_copy, J_copy;
+   bool set;
+
+public:
+   SuiteSparsePattern() : size(0), nnz(0), set(false) { }
+
+   /// Forget the pattern; Matches() returns false until the next Set().
+   void Clear()
+   {
+      size = nnz = 0;
+      I_copy.DeleteAll();
+      J_copy.DeleteAll();
+      set = false;
+   }
+
+   /// Record the sparsity pattern of the finalized matrix @a A.
+   void Set(const SparseMatrix &A)
+   {
+      const int *I = A.HostReadI();
+      const int *J = A.HostReadJ();
+      MFEM_ASSERT(I && J, "the matrix is not finalized");
+      size = A.Height();
+      nnz = I[size];
+      I_copy.SetSize(size+1);
+      J_copy.SetSize(nnz);
+      std::copy(I, I + size + 1, I_copy.begin());
+      std::copy(J, J + nnz, J_copy.begin());
+      set = true;
+   }
+
+   /// Whether @a A has the pattern recorded by the last Set().
+   bool Matches(const SparseMatrix &A) const
+   {
+      if (!set) { return false; }
+      if (A.Height() != size || A.Width() != size) { return false; }
+      const int *Ai = A.HostReadI();
+      const int *Aj = A.HostReadJ();
+      if (!Ai || !Aj) { return false; }
+      if (Ai[size] != nnz) { return false; }
+      return std::equal(I_copy.begin(), I_copy.end(), Ai) &&
+             std::equal(J_copy.begin(), J_copy.end(), Aj);
+   }
+};
+
 void UMFPackSolver::Init()
 {
    mat = NULL;
    Numeric = NULL;
    AI = AJ = NULL;
+   Symbolic = NULL;
+   reuse_symbolic = false;
+   pattern = NULL;
+   num_symbolic = 0;
+   num_numeric = 0;
    if (!use_long_ints)
    {
       umfpack_di_defaults(Control);
@@ -3365,9 +3440,63 @@ void UMFPackSolver::Init()
    }
 }
 
+void UMFPackSolver::FreeSymbolic()
+{
+   if (Symbolic)
+   {
+      if (!use_long_ints)
+      {
+         umfpack_di_free_symbolic(&Symbolic);
+      }
+      else
+      {
+         umfpack_dl_free_symbolic(&Symbolic);
+      }
+      Symbolic = NULL;
+   }
+   if (pattern) { pattern->Clear(); }
+}
+
+bool UMFPackSolver::CanReuseSymbolic(const SparseMatrix &A) const
+{
+   return reuse_symbolic && Symbolic && pattern && pattern->Matches(A);
+}
+
+void UMFPackSolver::SetReuseSymbolic(bool reuse)
+{
+   reuse_symbolic = reuse;
+   if (reuse)
+   {
+      if (!pattern) { pattern = new SuiteSparsePattern; }
+   }
+   else
+   {
+      FreeSymbolic();
+      delete pattern;
+      pattern = NULL;
+   }
+}
+
 void UMFPackSolver::SetOperator(const Operator &op)
 {
-   void *Symbolic;
+   mat = const_cast<SparseMatrix *>(dynamic_cast<const SparseMatrix *>(&op));
+   MFEM_VERIFY(mat, "not a SparseMatrix");
+
+   // UMFPack requires that the column-indices in mat corresponding to each
+   // row be sorted.
+   // Generally, this will modify the ordering of the entries of mat.
+   mat->SortColumnIndices();
+
+   height = mat->Height();
+   width = mat->Width();
+   MFEM_VERIFY(width == height, "not a square matrix");
+
+   // Whether the retained symbolic analysis, if there is one, was made for this
+   // pattern. Checked against the pattern itself, never assumed; see
+   // SetReuseSymbolic(). Without reuse there is never one to retain, and this
+   // is false on every call.
+   const bool reuse = CanReuseSymbolic(*mat);
+   if (!reuse) { FreeSymbolic(); }
 
    if (Numeric)
    {
@@ -3381,32 +3510,26 @@ void UMFPackSolver::SetOperator(const Operator &op)
       }
    }
 
-   mat = const_cast<SparseMatrix *>(dynamic_cast<const SparseMatrix *>(&op));
-   MFEM_VERIFY(mat, "not a SparseMatrix");
-
-   // UMFPack requires that the column-indices in mat corresponding to each
-   // row be sorted.
-   // Generally, this will modify the ordering of the entries of mat.
-   mat->SortColumnIndices();
-
-   height = mat->Height();
-   width = mat->Width();
-   MFEM_VERIFY(width == height, "not a square matrix");
-
    const int * Ap = mat->HostReadI();
    const int * Ai = mat->HostReadJ();
    const real_t * Ax = mat->HostReadData();
 
    if (!use_long_ints)
    {
-      int status = umfpack_di_symbolic(width, width, Ap, Ai, Ax, &Symbolic,
-                                       Control, Info);
-      if (status < 0)
+      int status;
+      if (!Symbolic)
       {
-         umfpack_di_report_info(Control, Info);
-         umfpack_di_report_status(Control, status);
-         mfem_error("UMFPackSolver::SetOperator :"
-                    " umfpack_di_symbolic() failed!");
+         status = umfpack_di_symbolic(width, width, Ap, Ai, Ax, &Symbolic,
+                                      Control, Info);
+         if (status < 0)
+         {
+            umfpack_di_report_info(Control, Info);
+            umfpack_di_report_status(Control, status);
+            mfem_error("UMFPackSolver::SetOperator :"
+                       " umfpack_di_symbolic() failed!");
+         }
+         num_symbolic++;
+         if (reuse_symbolic) { pattern->Set(*mat); }
       }
 
       status = umfpack_di_numeric(Ap, Ai, Ax, Symbolic, &Numeric,
@@ -3418,33 +3541,49 @@ void UMFPackSolver::SetOperator(const Operator &op)
          mfem_error("UMFPackSolver::SetOperator :"
                     " umfpack_di_numeric() failed!");
       }
-      umfpack_di_free_symbolic(&Symbolic);
+      num_numeric++;
+      // Without reuse the analysis is discarded here, as it always has been;
+      // umfpack_di_free_symbolic() sets Symbolic back to NULL.
+      if (!reuse_symbolic)
+      {
+         umfpack_di_free_symbolic(&Symbolic);
+      }
    }
    else
    {
       SuiteSparse_long status;
 
-      delete [] AJ;
-      delete [] AI;
-      AI = new SuiteSparse_long[width + 1];
-      AJ = new SuiteSparse_long[Ap[width]];
-      for (int i = 0; i <= width; i++)
+      // The long copies of the pattern are the pattern: when it is unchanged,
+      // so are they, and rebuilding them would only copy it again.
+      if (!reuse)
       {
-         AI[i] = (SuiteSparse_long)(Ap[i]);
-      }
-      for (int i = 0; i < Ap[width]; i++)
-      {
-         AJ[i] = (SuiteSparse_long)(Ai[i]);
+         delete [] AJ;
+         delete [] AI;
+         AI = new SuiteSparse_long[width + 1];
+         AJ = new SuiteSparse_long[Ap[width]];
+         for (int i = 0; i <= width; i++)
+         {
+            AI[i] = (SuiteSparse_long)(Ap[i]);
+         }
+         for (int i = 0; i < Ap[width]; i++)
+         {
+            AJ[i] = (SuiteSparse_long)(Ai[i]);
+         }
       }
 
-      status = umfpack_dl_symbolic(width, width, AI, AJ, Ax, &Symbolic,
-                                   Control, Info);
-      if (status < 0)
+      if (!Symbolic)
       {
-         umfpack_dl_report_info(Control, Info);
-         umfpack_dl_report_status(Control, status);
-         mfem_error("UMFPackSolver::SetOperator :"
-                    " umfpack_dl_symbolic() failed!");
+         status = umfpack_dl_symbolic(width, width, AI, AJ, Ax, &Symbolic,
+                                      Control, Info);
+         if (status < 0)
+         {
+            umfpack_dl_report_info(Control, Info);
+            umfpack_dl_report_status(Control, status);
+            mfem_error("UMFPackSolver::SetOperator :"
+                       " umfpack_dl_symbolic() failed!");
+         }
+         num_symbolic++;
+         if (reuse_symbolic) { pattern->Set(*mat); }
       }
 
       status = umfpack_dl_numeric(AI, AJ, Ax, Symbolic, &Numeric,
@@ -3456,7 +3595,11 @@ void UMFPackSolver::SetOperator(const Operator &op)
          mfem_error("UMFPackSolver::SetOperator :"
                     " umfpack_dl_numeric() failed!");
       }
-      umfpack_dl_free_symbolic(&Symbolic);
+      num_numeric++;
+      if (!reuse_symbolic)
+      {
+         umfpack_dl_free_symbolic(&Symbolic);
+      }
    }
 }
 
@@ -3547,24 +3690,55 @@ UMFPackSolver::~UMFPackSolver()
          umfpack_dl_free_numeric(&Numeric);
       }
    }
+   FreeSymbolic();
+   delete pattern;
 }
 
 void KLUSolver::Init()
 {
+   reuse_symbolic = false;
+   reuse_numeric = false;
+   pattern = NULL;
+   num_symbolic = 0;
+   num_numeric = 0;
+   num_refactor = 0;
    klu_defaults(&Common);
+}
+
+bool KLUSolver::CanReuseSymbolic(const SparseMatrix &A) const
+{
+   return reuse_symbolic && Symbolic && pattern && pattern->Matches(A);
+}
+
+void KLUSolver::SetReuseSymbolic(bool reuse)
+{
+   reuse_symbolic = reuse;
+   if (reuse)
+   {
+      if (!pattern) { pattern = new SuiteSparsePattern; }
+   }
+   else
+   {
+      // Symbolic is not freed here: klu_solve() needs it, so it is held for the
+      // life of the factorization whether or not it is reused. Dropping the
+      // pattern is what stops it being reused: the next SetOperator() rebuilds
+      // it, exactly as it does without this flag.
+      delete pattern;
+      pattern = NULL;
+      reuse_numeric = false;
+   }
+}
+
+void KLUSolver::SetReuseNumeric(bool reuse)
+{
+   reuse_numeric = reuse;
+   if (reuse) { SetReuseSymbolic(true); }
 }
 
 void KLUSolver::SetOperator(const Operator &op)
 {
-   if (Numeric)
-   {
-      MFEM_VERIFY(Symbolic != 0,
-                  "Had Numeric pointer in KLU, but not Symbolic");
-      klu_free_symbolic(&Symbolic, &Common);
-      Symbolic = 0;
-      klu_free_numeric(&Numeric, &Common);
-      Numeric = 0;
-   }
+   MFEM_VERIFY(Numeric == 0 || Symbolic != 0,
+               "Had Numeric pointer in KLU, but not Symbolic");
 
    mat = const_cast<SparseMatrix *>(dynamic_cast<const SparseMatrix *>(&op));
    MFEM_VERIFY(mat != NULL, "not a SparseMatrix");
@@ -3581,8 +3755,53 @@ void KLUSolver::SetOperator(const Operator &op)
    int * Ai = mat->GetJ();
    real_t * Ax = mat->GetData();
 
-   Symbolic = klu_analyze( height, Ap, Ai, &Common);
-   Numeric = klu_factor(Ap, Ai, Ax, Symbolic, &Common);
+   // Whether the analysis in hand was made for this pattern. Checked against
+   // the pattern itself, never assumed; see SetReuseSymbolic().
+   const bool reuse_sym = CanReuseSymbolic(*mat);
+   // klu_refactor() reuses the pivot ordering of the existing factorization as
+   // well as the analysis, so it needs both of them present.
+   const bool refactor = reuse_sym && reuse_numeric && Numeric != 0;
+
+   if (Numeric && !refactor)
+   {
+      klu_free_numeric(&Numeric, &Common);
+      Numeric = 0;
+   }
+   if (Symbolic && !reuse_sym)
+   {
+      klu_free_symbolic(&Symbolic, &Common);
+      Symbolic = 0;
+   }
+
+   if (!Symbolic)
+   {
+      Symbolic = klu_analyze(height, Ap, Ai, &Common);
+      num_symbolic++;
+      if (reuse_symbolic && Symbolic) { pattern->Set(*mat); }
+   }
+
+   if (refactor)
+   {
+      if (klu_refactor(Ap, Ai, Ax, Symbolic, Numeric, &Common) &&
+          Common.status == KLU_OK)
+      {
+         num_refactor++;
+      }
+      else
+      {
+         // A refactorization keeps the pivot order chosen for the previous
+         // values, so it can fail where a full factorization succeeds. Fall
+         // back to one rather than report a failure the caller did not ask for.
+         klu_free_numeric(&Numeric, &Common);
+         Numeric = 0;
+      }
+   }
+
+   if (!Numeric)
+   {
+      Numeric = klu_factor(Ap, Ai, Ax, Symbolic, &Common);
+      num_numeric++;
+   }
 }
 
 void KLUSolver::Mult(const Vector &b, Vector &x) const
@@ -3619,6 +3838,7 @@ KLUSolver::~KLUSolver()
    klu_free_numeric (&Numeric, &Common) ;
    Symbolic = 0;
    Numeric = 0;
+   delete pattern;
 }
 
 #endif // MFEM_USE_SUITESPARSE

--- a/linalg/solvers.cpp
+++ b/linalg/solvers.cpp
@@ -3350,76 +3350,6 @@ void ResidualBCMonitor::MonitorResidual(
 
 #ifdef MFEM_USE_SUITESPARSE
 
-/** The sparsity pattern of a SparseMatrix, copied so that a matrix seen later
-    can be tested against it.
-
-    The test is exact: the size and the number of nonzeros first, which rejects
-    most changes at O(1), and then the pattern itself, entry by entry, at O(nnz)
-    integer compares. That is a fraction of a percent of the factorization it
-    guards -- some 1 ms against the 100 ms symbolic analysis of a matrix with a
-    million nonzeros -- and it is the whole safety of reusing an analysis, so it
-    is not worth shortening.
-
-    In particular it is not enough to ask whether this is the same matrix object
-    with the same I and J arrays, tempting though that O(1) test is for a matrix
-    reassembled in place. A matrix destroyed and rebuilt with different
-    structure but the same size and the same number of nonzeros asks the
-    allocator for blocks of exactly the sizes just freed, and readily lands on
-    the same addresses; a SparseMatrix built in a loop can even be the same
-    object every time. Identity would then hold for a pattern that had changed,
-    which is the one failure this check exists to prevent, and it would be
-    silent.
-
-    The pattern is copied rather than pointed at so that the comparison stays
-    valid, and stays safe, after the matrix it was taken from is destroyed. */
-class SuiteSparsePattern
-{
-private:
-   int size, nnz;
-   Array<int> I_copy, J_copy;
-   bool set;
-
-public:
-   SuiteSparsePattern() : size(0), nnz(0), set(false) { }
-
-   /// Forget the pattern; Matches() returns false until the next Set().
-   void Clear()
-   {
-      size = nnz = 0;
-      I_copy.DeleteAll();
-      J_copy.DeleteAll();
-      set = false;
-   }
-
-   /// Record the sparsity pattern of the finalized matrix @a A.
-   void Set(const SparseMatrix &A)
-   {
-      const int *I = A.HostReadI();
-      const int *J = A.HostReadJ();
-      MFEM_ASSERT(I && J, "the matrix is not finalized");
-      size = A.Height();
-      nnz = I[size];
-      I_copy.SetSize(size+1);
-      J_copy.SetSize(nnz);
-      std::copy(I, I + size + 1, I_copy.begin());
-      std::copy(J, J + nnz, J_copy.begin());
-      set = true;
-   }
-
-   /// Whether @a A has the pattern recorded by the last Set().
-   bool Matches(const SparseMatrix &A) const
-   {
-      if (!set) { return false; }
-      if (A.Height() != size || A.Width() != size) { return false; }
-      const int *Ai = A.HostReadI();
-      const int *Aj = A.HostReadJ();
-      if (!Ai || !Aj) { return false; }
-      if (Ai[size] != nnz) { return false; }
-      return std::equal(I_copy.begin(), I_copy.end(), Ai) &&
-             std::equal(J_copy.begin(), J_copy.end(), Aj);
-   }
-};
-
 void UMFPackSolver::Init()
 {
    mat = NULL;
@@ -3427,7 +3357,7 @@ void UMFPackSolver::Init()
    AI = AJ = NULL;
    Symbolic = NULL;
    reuse_symbolic = false;
-   pattern = NULL;
+   pattern.Clear();
    num_symbolic = 0;
    num_numeric = 0;
    if (!use_long_ints)
@@ -3454,27 +3384,18 @@ void UMFPackSolver::FreeSymbolic()
       }
       Symbolic = NULL;
    }
-   if (pattern) { pattern->Clear(); }
+   pattern.Clear();
 }
 
 bool UMFPackSolver::CanReuseSymbolic(const SparseMatrix &A) const
 {
-   return reuse_symbolic && Symbolic && pattern && pattern->Matches(A);
+   return reuse_symbolic && Symbolic && pattern.Matches(A);
 }
 
 void UMFPackSolver::SetReuseSymbolic(bool reuse)
 {
    reuse_symbolic = reuse;
-   if (reuse)
-   {
-      if (!pattern) { pattern = new SuiteSparsePattern; }
-   }
-   else
-   {
-      FreeSymbolic();
-      delete pattern;
-      pattern = NULL;
-   }
+   if (!reuse) { FreeSymbolic(); }
 }
 
 void UMFPackSolver::SetOperator(const Operator &op)
@@ -3529,7 +3450,7 @@ void UMFPackSolver::SetOperator(const Operator &op)
                        " umfpack_di_symbolic() failed!");
          }
          num_symbolic++;
-         if (reuse_symbolic) { pattern->Set(*mat); }
+         if (reuse_symbolic) { pattern.Set(*mat); }
       }
 
       status = umfpack_di_numeric(Ap, Ai, Ax, Symbolic, &Numeric,
@@ -3583,7 +3504,7 @@ void UMFPackSolver::SetOperator(const Operator &op)
                        " umfpack_dl_symbolic() failed!");
          }
          num_symbolic++;
-         if (reuse_symbolic) { pattern->Set(*mat); }
+         if (reuse_symbolic) { pattern.Set(*mat); }
       }
 
       status = umfpack_dl_numeric(AI, AJ, Ax, Symbolic, &Numeric,
@@ -3691,14 +3612,13 @@ UMFPackSolver::~UMFPackSolver()
       }
    }
    FreeSymbolic();
-   delete pattern;
 }
 
 void KLUSolver::Init()
 {
    reuse_symbolic = false;
    reuse_numeric = false;
-   pattern = NULL;
+   pattern.Clear();
    num_symbolic = 0;
    num_numeric = 0;
    num_refactor = 0;
@@ -3707,24 +3627,19 @@ void KLUSolver::Init()
 
 bool KLUSolver::CanReuseSymbolic(const SparseMatrix &A) const
 {
-   return reuse_symbolic && Symbolic && pattern && pattern->Matches(A);
+   return reuse_symbolic && Symbolic && pattern.Matches(A);
 }
 
 void KLUSolver::SetReuseSymbolic(bool reuse)
 {
    reuse_symbolic = reuse;
-   if (reuse)
-   {
-      if (!pattern) { pattern = new SuiteSparsePattern; }
-   }
-   else
+   if (!reuse)
    {
       // Symbolic is not freed here: klu_solve() needs it, so it is held for the
       // life of the factorization whether or not it is reused. Dropping the
       // pattern is what stops it being reused: the next SetOperator() rebuilds
       // it, exactly as it does without this flag.
-      delete pattern;
-      pattern = NULL;
+      pattern.Clear();
       reuse_numeric = false;
    }
 }
@@ -3777,7 +3692,7 @@ void KLUSolver::SetOperator(const Operator &op)
    {
       Symbolic = klu_analyze(height, Ap, Ai, &Common);
       num_symbolic++;
-      if (reuse_symbolic && Symbolic) { pattern->Set(*mat); }
+      if (reuse_symbolic && Symbolic) { pattern.Set(*mat); }
    }
 
    if (refactor)
@@ -3838,7 +3753,6 @@ KLUSolver::~KLUSolver()
    klu_free_numeric (&Numeric, &Common) ;
    Symbolic = 0;
    Numeric = 0;
-   delete pattern;
 }
 
 #endif // MFEM_USE_SUITESPARSE

--- a/linalg/solvers.hpp
+++ b/linalg/solvers.hpp
@@ -23,6 +23,7 @@
 
 #ifdef MFEM_USE_SUITESPARSE
 #include "sparsemat.hpp"
+#include "sparsitypattern.hpp"
 #include <umfpack.h>
 #include <klu.h>
 #endif
@@ -1205,14 +1206,6 @@ public:
 
 #ifdef MFEM_USE_SUITESPARSE
 
-/** @brief The sparsity pattern of a SparseMatrix, retained so that a matrix
-    seen later can be tested against it.
-
-    An implementation detail of the SuiteSparse solver wrappers, which use it to
-    decide whether a symbolic factorization may be reused; see
-    UMFPackSolver::SetReuseSymbolic(). Defined in solvers.cpp. */
-class SuiteSparsePattern;
-
 /// Direct sparse solver using UMFPACK
 class UMFPackSolver : public Solver
 {
@@ -1227,8 +1220,8 @@ protected:
    void *Symbolic;
    /// Whether #Symbolic may be retained and reused; see SetReuseSymbolic().
    bool reuse_symbolic;
-   /// The pattern #Symbolic was computed from. Owned; NULL unless reusing.
-   SuiteSparsePattern *pattern;
+   /// The pattern #Symbolic was computed from; empty unless reusing.
+   RetainedSparsityPattern pattern;
    /// The number of symbolic analyses actually performed.
    long num_symbolic;
    /// The number of numeric factorizations actually performed.
@@ -1336,8 +1329,8 @@ protected:
    bool reuse_symbolic;
    /// Whether #Numeric may be refactorized; see SetReuseNumeric().
    bool reuse_numeric;
-   /// The pattern #Symbolic was computed from. Owned; NULL unless reusing.
-   SuiteSparsePattern *pattern;
+   /// The pattern #Symbolic was computed from; empty unless reusing.
+   RetainedSparsityPattern pattern;
    /// The number of symbolic analyses actually performed.
    long num_symbolic;
    /// The number of full numeric factorizations actually performed.

--- a/linalg/solvers.hpp
+++ b/linalg/solvers.hpp
@@ -1205,6 +1205,14 @@ public:
 
 #ifdef MFEM_USE_SUITESPARSE
 
+/** @brief The sparsity pattern of a SparseMatrix, retained so that a matrix
+    seen later can be tested against it.
+
+    An implementation detail of the SuiteSparse solver wrappers, which use it to
+    decide whether a symbolic factorization may be reused; see
+    UMFPackSolver::SetReuseSymbolic(). Defined in solvers.cpp. */
+class SuiteSparsePattern;
+
 /// Direct sparse solver using UMFPACK
 class UMFPackSolver : public Solver
 {
@@ -1214,7 +1222,26 @@ protected:
    void *Numeric;
    SuiteSparse_long *AI, *AJ;
 
+   /** @brief The symbolic analysis: retained between SetOperator() calls when
+       reuse is enabled, and NULL otherwise. */
+   void *Symbolic;
+   /// Whether #Symbolic may be retained and reused; see SetReuseSymbolic().
+   bool reuse_symbolic;
+   /// The pattern #Symbolic was computed from. Owned; NULL unless reusing.
+   SuiteSparsePattern *pattern;
+   /// The number of symbolic analyses actually performed.
+   long num_symbolic;
+   /// The number of numeric factorizations actually performed.
+   long num_numeric;
+
    void Init();
+
+   /// Discard the retained symbolic analysis, and the pattern it was made for.
+   void FreeSymbolic();
+
+   /** @brief Whether the retained symbolic analysis applies to @a A, that is,
+       whether @a A has the sparsity pattern it was computed from. */
+   bool CanReuseSymbolic(const SparseMatrix &A) const;
 
 public:
    real_t Control[UMFPACK_CONTROL];
@@ -1237,6 +1264,54 @@ public:
        modifying the matrix if the column indices are not already sorted. */
    void SetOperator(const Operator &op) override;
 
+   /** @brief Retain the symbolic factorization across SetOperator() calls and
+       reuse it whenever the sparsity pattern is unchanged. Off by default.
+
+       The symbolic analysis is a fifth to a quarter of the cost of a
+       factorization, and it depends only on the sparsity pattern. Any caller
+       that refactorizes a matrix whose pattern does not change -- a Newton
+       iteration, an implicit time step, a continuation loop, a parameter
+       sweep -- otherwise pays for it on every SetOperator() call and uses it
+       once.
+
+       The pattern is checked, not assumed: reuse is a request, and the
+       analysis is redone whenever the check fails. The check is exact -- the
+       size and the number of nonzeros, and then the pattern itself compared
+       entry by entry against a copy retained alongside the analysis. It costs
+       O(nnz) integer compares, a fraction of a percent of the factorization it
+       guards, and it accepts a matrix reassembled in place and a matrix
+       rebuilt into a fresh object with the same structure alike. It is
+       deliberately not the O(1) test of asking whether this is the same matrix
+       object with the same I and J arrays: a matrix destroyed and rebuilt with
+       a different structure but the same size and nnz readily lands on exactly
+       those addresses again, and the wrong answer that would follow would be a
+       silent one.
+
+       @note umfpack_*_symbolic() reads the values as well as the pattern:
+       under UMFPACK_STRATEGY_AUTO it uses them to choose between the symmetric
+       and unsymmetric strategies and to find singletons. A retained analysis
+       stays *correct* whatever the values become, but it may carry a poorer
+       ordering than a fresh analysis of the current values would have chosen.
+       This is a performance caveat, not a correctness one.
+
+       @note Retaining the analysis also retains a copy of the pattern: one int
+       array of length nnz, and one of length n+1. */
+   void SetReuseSymbolic(bool reuse = true);
+
+   /// Whether symbolic reuse is enabled; see SetReuseSymbolic().
+   bool GetReuseSymbolic() const { return reuse_symbolic; }
+
+   /** @brief The number of symbolic analyses actually performed, that is, of
+       umfpack_*_symbolic() calls. Without reuse this is the number of
+       SetOperator() calls; with reuse it is the number of times the pattern
+       changed. */
+   long GetNumSymbolicFactorizations() const { return num_symbolic; }
+
+   /** @brief The number of numeric factorizations actually performed, that is,
+       of umfpack_*_numeric() calls. Reuse never skips one of these: it is the
+       number of SetOperator() calls either way. */
+   long GetNumNumericFactorizations() const { return num_numeric; }
+
    /// Set the print level field in the #Control data member.
    void SetPrintLevel(int print_lvl) { Control[UMFPACK_PRL] = print_lvl; }
 
@@ -1257,7 +1332,24 @@ protected:
    klu_symbolic *Symbolic;
    klu_numeric *Numeric;
 
+   /// Whether #Symbolic may be reused; see SetReuseSymbolic().
+   bool reuse_symbolic;
+   /// Whether #Numeric may be refactorized; see SetReuseNumeric().
+   bool reuse_numeric;
+   /// The pattern #Symbolic was computed from. Owned; NULL unless reusing.
+   SuiteSparsePattern *pattern;
+   /// The number of symbolic analyses actually performed.
+   long num_symbolic;
+   /// The number of full numeric factorizations actually performed.
+   long num_numeric;
+   /// The number of refactorizations actually performed.
+   long num_refactor;
+
    void Init();
+
+   /** @brief Whether the symbolic analysis in hand applies to @a A, that is,
+       whether @a A has the sparsity pattern it was computed from. */
+   bool CanReuseSymbolic(const SparseMatrix &A) const;
 
 public:
    KLUSolver()
@@ -1269,6 +1361,53 @@ public:
 
    // Works on sparse matrices only; calls SparseMatrix::SortColumnIndices().
    void SetOperator(const Operator &op) override;
+
+   /** @brief Reuse the symbolic analysis across SetOperator() calls whenever
+       the sparsity pattern is unchanged, instead of discarding it and calling
+       klu_analyze() again. Off by default.
+
+       The pattern is checked, not assumed, by the same exact comparison against
+       a retained copy that UMFPackSolver::SetReuseSymbolic() documents.
+
+       Turning reuse off also turns off numeric reuse, which requires it. */
+   void SetReuseSymbolic(bool reuse = true);
+
+   /** @brief Reuse the numeric factorization as well, through klu_refactor(),
+       whenever the sparsity pattern is unchanged. Off by default; turning it
+       on turns on SetReuseSymbolic(), which it requires.
+
+       This is the case KLU is written for and the larger of the two savings:
+       klu_refactor() keeps the pivot ordering and the nonzero structure of the
+       existing factorization and only recomputes its values.
+
+       @note Keeping the pivot ordering means no partial pivoting is done for
+       the new values, so the refactorization can be less accurate than a fresh
+       one, and for values far from those it was built for it can fail
+       outright. Failure is caught and falls back to a full klu_factor(); loss
+       of accuracy is not, so this is the flag to turn off first if a converging
+       iteration stops converging. */
+   void SetReuseNumeric(bool reuse = true);
+
+   /// Whether symbolic reuse is enabled; see SetReuseSymbolic().
+   bool GetReuseSymbolic() const { return reuse_symbolic; }
+
+   /// Whether numeric reuse is enabled; see SetReuseNumeric().
+   bool GetReuseNumeric() const { return reuse_numeric; }
+
+   /** @brief The number of symbolic analyses actually performed, that is, of
+       klu_analyze() calls. Without reuse this is the number of SetOperator()
+       calls; with reuse it is the number of times the pattern changed. */
+   long GetNumSymbolicFactorizations() const { return num_symbolic; }
+
+   /** @brief The number of full numeric factorizations actually performed,
+       that is, of klu_factor() calls. Refactorizations are not counted here;
+       see GetNumRefactorizations(). */
+   long GetNumNumericFactorizations() const { return num_numeric; }
+
+   /** @brief The number of refactorizations actually performed, that is, of
+       klu_refactor() calls that succeeded. One that fails falls back to a full
+       factorization and is counted there instead. */
+   long GetNumRefactorizations() const { return num_refactor; }
 
    /// Direct solution of the linear system using KLU
    void Mult(const Vector &b, Vector &x) const override;

--- a/linalg/sparsitypattern.hpp
+++ b/linalg/sparsitypattern.hpp
@@ -1,0 +1,113 @@
+// Copyright (c) 2010-2025, Lawrence Livermore National Security, LLC. Produced
+// at the Lawrence Livermore National Laboratory. All Rights reserved. See files
+// LICENSE and NOTICE for details. LLNL-CODE-806117.
+//
+// This file is part of the MFEM library. For more information and source code
+// availability visit https://mfem.org.
+//
+// MFEM is free software; you can redistribute it and/or modify it under the
+// terms of the BSD-3 license. We welcome feedback and contributions, see file
+// CONTRIBUTING.md for details.
+
+#ifndef MFEM_SPARSITYPATTERN
+#define MFEM_SPARSITYPATTERN
+
+#include "../config/config.hpp"
+#include "../general/array.hpp"
+#include "sparsemat.hpp"
+
+#include <algorithm>
+
+namespace mfem
+{
+
+/** @brief The sparsity pattern of a matrix in CSR form, copied so that a matrix
+    seen later can be tested against it.
+
+    The direct solver wrappers use this to decide whether a symbolic
+    factorization computed earlier still describes the matrix in hand, and may
+    therefore be reused rather than recomputed; see
+    UMFPackSolver::SetReuseSymbolic().
+
+    The test is exact: the size and the number of nonzeros first, which rejects
+    most changes at O(1), and then the pattern itself, entry by entry, at O(nnz)
+    integer compares. That is a fraction of a percent of the factorization it
+    guards -- some 1 ms against the 100 ms symbolic analysis of a matrix with a
+    million nonzeros -- and it is the whole safety of reusing an analysis, so it
+    is not worth shortening.
+
+    In particular it is not enough to ask whether this is the same matrix object
+    with the same I and J arrays, tempting though that O(1) test is for a matrix
+    reassembled in place. A matrix destroyed and rebuilt with a different
+    structure, but the same size and the same number of nonzeros, asks the
+    allocator for blocks of exactly the sizes just freed and readily lands on
+    the same addresses; a matrix built in a loop can even be the same object
+    every time. Identity would then hold for a pattern that had changed, which
+    is the one failure this check exists to prevent, and it would be silent.
+
+    The pattern is copied rather than pointed at so that the comparison stays
+    valid, and stays safe, after the matrix it was taken from is destroyed. */
+class RetainedSparsityPattern
+{
+private:
+   int size, nnz;
+   Array<int> I_copy, J_copy;
+   bool set;
+
+public:
+   RetainedSparsityPattern() : size(0), nnz(0), set(false) { }
+
+   /// Whether a pattern has been recorded and not since cleared.
+   bool IsSet() const { return set; }
+
+   /// Forget the pattern. Matches() returns false until the next Set().
+   void Clear()
+   {
+      size = nnz = 0;
+      I_copy.DeleteAll();
+      J_copy.DeleteAll();
+      set = false;
+   }
+
+   /** @brief Record the pattern of a CSR matrix with @a s rows and @a nz
+       nonzeros, row pointers @a I and column indices @a J. */
+   void Set(int s, int nz, const int *I, const int *J)
+   {
+      MFEM_ASSERT(I && J, "no pattern to record");
+      MFEM_ASSERT(I[s] == nz, "the row pointers do not end at nnz");
+      size = s;
+      nnz = nz;
+      I_copy.SetSize(size+1);
+      J_copy.SetSize(nnz);
+      std::copy(I, I + size + 1, I_copy.begin());
+      std::copy(J, J + nnz, J_copy.begin());
+      set = true;
+   }
+
+   /// Record the sparsity pattern of the finalized matrix @a A.
+   void Set(const SparseMatrix &A)
+   {
+      Set(A.Height(), A.NumNonZeroElems(), A.HostReadI(), A.HostReadJ());
+   }
+
+   /** @brief Whether the CSR matrix with @a s rows, @a nz nonzeros, row
+       pointers @a I and column indices @a J has the recorded pattern. */
+   bool Matches(int s, int nz, const int *I, const int *J) const
+   {
+      if (!set || s != size || nz != nnz || !I || !J) { return false; }
+      return std::equal(I_copy.begin(), I_copy.end(), I) &&
+             std::equal(J_copy.begin(), J_copy.end(), J);
+   }
+
+   /// Whether the finalized matrix @a A has the recorded pattern.
+   bool Matches(const SparseMatrix &A) const
+   {
+      const int *I = A.HostReadI();
+      if (!I) { return false; }
+      return Matches(A.Height(), I[A.Height()], I, A.HostReadJ());
+   }
+};
+
+} // namespace mfem
+
+#endif

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -56,6 +56,7 @@ set(UNIT_TESTS_SRCS
   linalg/test_complex_dense_matrix.cpp
   linalg/test_complex_operator.cpp
   linalg/test_constrainedsolver.cpp
+  linalg/test_direct_solver_reuse.cpp
   linalg/test_direct_solvers.cpp
   linalg/test_hypre_ilu.cpp
   linalg/test_hypre_prec.cpp

--- a/tests/unit/linalg/test_direct_solver_reuse.cpp
+++ b/tests/unit/linalg/test_direct_solver_reuse.cpp
@@ -60,6 +60,27 @@ void SetDiagonal(SparseMatrix &A, real_t s)
    }
 }
 
+// The same, but with a structurally symmetric pattern: both neighbours at each
+// of the two offsets, so that (i,j) is filled whenever (j,i) is. The values
+// stay asymmetric. PARDISO is told about this through SetMatrixType(), and it
+// has to be true when it is: told REAL_STRUCTURE_SYMMETRIC about a matrix that
+// is not, MKL does not report an error, it fails to return.
+SparseMatrix *MakeSymmetricBanded(int n, int d)
+{
+   MFEM_VERIFY(d > 1 && n > 2*d + 1, "the five columns would not be distinct");
+   SparseMatrix *A = new SparseMatrix(n, n);
+   for (int i = 0; i < n; i++)
+   {
+      A->Add(i, i, 10.0);
+      A->Add(i, (i+1)%n, -1.0);
+      A->Add(i, (i-1+n)%n, -0.6);
+      A->Add(i, (i+d)%n, -1.2);
+      A->Add(i, (i-d+n)%n, -0.4);
+   }
+   A->Finalize();
+   return A;
+}
+
 Vector MakeRHS(int n)
 {
    Vector b(n);
@@ -586,6 +607,265 @@ TEST_CASE("KLU without reuse is bit-for-bit unchanged", "[DirectSolvers]")
       REQUIRE(solver.GetNumSymbolicFactorizations() == 0);
       REQUIRE(solver.GetNumNumericFactorizations() == 0);
       REQUIRE(solver.GetNumRefactorizations() == 0);
+   }
+}
+
+
+namespace direct_solver_reuse
+{
+
+// A complex matrix whose real and imaginary parts share a sparsity pattern,
+// which is what ComplexUMFPackSolver requires.
+ComplexSparseMatrix *MakeComplexBanded(int n, int d, SparseMatrix *&re,
+                                       SparseMatrix *&im,
+                                       ComplexOperator::Convention conv =
+                                          ComplexOperator::HERMITIAN)
+{
+   re = MakeBanded(n, d);
+   im = MakeBanded(n, d);
+   real_t *data = im->HostReadWriteData();
+   for (int k = 0; k < im->NumNonZeroElems(); k++) { data[k] *= 0.3; }
+   return new ComplexSparseMatrix(re, im, true, true, conv);
+}
+
+Vector MakeComplexRHS(int n)
+{
+   Vector b(2*n);
+   for (int i = 0; i < 2*n; i++)
+   {
+      b(i) = 1.0 + std::sin(real_t(2*i)) + real_t(i%5);
+   }
+   return b;
+}
+
+real_t RelResidual(ComplexSparseMatrix &A, const Vector &x, const Vector &b)
+{
+   Vector r(b.Size());
+   A.Mult(x, r);
+   r -= b;
+   return r.Norml2() / b.Norml2();
+}
+
+// The old ComplexUMFPackSolver::SetOperator() and Mult(), written out.
+void RawComplexUMFPackSolve(ComplexSparseMatrix &A, const Vector &b, Vector &x,
+                            bool use_long_ints)
+{
+   A.real().SortColumnIndices();
+   A.imag().SortColumnIndices();
+   const int n = A.real().Height();
+   const int *Ap = A.real().HostReadI();
+   const int *Ai = A.real().HostReadJ();
+   const real_t *Ax = A.real().HostReadData();
+   const real_t *Az = A.imag().HostReadData();
+   real_t Control[UMFPACK_CONTROL], Info[UMFPACK_INFO];
+   void *Symbolic, *Numeric;
+   x.SetSize(2*n);
+   real_t *datax = x.GetData();
+   const real_t *datab = b.GetData();
+   if (!use_long_ints)
+   {
+      umfpack_zi_defaults(Control);
+      umfpack_zi_symbolic(n, n, Ap, Ai, Ax, Az, &Symbolic, Control, Info);
+      umfpack_zi_numeric(Ap, Ai, Ax, Az, Symbolic, &Numeric, Control, Info);
+      umfpack_zi_free_symbolic(&Symbolic);
+      umfpack_zi_solve(UMFPACK_Aat, Ap, Ai, Ax, Az, datax, &datax[n], datab,
+                       &datab[n], Numeric, Control, Info);
+      umfpack_zi_free_numeric(&Numeric);
+   }
+   else
+   {
+      umfpack_zl_defaults(Control);
+      SuiteSparse_long *AI = new SuiteSparse_long[n+1];
+      SuiteSparse_long *AJ = new SuiteSparse_long[Ap[n]];
+      for (int i = 0; i <= n; i++) { AI[i] = (SuiteSparse_long)(Ap[i]); }
+      for (int i = 0; i < Ap[n]; i++) { AJ[i] = (SuiteSparse_long)(Ai[i]); }
+      umfpack_zl_symbolic(n, n, AI, AJ, Ax, Az, &Symbolic, Control, Info);
+      umfpack_zl_numeric(AI, AJ, Ax, Az, Symbolic, &Numeric, Control, Info);
+      umfpack_zl_free_symbolic(&Symbolic);
+      umfpack_zl_solve(UMFPACK_Aat, AI, AJ, Ax, Az, datax, &datax[n], datab,
+                       &datab[n], Numeric, Control, Info);
+      umfpack_zl_free_numeric(&Numeric);
+      delete [] AJ;
+      delete [] AI;
+   }
+}
+
+} // namespace direct_solver_reuse
+
+TEST_CASE("ComplexUMFPack symbolic reuse", "[DirectSolvers]")
+{
+   const int n = 300;
+   const real_t tol = 1e-11;
+   const bool use_long_ints = GENERATE(false, true);
+   CAPTURE(use_long_ints);
+
+   SparseMatrix *re = nullptr, *im = nullptr;
+   std::unique_ptr<ComplexSparseMatrix> A(MakeComplexBanded(n, 7, re, im));
+   const Vector b = MakeComplexRHS(n);
+   Vector x(2*n), x_ref(2*n);
+
+   ComplexUMFPackSolver solver(use_long_ints);
+   solver.SetReuseSymbolic();
+   REQUIRE(solver.GetReuseSymbolic());
+
+   SECTION("nothing is analysed twice, and the answer does not move")
+   {
+      solver.SetOperator(*A);
+      solver.Mult(b, x_ref);
+      REQUIRE(solver.GetNumSymbolicFactorizations() == 1);
+      REQUIRE(solver.GetNumNumericFactorizations() == 1);
+      REQUIRE(RelResidual(*A, x_ref, b) < tol);
+
+      solver.SetOperator(*A);
+      solver.Mult(b, x);
+      REQUIRE(solver.GetNumSymbolicFactorizations() == 1);
+      REQUIRE(solver.GetNumNumericFactorizations() == 2);
+      REQUIRE(BitwiseEqual(x, x_ref));
+   }
+
+   SECTION("values change in place, as a reassembled Jacobian does")
+   {
+      solver.SetOperator(*A);
+      solver.Mult(b, x);
+
+      for (int step = 1; step <= 3; step++)
+      {
+         const real_t s = 0.4*step - 1.0;
+         CAPTURE(step);
+         SetDiagonal(*re, s);
+         solver.SetOperator(*A);
+         solver.Mult(b, x);
+
+         REQUIRE(solver.GetNumSymbolicFactorizations() == 1);
+         REQUIRE(solver.GetNumNumericFactorizations() == step + 1);
+         REQUIRE(RelResidual(*A, x, b) < tol);
+
+         SparseMatrix *re2 = nullptr, *im2 = nullptr;
+         std::unique_ptr<ComplexSparseMatrix> A2(MakeComplexBanded(n, 7, re2,
+                                                                   im2));
+         SetDiagonal(*re2, s);
+         ComplexUMFPackSolver fresh(use_long_ints);
+         fresh.SetOperator(*A2);
+         fresh.Mult(b, x_ref);
+         REQUIRE(RelDiff(x, x_ref) < tol);
+      }
+   }
+
+   SECTION("rebuilt into a fresh matrix with the same pattern")
+   {
+      solver.SetOperator(*A);
+      solver.Mult(b, x_ref);
+
+      SparseMatrix *re2 = nullptr, *im2 = nullptr;
+      std::unique_ptr<ComplexSparseMatrix> A2(MakeComplexBanded(n, 7, re2, im2));
+      SetDiagonal(*re2, 0.5);
+      solver.SetOperator(*A2);
+      solver.Mult(b, x);
+      REQUIRE(solver.GetNumSymbolicFactorizations() == 1);
+      REQUIRE(solver.GetNumNumericFactorizations() == 2);
+      REQUIRE(RelResidual(*A2, x, b) < tol);
+   }
+
+   SECTION("the pattern changes: the analysis is redone")
+   {
+      solver.SetOperator(*A);
+      solver.Mult(b, x);
+      REQUIRE(solver.GetNumSymbolicFactorizations() == 1);
+
+      // The same size and the same number of nonzeros, a different structure.
+      SparseMatrix *re2 = nullptr, *im2 = nullptr;
+      std::unique_ptr<ComplexSparseMatrix> A2(MakeComplexBanded(n, 11, re2,
+                                                                im2));
+      REQUIRE(re2->NumNonZeroElems() == re->NumNonZeroElems());
+      solver.SetOperator(*A2);
+      solver.Mult(b, x);
+      REQUIRE(solver.GetNumSymbolicFactorizations() == 2);
+      REQUIRE(RelResidual(*A2, x, b) < tol);
+   }
+
+   SECTION("reuse can be turned off again")
+   {
+      solver.SetOperator(*A);
+      solver.SetOperator(*A);
+      REQUIRE(solver.GetNumSymbolicFactorizations() == 1);
+
+      solver.SetReuseSymbolic(false);
+      REQUIRE_FALSE(solver.GetReuseSymbolic());
+      solver.SetOperator(*A);
+      solver.Mult(b, x);
+      REQUIRE(solver.GetNumSymbolicFactorizations() == 2);
+      REQUIRE(RelResidual(*A, x, b) < tol);
+   }
+
+   SECTION("the block-symmetric convention")
+   {
+      SparseMatrix *re2 = nullptr, *im2 = nullptr;
+      std::unique_ptr<ComplexSparseMatrix> A2(
+         MakeComplexBanded(n, 7, re2, im2, ComplexOperator::BLOCK_SYMMETRIC));
+      solver.SetOperator(*A2);
+      solver.Mult(b, x_ref);
+      REQUIRE(RelResidual(*A2, x_ref, b) < tol);
+
+      SetDiagonal(*re2, 0.6);
+      solver.SetOperator(*A2);
+      solver.Mult(b, x);
+      REQUIRE(solver.GetNumSymbolicFactorizations() == 1);
+      REQUIRE(RelResidual(*A2, x, b) < tol);
+   }
+}
+
+TEST_CASE("ComplexUMFPack without reuse is bit-for-bit unchanged",
+          "[DirectSolvers]")
+{
+   const int n = 300;
+   const bool use_long_ints = GENERATE(false, true);
+   CAPTURE(use_long_ints);
+
+   SparseMatrix *re = nullptr, *im = nullptr;
+   std::unique_ptr<ComplexSparseMatrix> A(MakeComplexBanded(n, 7, re, im));
+   const Vector b = MakeComplexRHS(n);
+   Vector x(2*n), x_raw(2*n);
+
+   SECTION("against UMFPACK called directly, as the wrapper used to")
+   {
+      ComplexUMFPackSolver solver(use_long_ints);
+      solver.SetOperator(*A);
+      solver.Mult(b, x);
+      RawComplexUMFPackSolve(*A, b, x_raw, use_long_ints);
+      REQUIRE(BitwiseEqual(x, x_raw));
+
+      ComplexUMFPackSolver ctor_solver(*A, use_long_ints);
+      ctor_solver.Mult(b, x);
+      REQUIRE(BitwiseEqual(x, x_raw));
+   }
+
+   SECTION("a solver used again is a solver used the first time")
+   {
+      ComplexUMFPackSolver solver(use_long_ints);
+      for (int step = 0; step < 3; step++)
+      {
+         CAPTURE(step);
+         SetDiagonal(*re, 0.4*step - 1.0);
+
+         solver.SetOperator(*A);
+         solver.Mult(b, x);
+
+         ComplexUMFPackSolver fresh(use_long_ints);
+         fresh.SetOperator(*A);
+         fresh.Mult(b, x_raw);
+
+         REQUIRE(BitwiseEqual(x, x_raw));
+         REQUIRE(solver.GetNumSymbolicFactorizations() == step + 1);
+         REQUIRE(solver.GetNumNumericFactorizations() == step + 1);
+      }
+   }
+
+   SECTION("the counters start at zero and reuse is off")
+   {
+      ComplexUMFPackSolver solver(use_long_ints);
+      REQUIRE_FALSE(solver.GetReuseSymbolic());
+      REQUIRE(solver.GetNumSymbolicFactorizations() == 0);
+      REQUIRE(solver.GetNumNumericFactorizations() == 0);
    }
 }
 

--- a/tests/unit/linalg/test_direct_solver_reuse.cpp
+++ b/tests/unit/linalg/test_direct_solver_reuse.cpp
@@ -19,7 +19,8 @@
 
 using namespace mfem;
 
-#ifdef MFEM_USE_SUITESPARSE
+#if defined(MFEM_USE_SUITESPARSE) || defined(MFEM_USE_MKL_PARDISO) || \
+    defined(MFEM_USE_MKL_CPARDISO)
 
 namespace direct_solver_reuse
 {
@@ -115,6 +116,8 @@ bool BitwiseEqual(const Vector &x, const Vector &y)
                       x.Size()*sizeof(real_t)) == 0;
 }
 
+#ifdef MFEM_USE_SUITESPARSE
+
 // The old UMFPackSolver::SetOperator() and Mult(), written out: analyse,
 // factorize, throw the analysis away, solve. Whatever the wrapper does with
 // reuse turned off has to agree with this to the bit.
@@ -184,9 +187,13 @@ void RawKLUSolve(SparseMatrix &A, const Vector &b, Vector &x,
    klu_free_numeric(&Numeric, &Common);
 }
 
+#endif // MFEM_USE_SUITESPARSE
+
 } // namespace direct_solver_reuse
 
 using namespace direct_solver_reuse;
+
+#ifdef MFEM_USE_SUITESPARSE
 
 TEST_CASE("UMFPack symbolic reuse", "[DirectSolvers]")
 {
@@ -870,3 +877,416 @@ TEST_CASE("ComplexUMFPack without reuse is bit-for-bit unchanged",
 }
 
 #endif // MFEM_USE_SUITESPARSE
+
+#ifdef MFEM_USE_MKL_PARDISO
+
+TEST_CASE("Pardiso analysis reuse", "[DirectSolvers]")
+{
+   const int n = 400;
+   const real_t tol = 1e-11;
+
+   std::unique_ptr<SparseMatrix> A(MakeBanded(n, 7));
+   const Vector b = MakeRHS(n);
+   Vector x(n), x_ref(n);
+
+   PardisoSolver solver;
+   solver.SetReuseSymbolic();
+   REQUIRE(solver.GetReuseSymbolic());
+
+   SECTION("nothing is analysed twice, and the answer does not move")
+   {
+      solver.SetOperator(*A);
+      solver.Mult(b, x_ref);
+      REQUIRE(solver.GetNumSymbolicFactorizations() == 1);
+      REQUIRE(solver.GetNumNumericFactorizations() == 1);
+      REQUIRE(RelResidual(*A, x_ref, b) < tol);
+
+      // Phase 22 runs again, phase 11 does not, and the answer is bit-for-bit
+      // what the first solve gave.
+      solver.SetOperator(*A);
+      solver.Mult(b, x);
+      REQUIRE(solver.GetNumSymbolicFactorizations() == 1);
+      REQUIRE(solver.GetNumNumericFactorizations() == 2);
+      REQUIRE(BitwiseEqual(x, x_ref));
+   }
+
+   SECTION("values change in place, as a reassembled Jacobian does")
+   {
+      solver.SetOperator(*A);
+      solver.Mult(b, x);
+
+      for (int step = 1; step <= 4; step++)
+      {
+         const real_t s = 0.4*step - 1.0;
+         CAPTURE(step);
+         SetDiagonal(*A, s);
+         solver.SetOperator(*A);
+         solver.Mult(b, x);
+
+         REQUIRE(solver.GetNumSymbolicFactorizations() == 1);
+         REQUIRE(solver.GetNumNumericFactorizations() == step + 1);
+         REQUIRE(RelResidual(*A, x, b) < tol);
+
+         // PARDISO's phase 11 does not read the values, so a reused analysis
+         // is the analysis a fresh solver would compute, and the answers agree
+         // to the bit rather than merely to round-off.
+         std::unique_ptr<SparseMatrix> A_fresh(MakeBanded(n, 7));
+         SetDiagonal(*A_fresh, s);
+         PardisoSolver fresh;
+         fresh.SetOperator(*A_fresh);
+         fresh.Mult(b, x_ref);
+         REQUIRE(BitwiseEqual(x, x_ref));
+      }
+   }
+
+   SECTION("rebuilt into a fresh matrix with the same pattern")
+   {
+      solver.SetOperator(*A);
+      solver.Mult(b, x_ref);
+
+      std::unique_ptr<SparseMatrix> A2(MakeBanded(n, 7));
+      SetDiagonal(*A2, 0.5);
+      REQUIRE(A2.get() != A.get());
+
+      solver.SetOperator(*A2);
+      solver.Mult(b, x);
+      REQUIRE(solver.GetNumSymbolicFactorizations() == 1);
+      REQUIRE(solver.GetNumNumericFactorizations() == 2);
+      REQUIRE(RelResidual(*A2, x, b) < tol);
+   }
+
+   SECTION("a matrix rebuilt where the old one stood")
+   {
+      std::unique_ptr<SparseMatrix> A1(MakeBanded(n, 7));
+      solver.SetOperator(*A1);
+      solver.Mult(b, x);
+      const uintptr_t addr = (uintptr_t) A1.get();
+      const uintptr_t addr_I = (uintptr_t) A1->HostReadI();
+      const uintptr_t addr_J = (uintptr_t) A1->HostReadJ();
+      A1.reset();
+
+      std::unique_ptr<SparseMatrix> A2(MakeBanded(n, 11));
+      const bool recycled = (uintptr_t) A2.get() == addr &&
+                            (uintptr_t) A2->HostReadI() == addr_I &&
+                            (uintptr_t) A2->HostReadJ() == addr_J;
+      CAPTURE(recycled);
+
+      solver.SetOperator(*A2);
+      solver.Mult(b, x);
+      REQUIRE(solver.GetNumSymbolicFactorizations() == 2);
+      REQUIRE(RelResidual(*A2, x, b) < tol);
+   }
+
+   SECTION("the pattern changes: the analysis is redone")
+   {
+      solver.SetOperator(*A);
+      solver.Mult(b, x);
+      REQUIRE(solver.GetNumSymbolicFactorizations() == 1);
+
+      std::unique_ptr<SparseMatrix> A2(MakeBanded(n, 11));
+      REQUIRE(A2->NumNonZeroElems() == A->NumNonZeroElems());
+      solver.SetOperator(*A2);
+      solver.Mult(b, x);
+      REQUIRE(solver.GetNumSymbolicFactorizations() == 2);
+      REQUIRE(RelResidual(*A2, x, b) < tol);
+
+      std::unique_ptr<SparseMatrix> A3(MakeBanded(n/2, 11));
+      const Vector b3 = MakeRHS(n/2);
+      Vector x3(n/2);
+      solver.SetOperator(*A3);
+      solver.Mult(b3, x3);
+      REQUIRE(solver.GetNumSymbolicFactorizations() == 3);
+      REQUIRE(RelResidual(*A3, x3, b3) < tol);
+   }
+
+   SECTION("reuse can be turned off again")
+   {
+      solver.SetOperator(*A);
+      solver.SetOperator(*A);
+      REQUIRE(solver.GetNumSymbolicFactorizations() == 1);
+
+      solver.SetReuseSymbolic(false);
+      REQUIRE_FALSE(solver.GetReuseSymbolic());
+      solver.SetOperator(*A);
+      solver.Mult(b, x);
+      REQUIRE(solver.GetNumSymbolicFactorizations() == 2);
+      REQUIRE(RelResidual(*A, x, b) < tol);
+   }
+}
+
+TEST_CASE("Pardiso without reuse is bit-for-bit unchanged", "[DirectSolvers]")
+{
+   const int n = 400;
+
+   std::unique_ptr<SparseMatrix> A(MakeBanded(n, 7));
+   const Vector b = MakeRHS(n);
+   Vector x(n), x_raw(n);
+
+   SECTION("a solver used again is a solver used the first time")
+   {
+      // Without reuse the solver keeps no analysis, so a sequence of operators
+      // through one solver has to give exactly what a new solver per operator
+      // gives. That is what every existing caller does.
+      PardisoSolver solver;
+      for (int step = 0; step < 4; step++)
+      {
+         CAPTURE(step);
+         SetDiagonal(*A, 0.4*step - 1.0);
+
+         solver.SetOperator(*A);
+         solver.Mult(b, x);
+
+         PardisoSolver fresh;
+         fresh.SetOperator(*A);
+         fresh.Mult(b, x_raw);
+
+         REQUIRE(BitwiseEqual(x, x_raw));
+         REQUIRE(solver.GetNumSymbolicFactorizations() == step + 1);
+         REQUIRE(solver.GetNumNumericFactorizations() == step + 1);
+      }
+   }
+
+   SECTION("a solver that is never given an operator")
+   {
+      // The destructor has nothing to release, and must not ask MKL to release
+      // a factorization that was never made.
+      PardisoSolver solver;
+      REQUIRE_FALSE(solver.GetReuseSymbolic());
+      REQUIRE(solver.GetNumSymbolicFactorizations() == 0);
+      REQUIRE(solver.GetNumNumericFactorizations() == 0);
+   }
+
+   SECTION("a structurally symmetric matrix type still works")
+   {
+      std::unique_ptr<SparseMatrix> S(MakeSymmetricBanded(n, 7));
+      PardisoSolver solver;
+      solver.SetMatrixType(PardisoSolver::MatType::REAL_STRUCTURE_SYMMETRIC);
+      solver.SetReuseSymbolic();
+      solver.SetOperator(*S);
+      solver.Mult(b, x);
+      REQUIRE(RelResidual(*S, x, b) < 1e-11);
+
+      SetDiagonal(*S, 0.3);
+      solver.SetOperator(*S);
+      solver.Mult(b, x);
+      REQUIRE(solver.GetNumSymbolicFactorizations() == 1);
+      REQUIRE(solver.GetNumNumericFactorizations() == 2);
+      REQUIRE(RelResidual(*S, x, b) < 1e-11);
+   }
+}
+
+#endif // MFEM_USE_MKL_PARDISO
+
+#ifdef MFEM_USE_MKL_CPARDISO
+
+namespace direct_solver_reuse
+{
+
+// A block-diagonal parallel matrix: every rank owns a square block and couples
+// to no other rank. That leaves the local sparsity pattern each rank's own to
+// choose, which is what the collective half of the check needs to be put under
+// any pressure at all.
+HypreParMatrix *MakeBlockDiagonal(SparseMatrix &diag, int rank, int nranks,
+                                  HYPRE_BigInt *row_starts)
+{
+   const int n_loc = diag.Height();
+   row_starts[0] = (HYPRE_BigInt) rank * n_loc;
+   row_starts[1] = (HYPRE_BigInt) (rank + 1) * n_loc;
+   const HYPRE_BigInt glob = (HYPRE_BigInt) nranks * n_loc;
+   return new HypreParMatrix(MPI_COMM_WORLD, glob, row_starts, &diag);
+}
+
+real_t RelResidual(const HypreParMatrix &A, const Vector &x, const Vector &b)
+{
+   Vector r(b.Size());
+   A.Mult(x, r);
+   r -= b;
+   real_t local[2] = { r*r, b*b }, global[2];
+   MPI_Allreduce(local, global, 2, MPITypeMap<real_t>::mpi_type, MPI_SUM,
+                 MPI_COMM_WORLD);
+   return std::sqrt(global[0] / global[1]);
+}
+
+// The same on every rank, or the count is not the collective thing it claims.
+long AgreedCount(long count)
+{
+   long lo, hi;
+   MPI_Allreduce(&count, &lo, 1, MPI_LONG, MPI_MIN, MPI_COMM_WORLD);
+   MPI_Allreduce(&count, &hi, 1, MPI_LONG, MPI_MAX, MPI_COMM_WORLD);
+   return (lo == hi) ? lo : -1;
+}
+
+} // namespace direct_solver_reuse
+
+TEST_CASE("CPardiso analysis reuse", "[Parallel][DirectSolvers]")
+{
+   int rank, nranks;
+   MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+   MPI_Comm_size(MPI_COMM_WORLD, &nranks);
+
+   const int n_loc = 200;
+   const real_t tol = 1e-11;
+
+   std::unique_ptr<SparseMatrix> D(MakeBanded(n_loc, 7));
+   HYPRE_BigInt row_starts[2];
+   std::unique_ptr<HypreParMatrix> A(MakeBlockDiagonal(*D, rank, nranks,
+                                                       row_starts));
+
+   Vector b(n_loc), x(n_loc);
+   for (int i = 0; i < n_loc; i++) { b(i) = 1.0 + real_t((i + rank) % 7); }
+
+   CPardisoSolver solver(MPI_COMM_WORLD);
+   solver.SetReuseSymbolic();
+   REQUIRE(solver.GetReuseSymbolic());
+
+   SECTION("nothing is analysed twice, and the answer does not move")
+   {
+      solver.SetOperator(*A);
+      solver.Mult(b, x);
+      REQUIRE(AgreedCount(solver.GetNumSymbolicFactorizations()) == 1);
+      REQUIRE(AgreedCount(solver.GetNumNumericFactorizations()) == 1);
+      REQUIRE(RelResidual(*A, x, b) < tol);
+
+      Vector x2(n_loc);
+      solver.SetOperator(*A);
+      solver.Mult(b, x2);
+      REQUIRE(AgreedCount(solver.GetNumSymbolicFactorizations()) == 1);
+      REQUIRE(AgreedCount(solver.GetNumNumericFactorizations()) == 2);
+      REQUIRE(BitwiseEqual(x2, x));
+   }
+
+   SECTION("the values change: phase 22 alone")
+   {
+      solver.SetOperator(*A);
+      solver.Mult(b, x);
+
+      for (int step = 1; step <= 3; step++)
+      {
+         CAPTURE(step);
+         // A matrix rebuilt with the same structure and different values, as a
+         // reassembled Jacobian is.
+         std::unique_ptr<SparseMatrix> D2(MakeBanded(n_loc, 7));
+         SetDiagonal(*D2, 0.4*step - 1.0);
+         HYPRE_BigInt starts2[2];
+         std::unique_ptr<HypreParMatrix> A2(MakeBlockDiagonal(*D2, rank, nranks,
+                                                              starts2));
+         solver.SetOperator(*A2);
+         solver.Mult(b, x);
+
+         REQUIRE(AgreedCount(solver.GetNumSymbolicFactorizations()) == 1);
+         REQUIRE(AgreedCount(solver.GetNumNumericFactorizations()) == step + 1);
+         REQUIRE(RelResidual(*A2, x, b) < tol);
+      }
+   }
+
+   SECTION("the pattern changes on one rank only")
+   {
+      // The case the reduction exists for. Rank 0 gets a different structure,
+      // with the same size and the same number of nonzeros; every other rank's
+      // local pattern is untouched and would, left to itself, reuse the
+      // analysis while rank 0 recomputed it. cluster_sparse_solver() is
+      // collective, so the two of them would then be in different calls, and
+      // the run would hang rather than fail.
+      solver.SetOperator(*A);
+      solver.Mult(b, x);
+      REQUIRE(AgreedCount(solver.GetNumSymbolicFactorizations()) == 1);
+
+      std::unique_ptr<SparseMatrix> D2(MakeBanded(n_loc, rank == 0 ? 11 : 7));
+      REQUIRE(D2->NumNonZeroElems() == D->NumNonZeroElems());
+      HYPRE_BigInt starts2[2];
+      std::unique_ptr<HypreParMatrix> A2(MakeBlockDiagonal(*D2, rank, nranks,
+                                                           starts2));
+      solver.SetOperator(*A2);
+      solver.Mult(b, x);
+
+      // Every rank analysed again, including the ranks that saw no change.
+      REQUIRE(AgreedCount(solver.GetNumSymbolicFactorizations()) == 2);
+      REQUIRE(AgreedCount(solver.GetNumNumericFactorizations()) == 2);
+      REQUIRE(RelResidual(*A2, x, b) < tol);
+   }
+
+   SECTION("the size changes")
+   {
+      solver.SetOperator(*A);
+      solver.Mult(b, x);
+
+      std::unique_ptr<SparseMatrix> D2(MakeBanded(n_loc/2, 7));
+      HYPRE_BigInt starts2[2];
+      std::unique_ptr<HypreParMatrix> A2(MakeBlockDiagonal(*D2, rank, nranks,
+                                                           starts2));
+      Vector b2(n_loc/2), x2(n_loc/2);
+      for (int i = 0; i < n_loc/2; i++) { b2(i) = 1.0 + real_t(i % 5); }
+      solver.SetOperator(*A2);
+      solver.Mult(b2, x2);
+      REQUIRE(AgreedCount(solver.GetNumSymbolicFactorizations()) == 2);
+      REQUIRE(RelResidual(*A2, x2, b2) < tol);
+   }
+
+   SECTION("reuse can be turned off again")
+   {
+      solver.SetOperator(*A);
+      solver.SetOperator(*A);
+      REQUIRE(AgreedCount(solver.GetNumSymbolicFactorizations()) == 1);
+
+      solver.SetReuseSymbolic(false);
+      REQUIRE_FALSE(solver.GetReuseSymbolic());
+      solver.SetOperator(*A);
+      solver.Mult(b, x);
+      REQUIRE(AgreedCount(solver.GetNumSymbolicFactorizations()) == 2);
+      REQUIRE(RelResidual(*A, x, b) < tol);
+   }
+}
+
+TEST_CASE("CPardiso without reuse is unchanged", "[Parallel][DirectSolvers]")
+{
+   int rank, nranks;
+   MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+   MPI_Comm_size(MPI_COMM_WORLD, &nranks);
+
+   const int n_loc = 200;
+
+   std::unique_ptr<SparseMatrix> D(MakeBanded(n_loc, 7));
+   HYPRE_BigInt row_starts[2];
+   std::unique_ptr<HypreParMatrix> A(MakeBlockDiagonal(*D, rank, nranks,
+                                                       row_starts));
+   Vector b(n_loc), x(n_loc), x_ref(n_loc);
+   for (int i = 0; i < n_loc; i++) { b(i) = 1.0 + real_t((i + rank) % 7); }
+
+   SECTION("a solver used again is a solver used the first time")
+   {
+      CPardisoSolver solver(MPI_COMM_WORLD);
+      for (int step = 0; step < 3; step++)
+      {
+         CAPTURE(step);
+         std::unique_ptr<SparseMatrix> D2(MakeBanded(n_loc, 7));
+         SetDiagonal(*D2, 0.4*step - 1.0);
+         HYPRE_BigInt starts2[2];
+         std::unique_ptr<HypreParMatrix> A2(MakeBlockDiagonal(*D2, rank, nranks,
+                                                              starts2));
+
+         solver.SetOperator(*A2);
+         solver.Mult(b, x);
+
+         CPardisoSolver fresh(MPI_COMM_WORLD);
+         fresh.SetOperator(*A2);
+         fresh.Mult(b, x_ref);
+
+         REQUIRE(BitwiseEqual(x, x_ref));
+         REQUIRE(AgreedCount(solver.GetNumSymbolicFactorizations()) == step + 1);
+         REQUIRE(AgreedCount(solver.GetNumNumericFactorizations()) == step + 1);
+      }
+   }
+
+   SECTION("a solver that is never given an operator")
+   {
+      CPardisoSolver solver(MPI_COMM_WORLD);
+      REQUIRE_FALSE(solver.GetReuseSymbolic());
+      REQUIRE(AgreedCount(solver.GetNumSymbolicFactorizations()) == 0);
+      REQUIRE(AgreedCount(solver.GetNumNumericFactorizations()) == 0);
+   }
+}
+
+#endif // MFEM_USE_MKL_CPARDISO
+
+#endif // MFEM_USE_SUITESPARSE || MFEM_USE_MKL_PARDISO ||
+// MFEM_USE_MKL_CPARDISO

--- a/tests/unit/linalg/test_direct_solver_reuse.cpp
+++ b/tests/unit/linalg/test_direct_solver_reuse.cpp
@@ -1,0 +1,592 @@
+// Copyright (c) 2010-2025, Lawrence Livermore National Security, LLC. Produced
+// at the Lawrence Livermore National Laboratory. All Rights reserved. See files
+// LICENSE and NOTICE for details. LLNL-CODE-806117.
+//
+// This file is part of the MFEM library. For more information and source code
+// availability visit https://mfem.org.
+//
+// MFEM is free software; you can redistribute it and/or modify it under the
+// terms of the BSD-3 license. We welcome feedback and contributions, see file
+// CONTRIBUTING.md for details.
+
+#include "unit_tests.hpp"
+#include "mfem.hpp"
+
+#include <cmath>
+#include <cstdint>
+#include <cstring>
+#include <memory>
+
+using namespace mfem;
+
+#ifdef MFEM_USE_SUITESPARSE
+
+namespace direct_solver_reuse
+{
+
+// A banded matrix with wrap-around, diagonally dominant: three entries per row,
+// at columns i, (i+1)%n and (i+d)%n. The number of nonzeros is 3n whatever d
+// is, so two different values of d give two different sparsity patterns of the
+// same size and the same nnz -- which is the case a size or a count check would
+// miss, and which a symbolic factorization reused when it should not have been
+// would get wrong.
+SparseMatrix *MakeBanded(int n, int d)
+{
+   MFEM_VERIFY(d > 1 && d < n, "the three columns would not be distinct");
+   SparseMatrix *A = new SparseMatrix(n, n);
+   for (int i = 0; i < n; i++)
+   {
+      A->Add(i, i, 10.0);
+      A->Add(i, (i+1)%n, -1.0);
+      A->Add(i, (i+d)%n, -1.2);
+   }
+   A->Finalize();
+   return A;
+}
+
+// Change the values of A in place, leaving its sparsity pattern -- and the I
+// and J arrays that hold it -- untouched. This is what a reassembled Jacobian
+// looks like to the solver.
+void SetDiagonal(SparseMatrix &A, real_t s)
+{
+   const int *I = A.HostReadI(), *J = A.HostReadJ();
+   real_t *data = A.HostReadWriteData();
+   for (int i = 0; i < A.Height(); i++)
+   {
+      for (int k = I[i]; k < I[i+1]; k++)
+      {
+         if (J[k] == i) { data[k] = 10.0 + s*(1.0 + real_t(i)/A.Height()); }
+      }
+   }
+}
+
+Vector MakeRHS(int n)
+{
+   Vector b(n);
+   for (int i = 0; i < n; i++)
+   {
+      b(i) = 1.0 + std::sin(real_t(3*i)) + real_t(i%7);
+   }
+   return b;
+}
+
+real_t RelResidual(const SparseMatrix &A, const Vector &x, const Vector &b)
+{
+   Vector r(b.Size());
+   A.Mult(x, r);
+   r -= b;
+   return r.Norml2() / b.Norml2();
+}
+
+real_t RelDiff(const Vector &x, const Vector &y)
+{
+   Vector d(x);
+   d -= y;
+   return d.Norml2() / y.Norml2();
+}
+
+// The strictest reading of "unchanged": the same bits, not merely the same
+// answer to round-off.
+bool BitwiseEqual(const Vector &x, const Vector &y)
+{
+   if (x.Size() != y.Size()) { return false; }
+   return std::memcmp(x.GetData(), y.GetData(),
+                      x.Size()*sizeof(real_t)) == 0;
+}
+
+// The old UMFPackSolver::SetOperator() and Mult(), written out: analyse,
+// factorize, throw the analysis away, solve. Whatever the wrapper does with
+// reuse turned off has to agree with this to the bit.
+void RawUMFPackSolve(SparseMatrix &A, const Vector &b, Vector &x,
+                     bool use_long_ints, bool transpose = false)
+{
+   A.SortColumnIndices();
+   const int n = A.Height();
+   const int *Ap = A.HostReadI();
+   const int *Ai = A.HostReadJ();
+   const real_t *Ax = A.HostReadData();
+   const int sys = transpose ? UMFPACK_A : UMFPACK_At;
+   real_t Control[UMFPACK_CONTROL], Info[UMFPACK_INFO];
+   void *Symbolic, *Numeric;
+   x.SetSize(n);
+   if (!use_long_ints)
+   {
+      umfpack_di_defaults(Control);
+      umfpack_di_symbolic(n, n, Ap, Ai, Ax, &Symbolic, Control, Info);
+      umfpack_di_numeric(Ap, Ai, Ax, Symbolic, &Numeric, Control, Info);
+      umfpack_di_free_symbolic(&Symbolic);
+      umfpack_di_solve(sys, Ap, Ai, Ax, x.GetData(), b.GetData(), Numeric,
+                       Control, Info);
+      umfpack_di_free_numeric(&Numeric);
+   }
+   else
+   {
+      umfpack_dl_defaults(Control);
+      SuiteSparse_long *AI = new SuiteSparse_long[n+1];
+      SuiteSparse_long *AJ = new SuiteSparse_long[Ap[n]];
+      for (int i = 0; i <= n; i++) { AI[i] = (SuiteSparse_long)(Ap[i]); }
+      for (int i = 0; i < Ap[n]; i++) { AJ[i] = (SuiteSparse_long)(Ai[i]); }
+      umfpack_dl_symbolic(n, n, AI, AJ, Ax, &Symbolic, Control, Info);
+      umfpack_dl_numeric(AI, AJ, Ax, Symbolic, &Numeric, Control, Info);
+      umfpack_dl_free_symbolic(&Symbolic);
+      umfpack_dl_solve(sys, AI, AJ, Ax, x.GetData(), b.GetData(), Numeric,
+                       Control, Info);
+      umfpack_dl_free_numeric(&Numeric);
+      delete [] AJ;
+      delete [] AI;
+   }
+}
+
+// The old KLUSolver::SetOperator() and Mult(), likewise.
+void RawKLUSolve(SparseMatrix &A, const Vector &b, Vector &x,
+                 bool transpose = false)
+{
+   A.SortColumnIndices();
+   const int n = A.Height();
+   int *Ap = A.GetI();
+   int *Ai = A.GetJ();
+   real_t *Ax = A.GetData();
+   klu_common Common;
+   klu_defaults(&Common);
+   klu_symbolic *Symbolic = klu_analyze(n, Ap, Ai, &Common);
+   klu_numeric *Numeric = klu_factor(Ap, Ai, Ax, Symbolic, &Common);
+   x = b;
+   if (!transpose)
+   {
+      klu_tsolve(Symbolic, Numeric, n, 1, x.GetData(), &Common);
+   }
+   else
+   {
+      klu_solve(Symbolic, Numeric, n, 1, x.GetData(), &Common);
+   }
+   klu_free_symbolic(&Symbolic, &Common);
+   klu_free_numeric(&Numeric, &Common);
+}
+
+} // namespace direct_solver_reuse
+
+using namespace direct_solver_reuse;
+
+TEST_CASE("UMFPack symbolic reuse", "[DirectSolvers]")
+{
+   const int n = 400;
+   const real_t tol = 1e-11;
+   const bool use_long_ints = GENERATE(false, true);
+   CAPTURE(use_long_ints);
+
+   std::unique_ptr<SparseMatrix> A(MakeBanded(n, 7));
+   const Vector b = MakeRHS(n);
+   Vector x(n), x_ref(n);
+
+   UMFPackSolver solver(use_long_ints);
+   solver.SetReuseSymbolic();
+   REQUIRE(solver.GetReuseSymbolic());
+
+   SECTION("nothing is analysed twice, and the answer does not move")
+   {
+      solver.SetOperator(*A);
+      solver.Mult(b, x_ref);
+      REQUIRE(solver.GetNumSymbolicFactorizations() == 1);
+      REQUIRE(solver.GetNumNumericFactorizations() == 1);
+      REQUIRE(RelResidual(*A, x_ref, b) < tol);
+
+      // The same matrix with the same values: the analysis is reused, the
+      // numeric factorization is not, and the answer is bit-for-bit what the
+      // first solve gave -- which it would not be if the retained analysis
+      // were stale, or if the numeric factorization had been skipped with it.
+      solver.SetOperator(*A);
+      solver.Mult(b, x);
+      REQUIRE(solver.GetNumSymbolicFactorizations() == 1);
+      REQUIRE(solver.GetNumNumericFactorizations() == 2);
+      REQUIRE(BitwiseEqual(x, x_ref));
+   }
+
+   SECTION("values change in place, as a reassembled Jacobian does")
+   {
+      solver.SetOperator(*A);
+      solver.Mult(b, x);
+
+      for (int step = 1; step <= 4; step++)
+      {
+         const real_t s = 0.4*step - 1.0;
+         CAPTURE(step);
+         SetDiagonal(*A, s);
+         solver.SetOperator(*A);
+         solver.Mult(b, x);
+
+         REQUIRE(solver.GetNumSymbolicFactorizations() == 1);
+         REQUIRE(solver.GetNumNumericFactorizations() == step + 1);
+         REQUIRE(RelResidual(*A, x, b) < tol);
+
+         // Against a solver that analysed these values from scratch.
+         std::unique_ptr<SparseMatrix> A_fresh(MakeBanded(n, 7));
+         SetDiagonal(*A_fresh, s);
+         UMFPackSolver fresh(use_long_ints);
+         fresh.SetOperator(*A_fresh);
+         fresh.Mult(b, x_ref);
+         REQUIRE(RelDiff(x, x_ref) < tol);
+      }
+   }
+
+   SECTION("rebuilt into a fresh matrix with the same pattern")
+   {
+      solver.SetOperator(*A);
+      solver.Mult(b, x_ref);
+
+      // A different object, with the same structure: the analysis describes it
+      // just as well, and the comparison is what establishes that.
+      std::unique_ptr<SparseMatrix> A2(MakeBanded(n, 7));
+      SetDiagonal(*A2, 0.5);
+      REQUIRE(A2.get() != A.get());
+
+      solver.SetOperator(*A2);
+      solver.Mult(b, x);
+      REQUIRE(solver.GetNumSymbolicFactorizations() == 1);
+      REQUIRE(solver.GetNumNumericFactorizations() == 2);
+      REQUIRE(RelResidual(*A2, x, b) < tol);
+   }
+
+   SECTION("the pattern changes: the analysis is redone")
+   {
+      solver.SetOperator(*A);
+      solver.Mult(b, x);
+      REQUIRE(solver.GetNumSymbolicFactorizations() == 1);
+
+      // The same size and the same number of nonzeros, a different structure.
+      // This is the one that catches a stale symbolic factorization.
+      std::unique_ptr<SparseMatrix> A2(MakeBanded(n, 11));
+      REQUIRE(A2->NumNonZeroElems() == A->NumNonZeroElems());
+      solver.SetOperator(*A2);
+      solver.Mult(b, x);
+      REQUIRE(solver.GetNumSymbolicFactorizations() == 2);
+      REQUIRE(RelResidual(*A2, x, b) < tol);
+
+      // And a different size.
+      std::unique_ptr<SparseMatrix> A3(MakeBanded(n/2, 11));
+      const Vector b3 = MakeRHS(n/2);
+      Vector x3(n/2);
+      solver.SetOperator(*A3);
+      solver.Mult(b3, x3);
+      REQUIRE(solver.GetNumSymbolicFactorizations() == 3);
+      REQUIRE(RelResidual(*A3, x3, b3) < tol);
+
+      // Back to the first pattern, which is no longer the retained one.
+      solver.SetOperator(*A);
+      solver.Mult(b, x);
+      REQUIRE(solver.GetNumSymbolicFactorizations() == 4);
+      REQUIRE(RelResidual(*A, x, b) < tol);
+   }
+
+   SECTION("a matrix rebuilt where the old one stood")
+   {
+      // The pattern is compared, never the address it lives at. A matrix
+      // destroyed and rebuilt with a different structure, but the same size and
+      // the same number of nonzeros, asks the allocator for blocks of exactly
+      // the sizes just freed and commonly gets those same blocks back. An
+      // identity test would take it for the matrix it replaced and reuse an
+      // analysis that does not describe it, silently. Whether the addresses
+      // really do coincide on this run is the allocator's business -- captured
+      // below, and not required either way.
+      std::unique_ptr<SparseMatrix> A1(MakeBanded(n, 7));
+      solver.SetOperator(*A1);
+      solver.Mult(b, x);
+      const uintptr_t addr = (uintptr_t) A1.get();
+      const uintptr_t addr_I = (uintptr_t) A1->HostReadI();
+      const uintptr_t addr_J = (uintptr_t) A1->HostReadJ();
+      A1.reset();
+
+      std::unique_ptr<SparseMatrix> A2(MakeBanded(n, 11));
+      const bool recycled = (uintptr_t) A2.get() == addr &&
+                            (uintptr_t) A2->HostReadI() == addr_I &&
+                            (uintptr_t) A2->HostReadJ() == addr_J;
+      CAPTURE(recycled);
+
+      solver.SetOperator(*A2);
+      solver.Mult(b, x);
+      REQUIRE(solver.GetNumSymbolicFactorizations() == 2);
+      REQUIRE(RelResidual(*A2, x, b) < tol);
+   }
+
+   SECTION("reuse with a non-default ordering")
+   {
+      // The ordering the symbolic analysis is asked for is the reason to keep
+      // it: the better it is, the more it costs to compute.
+      UMFPackSolver metis(use_long_ints);
+      metis.Control[UMFPACK_ORDERING] = UMFPACK_ORDERING_METIS;
+      metis.SetReuseSymbolic();
+      metis.SetOperator(*A);
+      metis.Mult(b, x_ref);
+
+      SetDiagonal(*A, 0.6);
+      metis.SetOperator(*A);
+      metis.Mult(b, x);
+      REQUIRE(metis.GetNumSymbolicFactorizations() == 1);
+      REQUIRE(metis.GetNumNumericFactorizations() == 2);
+      REQUIRE(RelResidual(*A, x, b) < tol);
+   }
+
+   SECTION("reuse can be turned off again")
+   {
+      solver.SetOperator(*A);
+      solver.SetOperator(*A);
+      REQUIRE(solver.GetNumSymbolicFactorizations() == 1);
+
+      solver.SetReuseSymbolic(false);
+      REQUIRE_FALSE(solver.GetReuseSymbolic());
+      solver.SetOperator(*A);
+      solver.Mult(b, x);
+      REQUIRE(solver.GetNumSymbolicFactorizations() == 2);
+      REQUIRE(RelResidual(*A, x, b) < tol);
+
+      solver.SetOperator(*A);
+      REQUIRE(solver.GetNumSymbolicFactorizations() == 3);
+   }
+}
+
+TEST_CASE("UMFPack without reuse is bit-for-bit unchanged", "[DirectSolvers]")
+{
+   const int n = 400;
+   const bool use_long_ints = GENERATE(false, true);
+   CAPTURE(use_long_ints);
+
+   std::unique_ptr<SparseMatrix> A(MakeBanded(n, 7));
+   const Vector b = MakeRHS(n);
+   Vector x(n), x_raw(n);
+
+   SECTION("against UMFPACK called directly, as the wrapper used to")
+   {
+      UMFPackSolver solver(use_long_ints);
+      solver.SetOperator(*A);
+      solver.Mult(b, x);
+      RawUMFPackSolve(*A, b, x_raw, use_long_ints);
+      REQUIRE(BitwiseEqual(x, x_raw));
+
+      solver.MultTranspose(b, x);
+      RawUMFPackSolve(*A, b, x_raw, use_long_ints, true);
+      REQUIRE(BitwiseEqual(x, x_raw));
+
+      // The constructor that factorizes on the way in.
+      UMFPackSolver ctor_solver(*A, use_long_ints);
+      ctor_solver.Mult(b, x);
+      RawUMFPackSolve(*A, b, x_raw, use_long_ints);
+      REQUIRE(BitwiseEqual(x, x_raw));
+   }
+
+   SECTION("a solver used again is a solver used the first time")
+   {
+      // Without reuse the solver keeps no analysis, so putting a sequence of
+      // operators through one solver has to give exactly what a new solver per
+      // operator gives. That is what every existing caller does.
+      UMFPackSolver solver(use_long_ints);
+      for (int step = 0; step < 4; step++)
+      {
+         CAPTURE(step);
+         SetDiagonal(*A, 0.4*step - 1.0);
+
+         solver.SetOperator(*A);
+         solver.Mult(b, x);
+
+         UMFPackSolver fresh(use_long_ints);
+         fresh.SetOperator(*A);
+         fresh.Mult(b, x_raw);
+
+         REQUIRE(BitwiseEqual(x, x_raw));
+         REQUIRE(solver.GetNumSymbolicFactorizations() == step + 1);
+         REQUIRE(solver.GetNumNumericFactorizations() == step + 1);
+         REQUIRE(fresh.GetNumSymbolicFactorizations() == 1);
+      }
+   }
+
+   SECTION("the counters start at zero and reuse is off")
+   {
+      UMFPackSolver solver(use_long_ints);
+      REQUIRE_FALSE(solver.GetReuseSymbolic());
+      REQUIRE(solver.GetNumSymbolicFactorizations() == 0);
+      REQUIRE(solver.GetNumNumericFactorizations() == 0);
+   }
+}
+
+TEST_CASE("KLU symbolic and numeric reuse", "[DirectSolvers]")
+{
+   const int n = 400;
+   const real_t tol = 1e-11;
+
+   std::unique_ptr<SparseMatrix> A(MakeBanded(n, 7));
+   const Vector b = MakeRHS(n);
+   Vector x(n), x_ref(n);
+
+   SECTION("symbolic reuse alone is bit-for-bit: klu_analyze() never reads "
+           "the values")
+   {
+      KLUSolver solver;
+      solver.SetReuseSymbolic();
+      solver.SetOperator(*A);
+      solver.Mult(b, x);
+      REQUIRE(solver.GetNumSymbolicFactorizations() == 1);
+      REQUIRE(solver.GetNumNumericFactorizations() == 1);
+      REQUIRE(solver.GetNumRefactorizations() == 0);
+
+      for (int step = 1; step <= 3; step++)
+      {
+         CAPTURE(step);
+         SetDiagonal(*A, 0.4*step - 1.0);
+
+         solver.SetOperator(*A);
+         solver.Mult(b, x);
+
+         KLUSolver fresh;
+         fresh.SetOperator(*A);
+         fresh.Mult(b, x_ref);
+
+         REQUIRE(solver.GetNumSymbolicFactorizations() == 1);
+         REQUIRE(solver.GetNumNumericFactorizations() == step + 1);
+         REQUIRE(solver.GetNumRefactorizations() == 0);
+         REQUIRE(BitwiseEqual(x, x_ref));
+      }
+   }
+
+   SECTION("numeric reuse goes through klu_refactor()")
+   {
+      KLUSolver solver;
+      solver.SetReuseNumeric();
+      REQUIRE(solver.GetReuseNumeric());
+      // It needs the symbolic analysis kept, so it turns that on too.
+      REQUIRE(solver.GetReuseSymbolic());
+
+      solver.SetOperator(*A);
+      solver.Mult(b, x);
+      REQUIRE(solver.GetNumNumericFactorizations() == 1);
+      REQUIRE(solver.GetNumRefactorizations() == 0);
+
+      for (int step = 1; step <= 3; step++)
+      {
+         CAPTURE(step);
+         SetDiagonal(*A, 0.4*step - 1.0);
+
+         solver.SetOperator(*A);
+         solver.Mult(b, x);
+
+         KLUSolver fresh;
+         fresh.SetOperator(*A);
+         fresh.Mult(b, x_ref);
+
+         // One analysis and one full factorization for the whole sequence;
+         // everything after that is a refactorization.
+         REQUIRE(solver.GetNumSymbolicFactorizations() == 1);
+         REQUIRE(solver.GetNumNumericFactorizations() == 1);
+         REQUIRE(solver.GetNumRefactorizations() == step);
+         REQUIRE(RelResidual(*A, x, b) < tol);
+         REQUIRE(RelDiff(x, x_ref) < tol);
+      }
+   }
+
+   SECTION("the pattern changes: both are redone")
+   {
+      KLUSolver solver;
+      solver.SetReuseNumeric();
+      solver.SetOperator(*A);
+      solver.Mult(b, x);
+
+      std::unique_ptr<SparseMatrix> A2(MakeBanded(n, 11));
+      REQUIRE(A2->NumNonZeroElems() == A->NumNonZeroElems());
+      solver.SetOperator(*A2);
+      solver.Mult(b, x);
+      REQUIRE(solver.GetNumSymbolicFactorizations() == 2);
+      REQUIRE(solver.GetNumNumericFactorizations() == 2);
+      REQUIRE(solver.GetNumRefactorizations() == 0);
+      REQUIRE(RelResidual(*A2, x, b) < tol);
+
+      // The same pattern in a fresh object: the exact comparison accepts it,
+      // and the refactorization goes ahead.
+      std::unique_ptr<SparseMatrix> A3(MakeBanded(n, 11));
+      SetDiagonal(*A3, 0.7);
+      solver.SetOperator(*A3);
+      solver.Mult(b, x);
+      REQUIRE(solver.GetNumSymbolicFactorizations() == 2);
+      REQUIRE(solver.GetNumNumericFactorizations() == 2);
+      REQUIRE(solver.GetNumRefactorizations() == 1);
+      REQUIRE(RelResidual(*A3, x, b) < tol);
+   }
+
+   SECTION("reuse can be turned off again")
+   {
+      KLUSolver solver;
+      solver.SetReuseNumeric();
+      solver.SetOperator(*A);
+      solver.SetOperator(*A);
+      REQUIRE(solver.GetNumSymbolicFactorizations() == 1);
+      REQUIRE(solver.GetNumRefactorizations() == 1);
+
+      solver.SetReuseSymbolic(false);
+      // Numeric reuse requires it, so it goes too.
+      REQUIRE_FALSE(solver.GetReuseNumeric());
+
+      solver.SetOperator(*A);
+      solver.Mult(b, x);
+      REQUIRE(solver.GetNumSymbolicFactorizations() == 2);
+      REQUIRE(solver.GetNumNumericFactorizations() == 2);
+      REQUIRE(solver.GetNumRefactorizations() == 1);
+      REQUIRE(RelResidual(*A, x, b) < tol);
+   }
+}
+
+TEST_CASE("KLU without reuse is bit-for-bit unchanged", "[DirectSolvers]")
+{
+   const int n = 400;
+
+   std::unique_ptr<SparseMatrix> A(MakeBanded(n, 7));
+   const Vector b = MakeRHS(n);
+   Vector x(n), x_raw(n);
+
+   SECTION("against KLU called directly, as the wrapper used to")
+   {
+      KLUSolver solver;
+      solver.SetOperator(*A);
+      solver.Mult(b, x);
+      RawKLUSolve(*A, b, x_raw);
+      REQUIRE(BitwiseEqual(x, x_raw));
+
+      solver.MultTranspose(b, x);
+      RawKLUSolve(*A, b, x_raw, true);
+      REQUIRE(BitwiseEqual(x, x_raw));
+
+      KLUSolver ctor_solver(*A);
+      ctor_solver.Mult(b, x);
+      RawKLUSolve(*A, b, x_raw);
+      REQUIRE(BitwiseEqual(x, x_raw));
+   }
+
+   SECTION("a solver used again is a solver used the first time")
+   {
+      KLUSolver solver;
+      for (int step = 0; step < 4; step++)
+      {
+         CAPTURE(step);
+         SetDiagonal(*A, 0.4*step - 1.0);
+
+         solver.SetOperator(*A);
+         solver.Mult(b, x);
+
+         KLUSolver fresh;
+         fresh.SetOperator(*A);
+         fresh.Mult(b, x_raw);
+
+         REQUIRE(BitwiseEqual(x, x_raw));
+         REQUIRE(solver.GetNumSymbolicFactorizations() == step + 1);
+         REQUIRE(solver.GetNumNumericFactorizations() == step + 1);
+         REQUIRE(solver.GetNumRefactorizations() == 0);
+      }
+   }
+
+   SECTION("the counters start at zero and reuse is off")
+   {
+      KLUSolver solver;
+      REQUIRE_FALSE(solver.GetReuseSymbolic());
+      REQUIRE_FALSE(solver.GetReuseNumeric());
+      REQUIRE(solver.GetNumSymbolicFactorizations() == 0);
+      REQUIRE(solver.GetNumNumericFactorizations() == 0);
+      REQUIRE(solver.GetNumRefactorizations() == 0);
+   }
+}
+
+#endif // MFEM_USE_SUITESPARSE


### PR DESCRIPTION
While working on other branches a minor performance hit was found in the UMFPack/KLU/Pardiso interfaces. 
If one is using these solvers to solve A x = b for a set of matrices {A_i} with the same sparsity structure, the symbolic analysis do not have to be repeated. Given the sparsity structure can be the same for a fixed FEM discretization, it is useful in the MFEM context to be able to gain the speedup from reuse.

This patch adds the feature, in these three sparse solvers that expose it in the underlying library.  Simply call solver->SetReuseSymbolic(); and it will reuse the analysis so long as the sparsity structure doesn't change. For safety, this pathway checks the structure every time for a cost of O(# nonzero elements)  but saving a much more expensive analysis (measured for a simple matrix that would arise form a 5-point stencil for the Laplacian and recorded in commits below).

Existing code paths compile and work without any changes, and do not enable reuse.

[Created through Claude Code using Opus 5]