### PR TITLE
Add metric to eltrans

### DIFF
--- a/fem/eltrans.cpp
+++ b/fem/eltrans.cpp
@@ -68,6 +68,20 @@ const DenseMatrix &ElementTransformation::EvalInverseJ()
    return invJ;
 }
 
+const DenseMatrix &ElementTransformation::EvalMetric()
+{
+   MFEM_ASSERT((EvalState & METRIC_MASK) == 0, "");
+   InverseJacobian();
+   DenseMatrix invJP(dFdx.Height());
+   Geometries.InvJacToInvPerfJac(geom, invJ, invJP);
+
+   Gij.SetSize(dFdx.Height(), dFdx.Height());
+   MultAtB(invJP, invJP, Gij);
+
+   EvalState |= METRIC_MASK;
+   return Gij;
+}
+
 int InverseElementTransformation::FindClosestPhysPoint(
    const Vector& pt, const IntegrationRule &ir)
 {

--- a/fem/eltrans.cpp
+++ b/fem/eltrans.cpp
@@ -68,15 +68,34 @@ const DenseMatrix &ElementTransformation::EvalInverseJ()
    return invJ;
 }
 
+const DenseMatrix &ElementTransformation::EvalPerfectJ()
+{
+   MFEM_ASSERT((EvalState & PERF_JACOBIAN_MASK) == 0, "");
+   Jacobian();
+   PJ.SetSize(dFdx.Height());
+   Geometries.JacToPerfJac(geom, dFdx, PJ);
+
+   EvalState |= PERF_JACOBIAN_MASK;
+   return PJ;
+}
+
+const DenseMatrix &ElementTransformation::EvalPerfectInverseJ()
+{
+   MFEM_ASSERT((EvalState & PERF_INVERSE_MASK) == 0, "");
+   InverseJacobian();
+   PInvJ.SetSize(dFdx.Height());
+   Geometries.InvJacToInvPerfJac(geom, invJ, PInvJ);
+
+   EvalState |= PERF_INVERSE_MASK;
+   return PInvJ;
+}
+
 const DenseMatrix &ElementTransformation::EvalMetric()
 {
    MFEM_ASSERT((EvalState & METRIC_MASK) == 0, "");
-   InverseJacobian();
-   DenseMatrix invJP(dFdx.Height());
-   Geometries.InvJacToInvPerfJac(geom, invJ, invJP);
-
-   Gij.SetSize(dFdx.Height(), dFdx.Height());
-   MultAtB(invJP, invJP, Gij);
+   PerfectInverseJacobian();
+   Gij.SetSize(dFdx.Height());
+   MultAtB(PInvJ, PInvJ, Gij);
 
    EvalState |= METRIC_MASK;
    return Gij;

--- a/fem/eltrans.hpp
+++ b/fem/eltrans.hpp
@@ -28,7 +28,7 @@ class ElementTransformation
 {
 protected:
    const IntegrationPoint *IntPoint;
-   DenseMatrix dFdx, adjJ, invJ;
+   DenseMatrix dFdx, adjJ, invJ, Gij;
    DenseMatrix d2Fdx2, adjJT;
    real_t Wght;
    int EvalState;
@@ -39,7 +39,8 @@ protected:
       ADJUGATE_MASK = 4,
       INVERSE_MASK  = 8,
       HESSIAN_MASK  = 16,
-      TRANS_ADJUGATE_MASK = 32
+      TRANS_ADJUGATE_MASK = 32,
+      METRIC_MASK = 64
    };
    Geometry::Type geom;
 
@@ -55,6 +56,7 @@ protected:
    const DenseMatrix &EvalAdjugateJ();
    const DenseMatrix &EvalTransAdjugateJ();
    const DenseMatrix &EvalInverseJ();
+   const DenseMatrix &EvalMetric();
 
    /// @name Tolerance used for point comparisons
    ///@{
@@ -157,6 +159,11 @@ public:
         at the currently set IntegrationPoint. */
    const DenseMatrix &InverseJacobian()
    { return (EvalState & INVERSE_MASK) ? invJ : EvalInverseJ(); }
+
+   /** @brief Return the metric tensor of the transformation
+        at the currently set IntegrationPoint. */
+   const DenseMatrix &Metric()
+   { return (EvalState & METRIC_MASK) ? Gij : EvalMetric(); }
 
    /// Return the order of the current element we are using for the transformation.
    virtual int Order() const = 0;

--- a/fem/eltrans.hpp
+++ b/fem/eltrans.hpp
@@ -28,7 +28,7 @@ class ElementTransformation
 {
 protected:
    const IntegrationPoint *IntPoint;
-   DenseMatrix dFdx, adjJ, invJ, Gij;
+   DenseMatrix dFdx, adjJ, invJ, PJ, PInvJ, Gij;
    DenseMatrix d2Fdx2, adjJT;
    real_t Wght;
    int EvalState;
@@ -40,7 +40,9 @@ protected:
       INVERSE_MASK  = 8,
       HESSIAN_MASK  = 16,
       TRANS_ADJUGATE_MASK = 32,
-      METRIC_MASK = 64
+      PERF_JACOBIAN_MASK  = 64,
+      PERF_INVERSE_MASK  = 128,
+      METRIC_MASK = 256
    };
    Geometry::Type geom;
 
@@ -56,6 +58,8 @@ protected:
    const DenseMatrix &EvalAdjugateJ();
    const DenseMatrix &EvalTransAdjugateJ();
    const DenseMatrix &EvalInverseJ();
+   const DenseMatrix &EvalPerfectJ();
+   const DenseMatrix &EvalPerfectInverseJ();
    const DenseMatrix &EvalMetric();
 
    /// @name Tolerance used for point comparisons
@@ -134,7 +138,6 @@ public:
    const DenseMatrix &Jacobian()
    { return (EvalState & JACOBIAN_MASK) ? dFdx : EvalJacobian(); }
 
-
    /** @brief Return the Hessian matrix of the transformation at the currently
        set IntegrationPoint, using the method SetIntPoint(). */
    const DenseMatrix &Hessian()
@@ -159,6 +162,16 @@ public:
         at the currently set IntegrationPoint. */
    const DenseMatrix &InverseJacobian()
    { return (EvalState & INVERSE_MASK) ? invJ : EvalInverseJ(); }
+
+   /** @brief Return the metric tensor of the transformation
+        at the currently set IntegrationPoint. */
+   const DenseMatrix &PerfectJacobian()
+   { return (EvalState & PERF_JACOBIAN_MASK) ? PJ : EvalPerfectJ(); }
+
+   /** @brief Return the metric tensor of the transformation
+        at the currently set IntegrationPoint. */
+   const DenseMatrix &PerfectInverseJacobian()
+   { return (EvalState & PERF_INVERSE_MASK) ? PInvJ : EvalPerfectInverseJ(); }
 
    /** @brief Return the metric tensor of the transformation
         at the currently set IntegrationPoint. */

--- a/fem/geom.cpp
+++ b/fem/geom.cpp
@@ -919,6 +919,19 @@ void Geometry::JacToPerfJac(int GeomType, const DenseMatrix &J,
    }
 }
 
