### PR TITLE
Fix parallel NC hanging-vertex ownership and tetrahedral edge-face communication

### DIFF
--- a/fem/pfespace.cpp
+++ b/fem/pfespace.cpp
@@ -4098,6 +4098,7 @@ int ParFiniteElementSpace
                constexpr int variant = 0;
                const int q = GetEntityDofs(entity, sf.index, slave_dofs, mf.Geom(), variant);
                if (q < 0) { break; }
+               if (slave_dofs.Size() == 0) { continue; }
 
                list.OrientedPointMatrix(sf, T.GetPointMat());
 

--- a/mesh/ncmesh.cpp
+++ b/mesh/ncmesh.cpp
@@ -3656,19 +3656,24 @@ NCMesh::TriFaceTraverseResults NCMesh::TraverseTriFace(int vn0, int vn1,
                              PointMatrix(pmid1, pmid2, pmid0),
                              level+1, matrix_map);
 
-      // Traverse possible tet edges constrained by the master face. This needs
-      // to occur if none of these first NC level faces are split further, OR if
-      // they are on different processors. The different processor constraint is
-      // needed in the case of local elements constrained by this face via the
-      // edge alone. Cannot know this a priori, so just constrain any edge
-      // attached to two neighbors.
-      if (HaveTets() && (!b[3].unsplit || b[3].ghost_neighbor))
+      // In parallel, child-face state is observer-relative: a rank can touch
+      // an interior edge without owning a slave face. Visit every possible tet
+      // edge so all ranks discover the same relations.
+      const bool all_edges = IsParallel();
+      if (HaveTets() && (all_edges || !b[3].unsplit || b[3].ghost_neighbor))
       {
-         // If the faces have no further splits, so would not be captured by
-         // normal face relations, add possible edge constraints.
-         if (!b[1].unsplit || b[1].ghost_neighbor) { TraverseTetEdge(mid[0],mid[1], pmid0,pmid1, matrix_map); }
-         if (!b[2].unsplit || b[2].ghost_neighbor) { TraverseTetEdge(mid[1],mid[2], pmid1,pmid2, matrix_map); }
-         if (!b[0].unsplit || b[0].ghost_neighbor) { TraverseTetEdge(mid[2],mid[0], pmid2,pmid0, matrix_map); }
+         if (all_edges || !b[1].unsplit || b[1].ghost_neighbor)
+         {
+            TraverseTetEdge(mid[0],mid[1], pmid0,pmid1, matrix_map);
+         }
+         if (all_edges || !b[2].unsplit || b[2].ghost_neighbor)
+         {
+            TraverseTetEdge(mid[1],mid[2], pmid1,pmid2, matrix_map);
+         }
+         if (all_edges || !b[0].unsplit || b[0].ghost_neighbor)
+         {
+            TraverseTetEdge(mid[2],mid[0], pmid2,pmid0, matrix_map);
+         }
       }
    }
    return {false, false};

--- a/mesh/ncmesh.cpp
+++ b/mesh/ncmesh.cpp
@@ -3656,9 +3656,10 @@ NCMesh::TriFaceTraverseResults NCMesh::TraverseTriFace(int vn0, int vn1,
                              PointMatrix(pmid1, pmid2, pmid0),
                              level+1, matrix_map);
 
