### PR TITLE
Pre-release fixes: Gmsh reader issues and simplicial PA diagonal guard

### DIFF
--- a/fem/integ/bilininteg_diffusion_ea.cpp
+++ b/fem/integ/bilininteg_diffusion_ea.cpp
@@ -247,6 +247,8 @@ void DiffusionIntegrator::AssembleEA(const FiniteElementSpace &fes,
                                      const bool add)
 {
    AssemblePA(fes);
+   MFEM_VERIFY(maps->mode != DofToQuad::RAGGED_TENSOR,
+               "AssembleEA not implemented for ragged tensor bases");
    ne = fes.GetMesh()->GetNE();
    const Array<real_t> &B = maps->B;
    const Array<real_t> &G = maps->G;

--- a/fem/integ/bilininteg_diffusion_pa.cpp
+++ b/fem/integ/bilininteg_diffusion_pa.cpp
@@ -29,6 +29,8 @@ void DiffusionIntegrator::AssembleDiagonalPA(Vector &diag)
    else
    {
       if (pa_data.Size() == 0) { AssemblePA(*fespace); }
+      MFEM_VERIFY(!fespace->UsesRaggedTensorBasis(),
+                  "AssembleDiagonalPA not implemented for ragged tensor basis");
       const Array<real_t> &B = maps->B;
       const Array<real_t> &G = maps->G;
       const Vector &Dv = pa_data;

--- a/fem/integ/bilininteg_diffusion_pa.cpp
+++ b/fem/integ/bilininteg_diffusion_pa.cpp
@@ -29,8 +29,8 @@ void DiffusionIntegrator::AssembleDiagonalPA(Vector &diag)
    else
    {
       if (pa_data.Size() == 0) { AssemblePA(*fespace); }
-      MFEM_VERIFY(!fespace->UsesRaggedTensorBasis(),
-                  "AssembleDiagonalPA not implemented for ragged tensor basis");
+      MFEM_VERIFY(maps->mode != DofToQuad::RAGGED_TENSOR,
+                  "AssembleDiagonalPA not implemented for ragged tensor bases");
       const Array<real_t> &B = maps->B;
       const Array<real_t> &G = maps->G;
       const Vector &Dv = pa_data;

--- a/fem/integ/bilininteg_mass_ea.cpp
+++ b/fem/integ/bilininteg_mass_ea.cpp
@@ -24,6 +24,8 @@ void MassIntegrator::AssembleEA_(Vector &ea_data,
    using internal::EAMassAssemble2D;
    using internal::EAMassAssemble3D;
 
+   MFEM_VERIFY(maps->mode != DofToQuad::RAGGED_TENSOR,
+               "AssembleEA not implemented for ragged tensor bases");
    const Array<real_t> &B = maps->B;
    if (dim == 1)
    {

--- a/fem/integ/bilininteg_mass_pa.cpp
+++ b/fem/integ/bilininteg_mass_pa.cpp
@@ -143,6 +143,8 @@ void MassIntegrator::AssembleDiagonalPA(Vector &diag)
    }
    else
    {
+      MFEM_VERIFY(!fespace->UsesRaggedTensorBasis(),
+                  "AssembleDiagonalPA not implemented for ragged tensor basis");
       DiagonalPAKernels::Run(dim, dofs1D, quad1D, ne, maps->B, pa_data,
                              diag, dofs1D, quad1D);
    }

--- a/fem/integ/bilininteg_mass_pa.cpp
+++ b/fem/integ/bilininteg_mass_pa.cpp
@@ -143,8 +143,9 @@ void MassIntegrator::AssembleDiagonalPA(Vector &diag)
    }
    else
    {
-      MFEM_VERIFY(!fespace->UsesRaggedTensorBasis(),
-                  "AssembleDiagonalPA not implemented for ragged tensor basis");
+      MFEM_VERIFY(maps && maps->mode != DofToQuad::RAGGED_TENSOR,
+                  "AssembleDiagonalPA requires AssemblePA to be called first,"
+                  " and is not implemented for ragged tensor bases");
       DiagonalPAKernels::Run(dim, dofs1D, quad1D, ne, maps->B, pa_data,
                              diag, dofs1D, quad1D);
    }

--- a/mesh/gmsh.cpp
+++ b/mesh/gmsh.cpp
@@ -1005,12 +1005,6 @@ class GmshReader
             }
             mesh.NumOfElements = mesh.elements.Size();
             mesh.NumOfBdrElements = mesh.boundary.Size();
-            MFEM_VERIFY(mesh.NumOfElements > 0,
-                        "Gmsh 4.1 reader: no elements of dimension " << mesh.Dim
-                        << " were found. The mesh dimension is inferred from"
-                        " the $Entities section; reading a mesh whose elements"
-                        " have lower dimension than its entities (e.g. a"
-                        " surface mesh of a 3D model) is not supported yet.");
          }
          else if (section == "Periodic")
          {
@@ -1044,6 +1038,15 @@ class GmshReader
          }
       }
       while (!section.empty());