+void Geometry::InvJacToInvPerfJac(int GeomType, const DenseMatrix &invJ,
+                                  DenseMatrix &invPJ) const
+{
+   if (GeomToPerfGeomJac[GeomType])
+   {
+      Mult(*GeomToPerfGeomJac[GeomType], invJ, invPJ);
+   }
+   else
+   {
+      invPJ = invJ;
+   }
+}
+
 const int Geometry::NumBdrArray[NumGeom] = { 0, 2, 3, 4, 4, 6, 5, 5 };
 const int Geometry::Dimension[NumGeom] = { 0, 1, 2, 2, 3, 3, 3, 3 };
 const int Geometry::DimStart[MaxDim+2] =

--- a/fem/geom.hpp
+++ b/fem/geom.hpp
@@ -106,6 +106,8 @@ public:
    void GetPerfPointMat(int GeomType, DenseMatrix &pm) const;
    void JacToPerfJac(int GeomType, const DenseMatrix &J,
                      DenseMatrix &PJ) const;
+   void InvJacToInvPerfJac(int GeomType, const DenseMatrix &invJ,
+                           DenseMatrix &invPJ) const;
 
    /// Returns true if the given @a geom is of tensor-product type (i.e. if geom
    /// is a segment, quadrilateral, or hexahedron), returns false otherwise.

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -143,6 +143,7 @@ set(UNIT_TESTS_SRCS
   fem/test_lor_batched.cpp
   fem/test_lor_dg.cpp
   fem/test_lor.cpp
+  fem/test_metric.cpp
   fem/test_mixedsesqform.cpp
   fem/test_nonlinearform.cpp
   fem/test_operatorjacobismoother.cpp

--- a/tests/unit/fem/test_metric.cpp
+++ b/tests/unit/fem/test_metric.cpp
@@ -1,0 +1,238 @@
+// Copyright (c) 2010-2026, Lawrence Livermore National Security, LLC. Produced
+// at the Lawrence Livermore National Laboratory. All Rights reserved. See files
+// LICENSE and NOTICE for details. LLNL-CODE-806117.
+//
+// This file is part of the MFEM library. For more information and source code
+// availability visit https://mfem.org.
+//
+// MFEM is free software; you can redistribute it and/or modify it under the
+// terms of the BSD-3 license. We welcome feedback and contributions, see file
+// CONTRIBUTING.md for details.
+
+#include "mfem.hpp"
+#include "unit_tests.hpp"
+
+using namespace mfem;
+
+/// Create a mesh with one triangle, with different element vertices
+static Mesh *BuildSingleTriMesh(const int shift)
+{
+   // Reproduce mfem/data/ref-triangle.mesh layout but with custom vertex order
+   std::ostringstream os;
+   os << "MFEM mesh v1.0\n\n";
+   os << "dimension\n2\n\n";
+   os << "elements\n1\n";
+   os << "1 2";
+   for (int i = 0; i < 3; i++)
+   {
+      os << " "<<(i + shift)%3;
+   }
+   os << "\n\n";
+   os << "boundary\n3\n";
+   os << "1 1 0 1\n";
+   os << "2 1 1 2\n";
+   os << "3 1 2 0\n\n";
+   os << "vertices\n3\n2\n";
+   os << "0 0\n";
+   os << "1 0\n";
+   os << "0 1\n";
+   os << "\n";
+   std::istringstream is(os.str());
+   return new Mesh(is, 1, 0, false);
+}
+
+/// Create a mesh with one tetrahadron, with different element vertices
+static Mesh *BuildSingleTetMesh(const int shift)
+{
+   // Reproduce mfem/data/ref-tetrahedron.mesh layout but with custom vertex order
+   std::ostringstream os;
+   os << "MFEM mesh v1.0\n\n";
+   os << "dimension\n3\n\n";
+   os << "elements\n1\n";
+   // Element: attribute=1, geometry=4 (TETRAHEDRON), vertices 0 1 2 3
+   os << "1 4";
+   for (int i = 0; i < 4; i++)
+   {
+      os << " "<<(i + shift)%4;
+   }
+   os << "\n\n";
+   // Boundary: 4 triangular faces with attributes 1..4
+   os << "boundary\n4\n";
+   os << "1 2 1 2 3\n";
+   os << "2 2 0 3 2\n";
+   os << "3 2 0 1 3\n";
+   os << "4 2 0 2 1\n\n";
+   // Vertices (4) with dimension flag 3
+   os << "vertices\n4\n3\n";
+   os << "0 0 0\n";
+   os << "1 0 0\n";
+   os << "0 1 0\n";
+   os << "0 0 1\n";
+   os << "\n";
+   std::istringstream is(os.str());
+   return new Mesh(is, 1, 0, false);
+}
+
+/// Create a mesh with one wedge, with different element vertices
+static Mesh *BuildSingleWedgeMesh(const int shift)
+{
+   // Reproduce mfem/data/ref-tetrahedron.mesh layout but with custom vertex order
+   std::ostringstream os;
+   os << "MFEM mesh v1.0\n\n";
+   os << "dimension\n3\n\n";
+   os << "elements\n1\n";
+   // Element: attribute=1, geometry=6 (PRISM), vertices 0 1 2 3 4 5
+   os << "1 6";
+   for (int i = 0; i < 3; i++)
+   {
+      os << " "<<(i + shift)%3;
+   }
+   for (int i = 0; i < 3; i++)
+   {
+      os << " "<<((i + shift)%3) + 3;
+   }
+   os << "\n\n";
+   // Boundary: 2 triangular faces & 3 quad faces
+   os << "boundary\n5\n";
+   os << "1 2 0 1 2\n";
+   os << "2 3 0 3 4 1\n";
+   os << "3 3 1 4 5 2\n";
+   os << "4 3 2 5 3 0\n";
+   os << "5 2 3 4 5\n\n";
+   // Vertices (4) with dimension flag 3
+   os << "vertices\n6\n3\n";
+   os << "0 0 0\n";
+   os << "1 0 0\n";
+   os << "0 1 0\n";
+   os << "0 0 1\n";
+   os << "1 0 1\n";
+   os << "0 1 1\n";
+   os << "\n";
+   std::istringstream is(os.str());
+   return new Mesh(is, 1, 0, false);
+}
+
+/// Create a mesh with one pyramid, with different element vertices
+static Mesh *BuildSinglePyrMesh(const int shift)
+{
+   std::ostringstream os;
+   os << "MFEM mesh v1.0\n\n";
+   os << "dimension\n3\n\n";
+   os << "elements\n1\n";
+   // Element: attribute=1, geometry=7 (PYRAMID), vertices 0 1 2 3 4
+   os << "1 7";
+   for (int i = 0; i < 4; i++)
+   {
+      os << " "<<(i + shift)%4;
+   }
+   os << " 4 \n\n";
+   // Boundary:1 quad face & 4 triangular faces
+   os << "boundary\n5\n";
+   os << "1 3 0 1 2 3\n";
+   os << "2 2 0 1 4\n";
+   os << "3 2 1 2 4\n";
+   os << "4 2 2 3 4\n";
+   os << "5 2 3 0 4\n\n";
+   // Vertices (4) with dimension flag 3
+   os << "vertices\n5\n3\n";
+   os << "0 0 0\n";
+   os << "1 0 0\n";
+   os << "1 1 0\n";
+   os << "0 1 0\n";
+   os << "0 0 1\n";
+   os << "\n";
+   std::istringstream is(os.str());
+   return new Mesh(is, 1, 0, false);
+}
+
+static const DenseMatrix & GetMetric(Mesh *mesh)
+{
+   // One element mesh, pick centroid of reference element (triangle/tetra)
+   ElementTransformation *T = mesh->GetElementTransformation(0);
+   IntegrationPoint ip;
+   if (mesh->Dimension() == 2)
+   {
+      ip.Set2(1.0/3.0, 1.0/3.0);
+   }
+   else if (mesh->Dimension() == 3)
+   {
+      ip.Set3(1.0/4.0, 1.0/4.0, 1.0/4.0);
+   }
+   else
+   {
+      MFEM_ABORT("Unsupported mesh dimension in tau_variance test.");
+   }
+   T->SetIntPoint(&ip);
+   return T->Metric();
+}
+
+
+TEST_CASE("Metrics for different Finite Elements",
+          "[Triangle]"
+          "[Tetrahedron]"
+          "[Wedge]"
+          "[Pyramid]")
+{
+   Mesh *mesh = nullptr;
+   SECTION("Triangle")
+   {
+      mesh = BuildSingleTriMesh(0);
+      DenseMatrix Gij_ref = GetMetric(mesh);
+      delete mesh;
+      for (size_t i = 1; i < 3; i++)
+      {
+         mesh = BuildSingleTriMesh(i);
+         DenseMatrix Gij = GetMetric(mesh);
+         Gij.Print();
+         Gij -= Gij_ref;
+         Gij.Print();
+         REQUIRE(Gij.FNorm() == MFEM_Approx(0.0));
+         delete mesh;
+      }
+   }
+
+   SECTION("Tetrahedron")
+   {
+      mesh = BuildSingleTetMesh(0);
+      DenseMatrix Gij_ref = GetMetric(mesh);
+      delete mesh;
+      for (size_t i = 1; i < 4; i++)
+      {
+         mesh = BuildSingleTetMesh(i);
+         DenseMatrix Gij = GetMetric(mesh);
+         delete mesh;
+         Gij -= Gij_ref;
+         REQUIRE(Gij.FNorm() == MFEM_Approx(0.0));
+      }
+   }
+
+   SECTION("Wedge")
+   {
+      mesh = BuildSingleWedgeMesh(0);
+      DenseMatrix Gij_ref = GetMetric(mesh);
+      delete mesh;
+      for (size_t i = 1; i < 3; i++)
+      {
+         mesh = BuildSingleWedgeMesh(i);
+         DenseMatrix Gij = GetMetric(mesh);
+         delete mesh;
+         Gij -= Gij_ref;
+         REQUIRE(Gij.FNorm() == MFEM_Approx(0.0));
+      }
+   }
+
+   SECTION("Pyramid")
+   {
+      mesh = BuildSinglePyrMesh(0);
+      DenseMatrix Gij_ref = GetMetric(mesh);
+      delete mesh;
+      for (size_t i = 1; i < 4; i++)
+      {
+         mesh = BuildSinglePyrMesh(i);
+         DenseMatrix Gij = GetMetric(mesh);
+         delete mesh;
+         Gij -= Gij_ref;
+         REQUIRE(Gij.FNorm() == MFEM_Approx(0.0));
+      }
+   }
+}


### PR DESCRIPTION
To simplify defining mesh depended parameters, such a stabilisation parameters it is convenient to have a uniform way to compute the mesh metric. This is particularly important as the metric is computed wrt the idealized reference domain( eg Equilateral triangle with 60deg corners ) instead of the standard reference domain (eq triangle with 90-45-45 corners).