### PR TITLE
Fix fe resize

### DIFF
--- a/fem/fe/fe_base.cpp
+++ b/fem/fe/fe_base.cpp
@@ -47,6 +47,14 @@ FiniteElement::FiniteElement(int D, Geometry::Type G,
 #endif
 }
 
+void FiniteElement::SetDof(int newdof) const
+{
+   dof = newdof;
+#ifndef MFEM_THREAD_SAFE
+   vshape.SetSize(dof, dim);
+#endif
+}
+
 void FiniteElement::CalcVShape(
    const IntegrationPoint &ip, DenseMatrix &shape) const
 {

--- a/fem/fe/fe_base.hpp
+++ b/fem/fe/fe_base.hpp
@@ -409,6 +409,9 @@ public:
    /// Returns the number of degrees of freedom in the finite element.
    int GetDof() const { return dof; }
 
+   /// Set the number of degrees of freedom in the finite element.
+   void SetDof(int newdof) const;
+
    /** @brief Returns the order of the finite element. In the case of
        anisotropic orders, returns the maximum order. */
    int GetOrder() const { return order; }

--- a/fem/fe/fe_nurbs.cpp
+++ b/fem/fe/fe_nurbs.cpp
@@ -22,7 +22,7 @@ using namespace std;
 void NURBS1DFiniteElement::SetOrder() const
 {
    order = kv[0]->GetOrder();
-   dof = order + 1;
+   SetDof(order + 1);
 
    weights.SetSize(dof);
    shape_x.SetSize(dof);
@@ -137,7 +137,7 @@ void NURBS2DFiniteElement::SetOrder() const
    d2shape_y.SetSize(orders[1]+1);
 
    order = max(orders[0], orders[1]);
-   dof = (orders[0] + 1)*(orders[1] + 1);
+   SetDof((orders[0] + 1)*(orders[1] + 1));
    u.SetSize(dof);
    du.SetSize(dof);
    weights.SetSize(dof);
@@ -331,7 +331,7 @@ void NURBS3DFiniteElement::SetOrder() const
    d2shape_z.SetSize(orders[2]+1);
 
    order = max(max(orders[0], orders[1]), orders[2]);
-   dof = (orders[0] + 1)*(orders[1] + 1)*(orders[2] + 1);
+   SetDof((orders[0] + 1)*(orders[1] + 1)*(orders[2] + 1));
    u.SetSize(dof);
    du.SetSize(dof);
    weights.SetSize(dof);
@@ -607,8 +607,8 @@ void NURBS_HDiv2DFiniteElement::SetOrder() const
    d2shape1_y.SetSize(orders[1]+2);
 
    order = max(orders[0]+1, orders[1]+1);
-   dof = (orders[0] + 2)*(orders[1] + 1)
-         + (orders[1] + 1)*(orders[1] + 2);
+   SetDof((orders[0] + 2)*(orders[1] + 1)
+          + (orders[1] + 1)*(orders[1] + 2));
    u.SetSize(dof);
    du.SetSize(dof);
    weights.SetSize(dof);
@@ -795,9 +795,9 @@ void NURBS_HDiv3DFiniteElement::SetOrder() const
    d2shape1_z.SetSize(orders[2]+2);
 
    order = max(orders[0]+1, max( orders[1]+1, orders[2]+1));
-   dof = (orders[0] + 2)*(orders[1] + 1)*(orders[2] + 1) +
-         (orders[0] + 1)*(orders[1] + 2)*(orders[2] + 1) +
-         (orders[0] + 1)*(orders[1] + 1)*(orders[2] + 2);
+   SetDof( (orders[0] + 2)*(orders[1] + 1)*(orders[2] + 1) +
+           (orders[0] + 1)*(orders[1] + 2)*(orders[2] + 1) +
+           (orders[0] + 1)*(orders[1] + 1)*(orders[2] + 2));
    u.SetSize(dof);
    du.SetSize(dof);
    weights.SetSize(dof);
@@ -1079,8 +1079,8 @@ void NURBS_HCurl2DFiniteElement::SetOrder() const
    d2shape1_y.SetSize(orders[1]+2);
 
    order = max(orders[0]+1, orders[1]+1);
-   dof = (orders[0] + 1)*(orders[1] + 2)
-         + (orders[1] + 2)*(orders[1] + 1);
+   SetDof ( (orders[0] + 1)*(orders[1] + 2)
+            + (orders[1] + 2)*(orders[1] + 1));
    u.SetSize(dof);
    du.SetSize(dof);
    weights.SetSize(dof);

--- a/miniapps/nurbs/CMakeLists.txt
+++ b/miniapps/nurbs/CMakeLists.txt
@@ -127,6 +127,11 @@ if (MFEM_ENABLE_TESTING)
     -m ${PROJECT_SOURCE_DIR}/data/square-disc-nurbs-patch.mesh
     -o 2 --weak-bc -r 1)
 
+  add_test(NAME nurbs_ex1_hess_ser
+    COMMAND $<TARGET_FILE:nurbs_ex1> -no-vis
+    -m ${PROJECT_SOURCE_DIR}/miniapps/nurbs/meshes/square-nurbs-distorted.mesh
+    -o 2 -mo 3 -r 1 -no-ibp)
+
   add_test(NAME nurbs_printfunc
     COMMAND $<TARGET_FILE:nurbs_printfunc>)
 

--- a/miniapps/nurbs/makefile
+++ b/miniapps/nurbs/makefile
@@ -84,6 +84,8 @@ EX1_ARGS_15 := -m meshes/two-cubes-nurbs.mesh -o 1 -r 3 -rf meshes/two-cubes.ref
 EX1_ARGS_16 := -m meshes/two-cubes-nurbs-rot.mesh -o 1 -r 3 -rf meshes/two-cubes.ref
 EX1_ARGS_17 := -m meshes/two-cubes-nurbs-autoedge.mesh -o 1 -r 3 -rf meshes/two-cubes.ref
 EX1_ARGS_18 := -m meshes/cube-nurbs.mesh -pm "1" -ps "2" -rf meshes/cube.ref
+EX1_ARGS_19 := -m meshes/square-nurbs-distorted.mesh -o 2 -mo 3 -r 1 -no-ibp
+
 
 nurbs_ex1-test-seq: nurbs_ex1
 	@$(call mfem-test,$<,, NURBS miniapp)
@@ -104,6 +106,7 @@ nurbs_ex1-test-seq: nurbs_ex1
 	@$(call mfem-test,$<,, NURBS miniapp,$(EX1_ARGS_16))
 	@$(call mfem-test,$<,, NURBS miniapp,$(EX1_ARGS_17))
 	@$(call mfem-test,$<,, NURBS miniapp,$(EX1_ARGS_18))
+	@$(call mfem-test,$<,, NURBS miniapp,$(EX1_ARGS_19))
 
 EX1PATCH_ARGS_1 := -incdeg 3 -ref 1 -iro 8 -patcha
 EX1PATCH_ARGS_2 := -incdeg 3 -ref 1 -iro 8 -patcha -pa

--- a/miniapps/nurbs/meshes/square-nurbs-distorted.mesh
+++ b/miniapps/nurbs/meshes/square-nurbs-distorted.mesh
@@ -1,0 +1,82 @@
+MFEM NURBS mesh v1.0
+
+#
+# MFEM Geometry Types (see fem/geom.hpp):
+#
+# SEGMENT     = 1
+# SQUARE      = 3
+# CUBE        = 5
+#
+
+dimension
+2
+
+elements
+1
+1 3 0 1 2 3
+
+boundary
+4
+1 1 0 1
+1 1 2 3
+1 1 3 0
+1 1 1 2
+
+edges
+4
+0 0 1
+0 3 2
+1 0 3
+1 1 2
+
+vertices
+4
+
+knotvectors
+2
+2 4 0 0 0 0.5 1 1 1
+2 4 0 0 0 0.5 1 1 1
+
+weights
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1.3
+1.3
+0.7
+0.7
+
+FiniteElementSpace
+FiniteElementCollection: NURBS2
+VDim: 2
+Ordering: 1
+
+0 0
+1 0
+1 1
+0 1
+0.25 0
+0.75 0
+0.75 1
+0.25 1
+0 0.25
+0 0.75
+1 0.25
+1 0.75
+0.75 0.25
+0.75 0.75
+0.25 0.25
+0.25 0.75
+
+
+
+

--- a/miniapps/nurbs/nurbs_ex1.cpp
+++ b/miniapps/nurbs/nurbs_ex1.cpp
@@ -20,6 +20,8 @@
 //               nurbs_ex1 -m ../../data/segment-nurbs.mesh -r 2 -o 2 -lod 3
 //               nurbs_ex1 -m meshes/square-nurbs-deformed.mesh -o 2
 //               nurbs_ex1 -m meshes/square-nurbs-deformed.mesh -o 2 -no-ibp
+//               nurbs_ex1 -m meshes/square-nurbs-distorted.mesh -o 2 -mo 3
+//               nurbs_ex1 -m meshes/square-nurbs-distorted.mesh -o 2 -mo 3 -no-ibp
 //               nurbs_ex1 -m meshes/cube-nurbs-deformed.mesh -o 2
 //               nurbs_ex1 -m meshes/cube-nurbs-deformed.mesh -o 2 -no-ibp
 //
@@ -161,6 +163,7 @@ int main(int argc, char *argv[])
 {
    // 1. Parse command-line options.
    const char *mesh_file = "../../data/square-nurbs.mesh";
+   int mOrder = -1;
    const char *per_file  = "none";
    const char *ref_file  = "";
    int ref_levels = -1;
@@ -181,6 +184,8 @@ int main(int argc, char *argv[])
    OptionsParser args(argc, argv);
    args.AddOption(&mesh_file, "-m", "--mesh",
                   "Mesh file to use.");
+   args.AddOption(&mOrder, "-mo", "--mesh-order",
+                  "Order for the isoparametric  mesh");
    args.AddOption(&ref_levels, "-r", "--refine",
                   "Number of times to refine the mesh uniformly, -1 for auto.");
    args.AddOption(&per_file, "-p", "--per",
@@ -239,6 +244,16 @@ int main(int argc, char *argv[])
    //    in a refinement file. We choose 'ref_levels' to be the largest number
    //    that gives a final mesh with no more than 50,000 elements.
    {
+      if (mesh->NURBSext)
+      {
+         int mOrder_cur = mesh->NURBSext->GetOrder();
+         if ((mOrder_cur != NURBSFECollection::VariableOrder) &&
+             (mOrder > 0))
+         {
+            mesh->DegreeElevate(mOrder - mOrder_cur);
+         }
+      }
+
       // Mesh refinement as defined in refinement file
       if (mesh->NURBSext && (strlen(ref_file) != 0))
       {


### PR DESCRIPTION
This PR fixes a lingering bug in NURBS FiniteElements.

The not THREAD_SAFE version of the `FiniteElement` class has a scratch data member `vshape` that is occasionally used as temporary variable. This variable is allocated in the constructor, but was not resized when the `dof` variable changes.

This was fixed by creating a member function that sets the dof variable and resize the scratch data member.
An additional test and mesh was added to test this.
<!--GHEX{"author":"IdoAkkerman","assignment":"2026-09-09T07:37:14","editor":"tzanio","id":5486,"reviewers":["dylan-copeland","mlstowell"],"merge":"2026-09-30T07:37:14","approval":"2026-09-23T07:37:14"}XEHG-->
<!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge|
 | --- | --- | --- | --- | --- | --- | --- |
| [#5486](https://github.com/mfem/mfem/pull/5486) | @IdoAkkerman | @tzanio | @dylan-copeland + @mlstowell | 9/9/26 | ⌛due 9/23/26 | ⌛due 9/30/26 | |
<!--ELBATXEHG-->
<details>
<summary>PR Checklist</summary>
    
- [ ] Code builds.
- [ ] Code passes `make style`.
- [ ] Update `CHANGELOG`:
    - [ ] Is this a new feature users need to be aware of? New or updated example or miniapp?
    - [ ] Does it make sense to create a new section in the `CHANGELOG` to group with other related features?
- [ ] Update `INSTALL`:
    - [ ] Had a new optional library been added? If so, what range of versions of this library are required? (*Make sure the external library is compatible with our BSD license, e.g. it is not licensed under GPL!*)
    - [ ] Have the version ranges for any required or optional libraries changed?
    - [ ] Does `make` or `cmake` have a new target?
    - [ ] Did the requirements or the installation process change? *(rare)*
- [ ] Update continuous integration server configurations if necessary (e.g. with new version requirements for each of MFEM's dependencies)
    - [ ] `.github`
    - [ ] `.appveyor.yml`
- [ ] Update `.gitignore`:
    - [ ] Check if `make distclean; git status` shows any files that were generated from the source by the project (not an IDE) but we don't want to track in the repository.
    - [ ] Add new patterns (just for the new files above) and re-run the above test.
- [ ] New examples:
    - [ ] All sample runs at the top of the example source file work.
    - [ ] Update `examples/makefile`:
      - [ ] Add the example code to the appropriate `SEQ_EXAMPLES` and `PAR_EXAMPLES` variables.
      - [ ] Add any files generated by it to the `clean` target.
      - [ ] Add the example binary and any files generated by it to the top-level `.gitignore` file.
    - [ ] Update `examples/CMakeLists.txt`:
      - [ ] Add the example code to the `ALL_EXE_SRCS` variable.
      - [ ] Make sure `THIS_TEST_OPTIONS` is set correctly for the new example.
   - [ ] List the new example in `doc/CodeDocumentation.dox`.
   - [ ] If new examples directory (e.g.`examples/pumi`), list it in `doc/CodeDocumentation.conf.in`
   - [ ] Companion pull request for documentation in [mfem/web](https://github.com/mfem/web) repo:
      - [ ] Update or add example-specific documentation, see e.g. the `src/examples.md`.
      - [ ] Add the description, labels and screenshots in `src/examples.md` and `src/img`.
      - [ ] In `examples.md`, list the example under the appropriate categories, add new categories if necessary.
      - [ ] Add a short description of the example in the "Extensive Examples" section of `features.md`.
- [ ] New miniapps:
   - [ ] All sample runs at the top of the miniapp source file work.
   - [ ] Update top-level `makefile` and `makefile` in corresponding miniapp directory.
   - [ ] Add the miniapp binary and any files generated by it to the top-level `.gitignore` file.
   - [ ] Update CMake build system:
      - [ ] Update the `CMakeLists.txt` file in the `miniapps` directory, if the new miniapp is in a new directory.
      - [ ] Add/update the `CMakeLists.txt` file in the new miniapp directory.
      - [ ] Consider adding a new test for the new miniapp.
   - [ ] List the new miniapp in `doc/CodeDocumentation.dox`
   - [ ] If new miniapps directory (e.g.`miniapps/nurbs`), add it to `MINIAPP_SUBDIRS` in the `makefile`.
   - [ ] If new miniapps directory (e.g.`miniapps/nurbs`), list it in `doc/CodeDocumentation.conf.in`
   - [ ] Companion pull request for documentation in [mfem/web](https://github.com/mfem/web) repo:
     - [ ] Update or add miniapp-specific documentation, see e.g. the `src/meshing.md` and `src/electromagnetics.md` files.
     - [ ] Add the description, labels and screenshots in `src/examples.md` and `src/img`.
     - [ ] The miniapps go at the end of the page, and are usually listed only under a specific "Application (PDE)" category.
     - [ ] Add a short description of the miniapp in the "Extensive Examples" section of `features.md`.
- [ ] New capability:
   - [ ] All new public, protected, and private classes, methods, data members, and functions have full Doxygen-style documentation in source comments. Documentation should include descriptions of member data, function arguments and return values, template parameters, and prerequisites for calling new functions.
   - [ ] Pointer arguments and return values must specify whether ownership is being transferred or lent with the call.
   - [ ] Any new functions should include descriptions of their intended use e.g. for internal use only, user-facing, etc., along with references to example code whenever possible/appropriate.
   - [ ] Consider adding new sample runs in existing examples to highlight the new capability.
   - [ ] Consider saving cool simulation pictures with the new capability in the Confluence gallery (LLNL only) or submitting them, via pull request, to the gallery section of the `mfem/web` repo.
   - [ ] If this is a major new feature, consider mentioning it in the short summary inside `README` *(rare)*.
   - [ ] List major new classes in `doc/CodeDocumentation.dox` *(rare)*.
- [ ] Update this checklist, if the new pull request affects it.
- [ ] Run `make unittest` to make sure all unit tests pass.
- [ ] Run the tests in `tests/scripts`.
- [ ] (LLNL only) After merging:
   - [ ] Update internal tests to include the new features.
</details>