-      // In parallel, child-face state is observer-relative: a rank can touch
-      // an interior edge without owning a slave face. Visit every possible tet
-      // edge so all ranks discover the same relations.
+      // In parallel, also visit interior tet edges covered by local slave faces.
+      // Their owners can lack a local slave face and need the master face's
+      // interpolation rows. These records supply the owners to the master face
+      // and boundary-entity P-matrix communication groups.
       const bool all_edges = IsParallel();
       if (HaveTets() && (all_edges || !b[3].unsplit || b[3].ghost_neighbor))
       {

--- a/mesh/ncmesh.cpp
+++ b/mesh/ncmesh.cpp
@@ -3656,10 +3656,9 @@ NCMesh::TriFaceTraverseResults NCMesh::TraverseTriFace(int vn0, int vn1,
                              PointMatrix(pmid1, pmid2, pmid0),
                              level+1, matrix_map);
 
-      // In parallel, also visit interior tet edges covered by local slave faces.
-      // Their owners can lack a local slave face and need the master face's
-      // interpolation rows. These records supply the owners to the master face
-      // and boundary-entity P-matrix communication groups.
+      // An interior edge may be owned by a rank with no local slave face.
+      // Record the edge-face relation so that rank receives the master face's
+      // P rows, including its edge and vertex rows.
       const bool all_edges = IsParallel();
       if (HaveTets() && (all_edges || !b[3].unsplit || b[3].ghost_neighbor))
       {

--- a/mesh/pncmesh.cpp
+++ b/mesh/pncmesh.cpp
@@ -403,15 +403,14 @@ void ParNCMesh::BuildVertexList()
 
    NCMesh::BuildVertexList();
 
-   // A hanging vertex must be owned by a rank that holds a constraining slave
-   // locally. Every vertex toucher has all vertex-neighbor elements in its
-   // ghost layer, so all touchers see the same relevant slave owners.
+   // The owner needs a local slave to build the vertex constraint.
+   // Vertex-neighbor ghosts give all sharing ranks the same candidates.
    Array<int> hanging_owner(nvertices);
    hanging_owner = INT_MAX;
 
    auto owner_rank = [&](int entity, int index, int nlocal)
    {
-      // Group 0 on a ghost entity means its owner was not observed locally.
+      // For a ghost, group 0 means unknown owner, not self.
       if (index < 0 || index >= entity_owner[entity].Size() ||
           (index >= nlocal && entity_owner[entity][index] == 0))
       {

--- a/mesh/pncmesh.cpp
+++ b/mesh/pncmesh.cpp
@@ -409,27 +409,6 @@ void ParNCMesh::BuildVertexList()
    Array<int> hanging_owner(nvertices);
    hanging_owner = INT_MAX;
 
-   Array<int> edge_node(NEdges + NGhostEdges);
-   edge_node = -1;
-   for (auto node = nodes.cbegin(); node != nodes.cend(); ++node)
-   {
-      if (node->HasEdge() && node->edge_index >= 0 &&
-          node->edge_index < edge_node.Size())
-      {
-         edge_node[node->edge_index] = node.index();
-      }
-   }
-   auto edge_vertices = [&](int edge, int vertices[2])
-   {
-      if (edge < 0 || edge >= edge_node.Size() || edge_node[edge] < 0)
-      {
-         return false;
-      }
-      const Node &node = nodes[edge_node[edge]];
-      vertices[0] = nodes[node.p1].HasVertex() ? nodes[node.p1].vert_index : -1;
-      vertices[1] = nodes[node.p2].HasVertex() ? nodes[node.p2].vert_index : -1;
-      return vertices[0] >= 0 && vertices[1] >= 0;
-   };
    auto owner_rank = [&](int entity, int index, int nlocal)
    {
       // Group 0 on a ghost entity means its owner was not observed locally.
@@ -452,12 +431,14 @@ void ParNCMesh::BuildVertexList()
    int mv[4], me[4], mo[4], sv[4];
    for (const auto &master : edge_list.masters)
    {
-      if (!edge_vertices(master.index, mv)) { continue; }
+      GetEdgeVertices(master, mv);
       for (int i = master.slaves_begin; i < master.slaves_end; i++)
       {
          const Slave &slave = edge_list.slaves[i];
          const int owner = owner_rank(1, slave.index, NEdges);
-         if (!edge_vertices(slave.index, sv)) { continue; }
+         if (owner == INT_MAX) { continue; }
+         MFEM_ASSERT(slave.element >= 0, "observed slave edge has no element");
+         GetEdgeVertices(slave, sv);
          update_owner(sv[0], owner, mv, 2);
          update_owner(sv[1], owner, mv, 2);
       }
@@ -482,7 +463,9 @@ void ParNCMesh::BuildVertexList()
          {
             const int edge = FlipIndexSign(slave.index);
             const int owner = owner_rank(1, edge, NEdges);
-            if (!edge_vertices(edge, sv)) { continue; }
+            if (owner == INT_MAX) { continue; }
+            MFEM_ASSERT(slave.element >= 0, "observed edge-face slave has no element");
+            GetEdgeVertices(slave, sv);
             update_owner(sv[0], owner, mv, nmv);
             update_owner(sv[1], owner, mv, nmv);
          }
@@ -534,9 +517,9 @@ void ParNCMesh::MakeSharedList(const NCList &list, NCList &shared)
             master_flag |= slave_flag;
             slave_flag |= master_old_flag;
          }
-         else // special case: prism edge-face constraint
+         else // special case: edge-face constraint
          {
-            if (entity_owner[1][FlipIndexSign(si)] != MyRank)
+            if (entity_owner[1][FlipIndexSign(si)] != 0)
             {
                master_flag |= 0x2;
             }

--- a/mesh/pncmesh.cpp
+++ b/mesh/pncmesh.cpp
@@ -18,6 +18,7 @@
 #include "../general/binaryio.hpp"
 #include "../general/communication.hpp"
 
+#include <algorithm>
 #include <numeric> // std::accumulate
 #include <map>
 #include <climits> // INT_MIN, INT_MAX
@@ -383,6 +384,9 @@ void ParNCMesh::BuildVertexList()
    // This is an extension of NCMesh::BuildVertexList() which also determines
    // vertex ownership and creates vertex processor groups.
 
+   GetEdgeList();
+   if (Dim >= 3) { GetFaceList(); }
+
    int nvertices = NVertices + NGhostVertices;
 
    tmp_owner.SetSize(nvertices);
@@ -398,6 +402,96 @@ void ParNCMesh::BuildVertexList()
    entity_elem_local[0] = -1;
 
    NCMesh::BuildVertexList();
+
+   // A hanging vertex must be owned by a rank that holds a constraining slave
+   // locally. Every vertex toucher has all vertex-neighbor elements in its
+   // ghost layer, so all touchers see the same relevant slave owners.
+   Array<int> hanging_owner(nvertices);
+   hanging_owner = INT_MAX;
+
+   Array<int> edge_node(NEdges + NGhostEdges);
+   edge_node = -1;
+   for (auto node = nodes.cbegin(); node != nodes.cend(); ++node)
+   {
+      if (node->HasEdge() && node->edge_index >= 0 &&
+          node->edge_index < edge_node.Size())
+      {
+         edge_node[node->edge_index] = node.index();
+      }
+   }
+   auto edge_vertices = [&](int edge, int vertices[2])
+   {
+      if (edge < 0 || edge >= edge_node.Size() || edge_node[edge] < 0)
+      {
+         return false;
+      }
+      const Node &node = nodes[edge_node[edge]];
+      vertices[0] = nodes[node.p1].HasVertex() ? nodes[node.p1].vert_index : -1;
+      vertices[1] = nodes[node.p2].HasVertex() ? nodes[node.p2].vert_index : -1;
+      return vertices[0] >= 0 && vertices[1] >= 0;
+   };
+   auto owner_rank = [&](int entity, int index, int nlocal)
+   {
+      // Group 0 on a ghost entity means its owner was not observed locally.
+      if (index < 0 || index >= entity_owner[entity].Size() ||
+          (index >= nlocal && entity_owner[entity][index] == 0))
+      {
+         return INT_MAX;
+      }
+      return groups[entity_owner[entity][index]][0];
+   };
+   auto update_owner = [&](int vertex, int owner, const int *master, int nmaster)
+   {
+      if (vertex >= 0 && vertex < nvertices && owner != INT_MAX &&
+          std::find(master, master + nmaster, vertex) == master + nmaster)
+      {
+         hanging_owner[vertex] = std::min(hanging_owner[vertex], owner);
+      }
+   };
+
+   int mv[4], me[4], mo[4], sv[4];
+   for (const auto &master : edge_list.masters)
+   {
+      if (!edge_vertices(master.index, mv)) { continue; }
+      for (int i = master.slaves_begin; i < master.slaves_end; i++)
+      {
+         const Slave &slave = edge_list.slaves[i];
+         const int owner = owner_rank(1, slave.index, NEdges);
+         if (!edge_vertices(slave.index, sv)) { continue; }
+         update_owner(sv[0], owner, mv, 2);
+         update_owner(sv[1], owner, mv, 2);
+      }
+   }
+   for (const auto &master : face_list.masters)
+   {
+      const int nmv = GetFaceVerticesEdges(master, mv, me, mo);
+      for (int i = master.slaves_begin; i < master.slaves_end; i++)
+      {
+         const Slave &slave = face_list.slaves[i];
+         if (slave.index >= 0)
+         {
+            if (slave.element < 0 || elements[slave.element].rank < 0) { continue; }
+            const int owner = owner_rank(2, slave.index, NFaces);
+            const int nsv = GetFaceVerticesEdges(slave, sv, me, mo);
+            for (int j = 0; j < nsv; j++)
+            {
+               update_owner(sv[j], owner, mv, nmv);
+            }
+         }
+         else
+         {
+            const int edge = FlipIndexSign(slave.index);
+            const int owner = owner_rank(1, edge, NEdges);
+            if (!edge_vertices(edge, sv)) { continue; }
+            update_owner(sv[0], owner, mv, nmv);
+            update_owner(sv[1], owner, mv, nmv);
+         }
+      }
+   }
+   for (int i = 0; i < nvertices; i++)
+   {
+      if (hanging_owner[i] != INT_MAX) { tmp_owner[i] = hanging_owner[i]; }
+   }
 
    InitOwners(nvertices, entity_owner[0]);
    MakeSharedList(vertex_list, shared_vertices);

--- a/mesh/pncmesh.hpp
+++ b/mesh/pncmesh.hpp
@@ -46,10 +46,9 @@ namespace mfem
  *  seen by the rest of MFEM as they are skipped when a Mesh is created from
  *  the NCMesh.
  *
- *  Edges, faces, and non-hanging vertices are owned by the lowest rank in the
- *  group of processors that share the entity. A hanging vertex is owned by the
- *  lowest rank among the owners of the constraining slaves whose closure
- *  contains it.
+ *  Edges, faces, and non-hanging vertices use the lowest sharing rank as owner.
+ *  A hanging vertex uses the lowest-ranked owner of a constraining slave
+ *  edge or face containing it.
  *
  *  Vertices, edges and faces that are not owned by this ('MyRank') processor
  *  are ghosts, and are numbered after all real vertices/edges/faces, i.e.,

--- a/mesh/pncmesh.hpp
+++ b/mesh/pncmesh.hpp
@@ -46,9 +46,10 @@ namespace mfem
  *  seen by the rest of MFEM as they are skipped when a Mesh is created from
  *  the NCMesh.
  *
- *  The processor that owns a vertex, edge or a face (and in turn its DOFs) is
- *  currently defined to be the one with the lowest rank in the group of
- *  processors that share the entity.
+ *  Edges, faces, and non-hanging vertices are owned by the lowest rank in the
+ *  group of processors that share the entity. A hanging vertex is owned by the
+ *  lowest rank among the owners of the constraining slaves whose closure
+ *  contains it.
  *
  *  Vertices, edges and faces that are not owned by this ('MyRank') processor
  *  are ghosts, and are numbered after all real vertices/edges/faces, i.e.,

--- a/tests/unit/mesh/test_ncmesh.cpp
+++ b/tests/unit/mesh/test_ncmesh.cpp
@@ -13,6 +13,7 @@
 #include "mesh_test_utils.hpp"
 #include "unit_tests.hpp"
 
+#include <algorithm>
 #include <array>
 namespace mfem
 {
@@ -465,6 +466,45 @@ TEST_CASE("EdgeFaceConstraint", "[Parallel], [NCMesh]")
          Mesh sttmp(stmp);
          sttmp.GeneralRefinement(serial_refines);
          REQUIRE(sttmp.GetNE() == 1 + 8 - 1 + 8 - 1 + 8); // 23 elements
+
+         auto count_edge_face_slaves = [](const NCMesh::NCList &list)
+         {
+            int count = 0;
+            for (const auto &slave : list.slaves)
+            {
+               count += slave.index < 0;
+            }
+            return count;
+         };
+         const auto &serial_faces = sttmp.ncmesh->GetFaceList();
+         const auto &parallel_faces = ttmp.pncmesh->GetFaceList();
+         const int serial_slaves = count_edge_face_slaves(serial_faces);
+
+         std::vector<int> edge_face_edges;
+         for (const auto &slave : parallel_faces.slaves)
+         {
+            if (slave.index < 0)
+            {
+               edge_face_edges.push_back(slave.index);
+            }
+         }
+         std::sort(edge_face_edges.begin(), edge_face_edges.end());
+         const auto last =
+            std::unique(edge_face_edges.begin(), edge_face_edges.end());
+         const bool unique_edges = last == edge_face_edges.end();
+
+         const int expected_parallel_slaves =
+            ttmp.GetNE() ? (Mpi::WorldSize() > 1 ? 21 : 1) : 0;
+         const int parallel_slaves = static_cast<int>(edge_face_edges.size());
+         CAPTURE(serial_slaves, parallel_slaves, expected_parallel_slaves,
+                 unique_edges);
+         int valid_relations =
+            serial_slaves == 1 &&
+            parallel_slaves == expected_parallel_slaves &&
+            unique_edges;
+         MPI_Allreduce(MPI_IN_PLACE, &valid_relations, 1, MPI_INT, MPI_MIN,
+                       MPI_COMM_WORLD);
+         CHECK(valid_relations);
 
          // Loop over interior faces, fill and check face transform on the
          // serial.

--- a/tests/unit/mesh/test_ncmesh.cpp
+++ b/tests/unit/mesh/test_ncmesh.cpp
@@ -419,6 +419,14 @@ TEST_CASE("EdgeFaceConstraint", "[Parallel], [NCMesh]")
       REQUIRE(pmesh.GetGlobalNE() == 8 + 1);
       REQUIRE(smesh.GetNE() == 8 + 1);
 
+      // This fixed-order collection has no DOFs on the extra edge-face records.
+      {
+         RT0_3DFECollection fec;
+         FiniteElementSpace fes(&smesh, &fec);
+         ParFiniteElementSpace pfes(&pmesh, &fec);
+         CHECK(pfes.GlobalTrueVSize() == fes.GetTrueVSize());
+      }
+
       // Each pair of indices here represents sequential element indices to
       // refine. First the i element is refined, then in the resulting mesh the
       // j element is refined. These pairs were arrived at by looping over all
@@ -466,45 +474,6 @@ TEST_CASE("EdgeFaceConstraint", "[Parallel], [NCMesh]")
          Mesh sttmp(stmp);
          sttmp.GeneralRefinement(serial_refines);
          REQUIRE(sttmp.GetNE() == 1 + 8 - 1 + 8 - 1 + 8); // 23 elements
-
-         auto count_edge_face_slaves = [](const NCMesh::NCList &list)
-         {
-            int count = 0;
-            for (const auto &slave : list.slaves)
-            {
-               count += slave.index < 0;
-            }
-            return count;
-         };
-         const auto &serial_faces = sttmp.ncmesh->GetFaceList();
-         const auto &parallel_faces = ttmp.pncmesh->GetFaceList();
-         const int serial_slaves = count_edge_face_slaves(serial_faces);
-
-         std::vector<int> edge_face_edges;
-         for (const auto &slave : parallel_faces.slaves)
-         {
-            if (slave.index < 0)
-            {
-               edge_face_edges.push_back(slave.index);
-            }
-         }
-         std::sort(edge_face_edges.begin(), edge_face_edges.end());
-         const auto last =
-            std::unique(edge_face_edges.begin(), edge_face_edges.end());
-         const bool unique_edges = last == edge_face_edges.end();
-
-         const int expected_parallel_slaves =
-            ttmp.GetNE() ? (Mpi::WorldSize() > 1 ? 21 : 1) : 0;
-         const int parallel_slaves = static_cast<int>(edge_face_edges.size());
-         CAPTURE(serial_slaves, parallel_slaves, expected_parallel_slaves,
-                 unique_edges);
-         int valid_relations =
-            serial_slaves == 1 &&
-            parallel_slaves == expected_parallel_slaves &&
-            unique_edges;
-         MPI_Allreduce(MPI_IN_PLACE, &valid_relations, 1, MPI_INT, MPI_MIN,
-                       MPI_COMM_WORLD);
-         CHECK(valid_relations);
 
          // Loop over interior faces, fill and check face transform on the
          // serial.
@@ -650,7 +619,7 @@ TEST_CASE("EdgeFaceConstraint", "[Parallel], [NCMesh]")
 
 } // test case
 
-TEST_CASE("HangingVertexOwnership", "[Parallel], [NCMesh]")
+TEST_CASE("TetEdgeFaceCommunication", "[Parallel], [NCMesh]")
 {
    if (Mpi::WorldSize() < 3) { return; }
 
@@ -662,27 +631,173 @@ TEST_CASE("HangingVertexOwnership", "[Parallel], [NCMesh]")
    smesh.GeneralRefinement(ref);
    REQUIRE(smesh.GetNE() == 15);
 
-   H1_FECollection fec(1, 3);
-   FiniteElementSpace fes(&smesh, &fec);
-   const auto serial_ntdof = fes.GetTrueVSize();
-
-   const std::array<int, 15> base =
-   {2, 2, 1, 2, 0, 1, 2, 2, 0, 2, 1, 1, 2, 1, 0};
-   std::array<int, 3> labels = {0, 1, 2};
-   do
+   // On a nonzero rank, self ownership is still group 0. Entirely local
+   // master/slave relations must not be classified as shared.
    {
-      Array<int> partition(static_cast<int>(base.size()));
-      for (int i = 0; i < partition.Size(); i++)
-      {
-         partition[i] = labels[base[i]];
-      }
-
-      CAPTURE(labels[0], labels[1], labels[2]);
-      ParMesh pmesh(MPI_COMM_WORLD, smesh, partition.GetData());
-      ParFiniteElementSpace pfes(&pmesh, &fec);
-      CHECK(pfes.GlobalTrueVSize() == serial_ntdof);
+      Array<int> local_partition(smesh.GetNE());
+      local_partition = 1;
+      ParMesh local(MPI_COMM_WORLD, smesh, local_partition.GetData());
+      int shared = local.GetNE() ? local.pncmesh->GetSharedFaces().masters.Size() : 0;
+      MPI_Allreduce(MPI_IN_PLACE, &shared, 1, MPI_INT, MPI_SUM, MPI_COMM_WORLD);
+      CHECK(shared == 0);
    }
-   while (std::next_permutation(labels.begin(), labels.end()));
+
+   // Rank 0 owns an interior edge of a slave face local to rank 2, but
+   // does not own a slave face supplying that edge's constraint.
+   const std::array<int, 15> partition =
+   {0, 1, 2, 1, 0, 1, 1, 0, 2, 2, 0, 2, 1, 0, 0};
+   ParMesh pmesh(MPI_COMM_WORLD, smesh, partition.data());
+   auto &nc = *pmesh.pncmesh;
+   const auto &faces = nc.GetFaceList();
+   const auto &edges = nc.GetEdgeList();
+
+   int checked = 0, missing = 0;
+   for (const auto &master : faces.masters)
+   {
+      if (nc.IsGhost(2, master.index)) { continue; }
+      int mv[4], me[4], mo[4];
+      const int nmv = nc.GetFaceVerticesEdges(master, mv, me, mo);
+      for (int i = master.slaves_begin; i < master.slaves_end; i++)
+      {
+         const auto &slave = faces.slaves[i];
+         if (slave.index < 0 || nc.IsGhost(2, slave.index)) { continue; }
+         int sv[4], se[4], so[4];
+         const int nsv = nc.GetFaceVerticesEdges(slave, sv, se, so);
+         for (int j = 0; j < nsv; j++)
+         {
+            const int edge = se[j];
+            if (std::find(me, me + nmv, edge) != me + nmv) { continue; }
+            const auto type = edges.GetMeshIdAndType(edge).type;
+            if (type != NCMesh::NCList::MeshIdType::MASTER &&
+                type != NCMesh::NCList::MeshIdType::CONFORMING) { continue; }
+
+            // Infer the required recipient from ordinary slave-face edges,
+            // independently of whether an edge-face record was discovered.
+            const int owner = nc.GetGroup(nc.GetEntityOwnerId(1, edge))[0];
+            checked++;
+            const auto group = nc.GetEntityGroupId(2, master.index);
+            missing += !nc.GroupContains(group, owner);
+         }
+      }
+   }
+   MPI_Allreduce(MPI_IN_PLACE, &checked, 1, MPI_INT, MPI_SUM, MPI_COMM_WORLD);
+   MPI_Allreduce(MPI_IN_PLACE, &missing, 1, MPI_INT, MPI_SUM, MPI_COMM_WORLD);
+   REQUIRE(checked > 0);
+   // Fail collectively before space construction can wait for a missing row.
+   REQUIRE(missing == 0);
+
+   ND_FECollection fec(2, 3);
+   FiniteElementSpace fes(&smesh, &fec);
+   ParFiniteElementSpace pfes(&pmesh, &fec);
+   CHECK(pfes.GlobalTrueVSize() == fes.GetTrueVSize());
+}
+
+TEST_CASE("HangingVertexOwnership", "[Parallel], [NCMesh]")
+{
+   if (Mpi::WorldSize() < 3) { return; }
+
+   auto check_ownership = [](Mesh &smesh, const Array<int> &base)
+   {
+      std::array<int, 3> labels = {0, 1, 2};
+      do
+      {
+         Array<int> partition(base.Size());
+         for (int i = 0; i < partition.Size(); i++)
+         {
+            partition[i] = labels[base[i]];
+         }
+
+         CAPTURE(labels[0], labels[1], labels[2]);
+         ParMesh pmesh(MPI_COMM_WORLD, smesh, partition.GetData());
+         for (int order : {1, 2, 3})
+         {
+            CAPTURE(order);
+            H1_FECollection fec(order, smesh.Dimension());
+            FiniteElementSpace fes(&smesh, &fec);
+            ParFiniteElementSpace pfes(&pmesh, &fec);
+            CHECK(pfes.GlobalTrueVSize() == fes.GetTrueVSize());
+            if (order != 1) { continue; }
+
+            // Copy each serial P1 nodal basis to all its parallel copies and
+            // compare P R, including hanging vertices. Affine fields alone
+            // can conceal a spurious true DOF.
+            GridFunction serial_values(&fes);
+            Vector true_values;
+            int finite = 1;
+            real_t error = 0.0;
+            for (int i = 0; i < fes.GetVSize(); i++)
+            {
+               serial_values = 0.0;
+               serial_values[i] = 1.0;
+               ParGridFunction actual(&pmesh, &serial_values, partition.GetData());
+               actual.GetTrueDofs(true_values);
+               actual.SetFromTrueDofs(true_values);
+               serial_values.GetTrueDofs(true_values);
+               serial_values.SetFromTrueDofs(true_values);
+               ParGridFunction expected(&pmesh, &serial_values, partition.GetData());
+               actual -= expected;
+               if (actual.CheckFinite()) { finite = 0; }
+               else { error = std::max(error, actual.Normlinf()); }
+            }
+            MPI_Allreduce(MPI_IN_PLACE, &finite, 1, MPI_INT, MPI_MIN, MPI_COMM_WORLD);
+            MPI_Allreduce(MPI_IN_PLACE, &error, 1, MPITypeMap<real_t>::mpi_type,
+                          MPI_MAX, MPI_COMM_WORLD);
+            CHECK(finite);
+            CHECK(error == MFEM_Approx(0.0));
+         }
+      }
+      while (std::next_permutation(labels.begin(), labels.end()));
+   };
+
+   SECTION("VertexFan")
+   {
+      Mesh smesh("../../data/ref-tetrahedron.mesh");
+      smesh.UniformRefinement();
+      smesh.EnsureNCMesh(true);
+      smesh.GeneralRefinement(Array<int>({0}));
+      REQUIRE(smesh.GetNE() == 15);
+      const Array<int> partition({2, 2, 1, 2, 0, 1, 2, 2, 0, 2, 1, 1, 2, 1, 0});
+      check_ownership(smesh, partition);
+   }
+
+   SECTION("Edge")
+   {
+      // The central child (3) touches the diagonal midpoint but holds neither
+      // constraining half-edge. Both half-edges are held by rank 1.
+      Mesh smesh = Mesh::MakeCartesian2D(1, 1, Element::TRIANGLE);
+      smesh.EnsureNCMesh(true);
+      smesh.GeneralRefinement(Array<int>({0}));
+      REQUIRE(smesh.GetNE() == 5);
+      const Array<int> partition({1, 1, 2, 0, 2});
+      check_ownership(smesh, partition);
+   }
+
+   SECTION("Face")
+   {
+      // Two tetrahedra share z=0. Refine both children incident on the edge
+      // [(0,1/2,0),(1/2,1/2,0)] so its midpoint has no constraining master edge.
+      Mesh smesh(3, 5, 2, 0);
+      smesh.AddVertex(0, 0, 0);
+      smesh.AddVertex(1, 0, 0);
+      smesh.AddVertex(0, 1, 0);
+      smesh.AddVertex(0, 0, 1);
+      smesh.AddVertex(0, 0, -1);
+      smesh.AddTet(0, 1, 2, 3);
+      smesh.AddTet(0, 2, 1, 4);
+      smesh.FinalizeTetMesh(1, 0, true);
+      smesh.EnsureNCMesh(true);
+      smesh.GeneralRefinement(Array<int>({0}));
+      smesh.GeneralRefinement(Array<int>({2, 7}));
+      REQUIRE(smesh.GetNE() == 23);
+
+      // Element 20 touches the coarse face only at (1/4,1/2,0); element 22
+      // is the lower tetrahedron. Rank 1 holds all constraining slave faces.
+      Array<int> partition(smesh.GetNE());
+      partition = 1;
+      partition[20] = 0;
+      partition[22] = 2;
+      check_ownership(smesh, partition);
+   }
 }
 
 TEST_CASE("P2Q1PureTetHexPri",  "[Parallel], [NCMesh]")

--- a/tests/unit/mesh/test_ncmesh.cpp
+++ b/tests/unit/mesh/test_ncmesh.cpp
@@ -419,7 +419,7 @@ TEST_CASE("EdgeFaceConstraint", "[Parallel], [NCMesh]")
       REQUIRE(pmesh.GetGlobalNE() == 8 + 1);
       REQUIRE(smesh.GetNE() == 8 + 1);
 
-      // This fixed-order collection has no DOFs on the extra edge-face records.
+      // RT0 has no edge DOFs; skip its empty edge-face constraints.
       {
          RT0_3DFECollection fec;
          FiniteElementSpace fes(&smesh, &fec);
@@ -631,8 +631,7 @@ TEST_CASE("TetEdgeFaceCommunication", "[Parallel], [NCMesh]")
    smesh.GeneralRefinement(ref);
    REQUIRE(smesh.GetNE() == 15);
 
-   // On a nonzero rank, self ownership is still group 0. Entirely local
-   // master/slave relations must not be classified as shared.
+   // On rank 1, group 0 still means self. No faces should be shared.
    {
       Array<int> local_partition(smesh.GetNE());
       local_partition = 1;
@@ -642,8 +641,8 @@ TEST_CASE("TetEdgeFaceCommunication", "[Parallel], [NCMesh]")
       CHECK(shared == 0);
    }
 
-   // Rank 0 owns an interior edge of a slave face local to rank 2, but
-   // does not own a slave face supplying that edge's constraint.
+   // Rank 0 owns an interior edge of rank 2's slave face, but no local
+   // slave face constrains that edge.
    const std::array<int, 15> partition =
    {0, 1, 2, 1, 0, 1, 1, 0, 2, 2, 0, 2, 1, 0, 0};
    ParMesh pmesh(MPI_COMM_WORLD, smesh, partition.data());
@@ -671,8 +670,7 @@ TEST_CASE("TetEdgeFaceCommunication", "[Parallel], [NCMesh]")
             if (type != NCMesh::NCList::MeshIdType::MASTER &&
                 type != NCMesh::NCList::MeshIdType::CONFORMING) { continue; }
 
-            // Infer the required recipient from ordinary slave-face edges,
-            // independently of whether an edge-face record was discovered.
+            // Use the slave face's edges, not the edge-face records.
             const int owner = nc.GetGroup(nc.GetEntityOwnerId(1, edge))[0];
             checked++;
             const auto group = nc.GetEntityGroupId(2, master.index);
@@ -683,7 +681,7 @@ TEST_CASE("TetEdgeFaceCommunication", "[Parallel], [NCMesh]")
    MPI_Allreduce(MPI_IN_PLACE, &checked, 1, MPI_INT, MPI_SUM, MPI_COMM_WORLD);
    MPI_Allreduce(MPI_IN_PLACE, &missing, 1, MPI_INT, MPI_SUM, MPI_COMM_WORLD);
    REQUIRE(checked > 0);
-   // Fail collectively before space construction can wait for a missing row.
+   // Fail on all ranks before a missing row can hang space construction.
    REQUIRE(missing == 0);
 
    ND_FECollection fec(2, 3);
@@ -718,9 +716,8 @@ TEST_CASE("HangingVertexOwnership", "[Parallel], [NCMesh]")
             CHECK(pfes.GlobalTrueVSize() == fes.GetTrueVSize());
             if (order != 1) { continue; }
 
-            // Copy each serial P1 nodal basis to all its parallel copies and
-            // compare P R, including hanging vertices. Affine fields alone
-            // can conceal a spurious true DOF.
+            // Compare serial and parallel P R for every P1 nodal basis vector.
+            // Affine fields can hide extra true DOFs.
             GridFunction serial_values(&fes);
             Vector true_values;
             int finite = 1;
@@ -762,8 +759,8 @@ TEST_CASE("HangingVertexOwnership", "[Parallel], [NCMesh]")
 
    SECTION("Edge")
    {
-      // The central child (3) touches the diagonal midpoint but holds neither
-      // constraining half-edge. Both half-edges are held by rank 1.
+      // Child 3 on rank 0 touches the midpoint, but neither half-edge.
+      // Rank 1 holds both constraining half-edges.
       Mesh smesh = Mesh::MakeCartesian2D(1, 1, Element::TRIANGLE);
       smesh.EnsureNCMesh(true);
       smesh.GeneralRefinement(Array<int>({0}));
@@ -774,8 +771,8 @@ TEST_CASE("HangingVertexOwnership", "[Parallel], [NCMesh]")
 
    SECTION("Face")
    {
-      // Two tetrahedra share z=0. Refine both children incident on the edge
-      // [(0,1/2,0),(1/2,1/2,0)] so its midpoint has no constraining master edge.
+      // Refine both children sharing edge [(0,1/2,0),(1/2,1/2,0)].
+      // Its midpoint then depends on the coarse face, not a master edge.
       Mesh smesh(3, 5, 2, 0);
       smesh.AddVertex(0, 0, 0);
       smesh.AddVertex(1, 0, 0);
@@ -790,8 +787,8 @@ TEST_CASE("HangingVertexOwnership", "[Parallel], [NCMesh]")
       smesh.GeneralRefinement(Array<int>({2, 7}));
       REQUIRE(smesh.GetNE() == 23);
 
-      // Element 20 touches the coarse face only at (1/4,1/2,0); element 22
-      // is the lower tetrahedron. Rank 1 holds all constraining slave faces.
+      // Element 20 touches the coarse face only at (1/4,1/2,0).
+      // Rank 1 holds all constraining faces; element 22 is the lower tet.
       Array<int> partition(smesh.GetNE());
       partition = 1;
       partition[20] = 0;

--- a/tests/unit/mesh/test_ncmesh.cpp
+++ b/tests/unit/mesh/test_ncmesh.cpp
@@ -650,6 +650,41 @@ TEST_CASE("EdgeFaceConstraint", "[Parallel], [NCMesh]")
 
 } // test case
 
+TEST_CASE("HangingVertexOwnership", "[Parallel], [NCMesh]")
+{
+   if (Mpi::WorldSize() < 3) { return; }
+
+   Mesh smesh("../../data/ref-tetrahedron.mesh");
+   smesh.UniformRefinement();
+   smesh.EnsureNCMesh(true);
+   Array<int> ref(1);
+   ref[0] = 0;
+   smesh.GeneralRefinement(ref);
+   REQUIRE(smesh.GetNE() == 15);
+
+   H1_FECollection fec(1, 3);
+   FiniteElementSpace fes(&smesh, &fec);
+   const auto serial_ntdof = fes.GetTrueVSize();
+
+   const std::array<int, 15> base =
+   {2, 2, 1, 2, 0, 1, 2, 2, 0, 2, 1, 1, 2, 1, 0};
+   std::array<int, 3> labels = {0, 1, 2};
+   do
+   {
+      Array<int> partition(static_cast<int>(base.size()));
+      for (int i = 0; i < partition.Size(); i++)
+      {
+         partition[i] = labels[base[i]];
+      }
+
+      CAPTURE(labels[0], labels[1], labels[2]);
+      ParMesh pmesh(MPI_COMM_WORLD, smesh, partition.GetData());
+      ParFiniteElementSpace pfes(&pmesh, &fec);
+      CHECK(pfes.GlobalTrueVSize() == serial_ntdof);
+   }
+   while (std::next_permutation(labels.begin(), labels.end()));
+}
+
 TEST_CASE("P2Q1PureTetHexPri",  "[Parallel], [NCMesh]")
 {
    auto exact_soln = [](const Vector& x)


### PR DESCRIPTION
Distributing a nonconforming mesh can produce partition-dependent H1 true-DOF counts or hang during `ParFiniteElementSpace` construction for ND elements. These failures were encountered when restarting Palace from AMR-produced meshes. First, I found that the simulation would hang with 96 ranks, fixed that, I found that the physics was wrong. I am attaching an MFEM-only reproducer below. 

In my ways, this continues the work in #3926.

Thie PR fixes two problems:

1. Hanging-vertex ownership. The lowest rank touching a hanging vertex can own none of its constraining slave edges or faces. Since parallel interpolation skips ghost slaves, that rank can leave the vertex unconstrained and introduce a spurious true DOF. With this PR, we choose the lowest owner of a constraining slave instead, using the existing edge/face mesh IDs.
2. Tetrahedral edge-face communication. An unsplit local slave face can have an interior edge owned by an edge-only neighboring rank. Suppressing the corresponding edge-face relation omits that rank from the master-row communication group, leaving interpolation construction waiting for a row. With this PR, we discover these relations in parallel while preserving the existing serial traversal.

The additional edge-face records also require skipping empty slave-DOF lists before requesting a finite element, preserving support for fixed-order `RT0_3DFECollection`. Shared-master classification now compares the edge owner group ID with self group `0`, rather than with the MPI rank.

The reproducer below builds and refines both meshes in memory and uses explicit three-rank partitions.

| Case | Mesh after refinement | Without the corresponding fix | With this PR |
| --- | --- | --- | --- |
| `h1` | 5 triangles | Serial true size 6, parallel true size 7 | Both 6 |
| `nd` | 15 tetrahedra | Serial true size 158; hangs constructing the parallel space | Both 158 |

<details>
<summary>Standalone refinement reproducer and build commands</summary>

Save as `repro.cpp`:

```cpp
#include "mfem.hpp"
#include <iostream>
#include <string>

using namespace mfem;

int Check(Mesh &mesh, const Array<int> &partition, FiniteElementCollection &fec)
{
   FiniteElementSpace serial(&mesh, &fec);
   const int expected = serial.GetTrueVSize();
   ParMesh parallel(MPI_COMM_WORLD, mesh, partition.GetData());
   if (Mpi::WorldRank() == 0)
   {
      std::cout << "elements=" << mesh.GetNE() << ", serial_true=" << expected
                << "; constructing parallel space..." << std::endl;
   }
   ParFiniteElementSpace pfes(&parallel, &fec);
   const auto actual = pfes.GlobalTrueVSize(); // Called on every rank.
   if (Mpi::WorldRank() == 0)
   {
      std::cout << "parallel_true=" << actual << std::endl;
   }
   return actual != expected;
}

int main(int argc, char *argv[])
{
   Mpi::Init(argc, argv);
   Hypre::Init();
   MFEM_VERIFY(Mpi::WorldSize() == 3 && argc == 2,
               "Run with three MPI ranks and argument h1 or nd.");

   const std::string mode(argv[1]);
   if (mode == "h1")
   {
      Mesh mesh = Mesh::MakeCartesian2D(1, 1, Element::TRIANGLE);
      mesh.EnsureNCMesh(true);
      mesh.GeneralRefinement(Array<int>({0})); // Two triangles become five.
      const Array<int> partition({1, 1, 2, 0, 2});
      MFEM_VERIFY(mesh.GetNE() == partition.Size(), "Unexpected mesh size.");
      H1_FECollection fec(1, 2);
      return Check(mesh, partition, fec);
   }
   if (mode == "nd")
   {
      Mesh mesh(3, 4, 1, 0);
      mesh.AddVertex(0, 0, 0);
      mesh.AddVertex(1, 0, 0);
      mesh.AddVertex(0, 1, 0);
      mesh.AddVertex(0, 0, 1);
      mesh.AddTet(0, 1, 2, 3);
      mesh.FinalizeTetMesh(1, 1, true);
      mesh.UniformRefinement();              // One tetrahedron becomes eight.
      mesh.EnsureNCMesh(true);
      mesh.GeneralRefinement(Array<int>({0})); // Eight become fifteen.
      const Array<int> partition(
      {0, 1, 2, 1, 0, 1, 1, 0, 2, 2, 0, 2, 1, 0, 0});
      MFEM_VERIFY(mesh.GetNE() == partition.Size(), "Unexpected mesh size.");
      ND_FECollection fec(2, 3);
      return Check(mesh, partition, fec);
   }
   MFEM_ABORT("Expected h1 or nd.");
}
```

Save this `CMakeLists.txt` alongside it:

```cmake
cmake_minimum_required(VERSION 3.16)
project(nc_partition_repro LANGUAGES CXX)
find_package(MFEM CONFIG REQUIRED)
if(NOT MFEM_USE_MPI)
  message(FATAL_ERROR "This reproducer requires an MPI-enabled MFEM build.")
endif()
add_executable(repro repro.cpp)
target_link_libraries(repro PRIVATE mfem)
target_compile_features(repro PRIVATE cxx_std_17)
```

Set `MFEM_DIR` to the directory containing `MFEMConfig.cmake` for an MPI-enabled MFEM build or installation. Build and run the cases separately:

```sh
cmake -S . -B build -DMFEM_DIR=/path/to/mfem-config-directory
cmake --build build -j
mpiexec -n 3 ./build/repro h1
mpiexec --timeout 15 -n 3 ./build/repro nd
```

`--timeout 15` is an Open MPI option that bounds the pre-fix hang; use the equivalent timeout mechanism for another MPI implementation.

With this PR, the output is:

```text
# h1
elements=5, serial_true=6; constructing parallel space...
parallel_true=6

# nd
elements=15, serial_true=158; constructing parallel space...
parallel_true=158
```

Both runs exit successfully. Selectively restoring the original ownership or tetrahedral traversal implementation reproduces the corresponding failure in the table.

</details>

