### PR TITLE
[BUG] Fixed GlobalVector() to avoid calloc/delete mismatch

### DIFF
--- a/linalg/hypre.cpp
+++ b/linalg/hypre.cpp
@@ -321,9 +321,8 @@ Vector * HypreParVector::GlobalVector() const
                "GlobalVector method can only be called on vectors wherein each "
                "process owns one or more entries");
    hypre_Vector *hv = hypre_ParVectorToVectorAll(*this);
-   Vector *v = new Vector(hv->data, internal::to_int(hv->size));
-   v->MakeDataOwner();
-   hypre_SeqVectorSetDataOwner(hv,0);
+   Vector *v = new Vector(internal::to_int(hv->size));
+   *v = hv->data;
    hypre_SeqVectorDestroy(hv);
    return v;
 }


### PR DESCRIPTION
This is a small bugfix for `HypreParVector::GlobalVector()`, which wraps the `hypre_Vector` vector data by MFEM `Vector`. This leads to mismatch between alloc and delete (detected by valgrind, for example), as hypre uses alloc/free instead of new/delete of MFEM. This is technically undefined behavior 💣, even though it might be fine practically. Therefore, wrapping is replaced by copying here to avoid this.