+
+      // Note: this check is performed after all sections are read since the
+      // format allows repeated $Elements sections.
+      MFEM_VERIFY(mesh.NumOfElements > 0,
+                  "Gmsh 4.1 reader: no elements of dimension " << mesh.Dim
+                  << " were found. The mesh dimension is inferred from the"
+                  " $Entities section; reading a mesh whose elements have"
+                  " lower dimension than its entities (e.g. a surface mesh"
+                  " of a 3D model) is not supported yet.");
    }
 
    /// @brief Read the mesh in Gmsh 2.2 format from the input stream into the

--- a/mesh/gmsh.cpp
+++ b/mesh/gmsh.cpp
@@ -978,9 +978,14 @@ class GmshReader
                   Skip<size_t>(input, 1, b); // Skip element tag
                   const auto [geom, el_order] = GetGeometryAndOrder(element_type);
 
-                  if (mesh_order < 0) { mesh_order = el_order; }
-                  MFEM_VERIFY(mesh_order == el_order,
-                              "Variable order Gmsh meshes are not supported");
+                  // Point elements (Gmsh type 15) always decode as order 1 and
+                  // are therefore exempt from the mesh-order consistency check.
+                  if (geom != Geometry::POINT)
+                  {
+                     if (mesh_order < 0) { mesh_order = el_order; }
+                     MFEM_VERIFY(mesh_order == el_order,
+                                 "Variable order Gmsh meshes are not supported");
+                  }
 
                   const int n_elem_nodes = NumNodesInElement(geom, el_order);
                   vector<size_t> node_tags(n_elem_nodes);
@@ -1000,6 +1005,12 @@ class GmshReader
             }
             mesh.NumOfElements = mesh.elements.Size();
             mesh.NumOfBdrElements = mesh.boundary.Size();
+            MFEM_VERIFY(mesh.NumOfElements > 0,
+                        "Gmsh 4.1 reader: no elements of dimension " << mesh.Dim
+                        << " were found. The mesh dimension is inferred from"
+                        " the $Entities section; reading a mesh whose elements"
+                        " have lower dimension than its entities (e.g. a"
+                        " surface mesh of a 3D model) is not supported yet.");
          }
          else if (section == "Periodic")
          {
@@ -1020,7 +1031,14 @@ class GmshReader
                {
                   const size_t node_num = ReadBinaryOrASCII<size_t>(input, b);
                   const size_t primary_node_num = ReadBinaryOrASCII<size_t>(input, b);
-                  v2v[node_num - 1] = int(primary_node_num - 1);
+                  // Map the Gmsh node tags (which need not be contiguous or
+                  // 1-based) to vertex indices.
+                  const auto node_it = vertex_map.find(int(node_num));
+                  const auto primary_it = vertex_map.find(int(primary_node_num));
+                  MFEM_VERIFY(node_it != vertex_map.end() &&
+                              primary_it != vertex_map.end(),
+                              "Unknown node tag in the $Periodic section");
+                  v2v[node_it->second] = primary_it->second;
                }
             }
          }
@@ -1074,9 +1092,14 @@ class GmshReader
                auto add_element = [&](int el_type, int el_phys_tag, Geometry::Type geom,
                                       int el_order, const vector<int> &el_nodes)
                {
-                  if (mesh_order < 0) { mesh_order = el_order; }
-                  MFEM_VERIFY(mesh_order == el_order,
-                              "Variable order Gmsh meshes are not supported");
+                  // Point elements (Gmsh type 15) always decode as order 1 and
+                  // are therefore exempt from the mesh-order consistency check.
+                  if (geom != Geometry::POINT)
+                  {
+                     if (mesh_order < 0) { mesh_order = el_order; }
+                     MFEM_VERIFY(mesh_order == el_order,
+                                 "Variable order Gmsh meshes are not supported");
+                  }
                   Element *e = NewElement(mesh, geom, el_order, el_nodes, el_phys_tag);
                   elems_by_dim[Geometry::Dimension[geom]].emplace_back(e);
                };
@@ -1184,7 +1207,14 @@ class GmshReader
                {
                   const int node_num = ReadBinaryOrASCII<int>(input, ASCII);
                   const int primary_node_num = ReadBinaryOrASCII<int>(input, ASCII);
-                  v2v[node_num - 1] = primary_node_num - 1;
+                  // Map the Gmsh node numbers (which need not be contiguous or
+                  // 1-based) to vertex indices.
+                  const auto node_it = vertex_map.find(node_num);
+                  const auto primary_it = vertex_map.find(primary_node_num);
+                  MFEM_VERIFY(node_it != vertex_map.end() &&
+                              primary_it != vertex_map.end(),
+                              "Unknown node number in the $Periodic section");
+                  v2v[node_it->second] = primary_it->second;
                }
             }
          }


### PR DESCRIPTION
### Summary

Fixes for three user-facing issues found during the 4.10 release review, scoped for fast review before the tag: real fixes where the change is small, `MFEM_VERIFY` guards where the proper fix needs more review time than the release window allows.

### Gmsh reader (`mesh/gmsh.cpp`)

- **Point elements in high-order meshes (fixed; regression vs v4.9).** The mesh-order consistency check runs before the codimension filter, and point elements (Gmsh type 15) always decode as order 1, so any order >= 2 mesh containing a 0D Physical Point was rejected. Point elements are now exempt from the check in both the 4.1 and 2.2 paths.
- **`$Periodic` node tags (fixed).** Both parsers used raw Gmsh node tags as vertex indices. The format permits non-contiguous tags, producing silently wrong periodic topology or out-of-bounds writes. Tags are now mapped through `vertex_map`, with a clear error for unknown tags. For dense, in-order tags (all in-tree meshes and typical Gmsh output) the result is identical to the previous behavior.
- **Surface meshes of 3D models (guarded; regression vs v4.9).** The 4.1 reader infers `mesh.Dim` from the `$Entities` counts, so a surface mesh exported from a 3D CAD model (volume entities present, only 2D elements) crashed later in `FinalizeTopology`. It now fails at read time with an explanatory error. The proper fix — inferring the dimension from the elements actually read, as the 2.2 path does — is a larger change proposed for a follow-up.

### Simplicial Bernstein PA diagonal (guarded)

`MassIntegrator::AssembleDiagonalPA` and `DiffusionIntegrator::AssembleDiagonalPA` dispatch unconditionally on `maps->B`/`maps->G`, which the ragged (simplicial Bernstein) basis builders do not populate — for example, `OperatorJacobiSmoother` on the new simplex PA segfaults at solver setup. Both methods now fail with a clear error, following the existing `AddAbsMultPA` precedent. Implementing the actual ragged diagonal kernels is a larger effort planned as a follow-up.

### Testing

- An order-2 Gmsh 4.1 mesh containing a Physical Point now loads (reproduced the abort before the fix).
- A surface-of-3D-model 4.1 file fails with the clean error instead of the `STable3D` abort.
- A sparse-node-tag periodic 4.1 mesh produces byte-identical `Mesh::Print` output to its dense-tag equivalent.
- All 7 in-tree `data/*.msh` meshes (including the 3 periodic ones) load unchanged.
- Unit tests: `[Simplices]` (20 assertions) and `*periodic*` (42 assertions) pass.
- Both diagonal guards fire cleanly after a successful ragged `AddMultPA` apply on the same operator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)